### PR TITLE
Add FastAPI gateway for Lucidia

### DIFF
--- a/api/lucidia/main.py
+++ b/api/lucidia/main.py
@@ -1,0 +1,33 @@
+import os, json, asyncio
+from fastapi import FastAPI, Request
+from fastapi.responses import StreamingResponse, JSONResponse, PlainTextResponse
+from pydantic import BaseModel
+from runtime.ollama_client import chat as ollama_chat
+
+LUCIDIA_MODEL = os.getenv("LUCIDIA_MODEL", "lucidia")
+app = FastAPI()
+
+class ChatBody(BaseModel):
+    messages: list
+    model: str | None = None
+    stream: bool = True
+
+@app.get("/health")
+async def health():
+    return {"ok": True, "model": LUCIDIA_MODEL}
+
+@app.post("/chat")
+async def chat(body: ChatBody):
+    model = body.model or LUCIDIA_MODEL
+    if body.stream:
+        async def gen():
+            async for chunk in ollama_chat(model, body.messages, stream=True):
+                yield chunk
+        return StreamingResponse(gen(), media_type="application/json")
+    else:
+        data = await ollama_chat(model, body.messages, stream=False)
+        return JSONResponse(data)
+
+@app.get("/")
+async def root():
+    return PlainTextResponse("Lucidia API OK")

--- a/api/lucidia/run.sh
+++ b/api/lucidia/run.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+source ../.venv/bin/activate
+export LUCIDIA_MODEL="${LUCIDIA_MODEL:-lucidia}"
+uvicorn lucidia.main:app --host 0.0.0.0 --port 8088


### PR DESCRIPTION
## Summary
- add Lucidia FastAPI gateway exposing chat and health endpoints
- provide run script to launch the gateway on port 8088

## Testing
- `python -m py_compile api/lucidia/main.py`
- `bash -n api/lucidia/run.sh`
- ⚠️ `pre-commit run --files api/lucidia/main.py api/lucidia/run.sh` *(pre-commit not installed and installation failed: Tunnel connection failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ae24e0b083298919384ec46aefa4