### PR TITLE
chore: silence lint and husky warnings

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,3 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
 command -v npx >/dev/null 2>&1 || exit 0
 npx prettier -w . >/dev/null 2>&1 || true
 npx eslint . --ext .js,.mjs,.cjs --fix >/dev/null 2>&1 || true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "blackroad-quantum",
   "private": true,
+  "type": "module",
   "devDependencies": {
     "eslint": "^9.9.0",
     "eslint-config-prettier": "^9.1.0",


### PR DESCRIPTION
## Summary
- declare package as ES module to avoid Node lint warnings
- drop deprecated Husky shim in pre-commit hook

## Testing
- `npm install`
- `pip install -r requirements.txt`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a016b735e483298d95144ea2bd4a97