### PR TITLE
Fix evaluation and buffer handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,12 +2,11 @@ import streamlit as st
 import openai
 import numpy as np
 import matplotlib.pyplot as plt
-from mpl_toolkits.mplot3d import Axes3D
 import io
 import os
-import base64
 import tempfile
 import whisper
+import ast
 
 openai.api_key = os.getenv("OPENAI_API_KEY")
 
@@ -51,8 +50,11 @@ if user_input:
         st.markdown(f"**Venture Console AI:** {assistant_reply}")
 
         try:
-            result = eval(user_input.split(',')[0])
-        except:
+            # Safely evaluate numerical input without executing arbitrary code
+            result = ast.literal_eval(user_input.split(',')[0])
+            if not isinstance(result, (int, float)):
+                raise ValueError("Result is not numeric")
+        except Exception:
             result = 1
 
         fig = plt.figure(figsize=(6, 4))
@@ -65,9 +67,11 @@ if user_input:
         ax.plot_surface(X, Y, Z, cmap='plasma')
         ax.axis('off')
 
-        buf = io.BytesIO()
-        plt.savefig(buf, format="png")
-        st.image(buf)
+        with io.BytesIO() as buf:
+            plt.savefig(buf, format="png")
+            buf.seek(0)
+            st.image(buf)
+        plt.close(fig)
 
     except Exception as e:
         st.error(f"Error: {e}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-streamlit==1.35.0
-openai==1.30.1
 matplotlib==3.8.4
 numpy==1.26.4
-whisper
+openai==1.30.1
+streamlit==1.35.0
 torch
+whisper


### PR DESCRIPTION
## Summary
- safely parse numeric input instead of using `eval`
- reset buffer position and close figure when rendering image
- clean up requirements.txt newline

## Testing
- `python3 -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_682caf06b6a88329b26af053609c5605