### PR TITLE
feat: add deploy workflow and history page

### DIFF
--- a/.github/tools/deploy-history.js
+++ b/.github/tools/deploy-history.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+/**
+ * Append a deploy record to sites/blackroad/public/deploys.json (keeps last 25).
+ * usage: node deploy-history.js <channel> <sha> [ref]
+ */
+const fs = require('fs');
+const path = require('path');
+const channel = process.argv[2] || 'canary';
+const sha = process.argv[3] || process.env.GITHUB_SHA || '';
+const ref = process.argv[4] || '';
+const file = path.join(process.cwd(), 'sites', 'blackroad', 'public', 'deploys.json');
+let j = { history: [] };
+try {
+  j = JSON.parse(fs.readFileSync(file, 'utf8'));
+} catch {}
+if (!Array.isArray(j.history)) j.history = [];
+j.history.unshift({ ts: new Date().toISOString(), channel, sha, ref });
+j.history = j.history.slice(0, 25);
+// also compute per-channel heads
+j.channels = j.history.reduce((acc, d) => {
+  acc[d.channel] = acc[d.channel] || [];
+  acc[d.channel].push(d);
+  return acc;
+}, {});
+fs.mkdirSync(path.dirname(file), { recursive: true });
+fs.writeFileSync(file, JSON.stringify(j, null, 2));
+console.log('Recorded deploy:', channel, sha.slice(0, 7));

--- a/.github/workflows/deploy-blackroad-channel.yml
+++ b/.github/workflows/deploy-blackroad-channel.yml
@@ -1,0 +1,125 @@
+name: Deploy blackroad.io — Channel (Pages + optional providers)
+on:
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: 'Channel: canary | beta | prod'
+        required: true
+        default: 'canary'
+      provider:
+        description: 'Optional provider: pages | vercel | cloudflare | netlify | all'
+        required: false
+        default: 'all'
+      ref:
+        description: 'Git ref/sha to deploy (for rollback). Leave empty to use default branch.'
+        required: false
+        default: ''
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install & Build
+        run: |
+          cd sites/blackroad
+          npm ci --omit=optional || npm i --package-lock-only
+          export VITE_CHANNEL="${{ github.event.inputs.channel }}"
+          echo "$VITE_CHANNEL" > public/_env
+          npm run build
+          cp -f public/_env dist/_env || echo "${{ github.event.inputs.channel }}" > dist/_env
+          cp dist/index.html dist/404.html
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: sites/blackroad/dist
+      - name: Upload dist snapshot (artifact)
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ github.event.inputs.channel }}-${{ github.sha }}
+          path: sites/blackroad/dist/**
+  deploy_pages:
+    needs: build
+    runs-on: ubuntu-latest
+    if: ${{ inputs.provider == 'all' || inputs.provider == 'pages' }}
+    environment: github-pages
+    steps:
+      - uses: actions/deploy-pages@v4
+  deploy_vercel:
+    needs: build
+    runs-on: ubuntu-latest
+    if: ${{ (inputs.provider == 'all' || inputs.provider == 'vercel') && secrets.VERCEL_TOKEN != '' && secrets.VERCEL_ORG_ID != '' && secrets.VERCEL_PROJECT_ID != '' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Deploy to Vercel (channel alias)
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          npm i -g vercel@latest
+          cd sites/blackroad
+          vercel pull --yes --environment=production --token "$VERCEL_TOKEN"
+          url=$(vercel deploy dist --prebuilt --token "$VERCEL_TOKEN" --confirm)
+          chan="${{ inputs.channel }}"
+          if [ -n "$chan" ]; then vercel alias set "$url" "blackroad-${chan}" --token "$VERCEL_TOKEN" || true; fi
+          echo "VERCEL_URL=$url" >> $GITHUB_ENV
+  deploy_cloudflare:
+    needs: build
+    runs-on: ubuntu-latest
+    if: ${{ (inputs.provider == 'all' || inputs.provider == 'cloudflare') && secrets.CF_API_TOKEN != '' && secrets.CF_ACCOUNT_ID != '' && vars.CF_PAGES_PROJECT != '' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+      - name: Deploy to Cloudflare Pages
+        id: cf
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CF_API_TOKEN }}
+          accountId: ${{ secrets.CF_ACCOUNT_ID }}
+          projectName: ${{ vars.CF_PAGES_PROJECT }}
+          directory: sites/blackroad/dist
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+  deploy_netlify:
+    needs: build
+    runs-on: ubuntu-latest
+    if: ${{ (inputs.provider == 'all' || inputs.provider == 'netlify') && secrets.NETLIFY_AUTH_TOKEN != '' && secrets.NETLIFY_SITE_ID != '' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Deploy to Netlify (channel)
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        run: |
+          npm i -g netlify-cli@latest
+          out=$(netlify deploy --dir "sites/blackroad/dist" --prodIfUnlocked --message "channel:${{ inputs.channel }}" || netlify deploy --dir "sites/blackroad/dist")
+          echo "$out"
+      - name: Record deploy (deploys.json)
+        if: always()
+        run: node .github/tools/deploy-history.js "${{ inputs.channel }}" "${{ github.sha }}" "${{ github.event.inputs.ref || '' }}"
+      - name: Commit deploy history
+        if: always()
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          git add sites/blackroad/public/deploys.json || true
+          git diff --staged --quiet || (git config user.name  "${{ secrets.BOT_USER || 'blackroad-bot' }}"; git config user.email "${{ secrets.BOT_USER || 'blackroad-bot' }}@users.noreply.github.com"; git commit -m "chore(deploy): record ${{ inputs.channel }} @ ${{ github.sha }}"; git push || true)

--- a/docs/ops-content.md
+++ b/docs/ops-content.md
@@ -1,0 +1,23 @@
+# BlackRoad.io — Ops & Content
+
+## Rollbacks & Deploy Dashboard
+
+- **Deploy to channel**:
+
+```
+/deploy blackroad canary
+/deploy blackroad beta vercel
+/deploy blackroad prod pages
+```
+
+- **Rollback** (to previous successful SHA recorded per channel):
+
+```
+/rollback blackroad canary
+/rollback blackroad prod 2 pages   # go back two entries, deploy on Pages
+```
+
+- The site shows **Deploy History** at `/deploys` (reads `/deploys.json` committed by the deploy workflow).
+
+> If anything fails:  
+> `/codex apply .github/prompts/codex-fix-anything.md`

--- a/sites/blackroad/public/deploys.json
+++ b/sites/blackroad/public/deploys.json
@@ -1,0 +1,1 @@
+{ "history": [], "channels": {} }

--- a/sites/blackroad/src/Router.jsx
+++ b/sites/blackroad/src/Router.jsx
@@ -11,6 +11,7 @@ import Tutorials from './pages/Tutorials.jsx';
 import Roadmap from './pages/Roadmap.jsx';
 import Changelog from './pages/Changelog.jsx';
 import Blog from './pages/Blog.jsx';
+import Deploys from './pages/Deploys.jsx';
 import NotFound from './pages/NotFound.jsx';
 
 const routes = {
@@ -25,6 +26,7 @@ const routes = {
   '/roadmap': <Roadmap />,
   '/changelog': <Changelog />,
   '/blog': <Blog />,
+  '/deploys': <Deploys />,
 };
 
 export default function Router() {

--- a/sites/blackroad/src/pages/Deploys.jsx
+++ b/sites/blackroad/src/pages/Deploys.jsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+
+export default function Deploys() {
+  const [data, setData] = useState(null);
+  useEffect(() => {
+    fetch('/deploys.json', { cache: 'no-cache' })
+      .then((r) => r.json())
+      .then(setData)
+      .catch(() => setData({ history: [] }));
+  }, []);
+  return (
+    <div className="card">
+      <h2 className="text-xl font-semibold mb-3">Deploy History</h2>
+      {!data ? (
+        <p>Loading…</p>
+      ) : data.history?.length ? (
+        <table className="w-full text-sm">
+          <thead>
+            <tr>
+              <th align="left">When</th>
+              <th>Channel</th>
+              <th>SHA</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.history.map((d, i) => (
+              <tr key={i}>
+                <td>{new Date(d.ts).toLocaleString()}</td>
+                <td align="center">
+                  <span className="px-2 py-0.5 rounded bg-white/10">{d.channel}</span>
+                </td>
+                <td align="center">
+                  <code>{(d.sha || '').slice(0, 7)}</code>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <p>No deploys recorded yet.</p>
+      )}
+      <p className="mt-3 opacity-70 text-xs">
+        History file: <code>/deploys.json</code> (last 25)
+      </p>
+    </div>
+  );
+}

--- a/sites/blackroad/src/ui/Layout.jsx
+++ b/sites/blackroad/src/ui/Layout.jsx
@@ -10,6 +10,7 @@ const links = [
   { to: '/roadmap', label: 'Roadmap' },
   { to: '/changelog', label: 'Changelog' },
   { to: '/blog', label: 'Blog' },
+  { to: '/deploys', label: 'Deploys' },
 ];
 
 function navigate(e, to) {


### PR DESCRIPTION
## Summary
- add channel-based deploy workflow supporting multiple providers
- record deployments in deploys.json via new script
- expose deploy history page and nav link
- document deploy and rollback commands

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a035cdd41c832986ce7558b1a97716