### PR TITLE
Handle empty tokens in repo URL tokenization

### DIFF
--- a/tests/test_tokenize_url.py
+++ b/tests/test_tokenize_url.py
@@ -1,0 +1,26 @@
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "codex_multi_repo_loader",
+    Path(__file__).resolve().parent.parent / "tools" / "codex_multi_repo_loader.py",
+)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+tokenize_url = module.tokenize_url
+
+
+def test_tokenize_url_with_token():
+    original = "https://github.com/org/repo.git"
+    expected = "https://TOKEN@github.com/org/repo.git"
+    assert tokenize_url(original, "TOKEN") == expected
+
+
+def test_tokenize_url_empty_token_returns_original():
+    original = "https://github.com/org/repo.git"
+    assert tokenize_url(original, "") == original
+
+
+def test_tokenize_url_non_https_unchanged():
+    ssh_url = "git@github.com:org/repo.git"
+    assert tokenize_url(ssh_url, "TOKEN") == ssh_url

--- a/tools/codex_multi_repo_loader.py
+++ b/tools/codex_multi_repo_loader.py
@@ -39,9 +39,30 @@ def build_env(cfg):
 
 
 def tokenize_url(url: str, token: str):
-    # Convert https://host/org/repo.git -> https://TOKEN@host/org/repo.git
-    if not url.startswith("https://"):
+    """Return a token-authenticated HTTPS URL.
+
+    If ``token`` is empty or ``None`` the original ``url`` is returned
+    unchanged.  This guards against creating URLs with an empty username
+    portion such as ``https://@github.com/...`` which Git would reject.
+
+    Parameters
+    ----------
+    url: str
+        The repository URL.
+    token: str
+        Personal access token to embed in the URL.
+
+    Returns
+    -------
+    str
+        URL with the token embedded for HTTPS, or the original URL when
+        token authentication is not applicable.
+    """
+
+    # Only HTTPS URLs can be tokenized; others (e.g. SSH) are returned as-is.
+    if not url.startswith("https://") or not token:
         return url
+
     parts = url.split("https://", 1)[1]
     return f"https://{token}@{parts}"
 


### PR DESCRIPTION
## Summary
- prevent tokenize_url from inserting empty username when token is missing
- add Python tests covering tokenize_url edge cases

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3756a266c8329bbaf734415fd7819