### PR TITLE
Add Vercel previews, Netlify deploy, and status UI for blackroad.io

### DIFF
--- a/.github/workflows/deploy-blackroad-netlify.yml
+++ b/.github/workflows/deploy-blackroad-netlify.yml
@@ -1,0 +1,27 @@
+name: Deploy blackroad.io — Netlify (prod, optional)
+on:
+  push:
+    branches: [ main ]
+    paths: [ 'sites/blackroad/**' ]
+  workflow_dispatch:
+permissions: { contents: read }
+jobs:
+  netlify-prod:
+    if: ${{ secrets.NETLIFY_AUTH_TOKEN != '' && secrets.NETLIFY_SITE_ID != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 20 }
+      - name: Build site
+        run: |
+          cd sites/blackroad
+          npm ci --omit=optional || npm i --package-lock-only
+          npm run build
+      - name: Deploy production
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        run: |
+          npm i -g netlify-cli@latest
+          netlify deploy --dir "sites/blackroad/dist" --prod --message "main@${GITHUB_SHA:0:7}"

--- a/.github/workflows/pr-preview-vercel.yml
+++ b/.github/workflows/pr-preview-vercel.yml
@@ -1,0 +1,54 @@
+name: PR Preview — Vercel
+on:
+  pull_request:
+    paths: [ 'sites/blackroad/**' ]
+  workflow_dispatch:
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  vercel-preview:
+    if: ${{ secrets.VERCEL_TOKEN != '' && secrets.VERCEL_ORG_ID != '' && secrets.VERCEL_PROJECT_ID != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 20 }
+      - name: Install & Build
+        run: |
+          cd sites/blackroad
+          npm ci --omit=optional || npm i --package-lock-only
+          npm run build
+      - name: Deploy Preview (Vercel)
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        id: vercel
+        run: |
+          npm i -g vercel@latest
+          cd sites/blackroad
+          vercel pull --yes --environment=preview --token "$VERCEL_TOKEN"
+          url=$(vercel deploy --prebuilt --token "$VERCEL_TOKEN" --confirm --env VITE_SITE_URL="${{ vars.BLACKROAD_URL || format('https://{0}', vars.BLACKROAD_DOMAIN || 'blackroad.io') }}")
+          echo "url=$url" >> $GITHUB_OUTPUT
+      - name: Comment Preview URL
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const url = `${{ steps.vercel.outputs.url }}`;
+            const pr = context.payload.pull_request.number;
+            if (!url) return;
+            await github.issues.createComment({
+              owner: context.repo.owner, repo: context.repo.repo, issue_number: pr,
+              body: `▲ **Vercel preview**: ${url}`
+            });
+      - name: Update PR Preview Badge
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const url = `${{ steps.vercel.outputs.url }}`;
+            if (!url) return;
+            const badge = `![Preview](https://img.shields.io/badge/preview-vercel-success?logo=vercel)`;
+            const body = (`${badge}\n\n🔗 ${url}\n\n` + (pr.body || '').replace(/!\[Preview\]\([^\)]+\)[\s\S]*?(?=\n\n|$)/,'')).trim();
+            await github.pulls.update({owner: context.repo.owner, repo: context.repo.repo, pull_number: pr.number, body});

--- a/.github/workflows/uptime-json.yml
+++ b/.github/workflows/uptime-json.yml
@@ -1,0 +1,41 @@
+name: Uptime JSON (commit status.json)
+on:
+  schedule: [ { cron: "*/30 * * * *" } ]  # every 30 min
+  workflow_dispatch:
+permissions:
+  contents: write
+jobs:
+  write-json:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { persist-credentials: false, fetch-depth: 0 }
+      - name: Ping endpoints
+        id: ping
+        run: |
+          set -e
+          URL_MAIN="${{ vars.BLACKROAD_URL || format('https://{0}', vars.BLACKROAD_DOMAIN || 'blackroad.io') }}"
+          URL_PAGES="https://$(echo '${{ github.repository }}' | cut -d'/' -f1).github.io"
+          ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          code_main=$(curl -s -o /dev/null -w "%{http_code}" "$URL_MAIN" || echo 000)
+          code_pages=$(curl -s -o /dev/null -w "%{http_code}" "$URL_PAGES" || echo 000)
+          mkdir -p sites/blackroad/public
+          cat > sites/blackroad/public/status.json <<JSON
+          {
+            "timestamp": "$ts",
+            "checks": [
+              { "name": "main", "url": "$URL_MAIN", "status": $code_main },
+              { "name": "pages", "url": "$URL_PAGES", "status": $code_pages }
+            ]
+          }
+          JSON
+      - name: Commit status.json
+        run: |
+          if git diff --quiet; then
+            echo "No changes"; exit 0
+          fi
+          git config user.name  "${{ secrets.BOT_USER || 'blackroad-bot' }}"
+          git config user.email "${{ secrets.BOT_USER || 'blackroad-bot' }}@users.noreply.github.com"
+          git add sites/blackroad/public/status.json
+          git commit -m "chore(status): update status.json"
+          git push "https://${{ secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git" HEAD:${GITHUB_REF#refs/heads/}

--- a/.github/workflows/urls-previews.yml
+++ b/.github/workflows/urls-previews.yml
@@ -1,0 +1,21 @@
+name: ChatOps: URLs & Previews
+on: { issue_comment: { types: [created] } }
+permissions: { pull-requests: write }
+jobs:
+  urls:
+    if: startsWith(github.event.comment.body, '/urls')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const d = process.env.BLACKROAD_DOMAIN || '';
+            const base = process.env.BLACKROAD_URL || (d?`https://${d}`:'(not set)');
+            const ghPages = `https://${context.repo.owner}.github.io`;
+            const msg = [
+              `**BlackRoad URLs**`,
+              `• Primary: ${base}`,
+              `• GitHub Pages: ${ghPages}`,
+              `• Status JSON: ${base !== '(not set)' ? base + '/status.json' : '(set BLACKROAD_URL)' }`
+            ].join('\n');
+            await github.issues.createComment({owner: context.repo.owner, repo: context.repo.repo, issue_number: context.payload.issue.number, body: msg});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,6 +5,9 @@ export default [
   js.configs.recommended,
   prettier,
   {
+    languageOptions: {
+      parserOptions: { ecmaVersion: "latest", sourceType: "module", ecmaFeatures: { jsx: true } }
+    },
     ignores: ["node_modules/", "dist/", "build/", ".github/", ".tools/"],
     rules: {
       "no-unused-vars": ["warn", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],

--- a/sites/blackroad/README.md
+++ b/sites/blackroad/README.md
@@ -1,0 +1,13 @@
+# BlackRoad.io — Ops
+
+**Deploy commands (ChatOps):**
+- `/deploy blackroad pages` — GitHub Pages
+- `/deploy blackroad vercel` — Vercel (needs `VERCEL_*` secrets)
+- `/deploy blackroad cloudflare` — Cloudflare Pages (needs `CF_*` + `CF_PAGES_PROJECT`)
+
+**Useful:**
+- `/site status` — quick HTTP code check
+- `/site url` — prints configured URL
+- `/urls` — lists primary, GH Pages, and status.json URLs
+
+**Status page:** available at `/status` (reads `sites/blackroad/public/status.json`, updated every 30 minutes by workflow).

--- a/sites/blackroad/public/status.json
+++ b/sites/blackroad/public/status.json
@@ -1,0 +1,4 @@
+{
+  "timestamp": "",
+  "checks": []
+}

--- a/sites/blackroad/src/lib/telemetry.ts
+++ b/sites/blackroad/src/lib/telemetry.ts
@@ -1,0 +1,5 @@
+export function telemetryInit() {
+  // Placeholder for analytics/telemetry setup
+  if (typeof window === 'undefined') return
+  // no-op
+}

--- a/sites/blackroad/src/ui/App.jsx
+++ b/sites/blackroad/src/ui/App.jsx
@@ -1,4 +1,9 @@
+import { useEffect } from 'react'
+import { telemetryInit } from '../lib/telemetry.ts'
+import Status from './Status.jsx'
+
 export default function App() {
+  useEffect(() => { telemetryInit() }, [])
   return (
     <main className="min-h-screen bg-gradient-to-br from-slate-900 to-slate-800 text-white">
       <div className="max-w-5xl mx-auto p-6">
@@ -8,16 +13,14 @@ export default function App() {
         </header>
 
         <section className="grid md:grid-cols-2 gap-6">
-          <Card title="Docs">
+          <Card title="Quick Commands">
             <ul className="list-disc ml-5">
-              <li>Use <code>/toggle ai off</code> to disable AI helpers</li>
-              <li>Use <code>/toggle security off</code> to skip security scans</li>
-              <li>Run <code>/deploy blackroad</code> to publish</li>
+              <li><code>/deploy blackroad pages</code>, <code>vercel</code>, or <code>cloudflare</code></li>
+              <li><code>/toggle ai off</code> / <code>/toggle security off</code></li>
+              <li><code>/fix</code>, <code>/lint</code>, <code>/bump deps</code>, <code>/release</code></li>
             </ul>
           </Card>
-          <Card title="Status">
-            <p>Everything is skip-safe. If a tool is missing, the workflow skips instead of failing.</p>
-          </Card>
+          <Status />
         </section>
 
         <footer className="opacity-70 mt-16">© {new Date().getFullYear()} blackroad</footer>
@@ -25,7 +28,6 @@ export default function App() {
     </main>
   )
 }
-
 function Card({ title, children }) {
   return (
     <div className="rounded-2xl border border-white/10 bg-white/5 p-5">

--- a/sites/blackroad/src/ui/Status.jsx
+++ b/sites/blackroad/src/ui/Status.jsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react'
+
+export default function Status() {
+  const [data, setData] = useState(null)
+  useEffect(() => {
+    fetch('/status.json', { cache: 'no-cache' })
+      .then(r => r.json())
+      .then(setData)
+      .catch(() => setData({ error: 'unavailable' }))
+  }, [])
+  return (
+    <section className="rounded-2xl border border-white/10 bg-white/5 p-5">
+      <h2 className="text-xl font-semibold mb-3">Status</h2>
+      {!data ? <p>Loading…</p> :
+        data.error ? <p className="text-red-300">Status unavailable</p> :
+        <>
+          <p className="opacity-70 mb-3">Last update: {data.timestamp}</p>
+          <table className="w-full text-sm">
+            <thead><tr className="opacity-70"><th className="text-left">Name</th><th className="text-left">URL</th><th>Status</th></tr></thead>
+            <tbody>
+              {data.checks?.map((c,i)=>(
+                <tr key={i} className="border-t border-white/10">
+                  <td className="py-2">{c.name}</td>
+                  <td className="py-2 break-all"><a className="underline" href={c.url}>{c.url}</a></td>
+                  <td className="py-2">{c.status}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </>
+      }
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- add Vercel pull request preview workflow with automatic comment and badge
- add optional Netlify production deploy
- track uptime via scheduled status.json and expose in new Status component and ops docs
- add `/urls` ChatOps command for key URLs

## Testing
- `npm test`
- `npm run lint`
- `cd sites/blackroad && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a02138e3308329bd35ccdb849af8ca