### PR TITLE
ci: add default npm test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "scripts": {
     "prepare": "husky install",
     "lint": "eslint . --ext .js,.mjs,.cjs",
-    "format": "prettier -w ."
+    "format": "prettier -w .",
+    "test": "echo \"No tests specified\" && exit 0"
   },
   "lint-staged": {
     "**/*.{js,mjs,cjs,html,css,md,yml,yaml,json}": [


### PR DESCRIPTION
## Summary
- ensure `npm test` always succeeds with a default placeholder script

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68a003c59d0c8329bea9fd00a19ae579