### PR TITLE
chore: update OpenAI client usage

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 import streamlit as st
-import openai
+from openai import OpenAI
 import numpy as np
 import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D
@@ -9,7 +9,8 @@ import base64
 import tempfile
 import whisper
 
-openai.api_key = os.getenv("OPENAI_API_KEY")
+api_key = os.getenv("OPENAI_API_KEY")
+client = OpenAI(api_key=api_key) if api_key else None
 
 st.set_page_config(layout="wide")
 st.title("BlackRoad Prism Generator with GPT + Voice Console")
@@ -41,11 +42,13 @@ if user_input:
         st.session_state.chat_history.append({"role": "user", "content": user_input})
 
         # GPT response with full history
-        response = openai.ChatCompletion.create(
+        if client is None:
+            raise ValueError("OpenAI API key is not configured")
+        response = client.chat.completions.create(
             model="gpt-4",
-            messages=st.session_state.chat_history
+            messages=st.session_state.chat_history,
         )
-        assistant_reply = response["choices"][0]["message"]["content"]
+        assistant_reply = response.choices[0].message.content
         st.session_state.chat_history.append({"role": "assistant", "content": assistant_reply})
 
         st.markdown(f"**Venture Console AI:** {assistant_reply}")


### PR DESCRIPTION
## Summary
- update main app to use the new `OpenAI` client
- handle missing OpenAI API key before sending chat completions

## Testing
- `python -m py_compile main.py`
- `pytest`
- `python main.py`

------
https://chatgpt.com/codex/tasks/task_e_68a1184b80508329a6fd4f9a8738c262