### PR TITLE
chore: fix lint warnings

### DIFF
--- a/.danger/dangerfile.js
+++ b/.danger/dangerfile.js
@@ -1,5 +1,7 @@
 /* Dangerfile: comment on PRs with quick quality checks */
-const fs = require('fs');
+/* global danger, warn, message */
+
+// PR quality checks executed by Danger.js
 
 const files = danger.git.modified_files.concat(danger.git.created_files);
 const big = files.filter((f) => f.endsWith('.html') || f.endsWith('.js'));
@@ -21,3 +23,4 @@ const hasScreenshot = /!\[.*\]\(.*\)/.test(danger.github.pr.body || '');
 if (!hasScreenshot && files.some((f) => f.endsWith('.html'))) {
   warn('UI change detected, but no screenshot in the PR body.');
 }
+

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ runtime/
 .env
 __pycache__/
 codex/runtime/
+**/node_modules/

--- a/services/health-sidecar/server.js
+++ b/services/health-sidecar/server.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+/* global process, console */
 import express from 'express';
 import fs from 'fs';
 import path from 'path';
@@ -48,3 +50,4 @@ app.get('/readyz', (_req, res) => {
 app.listen(PORT, () => {
   console.log(`[health-sidecar] listening on :${PORT}`);
 });
+


### PR DESCRIPTION
## Summary
- declare Danger.js globals and drop unused import to fix lint warnings
- flag health-sidecar server for Node environment globals
- ignore node_modules directories

## Testing
- `npm run lint`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a113043a6883298fbf2b7a938bfb72