### PR TITLE
feat: add lucidia API NGINX snippet

### DIFF
--- a/config/nginx/llm.conf
+++ b/config/nginx/llm.conf
@@ -19,4 +19,6 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
     }
+
+    include snippets/lucidia_api.conf;
 }

--- a/config/nginx/snippets/lucidia_api.conf
+++ b/config/nginx/snippets/lucidia_api.conf
@@ -1,0 +1,11 @@
+# Assumes SSL already configured on server block
+location /api/lucidia/ {
+    proxy_pass http://127.0.0.1:8088/;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    add_header Access-Control-Allow-Origin *;
+    add_header Access-Control-Allow-Headers *;
+    add_header Access-Control-Allow-Methods "GET, POST, OPTIONS";
+    if ($request_method = OPTIONS) { return 204; }
+}


### PR DESCRIPTION
## Summary
- add NGINX snippet to proxy `/api/lucidia/` requests to local Lucidia API service
- include Lucidia snippet in main `llm.conf` server configuration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2ae52a0c08329a4b37b928f0c523d