### PR TITLE
policy: add best-effort Rulesets workflow

### DIFF
--- a/.github/workflows/apply-rulesets.yml
+++ b/.github/workflows/apply-rulesets.yml
@@ -1,0 +1,95 @@
+name: Apply Rulesets (best-effort)
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  rulesets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup gh cli
+        uses: cli/cli-action@v2
+      - name: Upsert ruleset for main
+        env:
+          GH_TOKEN: ${{ secrets.ADMIN_TOKEN || secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+        run: |
+          set -e
+          header='-H Accept: application/vnd.github+json'
+          base="/repos/$OWNER/$REPO/rulesets"
+
+          echo "🔎 Checking existing rulesets…"
+          gh api $header "$base" > /tmp/rs.json || { echo "::warning::Cannot list rulesets (insufficient scope/plan?)"; exit 0; }
+
+          # Prepare payload (GitHub may evolve this schema; if the API rejects it, we log and exit 0)
+          cat > /tmp/main_ruleset.json <<'JSON'
+          {
+            "name": "Main branch protections",
+            "target": "branch",
+            "enforcement": "active",
+            "conditions": {
+              "ref_name": {
+                "include": ["~DEFAULT_BRANCH", "main"],
+                "exclude": []
+              }
+            },
+            "bypass_actors": [],
+            "rules": [
+              { "type": "required_signatures" },
+              { "type": "required_linear_history" },
+              {
+                "type": "pull_request",
+                "parameters": {
+                  "dismiss_stale_reviews_on_push": true,
+                  "require_code_owner_review": true,
+                  "required_approving_review_count": 1
+                }
+              },
+              {
+                "type": "required_status_checks",
+                "parameters": {
+                  "strict_required_status_checks": true,
+                  "required_status_checks": [
+                    { "context": "Deploy Quantum App (safe)" },
+                    { "context": "CodeQL" },
+                    { "context": "Snyk Scan" },
+                    { "context": "Trivy FS Scan" },
+                    { "context": "Gitleaks (secrets)" }
+                  ]
+                }
+              }
+            ]
+          }
+          JSON
+
+          # Resolve default branch name in payload
+          default_branch=$(gh api $header "/repos/$OWNER/$REPO" --jq .default_branch || echo main)
+          jq --arg def "~DEFAULT_BRANCH" --arg real "$default_branch" \
+            '(.. | select(type == "string")) |= if . == $def then $real else . end' \
+            /tmp/main_ruleset.json >/tmp/main_ruleset_resolved.json
+
+          # Find existing ruleset with same name
+          rs_id=$(jq -r '.[] | select(.name=="Main branch protections") | .id' /tmp/rs.json || true)
+          if [ -n "$rs_id" ] && [ "$rs_id" != "null" ]; then
+            echo "✏️  Updating existing ruleset id=$rs_id"
+            code=$(gh api $header -X PATCH "$base/$rs_id" --input /tmp/main_ruleset_resolved.json -i 2>&1 | tail -n1 | awk '{print $2}')
+            # gh prints response headers on -i; ignore parse if layout changes
+            echo "Updated (best-effort)."
+          else
+            echo "➕ Creating ruleset…"
+            if ! gh api $header -X POST "$base" --input /tmp/main_ruleset_resolved.json >/dev/null 2>&1; then
+              echo "::warning::Ruleset create failed (token scope/plan restrictions or API changes). Skipping without error."
+              exit 0
+            fi
+            echo "✅ Ruleset created."
+          fi
+
+      - name: Summarize
+        run: |
+          echo "If your plan or token doesn't allow Rulesets, the step above posted a warning."
+          echo "No action needed; everything else (branch protection workflow, project board, CI) still works."


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to upsert branch rulesets on main requiring signed commits, linear history, code-owner reviews, and specific status checks

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint couldn't find an eslint.config.* file)

------
https://chatgpt.com/codex/tasks/task_e_689ff9f82d5c8329af5b0c52bf3c84d3