### PR TITLE
feat: add news model with preview support

### DIFF
--- a/sites/blackroad/public/news.json
+++ b/sites/blackroad/public/news.json
@@ -1,0 +1,10 @@
+{
+  "news": [
+    {
+      "id": "example-draft",
+      "title": "Example draft item",
+      "body": "This is a draft news item.",
+      "published": false
+    }
+  ]
+}

--- a/sites/blackroad/src/Router.jsx
+++ b/sites/blackroad/src/Router.jsx
@@ -15,6 +15,7 @@ import MathLab from './pages/MathLab.jsx';
 import Deploys from './pages/Deploys.jsx';
 import Metrics from './pages/Metrics.jsx';
 import ExperimentsDash from './pages/ExperimentsDash.jsx';
+import News from './pages/News.jsx';
 import NotFound from './pages/NotFound.jsx';
 
 const routes = {
@@ -33,6 +34,7 @@ const routes = {
   '/deploys': <Deploys />,
   '/metrics': <Metrics />,
   '/experiments': <ExperimentsDash />,
+  '/news': <News />,
 };
 
 export default function Router() {

--- a/sites/blackroad/src/pages/News.jsx
+++ b/sites/blackroad/src/pages/News.jsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+
+function useJson(url, fallback){
+  const [d,setD]=useState(fallback);
+  useEffect(()=>{ fetch(url,{cache:'no-cache'}).then(r=>r.json()).then(setD).catch(()=>setD(fallback)) },[url]);
+  return d;
+}
+
+export default function News(){
+  const data = useJson('/news.json', { news: [] });
+  const preview = new window.URLSearchParams(window.location.search).has('preview');
+  const items = (data.news||[]).filter(n=>preview || n.published);
+  return (
+    <div className="card">
+      <h2 className="text-xl font-semibold mb-3">News</h2>
+      {items.length ? (
+        <ul className="space-y-3">
+          {items.map(n=>(
+            <li key={n.id} className="p-3 rounded bg-white/5 border border-white/10">
+              <h3 className="font-semibold">{n.title}</h3>
+              <p className="text-sm mt-1">{n.body}</p>
+              {!n.published && <span className="text-xs opacity-60">draft</span>}
+            </li>
+          ))}
+        </ul>
+      ) : <p>No news items found.</p>}
+    </div>
+  );
+}

--- a/sites/blackroad/src/ui/Layout.jsx
+++ b/sites/blackroad/src/ui/Layout.jsx
@@ -14,6 +14,7 @@ const links = [
   { to: '/deploys', label: 'Deploys' },
   { to: '/metrics', label: 'Metrics' },
   { to: '/experiments', label: 'Experiments' },
+  { to: '/news', label: 'News' },
 ];
 
 function navigate(e, to) {


### PR DESCRIPTION
## Summary
- add news JSON model with published flag
- add News page with preview filtering and route
- include News link in site navigation

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2aab28ae48329a0f4a00c323556ca