### PR TITLE
Fix lint configuration and telemetry globals

### DIFF
--- a/.github/tools/deploy-history.js
+++ b/.github/tools/deploy-history.js
@@ -12,7 +12,9 @@ const file = path.join(process.cwd(), 'sites', 'blackroad', 'public', 'deploys.j
 let j = { history: [] };
 try {
   j = JSON.parse(fs.readFileSync(file, 'utf8'));
-} catch {}
+} catch {
+  // Ignore malformed or missing deploy history file
+}
 if (!Array.isArray(j.history)) j.history = [];
 j.history.unshift({ ts: new Date().toISOString(), channel, sha, ref });
 j.history = j.history.slice(0, 25);

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,6 +2,7 @@ import js from '@eslint/js';
 import prettier from 'eslint-config-prettier';
 
 export default [
+  { ignores: ['node_modules/', 'dist/', 'build/', '.github/', '.tools/', '**/*.ts'] },
   js.configs.recommended,
   prettier,
   {
@@ -10,7 +11,6 @@ export default [
         ecmaFeatures: { jsx: true },
       },
     },
-    ignores: ['node_modules/', 'dist/', 'build/', '.github/', '.tools/', '**/*.ts'],
     rules: {
       'no-unused-vars': ['warn', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
       'no-undef': 'warn',

--- a/sites/blackroad/src/lib/telemetry.ts
+++ b/sites/blackroad/src/lib/telemetry.ts
@@ -1,8 +1,12 @@
 export function telemetryInit() {
   if (import.meta.env?.VITE_TELEMETRY !== 'on') return;
   try {
-    const t = { ts: Date.now(), event: 'pageview', path: location.pathname };
-    console.log('[telemetry]', t);
+    const t = {
+      ts: Date.now(),
+      event: 'pageview',
+      path: globalThis.location.pathname,
+    };
+    globalThis.console.log('[telemetry]', t);
   } catch {
     // ignore
   }


### PR DESCRIPTION
## Summary
- ensure ESLint ignores tooling and TypeScript files
- log telemetry using explicit globalThis references
- clarify deploy-history error handling

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0527b4c508329a6cc67209bc84731