### PR TITLE
chore: fix lint config and dependencies

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,17 +2,25 @@ import js from "@eslint/js";
 import prettier from "eslint-config-prettier";
 
 export default [
+  {
+    ignores: [
+      "node_modules/**",
+      "dist/**",
+      "build/**",
+      ".github/**",
+      ".tools/**"
+    ]
+  },
   js.configs.recommended,
   prettier,
-  { 
-    ignores: ["node_modules/", "dist/", "build/", ".github/", ".tools/"],
+  {
     languageOptions: {
       ecmaVersion: "latest",
       sourceType: "module",
       parserOptions: { ecmaFeatures: { jsx: true } }
     },
     rules: {
-      "no-unused-vars": ["warn", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
+      "no-unused-vars": ["warn", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
       "no-undef": "warn"
     }
   }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "eslint-config-prettier": "^9.1.0",
     "husky": "^9.1.5",
     "lint-staged": "^15.2.8",
-    "prettier": "^3.3.3"
+    "prettier": "^3.3.3",
+    "gray-matter": "^4.0.3",
+    "marked": "^14.1.1"
   },
   "scripts": {
     "prepare": "husky",

--- a/sites/blackroad/scripts/build-blog.js
+++ b/sites/blackroad/scripts/build-blog.js
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+/* eslint-env node */
+/* global process, console */
 /**
  * Build-time blog generator (skip-safe).
  * - Reads Markdown from sites/blackroad/content/blog/ (recursive .md files)


### PR DESCRIPTION
## Summary
- ignore internal tooling directories in ESLint and keep Node globals
- declare Node globals for blog build script
- add missing blog tooling dependencies

## Testing
- `npm run lint`
- `npm test`
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a375a58ec083299a41a986e9eb8d67