### PR TITLE
feat: add conversion tracking and metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,28 @@ npm test
 ```
 
 Additional operational docs live in the [`docs/`](docs) folder.
+
+## Conversions (end-to-end)
+**Worker API**
+- `POST /convert` — body: `{ id: "signup_click", value?: 1.0, ts?: ISO, route?, uid?, meta? }`
+- `GET /conversions?since=YYYY-MM-DD&limit=1000` — returns top IDs, day rows, totals
+- Auth: if you set `ERROR_API_KEY` secret/var, include header `x-api-key: <key>` from the client.
+
+**Site**
+- Set `VITE_ANALYTICS_BASE="https://<worker>.workers.dev"`.
+- Use `recordConversion('cta_click', 1, { where: 'home.hero' })`.
+- Charts appear on **/metrics** (Conversions section).
+
+**Notes**
+- Storage window: logs 14 days, conversions 30 days (KV TTL).
+- Aggregation is computed on read; for very high volume, consider Durable Objects / D1.
+
+### How to use (right now)
+1. In Cloudflare:
+   - Make sure the KV namespace (ERROR_LOGS) exists and your Deploy CF Worker workflow is green.
+   - Set repo vars: ERROR_LOGS_KV_ID. Optional: ERROR_API_KEY to require write auth.
+2. In your site env (Vite):
+   - `VITE_ANALYTICS_BASE=https://<your-worker>.workers.dev`
+3. Fire a test conversion:
+   - Hit the Home page and click “Demo: Record Conversion”.
+   - Open `/metrics` → Conversions should light up with `cta_click`.

--- a/services/error-logger/package.json
+++ b/services/error-logger/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "error-logger",
+  "private": true,
+  "type": "module"
+}

--- a/services/error-logger/worker.ts
+++ b/services/error-logger/worker.ts
@@ -1,0 +1,144 @@
+export interface LogItem {
+  ts: string
+  level: 'error'|'warn'|'info'
+  msg: string
+  route?: string
+  ua?: string
+  ref?: string
+  meta?: Record<string, unknown>
+}
+
+/* NEW: conversion event */
+export interface ConvItem {
+  ts: string
+  id: string          // conversion name (e.g., "signup_click")
+  value?: number      // optional numeric value (e.g., revenue)
+  route?: string
+  uid?: string        // optional user id/session hash
+  meta?: Record<string, unknown>
+}
+
+function jsonResponse(obj: unknown, status = 200, origin?: string) {
+  return new Response(JSON.stringify(obj, null, 2), {
+    status,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'access-control-allow-origin': origin || '*',
+      'access-control-allow-headers': 'content-type,authorization,x-api-key',
+      'access-control-allow-methods': 'GET,POST,OPTIONS',
+    }
+  })
+}
+
+async function pushLog(env: Env, item: LogItem) {
+  const key = `log:${item.ts}:${Math.random().toString(36).slice(2,8)}`
+  await env.ERROR_LOGS.put(key, JSON.stringify(item), { expirationTtl: 60*60*24*14 }) // 14d
+  await env.ERROR_LOGS.put('latest', key)
+}
+
+/* NEW: store conversion as a raw item (conv:...) for last 30d */
+async function pushConv(env: Env, item: ConvItem) {
+  const key = `conv:${item.ts}:${item.id}:${Math.random().toString(36).slice(2,8)}`
+  await env.ERROR_LOGS.put(key, JSON.stringify(item), { expirationTtl: 60*60*24*30 }) // 30d
+}
+
+/* NEW: list recent conversions (optionally since=? ISO string) and aggregate by id/day */
+async function listConvs(env: Env, limit=1000, sinceISO?: string) {
+  // KV listing is lexicographic: we fetch all 'conv:' keys (bounded by 1000/req)
+  const list = await env.ERROR_LOGS.list({ prefix: 'conv:' })
+  let keys = list.keys.sort((a,b)=> (a.name<b.name?1:-1)) // newest first
+  if (limit) keys = keys.slice(0, limit)
+  const items: ConvItem[] = []
+  for (const k of keys) {
+    const raw = await env.ERROR_LOGS.get(k.name)
+    if (!raw) continue
+    const item = JSON.parse(raw) as ConvItem
+    if (sinceISO && new Date(item.ts) < new Date(sinceISO)) continue
+    items.push(item)
+  }
+  // aggregate by day + id
+  const byId: Record<string, { total: number, value: number, series: Record<string, {count:number, value:number}> }> = {}
+  for (const it of items) {
+    const day = it.ts.slice(0,10) // YYYY-MM-DD
+    const rec = (byId[it.id] ||= { total:0, value:0, series:{} })
+    rec.total += 1
+    rec.value += (typeof it.value === 'number' ? it.value : 0)
+    const cell = (rec.series[day] ||= { count:0, value:0 })
+    cell.count += 1
+    cell.value += (typeof it.value === 'number' ? it.value : 0)
+  }
+  // build timeseries rows (aligned days) for top 5 ids
+  const ids = Object.keys(byId).sort((a,b)=> byId[b].total - byId[a].total).slice(0,5)
+  const allDays = new Set<string>()
+  for (const id of ids) Object.keys(byId[id].series).forEach(d => allDays.add(d))
+  const days = [...allDays].sort()
+  const rows = days.map(d => {
+    const r: any = { day: d }
+    for (const id of ids) r[id] = byId[id].series[d]?.count || 0
+    return r
+  })
+  return { ids, days, rows, totals: ids.map(id => ({ id, total: byId[id].total, value: byId[id].value })) }
+}
+
+type Env = {
+  ERROR_LOGS: KVNamespace
+  CORS_ORIGIN?: string
+  API_KEY?: string
+}
+
+export default {
+  async fetch(req: Request, env: Env): Promise<Response> {
+    const url = new URL(req.url)
+    const origin = env.CORS_ORIGIN || '*'
+    if (req.method === 'OPTIONS') return jsonResponse({}, 204, origin)
+
+    // GET /logs?limit=200
+    if (url.pathname === '/logs' && req.method === 'GET') {
+      const lim = Math.min(parseInt(url.searchParams.get('limit') || '100',10), 1000)
+      const items = await (async()=>{
+        const list = await env.ERROR_LOGS.list({ prefix: 'log:' })
+        const keys = list.keys.sort((a,b)=> (a.name<b.name?1:-1)).slice(0, lim)
+        const arr: LogItem[] = []
+        for (const k of keys) { const raw = await env.ERROR_LOGS.get(k.name); if (raw) arr.push(JSON.parse(raw)) }
+        return arr
+      })()
+      return jsonResponse({ ts: new Date().toISOString(), count: items.length, items }, 200, origin)
+    }
+
+    // POST /log (write)
+    if (url.pathname === '/log' && req.method === 'POST') {
+      if (env.API_KEY) {
+        const key = req.headers.get('x-api-key')
+        if (key !== env.API_KEY) return jsonResponse({ error: 'unauthorized' }, 401, origin)
+      }
+      const item = await req.json().catch(()=>null) as LogItem|null
+      if (!item || !item.msg) return jsonResponse({ error:'bad payload' }, 400, origin)
+      if (!item.ts) item.ts = new Date().toISOString()
+      await pushLog(env, item)
+      return jsonResponse({ ok: true }, 200, origin)
+    }
+
+    /* NEW: POST /convert (record conversion) */
+    if (url.pathname === '/convert' && req.method === 'POST') {
+      if (env.API_KEY) {
+        const key = req.headers.get('x-api-key')
+        if (key !== env.API_KEY) return jsonResponse({ error: 'unauthorized' }, 401, origin)
+      }
+      const item = await req.json().catch(()=>null) as ConvItem|null
+      if (!item || !item.id) return jsonResponse({ error:'bad payload' }, 400, origin)
+      if (!item.ts) item.ts = new Date().toISOString()
+      await pushConv(env, item)
+      return jsonResponse({ ok: true }, 200, origin)
+    }
+
+    /* NEW: GET /conversions?since=YYYY-MM-DD&limit=1000 */
+    if (url.pathname === '/conversions' && req.method === 'GET') {
+      const lim = Math.min(parseInt(url.searchParams.get('limit') || '1000',10), 2000)
+      const since = url.searchParams.get('since') || undefined
+      const data = await listConvs(env, lim, since)
+      return jsonResponse({ ts: new Date().toISOString(), ...data }, 200, origin)
+    }
+
+    return jsonResponse({ ok: true, service: 'blackroad-error-logger' }, 200, origin)
+  }
+}

--- a/services/error-logger/wrangler.toml
+++ b/services/error-logger/wrangler.toml
@@ -1,0 +1,11 @@
+name = "blackroad-error-logger"
+main = "worker.ts"
+compatibility_date = "2024-01-01"
+
+[[kv_namespaces]]
+binding = "ERROR_LOGS"
+id = "$ERROR_LOGS_KV_ID"
+
+# Optionally set via vars or secrets:
+# CORS_ORIGIN = "https://example.com"
+# API_KEY = "$ERROR_API_KEY"

--- a/sites/blackroad/package.json
+++ b/sites/blackroad/package.json
@@ -12,7 +12,8 @@
   },
   "dependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "recharts": "^2.11.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/sites/blackroad/src/Router.jsx
+++ b/sites/blackroad/src/Router.jsx
@@ -13,6 +13,7 @@ import Changelog from './pages/Changelog.jsx';
 import Blog from './pages/Blog.jsx';
 import MathLab from './pages/MathLab.jsx';
 import Deploys from './pages/Deploys.jsx';
+import Metrics from './pages/Metrics.jsx';
 import NotFound from './pages/NotFound.jsx';
 
 const routes = {
@@ -27,9 +28,10 @@ const routes = {
   '/roadmap': <Roadmap />,
   '/changelog': <Changelog />,
   '/blog': <Blog />,
-  '/math': <MathLab />,
-  '/deploys': <Deploys />,
-};
+    '/math': <MathLab />,
+    '/deploys': <Deploys />,
+    '/metrics': <Metrics />,
+  };
 
 export default function Router() {
   const [path, setPath] = useState(window.location.pathname);

--- a/sites/blackroad/src/lib/convert.ts
+++ b/sites/blackroad/src/lib/convert.ts
@@ -1,0 +1,27 @@
+// Client helper to record conversions to your worker.
+// Set VITE_ANALYTICS_BASE like "https://<worker-subdomain>.workers.dev"
+function base(){ return import.meta.env.VITE_ANALYTICS_BASE || '' }
+export function recordConversion(id: string, value?: number, meta: Record<string,unknown> = {}){
+  const endpoint = base() ? `${base()}/convert` : (import.meta.env.VITE_LOG_WRITE_URL ? import.meta.env.VITE_LOG_WRITE_URL.replace(/\/log$/, '/convert') : '')
+  if (!endpoint) return
+  const payload = {
+    ts: new Date().toISOString(),
+    id, value,
+    route: location.pathname,
+    uid: getAnonId(),
+    meta
+  }
+  try {
+    navigator.sendBeacon?.(endpoint, new Blob([JSON.stringify(payload)], { type: 'application/json' }))
+  } catch {
+    fetch(endpoint, { method:'POST', headers:{'content-type':'application/json'}, body: JSON.stringify(payload) }).catch(()=>{})
+  }
+}
+function getAnonId(){
+  const k='br_uid'
+  const m=document.cookie.match(/br_uid=([^;]+)/)
+  if (m) return decodeURIComponent(m[1])
+  const v = Math.random().toString(36).slice(2) + Date.now().toString(36)
+  document.cookie = `br_uid=${encodeURIComponent(v)}; path=/; max-age=${60*60*24*365}`
+  return v
+}

--- a/sites/blackroad/src/lib/logger.ts
+++ b/sites/blackroad/src/lib/logger.ts
@@ -1,0 +1,16 @@
+export function logToWorker(url: string, level: 'error'|'warn'|'info', msg: string, meta: Record<string, unknown> = {}) {
+  const payload = {
+    ts: new Date().toISOString(),
+    level,
+    msg,
+    route: location.pathname,
+    ua: navigator.userAgent,
+    ref: document.referrer,
+    meta
+  }
+  try {
+    navigator.sendBeacon?.(url, new Blob([JSON.stringify(payload)], { type: 'application/json' }))
+  } catch {
+    fetch(url, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(payload) }).catch(()=>{})
+  }
+}

--- a/sites/blackroad/src/pages/Home.jsx
+++ b/sites/blackroad/src/pages/Home.jsx
@@ -1,8 +1,20 @@
-export default function Home() {
+import { useEffect } from 'react'
+import { logToWorker } from '../lib/logger.ts'
+import { recordConversion } from '../lib/convert.ts'
+
+export default function Home(){
+  useEffect(()=>{
+    const url = import.meta.env.VITE_LOG_WRITE_URL // worker /log endpoint
+    if (url) logToWorker(url, 'info', 'home_view', { hint: 'home page mounted' })
+  },[])
   return (
     <div className="card">
-      <h2 className="text-xl font-semibold mb-2">Home</h2>
-      <p>Welcome to blackroad.</p>
+      <h1 className="text-2xl font-bold mb-2">BlackRoad</h1>
+      <p>Welcome. Explore MathLab, Metrics, Logs, and the Agent Inbox.</p>
+      <button className="btn mt-4" onClick={()=> recordConversion('cta_click', 1, { where: 'home.hero' })}>
+        Demo: Record Conversion (cta_click)
+      </button>
+      <p className="text-xs opacity-70 mt-2">Set <code>VITE_ANALYTICS_BASE</code> to your worker base URL (e.g. https://<name>.workers.dev).</p>
     </div>
-  );
+  )
 }

--- a/sites/blackroad/src/pages/Metrics.jsx
+++ b/sites/blackroad/src/pages/Metrics.jsx
@@ -1,0 +1,121 @@
+import { useEffect, useMemo, useState } from 'react'
+import { LineChart, Line, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer, CartesianGrid, BarChart, Bar } from 'recharts'
+
+function useJson(url, fallback){ const [d,setD]=useState(fallback); useEffect(()=>{ fetch(url,{cache:'no-cache'}).then(r=>r.json()).then(setD).catch(()=>setD(fallback)) },[url]); return d }
+function fmtTs(s){ try{ return new Date(s).toLocaleString() }catch{ return s } }
+function msToMin(ms){ return (ms/60000).toFixed(2) }
+
+function getAnalyticsBase(){
+  const direct = import.meta.env.VITE_ANALYTICS_BASE
+  if (direct) return direct
+  const logs = import.meta.env.VITE_LOGS_URL
+  if (logs) return logs.replace(/\/logs$/, '')
+  return ''
+}
+
+export default function Metrics(){
+  const ci = useJson('/metrics/ci.json', { runs: [] })
+  const lh = useJson('/metrics/lh.json', { history: [] })
+  const convUrl = getAnalyticsBase() ? `${getAnalyticsBase()}/conversions?since=${new Date(Date.now()-1000*60*60*24*30).toISOString().slice(0,10)}` : ''
+  const conv = useJson(convUrl || '/__nope__.json', { ids:[], rows:[], totals:[] })
+
+  const byWF = useMemo(()=> {
+    const m = {}
+    for (const r of ci.runs || []) { (m[r.wf] ||= []).push(r) }
+    for (const k of Object.keys(m)) m[k] = m[k].slice(-20)
+    return m
+  }, [ci])
+
+  const lhSeries = useMemo(()=> (lh.history||[]).slice(0,30).reverse().map(x=>({
+    ts: fmtTs(x.ts), perf: +(x.perf*100).toFixed(1), a11y:+(x.a11y*100).toFixed(1),
+    bp:+(x.bp*100).toFixed(1), seo:+(x.seo*100).toFixed(1),
+    LCP:+(x.LCP/1000).toFixed(2), FCP:+(x.FCP/1000).toFixed(2), CLS:+(+x.CLS).toFixed(3), TBT:+(x.TBT/1000).toFixed(2)
+  })), [lh])
+
+  return (
+    <div className="card">
+      <h2 className="text-xl font-semibold mb-3">Metrics & Observability</h2>
+
+      <section className="p-3 rounded-lg bg-white/5 border border-white/10 mb-4">
+        <h3 className="font-semibold mb-2">Lighthouse (averaged across key pages)</h3>
+        <div className="grid" style={{gridTemplateColumns:'repeat(auto-fit,minmax(320px,1fr))', gap:16}}>
+          <Chart title="Scores (%)" data={lhSeries} lines={[['perf','Performance'],['a11y','Accessibility'],['bp','Best Practices'],['seo','SEO']]} />
+          <Chart title="Core timings (s)" data={lhSeries} lines={[['FCP','FCP'],['LCP','LCP'],['TBT','TBT (s)']]} />
+          <Chart title="Layout shift (CLS)" data={lhSeries} lines={[['CLS','CLS']]} />
+        </div>
+      </section>
+
+      <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+        <h3 className="font-semibold mb-2">CI History (last 20 per workflow)</h3>
+        <div className="grid" style={{gridTemplateColumns:'repeat(auto-fit,minmax(360px,1fr))', gap:16}}>
+          {Object.entries(byWF).map(([wf,runs])=>(
+            <div key={wf} className="p-3 rounded bg-black/20">
+              <h4 className="font-semibold mb-2">{wf}</h4>
+              <ResponsiveContainer width="100%" height={180}>
+                <BarChart data={runs.map(r=>({ ts: fmtTs(r.updated_at||r.started_at), min: +msToMin(r.duration_ms), ok: r.conclusion==='success' ? 1 : 0 }))}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="ts" hide/>
+                  <YAxis yAxisId="left" label={{ value: 'min', angle:-90, position:'insideLeft' }}/>
+                  <Tooltip />
+                  <Legend />
+                  <Bar yAxisId="left" dataKey="min" name="duration (min)" fill="currentColor" />
+                </BarChart>
+              </ResponsiveContainer>
+              <ul className="text-xs mt-2 space-y-1">
+                {runs.slice(-5).reverse().map((r,i)=>(
+                  <li key={i}>
+                    <code>{(r.sha||'').slice(0,7)}</code> — {r.conclusion || r.status} — {msToMin(r.duration_ms)} min — <span className="opacity-70">{fmtTs(r.updated_at||r.started_at)}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="p-3 rounded-lg bg-white/5 border border-white/10 mt-4">
+        <h3 className="font-semibold mb-2">Conversions (last 30 days)</h3>
+        {conv.ids?.length ? (
+          <>
+            <ResponsiveContainer width="100%" height={240}>
+              <LineChart data={conv.rows}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="day" />
+                <YAxis allowDecimals={false}/>
+                <Tooltip />
+                <Legend />
+                {conv.ids.map(id=> <Line key={id} type="monotone" dataKey={id} name={id} dot={false} />)}
+              </LineChart>
+            </ResponsiveContainer>
+            <ul className="text-sm mt-3 grid" style={{gridTemplateColumns:'repeat(auto-fit,minmax(220px,1fr))', gap:12}}>
+              {conv.totals.map(t=>(
+                <li key={t.id} className="p-2 rounded bg-black/20">
+                  <b>{t.id}</b><br/>
+                  total: <code>{t.total}</code>{typeof t.value==='number' ? <> • value: <code>{t.value.toFixed(2)}</code></> : null}
+                </li>
+              ))}
+            </ul>
+          </>
+        ) : <p className="text-sm opacity-70">No conversion data yet. Call <code>recordConversion(id)</code> in the client and set <code>VITE_ANALYTICS_BASE</code>.</p>}
+      </section>
+    </div>
+  )
+}
+
+function Chart({title,data,lines}){
+  return (
+    <div className="p-3 rounded bg-black/20">
+      <h4 className="font-semibold mb-2">{title}</h4>
+      <ResponsiveContainer width="100%" height={200}>
+        <LineChart data={data}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="ts" hide/>
+          <YAxis />
+          <Tooltip />
+          <Legend />
+          {lines.map(([k,label])=> <Line key={k} type="monotone" dataKey={k} name={label} dot={false} />)}
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}

--- a/sites/blackroad/src/ui/Layout.jsx
+++ b/sites/blackroad/src/ui/Layout.jsx
@@ -12,6 +12,7 @@ const links = [
   { to: '/blog', label: 'Blog' },
   { to: '/math', label: 'MathLab' },
   { to: '/deploys', label: 'Deploys' },
+  { to: '/metrics', label: 'Metrics' },
 ];
 
 function navigate(e, to) {


### PR DESCRIPTION
## Summary
- add Cloudflare worker endpoints for logs and conversions
- record client conversions and chart them on Metrics page
- document conversion API and usage

## Testing
- `npm --prefix sites/blackroad install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/recharts)*
- `npm test`
- `npm run lint` *(fails: 8 errors, 80 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a05065886483299a5bcf4f20bd1d7c