### PR TITLE
chore(automation): add repo automation agents

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:best-practices",
+    ":semanticCommits",
+    ":separateMultipleMajorReleases",
+    ":rebaseStalePrs",
+    "group:allNonMajor"
+  ],
+  "labels": ["dependencies"],
+  "rangeStrategy": "bump",
+  "timezone": "America/Chicago",
+  "assignees": [],
+  "packageRules": [
+    {
+      "matchManagers": ["npm"],
+      "rangeStrategy": "auto",
+      "labels": ["deps:npm"]
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "labels": ["deps:actions"]
+    }
+  ],
+  "prHourlyLimit": 4,
+  "prConcurrentLimit": 10,
+  "rebaseWhen": "behind-base-branch"
+}

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -1,0 +1,23 @@
+name: OSSF Scorecard
+on:
+  schedule:
+    - cron: "0 8 * * 1" # Mondays
+  push:
+    branches: [ main ]
+permissions:
+  security-events: write
+  id-token: write
+  contents: read
+jobs:
+  analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+      - uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,15 @@
+name: Release Please
+on:
+  push:
+    branches: [ main ]
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v4
+        with:
+          release-type: simple
+          package-name: blackroad-quantum

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,0 +1,24 @@
+name: Semantic PR Title
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            chore
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+          requireScope: false

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,25 @@
+name: Mark stale issues and PRs
+on:
+  schedule:
+    - cron: "17 6 * * *" # daily 06:17 UTC
+permissions:
+  issues: write
+  pull-requests: write
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 30
+          days-before-close: 7
+          stale-issue-label: "stale"
+          stale-pr-label: "stale"
+          exempt-issue-labels: "pinned,security"
+          exempt-pr-labels: "work-in-progress"
+          stale-issue-message: >
+            This issue has been automatically marked as stale due to inactivity.
+            It will be closed if no further activity occurs.
+          stale-pr-message: >
+            This PR has been automatically marked as stale due to inactivity.
+            It will be closed if no further activity occurs.

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,20 @@
+pull_request_rules:
+  - name: Auto-merge safe dependency updates
+    conditions:
+      - author~=^(dependabot|renovate)\[bot\]$
+      - status-success=build
+      - status-success=CodeQL
+      - status-success=Deploy Quantum App (safe)
+      - check-success>=1
+      - base=main
+      - "#approved-reviews-by>=1"
+    actions:
+      merge:
+        method: squash
+      delete_head_branch: {}
+  - name: Label and request review
+    conditions:
+      - "#files-changed>0"
+    actions:
+      label:
+        add: ["needs-review"]


### PR DESCRIPTION
## Summary
- add Renovate configuration for grouped dependency updates
- set up Mergify for safe auto-merging and labelling
- introduce workflows for Stale bot, OSSF Scorecard, Release Please, and semantic PR title checks

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a config file)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ff7508b20832996e7703069aefc96