### PR TITLE
feat: add streaming chat with Vercel AI SDK

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,12 @@ CODEX_SSH_KEY=
 
 # Set to 1 to allow accept-new for unknown SSH host keys (dev convenience)
 CODEX_SSH_ACCEPT_NEW=0
+
+# ---- AI provider selection ----
+AI_PROVIDER=xai          # xai | openai | anthropic
+AI_MODEL=grok-2-1212     # optional; defaults set in lib/ai/models.ts
+
+# ---- Provider keys (set only what you use) ----
+GROK_API_KEY=
+OPENAI_API_KEY=
+ANTHROPIC_API_KEY=

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest } from "next/server";
+import { streamText } from "ai";
+import { getModel } from "@/lib/ai/models";
+
+export const runtime = "edge";
+
+export async function POST(req: NextRequest) {
+  const { messages = [], temperature = 0.7 } = await req.json();
+  const result = await streamText({
+    model: getModel(),
+    messages,
+    temperature,
+  });
+  return result.toDataStreamResponse();
+}

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import * as React from "react";
+import { useChat } from "ai/react";
+
+export default function ChatPage() {
+  const { messages, input, setInput, handleSubmit, isLoading } = useChat({
+    api: "/api/chat",
+    id: "default",
+  });
+
+  return (
+    <div style={{maxWidth: 840, margin: "40px auto", padding: 16}}>
+      <h1 style={{fontSize: 24, fontWeight: 700, marginBottom: 12}}>
+        Lucidia Chat
+      </h1>
+
+      <div
+        style={{
+          border: "1px solid #e5e7eb",
+          borderRadius: 12,
+          padding: 12,
+          minHeight: 360,
+          background: "#fff",
+        }}
+      >
+        {messages.length === 0 && (
+          <div style={{color: "#6b7280"}}>Ask me anything to begin…</div>
+        )}
+        {messages.map((m) => (
+          <div key={m.id} style={{marginBottom: 12}}>
+            <div style={{fontSize: 12, color: "#6b7280"}}>
+              {m.role === "user" ? "You" : "Assistant"}
+            </div>
+            <div style={{whiteSpace: "pre-wrap"}}>{m.content}</div>
+          </div>
+        ))}
+        {isLoading && (
+          <div style={{fontSize: 12, color: "#6b7280"}}>Thinking…</div>
+        )}
+      </div>
+
+      <form
+        onSubmit={handleSubmit}
+        style={{display: "flex", gap: 8, marginTop: 12}}
+      >
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Type a message…"
+          style={{
+            flex: 1,
+            padding: "10px 12px",
+            border: "1px solid #e5e7eb",
+            borderRadius: 10,
+          }}
+        />
+        <button
+          type="submit"
+          disabled={isLoading || input.trim().length === 0}
+          style={{
+            padding: "10px 14px",
+            borderRadius: 10,
+            border: "1px solid #111827",
+            background: "#111827",
+            color: "white",
+            fontWeight: 600,
+          }}
+        >
+          Send
+        </button>
+      </form>
+
+      <p style={{fontSize: 12, color: "#6b7280", marginTop: 8}}>
+        Powered by Vercel AI SDK · Streaming enabled
+      </p>
+    </div>
+  );
+}

--- a/lib/ai/models.ts
+++ b/lib/ai/models.ts
@@ -1,0 +1,28 @@
+import { xai } from "@ai-sdk/xai";
+import { openai } from "@ai-sdk/openai";
+import { anthropic } from "@ai-sdk/anthropic";
+
+/**
+ * Decide which provider & model to use from env:
+ *   AI_PROVIDER = xai | openai | anthropic
+ *   AI_MODEL    = model name (optional; defaults per provider)
+ *
+ * Required API keys (set only the one you use):
+ *   GROK_API_KEY        (for xAI)
+ *   OPENAI_API_KEY      (for OpenAI)
+ *   ANTHROPIC_API_KEY   (for Anthropic)
+ */
+export function getModel() {
+  const provider = (process.env.AI_PROVIDER || "xai").toLowerCase();
+  const modelName =
+    process.env.AI_MODEL ||
+    (provider === "openai"
+      ? "gpt-4o-mini"
+      : provider === "anthropic"
+      ? "claude-3-5-sonnet"
+      : "grok-2-1212");
+
+  if (provider === "openai") return openai(modelName);
+  if (provider === "anthropic") return anthropic(modelName);
+  return xai(modelName);
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,11 @@
   "dependencies": {
     "fast-json-stable-stringify": "^2.1.0",
     "prom-client": "^15.0.0",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "ai": "latest",
+    "@ai-sdk/xai": "latest",
+    "@ai-sdk/openai": "latest",
+    "@ai-sdk/anthropic": "latest"
   },
   "devDependencies": {
     "eslint": "^9.9.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,11 @@
     "esModuleInterop": true,
     "moduleResolution": "node",
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["*"]
+    }
   },
-  "include": ["types.d.ts", "src/**/*.ts"]
+  "include": ["types.d.ts", "src/**/*.ts", "app/**/*", "lib/**/*"]
 }


### PR DESCRIPTION
## Summary
- add edge runtime chat API using Vercel AI SDK
- configure model selection for xAI, OpenAI, or Anthropic via env vars
- create basic chat UI at /chat

## Testing
- `npx tsc -v`
- `npm run build`
- `npm run dev`
- `npm install ai @ai-sdk/xai @ai-sdk/openai @ai-sdk/anthropic` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c75ea5e0832986908a415e07e051