### PR TITLE
Add deployment workflow for Quantum App

### DIFF
--- a/.github/workflows/deploy-quantum.yml
+++ b/.github/workflows/deploy-quantum.yml
@@ -1,0 +1,29 @@
+name: Deploy Quantum App
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'apps/quantum/**'
+      - '.github/workflows/deploy-quantum.yml'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Copy to server
+        uses: burnett01/rsync-deployments@6.0
+        with:
+          switches: -avzr --delete
+          path: apps/quantum/
+          remote_path: /var/www/blackroad/apps/quantum/
+          remote_host: ${{ secrets.SSH_HOST }}
+          remote_user: ${{ secrets.SSH_USER }}
+          remote_key: ${{ secrets.SSH_KEY }}
+
+      - name: Health check
+        run: |
+          set -e
+          curl -fsS "https://${{ secrets.SITE_DOMAIN }}/apps/quantum/ternary_consciousness_v3.html" >/dev/null
+


### PR DESCRIPTION
## Summary
- add deployment workflow to sync Quantum app to remote server and verify health

## Testing
- `yamllint .github/workflows/deploy-quantum.yml` *(fails: command not found; attempted installation but network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_689ff2f3e26c8329a4353b69e301b368