### PR TITLE
fix: address lint warnings

### DIFF
--- a/.danger/dangerfile.js
+++ b/.danger/dangerfile.js
@@ -1,5 +1,6 @@
 /* Dangerfile: comment on PRs with quick quality checks */
-const fs = require('fs');
+/* eslint-env node */
+/* global danger, warn, message */
 
 const files = danger.git.modified_files.concat(danger.git.created_files);
 const big = files.filter((f) => f.endsWith('.html') || f.endsWith('.js'));

--- a/services/health-sidecar/server.js
+++ b/services/health-sidecar/server.js
@@ -1,3 +1,4 @@
+/* global process, console */
 import express from 'express';
 import fs from 'fs';
 import path from 'path';


### PR DESCRIPTION
## Summary
- declare danger/dangerfile globals and remove unused require
- mark process and console as globals in health sidecar server

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1138297b483298f1681fc51ca5135