### PR TITLE
chore: ignore git fetch errors in eval diff

### DIFF
--- a/.github/tools/llm/eval-diff.js
+++ b/.github/tools/llm/eval-diff.js
@@ -8,7 +8,11 @@ import fs from 'fs';
 import path from 'path';
 const dir = 'artifacts/llm-eval';
 if (!fs.existsSync(dir)) { console.log('No eval artifacts; skipping.'); process.exit(0); }
-try { sh('git fetch origin main:refs/remotes/origin/main', {stdio:'ignore'}); } catch {}
+try {
+  sh('git fetch origin main:refs/remotes/origin/main', { stdio: 'ignore' });
+} catch {
+  /* ignore fetch errors */
+}
 const tmp='.llm-eval-main'; fs.rmSync(tmp,{recursive:true,force:true}); fs.mkdirSync(tmp,{recursive:true});
 try { sh(`git show origin/main:${dir} 1>/dev/null 2>&1`); } catch { console.log('No prior artifacts on main; skipping diff.'); process.exit(0); }
 let md = '### LLM Eval Diff (advisory)\n';


### PR DESCRIPTION
## Summary
- handle git fetch failures in eval diff script
- keep CI green by avoiding empty catch block

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a03256ada48329b973802ecfb3482f