### PR TITLE
feat: add BlackRoad portals app

### DIFF
--- a/apps/portals/.env.example
+++ b/apps/portals/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=https://example.com/api

--- a/apps/portals/.eslintrc.cjs
+++ b/apps/portals/.eslintrc.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ["next/core-web-vitals", "prettier"],
+};

--- a/apps/portals/.prettierrc
+++ b/apps/portals/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "semi": true,
+  "singleQuote": false
+}

--- a/apps/portals/app/cocode/page.tsx
+++ b/apps/portals/app/cocode/page.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { Sidebar } from "../../components/ui/sidebar";
+import { Topbar } from "../../components/ui/topbar";
+import { Tabs } from "../../components/ui/tabs";
+
+export default function CoCodePage() {
+  return (
+    <div className="flex min-h-screen">
+      <Sidebar />
+      <div className="flex flex-1 flex-col">
+        <Topbar title="Co-Coding Workspace" />
+        <main className="flex-1 p-4">
+          <Tabs
+            tabs={[
+              {
+                value: "editor",
+                label: "Editor",
+                content: (
+                  <textarea className="h-96 w-full rounded bg-gray-800 p-2 font-mono" />
+                ),
+              },
+              {
+                value: "preview",
+                label: "Preview",
+                content: (
+                  <div className="h-96 w-full rounded bg-gray-800 p-2">
+                    Preview area
+                  </div>
+                ),
+              },
+            ]}
+          />
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/apps/portals/app/codex/page.tsx
+++ b/apps/portals/app/codex/page.tsx
@@ -1,0 +1,9 @@
+import { Card } from "../../components/ui/card";
+
+export default function CodexPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <Card className="p-8">Codex coming soon.</Card>
+    </div>
+  );
+}

--- a/apps/portals/app/globals.css
+++ b/apps/portals/app/globals.css
@@ -1,0 +1,13 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --brand-start: #FFB000;
+  --brand-mid: #FF2D95;
+  --brand-end: #5B8CFF;
+}
+
+body {
+  @apply bg-gray-900 text-gray-100;
+}

--- a/apps/portals/app/layout.tsx
+++ b/apps/portals/app/layout.tsx
@@ -1,0 +1,15 @@
+import "./globals.css";
+import type { ReactNode } from "react";
+
+export const metadata = {
+  title: "BlackRoad Portals",
+  description: "BlackRoad.io portal hub",
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en" className="dark">
+      <body className="min-h-screen bg-gray-900 text-gray-100">{children}</body>
+    </html>
+  );
+}

--- a/apps/portals/app/login/page.tsx
+++ b/apps/portals/app/login/page.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "../../components/ui/button";
+import { Card } from "../../components/ui/card";
+import { Input } from "../../components/ui/input";
+import { Logo } from "../../components/ui/logo";
+
+export default function LoginPage() {
+  const [loading, setLoading] = useState(false);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setTimeout(() => setLoading(false), 1000);
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-900">
+      <div className="absolute inset-0 -z-10 bg-gradient-to-br from-[#FFB000] via-[#FF2D95] to-[#5B8CFF] opacity-30" />
+      <Card className="w-full max-w-sm p-6">
+        <Logo className="mx-auto mb-6 h-12 w-12" />
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <Input type="email" placeholder="Email" required />
+          <Input type="password" placeholder="Password" required />
+          <Button
+            type="submit"
+            className="w-full bg-gradient-to-r from-[#FFB000] via-[#FF2D95] to-[#5B8CFF] text-black"
+          >
+            {loading ? "Loading..." : "Login"}
+          </Button>
+        </form>
+      </Card>
+    </div>
+  );
+}

--- a/apps/portals/app/lucidia/page.tsx
+++ b/apps/portals/app/lucidia/page.tsx
@@ -1,0 +1,9 @@
+import { Card } from "../../components/ui/card";
+
+export default function LucidiaPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <Card className="p-8">Lucidia coming soon.</Card>
+    </div>
+  );
+}

--- a/apps/portals/app/page.tsx
+++ b/apps/portals/app/page.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link";
+import { Card } from "../components/ui/card";
+import { Logo } from "../components/ui/logo";
+
+const portals = [
+  { name: "Login", href: "/login" },
+  { name: "Co-Code", href: "/cocode" },
+  { name: "RoadView", href: "/roadview" },
+  { name: "RoadCoin", href: "/roadcoin" },
+  { name: "RoadChain", href: "/roadchain" },
+  { name: "Roadie", href: "/roadie" },
+  { name: "Lucidia", href: "/lucidia" },
+  { name: "Codex", href: "/codex" },
+];
+
+export default function HomePage() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center p-4">
+      <Logo className="mb-8 h-16 w-16" />
+      <div className="grid w-full max-w-3xl grid-cols-2 gap-4 md:grid-cols-4">
+        {portals.map((p) => (
+          <Link key={p.href} href={p.href}>
+            <Card className="flex items-center justify-center p-6 text-center transition hover:bg-gray-800">
+              {p.name}
+            </Card>
+          </Link>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/apps/portals/app/roadchain/page.tsx
+++ b/apps/portals/app/roadchain/page.tsx
@@ -1,0 +1,9 @@
+import { Card } from "../../components/ui/card";
+
+export default function RoadChainPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <Card className="p-8">RoadChain coming soon.</Card>
+    </div>
+  );
+}

--- a/apps/portals/app/roadcoin/page.tsx
+++ b/apps/portals/app/roadcoin/page.tsx
@@ -1,0 +1,9 @@
+import { Card } from "../../components/ui/card";
+
+export default function RoadCoinPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <Card className="p-8">RoadCoin coming soon.</Card>
+    </div>
+  );
+}

--- a/apps/portals/app/roadie/page.tsx
+++ b/apps/portals/app/roadie/page.tsx
@@ -1,0 +1,9 @@
+import { Card } from "../../components/ui/card";
+
+export default function RoadiePage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <Card className="p-8">Roadie coming soon.</Card>
+    </div>
+  );
+}

--- a/apps/portals/app/roadview/page.tsx
+++ b/apps/portals/app/roadview/page.tsx
@@ -1,0 +1,9 @@
+import { Card } from "../../components/ui/card";
+
+export default function RoadViewPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <Card className="p-8">RoadView coming soon.</Card>
+    </div>
+  );
+}

--- a/apps/portals/components/ui/button.tsx
+++ b/apps/portals/components/ui/button.tsx
@@ -1,0 +1,10 @@
+import type { ButtonHTMLAttributes } from "react";
+
+export function Button({ className = "", ...props }: ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button
+      className={["rounded bg-gray-700 px-4 py-2 text-sm font-medium text-white hover:bg-gray-600 focus:outline-none", className].join(" ")}
+      {...props}
+    />
+  );
+}

--- a/apps/portals/components/ui/card.tsx
+++ b/apps/portals/components/ui/card.tsx
@@ -1,0 +1,10 @@
+import type { HTMLAttributes } from "react";
+
+export function Card({ className = "", ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={["rounded bg-gray-800 text-gray-100", className].join(" ")}
+      {...props}
+    />
+  );
+}

--- a/apps/portals/components/ui/input.tsx
+++ b/apps/portals/components/ui/input.tsx
@@ -1,0 +1,10 @@
+import type { InputHTMLAttributes } from "react";
+
+export function Input({ className = "", ...props }: InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <input
+      className={["w-full rounded bg-gray-800 px-3 py-2 text-sm text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-[#FFB000]", className].join(" ")}
+      {...props}
+    />
+  );
+}

--- a/apps/portals/components/ui/logo.tsx
+++ b/apps/portals/components/ui/logo.tsx
@@ -1,0 +1,11 @@
+import type { HTMLAttributes } from "react";
+
+export function Logo({ className = "" }: HTMLAttributes<HTMLSpanElement>) {
+  return (
+    <span
+      className={["bg-gradient-to-r from-[#FFB000] via-[#FF2D95] to-[#5B8CFF] bg-clip-text font-bold text-transparent", className].join(" ")}
+    >
+      BR
+    </span>
+  );
+}

--- a/apps/portals/components/ui/sidebar.tsx
+++ b/apps/portals/components/ui/sidebar.tsx
@@ -1,0 +1,25 @@
+import Link from "next/link";
+
+const links = [
+  { href: "/", label: "Home" },
+  { href: "/cocode", label: "Workspace" },
+];
+
+export function Sidebar() {
+  return (
+    <nav className="hidden w-48 bg-gray-800 p-4 sm:block">
+      <ul className="space-y-2">
+        {links.map((l) => (
+          <li key={l.href}>
+            <Link
+              href={l.href}
+              className="block rounded px-2 py-1 text-sm text-gray-200 hover:bg-gray-700"
+            >
+              {l.label}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}

--- a/apps/portals/components/ui/tabs.tsx
+++ b/apps/portals/components/ui/tabs.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import * as TabsPrimitive from "@radix-ui/react-tabs";
+import type { ReactNode } from "react";
+
+interface TabItem {
+  value: string;
+  label: string;
+  content: ReactNode;
+}
+
+export function Tabs({ tabs }: { tabs: TabItem[] }) {
+  return (
+    <TabsPrimitive.Root defaultValue={tabs[0]?.value} className="flex flex-col">
+      <TabsPrimitive.List className="mb-4 flex space-x-2 border-b border-gray-700">
+        {tabs.map((tab) => (
+          <TabsPrimitive.Trigger
+            key={tab.value}
+            value={tab.value}
+            className="px-3 py-2 text-sm text-gray-300 data-[state=active]:border-b-2 data-[state=active]:border-[#FFB000]"
+          >
+            {tab.label}
+          </TabsPrimitive.Trigger>
+        ))}
+      </TabsPrimitive.List>
+      {tabs.map((tab) => (
+        <TabsPrimitive.Content key={tab.value} value={tab.value}>
+          {tab.content}
+        </TabsPrimitive.Content>
+      ))}
+    </TabsPrimitive.Root>
+  );
+}

--- a/apps/portals/components/ui/topbar.tsx
+++ b/apps/portals/components/ui/topbar.tsx
@@ -1,0 +1,10 @@
+import { Logo } from "./logo";
+
+export function Topbar({ title }: { title: string }) {
+  return (
+    <header className="flex items-center justify-between border-b border-gray-800 bg-gray-900 px-4 py-2">
+      <Logo className="h-6 w-6" />
+      <span className="text-sm">{title}</span>
+    </header>
+  );
+}

--- a/apps/portals/next-env.d.ts
+++ b/apps/portals/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/apps/portals/next.config.mjs
+++ b/apps/portals/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+export default nextConfig;

--- a/apps/portals/package.json
+++ b/apps/portals/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "blackroad-portals",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@radix-ui/react-icons": "1.3.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "10.4.16",
+    "postcss": "8.4.31",
+    "tailwindcss": "3.4.1",
+    "typescript": "5.4.5",
+    "eslint": "9.9.0",
+    "eslint-config-next": "14.2.3",
+    "prettier": "3.3.3"
+  }
+}

--- a/apps/portals/postcss.config.mjs
+++ b/apps/portals/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/portals/tailwind.config.ts
+++ b/apps/portals/tailwind.config.ts
@@ -1,0 +1,24 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}"],
+  darkMode: "class",
+  theme: {
+    extend: {
+      colors: {
+        brand: {
+          start: "#FFB000",
+          mid: "#FF2D95",
+          end: "#5B8CFF",
+        },
+      },
+      backgroundImage: {
+        "brand-gradient":
+          "linear-gradient(to right, #FFB000, #FF2D95, #5B8CFF)",
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/apps/portals/tsconfig.json
+++ b/apps/portals/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add Next.js portals app with login page and co-code workspace
- include reusable UI components and placeholder portal pages

## Testing
- `npm test`
- `npm --prefix apps/portals run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a10f9835d8832988e574fbdaf22144