### PR TITLE
feat: add experiments dashboard and funnel metrics

### DIFF
--- a/.github/workflows/chatops-experiments.yml
+++ b/.github/workflows/chatops-experiments.yml
@@ -1,0 +1,53 @@
+name: ChatOps: Experiments JSON
+on: { issue_comment: { types: [created] } }
+permissions: { contents: write, pull-requests: write }
+jobs:
+  edit:
+    if: startsWith(github.event.comment.body, '/exp ')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - name: Parse command
+        id: p
+        run: |
+          RAW="${{ github.event.comment.body }}"
+          echo "RAW=$RAW"
+          # /exp set <id> active on|off weights A=<num> B=<num>
+          if [[ "$RAW" =~ ^/exp[[:space:]]+set[[:space:]]+([a-zA-Z0-9_-]+)[[:space:]]+active[[:space:]]+(on|off)[[:space:]]+weights[[:space:]]+A=([0-9.]+)[[:space:]]+B=([0-9.]+) ]]; then
+            echo "id=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
+            echo "active=${BASH_REMATCH[2]}" >> $GITHUB_OUTPUT
+            echo "wa=${BASH_REMATCH[3]}" >> $GITHUB_OUTPUT
+            echo "wb=${BASH_REMATCH[4]}" >> $GITHUB_OUTPUT
+          else
+            echo "Invalid syntax"; exit 1
+          fi
+      - name: Modify experiments.json
+        run: |
+          FILE="sites/blackroad/public/experiments.json"
+          test -f "$FILE" || echo '{"experiments":[]}' > "$FILE"
+          node - <<'NODE'
+          const fs=require('fs'); const p=require('path');
+          const file = p.join(process.cwd(),'sites','blackroad','public','experiments.json');
+          const id=process.env.EID, act=process.env.ACT==='on', wa=parseFloat(process.env.WA||'0.5'), wb=parseFloat(process.env.WB||'0.5');
+          const j = JSON.parse(fs.readFileSync(file,'utf8'));
+          const i = (j.experiments||[]).findIndex(e=>e.id===id);
+          if (i>=0){ j.experiments[i].active=act; j.experiments[i].weights={A:wa,B:wb}; }
+          else { (j.experiments ||= []).push({ id, active: act, weights: {A:wa,B:wb}, desc: "" }); }
+          fs.writeFileSync(file, JSON.stringify(j,null,2));
+NODE
+        env:
+          EID: ${{ steps.p.outputs.id }}
+          ACT: ${{ steps.p.outputs.active }}
+          WA: ${{ steps.p.outputs.wa }}
+          WB: ${{ steps.p.outputs.wb }}
+      - name: Commit changes
+        env: { GITHUB_TOKEN: ${{ secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }} }
+        run: |
+          git add sites/blackroad/public/experiments.json
+          git diff --staged --quiet || (git -c user.name=blackroad-bot -c user.email=bot@users.noreply.github.com commit -m "exp: set ${{ steps.p.outputs.id }} active=${{ steps.p.outputs.active }} weights A=${{ steps.p.outputs.wa }} B=${{ steps.p.outputs.wb }}" && git push)
+      - name: Ack
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.issues.createComment({owner: context.repo.owner, repo: context.repo.repo, issue_number: context.payload.issue.number, body: "✅ Experiments updated. Deploy to apply."});

--- a/.github/workflows/chatops-funnels.yml
+++ b/.github/workflows/chatops-funnels.yml
@@ -1,0 +1,52 @@
+name: ChatOps: Funnels JSON
+on: { issue_comment: { types: [created] } }
+permissions: { contents: write, pull-requests: write }
+jobs:
+  edit:
+    if: startsWith(github.event.comment.body, '/funnel ')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - name: Parse command
+        id: p
+        run: |
+          RAW="${{ github.event.comment.body }}"
+          echo "RAW=$RAW"
+          # /funnel set "<name>" window <days> steps <id1,id2,id3>
+          if [[ "$RAW" =~ ^/funnel[[:space:]]+set[[:space:]]+"([^"]+)"[[:space:]]+window[[:space:]]+([0-9]+)[[:space:]]+steps[[:space:]]+([a-zA-Z0-9_,-]+) ]]; then
+            echo "name=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
+            echo "days=${BASH_REMATCH[2]}" >> $GITHUB_OUTPUT
+            echo "steps=${BASH_REMATCH[3]}" >> $GITHUB_OUTPUT
+          else
+            echo "Invalid syntax"; exit 1
+          fi
+      - name: Modify funnels.json
+        run: |
+          FILE="sites/blackroad/public/funnels.json"
+          test -f "$FILE" || echo '{"funnels":[]}' > "$FILE"
+          node - <<'NODE'
+          const fs=require('fs'); const p=require('path');
+          const file=p.join(process.cwd(),'sites','blackroad','public','funnels.json');
+          const name=process.env.NAME, days=parseInt(process.env.DAYS||'14',10);
+          const steps=(process.env.STEPS||'').split(',').map(s=>({id:s}));
+          const j=JSON.parse(fs.readFileSync(file,'utf8'));
+          const i=(j.funnels||[]).findIndex(f=>f.name===name);
+          if (i>=0){ j.funnels[i].windowDays=days; j.funnels[i].steps=steps; }
+          else { (j.funnels ||= []).push({ name, description:"(edited via ChatOps)", windowDays:days, steps }); }
+          fs.writeFileSync(file, JSON.stringify(j,null,2));
+NODE
+        env:
+          NAME: ${{ steps.p.outputs.name }}
+          DAYS: ${{ steps.p.outputs.days }}
+          STEPS: ${{ steps.p.outputs.steps }}
+      - name: Commit changes
+        env: { GITHUB_TOKEN: ${{ secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }} }
+        run: |
+          git add sites/blackroad/public/funnels.json
+          git diff --staged --quiet || (git -c user.name=blackroad-bot -c user.email=bot@users.noreply.github.com commit -m "funnels: set \"${{ steps.p.outputs.name }}\" steps=${{ steps.p.outputs.steps }}" && git push)
+      - name: Ack
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.issues.createComment({owner: context.repo.owner, repo: context.repo.repo, issue_number: context.payload.issue.number, body: "✅ Funnels updated. Check **/metrics**."});

--- a/README.md
+++ b/README.md
@@ -32,3 +32,55 @@ npm test
 ```
 
 Additional operational docs live in the [`docs/`](docs) folder.
+
+## Experiments & Funnels
+
+### Flip experiments (ChatOps)
+Comment on any PR/Issue:
+
+```
+/exp set <id> active on|off weights A=<num> B=<num>
+```
+
+This edits `sites/blackroad/public/experiments.json`, commits, and pushes.
+
+### Manage funnels (ChatOps)
+
+```
+/funnel set "Signup" window 14 steps cta_click,portal_open,signup_success
+```
+
+This edits `sites/blackroad/public/funnels.json`.
+
+### Experiments dashboard
+- Visit **/experiments** to preview experiments and generate the exact ChatOps command.
+
+### Per-variant lift
+- Conversions automatically include your A/B assignments (cookie `br_ab`) in `meta.ab`.
+- **/metrics** shows A vs B counts and naïve rates per conversion id, plus **lift**.
+
+### Funnels analytics
+- Configure `public/funnels.json`. **/metrics** computes per-step counts, step rate, and cumulative rate (last 30 days).
+- For very high volumes, move aggregation to the Worker/Durable Objects.
+
+### Quick use
+
+Flip an experiment:
+
+```
+/exp set new_nav active on weights A=0.4 B=0.6
+```
+
+Add a funnel:
+
+```
+/funnel set "Docs Journey" window 10 steps home_view,docs_view,docs_search,docs_copy_snippet
+```
+
+Record extra conversions from code:
+
+```ts
+import { recordConversion } from '@/lib/convert'
+recordConversion('portal_open')
+recordConversion('signup_success', 1, { plan: 'pro' })
+```

--- a/sites/blackroad/package.json
+++ b/sites/blackroad/package.json
@@ -12,7 +12,8 @@
   },
   "dependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "recharts": "^2.7.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/sites/blackroad/public/experiments.json
+++ b/sites/blackroad/public/experiments.json
@@ -1,0 +1,3 @@
+{
+  "experiments": []
+}

--- a/sites/blackroad/public/funnels.json
+++ b/sites/blackroad/public/funnels.json
@@ -1,0 +1,24 @@
+{
+  "funnels": [
+    {
+      "name": "Signup",
+      "description": "Homepage CTA → Portal open → Account created",
+      "windowDays": 14,
+      "steps": [
+        { "id": "cta_click" },
+        { "id": "portal_open" },
+        { "id": "signup_success" }
+      ]
+    },
+    {
+      "name": "MathLab Explore",
+      "description": "Visited MathLab → Ran Geodesic → Saved Snapshot",
+      "windowDays": 7,
+      "steps": [
+        { "id": "math_view" },
+        { "id": "geodesic_run" },
+        { "id": "snapshot_save" }
+      ]
+    }
+  ]
+}

--- a/sites/blackroad/src/Router.jsx
+++ b/sites/blackroad/src/Router.jsx
@@ -13,6 +13,8 @@ import Changelog from './pages/Changelog.jsx';
 import Blog from './pages/Blog.jsx';
 import MathLab from './pages/MathLab.jsx';
 import Deploys from './pages/Deploys.jsx';
+import Metrics from './pages/Metrics.jsx';
+import ExperimentsDash from './pages/ExperimentsDash.jsx';
 import NotFound from './pages/NotFound.jsx';
 
 const routes = {
@@ -29,6 +31,8 @@ const routes = {
   '/blog': <Blog />,
   '/math': <MathLab />,
   '/deploys': <Deploys />,
+  '/metrics': <Metrics />,
+  '/experiments': <ExperimentsDash />,
 };
 
 export default function Router() {

--- a/sites/blackroad/src/lib/ab.ts
+++ b/sites/blackroad/src/lib/ab.ts
@@ -1,0 +1,8 @@
+export function getAssignments(): Record<string, string> {
+  try {
+    const m = document.cookie.match(/br_ab=([^;]+)/)
+    return m ? JSON.parse(decodeURIComponent(m[1])) : {}
+  } catch {
+    return {}
+  }
+}

--- a/sites/blackroad/src/lib/convert.ts
+++ b/sites/blackroad/src/lib/convert.ts
@@ -1,0 +1,31 @@
+import { getAssignments } from './ab.ts'
+
+function base(){ return import.meta.env.VITE_ANALYTICS_BASE || '' }
+export function recordConversion(id: string, value?: number, meta: Record<string,unknown> = {}){
+  const endpoint = base() ? `${base()}/convert` : (import.meta.env.VITE_LOG_WRITE_URL ? import.meta.env.VITE_LOG_WRITE_URL.replace(/\/log$/, '/convert') : '')
+  if (!endpoint) return
+  const ab = safeAB()
+  const payload = {
+    ts: new Date().toISOString(),
+    id, value,
+    route: location.pathname,
+    uid: getAnonId(),
+    meta: { ...meta, ab }
+  }
+  try {
+    navigator.sendBeacon?.(endpoint, new Blob([JSON.stringify(payload)], { type: 'application/json' }))
+  } catch {
+    fetch(endpoint, { method:'POST', headers:{'content-type':'application/json'}, body: JSON.stringify(payload) }).catch(()=>{})
+  }
+}
+function getAnonId(){
+  const k='br_uid'
+  const m=document.cookie.match(new RegExp(`${k}=([^;]+)`))
+  if (m) return decodeURIComponent(m[1])
+  const v = Math.random().toString(36).slice(2) + Date.now().toString(36)
+  document.cookie = `${k}=${encodeURIComponent(v)}; path=/; max-age=${60*60*24*365}`
+  return v
+}
+function safeAB(){
+  try { return getAssignments() } catch { return {} }
+}

--- a/sites/blackroad/src/pages/ExperimentsDash.jsx
+++ b/sites/blackroad/src/pages/ExperimentsDash.jsx
@@ -1,0 +1,74 @@
+import { useEffect, useMemo, useState } from 'react'
+
+function useJson(url, fallback){ const [d,setD]=useState(fallback); useEffect(()=>{ fetch(url,{cache:'no-cache'}).then(r=>r.json()).then(setD).catch(()=>setD(fallback)) },[url]); return d }
+
+export default function ExperimentsDash(){
+  const data = useJson('/experiments.json', { experiments: [] })
+  const [sel,setSel]=useState('')
+  const [active,setActive]=useState('on')
+  const [a,setA]=useState(0.5)
+  const [b,setB]=useState(0.5)
+  useEffect(()=>{ if(data.experiments?.length && !sel) setSel(data.experiments[0].id) },[data,sel])
+
+  const cmd = useMemo(()=>{
+    if(!sel) return ''
+    return `/exp set ${sel} active ${active} weights A=${a} B=${b}`
+  },[sel,active,a,b])
+
+  return (
+    <div className="card">
+      <h2 className="text-xl font-semibold mb-3">Experiments Dashboard</h2>
+      <p className="text-sm opacity-80">This page _previews_ experiments from <code>/experiments.json</code> and prepares ChatOps commands to flip them live via a commit.</p>
+
+      <section className="p-3 rounded-lg bg-white/5 border border-white/10 mt-3">
+        <h3 className="font-semibold mb-2">Current Experiments</h3>
+        <ul className="text-sm grid" style={{gridTemplateColumns:'repeat(auto-fit,minmax(260px,1fr))', gap:12}}>
+          {(data.experiments||[]).map((e,i)=>(
+            <li key={i} className="p-2 rounded bg-black/20">
+              <div className="flex items-center justify-between">
+                <b>{e.id}</b>
+                <span className={`text-xs px-2 py-0.5 rounded ${e.active?'bg-green-500/30':'bg-gray-500/30'}`}>{e.active?'active':'off'}</span>
+              </div>
+              <div className="mt-1 text-xs opacity-80">{e.desc||''}</div>
+              <div className="mt-1 text-xs">A:{e.weights?.A ?? 0.5} • B:{e.weights?.B ?? 0.5}</div>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="p-3 rounded-lg bg-white/5 border border-white/10 mt-4">
+        <h3 className="font-semibold mb-2">Flip Experiment via ChatOps</h3>
+        {data.experiments?.length ? (
+          <>
+            <div className="grid" style={{gridTemplateColumns:'repeat(auto-fit,minmax(220px,1fr))', gap:12}}>
+              <div>
+                <label className="text-sm">Experiment</label>
+                <select className="w-full text-black" value={sel} onChange={e=>setSel(e.target.value)}>
+                  {data.experiments.map((e)=><option key={e.id} value={e.id}>{e.id}</option>)}
+                </select>
+              </div>
+              <div>
+                <label className="text-sm">Active</label>
+                <select className="w-full text-black" value={active} onChange={e=>setActive(e.target.value)}>
+                  <option value="on">on</option><option value="off">off</option>
+                </select>
+              </div>
+              <div>
+                <label className="text-sm">Weight A</label>
+                <input type="number" step="0.05" className="w-full text-black" value={a} onChange={e=>setA(parseFloat(e.target.value)||0)} />
+              </div>
+              <div>
+                <label className="text-sm">Weight B</label>
+                <input type="number" step="0.05" className="w-full text-black" value={b} onChange={e=>setB(parseFloat(e.target.value)||0)} />
+              </div>
+            </div>
+            <div className="mt-3">
+              <label className="block text-sm">Comment this on any PR/Issue:</label>
+              <pre className="p-2 rounded bg-black/40 text-xs overflow-auto">{cmd}</pre>
+            </div>
+          </>
+        ) : <p>No experiments found.</p>}
+      </section>
+    </div>
+  )
+}

--- a/sites/blackroad/src/pages/Metrics.jsx
+++ b/sites/blackroad/src/pages/Metrics.jsx
@@ -1,0 +1,235 @@
+import { useEffect, useMemo, useState } from 'react'
+import { LineChart, Line, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer, CartesianGrid, BarChart, Bar } from 'recharts'
+
+function useJson(url, fallback){ const [d,setD]=useState(fallback); useEffect(()=>{ if(!url){ setD(fallback); return } fetch(url,{cache:'no-cache'}).then(r=>r.json()).then(setD).catch(()=>setD(fallback)) },[url]); return d }
+function fmtTs(s){ try{ return new Date(s).toLocaleString() }catch{ return s } }
+function msToMin(ms){ return (ms/60000).toFixed(2) }
+
+function getAnalyticsBase(){
+  const direct = import.meta.env.VITE_ANALYTICS_BASE
+  if (direct) return direct
+  const logs = import.meta.env.VITE_LOGS_URL
+  if (logs) return logs.replace(/\/logs$/, '')
+  return ''
+}
+
+export default function Metrics(){
+  const ci = useJson('/metrics/ci.json', { runs: [] })
+  const lh = useJson('/metrics/lh.json', { history: [] })
+  const convBase = getAnalyticsBase()
+  const funnels = useJson('/funnels.json', { funnels: [] })
+
+  const byWF = useMemo(()=> {
+    const m = {}
+    for (const r of ci.runs || []) { (m[r.wf] ||= []).push(r) }
+    for (const k of Object.keys(m)) m[k] = m[k].slice(-20)
+    return m
+  }, [ci])
+
+  const lhSeries = useMemo(()=> (lh.history||[]).slice(0,30).reverse().map(x=>({
+    ts: fmtTs(x.ts), perf: +(x.perf*100).toFixed(1), a11y:+(x.a11y*100).toFixed(1),
+    bp:+(x.bp*100).toFixed(1), seo:+(x.seo*100).toFixed(1),
+    LCP:+(x.LCP/1000).toFixed(2), FCP:+(x.FCP/1000).toFixed(2), CLS:+(+x.CLS).toFixed(3), TBT:+(x.TBT/1000).toFixed(2)
+  })), [lh])
+
+  // Pull full raw conversions for variant lift and funnels (best-effort)
+  const rawConv = useRaw(convBase)
+
+  const expIds = useMemo(()=>{
+    const s = new Set()
+    for (const c of rawConv) {
+      const ab = c.meta?.ab || {}
+      Object.keys(ab).forEach(eid=>s.add(eid))
+    }
+    return Array.from(s)
+  }, [rawConv])
+
+  const [chosenExp,setChosenExp]=useState('')
+  useEffect(()=>{ if(!chosenExp && expIds.length) setChosenExp(expIds[0]) },[expIds,chosenExp])
+
+  const lift = useMemo(()=> variantLift(rawConv, chosenExp), [rawConv, chosenExp])
+  const funnelStats = useMemo(()=> computeFunnels(rawConv, funnels.funnels||[]), [rawConv, funnels])
+
+  return (
+    <div className="card">
+      <h2 className="text-xl font-semibold mb-3">Metrics & Observability</h2>
+
+      {/* Lighthouse */}
+      <section className="p-3 rounded-lg bg-white/5 border border-white/10 mb-4">
+        <h3 className="font-semibold mb-2">Lighthouse (averaged across key pages)</h3>
+        <div className="grid" style={{gridTemplateColumns:'repeat(auto-fit,minmax(320px,1fr))', gap:16}}>
+          <Chart title="Scores (%)" data={lhSeries} lines={[['perf','Performance'],['a11y','Accessibility'],['bp','Best Practices'],['seo','SEO']]} />
+          <Chart title="Core timings (s)" data={lhSeries} lines={[['FCP','FCP'],['LCP','LCP'],['TBT','TBT (s)']]} />
+          <Chart title="Layout shift (CLS)" data={lhSeries} lines={[['CLS','CLS']]} />
+        </div>
+      </section>
+
+      {/* CI */}
+      <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+        <h3 className="font-semibold mb-2">CI History (last 20 per workflow)</h3>
+        <div className="grid" style={{gridTemplateColumns:'repeat(auto-fit,minmax(360px,1fr))', gap:16}}>
+          {Object.entries(byWF).map(([wf,runs])=>(
+            <div key={wf} className="p-3 rounded bg-black/20">
+              <h4 className="font-semibold mb-2">{wf}</h4>
+              <ResponsiveContainer width="100%" height={180}>
+                <BarChart data={runs.map(r=>({ ts: fmtTs(r.updated_at||r.started_at), min: +msToMin(r.duration_ms), ok: r.conclusion==='success' ? 1 : 0 }))}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="ts" hide/>
+                  <YAxis yAxisId="left" label={{ value: 'min', angle:-90, position:'insideLeft' }}/>
+                  <Tooltip />
+                  <Legend />
+                  <Bar yAxisId="left" dataKey="min" name="duration (min)" fill="currentColor" />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Variant Lift */}
+      <section className="p-3 rounded-lg bg-white/5 border border-white/10 mt-4">
+        <h3 className="font-semibold mb-2">Per-Variant Conversion Lift</h3>
+        {expIds.length ? (
+          <>
+            <div className="mb-2 text-sm">
+              <label>Select experiment: </label>
+              <select className="text-black" value={chosenExp} onChange={e=>setChosenExp(e.target.value)}>
+                {expIds.map(id=><option key={id}>{id}</option>)}
+              </select>
+            </div>
+            <div className="grid" style={{gridTemplateColumns:'repeat(auto-fit,minmax(280px,1fr))', gap:12}}>
+              {Object.entries(lift).map(([convId,stats])=>(
+                <div key={convId} className="p-2 rounded bg-black/20 text-sm">
+                  <b>{convId}</b>
+                  <div className="mt-1">A: <code>{stats.A.count}</code> ({pct(stats.A.rate)}) • B: <code>{stats.B.count}</code> ({pct(stats.B.rate)})</div>
+                  <div className="mt-1">Lift (B vs A): <b>{pct(stats.lift)}</b></div>
+                </div>
+              ))}
+            </div>
+            <p className="text-xs opacity-70 mt-2">Rates estimate unique-uid conversion probability per arm (naïve). Treat as directional unless normalized by traffic.</p>
+          </>
+        ) : <p className="text-sm opacity-70">No experiment assignments found in conversion meta. Ensure the client includes AB (it does by default now).</p>}
+      </section>
+
+      {/* Funnels */}
+      <section className="p-3 rounded-lg bg-white/5 border border-white/10 mt-4">
+        <h3 className="font-semibold mb-2">Funnels (last 30 days)</h3>
+        {funnelStats.length ? (
+          <div className="grid" style={{gridTemplateColumns:'repeat(auto-fit,minmax(280px,1fr))', gap:12}}>
+            {funnelStats.map(f=>(
+              <div key={f.name} className="p-2 rounded bg-black/20 text-sm">
+                <b>{f.name}</b><div className="text-xs opacity-70">{f.description||''}</div>
+                <ol className="mt-2 space-y-1">
+                  {f.steps.map((s,i)=>(
+                    <li key={i}>
+                      <span className="opacity-80">{i+1}. {s.id}</span> — <code>{s.count}</code> users
+                      {i>0 && <span className="opacity-70"> • step-rate {pct(s.rate)} • cum {pct(s.cumRate)}</span>}
+                    </li>
+                  ))}
+                </ol>
+              </div>
+            ))}
+          </div>
+        ) : <p className="text-sm opacity-70">No funnel data yet.</p>}
+        <p className="text-xs opacity-60 mt-2">Add/update funnels via ChatOps: <code>/funnel set "Signup" window 14 steps cta_click,portal_open,signup_success</code></p>
+      </section>
+    </div>
+  )
+}
+
+function Chart({title,data,lines}){
+  return (
+    <div className="p-3 rounded bg-black/20">
+      <h4 className="font-semibold mb-2">{title}</h4>
+      <ResponsiveContainer width="100%" height={200}>
+        <LineChart data={data}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="ts" hide/>
+          <YAxis />
+          <Tooltip />
+          <Legend />
+          {lines.map(([k,label])=> <Line key={k} type="monotone" dataKey={k} name={label} dot={false} />)}
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}
+
+function useRaw(base){
+  const [raw,setRaw]=useState([])
+  useEffect(()=>{
+    if(!base){ setRaw([]); return }
+    fetch(`${base}/conversions?limit=2000`, {cache:'no-cache'}).then(r=>r.json()).then(j=>{
+      setRaw((j.items||j.raw||[]))
+    }).catch(()=> setRaw([]))
+  }, [base])
+  return raw
+}
+
+function pct(x){ if(!isFinite(x)) return '—'; return (x*100).toFixed(1)+'%' }
+
+function variantLift(items, expId){
+  if(!expId) return {}
+  const byConv = {}
+  const seen = {A:new Set(), B:new Set()}
+  for(const it of items){
+    const uid = it.uid || it.meta?.uid
+    if(!uid) continue
+    const arm = it.meta?.ab?.[expId]
+    if(arm!=='A' && arm!=='B') continue
+    const id = it.id
+    byConv[id] ||= { A: new Map(), B: new Map() }
+    const bucket = byConv[id][arm]
+    bucket.set(uid, (bucket.get(uid)||0) + 1)
+    seen[arm].add(uid)
+  }
+  const out={}
+  for(const [cid, rec] of Object.entries(byConv)){
+    const A = rec.A.size, B = rec.B.size
+    const baseA = seen.A.size || 1
+    const baseB = seen.B.size || 1
+    const rateA = A/baseA, rateB = B/baseB
+    out[cid] = { A: {count:A, rate: rateA}, B: {count:B, rate: rateB}, lift: (rateB - rateA) }
+  }
+  return out
+}
+
+function computeFunnels(items, funnels){
+  if(!Array.isArray(items) || !items.length) return []
+  const byUid = new Map()
+  for(const it of items){
+    const uid = it.uid || it.meta?.uid; if(!uid) continue
+    const arr = byUid.get(uid) || []
+    arr.push(it)
+    byUid.set(uid, arr)
+  }
+  const out=[]
+  for(const f of (funnels||[])){
+    const windowMs = (f.windowDays||14) * 86400000
+    const steps = f.steps||[]
+    const stepCounts = Array(steps.length).fill(0)
+    const users = new Set()
+    for(const [uid, arr] of byUid.entries()){
+      const sorted = arr.slice().sort((a,b)=> new Date(a.ts).getTime()-new Date(b.ts).getTime())
+      let startIdx = sorted.findIndex(x=>x.id===steps[0]?.id)
+      if(startIdx<0) continue
+      users.add(uid)
+      let startTime = new Date(sorted[startIdx].ts).getTime()
+      stepCounts[0]++
+      for(let step=1; step<steps.length; step++){
+        const next = sorted.find(x=> x.id===steps[step].id && new Date(x.ts).getTime() - startTime <= windowMs)
+        if(next){ stepCounts[step]++; startTime = new Date(next.ts).getTime() }
+        else break
+      }
+    }
+    const totalUsers = users.size || 1
+    const formatted = steps.map((s,i)=>({
+      id: s.id,
+      count: stepCounts[i],
+      rate: i>0 ? stepCounts[i]/Math.max(1,stepCounts[i-1]) : 1,
+      cumRate: stepCounts[i]/totalUsers
+    }))
+    out.push({ name:f.name, description:f.description, steps: formatted })
+  }
+  return out
+}

--- a/sites/blackroad/src/ui/Layout.jsx
+++ b/sites/blackroad/src/ui/Layout.jsx
@@ -12,6 +12,8 @@ const links = [
   { to: '/blog', label: 'Blog' },
   { to: '/math', label: 'MathLab' },
   { to: '/deploys', label: 'Deploys' },
+  { to: '/metrics', label: 'Metrics' },
+  { to: '/experiments', label: 'Experiments' },
 ];
 
 function navigate(e, to) {


### PR DESCRIPTION
## Summary
- add goal funnels config and chatops workflows
- track conversions with AB assignments and expose experiments dashboard
- show per-variant lift and funnels analytics on metrics page

## Testing
- `npm test`
- `npm --prefix sites/blackroad run lint` *(warnings: 50)*


------
https://chatgpt.com/codex/tasks/task_e_68a051d39484832991f172e10abf9024