### PR TITLE
fix: address lint warnings

### DIFF
--- a/.danger/dangerfile.js
+++ b/.danger/dangerfile.js
@@ -1,5 +1,6 @@
 /* Dangerfile: comment on PRs with quick quality checks */
-const fs = require('fs');
+/* eslint-env node */
+/* global danger, message, warn */
 
 const files = danger.git.modified_files.concat(danger.git.created_files);
 const big = files.filter((f) => f.endsWith('.html') || f.endsWith('.js'));

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,10 +1,14 @@
 import js from "@eslint/js";
 import prettier from "eslint-config-prettier";
+import globals from "globals";
 
 export default [
   js.configs.recommended,
   prettier,
   {
+    languageOptions: {
+      globals: globals.node,
+    },
     ignores: ["node_modules/", "dist/", "build/", ".github/", ".tools/"],
     rules: {
       "no-unused-vars": ["warn", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],

--- a/services/health-sidecar/server.js
+++ b/services/health-sidecar/server.js
@@ -1,3 +1,4 @@
+/* eslint-env node */
 import express from 'express';
 import fs from 'fs';
 import path from 'path';


### PR DESCRIPTION
## Summary
- declare Danger and health-sidecar files as Node environments to clear lint warnings
- add Node globals in ESLint config and rename config to `.mjs`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1136ff1e88329b284e18d7d5b273c