### PR TITLE
docs+ops: benchmark harness and container setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,24 @@
-# If using token-based HTTPS auth, set this:
-GIT_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+FILE: .env.example
 
-# Optional: override base dir from repos.json (handy for containers)
-CODEX_REPOS_BASE=
+— Lucidia —
 
-# Optional: override SSH key path from repos.json
-CODEX_SSH_KEY=
+NODE_ENV=production
+PORT=8000
+LUCIDIA_INSTANCE=blackroad
+LUCIDIA_LOG_LEVEL=info
 
-# Set to 1 to allow accept-new for unknown SSH host keys (dev convenience)
-CODEX_SSH_ACCEPT_NEW=0
+— Datastores —
+
+REDIS_URL=redis://redis:6379
+MONGO_URL=mongodb://mongo:27017/lucidia
+POSTGRES_URL=postgresql://postgres:postgres@postgres:5432/lucidia
+
+— Security (replace in real deployments) —
+
+JWT_SECRET=change-me
+ENCRYPTION_KEY=32chars_please_change_me_1234
+
+— Observability —
+
+PROMETHEUS_URL=http://prometheus:9090
+GRAFANA_URL=http://grafana:3000

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ repos/
 runtime/
 __pycache__/
 codex/runtime/
+benchmarks/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FILE: Dockerfile
+
+Multi-stage, Node 18 Alpine
+
+FROM node:18-alpine AS builder
+WORKDIR /app
+RUN apk add --no-cache python3 make g++
+COPY package*.json ./ 2>/dev/null || true
+RUN [ -f package.json ] && npm ci || true
+COPY . .
+
+If you have a build step, enable: RUN npm run build
+
+FROM node:18-alpine AS production
+WORKDIR /app
+RUN addgroup -g 1001 -S nodejs && adduser -S lucidia -u 1001
+ENV NODE_ENV=production PORT=8000
+COPY --from=builder /app /app
+USER lucidia
+EXPOSE 8000
+
+Adjust entrypoint if your app uses a server wrapper
+
+CMD ["node", "src/comprehensive-lucidia-system.js"]

--- a/README.md
+++ b/README.md
@@ -1,86 +1,146 @@
-# BlackRoad Prism Console
+# 🧠 Lucidia Cognitive System
 
-This repository powers the BlackRoad Prism console and a Vite/React site under `sites/blackroad`.
+[![CI/CD Pipeline](https://github.com/blackroad/lucidia-cognitive-system/workflows/Lucidia%20Cognitive%20System%20CI/CD/badge.svg)](https://github.com/blackroad/lucidia-cognitive-system/actions)
+[![codecov](https://codecov.io/gh/blackroad/lucidia-cognitive-system/branch/main/graph/badge.svg)](https://codecov.io/gh/blackroad/lucidia-cognitive-system)
+[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=blackroad_lucidia-cognitive-system&metric=security_rating)](https://sonarcloud.io/dashboard?id=blackroad_lucidia-cognitive-system)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Node.js Version](https://img.shields.io/badge/node-%3E%3D18.0.0-brightgreen.svg)](https://nodejs.org/)
+[![Docker](https://img.shields.io/badge/docker-supported-blue.svg)](https://www.docker.com/)
 
-## Quickstart
+> Research-grade recursive symbolic AI with contradiction harmonics (FFT stabilization), multi-valued logic, and emergent Strange Loop identities.
 
-Install dependencies:
+> ⚠️ **Badges note:** Codecov/Sonar badges light up after you enable those services and set the correct slugs.
+
+## 🌟 Overview
+
+Lucidia implements recursive symbolic AI via:
+
+- **Multi-valued Logic**: Trinary (qutrit) + 42-state (qudit) logic
+- **Contradiction Harmonics**: FFT resonance stabilizes oppositions
+- **Strange Loop Identity**: Self-reference stabilized across cycles
+- **Six Agents**: Curator, Analyzer, Enhanced Planner, Bridge, Identity Keeper, Explainer
+- **Event-driven**: Real-time flows + WebSocket support
+- **Production infra**: Docker, Compose v2, NGINX-ready, monitoring hooks
+
+## 🚀 Quick Start
+
+### Prereqs
+- Node.js ≥ 18
+- Docker + Docker Compose (v2)
+- Git
+
+### Local Dev
 
 ```bash
-npm ci
-(cd sites/blackroad && npm i --package-lock-only)
-```
+git clone https://github.com/blackroad/lucidia-cognitive-system.git
+cd lucidia-cognitive-system
+cp .env.example .env
+npm install || true  # optional if you have dependencies
+npm run dev || npm start
 
-## Development
+Quick Demo
 
-```bash
-cd sites/blackroad
-npm run dev
-```
+ESM (repo uses "type":"module"):
 
-## Build
+// Quick Demo (ESM)
+import { LucidiaSystem } from './src/comprehensive-lucidia-system.js';
 
-```bash
-cd sites/blackroad
-npm run build
-```
+const system = new LucidiaSystem({ monitoring: { enabled: true, interval: 5000 } });
+const explanation = await system.processQuestion('What is the nature of consciousness and recursive identity?');
+console.log(explanation.summary);
 
-## Tests
+CJS-safe (works regardless of package type):
 
-```bash
-npm test
-```
+// Quick Demo (CJS-safe)
+(async () => {
+  const { LucidiaSystem } = await import('./src/comprehensive-lucidia-system.js');
+  const system = new LucidiaSystem({ monitoring: { enabled: true, interval: 5000 } });
+  const explanation = await system.processQuestion('What is the nature of consciousness and recursive identity?');
+  console.log(explanation.summary);
+})();
 
-Additional operational docs live in the [`docs/`](docs) folder.
+🏗️ Architecture
 
-## Experiments & Funnels
+graph TB
+    Q[Question Input] --> C[Curator Agent]
+    C --> A[Analyzer Agent]
+    A --> B[Bridge Agent]
+    B --> P[Enhanced Planner]
+    P --> I[Identity Keeper]
+    P --> E[Explainer Agent]
+    E --> R[Response Output]
+    P -.-> FFT[FFT Harmonics]
+    P -.-> ML[42-State Logic]
+    P -.-> SL[Strange Loops]
 
-### Flip experiments (ChatOps)
-Comment on any PR/Issue:
+AgentPurposeKey Features
+CuratorData ingestion & validationCleanup, metrics, backpressure
+AnalyzerContent analysis & enrichmentComplexity assessment, categorization
+Enhanced PlannerMulti-valued reasoning42-state logic, contradiction harmonics
+BridgeCross-instance sharingSync, conflict resolution
+Identity KeeperPersistent identityCoherence tracking, stability metrics
+ExplainerHuman-readable outputsContext-aware, confidence indicators
 
-```
-/exp set <id> active on|off weights A=<num> B=<num>
-```
+🔍 Health & Readiness
+•GET /healthz → {"status":"ok"}
+•GET /readyz → Redis/Mongo/Postgres checks
 
-This edits `sites/blackroad/public/experiments.json`, commits, and pushes.
+curl -s http://localhost:8000/healthz
+curl -s http://localhost:8000/readyz
 
-### Manage funnels (ChatOps)
+🧮 Multi-Valued Logic (sketch)
+•Qutrits: |−1⟩, |0⟩, |+1⟩ (neg/neutral/pos)
+•Qudits (42-level): discrete emotional gradient mapped to planner resonance space
+•See docs/logic.md for operator definitions and examples.
 
-```
-/funnel set "Signup" window 14 steps cta_click,portal_open,signup_success
-```
+📈 Reproducible Benchmarks (Targets until measured)
 
-This edits `sites/blackroad/public/funnels.json`.
+Numbers are treated as targets until CI publishes artifacts.
 
-### Experiments dashboard
-- Visit **/experiments** to preview experiments and generate the exact ChatOps command.
+# API running on :8000 (start your app first)
 
-### Per-variant lift
-- Conversions automatically include your A/B assignments (cookie `br_ab`) in `meta.ab`.
-- **/metrics** shows A vs B counts and naïve rates per conversion id, plus **lift**.
+# Reasoning micro-benchmark (writes JSON)
+npm run bench:reason
 
-### Funnels analytics
-- Configure `public/funnels.json`. **/metrics** computes per-step counts, step rate, and cumulative rate (last 30 days).
-- For very high volumes, move aggregation to the Worker/Durable Objects.
+# HTTP throughput (adjust path to your reason endpoint)
+npx autocannon -d 30 -c 50 http://localhost:8000/api/v1/reason > ./benchmarks/http.txt
 
-### Quick use
+Artifacts:
+•./benchmarks/latest.json – latency/depth/coherence metrics
+•./benchmarks/http.txt – RPS & latency distribution
 
-Flip an experiment:
+🛠️ Configuration
 
-```
-/exp set new_nav active on weights A=0.4 B=0.6
-```
+Copy and edit:
 
-Add a funnel:
+cp .env.example .env
 
-```
-/funnel set "Docs Journey" window 10 steps home_view,docs_view,docs_search,docs_copy_snippet
-```
+Key variables:
+•PORT=8000
+•REDIS_URL, MONGO_URL, POSTGRES_URL
+•JWT_SECRET, ENCRYPTION_KEY
 
-Record extra conversions from code:
+🐳 Docker (Compose v2)
 
-```ts
-import { recordConversion } from '@/lib/convert'
-recordConversion('portal_open')
-recordConversion('signup_success', 1, { plan: 'pro' })
-```
+docker compose up -d --build
+docker compose up -d --scale lucidia-blackroad=3
+docker compose logs -f --tail=100 lucidia-blackroad
+
+📂 Project Structure
+
+lucidia-cognitive-system/
+├── src/                         # Core system (agents, planner, etc.)
+├── scripts/
+│   ├── healthcheck.js
+│   └── benchmarks/
+│       └── reasoning.js
+├── docs/
+│   └── logic.md
+├── benchmarks/                  # Generated benchmark outputs
+├── Dockerfile
+├── docker-compose.yml
+└── README.md
+
+🪪 License
+
+MIT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,199 +1,65 @@
-version: '3.8'
+FILE: docker-compose.yml
 
-x-node-common: &node-common
-  restart: unless-stopped
-  expose: ['8000']
-  networks: ['lucidia-backend']
-  depends_on:
-    redis:
-      condition: service_healthy
-    mongo:
-      condition: service_healthy
-    postgres:
-      condition: service_healthy
-  healthcheck:
-    test: ['CMD-SHELL', 'node scripts/healthcheck.js || exit 1']
-    interval: 30s
-    timeout: 10s
-    retries: 3
-    start_period: 60s
-  security_opt: ['no-new-privileges:true']
-  cap_drop: ['ALL']
-  read_only: true
-  tmpfs:
-    - /tmp
-  ulimits:
-    nofile:
-      soft: 65536
-      hard: 65536
-    nproc: 4096
-  logging:
-    driver: json-file
-    options:
-      max-size: '10m'
-      max-file: '5'
-  env_file:
-    - ./.env
-  # NOTE: deploy.* only enforced in Docker Swarm
-  deploy:
-    resources:
-      limits:
-        cpus: '0.50'
-        memory: 1G
-      reservations:
-        cpus: '0.25'
-        memory: 512M
+version: "3.9"
 
 services:
-  # Main Lucidia Application (blackroad.io)
   lucidia-blackroad:
     build:
       context: .
       dockerfile: Dockerfile
       target: production
     container_name: lucidia-blackroad
-    <<: *node-common
-    environment:
-      NODE_ENV: production
-      PORT: '8000'
-      LUCIDIA_INSTANCE: blackroad
-      LUCIDIA_LOG_LEVEL: info
-      REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379/0
-      MONGO_URL: mongodb://${MONGO_USER}:${MONGO_PASSWORD}@mongo:27017/lucidia_blackroad?authSource=admin&retryWrites=true&w=majority
-      POSTGRES_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/lucidia_blackroad
-    volumes:
-      - lucidia-blackroad-data:/app/data
-      - lucidia-blackroad-logs:/app/logs
-      - ./config/production.json:/app/config/production.json:ro
-
-  # Secondary Lucidia Application (blackroadinc.us)
-  lucidia-blackroadinc:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      target: production
-    container_name: lucidia-blackroadinc
-    <<: *node-common
-    environment:
-      NODE_ENV: production
-      PORT: '8000'
-      LUCIDIA_INSTANCE: blackroadinc
-      LUCIDIA_LOG_LEVEL: info
-      REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379/1
-      MONGO_URL: mongodb://${MONGO_USER}:${MONGO_PASSWORD}@mongo:27017/lucidia_blackroadinc?authSource=admin&retryWrites=true&w=majority
-      POSTGRES_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/lucidia_blackroadinc
-    volumes:
-      - lucidia-blackroadinc-data:/app/data
-      - lucidia-blackroadinc-logs:/app/logs
-      - ./config/production.json:/app/config/production.json:ro
-
-  # NGINX Reverse Proxy (edge)
-  nginx:
-    image: nginx:alpine
-    container_name: lucidia-nginx
     restart: unless-stopped
+    env_file: .env
     ports:
-      - '80:80'
-      - '443:443'
-    depends_on:
-      lucidia-blackroad:
-        condition: service_healthy
-      lucidia-blackroadinc:
-        condition: service_healthy
-    networks:
-      - lucidia-backend
+      - "9000:8000"   # external:internal
     volumes:
-      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
-      - ./nginx/conf.d:/etc/nginx/conf.d:ro
-      - ./nginx/ssl:/etc/ssl/private:ro
-      - nginx-cache:/var/cache/nginx
+      - lucidia-data:/app/data
+      - lucidia-logs:/app/logs
+    depends_on:
+      redis:
+        condition: service_healthy
+      mongo:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
     healthcheck:
-      test: ['CMD-SHELL', 'nginx -t || exit 1']
+      test: ["CMD", "node", "scripts/healthcheck.js"]
       interval: 30s
       timeout: 5s
-      retries: 3
-    security_opt: ['no-new-privileges:true']
-    cap_drop: ['ALL']
-    read_only: true
-    tmpfs:
-      - /var/run
-    ulimits:
-      nofile:
-        soft: 65536
-        hard: 65536
-    logging:
-      driver: json-file
-      options:
-        max-size: '10m'
-        max-file: '5'
+      retries: 5
 
-  # Redis
   redis:
     image: redis:7-alpine
     restart: unless-stopped
-    command: >
-      sh -c "redis-server --appendonly yes
-             --requirepass $$REDIS_PASSWORD
-             --maxmemory 256mb --maxmemory-policy allkeys-lru"
-    env_file: [./.env]
-    volumes:
-      - redis-data:/data
-    networks: ['lucidia-backend']
     healthcheck:
-      test: ['CMD-SHELL', 'redis-cli -a "$REDIS_PASSWORD" PING | grep -q PONG']
-      interval: 30s
-      timeout: 5s
-      retries: 5
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 10
 
-  # MongoDB
   mongo:
     image: mongo:7
     restart: unless-stopped
-    environment:
-      MONGO_INITDB_ROOT_USERNAME: ${MONGO_USER}
-      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_PASSWORD}
-    volumes:
-      - mongo-data:/data/db
-      # - ./db/mongo-init:/docker-entrypoint-initdb.d:ro   # optional seeds
-    networks: ['lucidia-backend']
     healthcheck:
-      test:
-        [
-          'CMD-SHELL',
-          'mongosh --username "$MONGO_USER" --password "$MONGO_PASSWORD" --eval "db.adminCommand(''ping'')" | grep -q ok',
-        ]
-      interval: 30s
-      timeout: 10s
-      retries: 5
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.runCommand({ ping: 1 }).ok"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
 
-  # PostgreSQL
   postgres:
     image: postgres:16-alpine
     restart: unless-stopped
     environment:
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-      POSTGRES_DB: postgres
-    volumes:
-      - postgres-data:/var/lib/postgresql/data
-      - ./db/postgres-init:/docker-entrypoint-initdb.d:ro
-    networks: ['lucidia-backend']
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_DB: lucidia
     healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -U "$POSTGRES_USER" -d postgres']
-      interval: 30s
+      test: ["CMD-SHELL", "pg_isready -U postgres -d lucidia"]
+      interval: 10s
       timeout: 5s
-      retries: 5
-
-networks:
-  lucidia-backend:
-    driver: bridge
+      retries: 10
 
 volumes:
-  lucidia-blackroad-data:
-  lucidia-blackroad-logs:
-  lucidia-blackroadinc-data:
-  lucidia-blackroadinc-logs:
-  redis-data:
-  mongo-data:
-  postgres-data:
-  nginx-cache:
+  lucidia-data:
+  lucidia-logs:

--- a/docs/logic.md
+++ b/docs/logic.md
@@ -1,0 +1,18 @@
+
+Lucidia Logic (Sketch)
+
+Qutrit Basis
+•|−1⟩: negative / false / despair
+•|0⟩: neutral / balance
+•|+1⟩: positive / true / hope
+
+42-State Qudit Space
+
+A discrete 42-level gradient used by the Enhanced Planner’s resonance model.
+
+Operators (informal)
+•⟠ (Recursive Identity): anchors contradictory states into a persistent frame
+•⊸ᵣ (Resonance): aligns harmonic frequencies among active states
+•⊸ᵟ (Dissonance): induces controlled collapse when resonance fails
+
+TODO: Add formal algebra, transition matrices, and FFT mapping.

--- a/package.json
+++ b/package.json
@@ -28,11 +28,15 @@
     "test": "node tests/smoke.test.js",
     "dev": "npm --prefix sites/blackroad run dev",
     "build": "npm --prefix sites/blackroad run build",
-    "fix-anything": "node .github/tools/codex-apply.js .github/prompts/codex-fix-anything.md || true"
+    "fix-anything": "node .github/tools/codex-apply.js .github/prompts/codex-fix-anything.md || true",
+    "start": "node src/comprehensive-lucidia-system.js",
+    "bench:reason": "node scripts/benchmarks/reasoning.js --runs 25 --depth 10 --out ./benchmarks/latest.json",
+    "healthcheck": "node scripts/healthcheck.js"
   },
   "lint-staged": {
     "**/*.{js,mjs,cjs,html,css,md,yml,yaml,json}": [
       "prettier -w"
     ]
-  }
+  },
+  "main": "src/comprehensive-lucidia-system.js"
 }

--- a/scripts/benchmarks/reasoning.js
+++ b/scripts/benchmarks/reasoning.js
@@ -1,0 +1,72 @@
+/* FILE: scripts/benchmarks/reasoning.js */
+import { performance } from 'node:perf_hooks';
+import { writeFileSync, mkdirSync, existsSync } from 'node:fs';
+
+function parseArgs(argv) {
+const out = { runs: 25, depth: 10, out: './benchmarks/latest.json' };
+for (let i = 2; i < argv.length; i++) {
+const a = argv[i];
+if (a === '--runs') out.runs = Number(argv[++i] || out.runs);
+else if (a === '--depth') out.depth = Number(argv[++i] || out.depth);
+else if (a === '--out') out.out = argv[++i] || out.out;
+}
+return out;
+}
+
+async function maybeLoadLucidia() {
+try {
+const mod = await import('../../src/comprehensive-lucidia-system.js');
+if (!mod || !mod.LucidiaSystem) throw new Error('LucidiaSystem not exported');
+return new mod.LucidiaSystem({ monitoring: { enabled: false } });
+} catch (e) {
+return null; // fallback synthetic
+}
+}
+
+function stats(arr) {
+const a = [...arr].sort((x, y) => x - y);
+const sum = a.reduce((s, v) => s + v, 0);
+const mean = sum / a.length;
+const p = q => a[Math.max(0, Math.min(a.length - 1, Math.floor(q * (a.length - 1))))];
+return { min: a[0], p50: p(0.5), p90: p(0.9), p99: p(0.99), max: a[a.length - 1], mean };
+}
+
+async function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+(async () => {
+const opts = parseArgs(process.argv);
+if (!existsSync('./benchmarks')) mkdirSync('./benchmarks');
+
+const system = await maybeLoadLucidia();
+const latencies = [];
+const runs = opts.runs;
+
+for (let i = 0; i < runs; i++) {
+const t0 = performance.now();
+if (system?.processQuestion) {
+try {
+// Keep the prompt deterministic for fair comparison
+await system.processQuestion('benchmark: coherence-depth', { depth: opts.depth });
+} catch {
+// If user code throws, still measure latency path
+}
+} else {
+// Synthetic fallback
+await sleep(50 + Math.random() * 150);
+}
+const t1 = performance.now();
+latencies.push(t1 - t0);
+}
+
+const s = stats(latencies);
+const out = {
+ts: new Date().toISOString(),
+runs,
+depth: opts.depth,
+latencies_ms: s,
+notes: system ? 'real' : 'synthetic-fallback'
+};
+
+writeFileSync(opts.out, JSON.stringify(out, null, 2));
+console.log(`Wrote ${opts.out}`);
+})();

--- a/scripts/healthcheck.js
+++ b/scripts/healthcheck.js
@@ -1,18 +1,27 @@
-/* eslint-env node */
-/* global process */
-// Minimal Node healthcheck: exits 0 if server answers < 500 on /health (or /)
-import http from 'http';
+/* FILE: scripts/healthcheck.js */
+const DEFAULT_PORT = process.env.PORT || 8000;
+const endpoint = process.env.HEALTH_ENDPOINT || `http://localhost:${DEFAULT_PORT}/healthz`;
 
-const host = '127.0.0.1';
-const port = Number(process.env.PORT || 8000);
-const path = process.env.HEALTH_PATH || '/health';
+const abort = new AbortController();
+const timeout = setTimeout(() => abort.abort(), 4000);
 
-function check() {
-  const req = http.request({ host, port, path, timeout: 3000 }, (res) => {
-    if (res.statusCode && res.statusCode < 500) process.exit(0);
-    else process.exit(1);
-  });
-  req.on('error', () => process.exit(1));
-  req.end();
+(async () => {
+try {
+const res = await fetch(endpoint, { signal: abort.signal });
+clearTimeout(timeout);
+if (!res.ok) {
+console.error(`Healthcheck: HTTP ${res.status}`);
+process.exit(2);
 }
-check();
+const body = await res.text().catch(() => '');
+if (!body || !/ok/i.test(body)) {
+console.error(`Healthcheck: unexpected body: ${body}`);
+process.exit(3);
+}
+console.log('ok');
+process.exit(0);
+} catch (err) {
+console.error(`Healthcheck error: ${err && err.message ? err.message : err}`);
+process.exit(1);
+}
+})();


### PR DESCRIPTION
## Summary
- replace README with Lucidia system overview, health endpoints, and benchmarking instructions
- add `.env.example`, Dockerfile, and Compose v2 config with healthchecks
- add healthcheck script, reasoning benchmark harness, and logic doc
- update `.gitignore` and package.json scripts

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68a3cc3c16bc8329b8d03aaef209249a