### PR TITLE
chore(ci): refine deploy job notifications

### DIFF
--- a/.github/workflows/lucidia-ci.yml
+++ b/.github/workflows/lucidia-ci.yml
@@ -299,7 +299,7 @@ jobs:
           sleep 60
           npm run test:smoke -- --baseUrl=https://staging.blackroad.io
       - name: Notify Slack
-        if: always()
+        if: failure()
         uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}
@@ -342,11 +342,12 @@ jobs:
           curl -f https://blackroad.io/health
           curl -f https://blackroadinc.us/health
       - name: Notify Slack
+        if: always()
         uses: 8398a7/action-slack@v3
         with:
-          status: success
+          status: ${{ job.status }}
           channel: '#deployments'
-          text: '🚀 Lucidia deployed to production!'
+          text: 'Lucidia production deploy ${{ job.status }}'
           webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   # ---------- Scheduled Security Scan ----------


### PR DESCRIPTION
## Summary
- reduce noise by notifying Slack on staging deploy failures only
- report actual status for production deploy notifications

## Testing
- `npm test`
- `pre-commit run --files .github/workflows/lucidia-ci.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3d22b93b48329b48f365c567ea3c1