### PR TITLE
feat: add lucidia cognitive system service scaffolding

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,4 @@
-command -v npx >/dev/null 2>&1 || exit 0
-npx prettier -w . >/dev/null 2>&1 || true
-npx eslint . --ext .js,.mjs,.cjs --fix >/dev/null 2>&1 || true
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm test && npm --prefix services/lucidia-cognitive-system test

--- a/services/lucidia-cognitive-system/.dockerignore
+++ b/services/lucidia-cognitive-system/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+npm-debug.log
+Dockerfile
+.git
+.gitignore
+coverage
+dist
+docs

--- a/services/lucidia-cognitive-system/Dockerfile
+++ b/services/lucidia-cognitive-system/Dockerfile
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1
+FROM node:20-slim AS deps
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm ci
+
+FROM node:20-slim AS build
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build:prod
+
+FROM node:20-slim AS runner
+ENV NODE_ENV=production
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+COPY package.json ./
+EXPOSE 8000
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s CMD node -e "http=require('http');r=http.request({host:'127.0.0.1',port:8000,path:'/ready',timeout:2000},res=>{process.exit(res.statusCode===200?0:1)});r.on('error',()=>process.exit(1));r.end();"
+CMD ["node", "dist/comprehensive-lucidia-system.js"]

--- a/services/lucidia-cognitive-system/package.json
+++ b/services/lucidia-cognitive-system/package.json
@@ -1,0 +1,212 @@
+{
+  "name": "lucidia-cognitive-system",
+  "version": "2.0.0",
+  "description": "Advanced recursive symbolic AI system with contradiction harmonics and multi-valued logic",
+  "type": "module",
+  "main": "dist/comprehensive-lucidia-system.js",
+  "exports": "./dist/comprehensive-lucidia-system.js",
+  "files": [
+    "dist",
+    "src",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "start": "node dist/comprehensive-lucidia-system.js",
+    "dev": "nodemon src/comprehensive-lucidia-system.js",
+    "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --coverage",
+    "test:watch": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "test:integration": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --testPathPattern=integration",
+    "lint": "eslint \"src/**/*.{js,mjs}\"",
+    "lint:fix": "eslint \"src/**/*.{js,mjs}\" --fix",
+    "format": "prettier --write \"src/**/*.{js,mjs,json}\"",
+    "build": "rollup -c",
+    "build:prod": "cross-env NODE_ENV=production rollup -c",
+    "docker:build": "docker build -t lucidia-system .",
+    "docker:run": "docker run -p 8000:8000 -p 9000:9000 lucidia-system",
+    "compose:up": "docker compose up -d",
+    "deploy": "npm run build:prod && npm run docker:build",
+    "monitor": "node scripts/monitor.js",
+    "benchmark": "node scripts/benchmark.js",
+    "docs": "jsdoc src/ -d docs/",
+    "clean": "rimraf dist/ coverage/ docs/",
+    "security:audit": "npm audit --audit-level=moderate",
+    "security:fix": "npm audit fix",
+    "prepare": "husky install",
+    "typecheck": "tsc --noEmit"
+  },
+  "keywords": [
+    "ai",
+    "cognitive-architecture",
+    "symbolic-ai",
+    "multi-valued-logic",
+    "contradiction-harmonics",
+    "recursive-intelligence",
+    "lucidia",
+    "quantum-simulation",
+    "consciousness-modeling"
+  ],
+  "author": {
+    "name": "BlackRoad Inc",
+    "email": "dev@blackroadinc.us",
+    "url": "https://blackroadinc.us"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/blackroad/lucidia-cognitive-system.git"
+  },
+  "bugs": {
+    "url": "https://github.com/blackroad/lucidia-cognitive-system/issues"
+  },
+  "homepage": "https://blackroad.io/lucidia",
+  "engines": {
+    "node": ">=18.0.0",
+    "npm": ">=8.0.0"
+  },
+  "dependencies": {
+    "axios": "^1.6.0",
+    "bcryptjs": "^2.4.3",
+    "bull": "^4.11.5",
+    "cheerio": "^1.0.0-rc.12",
+    "compression": "^1.7.4",
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
+    "helmet": "^7.1.0",
+    "ioredis": "^5.3.2",
+    "joi": "^17.11.0",
+    "jsonwebtoken": "^9.0.2",
+    "lodash": "^4.17.21",
+    "moment": "^2.29.4",
+    "morgan": "^1.10.0",
+    "multer": "^1.4.5-lts.1",
+    "nodemailer": "^6.9.7",
+    "pg": "^8.11.3",
+    "pino": "^8.16.1",
+    "rate-limiter-flexible": "^3.0.8",
+    "sharp": "^0.32.6",
+    "uuid": "^9.0.1",
+    "ws": "^8.14.2"
+  },
+  "devDependencies": {
+    "@rollup/plugin-commonjs": "^25.0.7",
+    "@rollup/plugin-node-resolve": "^15.3.0",
+    "@rollup/plugin-terser": "^0.4.4",
+    "@types/node": "^20.8.10",
+    "concurrently": "^8.2.2",
+    "cross-env": "^7.0.3",
+    "eslint": "^8.53.0",
+    "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-jest": "^27.6.0",
+    "eslint-plugin-node": "^11.1.0",
+    "husky": "^8.0.3",
+    "jest": "^29.7.0",
+    "jsdoc": "^4.0.2",
+    "lint-staged": "^15.0.2",
+    "nodemon": "^3.0.1",
+    "nyc": "^15.1.0",
+    "pino-pretty": "^10.2.3",
+    "prettier": "^3.0.3",
+    "rimraf": "^6.0.1",
+    "rollup": "^4.3.0",
+    "supertest": "^6.3.3",
+    "typescript": "^5.2.2"
+  },
+  "optionalDependencies": {
+    "canvas": "^2.11.2",
+    "mongodb": "^6.2.0",
+    "sqlite3": "^5.1.6"
+  },
+  "jest": {
+    "testEnvironment": "node",
+    "extensionsToTreatAsEsm": [
+      ".mjs"
+    ],
+    "collectCoverageFrom": [
+      "src/**/*.{js,mjs}",
+      "!src/**/*.test.{js,mjs}",
+      "!src/tests/**"
+    ],
+    "coverageDirectory": "coverage",
+    "coverageReporters": [
+      "text",
+      "lcov",
+      "html"
+    ],
+    "testMatch": [
+      "**/tests/**/*.test.{js,mjs}",
+      "**/?(*.)+(spec|test).{js,mjs}"
+    ],
+    "setupFilesAfterEnv": [
+      "<rootDir>/tests/setup.js"
+    ],
+    "transform": {}
+  },
+  "eslintConfig": {
+    "extends": [
+      "eslint:recommended",
+      "prettier"
+    ],
+    "plugins": [
+      "jest",
+      "node"
+    ],
+    "env": {
+      "node": true,
+      "es2022": true,
+      "jest": true
+    },
+    "parserOptions": {
+      "ecmaVersion": 2022,
+      "sourceType": "module"
+    },
+    "rules": {
+      "no-console": "warn",
+      "no-unused-vars": [
+        "error",
+        {
+          "argsIgnorePattern": "^_"
+        }
+      ],
+      "prefer-const": "error",
+      "no-var": "error"
+    }
+  },
+  "prettier": {
+    "semi": true,
+    "trailingComma": "es5",
+    "singleQuote": true,
+    "printWidth": 100,
+    "tabWidth": 2,
+    "useTabs": false
+  },
+  "lint-staged": {
+    "*.{js,mjs}": [
+      "eslint --fix",
+      "prettier --write"
+    ],
+    "*.{json,md}": [
+      "prettier --write"
+    ]
+  },
+  "nyc": {
+    "exclude": [
+      "tests/**",
+      "coverage/**",
+      "dist/**"
+    ]
+  },
+  "config": {
+    "lucidia": {
+      "defaultPort": 8000,
+      "maxAgents": 6,
+      "monitoringInterval": 10000,
+      "supportedLogics": [
+        "binary",
+        "trinary",
+        "42-state"
+      ]
+    }
+  }
+}

--- a/services/lucidia-cognitive-system/rollup.config.mjs
+++ b/services/lucidia-cognitive-system/rollup.config.mjs
@@ -1,0 +1,15 @@
+import { nodeResolve } from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+import terser from '@rollup/plugin-terser';
+
+const prod = process.env.NODE_ENV === 'production';
+
+export default {
+  input: 'src/comprehensive-lucidia-system.js',
+  output: {
+    file: 'dist/comprehensive-lucidia-system.js',
+    format: 'esm',
+    sourcemap: true,
+  },
+  plugins: [nodeResolve({ preferBuiltins: true }), commonjs(), prod && terser()],
+};

--- a/services/lucidia-cognitive-system/scripts/benchmark.js
+++ b/services/lucidia-cognitive-system/scripts/benchmark.js
@@ -1,0 +1,5 @@
+import { performance } from 'node:perf_hooks';
+const t0 = performance.now();
+// ... run synthetic tasks
+const t1 = performance.now();
+console.log(`Benchmark finished in ${(t1 - t0).toFixed(2)}ms`);

--- a/services/lucidia-cognitive-system/scripts/monitor.js
+++ b/services/lucidia-cognitive-system/scripts/monitor.js
@@ -1,0 +1,4 @@
+import pino from 'pino';
+const log = pino();
+log.info({ ts: Date.now() }, 'Lucidia monitor tick');
+// Extend with real metrics as needed

--- a/services/lucidia-cognitive-system/src/comprehensive-lucidia-system.js
+++ b/services/lucidia-cognitive-system/src/comprehensive-lucidia-system.js
@@ -1,0 +1,29 @@
+import 'dotenv/config';
+import express from 'express';
+import helmet from 'helmet';
+import compression from 'compression';
+import morgan from 'morgan';
+import pino from 'pino';
+
+const log = pino();
+const app = express();
+
+app.use(helmet());
+app.use(compression());
+app.use(express.json({ limit: '1mb' }));
+app.use(morgan('tiny'));
+
+app.get('/health', (_req, res) => res.json({ ok: true }));
+app.get('/ready', (_req, res) => res.status(200).send('OK'));
+app.get('/live', (_req, res) => res.status(200).send('OK'));
+
+app.get('/', (_req, res) => {
+  res.json({
+    name: 'lucidia-cognitive-system',
+    status: 'online',
+    logic: ['binary', 'trinary', '42-state'],
+  });
+});
+
+const PORT = Number(process.env.PORT) || 8000;
+app.listen(PORT, () => log.info({ port: PORT }, 'Lucidia system listening'));

--- a/services/lucidia-cognitive-system/tests/setup.js
+++ b/services/lucidia-cognitive-system/tests/setup.js
@@ -1,0 +1,2 @@
+// Jest global setup
+jest.setTimeout(30000);


### PR DESCRIPTION
## Summary
- scaffold `lucidia-cognitive-system` service with express app, rollup build and docker support
- add monitoring and benchmark scripts
- wire up husky hooks for linting and tests

## Testing
- `npm test`
- `npm --prefix services/lucidia-cognitive-system test` *(fails: cross-env not found after install attempt blocked by 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b4e93e008329868af7970308b229