### PR TITLE
Add Aider integration server and UI scaffold

### DIFF
--- a/.aider.conf.yml
+++ b/.aider.conf.yml
@@ -1,0 +1,5 @@
+model: anthropic/claude-3-7-sonnet-20250219
+auto-commits: true
+dirty-commits: true
+map-tokens: 1500
+stream: true

--- a/.env.aider
+++ b/.env.aider
@@ -1,0 +1,8 @@
+# Fill the keys you actually use, then export into the process that runs Node.
+OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
+XAI_API_KEY=
+# Optional: local Ollama if used
+OLLAMA_API_BASE=http://127.0.0.1:11434
+# Aider default model override (optional)
+AIDER_MODEL=anthropic/claude-3-7-sonnet-20250219

--- a/lucidia-dev.html
+++ b/lucidia-dev.html
@@ -1,0 +1,34 @@
+<!-- FILE: /var/www/blackroad/lucidia-dev.html -->
+<!-- Aider Control Panel -->
+<section id="aider-panel" class="p-4 rounded-xl" style="border:1px solid #ddd;margin:1rem 0;">
+  <h3 style="margin:0 0 .5rem 0;">Aider: Repo-Aware Edits</h3>
+  <label>Message</label>
+  <textarea id="aider-message" rows="4" style="width:100%;margin:.25rem 0;"></textarea>
+  <label>Files (optional, space-separated)</label>
+  <input id="aider-files" placeholder="e.g., src/app.js package.json" style="width:100%;margin:.25rem 0;">
+  <div style="display:flex;gap:.5rem;margin:.5rem 0;">
+    <button id="aider-run">Edit with Aider</button>
+    <button id="aider-ask">Ask about code</button>
+  </div>
+  <pre id="aider-console" style="max-height:260px;overflow:auto;background:#f7f7f7;padding:.5rem;"></pre>
+</section>
+<script>
+(async function(){
+  const $ = (id) => document.getElementById(id);
+  async function call(mode){
+    const msg = $('aider-message').value.trim();
+    if(!msg){ alert('Enter a message.'); return; }
+    const files = $('aider-files').value.trim();
+    const body = {
+      message: msg,
+      mode,
+      files: files ? files.split(/\s+/) : []
+    };
+    const res = await fetch('/api/aider', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body) });
+    const data = await res.json();
+    $('aider-console').textContent = (data.console || JSON.stringify(data,null,2));
+  }
+  $('aider-run').onclick = () => call('code');
+  $('aider-ask').onclick = () => call('ask');
+})();
+</script>

--- a/package.json
+++ b/package.json
@@ -4,19 +4,21 @@
   "version": "0.0.0",
   "type": "module",
   "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.19.2",
     "fast-json-stable-stringify": "^2.1.0",
     "prom-client": "^15.0.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@types/node": "^20.11.30",
     "eslint": "^9.9.0",
     "eslint-config-prettier": "^9.1.0",
     "husky": "^9.1.5",
     "lint-staged": "^15.2.8",
     "prettier": "^3.3.3",
     "ts-node": "^10.9.2",
-    "typescript": "^5.5.4",
-    "@types/node": "^20.11.30"
+    "typescript": "^5.5.4"
   },
   "scripts": {
     "format": "prettier -w .",
@@ -28,7 +30,8 @@
     "test": "node tests/smoke.test.js",
     "dev": "npm --prefix sites/blackroad run dev",
     "build": "npm --prefix sites/blackroad run build",
-    "fix-anything": "node .github/tools/codex-apply.js .github/prompts/codex-fix-anything.md || true"
+    "fix-anything": "node .github/tools/codex-apply.js .github/prompts/codex-fix-anything.md || true",
+    "start": "node src/server.js"
   },
   "lint-staged": {
     "**/*.{js,mjs,cjs,html,css,md,yml,yaml,json}": [

--- a/src/routes/aider.js
+++ b/src/routes/aider.js
@@ -1,0 +1,85 @@
+/* FILE: /var/www/blackroad/src/routes/aider.js */
+import express from 'express';
+import cors from 'cors';
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import fs from 'node:fs';
+
+const router = express.Router();
+router.use(cors());
+router.use(express.json({ limit: '1mb' }));
+
+const REPO_ROOT = process.env.REPO_ROOT || '/var/www/blackroad';
+const AIDER_BIN = process.env.AIDER_BIN || 'aider'; // or absolute path if needed
+
+function resolveSafe(p) {
+  const abs = path.resolve(REPO_ROOT, p);
+  if (!abs.startsWith(path.resolve(REPO_ROOT) + path.sep) && abs !== path.resolve(REPO_ROOT)) {
+    throw new Error(`Illegal path: ${p}`);
+  }
+  return abs;
+}
+
+function run(cmd, args, options = {}) {
+  return new Promise((resolve) => {
+    const child = spawn(cmd, args, { ...options });
+    let stdout = '', stderr = '';
+    child.stdout.on('data', d => { stdout += d.toString(); });
+    child.stderr.on('data', d => { stderr += d.toString(); });
+    child.on('close', code => resolve({ code, stdout, stderr }));
+  });
+}
+
+router.post('/', async (req, res) => {
+  try {
+    const { message, files = [], model, mode } = req.body || {};
+    if (!message || typeof message !== 'string') {
+      return res.status(400).json({ status: 'error', error: 'message is required' });
+    }
+
+    // sanitize files
+    const safeFiles = [];
+    for (const f of files) {
+      const abs = resolveSafe(f);
+      if (!fs.existsSync(abs)) {
+        return res.status(400).json({ status: 'error', error: `file not found: ${f}` });
+      }
+      // store relative path for aider CLI
+      safeFiles.push(path.relative(REPO_ROOT, abs));
+    }
+
+    // Build aider args
+    const args = ['--yes', '--auto-commits', '--dirty-commits', '--message', message];
+    if (model) args.push('--model', model);
+    if (mode === 'ask') args.push('--chat-mode', 'ask'); // no edits/commits
+    args.push(...safeFiles);
+
+    // Run aider
+    const env = { ...process.env };
+    const aiderRes = await run(AIDER_BIN, args, { cwd: REPO_ROOT, env });
+
+    // If code mode, gather latest commit info (may be absent if nothing changed)
+    let commit = null, diff = null;
+    if (mode !== 'ask') {
+      const log = await run('git', ['log', '-1', '--pretty=%H%n%s'], { cwd: REPO_ROOT });
+      if (log.code === 0 && log.stdout.trim()) {
+        const [hash, title] = log.stdout.split('\n');
+        commit = { hash: (hash || '').trim(), title: (title || '').trim() };
+        const d = await run('git', ['diff', '--name-status', 'HEAD~1..HEAD'], { cwd: REPO_ROOT });
+        if (d.code === 0) diff = d.stdout;
+      }
+    }
+
+    return res.json({
+      status: aiderRes.code === 0 ? 'ok' : 'error',
+      code: aiderRes.code,
+      console: (aiderRes.stdout + '\n' + aiderRes.stderr).trim(),
+      commit,
+      diff
+    });
+  } catch (err) {
+    return res.status(500).json({ status: 'error', error: String(err?.message || err) });
+  }
+});
+
+export default router;

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,10 @@
+/* FILE: /var/www/blackroad/src/server.js */
+import express from 'express';
+import aiderRouter from './routes/aider.js';
+
+const app = express();
+app.get('/health', (_req, res) => res.json({ ok: true }));
+app.use('/api/aider', aiderRouter);
+
+const PORT = process.env.PORT || 8000;
+app.listen(PORT, () => console.log(`[server] listening on :${PORT}`));


### PR DESCRIPTION
## Summary
- add Aider CLI configuration and sample environment file
- scaffold Express server and `/api/aider` route for invoking Aider
- include basic web panel for interacting with Aider
- declare express & cors deps and start script

## Testing
- `npm test`
- `npm start` *(fails: Cannot find package 'express')*
- `curl -X POST http://127.0.0.1:8000/api/aider ...` *(fails: Couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_68a3cb8db810832996f623a71befa0b1