### PR TITLE
chore: add eslint flat config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ runtime/
 .env
 __pycache__/
 codex/runtime/
+node_modules/
+**/node_modules/

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,27 @@
+import js from "@eslint/js";
+import globals from "globals";
+import prettier from "eslint-config-prettier";
+
+export default [
+  {
+    ignores: ["node_modules/", "dist/", "build/", "public/vendor/", ".tools/", ".github/"]
+  },
+  js.configs.recommended,
+  {
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+        ...globals.es2021
+      },
+      ecmaVersion: 2022,
+      sourceType: "module"
+    },
+    rules: {
+      "no-unused-vars": ["warn", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
+      "no-undef": "warn",
+      "no-console": "off"
+    }
+  },
+  prettier
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,8 +6,10 @@
     "": {
       "name": "blackroad-quantum",
       "devDependencies": {
+        "@eslint/js": "^9.33.0",
         "eslint": "^9.9.0",
         "eslint-config-prettier": "^9.1.0",
+        "globals": "^14.0.0",
         "husky": "^9.1.5",
         "lint-staged": "^15.2.8",
         "prettier": "^3.3.3"

--- a/package.json
+++ b/package.json
@@ -2,8 +2,10 @@
   "name": "blackroad-quantum",
   "private": true,
   "devDependencies": {
+    "@eslint/js": "^9.33.0",
     "eslint": "^9.9.0",
     "eslint-config-prettier": "^9.1.0",
+    "globals": "^14.0.0",
     "husky": "^9.1.5",
     "lint-staged": "^15.2.8",
     "prettier": "^3.3.3"


### PR DESCRIPTION
## Summary
- add ESLint flat config and ignore node_modules
- declare missing @eslint/js and globals dev dependencies

## Testing
- `npm run lint`
- `npm audit` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a375ecabcc83298f37dbf8fe3a329b