### PR TITLE
Add ESLint config and ignore node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ runtime/
 .env
 __pycache__/
 codex/runtime/
+
+node_modules/

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,13 @@
+module.exports = [
+  {
+    ignores: ["node_modules/**"],
+  },
+  {
+    files: ["**/*.{js,mjs,cjs}"],
+    languageOptions: {
+      ecmaVersion: 2021,
+      sourceType: "module",
+    },
+    rules: {},
+  },
+];


### PR DESCRIPTION
## Summary
- add default ESLint configuration
- ignore node_modules directory in git

## Testing
- `npm run lint`
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_68a375c4c8248329a75c11b529d9fe9d