### PR TITLE
fix lint errors

### DIFF
--- a/.github/tools/llm/eval-diff.js
+++ b/.github/tools/llm/eval-diff.js
@@ -8,7 +8,11 @@ import fs from 'fs';
 import path from 'path';
 const dir = 'artifacts/llm-eval';
 if (!fs.existsSync(dir)) { console.log('No eval artifacts; skipping.'); process.exit(0); }
-try { sh('git fetch origin main:refs/remotes/origin/main', {stdio:'ignore'}); } catch {}
+try {
+  sh('git fetch origin main:refs/remotes/origin/main', { stdio: 'ignore' });
+} catch {
+  /* ignore errors if the main branch isn't available */
+}
 const tmp='.llm-eval-main'; fs.rmSync(tmp,{recursive:true,force:true}); fs.mkdirSync(tmp,{recursive:true});
 try { sh(`git show origin/main:${dir} 1>/dev/null 2>&1`); } catch { console.log('No prior artifacts on main; skipping diff.'); process.exit(0); }
 let md = '### LLM Eval Diff (advisory)\n';

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,14 +2,23 @@ import js from "@eslint/js";
 import prettier from "eslint-config-prettier";
 
 export default [
+  {
+    ignores: [
+      "node_modules/**",
+      "dist/**",
+      "build/**",
+      ".github/**",
+      ".tools/**"
+    ]
+  },
   js.configs.recommended,
   prettier,
-  { 
-    ignores: ["node_modules/", "dist/", "build/", ".github/", ".tools/"],
+  {
     languageOptions: {
       ecmaVersion: "latest",
       sourceType: "module",
-      parserOptions: { ecmaFeatures: { jsx: true } }
+      parserOptions: { ecmaFeatures: { jsx: true } },
+      globals: { console: "readonly", process: "readonly" }
     },
     rules: {
       "no-unused-vars": ["warn", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],

--- a/services/health-sidecar/server.js
+++ b/services/health-sidecar/server.js
@@ -1,5 +1,4 @@
 /* eslint-env node */
-/* global process, console */
 import express from 'express';
 import fs from 'fs';
 import path from 'path';


### PR DESCRIPTION
## Summary
- refine ESLint config with proper ignore patterns and node globals
- handle missing main branch gracefully in eval-diff script
- drop redundant global comment from health-sidecar server

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3757cc0c88329b15f7fb8553d4c73