### PR TITLE
feat: add rollback chatops and deploy dashboard

### DIFF
--- a/.github/workflows/chatops-rollback.yml
+++ b/.github/workflows/chatops-rollback.yml
@@ -1,0 +1,47 @@
+name: ChatOps: Rollback deploy
+on:
+  issue_comment:
+    types: [created]
+permissions:
+  actions: write
+  issues: write
+jobs:
+  run:
+    if: startsWith(github.event.comment.body, '/rollback blackroad')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find last successful run
+        id: last
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data } = await github.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'deploy-blackroad.yml',
+              status: 'success',
+              branch: context.payload.repository.default_branch,
+              per_page: 1
+            });
+            if (!data.workflow_runs.length) {
+              core.setFailed('No successful runs');
+              return;
+            }
+            core.setOutput('sha', data.workflow_runs[0].head_sha);
+      - name: Dispatch rollback
+        if: steps.last.outputs.sha
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'deploy-blackroad.yml',
+              ref: '${{ steps.last.outputs.sha }}'
+            });
+            await github.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body: `⏪ Rollback dispatched to commit \`${{ steps.last.outputs.sha }}\``
+            });

--- a/sites/blackroad/src/Router.jsx
+++ b/sites/blackroad/src/Router.jsx
@@ -11,6 +11,7 @@ import Tutorials from './pages/Tutorials.jsx';
 import Roadmap from './pages/Roadmap.jsx';
 import Changelog from './pages/Changelog.jsx';
 import Blog from './pages/Blog.jsx';
+import Deploys from './pages/Deploys.jsx';
 import NotFound from './pages/NotFound.jsx';
 
 const routes = {
@@ -25,6 +26,7 @@ const routes = {
   '/roadmap': <Roadmap />,
   '/changelog': <Changelog />,
   '/blog': <Blog />,
+  '/deploys': <Deploys />,
 };
 
 export default function Router() {

--- a/sites/blackroad/src/pages/Deploys.jsx
+++ b/sites/blackroad/src/pages/Deploys.jsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+
+const CHANNEL_URLS = {
+  prod: 'https://blackroad.io',
+  beta: 'https://blackroad-beta.vercel.app',
+  canary: 'https://blackroad-canary.vercel.app',
+};
+
+export default function Deploys() {
+  const [runs, setRuns] = useState([]);
+
+  useEffect(() => {
+    fetch('https://api.github.com/repos/blackboxprogramming/blackroad-prism-console/actions/workflows/deploy-blackroad.yml/runs?status=success&per_page=5')
+      .then((r) => r.json())
+      .then((d) => setRuns(d.workflow_runs || []))
+      .catch(() => {});
+  }, []);
+
+  return (
+    <div className="card">
+      <h2 className="text-xl font-semibold mb-2">Recent Deploys</h2>
+      <ul className="list-disc pl-4">
+        {runs.map((r) => (
+          <li key={r.id}>
+            {new Date(r.run_started_at).toLocaleString()} – {r.head_sha.slice(0, 7)}
+          </li>
+        ))}
+      </ul>
+      <h3 className="text-lg font-semibold mt-6 mb-2">Channels</h3>
+      <ul className="list-disc pl-4">
+        {Object.entries(CHANNEL_URLS).map(([chan, url]) => (
+          <li key={chan}>
+            {chan}: <a className="underline" href={url}>{url}</a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/sites/blackroad/src/ui/Layout.jsx
+++ b/sites/blackroad/src/ui/Layout.jsx
@@ -10,6 +10,7 @@ const links = [
   { to: '/roadmap', label: 'Roadmap' },
   { to: '/changelog', label: 'Changelog' },
   { to: '/blog', label: 'Blog' },
+  { to: '/deploys', label: 'Deploys' },
 ];
 
 function navigate(e, to) {


### PR DESCRIPTION
## Summary
- allow `/rollback blackroad` comments to redeploy the last successful build
- add simple dashboard listing recent deploy runs and channel URLs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 264 problems (66 errors, 198 warnings))*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a02e45df40832999e6faa0554d2307