### PR TITLE
Add Jetson Orin LLM serving scaffolding

### DIFF
--- a/scripts/export_onnx.py
+++ b/scripts/export_onnx.py
@@ -1,0 +1,25 @@
+import argparse, torch, os
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--model", default="models/merged/lucidia-neox-1.4b")
+parser.add_argument("--out", default="models/merged/onnx")
+parser.add_argument("--seq", type=int, default=2048)
+args = parser.parse_args()
+os.makedirs(args.out, exist_ok=True)
+
+tok = AutoTokenizer.from_pretrained(args.model, use_fast=True)
+model = AutoModelForCausalLM.from_pretrained(args.model, torch_dtype=torch.float16).eval()
+
+dummy = tok("Hello Lucidia", return_tensors="pt")
+dummy = {k: v for k, v in dummy.items()}
+
+torch.onnx.export(
+    model, (dummy["input_ids"], dummy["attention_mask"]),
+    f"{args.out}/model.onnx",
+    input_names=["input_ids","attention_mask"],
+    output_names=["logits"],
+    dynamic_axes={"input_ids":{0:"batch",1:"seq"}, "attention_mask":{0:"batch",1:"seq"}, "logits":{0:"batch",1:"seq"}},
+    opset_version=17
+)
+print("Exported ONNX to", args.out)

--- a/scripts/merge_lora.py
+++ b/scripts/merge_lora.py
@@ -1,0 +1,18 @@
+import argparse, torch
+from transformers import AutoTokenizer, AutoModelForCausalLM
+from peft import PeftModel
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--base", default="EleutherAI/pythia-1.4b")
+parser.add_argument("--adapter", default="outputs/lucidia-core-lora")
+parser.add_argument("--out", default="models/merged/lucidia-neox-1.4b")
+args = parser.parse_args()
+
+tok = AutoTokenizer.from_pretrained(args.base, use_fast=True)
+base = AutoModelForCausalLM.from_pretrained(args.base, torch_dtype=torch.bfloat16)
+merged = PeftModel.from_pretrained(base, args.adapter)
+merged = merged.merge_and_unload()
+
+tok.save_pretrained(args.out)
+merged.save_pretrained(args.out)
+print(f"Merged model saved to {args.out}")

--- a/serving/jetson/Dockerfile
+++ b/serving/jetson/Dockerfile
@@ -1,0 +1,18 @@
+FROM nvcr.io/nvidia/l4t-ml:r35.3.1-py3   # Jetson-compatible ML base (CUDA/TensorRT)
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y git python3-pip python3-dev build-essential && rm -rf /var/lib/apt/lists/*
+RUN pip3 install --upgrade pip
+
+# Core deps
+RUN pip3 install fastapi uvicorn[standard] pydantic==2.* transformers==4.43.3 accelerate==0.33.0 \
+    numpy onnx onnxruntime-gpu==1.17.1  # ORT GPU on Jetson builds against CUDA/TensorRT
+# Simple sampler for logits
+RUN pip3 install torch --extra-index-url https://download.pytorch.org/whl/cu118
+
+WORKDIR /app
+COPY server.py /app/server.py
+COPY ../../models/merged /app/models/merged
+
+EXPOSE 8000
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/serving/jetson/build_trt_engine.sh
+++ b/serving/jetson/build_trt_engine.sh
@@ -1,0 +1,15 @@
+# Prereqs: JetPack, TensorRT-LLM wheel installed (aarch64), and polygraphy if needed
+set -euo pipefail
+
+MODEL_DIR=models/merged/lucidia-neox-1.4b
+ENGINE_DIR=models/merged/trt
+SEQ=2048
+mkdir -p "$ENGINE_DIR"
+
+# (1) Convert HF -> TRT-LLM checkpoint format (NeoX config)
+python3 -m tensorrt_llm.tools.convert_checkpoint --model_dir $MODEL_DIR --dtype float16 --output_dir $ENGINE_DIR/ckpt --model_type gptneox
+
+# (2) Build engine (FP16; add --int8 if you’ve calibrated/quantized)
+python3 -m tensorrt_llm.runtime.build --checkpoint_dir $ENGINE_DIR/ckpt --engine_dir $ENGINE_DIR/engine --gpt_neox --logits_dtype float16 --max_seq_len $SEQ
+
+echo "Engine at $ENGINE_DIR/engine"

--- a/serving/jetson/docker-compose.yml
+++ b/serving/jetson/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3.8"
+services:
+  lucidia:
+    build: .
+    container_name: lucidia-orin
+    network_mode: host
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
+      - NVIDIA_DRIVER_CAPABILITIES=all
+    volumes:
+      - ../../models/merged:/app/models/merged:ro
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: [gpu]

--- a/serving/jetson/server.py
+++ b/serving/jetson/server.py
@@ -1,0 +1,76 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from typing import List, Optional
+import onnxruntime as ort
+import numpy as np
+from transformers import AutoTokenizer
+
+MODEL_DIR = "models/merged/lucidia-neox-1.4b"
+ONNX_PATH = "models/merged/onnx/model.onnx"
+
+tok = AutoTokenizer.from_pretrained(MODEL_DIR, use_fast=True)
+providers = ["CUDAExecutionProvider","CPUExecutionProvider"]
+sess = ort.InferenceSession(ONNX_PATH, providers=providers)
+
+class Message(BaseModel):
+    role: str
+    content: str
+
+class ChatRequest(BaseModel):
+    model: Optional[str] = "lucidia-core-neox"
+    messages: List[Message]
+    max_tokens: int = 256
+    temperature: float = 0.7
+    top_p: float = 0.9
+
+class Choice(BaseModel):
+    index: int
+    message: Message
+    finish_reason: str = "stop"
+
+class ChatResponse(BaseModel):
+    id: str = "chatcmpl-lucidia"
+    object: str = "chat.completion"
+    choices: List[Choice]
+
+app = FastAPI(title="Lucidia-Core (NeoX)")
+
+def sample_top_p(logits, top_p=0.9, temperature=0.7):
+    logits = logits / max(1e-6, temperature)
+    probs = np.exp(logits - logits.max())
+    probs = probs / probs.sum()
+    sorted_idx = np.argsort(-probs)
+    cum = np.cumsum(probs[sorted_idx])
+    cutoff = sorted_idx[cum <= top_p]
+    if cutoff.size == 0:
+        cutoff = sorted_idx[:1]
+    probs_cut = probs[cutoff]
+    probs_cut = probs_cut / probs_cut.sum()
+    return np.random.choice(cutoff, p=probs_cut)
+
+@app.post("/v1/chat/completions")
+def chat(req: ChatRequest):
+    # Simple prompt glue (system + user last)
+    system = ""
+    for m in req.messages:
+        if m.role == "system": system = m.content
+    user = req.messages[-1].content
+    prompt = ((system + "\n") if system else "") + user
+
+    ids = tok(prompt, return_tensors="np")
+    input_ids = ids["input_ids"]
+    attention_mask = ids["attention_mask"]
+    generated = input_ids.tolist()[0]
+
+    for _ in range(req.max_tokens):
+        outs = sess.run(["logits"], {"input_ids": input_ids, "attention_mask": attention_mask})[0]
+        last = outs[0, -1, :]  # (batch=1, seq, vocab)
+        next_id = int(sample_top_p(last, req.top_p, req.temperature))
+        generated.append(next_id)
+        input_ids = np.array([generated], dtype=np.int64)
+        attention_mask = np.ones_like(input_ids, dtype=np.int64)
+        if next_id == tok.eos_token_id:
+            break
+
+    text = tok.decode(generated[len(ids["input_ids"][0]):], skip_special_tokens=True)
+    return ChatResponse(choices=[Choice(index=0, message=Message(role="assistant", content=text))])

--- a/tools/lucidia_orin_scaffold.sh
+++ b/tools/lucidia_orin_scaffold.sh
@@ -1,0 +1,2 @@
+mkdir -p models/base models/merged outputs/lucidia-core-lora scripts serving/jetson rag/index logs
+echo "Scaffold ready."


### PR DESCRIPTION
## Summary
- add scaffold script to prep model, output, and serving directories for Jetson Orin
- include merge and ONNX export scripts for Lucidia GPT-NeoX models
- provide Jetson Docker/FastAPI serving setup with optional TensorRT build script

## Testing
- `python3 -m py_compile scripts/merge_lora.py scripts/export_onnx.py serving/jetson/server.py`
- `bash -n tools/lucidia_orin_scaffold.sh serving/jetson/build_trt_engine.sh`
- `npm test`
- `npm run lint` *(warnings: 35)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f23cba088329920f0d333a248ed7