### PR TITLE
automation: branch protection, project board, triage, labels

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,27 @@
+- name: priority: high
+  color: d73a4a
+  description: Must-do soon
+- name: priority: medium
+  color: fbca04
+  description: Should-do
+- name: priority: low
+  color: c2e0c6
+  description: Nice-to-have
+- name: deps
+  color: 0366d6
+  description: Dependencies
+- name: security
+  color: 8b949e
+  description: Security-related
+- name: bug
+  color: d73a4a
+  description: Something is broken
+- name: feature
+  color: a2eeef
+  description: New capability
+- name: automerge
+  color: 0e8a16
+  description: OK to auto-merge when checks pass
+- name: needs-review
+  color: 5319e7
+  description: Awaiting maintainer review

--- a/.github/workflows/apply-branch-protection.yml
+++ b/.github/workflows/apply-branch-protection.yml
@@ -1,0 +1,104 @@
+name: Apply Branch Protection (best-effort)
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+permissions:
+  contents: read
+  pull-requests: read
+  repository-projects: write
+jobs:
+  protect:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply protection with GITHUB_TOKEN
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+        run: |
+          set -e
+          BASE="https://api.github.com/repos/${OWNER}/${REPO}/branches/main/protection"
+          JSON_PAYLOAD=$(cat <<'JSON'
+          {
+            "required_status_checks": {
+              "strict": true,
+              "checks": [
+                {"context":"Deploy Quantum App (safe)"},
+                {"context":"CodeQL"},
+                {"context":"Snyk Scan"},
+                {"context":"Trivy FS Scan"},
+                {"context":"Gitleaks (secrets)"}
+              ]
+            },
+            "enforce_admins": true,
+            "required_pull_request_reviews": {
+              "dismiss_stale_reviews": true,
+              "require_code_owner_reviews": true,
+              "required_approving_review_count": 1
+            },
+            "restrictions": null,
+            "required_linear_history": true,
+            "allow_force_pushes": false,
+            "allow_deletions": false,
+            "required_conversation_resolution": true,
+            "lock_branch": false,
+            "allow_fork_syncing": true
+          }
+          JSON
+          )
+          code=$(curl -sS -o /tmp/resp.json -w "%{http_code}" \
+            -X PUT -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" \
+            "$BASE" -d "$JSON_PAYLOAD" || true)
+          echo "HTTP $code from protection API"
+          if [ "$code" = "200" ] || [ "$code" = "201" ]; then
+            echo "✅ Branch protection applied with GITHUB_TOKEN."
+            exit 0
+          fi
+          echo "::warning::Could not apply protection with GITHUB_TOKEN (HTTP $code)."
+      - name: Retry with ADMIN_TOKEN (optional)
+        if: ${{ secrets.ADMIN_TOKEN != '' }}
+        env:
+          ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+        run: |
+          set -e
+          BASE="https://api.github.com/repos/${OWNER}/${REPO}/branches/main/protection"
+          JSON_PAYLOAD=$(cat <<'JSON'
+          {
+            "required_status_checks": {
+              "strict": true,
+              "checks": [
+                {"context":"Deploy Quantum App (safe)"},
+                {"context":"CodeQL"},
+                {"context":"Snyk Scan"},
+                {"context":"Trivy FS Scan"},
+                {"context":"Gitleaks (secrets)"}
+              ]
+            },
+            "enforce_admins": true,
+            "required_pull_request_reviews": {
+              "dismiss_stale_reviews": true,
+              "require_code_owner_reviews": true,
+              "required_approving_review_count": 1
+            },
+            "restrictions": null,
+            "required_linear_history": true,
+            "allow_force_pushes": false,
+            "allow_deletions": false,
+            "required_conversation_resolution": true,
+            "lock_branch": false,
+            "allow_fork_syncing": true
+          }
+          JSON
+          )
+          code=$(curl -sS -o /tmp/resp.json -w "%{http_code}" \
+            -X PUT -H "Authorization: Bearer $ADMIN_TOKEN" -H "Accept: application/vnd.github+json" \
+            "$BASE" -d "$JSON_PAYLOAD" || true)
+          echo "HTTP $code from protection API (ADMIN_TOKEN)"
+          if [ "$code" = "200" ] || [ "$code" = "201" ]; then
+            echo "✅ Branch protection applied with ADMIN_TOKEN."
+          else
+            echo "::warning::Still cannot apply branch protection (HTTP $code). Admin rights are required."
+          fi

--- a/.github/workflows/project-triage.yml
+++ b/.github/workflows/project-triage.yml
@@ -1,0 +1,56 @@
+name: Project Triage
+on:
+  issues:
+    types: [opened, labeled, reopened]
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  repository-projects: write
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const isPR = !!context.payload.pull_request;
+            const number = isPR ? context.payload.pull_request.number : context.payload.issue.number;
+            // get/ensure project and columns
+            const pj = await github.request('GET /repos/{owner}/{repo}/projects', {
+              owner, repo, headers: { 'Accept': 'application/vnd.github.inertia-preview+json' }
+            });
+            const project = pj.data.find(p => p.name === 'Quantum Auto');
+            if (!project) { core.info('No project found; nothing to do.'); return; }
+            const cols = await github.request('GET /projects/{project_id}/columns', {
+              project_id: project.id, headers: { 'Accept': 'application/vnd.github.inertia-preview+json' }
+            });
+            const byName = Object.fromEntries(cols.data.map(c => [c.name, c]));
+            // choose column
+            let target = byName['Backlog'];
+            if (isPR) {
+              const pr = (await github.pulls.get({ owner, repo, pull_number: number })).data;
+              target = pr.draft ? byName['To do'] : byName['In progress'];
+            } else {
+              const labels = (context.payload.issue.labels || []).map(l => l.name);
+              if (labels.includes('priority: high')) target = byName['In progress'];
+              else if (labels.includes('priority: medium')) target = byName['To do'];
+            }
+            if (!target) { core.info('No target column; exiting'); return; }
+            // create card if not present
+            const link = isPR ? { content_id: context.payload.pull_request.id, content_type: 'PullRequest' }
+                              : { content_id: context.payload.issue.id, content_type: 'Issue' };
+            try {
+              await github.request('POST /projects/columns/{column_id}/cards', {
+                column_id: target.id, ...link,
+                headers: { 'Accept': 'application/vnd.github.inertia-preview+json' }
+              });
+              core.info(`Added card to ${target.name}`);
+            } catch (e) {
+              if (e.status === 422) core.info('Card already exists');
+              else throw e;
+            }

--- a/.github/workflows/setup-project.yml
+++ b/.github/workflows/setup-project.yml
@@ -1,0 +1,46 @@
+name: Ensure Repo Project
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+permissions:
+  contents: read
+  repository-projects: write
+jobs:
+  ensure-project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            // list existing projects
+            const { data: projects } = await github.request('GET /repos/{owner}/{repo}/projects', {
+              owner, repo, headers: { 'Accept': 'application/vnd.github.inertia-preview+json' }
+            });
+            let project = projects.find(p => p.name === 'Quantum Auto');
+            if (!project) {
+              const { data: created } = await github.request('POST /repos/{owner}/{repo}/projects', {
+                owner, repo, name: 'Quantum Auto', body: 'Automanaged board',
+                headers: { 'Accept': 'application/vnd.github.inertia-preview+json' }
+              });
+              project = created;
+              core.info(`Created project id=${project.id}`);
+            } else {
+              core.info(`Project exists id=${project.id}`);
+            }
+            // ensure columns
+            const { data: cols } = await github.request('GET /projects/{project_id}/columns', {
+              project_id: project.id, headers: { 'Accept': 'application/vnd.github.inertia-preview+json' }
+            });
+            const want = ['Backlog','To do','In progress','Done'];
+            for (const name of want) {
+              if (!cols.find(c => c.name === name)) {
+                await github.request('POST /projects/{project_id}/columns', {
+                  project_id: project.id, name,
+                  headers: { 'Accept': 'application/vnd.github.inertia-preview+json' }
+                });
+                core.info(`Added column ${name}`);
+              }
+            }

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,19 @@
+name: Sync Labels
+on:
+  push:
+    branches: [ main ]
+    paths: [ ".github/labels.yml", ".github/workflows/sync-labels.yml" ]
+  workflow_dispatch:
+permissions:
+  contents: read
+  issues: write
+jobs:
+  labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: crazy-max/ghaction-github-labeler@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          config-file: .github/labels.yml
+          skip-delete: false


### PR DESCRIPTION
## Summary
- add workflow to apply branch protections with fallback
- manage repo project board and auto-triage issues/PRs
- sync standard labels for automation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ff908ee8483299b2307ae790b3418