### PR TITLE
Add local HumanEval harness

### DIFF
--- a/opt/blackroad/lucidia/evals/humaneval/Dockerfile
+++ b/opt/blackroad/lucidia/evals/humaneval/Dockerfile
@@ -1,0 +1,27 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+# minimal hardening + tools
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git ca-certificates build-essential curl tini && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# copy our harness first
+COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# bring in HumanEval repo (local mirror path overridable)
+ARG HUMANEVAL_REPO=https://github.com/openai/human-eval
+RUN git clone --depth=1 "$HUMANEVAL_REPO" /app/third_party/human-eval && \
+    pip install --no-cache-dir -e /app/third_party/human-eval
+
+# copy the rest
+COPY . /app
+
+# default run: generate samples (ollama) then score
+ENTRYPOINT ["/usr/bin/tini","--"]
+CMD ["bash","-lc","python run_eval.py --config configs/ollama.yaml && evaluate_functional_correctness outputs/latest.samples.jsonl"]

--- a/opt/blackroad/lucidia/evals/humaneval/Makefile
+++ b/opt/blackroad/lucidia/evals/humaneval/Makefile
@@ -1,0 +1,50 @@
+VENV := .venv
+PY := $(VENV)/bin/python
+PIP := $(VENV)/bin/pip
+
+all: help
+
+help:
+@echo "Targets:"
+@echo "  make init            # venv + clone human-eval + install"
+@echo "  make eval-ollama     # generate + score (Ollama)"
+@echo "  make eval-llamacpp   # generate + score (llama.cpp server)"
+@echo "  make eval-hf         # generate + score (offline transformers)"
+@echo "  make docker-build    # build sandboxed image"
+@echo "  make docker-eval     # run eval inside Docker (no network)"
+
+init: $(VENV)/bin/activate third_party/human-eval/.git
+$(PIP) install -r requirements.txt
+$(PIP) install -e third_party/human-eval
+
+$(VENV)/bin/activate:
+python3 -m venv $(VENV)
+
+third_party/human-eval/.git:
+mkdir -p third_party
+git clone --depth=1 https://github.com/openai/human-eval third_party/human-eval
+
+eval-ollama:
+$(PY) run_eval.py --config configs/ollama.yaml
+evaluate_functional_correctness outputs/latest.samples.jsonl
+
+eval-llamacpp:
+$(PY) run_eval.py --config configs/llamacpp.yaml
+evaluate_functional_correctness outputs/latest.samples.jsonl
+
+eval-hf:
+$(PY) run_eval.py --config configs/transformers.yaml
+evaluate_functional_correctness outputs/latest.samples.jsonl
+
+docker-build:
+docker build -t blackroad/humaneval:local .
+
+# run in a strict sandbox: no network, memory + PID caps, read-only FS
+docker-eval:
+docker run --rm -it \
+  --network=none --pids-limit=128 -m 2g --cpus=1.0 \
+  --read-only --tmpfs /tmp:rw,noexec,nosuid,size=256m \
+  -v $$(pwd):/app -w /app blackroad/humaneval:local
+
+clean:
+rm -rf $(VENV) outputs/*.jsonl outputs/*.json outputs/*.txt || true

--- a/opt/blackroad/lucidia/evals/humaneval/README.md
+++ b/opt/blackroad/lucidia/evals/humaneval/README.md
@@ -1,0 +1,36 @@
+# HumanEval for BlackRoad/Lucidia (No-Cloud)
+
+This harness generates HumanEval completions using ONLY local models (Ollama / llama.cpp / offline Transformers), then scores with the HumanEval evaluator.
+
+## Security
+HumanEval executes **untrusted** model code during scoring. Always run in the provided Docker sandbox (`make docker-build && make docker-eval`) or inside your own jail (no net, resource caps).
+
+## Use
+
+```bash
+make init
+# pick one:
+make eval-ollama
+make eval-llamacpp
+make eval-hf
+
+Configure your model in configs/*.yaml. Results:
+•Samples → outputs/latest.samples.jsonl
+•CLI prints pass@k. For finer control, use evaluate_functional_correctness --help.
+
+Notes
+•The prompt template prompts/codex_prompt.txt is tuned for Codex Infinity: body-only output, zero chatter.
+•For deterministic runs set temperature: 0.0 and increase n_samples_per_task for pass@k.
+
+---
+
+## What you’ve got
+
+- **End-to-end local pipeline** for HumanEval with **Ollama**, **llama.cpp server**, or **offline Transformers** (no OpenAI calls).
+- **Sandboxed Docker** run mode (no network, PID/mem caps).
+- **Codex Infinity prompt** that machines respect: body-only, zero prose, passes to the harness cleanly.
+
+If you want, I can add:
+- a **vLLM** backend (OpenAI-*compatible* local server, still no OpenAI),  
+- a **results dashboard** (tiny HTML that parses `evaluate_functional_correctness` output), or  
+- a **Lucidia agent hook** so your Codex agent logs contradictions and pass@k deltas directly into your Ψ′ logs.

--- a/opt/blackroad/lucidia/evals/humaneval/backends/__init__.py
+++ b/opt/blackroad/lucidia/evals/humaneval/backends/__init__.py
@@ -1,0 +1,21 @@
+from typing import Dict, Any
+from .ollama_backend import OllamaBackend
+from .llamacpp_backend import LlamaCppBackend
+
+try:
+    from .transformers_backend import TransformersBackend
+    HAS_HF = True
+except Exception:
+    HAS_HF = False
+
+def make_backend(name: str, params: Dict[str, Any]):
+    name = name.lower()
+    if name == "ollama":
+        return OllamaBackend(**params)
+    if name == "llamacpp":
+        return LlamaCppBackend(**params)
+    if name == "transformers":
+        if not HAS_HF:
+            raise RuntimeError("Transformers backend requested but transformers/torch not installed.")
+        return TransformersBackend(**params)
+    raise ValueError(f"Unknown backend: {name}")

--- a/opt/blackroad/lucidia/evals/humaneval/backends/llamacpp_backend.py
+++ b/opt/blackroad/lucidia/evals/humaneval/backends/llamacpp_backend.py
@@ -1,0 +1,26 @@
+import requests
+from typing import List, Optional
+
+class LlamaCppBackend:
+    def __init__(self, host: str="http://localhost:8080",
+                 timeout_s: int=60, max_tokens: int=256, temperature: float=0.2, top_p: float=0.95,
+                 stop: Optional[List[str]]=None):
+        self.host = host.rstrip("/")
+        self.timeout_s = timeout_s
+        self.default = dict(max_tokens=max_tokens, temperature=temperature, top_p=top_p, stop=stop or [])
+
+    def generate(self, prompt: str, max_tokens: int, temperature: float, top_p: float, stop, timeout_s: int) -> str:
+        # llama.cpp server /completion API
+        payload = {
+            "prompt": prompt,
+            "n_predict": max_tokens,
+            "temperature": temperature,
+            "top_p": top_p,
+            "stop": stop or [],
+            "stream": False
+        }
+        r = requests.post(f"{self.host}/completion", json=payload, timeout=timeout_s)
+        r.raise_for_status()
+        data = r.json()
+        # The server may return either {"content": "..."} or {"completion": "..."} depending on build
+        return data.get("content") or data.get("completion") or ""

--- a/opt/blackroad/lucidia/evals/humaneval/backends/ollama_backend.py
+++ b/opt/blackroad/lucidia/evals/humaneval/backends/ollama_backend.py
@@ -1,0 +1,28 @@
+import requests, json
+from typing import List, Optional
+
+class OllamaBackend:
+    def __init__(self, host: str="http://localhost:11434", model: str="codellama:7b-instruct-q4_K_M",
+                 timeout_s: int=60, max_tokens: int=256, temperature: float=0.2, top_p: float=0.95,
+                 stop: Optional[List[str]]=None):
+        self.host = host.rstrip("/")
+        self.model = model
+        self.timeout_s = timeout_s
+        self.default = dict(max_tokens=max_tokens, temperature=temperature, top_p=top_p, stop=stop or [])
+
+    def generate(self, prompt: str, max_tokens: int, temperature: float, top_p: float, stop, timeout_s: int) -> str:
+        payload = {
+            "model": self.model,
+            "prompt": prompt,
+            "stream": False,
+            "options": {
+                "num_predict": max_tokens,
+                "temperature": temperature,
+                "top_p": top_p,
+                "stop": stop or []
+            }
+        }
+        r = requests.post(f"{self.host}/api/generate", json=payload, timeout=timeout_s)
+        r.raise_for_status()
+        data = r.json()
+        return data.get("response", "")

--- a/opt/blackroad/lucidia/evals/humaneval/backends/transformers_backend.py
+++ b/opt/blackroad/lucidia/evals/humaneval/backends/transformers_backend.py
@@ -1,0 +1,29 @@
+from typing import List, Optional
+from transformers import AutoTokenizer, AutoModelForCausalLM, pipeline
+
+class TransformersBackend:
+    def __init__(self, model_name_or_path: str, device: str="auto",
+                 max_tokens: int=256, temperature: float=0.2, top_p: float=0.95,
+                 stop: Optional[List[str]]=None):
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name_or_path, local_files_only=True)
+        self.model = AutoModelForCausalLM.from_pretrained(model_name_or_path, local_files_only=True)
+        self.pipe = pipeline("text-generation", model=self.model, tokenizer=self.tokenizer, device_map=device)
+        self.stop = stop or []
+        self.def_max_tokens = max_tokens
+        self.def_temp = temperature
+        self.def_top_p = top_p
+
+    def _apply_stops(self, text: str) -> str:
+        for s in self.stop:
+            idx = text.find(s)
+            if idx != -1:
+                text = text[:idx]
+        return text
+
+    def generate(self, prompt: str, max_tokens: int, temperature: float, top_p: float, stop, timeout_s: int) -> str:
+        gen = self.pipe(prompt, do_sample=(temperature>0), temperature=temperature, top_p=top_p,
+                        max_new_tokens=max_tokens, num_return_sequences=1)[0]["generated_text"]
+        # strip the prompt prefix
+        if gen.startswith(prompt):
+            gen = gen[len(prompt):]
+        return self._apply_stops(gen)

--- a/opt/blackroad/lucidia/evals/humaneval/configs/llamacpp.yaml
+++ b/opt/blackroad/lucidia/evals/humaneval/configs/llamacpp.yaml
@@ -1,0 +1,16 @@
+name: "lucidia-llamacpp"
+backend: "llamacpp"
+backend_params:
+  host: "http://localhost:8080"  # llama.cpp server /completion endpoint
+  timeout_s: 60
+  max_tokens: 256
+  temperature: 0.2
+  top_p: 0.95
+  stop: ["\n\n\n", "\n# End", "\nif __name__ == '__main__':"]
+sampling:
+  n_samples_per_task: 20
+  tasks: "all"
+prompt:
+  template_path: "prompts/codex_prompt.txt"
+paths:
+  output_dir: "outputs"

--- a/opt/blackroad/lucidia/evals/humaneval/configs/ollama.yaml
+++ b/opt/blackroad/lucidia/evals/humaneval/configs/ollama.yaml
@@ -1,0 +1,17 @@
+name: "lucidia-ollama"
+backend: "ollama"
+backend_params:
+  host: "http://localhost:11434"
+  model: "codellama:7b-instruct-q4_K_M"   # <-- set your local Ollama model tag
+  timeout_s: 60
+  max_tokens: 256
+  temperature: 0.2
+  top_p: 0.95
+  stop: ["\n\n\n", "\n# End", "\nif __name__ == '__main__':"]
+sampling:
+  n_samples_per_task: 20
+  tasks: "all"      # or list: ["HumanEval/0","HumanEval/1",...]
+prompt:
+  template_path: "prompts/codex_prompt.txt"
+paths:
+  output_dir: "outputs"

--- a/opt/blackroad/lucidia/evals/humaneval/configs/transformers.yaml
+++ b/opt/blackroad/lucidia/evals/humaneval/configs/transformers.yaml
@@ -1,0 +1,16 @@
+name: "lucidia-hf-offline"
+backend: "transformers"
+backend_params:
+  model_name_or_path: "/models/CodeLlama-7b-Instruct"  # local path only
+  device: "auto"
+  max_tokens: 256
+  temperature: 0.2
+  top_p: 0.95
+  stop: ["\n\n\n", "\n# End", "\nif __name__ == '__main__':"]
+sampling:
+  n_samples_per_task: 10
+  tasks: "all"
+prompt:
+  template_path: "prompts/codex_prompt.txt"
+paths:
+  output_dir: "outputs"

--- a/opt/blackroad/lucidia/evals/humaneval/prompts/codex_prompt.txt
+++ b/opt/blackroad/lucidia/evals/humaneval/prompts/codex_prompt.txt
@@ -1,0 +1,14 @@
+You are Codex Infinity inside Lucidia (BlackRoad). Produce **only Python code** that completes the provided function.
+Rules (hard):
+1) Do NOT add imports, prints, tests, or explanations.
+2) Do NOT repeat the `def ...:` line; write only the indented function body.
+3) Use pure Python and built-ins; deterministic; O(seconds) runtime; no I/O, no randomness.
+4) Cover edge cases; return the result; no global state.
+5) Output must contain ONLY code lines (no backticks, no prose).
+
+Task: Complete this Python function so that all hidden unit tests pass.
+
+# BEGIN STUB
+{prompt}
+
+# YOUR OUTPUT MUST START ON THE NEXT LINE, INDENTED BY 4 SPACES

--- a/opt/blackroad/lucidia/evals/humaneval/requirements.txt
+++ b/opt/blackroad/lucidia/evals/humaneval/requirements.txt
@@ -1,0 +1,7 @@
+pyyaml>=6.0.1
+tqdm>=4.66.4
+requests>=2.32.3
+regex>=2024.5.15
+# Optional for offline HF backend; install only if you plan to use eval-hf
+# transformers>=4.42.0
+# torch>=2.3.0

--- a/opt/blackroad/lucidia/evals/humaneval/run_eval.py
+++ b/opt/blackroad/lucidia/evals/humaneval/run_eval.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+import argparse, os, json, time, sys, subprocess, regex as re
+from pathlib import Path
+from typing import Dict, Any, Iterable, List
+import yaml
+from tqdm import tqdm
+
+# HumanEval local import (installed via -e third_party/human-eval)
+from human_eval.data import read_problems  # type: ignore
+
+from utils import load_prompt_template, ensure_dir, now_stamp
+from backends import make_backend
+
+def build_prompt(template: str, problem: Dict[str, Any]) -> str:
+    # HumanEval problem has key 'prompt' which contains the stub + docstring.
+    return template.format(prompt=problem["prompt"])
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--config", required=True, help="Path to YAML config")
+    args = ap.parse_args()
+
+    with open(args.config, "r") as f:
+        cfg = yaml.safe_load(f)
+
+    out_dir = Path(cfg["paths"]["output_dir"])
+    ensure_dir(out_dir)
+
+    # prepare backend
+    backend = make_backend(cfg["backend"], cfg.get("backend_params", {}))
+
+    # load prompt template
+    template = load_prompt_template(Path(cfg["prompt"]["template_path"]))
+
+    # load problems
+    problems = read_problems()
+    task_ids = list(problems.keys()) if cfg["sampling"]["tasks"] == "all" else cfg["sampling"]["tasks"]
+    task_ids = sorted(task_ids, key=lambda s: int(s.split("/")[-1]))
+
+    n_samples = int(cfg["sampling"]["n_samples_per_task"])
+
+    samples_path = out_dir / "latest.samples.jsonl"
+    with open(samples_path, "w") as out:
+        for task_id in tqdm(task_ids, desc="Generating"):
+            prob = problems[task_id]
+            prompt = build_prompt(template, prob)
+            ep = prob["entry_point"]
+
+            for i in range(n_samples):
+                text = backend.generate(
+                    prompt=prompt,
+                    max_tokens=cfg["backend_params"].get("max_tokens", 256),
+                    temperature=cfg["backend_params"].get("temperature", 0.2),
+                    top_p=cfg["backend_params"].get("top_p", 0.95),
+                    stop=cfg["backend_params"].get("stop", []),
+                    timeout_s=cfg["backend_params"].get("timeout_s", 60),
+                )
+
+                # sanitize: strip fences, ensure only code, and ensure the function body starts indented
+                text = sanitize_completion(text, entry_point=ep)
+
+                out.write(json.dumps({"task_id": task_id, "completion": text}) + "\n")
+                out.flush()
+
+    # Optionally trigger scoring here (or do it via Makefile)
+    print(f"\n[ok] Wrote samples → {samples_path}")
+    print("Run scoring:\n  evaluate_functional_correctness outputs/latest.samples.jsonl")
+
+FENCE_RE = re.compile(r"^```[a-zA-Z0-9]*\s*|\s*```$", re.MULTILINE)
+
+def sanitize_completion(s: str, entry_point: str) -> str:
+    # Remove markdown fences / extraneous prose
+    s = FENCE_RE.sub("", s).strip()
+
+    # If the model mistakenly repeats "def <entry_point>", drop it and keep body only
+    # Capture everything after the first newline following 'def entry_point(' line
+    m = re.search(rf"(?m)^\s*def\s+{re.escape(entry_point)}\s*\(.*?\):\s*\n(.*)$", s, flags=re.DOTALL)
+    if m:
+        s = m.group(1).lstrip("\n")
+
+    # Ensure it starts with an indentation block (4 spaces)
+    if not s.startswith("    "):
+        # Best-effort: indent each non-empty line by 4 spaces
+        s = "\n".join(("    " + ln if ln.strip() else "") for ln in s.splitlines())
+
+    # Stop at double blank line (common end for bodies)
+    s = re.split(r"\n\s*\n\s*\n", s, maxsplit=1)[0].rstrip() + "\n"
+    return s
+
+if __name__ == "__main__":
+    main()

--- a/opt/blackroad/lucidia/evals/humaneval/utils.py
+++ b/opt/blackroad/lucidia/evals/humaneval/utils.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+import datetime
+
+def load_prompt_template(path: Path) -> str:
+    with open(path, "r") as f:
+        return f.read()
+
+def ensure_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+def now_stamp() -> str:
+    return datetime.datetime.utcnow().strftime("%Y%m%d-%H%M%S")


### PR DESCRIPTION
## Summary
- introduce Lucidia HumanEval harness for local models
- include Makefile, Dockerfile, and configs for Ollama, llama.cpp, and offline HF
- add Python backend implementations and eval script

## Testing
- `python -m py_compile opt/blackroad/lucidia/evals/humaneval/run_eval.py opt/blackroad/lucidia/evals/humaneval/utils.py opt/blackroad/lucidia/evals/humaneval/backends/__init__.py opt/blackroad/lucidia/evals/humaneval/backends/ollama_backend.py opt/blackroad/lucidia/evals/humaneval/backends/llamacpp_backend.py opt/blackroad/lucidia/evals/humaneval/backends/transformers_backend.py`
- ⚠️ `pre-commit run --files opt/blackroad/lucidia/evals/humaneval/Dockerfile opt/blackroad/lucidia/evals/humaneval/Makefile opt/blackroad/lucidia/evals/humaneval/README.md opt/blackroad/lucidia/evals/humaneval/backends/__init__.py opt/blackroad/lucidia/evals/humaneval/backends/llamacpp_backend.py opt/blackroad/lucidia/evals/humaneval/backends/ollama_backend.py opt/blackroad/lucidia/evals/humaneval/backends/transformers_backend.py opt/blackroad/lucidia/evals/humaneval/configs/llamacpp.yaml opt/blackroad/lucidia/evals/humaneval/configs/ollama.yaml opt/blackroad/lucidia/evals/humaneval/configs/transformers.yaml opt/blackroad/lucidia/evals/humaneval/prompts/codex_prompt.txt opt/blackroad/lucidia/evals/humaneval/requirements.txt opt/blackroad/lucidia/evals/humaneval/run_eval.py opt/blackroad/lucidia/evals/humaneval/utils.py` (missing `pre-commit`)

------
https://chatgpt.com/codex/tasks/task_e_68a3ef5ff50483298e1040d7b379bde5