### PR TITLE
chore: silence lint warnings

### DIFF
--- a/.danger/dangerfile.js
+++ b/.danger/dangerfile.js
@@ -1,5 +1,7 @@
 /* Dangerfile: comment on PRs with quick quality checks */
-const fs = require('fs');
+/* global danger, message, warn */
+
+// Removed unused fs import; Danger provides necessary context.
 
 const files = danger.git.modified_files.concat(danger.git.created_files);
 const big = files.filter((f) => f.endsWith('.html') || f.endsWith('.js'));

--- a/services/health-sidecar/server.js
+++ b/services/health-sidecar/server.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+/* global process, console */
 import express from 'express';
 import fs from 'fs';
 import path from 'path';


### PR DESCRIPTION
## Summary
- remove unused fs import from Dangerfile and declare Danger globals
- mark Node globals in health-sidecar server to avoid no-undef warnings

## Testing
- `npx eslint .`
- `npm test`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a01226d7d48329b7ce851d846d12ec