### PR TITLE
feat: add hardened docker compose setup

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -1,0 +1,21 @@
+# Shared
+JWT_SECRET=change_me_now
+
+# Redis
+REDIS_PASSWORD=change_me_now
+REDIS_URL=redis://:${REDIS_PASSWORD}@redis:6379/0
+
+# Mongo (root)
+MONGO_INITDB_ROOT_USERNAME=admin
+MONGO_INITDB_ROOT_PASSWORD=change_me_now
+MONGO_URL_BLACKROAD=mongodb://${MONGO_INITDB_ROOT_USERNAME}:${MONGO_INITDB_ROOT_PASSWORD}@mongo:27017/lucidia_blackroad?authSource=admin
+MONGO_URL_BLACKROADINC=mongodb://${MONGO_INITDB_ROOT_USERNAME}:${MONGO_INITDB_ROOT_PASSWORD}@mongo:27017/lucidia_blackroadinc?authSource=admin
+
+# Postgres
+POSTGRES_PASSWORD=change_me_now
+POSTGRES_URL_BLACKROAD=postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/lucidia_blackroad
+POSTGRES_URL_BLACKROADINC=postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/lucidia_blackroadinc
+
+# Grafana (optional)
+GF_SECURITY_ADMIN_USER=admin
+GF_SECURITY_ADMIN_PASSWORD=change_me_now

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,186 @@
+version: '3.8'
+
+services:
+  # Main Lucidia Application (blackroad.io)
+  lucidia-blackroad:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: production
+    container_name: lucidia-blackroad
+    restart: unless-stopped
+    ports:
+      - '9000:8000'
+    environment:
+      NODE_ENV: production
+      PORT: 8000
+      LUCIDIA_INSTANCE: blackroad
+      LUCIDIA_LOG_LEVEL: info
+      REDIS_URL: ${REDIS_URL}
+      MONGO_URL: ${MONGO_URL_BLACKROAD}
+      POSTGRES_URL: ${POSTGRES_URL_BLACKROAD}
+      JWT_SECRET: ${JWT_SECRET}
+    volumes:
+      - lucidia-blackroad-data:/app/data
+      - lucidia-blackroad-logs:/app/logs
+      - ./config/production.json:/app/config/production.json:ro
+    networks: [lucidia-network]
+    depends_on:
+      - redis
+      - mongo
+      - postgres
+    healthcheck:
+      test: ['CMD', 'node', 'scripts/healthcheck.js']
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+  # Secondary Lucidia Application (blackroadinc.us)
+  lucidia-blackroadinc:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: production
+    container_name: lucidia-blackroadinc
+    restart: unless-stopped
+    ports:
+      - '8000:8000'
+    environment:
+      NODE_ENV: production
+      PORT: 8000
+      LUCIDIA_INSTANCE: blackroadinc
+      LUCIDIA_LOG_LEVEL: info
+      REDIS_URL: ${REDIS_URL}
+      MONGO_URL: ${MONGO_URL_BLACKROADINC}
+      POSTGRES_URL: ${POSTGRES_URL_BLACKROADINC}
+      JWT_SECRET: ${JWT_SECRET}
+    volumes:
+      - lucidia-blackroadinc-data:/app/data
+      - lucidia-blackroadinc-logs:/app/logs
+      - ./config/production.json:/app/config/production.json:ro
+    networks: [lucidia-network]
+    depends_on:
+      - redis
+      - mongo
+      - postgres
+    healthcheck:
+      test: ['CMD', 'node', 'scripts/healthcheck.js']
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+  # NGINX Reverse Proxy
+  nginx:
+    image: nginx:alpine
+    container_name: lucidia-nginx
+    restart: unless-stopped
+    ports:
+      - '80:80'
+      - '443:443'
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/conf.d:/etc/nginx/conf.d:ro # use conf.d includes
+      - ./nginx/ssl:/etc/nginx/ssl:ro
+      - /etc/letsencrypt:/etc/letsencrypt:ro
+      - nginx-cache:/var/cache/nginx
+      - nginx-logs:/var/log/nginx
+    networks: [lucidia-network]
+    depends_on:
+      - lucidia-blackroad
+      - lucidia-blackroadinc
+    healthcheck:
+      test: ['CMD-SHELL', 'nginx -t -q || exit 1']
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  # Redis (internal only)
+  redis:
+    image: redis:7-alpine
+    container_name: lucidia-redis
+    restart: unless-stopped
+    expose:
+      - '6379'
+    volumes:
+      - redis-data:/data
+      - ./config/redis.conf:/usr/local/etc/redis/redis.conf:ro
+    command: ['redis-server', '/usr/local/etc/redis/redis.conf']
+    networks: [lucidia-network]
+    healthcheck:
+      test: ['CMD-SHELL', 'redis-cli -a ${REDIS_PASSWORD} ping | grep PONG >/dev/null']
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  # MongoDB (internal only)
+  mongo:
+    image: mongo:7
+    container_name: lucidia-mongo
+    restart: unless-stopped
+    expose:
+      - '27017'
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_INITDB_ROOT_USERNAME}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_INITDB_ROOT_PASSWORD}
+      MONGO_INITDB_DATABASE: lucidia
+    volumes:
+      - mongo-data:/data/db
+      - mongo-config:/data/configdb
+      - ./scripts/mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro
+    networks: [lucidia-network]
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          "mongosh --username ${MONGO_INITDB_ROOT_USERNAME} --password ${MONGO_INITDB_ROOT_PASSWORD} --quiet --eval 'db.adminCommand({ ping: 1 }).ok' | grep 1 >/dev/null",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  # PostgreSQL (internal only)
+  postgres:
+    image: postgres:15-alpine
+    container_name: lucidia-postgres
+    restart: unless-stopped
+    expose:
+      - '5432'
+    environment:
+      POSTGRES_DB: lucidia
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      PGDATA: /var/lib/postgresql/data/pgdata
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+      - ./scripts/postgres-init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    networks: [lucidia-network]
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U postgres -d lucidia']
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+networks:
+  lucidia-network:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.20.0.0/16
+
+volumes:
+  lucidia-blackroad-data:
+  lucidia-blackroadinc-data:
+  lucidia-dev-data:
+  lucidia-blackroad-logs:
+  lucidia-blackroadinc-logs:
+  redis-data:
+  mongo-data:
+  mongo-config:
+  postgres-data:
+  prometheus-data:
+  grafana-data:
+  elasticsearch-data:
+  nginx-cache:
+  nginx-logs:


### PR DESCRIPTION
## Summary
- add production-ready docker compose for lucidia stack with health checks and internal db services
- provide example environment file for credentials and connection strings

## Testing
- `npm test`
- ⚠️ `pre-commit run --files docker-compose.yml .env.docker.example` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b4c365048329907df46b45f4130f