### PR TITLE
Add health sidecar and runtime checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ runtime/
 .env
 __pycache__/
 codex/runtime/
+node_modules/
+services/health-sidecar/node_modules/
+services/health-sidecar/.env

--- a/services/health-sidecar/.env.example
+++ b/services/health-sidecar/.env.example
@@ -1,0 +1,3 @@
+PORT=8088
+API_ROOT=/var/www/blackroad/api
+COMMIT_SHA=

--- a/services/health-sidecar/health-sidecar.service
+++ b/services/health-sidecar/health-sidecar.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Health Sidecar (Express)
+After=network.target
+
+[Service]
+Environment=PORT=8088
+Environment=API_ROOT=/var/www/blackroad/api
+Environment=COMMIT_SHA=
+WorkingDirectory=/var/www/blackroad/repo/services/health-sidecar
+ExecStart=/usr/bin/node server.js
+Restart=always
+RestartSec=3
+User=www-data
+Group=www-data
+
+[Install]
+WantedBy=multi-user.target

--- a/services/health-sidecar/package.json
+++ b/services/health-sidecar/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "health-sidecar",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "express": "^4.19.2"
+  },
+  "scripts": {
+    "start": "node server.js"
+  }
+}

--- a/services/health-sidecar/server.js
+++ b/services/health-sidecar/server.js
@@ -1,0 +1,50 @@
+import express from 'express';
+import fs from 'fs';
+import path from 'path';
+
+const app = express();
+const PORT = process.env.PORT || 8088;
+const API_ROOT = process.env.API_ROOT || "/var/www/blackroad/api";
+const HEALTH_FILE = path.join(API_ROOT, "health.json");
+
+// simple cache-control for JSON
+app.use((_req, res, next) => {
+  res.set('Cache-Control', 'no-store');
+  next();
+});
+
+// GET /api/health  (primary)
+app.get('/api/health', (_req, res) => {
+  let body = {
+    status: "ok",
+    app: "quantum-v3",
+    version: "v3.0.0",
+    commit: process.env.COMMIT_SHA || "unknown",
+    ts: new Date().toISOString()
+  };
+  try {
+    if (fs.existsSync(HEALTH_FILE)) {
+      const file = JSON.parse(fs.readFileSync(HEALTH_FILE, 'utf8'));
+      body = { ...file, status: "ok" };
+    }
+  } catch (e) {
+    body.status = "degraded";
+    body.error = String(e?.message || e);
+  }
+  res.json(body);
+});
+
+// Liveness/Readiness (K8s or uptime monitors)
+app.get('/livez', (_req, res) => res.send('OK'));
+app.get('/readyz', (_req, res) => {
+  try {
+    fs.accessSync(API_ROOT, fs.constants.R_OK);
+    return res.send('READY');
+  } catch {
+    return res.status(503).send('NOT_READY');
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`[health-sidecar] listening on :${PORT}`);
+});

--- a/ternary.html
+++ b/ternary.html
@@ -7,6 +7,60 @@
     <title>Ternary Quantum Consciousness Framework</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.9.1/chart.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/11.11.0/math.min.js"></script>
+
+    <script>
+    // --- Console-only runtime sanity checks ---
+    (function(){
+      const log = console.log.bind(console, '[runtime]');
+      const warn = console.warn.bind(console, '[runtime]');
+      const error = console.error.bind(console, '[runtime]');
+
+      try {
+        if (!window.Chart) error('Chart.js missing');
+        else log('Chart.js OK');
+
+        if (!window.math || !math.expm) error('math.js missing or no expm');
+        else {
+          // quick unitary sanity
+          const H = math.matrix([[1,0.1,0],[0.1,0,-0.2],[0,-0.2,-0.9]]);
+          const U  = math.expm(math.multiply(math.complex(0,-1), H));
+          const Ud = math.ctranspose(U);
+          const I  = math.identity(3);
+          const frob = (()=>{ const D = math.subtract(math.multiply(Ud,U), I); return Math.sqrt(math.sum(math.dotMultiply(D, math.conj(D)))); })();
+          if (frob > 1e-6) warn(`Unitary borderline: ||U†U−I||≈${frob.toExponential(2)}`); else log('Unitary OK');
+        }
+
+        // density sanity
+        if (window.math) {
+          const psi = math.divide(math.matrix([1,1,1]), Math.sqrt(3));
+          const rho = math.multiply(math.reshape(psi,[3,1]), math.ctranspose(math.reshape(psi,[3,1])));
+          const tr  = math.trace(rho); const pur = math.trace(math.multiply(rho,rho));
+          if (Math.abs((tr.re ?? tr)-1) > 1e-8) error(`Tr(ρ)=${tr}`);
+          else log('Tr(ρ)=1 OK');
+          const p = (pur.re ?? pur);
+          if (p<1/3-1e-6 || p>1+1e-6) error(`Purity out-of-bounds: ${p}`); else log(`Purity OK (${p.toFixed(4)})`);
+        }
+
+        // minimal paint timing
+        try {
+          new PerformanceObserver((list) => {
+            list.getEntries().forEach((e) => {
+              if (e.name === 'first-contentful-paint') {
+                const t = e.startTime.toFixed(0);
+                if (e.startTime > 2500) warn(`FCP ${t}ms (slow)`); else log(`FCP ${t}ms`);
+              }
+            });
+          }).observe({ type: 'paint', buffered: true });
+        } catch {}
+      } catch (e) {
+        error('Self-check error', e);
+      }
+
+      window.onerror = function(msg, src, line, col){
+        console.error('[runtime] Global error:', msg, src, line, col);
+      };
+    })();
+    </script>
     <style>
         * {
             margin: 0;
@@ -1327,6 +1381,58 @@
         setTimeout(() => {
             addExportButton();
         }, 100);
+    </script>
+
+    <script>
+    // --- Performance Budget: warn if slow (non-fatal) ---
+    (function(){
+      const B = {
+        fp_ms: 2000,        // First Paint budget
+        fcp_ms: 2500,       // First Contentful Paint budget
+        longtask_ms: 100,   // Long task threshold
+        total_long_ms: 600  // Total long-task time budget
+      };
+      let longTaskTotal = 0;
+
+      // Paint timing
+      new PerformanceObserver((list) => {
+        list.getEntries().forEach((e) => {
+          if (e.name === 'first-paint' && e.startTime > B.fp_ms) {
+            console.warn(`[perf] FP ${e.startTime.toFixed(0)}ms exceeds ${B.fp_ms}ms`);
+            markBadgeWarn(`FP ${e.startTime.toFixed(0)}ms > ${B.fp_ms}ms`);
+          }
+          if (e.name === 'first-contentful-paint' && e.startTime > B.fcp_ms) {
+            console.warn(`[perf] FCP ${e.startTime.toFixed(0)}ms exceeds ${B.fcp_ms}ms`);
+            markBadgeWarn(`FCP ${e.startTime.toFixed(0)}ms > ${B.fcp_ms}ms`);
+          }
+        });
+      }).observe({ type: 'paint', buffered: true });
+
+      // Long tasks (main thread)
+      if ('PerformanceObserver' in window && 'PerformanceLongTaskTiming' in window) {
+        new PerformanceObserver((list) => {
+          list.getEntries().forEach((t) => {
+            const d = t.duration;
+            if (d >= B.longtask_ms) {
+              longTaskTotal += d;
+              console.warn(`[perf] Long task ${d.toFixed(0)}ms (total ${longTaskTotal.toFixed(0)}ms)`);
+              if (longTaskTotal > B.total_long_ms) {
+                markBadgeWarn(`Long tasks total ${longTaskTotal.toFixed(0)}ms > ${B.total_long_ms}ms`);
+              }
+            }
+          });
+        }).observe({entryTypes:['longtask']});
+      }
+
+      function markBadgeWarn(msg){
+        const badge = document.getElementById('runtimeSelfCheck');
+        if (!badge) return;
+        badge.classList.remove('ok');
+        if (!badge.classList.contains('error')) badge.classList.add('warn');
+        const body = document.getElementById('runtimeSelfCheckBody');
+        if (body) body.insertAdjacentHTML('beforeend', `<div>⚠️ ${msg}</div>`);
+      }
+    })();
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add Express health sidecar with readiness endpoints
- provide systemd unit and env example
- embed runtime sanity checks and performance budgets into ternary app

## Testing
- `node --check server.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ff52292888329b3965b94cafd1a80