### PR TITLE
feat: add vercel preview, netlify deploy, and status page

### DIFF
--- a/.github/workflows/deploy-netlify.yml
+++ b/.github/workflows/deploy-netlify.yml
@@ -1,0 +1,26 @@
+name: Deploy — Netlify (production)
+on:
+  push:
+    branches: [ main ]
+    paths: [ 'sites/blackroad/**' ]
+  workflow_dispatch:
+permissions: { contents: read }
+jobs:
+  netlify:
+    if: ${{ secrets.NETLIFY_AUTH_TOKEN != '' && secrets.NETLIFY_SITE_ID != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 20 }
+      - run: |
+          cd sites/blackroad
+          npm ci --omit=optional || npm i --package-lock-only
+          npm run build
+      - name: Deploy production
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        run: |
+          npm i -g netlify-cli@latest
+          netlify deploy --dir "sites/blackroad/dist" --prod --json --message "${{ github.sha }}" --auth "$NETLIFY_AUTH_TOKEN" --site "$NETLIFY_SITE_ID"

--- a/.github/workflows/pr-preview-vercel.yml
+++ b/.github/workflows/pr-preview-vercel.yml
@@ -1,0 +1,34 @@
+name: PR Preview — Vercel (optional)
+on:
+  pull_request:
+    paths: [ 'sites/blackroad/**' ]
+  workflow_dispatch:
+permissions: { contents: read, pull-requests: write }
+jobs:
+  vercel:
+    if: ${{ secrets.VERCEL_TOKEN != '' && secrets.VERCEL_ORG_ID != '' && secrets.VERCEL_PROJECT_ID != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 20 }
+      - run: |
+          cd sites/blackroad
+          npm ci --omit=optional || npm i --package-lock-only
+          npm run build
+      - name: Deploy Preview
+        id: deploy
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          npm i -g vercel@latest
+          URL=$(vercel deploy --prebuilt --cwd sites/blackroad --token "$VERCEL_TOKEN" --scope "$VERCEL_ORG_ID" --yes --json | node -e "let s='';process.stdin.on('data',c=>s+=c).on('end',()=>console.log(JSON.parse(s).url||''))")
+          echo "URL=$URL" >> $GITHUB_OUTPUT
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const url = '${{ steps.deploy.outputs.URL }}';
+            if(!url) return;
+            await github.issues.createComment({owner: context.repo.owner, repo: context.repo.repo, issue_number: context.payload.pull_request.number, body:`▲ Vercel Preview: ${url}`});

--- a/sites/blackroad/status.html
+++ b/sites/blackroad/status.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Status | blackroad.io</title>
+  </head>
+  <body>
+    <h1>Status</h1>
+    <pre id="status">Loading...</pre>
+    <script>
+      async function load() {
+        try {
+          const res = await fetch('https://blackroad.io/api/health.json', {cache:'no-store'});
+          const json = await res.json();
+          document.getElementById('status').textContent = JSON.stringify(json, null, 2);
+        } catch (err) {
+          document.getElementById('status').textContent = 'Error fetching status';
+        }
+      }
+      load();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add optional Vercel PR preview workflow that comments the deployed URL
- add Netlify production deploy workflow for `sites/blackroad`
- add simple status page that reads health JSON

## Testing
- `npm test`
- `npm run lint` *(fails: parsing error and unused globals)*
- `npm run build` *(fails: Cannot find package '@vitejs/plugin-react')*

------
https://chatgpt.com/codex/tasks/task_e_68a020be0a448329be641cff3685c469