### PR TITLE
Fix site build by installing dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test": "node tests/smoke.test.js",
     "dev": "npm --prefix sites/blackroad run dev",
     "build": "npm --prefix sites/blackroad run build",
+    "postinstall": "npm --prefix sites/blackroad install",
     "fix-anything": "node .github/tools/codex-apply.js .github/prompts/codex-fix-anything.md || true"
   },
   "lint-staged": {

--- a/sites/blackroad/package.json
+++ b/sites/blackroad/package.json
@@ -13,14 +13,14 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "recharts": "^2.7.2"
+    "recharts": "^2.7.2",
+    "vite": "^5.4.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",
     "eslint": "^9.9.0",
     "eslint-config-prettier": "^9.1.0",
     "prettier": "^3.3.3",
-    "tailwindcss": "^3.4.10",
-    "vite": "^5.4.2"
+    "tailwindcss": "^3.4.10"
   }
 }


### PR DESCRIPTION
## Summary
- ensure site dependencies are installed after root install
- move Vite into dependencies for the Blackroad site so builds can run

## Testing
- `npm test`
- `npm run build` *(fails: sh: 1: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a37538c7f0832986098c367a2bf287