### PR TITLE
fix(codeql): JS-only, buildless workflow + sane excludes

### DIFF
--- a/.github/codeql/config.yml
+++ b/.github/codeql/config.yml
@@ -1,0 +1,12 @@
+name: "BlackRoad CodeQL JS config"
+disable-default-queries: false
+paths:
+  - apps/quantum
+paths-ignore:
+  - node_modules
+  - public/vendor
+  - dist
+  - build
+  - .husky
+  - .tools
+  - .github

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,11 +2,38 @@ name: CodeQL
 on:
   push: { branches: [ main ] }
   pull_request: { branches: [ main ] }
+  workflow_dispatch:
+permissions:
+  security-events: write
+  contents: read
 jobs:
   analyze:
+    name: Analyze (JavaScript)
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'javascript' ]
     steps:
-      - uses: actions/checkout@v4
-      - uses: github/codeql-action/init@v3
-        with: { languages: javascript }
-      - uses: github/codeql-action/analyze@v3
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Optional: show what CodeQL thinks the languages are
+      - name: Debug: list JS files
+        run: |
+          echo "First 20 JS-like files:"
+          git ls-files '**/*.js' '**/*.mjs' '**/*.cjs' | head -n 20 || true
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+          config-file: ./.github/codeql/config.yml
+          queries: security-and-quality
+
+      # For JS we don't build; analysis runs directly
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- add CodeQL workflow for JavaScript with debug listing of JS files
- configure CodeQL to analyze `apps/quantum` only and ignore common build folders

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_689ffb9f4238832984e07ec1c0563fe3