### PR TITLE
chore: fix lint config and adopt esm

### DIFF
--- a/.danger/dangerfile.js
+++ b/.danger/dangerfile.js
@@ -1,5 +1,4 @@
 /* Dangerfile: comment on PRs with quick quality checks */
-const fs = require('fs');
 
 const files = danger.git.modified_files.concat(danger.git.created_files);
 const big = files.filter((f) => f.endsWith('.html') || f.endsWith('.js'));
@@ -21,3 +20,4 @@ const hasScreenshot = /!\[.*\]\(.*\)/.test(danger.github.pr.body || '');
 if (!hasScreenshot && files.some((f) => f.endsWith('.html'))) {
   warn('UI change detected, but no screenshot in the PR body.');
 }
+

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,10 +5,20 @@ export default [
   js.configs.recommended,
   prettier,
   {
+    languageOptions: {
+      globals: {
+        process: "readonly",
+        console: "readonly",
+        require: "readonly",
+        danger: "readonly",
+        message: "readonly",
+        warn: "readonly",
+      },
+    },
     ignores: ["node_modules/", "dist/", "build/", ".github/", ".tools/"],
     rules: {
       "no-unused-vars": ["warn", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
-      "no-undef": "warn"
-    }
-  }
+      "no-undef": "warn",
+    },
+  },
 ];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "blackroad-quantum",
   "private": true,
+  "type": "module",
   "devDependencies": {
     "eslint": "^9.9.0",
     "eslint-config-prettier": "^9.1.0",


### PR DESCRIPTION
## Summary
- configure ESLint with Node and Danger globals
- convert Dangerfile to native ESM
- declare project as an ES module

## Testing
- `npm run lint`
- `npm test`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a374f66e00832991992bbef12dff08