### PR TITLE
Fix evaluation and buffer handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -51,8 +51,12 @@ if user_input:
         st.markdown(f"**Venture Console AI:** {assistant_reply}")
 
         try:
-            result = eval(user_input.split(',')[0])
-        except:
+            # Safely evaluate numerical input without executing arbitrary code
+            import ast
+            result = ast.literal_eval(user_input.split(',')[0])
+            if not isinstance(result, (int, float)):
+                raise ValueError("Result is not numeric")
+        except Exception:
             result = 1
 
         fig = plt.figure(figsize=(6, 4))
@@ -67,7 +71,9 @@ if user_input:
 
         buf = io.BytesIO()
         plt.savefig(buf, format="png")
+        buf.seek(0)
         st.image(buf)
+        plt.close(fig)
 
     except Exception as e:
         st.error(f"Error: {e}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ matplotlib==3.8.4
 numpy==1.26.4
 whisper
 torch
+


### PR DESCRIPTION
## Summary
- safely parse numeric input instead of using `eval`
- reset buffer position and close figure when rendering image
- clean up requirements.txt newline

## Testing
- `python3 -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_682caf06b6a88329b26af053609c5605