### PR TITLE
Add Lucidia CI workflow

### DIFF
--- a/.github/workflows/lucidia-ci.yml
+++ b/.github/workflows/lucidia-ci.yml
@@ -1,0 +1,26 @@
+name: lucidia-ci
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+jobs:
+  sanity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Basic tree + sizes
+        run: |
+          echo "Disk usage (top 50):"
+          du -h --max-depth=2 | sort -h | tail -n 50
+          echo "Git status:"
+          git status
+      - name: Create build artifact (tar)
+        run: |
+          mkdir -p build
+          tar -czf build/lucidia-src.tar.gz .
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lucidia-src
+          path: build/lucidia-src.tar.gz


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow `lucidia-ci` to build & upload tarball of repo source

## Testing
- `npm test`
- `pre-commit run --files .github/workflows/lucidia-ci.yml` *(fails: command not found; package install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68a2aa8a2a9083299efab3b0cca813bb