### PR TITLE
feat: add ops workflows and observability page

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,25 +1,16 @@
 {
-  "name": "Python 3",
-  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-  "image": "mcr.microsoft.com/devcontainers/python:1-3.11-bullseye",
+  "name": "BlackRoad Dev",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:20",
+  "features": {
+    "ghcr.io/devcontainers/features/python:1": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+  },
+  "postCreateCommand": "bash scripts/install-all.sh || true",
   "customizations": {
-    "codespaces": {
-      "openFiles": ["README.md", "main.py"]
-    },
     "vscode": {
-      "settings": {},
-      "extensions": ["ms-python.python", "ms-python.vscode-pylance"]
+      "settings": { "editor.formatOnSave": true, "files.eol": "\n" },
+      "extensions": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode", "ms-playwright.playwright"]
     }
   },
-  "updateContentCommand": "[ -f packages.txt ] && sudo apt update && sudo apt upgrade -y && sudo xargs apt install -y <packages.txt; [ -f requirements.txt ] && pip3 install --user -r requirements.txt; pip3 install --user streamlit; echo '✅ Packages installed and Requirements met'",
-  "postAttachCommand": {
-    "server": "streamlit run main.py --server.enableCORS false --server.enableXsrfProtection false"
-  },
-  "portsAttributes": {
-    "8501": {
-      "label": "Application",
-      "onAutoForward": "openPreview"
-    }
-  },
-  "forwardPorts": [8501]
+  "remoteUser": "node"
 }

--- a/.github/workflows/chatops-slack.yml
+++ b/.github/workflows/chatops-slack.yml
@@ -1,0 +1,19 @@
+name: ChatOps → Slack
+on: { issue_comment: { types: [created] } }
+permissions: { contents: read }
+jobs:
+  say:
+    if: startsWith(github.event.comment.body, '/slack ')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send to Slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          TEXT: ${{ github.event.comment.body }}
+          USER: ${{ github.event.comment.user.login }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "No SLACK_WEBHOOK_URL"; exit 0;
+          fi
+          msg="$(echo "$TEXT" | sed 's:^/slack ::')"
+          curl -X POST -H 'Content-type: application/json' --data "{\"text\":\"*$USER* says: $msg\"}" "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/pagerduty-incident.yml
+++ b/.github/workflows/pagerduty-incident.yml
@@ -1,0 +1,18 @@
+name: PagerDuty Incident (manual)
+on:
+  workflow_dispatch:
+    inputs:
+      summary: { required: true, description: 'Incident summary' }
+permissions: {}
+jobs:
+  page:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger incident
+        env:
+          PD_ROUTING_KEY: ${{ secrets.PD_ROUTING_KEY }}
+        run: |
+          if [ -z "$PD_ROUTING_KEY" ]; then echo "No PD key"; exit 0; fi
+          curl -s https://events.pagerduty.com/v2/enqueue \
+            -H 'Content-Type: application/json' \
+            -d '{"routing_key":"'"$PD_ROUTING_KEY"'","event_action":"trigger","payload":{"summary":"'"${{ inputs.summary }}"'","severity":"error","source":"github-actions"}}'

--- a/.github/workflows/policy-opa.yml
+++ b/.github/workflows/policy-opa.yml
@@ -1,0 +1,20 @@
+name: Policy-as-Code (OPA)
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - 'k8s/**'
+      - 'infra/**'
+  workflow_dispatch:
+permissions: { contents: read }
+jobs:
+  conftest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: instrumenta/conftest-action@v1
+        with:
+          files: |
+            .github/workflows
+            k8s
+            infra

--- a/.github/workflows/sbom-provenance.yml
+++ b/.github/workflows/sbom-provenance.yml
@@ -1,0 +1,21 @@
+name: SBOM & Provenance
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+permissions:
+  contents: write
+  id-token: write
+jobs:
+  sbom:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: CycloneDX (Node)
+        run: |
+          npm i -g @cyclonedx/cyclonedx-npm
+          (cd sites/blackroad && cyclonedx-npm --omit dev --output-format json --output-file sbom.json) || true
+          mkdir -p artifacts && cp sites/blackroad/sbom.json artifacts/sbom.blackroad.json || true
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with: { name: sbom, path: artifacts/*.json }

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -1,0 +1,18 @@
+name: Trivy Scan (files)
+on:
+  schedule: [{ cron: '0 5 * * *' }]
+  workflow_dispatch:
+permissions: { contents: read, security-events: write }
+jobs:
+  fs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: aquasecurity/trivy-action@0.20.0
+        with:
+          scan-type: fs
+          format: sarif
+          output: trivy.sarif
+          ignore-unfixed: true
+      - uses: github/codeql-action/upload-sarif@v3
+        with: { sarif_file: trivy.sarif }

--- a/.github/workflows/uptime-ping.yml
+++ b/.github/workflows/uptime-ping.yml
@@ -1,0 +1,35 @@
+name: Uptime Ping
+on:
+  schedule: [{ cron: '*/10 * * * *' }] # every 10 minutes
+  workflow_dispatch:
+permissions: { contents: read, issues: write }
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Hit health endpoints
+        id: ping
+        run: |
+          URL="${{ vars.BLACKROAD_URL || 'https://blackroad.io' }}"
+          set +e
+          curl -fsS "$URL/" -o /dev/null; A=$?
+          curl -fsS "$URL/status" -o /dev/null; B=$?
+          if [ $A -ne 0 ] || [ $B -ne 0 ]; then
+            echo "down=true" >> $GITHUB_OUTPUT
+          else
+            echo "down=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Open/append incident
+        if: steps.ping.outputs.down == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title='🚨 Uptime: blackroad.io is DOWN';
+            const query=`repo:${context.repo.owner}/${context.repo.repo} in:title "${title}" state:open`;
+            const {data:{items}} = await github.search.issuesAndPullRequests({ q: query });
+            const body=`Automated ping failed at ${new Date().toISOString()}\nURL: ${process.env.URL || 'https://blackroad.io'}`;
+            if (items.length) {
+              await github.issues.createComment({owner: context.repo.owner, repo: context.repo.repo, issue_number: items[0].number, body});
+            } else {
+              await github.issues.create({owner: context.repo.owner, repo: context.repo.repo, title, body, labels:['incident','uptime']});
+            }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.3.3
+    hooks:
+      - id: prettier
+        additional_dependencies: ['prettier@3.3.3']

--- a/README.md
+++ b/README.md
@@ -32,3 +32,14 @@ npm test
 ```
 
 Additional operational docs live in the [`docs/`](docs) folder.
+
+## Ops Integrations
+
+- **Slack**: add `SLACK_WEBHOOK_URL` secret → use `/slack message…` on any PR/Issue.
+- **PagerDuty**: add `PD_ROUTING_KEY` → run the **PagerDuty Incident (manual)** workflow to trigger.
+- **Uptime**: pings every 10m; opens/updates “🚨 Uptime … DOWN” issue on failure.
+- **SBOM**: CycloneDX JSON artifact pushes on `main`.
+- **Trivy**: scheduled file-system vulnerability scan.
+- **Policy-as-code**: OPA checks for risky workflow/infra changes (see `policy/ci.rego`).
+- **Devcontainer**: `Open in Dev Container` to get a ready-to-code Node 20 + Python toolchain.
+- **Pre-commit**: optional local hooks (`pre-commit install`).

--- a/policy/ci.rego
+++ b/policy/ci.rego
@@ -1,0 +1,18 @@
+package ci
+
+deny[msg] {
+  input.kind == "workflow"
+  not input.permissions.contents
+  msg := "workflows must declare explicit permissions"
+}
+
+deny[msg] {
+  input.kind == "workflow"
+  some k
+  input.permissions[k] == "write"
+  not allowed_write[k]
+  msg := sprintf("write permission %v not in allow-list", [k])
+}
+
+allowed_write := {"contents","pull-requests","pages","id-token","security-events"}
+

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "rangeStrategy": "replace",
+  "labels": ["dependencies"],
+  "timezone": "America/Chicago",
+  "packageRules": [
+    { "matchPackagePatterns": ["react", "vite", "eslint", "prettier"], "groupName": "web-core" }
+  ]
+}

--- a/sites/blackroad/src/Router.jsx
+++ b/sites/blackroad/src/Router.jsx
@@ -13,6 +13,9 @@ import Changelog from './pages/Changelog.jsx';
 import Blog from './pages/Blog.jsx';
 import MathLab from './pages/MathLab.jsx';
 import Deploys from './pages/Deploys.jsx';
+import Metrics from './pages/Metrics.jsx';
+import AgentInbox from './pages/AgentInbox.jsx';
+import Observability from './pages/Observability.jsx';
 import NotFound from './pages/NotFound.jsx';
 
 const routes = {
@@ -29,6 +32,9 @@ const routes = {
   '/blog': <Blog />,
   '/math': <MathLab />,
   '/deploys': <Deploys />,
+  '/metrics': <Metrics />,
+  '/inbox': <AgentInbox />,
+  '/observability': <Observability />,
 };
 
 export default function Router() {

--- a/sites/blackroad/src/main.jsx
+++ b/sites/blackroad/src/main.jsx
@@ -3,6 +3,9 @@ import { createRoot } from 'react-dom/client';
 import ErrorBoundary from './ui/ErrorBoundary.jsx';
 import Router from './Router.jsx';
 import './ui/styles.css';
+import { initSentry } from './ui/SentryBridge.ts';
+
+initSentry();
 
 createRoot(document.getElementById('root')).render(
   <ErrorBoundary>

--- a/sites/blackroad/src/pages/AgentInbox.jsx
+++ b/sites/blackroad/src/pages/AgentInbox.jsx
@@ -1,0 +1,8 @@
+export default function AgentInbox() {
+  return (
+    <div className="card">
+      <h2 className="text-xl font-semibold mb-3">Agent Inbox</h2>
+      <p className="text-sm">No messages.</p>
+    </div>
+  );
+}

--- a/sites/blackroad/src/pages/Metrics.jsx
+++ b/sites/blackroad/src/pages/Metrics.jsx
@@ -1,0 +1,8 @@
+export default function Metrics() {
+  return (
+    <div className="card">
+      <h2 className="text-xl font-semibold mb-3">Metrics</h2>
+      <p className="text-sm">Coming soon.</p>
+    </div>
+  );
+}

--- a/sites/blackroad/src/pages/Observability.jsx
+++ b/sites/blackroad/src/pages/Observability.jsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+export default function Observability() {
+  const [err, setErr] = useState('');
+  useEffect(() => {}, []);
+  return (
+    <div className="card">
+      <h2 className="text-xl font-semibold mb-3">Observability Panel</h2>
+      <ul className="list-disc ml-5 text-sm">
+        <li>
+          Set <code>VITE_SENTRY_DSN</code> to send errors to Sentry.
+        </li>
+        <li>
+          Set <code>VITE_OTEL_URL</code> to enable web tracing (coming soon).
+        </li>
+        <li>
+          Uptime workflow pings every 10m; incidents labeled <code>incident</code>.
+        </li>
+        <li>
+          Metrics at <code>/metrics</code>, Agent Inbox at <code>/inbox</code>.
+        </li>
+      </ul>
+      <div className="mt-4">
+        <button
+          className="btn"
+          onClick={() => {
+            try {
+              throw new Error('Manual test error from UI');
+            } catch (e) {
+              setErr(String(e.message));
+              console.error(e);
+            }
+          }}
+        >
+          Trigger test error
+        </button>
+        {err && (
+          <p className="text-xs mt-2 opacity-70">
+            Thrown: <code>{err}</code> (will go to Sentry if DSN set)
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/sites/blackroad/src/ui/Layout.jsx
+++ b/sites/blackroad/src/ui/Layout.jsx
@@ -12,6 +12,9 @@ const links = [
   { to: '/blog', label: 'Blog' },
   { to: '/math', label: 'MathLab' },
   { to: '/deploys', label: 'Deploys' },
+  { to: '/metrics', label: 'Metrics' },
+  { to: '/inbox', label: 'Inbox' },
+  { to: '/observability', label: 'Observability' },
 ];
 
 function navigate(e, to) {
@@ -26,7 +29,7 @@ export default function Layout({ children }) {
       <div className="max-w-5xl mx-auto p-6">
         <header className="py-8">
           <h1 className="text-4xl font-bold">blackroad.io</h1>
-          <nav className="mt-4 flex flex-wrap gap-4">
+          <nav className="mt-4 flex flex-wrap gap-2 text-sm items-center">
             {links.map((l) => (
               <a key={l.to} href={l.to} onClick={(e) => navigate(e, l.to)} className="underline">
                 {l.label}

--- a/sites/blackroad/src/ui/SentryBridge.ts
+++ b/sites/blackroad/src/ui/SentryBridge.ts
@@ -1,0 +1,10 @@
+// Optional Sentry bridge: set SENTRY_DSN env/var to enable silently
+export function initSentry() {
+  const DSN = (import.meta.env.VITE_SENTRY_DSN || (window as any).SENTRY_DSN) as string | undefined;
+  if (!DSN) return;
+  import(/* @vite-ignore */ 'https://esm.sh/@sentry/browser')
+    .then((S) => {
+      S.init({ dsn: DSN, integrations: [], tracesSampleRate: 0.1 });
+    })
+    .catch(() => {});
+}

--- a/sites/blackroad/src/ui/styles.css
+++ b/sites/blackroad/src/ui/styles.css
@@ -10,3 +10,7 @@ code {
 .card {
   @apply rounded-2xl border border-white/10 bg-white/5 p-5;
 }
+
+.btn {
+  @apply bg-sky-600 hover:bg-sky-500 text-white px-3 py-1 rounded;
+}


### PR DESCRIPTION
## Summary
- add uptime, security, chatops workflows and OPA policy
- wire optional Sentry bridge and observability UI
- configure devcontainer, pre-commit, and Renovate

## Testing
- `npm test`
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68a04e5548988329a220fb42f14ce597