### PR TITLE
ci: add markdown lint workflow

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,16 @@
+name: Markdown Lint
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+permissions:
+  contents: read
+jobs:
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DavidAnson/markdownlint-cli2-action@v15
+        with:
+          config: .markdownlint.yaml
+          globs: '**/*.md'


### PR DESCRIPTION
## Summary
- add markdownlint CLI workflow to lint Markdown files

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint couldn't find eslint.config.* file)
- `npx prettier -c CHANGELOG.md`


------
https://chatgpt.com/codex/tasks/task_e_68a0027218dc83298b2fb2b353e1df03