### PR TITLE
feat: add lucidia dev cursor-lite prototype

### DIFF
--- a/var/www/blackroad/lucidia-dev.html
+++ b/var/www/blackroad/lucidia-dev.html
@@ -1,0 +1,129 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Lucidia Dev — Cursor‑lite</title>
+  <style>
+    html, body { height: 100%; margin: 0; font-family: ui-sans-serif, system-ui, -apple-system; }
+    .layout { display: grid; grid-template-columns: 220px 1fr 360px; grid-template-rows: 48px 1fr 180px; height: 100%; }
+    header { grid-column: 1 / 4; display:flex; align-items:center; gap:12px; padding:8px 12px; border-bottom:1px solid #e5e7eb; }
+    #files { border-right:1px solid #e5e7eb; overflow:auto; padding:8px; }
+    #editor { position: relative; }
+    #monaco { position:absolute; inset:0; }
+    #chat { border-left:1px solid #e5e7eb; display:flex; flex-direction:column; }
+    #chatLog { flex:1; overflow:auto; padding:8px; white-space:pre-wrap; border-bottom:1px solid #e5e7eb; }
+    #chatForm { display:flex; gap:8px; padding:8px; }
+    #terminal { grid-column: 1 / 4; border-top:1px solid #e5e7eb; background:#0b1020; color:#d1d5db; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+    #termOut { height:100%; overflow:auto; padding:8px; white-space:pre-wrap; }
+    .kbd { font: 12px ui-monospace, SFMono-Regular, Menlo, monospace; border:1px solid #d1d5db; border-bottom-width:2px; padding:0 6px; border-radius:4px; }
+    .pill { border:1px solid #d1d5db; padding:2px 8px; border-radius:999px; font-size:12px; }
+    .btn { padding:8px 12px; border:1px solid #d1d5db; border-radius:8px; background:#fff; cursor:pointer; }
+    .btn:disabled { opacity:.5; cursor:not-allowed; }
+    #inlineBox { position:absolute; top:8px; right:8px; background:#fff; border:1px solid #d1d5db; border-radius:8px; padding:8px; display:none; gap:8px; }
+    #inlineBox textarea{ width:420px; height:90px; }
+  </style>
+  <script>window.MonacoEnvironment={getWorkerUrl:()=>URL.createObjectURL(new Blob([`self.MonacoEnvironment={baseUrl:'https://cdn.jsdelivr.net/npm/monaco-editor@0.49.0/min/'};importScripts('https://cdn.jsdelivr.net/npm/monaco-editor@0.49.0/min/vs/base/worker/workerMain.js');`],{type:'text/javascript'}))};</script>
+  <script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.49.0/min/vs/loader.min.js"></script>
+</head>
+<body>
+  <div class="layout">
+    <header>
+      <strong>Lucidia Dev — Cursor‑lite</strong>
+      <span class="pill">⌨︎ <span class="kbd">Ctrl/⌘+K</span> inline • <span class="kbd">Ctrl/⌘+I</span> agent</span>
+      <span id="status" class="pill">idle</span>
+    </header>
+    <aside id="files">
+      <div><strong>Files</strong></div>
+      <ul id="fileList"></ul>
+    </aside>
+    <main id="editor">
+      <div id="monaco"></div>
+      <div id="inlineBox">
+        <textarea id="inlinePrompt" placeholder="Describe the change for the selected code…"></textarea>
+        <div style="display:flex; gap:8px; align-items:center;">
+          <button id="inlineRun" class="btn">Propose patch</button>
+          <button id="inlineClose" class="btn">Close</button>
+        </div>
+      </div>
+    </main>
+    <section id="chat">
+      <div id="chatLog"></div>
+      <form id="chatForm">
+        <input id="chatInput" placeholder="Ask the agent…" style="flex:1; padding:8px;" />
+        <button class="btn" id="chatSend" type="submit">Run</button>
+      </form>
+    </section>
+    <section id="terminal"><pre id="termOut"></pre></section>
+  </div>
+
+  <script>
+    // --- Monaco boot ---
+    let editor, selectionAtInvoke=null;
+    require.config({ paths: { 'vs': 'https://cdn.jsdelivr.net/npm/monaco-editor@0.49.0/min/vs' } });
+    require(['vs/editor/editor.main'], function() {
+      editor = monaco.editor.create(document.getElementById('monaco'), {
+        value: `// Welcome to Lucidia Dev (Cursor‑lite)\n// Select some text and press Ctrl/⌘+K to draft an inline edit.\n// Press Ctrl/⌘+I to run an agent task.`,
+        language: 'typescript', automaticLayout: true, minimap: { enabled: false }
+      });
+    });
+
+    // --- UI helpers ---
+    const $ = (id)=>document.getElementById(id);
+    const status=(s)=>{ $('status').textContent=s };
+    const log=(m)=>{ const el=document.createElement('div'); el.textContent=m; $('chatLog').appendChild(el); $('chatLog').scrollTop = $('chatLog').scrollHeight; };
+
+    // --- Inline edit (Ctrl/⌘+K) ---
+    document.addEventListener('keydown', (e)=>{
+      const k = (e.ctrlKey||e.metaKey) && (e.key.toLowerCase()==='k');
+      const i = (e.ctrlKey||e.metaKey) && (e.key.toLowerCase()==='i');
+      if(!editor) return;
+      if(k){ e.preventDefault(); const sel=editor.getSelection(); selectionAtInvoke={
+          start: editor.getModel().getOffsetAt({lineNumber: sel.startLineNumber, column: sel.startColumn}),
+          end:   editor.getModel().getOffsetAt({lineNumber: sel.endLineNumber,   column: sel.endColumn  }),
+          file: 'virtual://current'
+        }; $('inlineBox').style.display='flex'; $('inlinePrompt').focus(); }
+      if(i){ e.preventDefault(); runAgentTask(($('chatInput').value||'Refactor selected code'), selectionAtInvoke); }
+    });
+    $('inlineClose').onclick=()=>{$('inlineBox').style.display='none'};
+
+    $('inlineRun').onclick=async()=>{
+      const prompt=$('inlinePrompt').value.trim(); if(!prompt) return; status('planning…');
+      const body={ prompt, selection: selectionAtInvoke, context: { buffer: editor.getValue() } };
+      const res=await fetch('/api/agent/task',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
+      const json=await res.json(); status('patch ready'); log('PLAN: '+json.plan.join(' → '));
+      if(json.patches && json.patches.length){
+        const apply=confirm(`Apply ${json.patches.length} patch(es)?`);
+        if(apply){ const applyRes=await fetch('/api/git/apply',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({patches:json.patches})});
+          const aj=await applyRes.json(); log('APPLY: '+JSON.stringify(aj)); }
+      }
+      $('inlineBox').style.display='none';
+    };
+
+    // --- Chat agent with SSE stream ---
+    $('chatForm').addEventListener('submit', async (e)=>{ e.preventDefault(); const q=$('chatInput').value.trim(); if(!q) return; $('chatInput').value=''; await streamComplete(q); });
+
+    async function streamComplete(prompt){
+      status('thinking…'); log('YOU: '+prompt);
+      const es = new EventSource(`/api/ai/complete?prompt=${encodeURIComponent(prompt)}`);
+      es.onmessage = (ev)=>{
+        try{ const d=JSON.parse(ev.data); if(d.done){ es.close(); status('idle'); return; }
+          if(d.token) log(d.token); }catch{ /* ignore */ }
+      };
+      es.onerror = ()=>{ es.close(); status('idle'); };
+    }
+
+    // --- Agent task runner (Ctrl/⌘+I shortcut) ---
+    async function runAgentTask(prompt, selection){
+      const body={ prompt, selection, context: { buffer: editor?.getValue?.() } };
+      const res=await fetch('/api/agent/task',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
+      const json=await res.json(); log('PLAN: '+json.plan.join(' → '));
+      if(json.patches?.length){
+        const apply=confirm(`Apply ${json.patches.length} patch(es)?`);
+        if(apply){ const applyRes=await fetch('/api/git/apply',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({patches:json.patches})});
+          const aj=await applyRes.json(); log('APPLY: '+JSON.stringify(aj)); }
+      }
+    }
+  </script>
+</body>
+</html>

--- a/var/www/blackroad/server/index.js
+++ b/var/www/blackroad/server/index.js
@@ -1,0 +1,19 @@
+const express = require('express');
+const cors = require('cors');
+const ai = require('./routes/ai');
+const agent = require('./routes/agent');
+const git = require('./routes/git');
+const term = require('./routes/term');
+
+const app = express();
+app.use(cors());
+app.use(express.json({ limit: '2mb' }));
+
+app.get('/api/ai/complete', ai.streamComplete); // SSE
+app.post('/api/agent/task', agent.runTask);
+app.post('/api/git/apply', git.applyPatches);
+app.post('/api/term/propose', term.propose);
+app.post('/api/term/approve', term.approve);
+
+const PORT = process.env.PORT || 9000;
+app.listen(PORT, ()=> console.log(`[lucidia-dev] server listening on :${PORT}`));

--- a/var/www/blackroad/server/lib/sse.js
+++ b/var/www/blackroad/server/lib/sse.js
@@ -1,0 +1,10 @@
+function open(res){
+  res.setHeader('Content-Type','text/event-stream');
+  res.setHeader('Cache-Control','no-cache');
+  res.setHeader('Connection','keep-alive');
+  res.flushHeaders?.();
+  const send = (obj)=>{ res.write(`data: ${JSON.stringify(obj)}\n\n`); };
+  const close = ()=> res.end();
+  return { send, close };
+}
+module.exports = { open };

--- a/var/www/blackroad/server/routes/agent.js
+++ b/var/www/blackroad/server/routes/agent.js
@@ -1,0 +1,16 @@
+// Returns a plan and a diff patch against a virtual buffer (demo)
+async function runTask(req, res){
+  const { prompt, selection } = req.body || {};
+  const plan = [
+    `Understand intent: ${String(prompt).slice(0,120)}`,
+    'Generate minimal cohesive patch',
+    'Request approval',
+    'Apply patch and verify build'
+  ];
+  const patches = [{
+    path: 'virtual://current',
+    diff: ['--- a/virtual','+++ b/virtual','@@ -1,2 +1,2 @@','-// TODO','+// Implemented: '+(prompt||'inline edit')].join('\n')+"\n"
+  }];
+  res.json({ plan, patches, commands: [] });
+}
+module.exports = { runTask };

--- a/var/www/blackroad/server/routes/ai.js
+++ b/var/www/blackroad/server/routes/ai.js
@@ -1,0 +1,11 @@
+const { open } = require('../lib/sse');
+
+async function streamComplete(req, res){
+  const prompt = String(req.query.prompt||'').slice(0, 4000);
+  const sse = open(res);
+  // TODO: Replace with real model stream. For now, stream a canned reply.
+  const demo = `Thinking about: ${prompt}\nThis is a streaming demo.`.split(' ');
+  for (const t of demo) { sse.send({ token: t+" " }); await new Promise(r=>setTimeout(r, 40)); }
+  sse.send({ done: true }); sse.close();
+}
+module.exports = { streamComplete };

--- a/var/www/blackroad/server/routes/git.js
+++ b/var/www/blackroad/server/routes/git.js
@@ -1,0 +1,8 @@
+// TODO: replace with real unified diff apply that edits files safely.
+async function applyPatches(req, res){
+  const { patches } = req.body || {};
+  if(!Array.isArray(patches)) return res.status(400).json({ error: 'patches[] required' });
+  const applied = Object.fromEntries(patches.map(p=>[p.path,'ok']));
+  res.json({ applied });
+}
+module.exports = { applyPatches };

--- a/var/www/blackroad/server/routes/term.js
+++ b/var/www/blackroad/server/routes/term.js
@@ -1,0 +1,20 @@
+const queue = new Map();
+
+async function propose(req, res){
+  const { cmd, cwd } = req.body || {};
+  if(!cmd) return res.status(400).json({ error: 'cmd required' });
+  const id = Math.random().toString(36).slice(2);
+  queue.set(id, { cmd, cwd: cwd||process.cwd() });
+  res.json({ proposalId: id, cmd });
+}
+
+async function approve(req, res){
+  const { proposalId } = req.body || {};
+  const item = queue.get(proposalId);
+  if(!item) return res.status(404).json({ error: 'not found' });
+  queue.delete(proposalId);
+  // SECURITY: In first pass, do NOT execute. Return a dry-run response.
+  res.json({ output: `DRY RUN — would execute: ${item.cmd} (cwd=${item.cwd})`, exitCode: 0 });
+}
+
+module.exports = { propose, approve };


### PR DESCRIPTION
## Summary
- scaffold single-file Lucidia Dev UI with Monaco editor, inline edits, chat panel, and terminal pane
- add Express server skeleton with SSE helper and stub routes for AI, agent, git, and terminal operations

## Testing
- `node var/www/blackroad/server/index.js` *(fails: ReferenceError require is not defined)*
- `npm install express cors --no-save` *(fails: 403 Forbidden accessing registry)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c55b447c83298b144454f0b3f2fd