### PR TITLE
chore: scope Dependabot to Actions only and add security scans

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,3 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule: { interval: "weekly" }
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule: { interval: "weekly" }

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -1,0 +1,16 @@
+name: npm audit (advisory)
+on:
+  pull_request:
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - run: npm ci --omit=optional || npm i --package-lock-only
+      - run: |
+          npx npm-audit-resolver --audit-level=high || echo "::warning::Advisories found (review logs)."

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,0 +1,20 @@
+name: Snyk Scan
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+permissions:
+  contents: read
+jobs:
+  snyk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - run: npm ci --omit=optional || npm i --package-lock-only
+      - uses: snyk/actions/node@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --severity-threshold=high


### PR DESCRIPTION
## Summary
- limit Dependabot to GitHub Actions since Renovate handles npm packages
- add optional Snyk scan workflow
- include lightweight npm audit advisory workflow

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689ff7a2f74c8329a4554f0e074b4fa8