### PR TITLE
chore: expand eslint coverage

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,9 +13,16 @@ export default [
       '**/*.tsx',
     ],
   },
-  js.configs.recommended,
-  prettier,
   {
+    files: ['**/*.{js,jsx,mjs,cjs}'],
+    ...js.configs.recommended,
+  },
+  {
+    files: ['**/*.{js,jsx,mjs,cjs}'],
+    ...prettier,
+  },
+  {
+    files: ['**/*.{js,jsx,mjs,cjs}'],
     languageOptions: {
       parserOptions: {
         ecmaFeatures: { jsx: true },
@@ -34,7 +41,10 @@ export default [
       },
     },
     rules: {
-      'no-unused-vars': ['warn', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
+      'no-unused-vars': [
+        'warn',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_|^[A-Z]' },
+      ],
       'no-undef': 'warn',
     },
   },

--- a/sites/blackroad/src/main.jsx
+++ b/sites/blackroad/src/main.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { createRoot } from 'react-dom/client';
 import ErrorBoundary from './ui/ErrorBoundary.jsx';
 import Router from './Router.jsx';


### PR DESCRIPTION
## Summary
- extend ESLint config to include JS/JSX files and ignore capitalized component names
- drop unused React import in browser entry point

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0eda158408329855f5b0e3d01530d