### PR TITLE
fix lint configuration

### DIFF
--- a/.github/tools/deploy-history.js
+++ b/.github/tools/deploy-history.js
@@ -12,7 +12,9 @@ const file = path.join(process.cwd(), 'sites', 'blackroad', 'public', 'deploys.j
 let j = { history: [] };
 try {
   j = JSON.parse(fs.readFileSync(file, 'utf8'));
-} catch {}
+} catch {
+  /* ignore errors when file is missing or invalid JSON */
+}
 if (!Array.isArray(j.history)) j.history = [];
 j.history.unshift({ ts: new Date().toISOString(), channel, sha, ref });
 j.history = j.history.slice(0, 25);

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,6 +2,17 @@ import js from '@eslint/js';
 import prettier from 'eslint-config-prettier';
 
 export default [
+  {
+    ignores: [
+      'node_modules/',
+      'dist/',
+      'build/',
+      '.github/',
+      '.tools/',
+      '**/*.ts',
+      '**/*.tsx',
+    ],
+  },
   js.configs.recommended,
   prettier,
   {
@@ -9,8 +20,19 @@ export default [
       parserOptions: {
         ecmaFeatures: { jsx: true },
       },
+      globals: {
+        navigator: 'readonly',
+        window: 'readonly',
+        document: 'readonly',
+        fetch: 'readonly',
+        location: 'readonly',
+        console: 'readonly',
+        Event: 'readonly',
+        URL: 'readonly',
+        alert: 'readonly',
+        setTimeout: 'readonly',
+      },
     },
-    ignores: ['node_modules/', 'dist/', 'build/', '.github/', '.tools/', '**/*.ts'],
     rules: {
       'no-unused-vars': ['warn', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
       'no-undef': 'warn',

--- a/services/health-sidecar/server.js
+++ b/services/health-sidecar/server.js
@@ -1,5 +1,5 @@
 /* eslint-env node */
-/* global process, console */
+/* global process */
 import express from 'express';
 import fs from 'fs';
 import path from 'path';


### PR DESCRIPTION
## Summary
- ignore TypeScript files and define browser globals in ESLint config
- document ignored errors in deploy-history script
- remove redundant console global in health-sidecar server

## Testing
- `npm test`
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0e027d8508329bd1a831afca4f3d0