### PR TITLE
docs: add CLI custom action example

### DIFF
--- a/docs/cli-custom-actions.md
+++ b/docs/cli-custom-actions.md
@@ -1,0 +1,36 @@
+# Custom CLI Actions
+
+The console's CLI can be extended at runtime by injecting additional actions. This allows local extensions without touching the core codebase.
+
+## Example: `greet`
+
+The snippet below registers a new action named `greet` that prints "Hello, world!" when invoked.
+
+```ts
+// greet-action.ts
+import type { CLI } from 'prism/cli';
+
+export default function inject(cli: CLI) {
+  cli.action('greet', () => {
+    console.log('Hello, world!');
+  });
+}
+```
+
+Load the action before running the CLI:
+
+```ts
+import { createCli } from 'prism/cli';
+import injectGreet from './greet-action';
+
+const cli = createCli();
+injectGreet(cli);
+cli.run();
+```
+
+Running the command prints the greeting:
+
+```bash
+$ prism greet
+Hello, world!
+```


### PR DESCRIPTION
## Summary
- document how to extend the CLI with custom actions
- show greet action printing "Hello, world!"

## Testing
- `npm test`
- `pre-commit run --files docs/cli-custom-actions.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2adffc8f08329afef70a82f894c94