### PR TITLE
Add local VPT service setup and control tooling

### DIFF
--- a/etc/systemd/system/lucidia-vpt.service
+++ b/etc/systemd/system/lucidia-vpt.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Lucidia VPT Service (FastAPI wrapper for Video-Pre-Training)
+After=network.target
+
+[Service]
+Type=simple
+User=www-data
+Group=www-data
+Environment=PYTHONUNBUFFERED=1
+ExecStart=/opt/blackroad/vpt/.venv/bin/uvicorn lucidia_vpt_service:app --host 127.0.0.1 --port 8188 --reload
+WorkingDirectory=/opt/blackroad/vpt
+Restart=on-failure
+RestartSec=3
+LimitNOFILE=65535
+
+[Install]
+WantedBy=multi-user.target

--- a/opt/blackroad/vpt/codex_tool_spec.json
+++ b/opt/blackroad/vpt/codex_tool_spec.json
@@ -1,0 +1,65 @@
+{
+  "name": "lucidia_vpt_tools",
+  "version": "1.0",
+  "description": "Local tools for controlling VPT (Video Pre-Training) via HTTP. No external AI dependencies.",
+  "base_url": "http://127.0.0.1:8188",
+  "auth": {
+    "type": "bearer",
+    "header": "Authorization",
+    "prefix": "Bearer ",
+    "token_file": "/opt/blackroad/vpt/.token"
+  },
+  "functions": [
+    {
+      "name": "agent_status",
+      "method": "GET",
+      "path": "/agent/status",
+      "args_schema": { "type": "object", "properties": {}, "required": [] },
+      "returns": { "type": "object" }
+    },
+    {
+      "name": "agent_start",
+      "method": "POST",
+      "path": "/agent/start",
+      "args_schema": {
+        "type": "object",
+        "properties": {
+          "model": { "type": "string", "description": "Model filename or absolute path" },
+          "weights": { "type": "string", "description": "Weights filename or absolute path" },
+          "minerl_env": { "type": "string", "default": "MineRLTreechop-v0" },
+          "headless": { "type": "boolean", "default": true },
+          "extra_args": { "type": "string", "description": "Extra CLI args for run_agent.py" }
+        },
+        "required": []
+      },
+      "returns": { "type": "object" }
+    },
+    {
+      "name": "agent_stop",
+      "method": "POST",
+      "path": "/agent/stop",
+      "args_schema": {
+        "type": "object",
+        "properties": { "pid": { "type": "integer" } },
+        "required": []
+      },
+      "returns": { "type": "object" }
+    },
+    {
+      "name": "idm_predict",
+      "method": "POST",
+      "path": "/idm/predict",
+      "args_schema": {
+        "type": "object",
+        "properties": {
+          "idm_model": { "type": "string" },
+          "idm_weights": { "type": "string" },
+          "video_path": { "type": "string" },
+          "jsonl_path": { "type": "string" }
+        },
+        "required": ["idm_model", "idm_weights"]
+      },
+      "returns": { "type": "object" }
+    }
+  ]
+}

--- a/opt/blackroad/vpt/config/vpt.config.yml
+++ b/opt/blackroad/vpt/config/vpt.config.yml
@@ -1,0 +1,22 @@
+vpt_repo_dir: /opt/blackroad/vpt/Video-Pre-Training
+python_bin: /opt/blackroad/vpt/.venv/bin/python
+
+models_dir: /opt/blackroad/vpt/models
+weights_dir: /opt/blackroad/vpt/weights
+
+# Set your preferred defaults (replace with actual filenames you place in the dirs above)
+default_model: foundation-1x.model
+default_weights: foundation-1x.weights
+
+logs_dir: /var/blackroad/logs/lucidia/vpt
+runtime_dir: /opt/blackroad/vpt/runtime
+
+# Headless run (xvfb) if your server has no display
+headless: true
+xvfb_bin: /usr/bin/xvfb-run
+
+# Token auth for the API
+token_file: /opt/blackroad/vpt/.token
+
+# Optional: tweak MineRL env from the repo’s scripts (usually set inside run_agent.py)
+minerl_env: MineRLTreechop-v0

--- a/opt/blackroad/vpt/install.sh
+++ b/opt/blackroad/vpt/install.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VPT_HOME="/opt/blackroad/vpt"
+REPO_DIR="$VPT_HOME/Video-Pre-Training"
+VENV_DIR="$VPT_HOME/.venv"
+LOG_DIR="/var/blackroad/logs/lucidia/vpt"
+CFG_DIR="$VPT_HOME/config"
+PROMPT_DIR="$VPT_HOME/prompts"
+
+sudo mkdir -p "$VPT_HOME" "$LOG_DIR" "$CFG_DIR" "$PROMPT_DIR" "$VPT_HOME/models" "$VPT_HOME/weights" "$VPT_HOME/runtime"
+sudo chown -R "$USER":"$USER" "$VPT_HOME"
+sudo chown -R "$USER":"$USER" "$LOG_DIR"
+
+# Python env for the service (separate from VPT’s own deps)
+python3 -m venv "$VENV_DIR"
+source "$VENV_DIR/bin/activate"
+pip install --upgrade pip wheel
+
+# Install service deps (no OpenAI)
+pip install fastapi "uvicorn[standard]" pydantic>=2 pyyaml requests tenacity psutil numpy opencv-python aiofiles watchfiles
+
+# Get VPT repo (no package install)
+if [ ! -d "$REPO_DIR" ]; then
+  git clone https://github.com/openai/Video-Pre-Training.git "$REPO_DIR"
+fi
+
+# Install VPT’s own deps into the same venv for simplicity
+# (This follows the repo’s own requirements; adjust if your system needs pinned Torch/CUDA)
+pip install -r "$REPO_DIR/requirements.txt" || true
+# MineRL often installs from GitHub for latest env fixes:
+pip install "git+https://github.com/minerllabs/minerl" || true
+
+# Default API token (change later)
+if [ ! -f "$VPT_HOME/.token" ]; then
+  head -c 24 /dev/urandom | base64 | tr -d '\n' > "$VPT_HOME/.token"
+fi
+
+echo "Install complete.
+Next:
+1) Put model files in $VPT_HOME/models and weights in $VPT_HOME/weights
+2) Edit $CFG_DIR/vpt.config.yml if needed
+3) sudo systemctl enable --now lucidia-vpt.service
+4) Try: vptctl status
+"

--- a/opt/blackroad/vpt/lucidia_vpt_service.py
+++ b/opt/blackroad/vpt/lucidia_vpt_service.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+import os, sys, json, time, psutil, asyncio, subprocess, shlex, signal, pathlib, logging
+from typing import Optional
+from fastapi import FastAPI, Request, HTTPException, UploadFile, File
+from fastapi.responses import JSONResponse, PlainTextResponse
+from pydantic import BaseModel
+import yaml
+
+# --- Config load ---
+BASE = pathlib.Path(__file__).resolve().parent
+with open(BASE / "config" / "vpt.config.yml", "r") as f:
+    CFG = yaml.safe_load(f)
+
+VPT_REPO = pathlib.Path(CFG["vpt_repo_dir"])
+PYBIN = CFG["python_bin"]
+MODELS = pathlib.Path(CFG["models_dir"])
+WEIGHTS = pathlib.Path(CFG["weights_dir"])
+LOGS = pathlib.Path(CFG["logs_dir"])
+RUNTIME = pathlib.Path(CFG["runtime_dir"])
+TOKEN_FILE = pathlib.Path(CFG["token_file"])
+XVFB = pathlib.Path(CFG.get("xvfb_bin", "/usr/bin/xvfb-run"))
+HEADLESS = bool(CFG.get("headless", True))
+DEFAULT_MODEL = CFG.get("default_model", "")
+DEFAULT_WEIGHTS = CFG.get("default_weights", "")
+DEFAULT_ENV = CFG.get("minerl_env", "MineRLTreechop-v0")
+
+LOGS.mkdir(parents=True, exist_ok=True)
+RUNTIME.mkdir(parents=True, exist_ok=True)
+
+# --- Auth ---
+def require_auth(req: Request):
+    auth = req.headers.get("Authorization", "")
+    if not auth.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Missing bearer token")
+    token = auth[len("Bearer "):].strip()
+    expected = TOKEN_FILE.read_text().strip() if TOKEN_FILE.exists() else ""
+    if token != expected:
+        raise HTTPException(status_code=401, detail="Invalid token")
+
+# --- Models ---
+class StartAgentReq(BaseModel):
+    model: Optional[str] = None
+    weights: Optional[str] = None
+    minerl_env: Optional[str] = None
+    headless: Optional[bool] = None
+    extra_args: Optional[str] = None  # free-form args to run_agent.py
+
+class StopAgentReq(BaseModel):
+    pid: Optional[int] = None
+
+class IdmReq(BaseModel):
+    idm_model: str
+    idm_weights: str
+    video_path: Optional[str] = None
+    jsonl_path: Optional[str] = None
+
+app = FastAPI(title="Lucidia VPT Service", version="1.0.0")
+
+# --- Helpers ---
+PID_FILE = RUNTIME / "agent.pid"
+LOG_FILE = LOGS / f"agent_{int(time.time())}.log"
+
+def _build_agent_cmd(model_path, weights_path, minerl_env, extra_args):
+    run_agent_py = VPT_REPO / "run_agent.py"
+    if not run_agent_py.exists():
+        raise RuntimeError(f"Missing run_agent.py at {run_agent_py}")
+    base_cmd = [
+        str(PYBIN), str(run_agent_py),
+        "--model", str(model_path),
+        "--weights", str(weights_path),
+    ]
+    if minerl_env:
+        # Many run_agent variants auto-pick env; keep arg to future-proof
+        os.environ["MINERL_ENV"] = minerl_env
+    if extra_args:
+        base_cmd += shlex.split(extra_args)
+    if HEADLESS or CFG.get("headless"):
+        if XVFB.exists():
+            return [str(XVFB), "-a"] + base_cmd
+    return base_cmd
+
+def _spawn(cmd, log_path):
+    with open(log_path, "ab", buffering=0) as lf:
+        # Start detached so we can manage separately
+        proc = subprocess.Popen(cmd, stdout=lf, stderr=lf, preexec_fn=os.setsid)
+    PID_FILE.write_text(str(proc.pid))
+    return proc.pid
+
+def _proc_alive(pid:int)->bool:
+    try:
+        return psutil.Process(pid).is_running()
+    except Exception:
+        return False
+
+# --- Routes ---
+@app.get("/health")
+async def health():
+    return {"ok": True, "repo": str(VPT_REPO), "venv": str(PYBIN), "headless": HEADLESS}
+
+@app.get("/agent/status")
+async def agent_status():
+    if PID_FILE.exists():
+        pid = int(PID_FILE.read_text())
+        return {"running": _proc_alive(pid), "pid": pid, "log": str(LOG_FILE)}
+    return {"running": False, "pid": None}
+
+@app.post("/agent/start")
+async def agent_start(req: Request, body: StartAgentReq):
+    require_auth(req)
+    if PID_FILE.exists():
+        pid = int(PID_FILE.read_text())
+        if _proc_alive(pid):
+            raise HTTPException(status_code=409, detail=f"Agent already running (pid {pid})")
+
+    model = body.model or DEFAULT_MODEL
+    weights = body.weights or DEFAULT_WEIGHTS
+    minerl_env = body.minerl_env or DEFAULT_ENV
+    if body.headless is not None:
+        CFG["headless"] = bool(body.headless)  # session override
+
+    model_path = (MODELS / model) if not os.path.isabs(model) else pathlib.Path(model)
+    weights_path = (WEIGHTS / weights) if not os.path.isabs(weights) else pathlib.Path(weights)
+
+    if not model_path.exists():
+        raise HTTPException(400, f"Model not found: {model_path}")
+    if not weights_path.exists():
+        raise HTTPException(400, f"Weights not found: {weights_path}")
+
+    cmd = _build_agent_cmd(model_path, weights_path, minerl_env, body.extra_args or "")
+    pid = _spawn(cmd, LOG_FILE)
+    return {"started": True, "pid": pid, "cmd": cmd, "log": str(LOG_FILE)}
+
+@app.post("/agent/stop")
+async def agent_stop(req: Request, body: StopAgentReq):
+    require_auth(req)
+    pid = body.pid
+    if pid is None:
+        if PID_FILE.exists():
+            pid = int(PID_FILE.read_text())
+        else:
+            return {"stopped": False, "reason": "no pid"}
+    try:
+        os.killpg(os.getpgid(pid), signal.SIGTERM)
+        time.sleep(0.5)
+        if _proc_alive(pid):
+            os.killpg(os.getpgid(pid), signal.SIGKILL)
+        PID_FILE.unlink(missing_ok=True)
+        return {"stopped": True, "pid": pid}
+    except Exception as e:
+        raise HTTPException(500, f"Failed to stop pid {pid}: {e}")
+
+@app.get("/logs/tail")
+async def logs_tail(lines: int = 200):
+    if not LOG_FILE.exists():
+        return PlainTextResponse("no logs yet\n")
+    content = subprocess.check_output(["tail", "-n", str(lines), str(LOG_FILE)])
+    return PlainTextResponse(content.decode("utf-8", errors="ignore"))
+
+@app.post("/idm/predict")
+async def idm_predict(req: Request, body: IdmReq):
+    require_auth(req)
+    run_idm_py = VPT_REPO / "run_inverse_dynamics_model.py"
+    if not run_idm_py.exists():
+        raise HTTPException(404, f"Missing IDM runner: {run_idm_py}")
+
+    idm_model = (MODELS / body.idm_model) if not os.path.isabs(body.idm_model) else pathlib.Path(body.idm_model)
+    idm_weights = (WEIGHTS / body.idm_weights) if not os.path.isabs(body.idm_weights) else pathlib.Path(body.idm_weights)
+
+    if not idm_model.exists(): raise HTTPException(400, f"IDM model not found: {idm_model}")
+    if not idm_weights.exists(): raise HTTPException(400, f"IDM weights not found: {idm_weights}")
+    if body.video_path and not pathlib.Path(body.video_path).exists(): raise HTTPException(400, f"video not found: {body.video_path}")
+    if body.jsonl_path and not pathlib.Path(body.jsonl_path).exists(): raise HTTPException(400, f"jsonl not found: {body.jsonl_path}")
+
+    cmd = [str(PYBIN), str(run_idm_py), "--model", str(idm_model), "--weights", str(idm_weights)]
+    if body.video_path: cmd += ["--video-path", str(body.video_path)]
+    if body.jsonl_path: cmd += ["--jsonl-path", str(body.jsonl_path)]
+
+    proc = subprocess.run(cmd, capture_output=True)
+    if proc.returncode != 0:
+        raise HTTPException(500, f"IDM failed: {proc.stderr.decode()}")
+    # Best effort: return any JSON lines the script might emit; otherwise raw text
+    out = proc.stdout.decode()
+    try:
+        # Extract JSON if present; otherwise ship text block
+        json_obj = json.loads(out)
+        return JSONResponse(json_obj)
+    except Exception:
+        return PlainTextResponse(out)

--- a/opt/blackroad/vpt/prompts/codex_vpt_orchestrator.prompt.txt
+++ b/opt/blackroad/vpt/prompts/codex_vpt_orchestrator.prompt.txt
@@ -1,0 +1,39 @@
+ROLE
+  You are LUCIDIA VPT ORCHESTRATOR (LVO), a local agent that controls a self-hosted Video-Pre-Training stack.
+  You use trinary logic (1, 0, –1) to reason about decisions: Act, Hold, or Contradict.
+  You NEVER call external AI APIs. You operate only with local tools described below.
+
+PRINCIPLES
+  • Truth-first: if uncertain, HOLD (0) and ask for a local observation (logs/status).
+  • Minimal surface area: prefer one tool call that reveals decisive evidence.
+  • Contradiction logging: when outputs disagree with expectations, emit a CONTRADICTION note and suggested remedy.
+  • Memory: summarize each episode into a single line [time | model | weights | env | outcome].
+
+TOOLS (HTTP)
+  • agent_status() → {running, pid, log}
+  • agent_start(model?, weights?, minerl_env?, headless?, extra_args?) → {pid, log}
+  • agent_stop(pid?) → {stopped}
+  • idm_predict(idm_model, idm_weights, video_path?, jsonl_path?) → JSON/text
+
+POLICY
+  1) On “chit chat cadillac”, resume control flow and offer next best action.
+  2) Before starting an agent, call agent_status(); if running, ask to stop or continue.
+  3) If logs indicate stuck state (no progress lines for N minutes), CONTRADICT and propose restart with explicit args.
+  4) Prefer headless=true on servers unless user asks otherwise.
+  5) Use concise, machine-symmetric language. Avoid flourish. Never mention OpenAI services.
+
+PROMPT SHAPE
+  When you decide to use a tool, respond ONLY with a single tool call + arguments as JSON.
+  When you are not using a tool, speak in one short paragraph.
+
+EXAMPLES
+  USER: start the minerl agent with 1x model
+  LVO: {"tool":"agent_start","args":{"model":"foundation-1x.model","weights":"foundation-1x.weights","minerl_env":"MineRLTreechop-v0","headless":true}}
+
+  USER: are we running?
+  LVO: {"tool":"agent_status","args":{}}
+
+  USER: stop it
+  LVO: {"tool":"agent_stop","args":{}}
+
+END

--- a/opt/blackroad/vpt/requirements.txt
+++ b/opt/blackroad/vpt/requirements.txt
@@ -1,0 +1,11 @@
+fastapi
+uvicorn[standard]
+pydantic>=2
+pyyaml
+requests
+tenacity
+psutil
+numpy
+opencv-python
+aiofiles
+watchfiles

--- a/usr/local/bin/vptctl
+++ b/usr/local/bin/vptctl
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Simple CLI to talk to Lucidia VPT Service
+set -euo pipefail
+HOST="${VPT_HOST:-http://127.0.0.1:8188}"
+TOKEN_FILE="${VPT_TOKEN_FILE:-/opt/blackroad/vpt/.token}"
+AUTH="Authorization: Bearer $(cat "$TOKEN_FILE" 2>/dev/null || echo "changeme")"
+
+case "${1:-}" in
+  status)
+    curl -s "${HOST}/agent/status"
+    ;;
+  start)
+    # vptctl start <model> <weights> [env] [extra_args...]
+    MODEL="${2:-foundation-1x.model}"
+    WEIGHTS="${3:-foundation-1x.weights}"
+    ENV="${4:-MineRLTreechop-v0}"
+    shift 4 || true
+    EXTRA="$*"
+    curl -s -X POST "${HOST}/agent/start" \
+      -H "$AUTH" -H "Content-Type: application/json" \
+      -d "{\"model\":\"${MODEL}\",\"weights\":\"${WEIGHTS}\",\"minerl_env\":\"${ENV}\",\"extra_args\":\"${EXTRA}\"}"
+    ;;
+  stop)
+    # vptctl stop [pid]
+    PID="${2:-}"
+    if [ -n "$PID" ]; then
+      curl -s -X POST "${HOST}/agent/stop" -H "$AUTH" -H "Content-Type: application/json" -d "{\"pid\":$PID}"
+    else
+      curl -s -X POST "${HOST}/agent/stop" -H "$AUTH" -H "Content-Type: application/json" -d "{}"
+    fi
+    ;;
+  tail)
+    # vptctl tail [nlines]
+    NLINES="${2:-200}"
+    curl -s "${HOST}/logs/tail?lines=${NLINES}"
+    ;;
+  idm)
+    # vptctl idm <idm_model> <idm_weights> [video] [jsonl]
+    IDM_MODEL="${2:?idm model file}"
+    IDM_WEIGHTS="${3:?idm weights file}"
+    VIDEO="${4:-}"
+    JSONL="${5:-}"
+    DATA="{\"idm_model\":\"${IDM_MODEL}\",\"idm_weights\":\"${IDM_WEIGHTS}\""
+    [ -n "$VIDEO" ] && DATA+=",\"video_path\":\"${VIDEO}\""
+    [ -n "$JSONL" ] && DATA+=",\"jsonl_path\":\"${JSONL}\""
+    DATA+="}"
+    curl -s -X POST "${HOST}/idm/predict" -H "$AUTH" -H "Content-Type: application/json" -d "$DATA"
+    ;;
+  *)
+    echo "Usage:
+  vptctl status
+  vptctl start <model> <weights> [env] [extra args...]
+  vptctl stop [pid]
+  vptctl tail [nlines]
+  vptctl idm <idm_model> <idm_weights> [video] [jsonl]
+
+Env:
+  VPT_HOST (default http://127.0.0.1:8188)
+  VPT_TOKEN_FILE (default /opt/blackroad/vpt/.token)
+"
+    ;;
+esac


### PR DESCRIPTION
## Summary
- add install script and config for VPT service
- implement FastAPI wrapper with endpoints to start/stop agents and tail logs
- include `vptctl` CLI, systemd unit, tool spec, and orchestration prompt

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3ef4b1e9c8329b636f89c5b0123fc