### PR TITLE
Add host key pinning utilities

### DIFF
--- a/secrets/hosts.json
+++ b/secrets/hosts.json
@@ -1,0 +1,6 @@
+{
+  "github.com":       "SHA256:p2QAMXNIC1TJYWeIOttrVc98/R1BUFWu3/LiyKgUfQM=",
+  "gitlab.com":       "SHA256:HbW3g8zUjNSksFbqTiUWPWg2Bq1x8xdGUrliXFzSnUw=",
+  "bitbucket.org":    "SHA256:FC73VB6C4OQLSCrjEayhMp9UMxS97caD/Yyi2bhW/J0=",
+  "159.65.43.12":     "SHA256:b3uikwBkwnxpMTZjWBFaNgscsWXHRRG3Snj9QYke+ok="
+}

--- a/secrets/known_hosts
+++ b/secrets/known_hosts
@@ -1,0 +1,1 @@
+# Placeholder known_hosts. Run tools/pin_known_hosts.py to populate.

--- a/tools/codex_audit_starter.py
+++ b/tools/codex_audit_starter.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+import json, pathlib
+
+m = json.loads(pathlib.Path("runtime/manifests/codex_repos_manifest.json").read_text())
+for r in m["repos"]:
+    p = pathlib.Path(r["path"])
+    print(f"\n=== {r['name']} ({r['branch']}) @ {r['head'][:7]} ===")
+    missing = []
+    for need in [".gitignore", "README.md", "LICENSE", "SECURITY.md", ".github/workflows"]:
+        if not (p / need).exists():
+            missing.append(need)
+    if missing:
+        print("Missing:", ", ".join(missing))
+    else:
+        print("Baseline files present.")

--- a/tools/pin_known_hosts.py
+++ b/tools/pin_known_hosts.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""
+Validates remote host keys against expected SHA256 fingerprints
+and writes a pinned secrets/known_hosts file for strict SSH.
+"""
+import subprocess, sys, json
+from pathlib import Path
+
+HOSTS = json.loads(Path("secrets/hosts.json").read_text())
+OUT   = Path("secrets/known_hosts")
+OUT.parent.mkdir(parents=True, exist_ok=True)
+
+def ssh_keyscan(host):
+    # scan common key types; quiet; 5s timeout
+    cmd = ["ssh-keyscan","-T","5","-t","rsa,ecdsa,ed25519",host]
+    p = subprocess.run(cmd, capture_output=True, text=True)
+    return p.stdout.strip().splitlines()
+
+def fp_of_line(line):
+    # compute SHA256 fingerprint of a known_hosts-format line
+    p = subprocess.run(["ssh-keygen","-lf","-"], input=line+"\n",
+                       capture_output=True, text=True)
+    if p.returncode != 0: return None
+    # Example: "2048 SHA256:abcdef... type comment"
+    parts = p.stdout.strip().split()
+    return parts[1] if len(parts) >= 2 else None
+
+valid_lines = []
+errors = []
+
+for host, expected in HOSTS.items():
+    lines = ssh_keyscan(host)
+    matched = False
+    for line in lines:
+        fp = fp_of_line(line)
+        if fp == expected:
+            valid_lines.append(line)
+            matched = True
+    if not matched:
+        errors.append(f"{host}: no scanned key matched expected fingerprint {expected}")
+
+if errors:
+    print("ERROR: Host pinning failed:\n- " + "\n- ".join(errors))
+    sys.exit(1)
+
+OUT.write_text("\n".join(valid_lines) + "\n")
+print(f"\u2714 Wrote pinned known_hosts -> {OUT}")

--- a/tools/ssh_env.sh
+++ b/tools/ssh_env.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Exports GIT_SSH_COMMAND to force strict host-key checking and chosen key.
+set -euo pipefail
+KEY_PATH="${CODEX_SSH_KEY:-$HOME/.ssh/id_ed25519}"
+KNOWN_HOSTS="${CODEX_KNOWN_HOSTS:-$(pwd)/secrets/known_hosts}"
+export GIT_SSH_COMMAND="ssh -i $KEY_PATH -o UserKnownHostsFile=$KNOWN_HOSTS -o StrictHostKeyChecking=yes"
+echo "GIT_SSH_COMMAND set with key=$KEY_PATH, known_hosts=$KNOWN_HOSTS"


### PR DESCRIPTION
## Summary
- add host fingerprint config in `secrets/hosts.json`
- script to pin host keys and strict SSH setup
- simple audit starter utility

## Testing
- `python3 tools/pin_known_hosts.py` *(fails: Host pinning failed: github.com: no scanned key matched expected fingerprint SHA256:p2QAMXNIC1TJYWeIOttrVc98/R1BUFWu3/LiyKgUfQM=, gitlab.com: no scanned key matched expected fingerprint SHA256:HbW3g8zUjNSksFbqTiUWPWg2Bq1x8xdGUrliXFzSnUw=, bitbucket.org: no scanned key matched expected fingerprint SHA256:FC73VB6C4OQLSCrjEayhMp9UMxS97caD/Yyi2bhW/J0=, 159.65.43.12: no scanned key matched expected fingerprint SHA256:b3uikwBkwnxpMTZjWBFaNgscsWXHRRG3Snj9QYke+ok=)*
- `source tools/ssh_env.sh`
- `python3 tools/codex_repo_wizard.py` *(fails: file not found)*
- `python3 tools/codex_audit_starter.py` *(fails: No such file or directory: runtime/manifests/codex_repos_manifest.json)*
- `python -m py_compile tools/pin_known_hosts.py tools/codex_audit_starter.py`


------
https://chatgpt.com/codex/tasks/task_e_689fb47243848329bca6c605f52ef861