### PR TITLE
fix: add missing requests dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ numpy==1.26.4
 whisper
 torch
 
+requests==2.32.3


### PR DESCRIPTION
## Summary
- add missing requests dependency for audit script

## Testing
- `npm test`
- `npm run lint`
- ⚠️ `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement requests==2.32.3 (from versions: none))*

------
https://chatgpt.com/codex/tasks/task_e_68a3760af5848329a124fc1a2551e38c