### PR TITLE
chore: add puppeteer and convert screenshot script to esm

### DIFF
--- a/.github/tools/site/screenshot.js
+++ b/.github/tools/site/screenshot.js
@@ -1,23 +1,30 @@
 #!/usr/bin/env node
+/* eslint-env node */
+/* global process, console */
 /**
  * Takes a full-page PNG screenshot of BLACKROAD_URL (or GH Pages fallback),
  * saves to artifacts/site-screenshots and copies the latest into the site public folder.
  */
-const fs = require('fs'); const path = require('path');
+import fs from 'fs';
+import path from 'path';
+import puppeteer from 'puppeteer';
+
 (async () => {
-  const puppeteer = require('puppeteer');
   const base =
     process.env.BLACKROAD_URL ||
     (process.env.BLACKROAD_DOMAIN ? `https://${process.env.BLACKROAD_DOMAIN}` : '') ||
-    `https://${(process.env.GITHUB_REPOSITORY||'user/repo').split('/')[0]}.github.io`;
-  const url = base.replace(/\/$/,'') + '/';
+    `https://${(process.env.GITHUB_REPOSITORY || 'user/repo').split('/')[0]}.github.io`;
+  const url = base.replace(/\/$/, '') + '/';
   const outDir = path.join(process.cwd(), 'artifacts', 'site-screenshots');
   fs.mkdirSync(outDir, { recursive: true });
-  const ts = new Date().toISOString().replace(/[:.]/g,'-');
+  const ts = new Date().toISOString().replace(/[:.]/g, '-');
   const file = path.join(outDir, `home-${ts}.png`);
-  const browser = await puppeteer.launch({headless: 'new', args:['--no-sandbox','--disable-setuid-sandbox']});
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--no-sandbox', '--disable-setuid-sandbox']
+  });
   const page = await browser.newPage();
-  page.setViewport({ width: 1440, height: 900, deviceScaleFactor: 1 });
+  await page.setViewport({ width: 1440, height: 900, deviceScaleFactor: 1 });
   try {
     await page.goto(url, { waitUntil: 'networkidle2', timeout: 60000 });
     await page.screenshot({ path: file, fullPage: true });
@@ -26,7 +33,10 @@ const fs = require('fs'); const path = require('path');
     fs.mkdirSync(pubDir, { recursive: true });
     const pubFile = path.join(pubDir, 'latest.png');
     fs.copyFileSync(file, pubFile);
-    fs.writeFileSync(path.join(pubDir, 'latest.json'), JSON.stringify({ updatedAt: new Date().toISOString(), file: 'latest.png', source: url }, null, 2));
+    fs.writeFileSync(
+      path.join(pubDir, 'latest.json'),
+      JSON.stringify({ updatedAt: new Date().toISOString(), file: 'latest.png', source: url }, null, 2)
+    );
     console.log('Saved screenshot:', file);
   } catch (e) {
     console.log('Screenshot failed (non-fatal):', e.message);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "eslint-config-prettier": "^9.1.0",
     "husky": "^9.1.5",
     "lint-staged": "^15.2.8",
-    "prettier": "^3.3.3"
+    "prettier": "^3.3.3",
+    "puppeteer": "^22.10.0"
   },
   "scripts": {
     "prepare": "husky",


### PR DESCRIPTION
## Summary
- convert the site screenshot helper to ESM and mark it as a Node script
- declare puppeteer as a dev dependency

## Testing
- `npm test`
- `npm run lint`
- `pytest`
- `npm install --save-dev puppeteer` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a37528c40483299e18a74710c0b300