### PR TITLE
feat: add macOS droplet manager skeleton with security tooling

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,4 @@
 /services/            @blackboxprogramming
 /**/*.py              @blackboxprogramming
 /**/*.ts              @blackboxprogramming
+/droplet-manager-macos/ @blackboxprogramming

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   analyze:
     runs-on: ubuntu-latest
-    strategy: { language: [ 'javascript', 'python' ] }
+    strategy: { language: [ 'javascript', 'python', 'cpp' ] }
     steps:
       - uses: actions/checkout@v4
       - uses: github/codeql-action/init@v3

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,15 @@
+name: gitleaks
+on:
+  push:
+    paths: ["droplet-manager-macos/**"]
+  pull_request:
+    paths: ["droplet-manager-macos/**"]
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gitleaks/gitleaks-action@v2
+        with:
+          config: .gitleaks.toml

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -1,0 +1,33 @@
+name: macOS build
+on:
+  push:
+    paths: ["droplet-manager-macos/**"]
+  pull_request:
+    paths: ["droplet-manager-macos/**"]
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build
+        run: xcodebuild -scheme DropletManager -configuration Release build
+      - name: Archive
+        run: |
+          mkdir -p artifacts
+          cp -R build/Release/DropletManager.app artifacts/
+      - name: Codesign (optional)
+        if: env.CODESIGN_IDENTITY != ''
+        run: codesign --force --deep --sign "$CODESIGN_IDENTITY" artifacts/DropletManager.app
+      - name: SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          path: artifacts
+          format: cyclonedx-json
+          artifact-name: droplet-manager-sbom
+      # TODO: Integrate Sparkle for auto-updates when signing keys are ready
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: droplet-manager
+          path: artifacts

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,7 @@ repos:
       - id: eslint
         args: ["--fix"]
         files: "\\.(js|jsx|ts|tsx)$"
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.18.1
+    hooks:
+      - id: gitleaks

--- a/droplet-manager-macos/.editorconfig
+++ b/droplet-manager-macos/.editorconfig
@@ -1,0 +1,12 @@
+root = false
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.{m,h}]
+indent_size = 2

--- a/droplet-manager-macos/.gitignore
+++ b/droplet-manager-macos/.gitignore
@@ -1,0 +1,6 @@
+# Xcode
+build/
+DerivedData/
+*.xcuserstate
+*.xcworkspace
+xcuserdata/

--- a/droplet-manager-macos/CONTRIBUTING.md
+++ b/droplet-manager-macos/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Contributing
+
+We welcome pull requests via GitHub.
+
+* Follow [Conventional Commits](https://www.conventionalcommits.org/).
+* Run `pre-commit run --files <files>` before submitting.
+* Ensure tests pass with `xcodebuild test`.

--- a/droplet-manager-macos/LICENSE
+++ b/droplet-manager-macos/LICENSE
@@ -1,0 +1,17 @@
+GNU GENERAL PUBLIC LICENSE
+Version 3, 29 June 2007
+
+Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/droplet-manager-macos/NOTICE
+++ b/droplet-manager-macos/NOTICE
@@ -1,0 +1,7 @@
+Droplet Manager for macOS
+Copyright (C) 2013 DODropletManager contributors
+
+This is a modified version maintained by BlackRoad.
+Upstream project: https://github.com/deivuh/DODropletManager-OSX
+Modifications include migration to DigitalOcean API v2, security hardening,
+and build tooling updates.

--- a/droplet-manager-macos/README.md
+++ b/droplet-manager-macos/README.md
@@ -1,0 +1,27 @@
+# Droplet Manager for macOS
+
+> **Note**: This is a community-maintained fork of the legacy
+> DODropletManager-OSX project. The original v1 API client is preserved
+> under the `legacy` branch. New development targets DigitalOcean API v2.
+
+## DigitalOcean Token
+
+Create a Personal Access Token with read and write scopes from your
+[DigitalOcean control panel](https://cloud.digitalocean.com/account/api/tokens).
+The app stores the token securely in your macOS Keychain. No token values
+are written to disk.
+
+## Privacy & Security
+
+* OAuth tokens are kept in the user's login Keychain.
+* API communication uses `NSURLSession` with TLS.
+* Secrets are scanned using [gitleaks](https://github.com/gitleaks/gitleaks).
+
+## Links
+
+* [DigitalOcean API v2 documentation](https://docs.digitalocean.com/reference/api/api-reference/)
+* [DigitalOcean OAuth overview](https://docs.digitalocean.com/reference/api/oauth/)
+
+## Screenshots
+
+Screenshots of the application will be added in a future update.

--- a/droplet-manager-macos/RELEASE.md
+++ b/droplet-manager-macos/RELEASE.md
@@ -1,0 +1,8 @@
+# Release 0.6.0 Checklist
+
+1. Ensure `CODESIGN_IDENTITY` and notarization credentials are configured.
+2. Run the macOS build workflow which produces a signed `.app` and SBOM.
+3. Zip the artifact and create a GitHub Release tagged `v0.6.0`.
+4. Attach the `.zip` and SBOM to the release.
+5. (Optional) Notarize the app using `xcrun notarytool`.
+6. Update the Homebrew cask with the new version and sha256.

--- a/droplet-manager-macos/SECURITY.md
+++ b/droplet-manager-macos/SECURITY.md
@@ -1,0 +1,6 @@
+# Security Policy
+
+If you discover a security issue, please disclose it responsibly by
+emailing security@blackroad.dev or via GitHub Security Advisories.
+
+This project runs automated scans with CodeQL and gitleaks.

--- a/droplet-manager-macos/Sources/DOClient.h
+++ b/droplet-manager-macos/Sources/DOClient.h
@@ -1,0 +1,10 @@
+#import <Foundation/Foundation.h>
+#import "TokenStore.h"
+
+typedef void (^DOClientCompletion)(NSData *data, NSURLResponse *response, NSError *error);
+
+@interface DOClient : NSObject
+- (instancetype)initWithTokenStore:(id<TokenStore>)store;
+- (void)listDropletsWithCompletion:(DOClientCompletion)completion;
+- (void)performAction:(NSString *)action dropletID:(NSNumber *)dropletID completion:(DOClientCompletion)completion;
+@end

--- a/droplet-manager-macos/Sources/DOClient.m
+++ b/droplet-manager-macos/Sources/DOClient.m
@@ -1,0 +1,40 @@
+#import "DOClient.h"
+
+@interface DOClient ()
+@property (nonatomic, strong) id<TokenStore> store;
+@end
+
+@implementation DOClient
+
+- (instancetype)initWithTokenStore:(id<TokenStore>)store {
+  if (self = [super init]) {
+    _store = store;
+  }
+  return self;
+}
+
+- (NSMutableURLRequest *)requestWithPath:(NSString *)path method:(NSString *)method {
+  NSString *token = [self.store readToken];
+  NSURL *url = [NSURL URLWithString:[@"https://api.digitalocean.com" stringByAppendingString:path]];
+  NSMutableURLRequest *req = [NSMutableURLRequest requestWithURL:url];
+  req.HTTPMethod = method;
+  [req setValue:[NSString stringWithFormat:@"Bearer %@", token] forHTTPHeaderField:@"Authorization"];
+  [req setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
+  return req;
+}
+
+- (void)listDropletsWithCompletion:(DOClientCompletion)completion {
+  NSURLRequest *req = [self requestWithPath:@"/v2/droplets" method:@"GET"];
+  [[[NSURLSession sharedSession] dataTaskWithRequest:req completionHandler:completion] resume];
+}
+
+- (void)performAction:(NSString *)action dropletID:(NSNumber *)dropletID completion:(DOClientCompletion)completion {
+  NSString *path = [NSString stringWithFormat:@"/v2/droplets/%@/actions", dropletID];
+  NSMutableURLRequest *req = [self requestWithPath:path method:@"POST"];
+  NSDictionary *body = @{@"type": action};
+  req.HTTPBody = [NSJSONSerialization dataWithJSONObject:body options:0 error:nil];
+  // TODO: Add rate-limit backoff and detailed error handling
+  [[[NSURLSession sharedSession] dataTaskWithRequest:req completionHandler:completion] resume];
+}
+
+@end

--- a/droplet-manager-macos/Sources/Models/Action.h
+++ b/droplet-manager-macos/Sources/Models/Action.h
@@ -1,0 +1,5 @@
+#import <Foundation/Foundation.h>
+
+@interface Action : NSObject
+@property (nonatomic, copy) NSString *type;
+@end

--- a/droplet-manager-macos/Sources/Models/Action.m
+++ b/droplet-manager-macos/Sources/Models/Action.m
@@ -1,0 +1,4 @@
+#import "Action.h"
+
+@implementation Action
+@end

--- a/droplet-manager-macos/Sources/Models/Droplet.h
+++ b/droplet-manager-macos/Sources/Models/Droplet.h
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+
+@interface Droplet : NSObject
+@property (nonatomic, strong) NSNumber *identifier;
+@property (nonatomic, copy) NSString *name;
+@property (nonatomic, copy) NSString *ipAddress;
+@end

--- a/droplet-manager-macos/Sources/Models/Droplet.m
+++ b/droplet-manager-macos/Sources/Models/Droplet.m
@@ -1,0 +1,4 @@
+#import "Droplet.h"
+
+@implementation Droplet
+@end

--- a/droplet-manager-macos/Sources/TokenStore.h
+++ b/droplet-manager-macos/Sources/TokenStore.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+@protocol TokenStore <NSObject>
+- (NSString *)readToken;
+- (BOOL)saveToken:(NSString *)token;
+@end
+
+@interface KeychainTokenStore : NSObject <TokenStore>
+@end

--- a/droplet-manager-macos/Sources/TokenStore.m
+++ b/droplet-manager-macos/Sources/TokenStore.m
@@ -1,0 +1,33 @@
+#import "TokenStore.h"
+#import <Security/Security.h>
+
+static NSString *const kService = @"droplet-manager-token";
+
+@implementation KeychainTokenStore
+
+- (NSString *)readToken {
+  NSDictionary *query = @{(__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
+                          (__bridge id)kSecAttrService: kService,
+                          (__bridge id)kSecReturnData: @YES};
+  CFTypeRef data = NULL;
+  OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, &data);
+  if (status != errSecSuccess) {
+    return nil;
+  }
+  NSData *result = (__bridge_transfer NSData *)data;
+  return [[NSString alloc] initWithData:result encoding:NSUTF8StringEncoding];
+}
+
+- (BOOL)saveToken:(NSString *)token {
+  NSData *data = [token dataUsingEncoding:NSUTF8StringEncoding];
+  NSDictionary *query = @{(__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
+                          (__bridge id)kSecAttrService: kService};
+  SecItemDelete((__bridge CFDictionaryRef)query);
+  NSDictionary *attributes = @{(__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
+                               (__bridge id)kSecAttrService: kService,
+                               (__bridge id)kSecValueData: data};
+  OSStatus status = SecItemAdd((__bridge CFDictionaryRef)attributes, NULL);
+  return status == errSecSuccess;
+}
+
+@end

--- a/droplet-manager-macos/Tests/DOClientTests.m
+++ b/droplet-manager-macos/Tests/DOClientTests.m
@@ -1,0 +1,24 @@
+#import <XCTest/XCTest.h>
+#import "DOClient.h"
+
+@interface DOClient (Testing)
+- (NSMutableURLRequest *)requestWithPath:(NSString *)path method:(NSString *)method;
+@end
+
+@interface MockTokenStore : NSObject <TokenStore>
+@end
+@implementation MockTokenStore
+- (NSString *)readToken { return @"abc"; }
+- (BOOL)saveToken:(NSString *)token { return YES; }
+@end
+
+@interface DOClientTests : XCTestCase
+@end
+
+@implementation DOClientTests
+- (void)testAuthorizationHeader {
+  DOClient *client = [[DOClient alloc] initWithTokenStore:[MockTokenStore new]];
+  NSMutableURLRequest *req = [client requestWithPath:@"/v2/droplets" method:@"GET"];
+  XCTAssertEqualObjects([req valueForHTTPHeaderField:@"Authorization"], @"Bearer abc");
+}
+@end

--- a/droplet-manager-macos/Tests/TokenStoreTests.m
+++ b/droplet-manager-macos/Tests/TokenStoreTests.m
@@ -1,0 +1,13 @@
+#import <XCTest/XCTest.h>
+#import "TokenStore.h"
+
+@interface TokenStoreTests : XCTestCase
+@end
+
+@implementation TokenStoreTests
+- (void)testSaveAndReadToken {
+  KeychainTokenStore *store = [KeychainTokenStore new];
+  XCTAssertTrue([store saveToken:@"xyz"]);
+  XCTAssertEqualObjects([store readToken], @"xyz");
+}
+@end

--- a/droplet-manager-macos/Tests/UISmokeTests.m
+++ b/droplet-manager-macos/Tests/UISmokeTests.m
@@ -1,0 +1,10 @@
+#import <XCTest/XCTest.h>
+
+@interface UISmokeTests : XCTestCase
+@end
+
+@implementation UISmokeTests
+- (void)testLoadListView {
+  XCTAssertTrue(YES); // placeholder for UI test fixture
+}
+@end

--- a/droplet-manager-macos/packaging/Homebrew/droplet-manager-macos.rb
+++ b/droplet-manager-macos/packaging/Homebrew/droplet-manager-macos.rb
@@ -1,0 +1,12 @@
+cask "droplet-manager-macos" do
+  version "0.6.0"
+  sha256 :no_check
+
+  url "https://github.com/blackroad/droplet-manager-macos/releases/download/v#{version}/DropletManager.zip"
+  name "Droplet Manager"
+  desc "Manage DigitalOcean droplets from macOS"
+  homepage "https://github.com/blackroad/droplet-manager-macos"
+
+  app "DropletManager.app"
+  # appcast "https://github.com/blackroad/droplet-manager-macos/releases.atom" # TODO: enable when stable
+end


### PR DESCRIPTION
## Summary
- scaffold GPL-licensed droplet manager for macOS with keychain token storage and API v2 client
- add macOS build workflow, gitleaks scanning, and CodeQL cpp coverage
- document contribution guidelines, security policy, and release checklist

## Testing
- `pre-commit run --files .github/workflows/codeql.yml .pre-commit-config.yaml .github/CODEOWNERS .github/workflows/gitleaks.yml .github/workflows/macos-build.yml droplet-manager-macos/README.md droplet-manager-macos/CONTRIBUTING.md droplet-manager-macos/SECURITY.md droplet-manager-macos/NOTICE droplet-manager-macos/LICENSE droplet-manager-macos/.gitignore droplet-manager-macos/.editorconfig droplet-manager-macos/RELEASE.md droplet-manager-macos/Sources/TokenStore.h droplet-manager-macos/Sources/TokenStore.m droplet-manager-macos/Sources/DOClient.h droplet-manager-macos/Sources/DOClient.m droplet-manager-macos/Sources/Models/Droplet.h droplet-manager-macos/Sources/Models/Droplet.m droplet-manager-macos/Sources/Models/Action.h droplet-manager-macos/Sources/Models/Action.m droplet-manager-macos/Tests/DOClientTests.m droplet-manager-macos/Tests/TokenStoreTests.m droplet-manager-macos/Tests/UISmokeTests.m droplet-manager-macos/packaging/Homebrew/droplet-manager-macos.rb` (fails: command not found)
- `xcodebuild test` (fails: command not found)
- `gitleaks detect --no-git` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a3d0d532748329990c15cc10ca5ab5