### PR TITLE
Add Bazel buildable rule

### DIFF
--- a/bazel/buildable.bzl
+++ b/bazel/buildable.bzl
@@ -1,0 +1,22 @@
+def _buildable_impl(ctx):
+    # Retrieve the file specified by the build_file attribute.
+    build_file = ctx.file.build_file
+    if build_file == None:
+        fail("Build file not found: {}".format(ctx.attr.build_file))
+
+    # Create a no-op action that depends on the file so that Bazel
+    # will ensure its existence at analysis time.
+    ctx.actions.do_nothing(inputs = [build_file])
+
+    return []
+
+buildable = rule(
+    implementation = _buildable_impl,
+    attrs = {
+        "build_file": attr.label(
+            doc = "File that should exist to mark a directory buildable.",
+            allow_single_file = True,
+            mandatory = True,
+        ),
+    },
+)


### PR DESCRIPTION
## Summary
- add `buildable` rule verifying that a specified build file exists

## Testing
- `npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68a2abb0fdf88329b37e12c0af37b834