### PR TITLE
Add codex control pack

### DIFF
--- a/bin/codex
+++ b/bin/codex
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# === Codex: single entrypoint ===
+# Subcommands:
+#   up            -> pin hosts (if needed) + discover + grab + merge + operator --watch
+#   discover      -> discover all repos for owner/org and sync
+#   merge         -> auto pull/rebase/ff-merge + push (non-read-only)
+#   watch         -> operator --watch (live alerts + report)
+#   once          -> operator --once (process new events then exit)
+#   report        -> operator --report (rewrite report)
+#   audit         -> re-run baseline audits via repo wizard (manifest needed)
+#   issues        -> open issues for failed audits (GitHub token required)
+#   help          -> show help
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Source .env if present (tokens, etc.)
+if [ -f "$ROOT/.env" ]; then
+  # shellcheck disable=SC2046
+  export $(grep -v '^#' "$ROOT/.env" | xargs -I {} echo {})
+fi
+
+# Defaults
+export CODEX_SSH_KEY="${CODEX_SSH_KEY:-$HOME/.ssh/id_ed25519}"
+export GITHUB_TOKEN="${GITHUB_TOKEN:-${GH_TOKEN:-${PERSONAL_ACCESS_TOKEN:-}}}"
+
+OWNER="$(python3 - <<'PY'
+import json,sys,os
+from pathlib import Path
+cfg = Path("codex/config/codex.yml")
+owner = "blackboxprogramming"
+try:
+    import yaml
+    d=yaml.safe_load(cfg.read_text())
+    owner=d.get("owner",owner)
+except Exception:
+    pass
+print(owner)
+PY
+)"
+
+cmd="${1:-help}"
+
+run() { ( set -x; "$@" ); }
+
+case "$cmd" in
+  up)
+    # If known_hosts missing, ask wizard to pin hosts once (non-interactive accepts defaults)
+    if [ ! -f "$ROOT/codex/secrets/known_hosts" ]; then
+      echo ">> Pinning hosts via repo wizard (one-time)…"
+      python3 "$ROOT/codex/tools/codex_repo_wizard.py" <<'WIZ'
+./codex/repos
+~/.ssh/id_ed25519
+y
+main
+y
+
+WIZ
+    fi
+    echo ">> Discover + grab all repos for $OWNER"
+    run python3 "$ROOT/codex/tools/codex_repo_discover.py" --owner "$OWNER" --exclude-forks ${INCLUDE_PRIVATE:+--include-private}
+    echo ">> Merge + push (where allowed)"
+    run python3 "$ROOT/codex/agents/merge_agent.py"
+    echo ">> Operator watch (Ctrl+C to stop)"
+    exec python3 "$ROOT/codex/agents/codex_operator.py" --watch
+    ;;
+
+  discover)
+    run python3 "$ROOT/codex/tools/codex_repo_discover.py" --owner "$OWNER" --exclude-forks ${INCLUDE_PRIVATE:+--include-private}
+    ;;
+
+  merge)
+    run python3 "$ROOT/codex/agents/merge_agent.py"
+    ;;
+
+  watch)
+    exec python3 "$ROOT/codex/agents/codex_operator.py" --watch
+    ;;
+
+  once)
+    run python3 "$ROOT/codex/agents/codex_operator.py" --once
+    ;;
+
+  report)
+    run python3 "$ROOT/codex/agents/codex_operator.py" --report
+    ;;
+
+  audit)
+    # re-use the wizard’s baseline audit emitter
+    run python3 "$ROOT/codex/tools/codex_repo_wizard.py" --audit
+    ;;
+
+  issues)
+    # opens GitHub issues for any baseline audit failures found in recent events
+    run python3 "$ROOT/codex/agents/issue_opener.py"
+    ;;
+
+  help|*)
+    cat <<'HELP'
+Usage: ./bin/codex <subcommand>
+
+  up         Pin hosts (if needed) -> discover -> sync -> merge -> operator --watch
+  discover   Discover & sync all repos for owner (from codex/config/codex.yml)
+  merge      Auto pull/merge/rebase and push (non-read-only)
+  watch      Operator live mode (alerts + rolling report)
+  once       Operator one-shot
+  report     Rewrite operator report now
+  audit      Re-run baseline audits (emits events)
+  issues     Open GitHub issues for audit failures (GITHUB_TOKEN required)
+
+Env:
+  CODEX_SSH_KEY          SSH private key path (default: ~/.ssh/id_ed25519)
+  GITHUB_TOKEN|GH_TOKEN  GitHub token (private repos, opening issues)
+  INCLUDE_PRIVATE=1      Include private repos during discover
+
+HELP
+    ;;
+esac

--- a/codex/agents/issue_opener.py
+++ b/codex/agents/issue_opener.py
@@ -1,64 +1,134 @@
 #!/usr/bin/env python3
-"""Minimal issue opener for GitHub, GitLab, and Bitbucket."""
+"""
+Codex Issue Opener (GitHub)
+- Reads recent audit events (repo.audit.baseline)
+- For each repo with missing baseline files, opens/ensures a tracking issue
+- Idempotent: searches open issues by a stable title tag and avoids duplicates
 
-import json
-import os
-import urllib.request
-import urllib.parse
-from typing import Optional
+Requirements:
+  - GITHUB_TOKEN with "repo" scope
+  - origin URL must be GitHub SSH/HTTPS
 
+Reads:
+  codex/runtime/events/*.jsonl
+  codex/runtime/manifests/codex_repos_manifest.json
 
-def open_issue(provider: str, repo: str, title: str, body: str,
-               token: Optional[str] = None, token_env: Optional[str] = None,
-               api_base: Optional[str] = None):
-    """Open an issue on the given provider.
+Emits:
+  repo.issues.opened
+"""
+import os, re, json, base64, time
+from pathlib import Path
+from datetime import datetime
+import urllib.request, urllib.error
 
-    Parameters
-    ----------
-    provider: str
-        One of ``github``, ``gitlab``, or ``bitbucket``.
-    repo: str
-        Repository identifier. For GitHub and Bitbucket this is ``owner/repo``;
-        for GitLab it is the project path (``group/project``).
-    title: str
-        Issue title.
-    body: str
-        Issue body/description.
-    token: str, optional
-        API token. If not provided, ``token_env`` will be consulted.
-    token_env: str, optional
-        Name of environment variable holding the API token.
-    api_base: str, optional
-        Override API base URL.
-    """
-    provider = (provider or "").lower()
-    token = token or (token_env and os.getenv(token_env))
-    if not token:
-        raise ValueError("API token is required to open an issue")
+BASE = Path("codex")
+EVENTS = BASE/"runtime"/"events"
+MANIFEST = BASE/"runtime"/"manifests"/"codex_repos_manifest.json"
+OUT_EVENTS = EVENTS
 
-    if provider == "github":
-        api_base = api_base or "https://api.github.com"
-        url = f"{api_base}/repos/{repo}/issues"
-        headers = {"Authorization": f"token {token}"}
-        payload = {"title": title, "body": body}
-    elif provider == "gitlab":
-        api_base = api_base or "https://gitlab.com/api/v4"
-        project = urllib.parse.quote_plus(repo)
-        url = f"{api_base}/projects/{project}/issues"
-        headers = {"PRIVATE-TOKEN": token}
-        payload = {"title": title, "description": body}
-    elif provider == "bitbucket":
-        api_base = api_base or "https://api.bitbucket.org/2.0"
-        url = f"{api_base}/repositories/{repo}/issues"
-        headers = {"Authorization": f"Bearer {token}"}
-        payload = {"title": title, "content": {"raw": body}}
-    else:
-        raise ValueError(f"Unknown issue provider: {provider}")
+TOKEN = os.getenv("GITHUB_TOKEN") or os.getenv("GH_TOKEN") or os.getenv("PERSONAL_ACCESS_TOKEN")
 
-    data = json.dumps(payload).encode("utf-8")
-    req = urllib.request.Request(url, data=data, headers={**headers, "Content-Type": "application/json"})
-    with urllib.request.urlopen(req, timeout=10) as resp:
-        resp.read()
-    return url
+def emit(kind, payload):
+    OUT_EVENTS.mkdir(parents=True, exist_ok=True)
+    fn = OUT_EVENTS / f"{datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')}_{kind}.jsonl"
+    with fn.open("a") as f:
+        f.write(json.dumps({"id": f"{kind}:{int(time.time()*1000)}", "kind": kind, "ts": datetime.utcnow().isoformat()+"Z", "payload": payload}) + "\n")
 
-__all__ = ["open_issue"]
+def recent_audits(limit=200):
+    files = sorted(EVENTS.glob("*.jsonl"))
+    audits = []
+    for fp in reversed(files):
+        try:
+            for line in reversed(fp.read_text().splitlines()):
+                if not line.strip():
+                    continue
+                evt = json.loads(line)
+                if evt.get("kind") != "repo.audit.baseline":
+                    continue
+                audits.append(evt)
+                if len(audits) >= limit:
+                    return list(reversed(audits))
+        except Exception:
+            continue
+    return list(reversed(audits))
+
+def parse_github_owner_repo(origin_url: str):
+    # Supports ssh: git@github.com:owner/repo.git  or https: https://github.com/owner/repo.git
+    m = re.search(r"github\.com[:/](?P<owner>[^/]+)/(?P<repo>[^\.]+)", origin_url)
+    if not m:
+        return None, None
+    return m.group("owner"), m.group("repo")
+
+def gh_api(path, method="GET", body=None):
+    if not TOKEN:
+        raise RuntimeError("GITHUB_TOKEN is required to open issues.")
+    url = f"https://api.github.com{path}"
+    hdrs = {"Accept": "application/vnd.github+json", "User-Agent": "codex-issue-opener/1.0", "Authorization": f"Bearer {TOKEN}"}
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    req = urllib.request.Request(url, headers=hdrs, method=method, data=data)
+    with urllib.request.urlopen(req, timeout=30) as r:
+        return json.loads(r.read().decode("utf-8"))
+
+def ensure_issue(owner, repo, title, body):
+    # search existing open issues
+    q = f'repo:{owner}/{repo} is:issue is:open in:title "{title}"'
+    res = gh_api(f"/search/issues?q={urllib.parse.quote(q)}")
+    if res.get("total_count",0) > 0:
+        return {"owner": owner, "repo": repo, "title": title, "existing": True}
+    # create
+    created = gh_api(f"/repos/{owner}/{repo}/issues", method="POST", body={"title": title, "body": body})
+    return {"owner": owner, "repo": repo, "title": title, "number": created.get("number"), "url": created.get("html_url"), "existing": False}
+
+def load_manifest():
+    try:
+        return json.loads(MANIFEST.read_text())
+    except Exception:
+        return {"repos": []}
+
+def origin_url_for(repo_name, manifest):
+    for r in manifest.get("repos", []):
+        if r.get("name") == repo_name:
+            return r.get("url")
+    return None
+
+def main():
+    manifest = load_manifest()
+    audits = recent_audits()
+    opened = []
+    for evt in audits:
+        name = evt.get("payload",{}).get("name")
+        findings = evt.get("payload",{}).get("findings",{})
+        missing = findings.get("missing",[])
+        if not name or not missing:
+            continue
+        origin = origin_url_for(name, manifest)
+        if not origin:
+            continue
+        owner, repo = parse_github_owner_repo(origin)
+        if not owner:
+            continue
+        title = f"[Codex] Baseline missing files: {name}"
+        body = (
+ f"""Codex baseline audit detected missing required files in **{name}**:
+
+- {os.linesep.join(f"* `{m}`" for m in missing)}
+
+**Action**
+Please add the missing files. This issue was opened automatically by Codex.
+
+_Opened: {datetime.utcnow().isoformat()}Z_
+""")
+        try:
+            info = ensure_issue(owner, repo, title, body)
+            opened.append(info)
+        except urllib.error.HTTPError as e:
+            opened.append({"owner": owner, "repo": repo, "title": title, "error": f"HTTP {e.code}"})
+        except Exception as e:
+            opened.append({"owner": owner, "repo": repo, "title": title, "error": str(e)})
+
+    if opened:
+        emit("repo.issues.opened", {"items": opened})
+    print(f"Issues processed: {len(opened)}")
+
+if __name__ == "__main__":
+    main()

--- a/codex/config/codex.yml
+++ b/codex/config/codex.yml
@@ -1,0 +1,11 @@
+owner: blackboxprogramming
+platforms:
+  github: true
+defaults:
+  base_dir: codex/repos
+  branch: main
+behavior:
+  include_private: false      # set true or export INCLUDE_PRIVATE=1
+  exclude_forks: true
+  strict_hostkey: true
+  audit_on_grab: true


### PR DESCRIPTION
## Summary
- Introduce unified `bin/codex` entrypoint to manage discovery, merging, and operator tasks
- Provide central `codex/config/codex.yml` configuration for repos and behavior
- Replace issue opener agent with GitHub-based audit issue creation

## Testing
- `./bin/codex up` *(fails: ssh-keyscan: Network is unreachable)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fbc680d948329a22232820d987568