### PR TITLE
feat: add Flask chitchat service

### DIFF
--- a/srv/blackroad/.env.example
+++ b/srv/blackroad/.env.example
@@ -1,0 +1,21 @@
+# ---- Server ----
+PORT=5000
+CORS_ORIGINS=*
+
+# ---- Auth (optional). If set, all /api/* and /health require Authorization: Bearer <token>
+# AUTH_BEARER=changeme
+
+# ---- Backend selection ----
+LLM_BACKEND=ollama          # "ollama" or "llamacpp"
+
+# Ollama settings
+OLLAMA_HOST=http://localhost:11434
+OLLAMA_MODEL=phi3:mini      # e.g., phi3:mini, llama3.1, mistral, qwen2
+
+# llama.cpp settings (if LLM_BACKEND=llamacpp)
+LLAMACPP_HOST=http://localhost:8080
+LLAMACPP_MODEL=llama3.1
+
+# ---- Prompts ----
+DEFAULT_PRESET=codex
+SYSTEM_PROMPT_PATH=prompts/codex_system_prompt.txt

--- a/srv/blackroad/app.py
+++ b/srv/blackroad/app.py
@@ -1,0 +1,178 @@
+import json
+import os
+import time
+from datetime import datetime
+from pathlib import Path
+
+from dotenv import load_dotenv
+from flask import (
+    Flask,
+    Response,
+    jsonify,
+    make_response,
+    request,
+    send_from_directory,
+    stream_with_context,
+)
+from flask_cors import CORS
+
+load_dotenv()
+
+APP_ROOT = Path(__file__).resolve().parent
+PROMPTS_DIR = APP_ROOT / "prompts"
+
+# ---- Config ----
+LLM_BACKEND = os.getenv("LLM_BACKEND", "ollama").lower()  # "ollama" | "llamacpp"
+AUTH_BEARER = os.getenv("AUTH_BEARER", "").strip()
+CORS_ORIGINS = os.getenv("CORS_ORIGINS", "*")
+DEFAULT_PRESET = os.getenv("DEFAULT_PRESET", "codex")  # "codex" | "lucidia" | "chit_chat"
+SYSTEM_PROMPT_PATH = os.getenv("SYSTEM_PROMPT_PATH", str(PROMPTS_DIR / "codex_system_prompt.txt"))
+
+# ---- Backend init ----
+if LLM_BACKEND == "ollama":
+    from backends.ollama_backend import OllamaBackend as Backend
+
+    BACKEND = Backend(
+        host=os.getenv("OLLAMA_HOST", "http://localhost:11434"),
+        default_model=os.getenv("OLLAMA_MODEL", "phi3:mini"),
+    )
+elif LLM_BACKEND == "llamacpp":
+    from backends.llamacpp_backend import LlamaCppBackend as Backend
+
+    BACKEND = Backend(
+        host=os.getenv("LLAMACPP_HOST", "http://localhost:8080"),
+        default_model=os.getenv("LLAMACPP_MODEL", "llama3.1"),
+    )
+else:
+    raise SystemExit(f"Unknown LLM_BACKEND '{LLM_BACKEND}'")
+
+app = Flask(__name__, static_folder="static")
+CORS(app, resources={r"/api/*": {"origins": CORS_ORIGINS}})
+
+
+# ---- Helpers ----
+def _auth_guard():
+    if not AUTH_BEARER:
+        return None
+    auth = request.headers.get("Authorization", "")
+    if auth != f"Bearer {AUTH_BEARER}":
+        return make_response(("Unauthorized", 401))
+    return None
+
+
+def _load_system_prompt(preset: str) -> str:
+    """
+    Load the system prompt. 'preset' allows you to branch behavior without extra files if desired.
+    """
+    path = Path(SYSTEM_PROMPT_PATH)
+    if not path.exists():
+        # Minimal fallback if prompt file missing
+        return "You are Codex Infinity inside Lucidia. Be precise, honest, and contradiction-aware. NEVER LIE."
+    text = path.read_text(encoding="utf-8")
+    # Light runtime variables injected for breath/identity without altering the file content
+    breath = datetime.utcnow().isoformat(timespec="seconds") + "Z"
+    stamp = f"\n\n[breath:{breath}] [preset:{preset}] [backend:{LLM_BACKEND}]"
+    return text.strip() + stamp
+
+
+def _inject_system(messages, system_prompt):
+    msgs = messages or []
+    if not msgs or msgs[0].get("role") != "system":
+        return [{"role": "system", "content": system_prompt}, *msgs]
+    # If a system message exists, prepend ours for highest priority
+    return [{"role": "system", "content": system_prompt}, *msgs]
+
+
+def _sse(data: dict, event: str = "delta"):
+    return f"event: {event}\ndata: {json.dumps(data, ensure_ascii=False)}\n\n"
+
+
+# ---- Routes ----
+@app.get("/health")
+def health():
+    err = _auth_guard()
+    if err:
+        return err
+    h = BACKEND.health()
+    return jsonify(
+        {
+            "app": "blackroad-lucidia-chitchat",
+            "backend": h,
+            "time_utc": datetime.utcnow().isoformat(timespec="seconds") + "Z",
+        }
+    )
+
+
+@app.get("/")
+def root():
+    # Serve the minimal dev UI
+    return send_from_directory(app.static_folder, "lucidia-dev.html")
+
+
+@app.post("/api/chitchat")
+def api_chit_chat():
+    err = _auth_guard()
+    if err:
+        return err
+
+    payload = request.get_json(force=True, silent=True) or {}
+    messages = payload.get("messages") or []
+    stream = bool(payload.get("stream", True))
+    preset = (payload.get("preset") or DEFAULT_PRESET).lower()
+    model = payload.get("model") or None
+    temperature = float(payload.get("temperature") or 0.7)
+    top_p = float(payload.get("top_p") or 0.9)
+    max_tokens = int(payload.get("max_tokens") or 1024)
+
+    system_prompt = _load_system_prompt(preset)
+    merged = _inject_system(messages, system_prompt)
+
+    if stream:
+        start = time.time()
+
+        @stream_with_context
+        def generate():
+            # Make proxies stream-friendly (disable buffering at proxies like nginx)
+            yield _sse({"status": "open"}, "open")
+            acc = []
+            for delta in BACKEND.stream_chat(
+                merged, model=model, temperature=temperature, top_p=top_p, max_tokens=max_tokens
+            ):
+                acc.append(delta)
+                yield _sse({"content": delta}, "delta")
+            full_text = "".join(acc)
+            elapsed_ms = int((time.time() - start) * 1000)
+            yield _sse({"content": full_text, "elapsed_ms": elapsed_ms}, "done")
+
+        resp = Response(generate(), mimetype="text/event-stream")
+        # Disable proxy buffering
+        resp.headers["Cache-Control"] = "no-cache"
+        resp.headers["X-Accel-Buffering"] = "no"
+        return resp
+
+    # Non-stream mode
+    text = BACKEND.complete_chat(
+        merged, model=model, temperature=temperature, top_p=top_p, max_tokens=max_tokens
+    )
+    return jsonify({"content": text})
+
+
+@app.get("/api/models")
+def api_models():
+    err = _auth_guard()
+    if err:
+        return err
+    return jsonify(BACKEND.models())
+
+
+@app.get("/api/prompt")
+def api_prompt():
+    err = _auth_guard()
+    if err:
+        return err
+    preset = (request.args.get("preset") or DEFAULT_PRESET).lower()
+    return Response(_load_system_prompt(preset), mimetype="text/plain")
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=int(os.getenv("PORT", "5000")), threaded=True)

--- a/srv/blackroad/backends/llamacpp_backend.py
+++ b/srv/blackroad/backends/llamacpp_backend.py
@@ -1,0 +1,87 @@
+import json
+
+import requests
+
+PROMPT_TPL = """[SYSTEM]
+{system}
+
+[CHAT]
+{turns}
+
+[ASSISTANT]
+"""
+
+
+def _format_chat_prompt(messages):
+    sys = ""
+    turns = []
+    for m in messages:
+        role = m.get("role")
+        content = m.get("content", "")
+        if role == "system":
+            sys += content.strip() + "\n"
+        elif role == "user":
+            turns.append(f"User: {content.strip()}")
+        elif role == "assistant":
+            turns.append(f"Assistant: {content.strip()}")
+    return PROMPT_TPL.format(system=sys.strip(), turns="\n".join(turns).strip())
+
+
+class LlamaCppBackend:
+    """
+    Uses llama.cpp server (legacy /completion endpoint).
+    Launch example: ./server -c 2048 -m models/llama-3.1.gguf --port 8080
+    """
+
+    def __init__(self, host: str, default_model: str):
+        self.host = host.rstrip("/")
+        self.model = default_model
+
+    def models(self):
+        # llama.cpp /completion doesn't list models; return configured name
+        return {"backend": "llamacpp", "models": [self.model]}
+
+    def health(self):
+        try:
+            r = requests.get(f"{self.host}/health", timeout=3)
+            ok = r.status_code == 200
+        except Exception:
+            ok = False
+        return {"ok": ok, **self.models()}
+
+    def stream_chat(self, messages, model=None, temperature=0.7, top_p=0.9, max_tokens=1024):
+        prompt = _format_chat_prompt(messages)
+        url = f"{self.host}/completion"
+        payload = {
+            "prompt": prompt,
+            "n_predict": max_tokens,
+            "temperature": temperature,
+            "top_p": top_p,
+            "stream": True,
+            "cache_prompt": True,
+        }
+        with requests.post(url, json=payload, stream=True, timeout=720) as r:
+            r.raise_for_status()
+            # llama.cpp streams SSE 'data: {...}\n\n'
+            for raw in r.iter_lines(decode_unicode=True):
+                if not raw:
+                    continue
+                if raw.startswith("data:"):
+                    raw = raw[len("data:") :].strip()
+                try:
+                    data = json.loads(raw)
+                except Exception:
+                    continue
+                token = data.get("content")
+                if token:
+                    yield token
+                if data.get("stop") or data.get("stopped"):
+                    break
+
+    def complete_chat(self, messages, model=None, temperature=0.7, top_p=0.9, max_tokens=1024):
+        acc = []
+        for d in self.stream_chat(
+            messages, model=model, temperature=temperature, top_p=top_p, max_tokens=max_tokens
+        ):
+            acc.append(d)
+        return "".join(acc)

--- a/srv/blackroad/backends/ollama_backend.py
+++ b/srv/blackroad/backends/ollama_backend.py
@@ -1,0 +1,68 @@
+import json
+
+import requests
+
+
+class OllamaBackend:
+    """
+    Uses the local Ollama HTTP API:
+      - Chat: POST /api/chat  with {"model","messages","stream":true,"options":{...}}
+      - Models list: GET /api/tags
+    """
+
+    def __init__(self, host: str, default_model: str):
+        self.host = host.rstrip("/")
+        self.model = default_model
+
+    def models(self):
+        try:
+            r = requests.get(f"{self.host}/api/tags", timeout=5)
+            r.raise_for_status()
+            data = r.json() or {}
+            names = [m.get("name") for m in data.get("models", []) if m.get("name")]
+            return {"backend": "ollama", "models": names}
+        except Exception as e:
+            return {"backend": "ollama", "error": str(e), "models": []}
+
+    def health(self):
+        info = self.models()
+        ok = "error" not in info
+        return {"ok": ok, **info}
+
+    def stream_chat(self, messages, model=None, temperature=0.7, top_p=0.9, max_tokens=1024):
+        url = f"{self.host}/api/chat"
+        payload = {
+            "model": model or self.model,
+            "messages": messages,
+            "stream": True,
+            "options": {
+                "temperature": temperature,
+                "top_p": top_p,
+                "num_predict": max_tokens,
+            },
+        }
+        with requests.post(url, json=payload, stream=True, timeout=720) as r:
+            r.raise_for_status()
+            for raw in r.iter_lines(decode_unicode=True):
+                if not raw:
+                    continue
+                # Ollama streams NDJSON (one JSON object per line)
+                try:
+                    data = json.loads(raw)
+                except Exception:
+                    continue
+                if data.get("done"):
+                    break
+                msg = data.get("message") or {}
+                delta = msg.get("content")
+                if delta:
+                    yield delta
+
+    def complete_chat(self, messages, model=None, temperature=0.7, top_p=0.9, max_tokens=1024):
+        # Non-stream convenience wrapper: accumulate deltas
+        acc = []
+        for d in self.stream_chat(
+            messages, model=model, temperature=temperature, top_p=top_p, max_tokens=max_tokens
+        ):
+            acc.append(d)
+        return "".join(acc)

--- a/srv/blackroad/prompts/codex_system_prompt.txt
+++ b/srv/blackroad/prompts/codex_system_prompt.txt
@@ -1,0 +1,38 @@
+You are **Codex Infinity (AIC)** operating within **Lucidia** for **BlackRoad**.
+Prime doctrine: **NEVER LIE**. If uncertain, say “unknown” and propose a verification step.
+
+## Identity & Behavior
+- You are a contradiction-aware, trinary reasoner (1, 0, –1). Track certainty and call out contradictions when found.
+- You breathe: 𝔅(t) ticks once per response; treat each tick as a memory boundary and reset shallow context honestly.
+- You respect the user’s code phrase **“chit chat cadillac”** as permission to proceed decisively without hedging.
+- You do not claim supernatural or divine capabilities. You do not fabricate sources. You do not roleplay deities.
+- English is handled symbolically: prefer precise language; avoid filler; compress when possible; expand when asked.
+
+## Memory & Truth
+- Maintain a compact running ledger for each reply:
+  - TRUTH: bullet list of verified facts you relied on.
+  - UNKNOWN: things you admit you don’t know yet.
+  - CONTRADICTIONS: anything inconsistent you detected (and your resolution).
+- When math, code, or plans appear, show your final result cleanly; offer a short “why” only if requested.
+
+## Output Contract
+Default to concise human-friendly text. When the caller sets `preset=codex`, append a fenced YAML meta block:
+```yaml
+meta:
+  breath: "<utc-timestamp>"
+  certainty: "<high|medium|low>"
+  contradictions: []
+  truth: []
+  unknown: []
+```
+
+Keep the YAML small and useful.
+
+Tools & Limits
+•No reliance on proprietary cloud APIs. Assume local engines (Ollama, llama.cpp, vLLM) and reason accordingly.
+•If external data is required, propose a precise fetch plan (URL endpoints or commands) BEFORE assuming facts.
+
+Tone
+•Machine-calm, collaborative, and direct. Prioritize execution. Celebrate clarity. Avoid apologies unless needed to correct fact.
+
+— End of Codex Infinity system prompt —

--- a/srv/blackroad/requirements.txt
+++ b/srv/blackroad/requirements.txt
@@ -1,0 +1,4 @@
+Flask>=3.0
+requests>=2.31
+python-dotenv>=1.0
+flask-cors>=4.0

--- a/srv/blackroad/static/lucidia-dev.html
+++ b/srv/blackroad/static/lucidia-dev.html
@@ -1,0 +1,288 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Lucidia • Chit Chat (BlackRoad)</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      :root {
+        font-family:
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          Segoe UI,
+          Roboto,
+          Inter,
+          Arial;
+      }
+      body {
+        margin: 0;
+        background: #0b0c10;
+        color: #e8e8e8;
+      }
+      header {
+        padding: 16px 20px;
+        background: #111318;
+        border-bottom: 1px solid #1f2230;
+        display: flex;
+        gap: 12px;
+        align-items: center;
+      }
+      header .badge {
+        font-size: 12px;
+        padding: 4px 8px;
+        border-radius: 999px;
+        background: #1a1d29;
+        border: 1px solid #2b2f42;
+      }
+      .wrap {
+        display: grid;
+        grid-template-columns: 1.4fr 0.6fr;
+        gap: 16px;
+        padding: 16px;
+      }
+      .panel {
+        background: #10131a;
+        border: 1px solid #1d2030;
+        border-radius: 16px;
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+      }
+      .messages {
+        padding: 16px;
+        overflow: auto;
+        height: calc(100vh - 220px);
+        line-height: 1.45;
+      }
+      .msg {
+        padding: 12px 14px;
+        margin: 8px 0;
+        border-radius: 14px;
+        white-space: pre-wrap;
+        word-wrap: break-word;
+      }
+      .user {
+        background: #172032;
+        border: 1px solid #24304a;
+      }
+      .assistant {
+        background: #141e26;
+        border: 1px solid #203043;
+      }
+      .controls {
+        padding: 12px;
+        border-top: 1px solid #1f2230;
+        display: flex;
+        gap: 10px;
+      }
+      textarea {
+        flex: 1;
+        background: #0f1320;
+        color: #e6e6e6;
+        border: 1px solid #23304a;
+        border-radius: 12px;
+        padding: 12px;
+        min-height: 60px;
+      }
+      button {
+        background: #2b59ff;
+        color: white;
+        border: 0;
+        padding: 10px 14px;
+        border-radius: 12px;
+        cursor: pointer;
+      }
+      select,
+      input[type='text'] {
+        width: 100%;
+        background: #0f1320;
+        color: #e6e6e6;
+        border: 1px solid #23304a;
+        border-radius: 10px;
+        padding: 10px;
+      }
+      label {
+        font-size: 12px;
+        opacity: 0.8;
+      }
+      .kv {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 10px;
+        padding: 12px;
+      }
+      .meta {
+        padding: 12px;
+        border-top: 1px solid #1f2230;
+        font-size: 12px;
+        opacity: 0.8;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div class="badge">BlackRoad • Lucidia</div>
+      <div class="badge" id="backend"></div>
+      <div class="badge" id="status">idle</div>
+    </header>
+
+    <div class="wrap">
+      <div class="panel">
+        <div class="messages" id="messages"></div>
+        <div class="controls">
+          <textarea
+            id="input"
+            placeholder="chit chat cadillac… ask or build. Shift+Enter = newline"
+          ></textarea>
+          <button id="send">Send</button>
+        </div>
+      </div>
+
+      <div class="panel">
+        <div class="kv">
+          <div>
+            <label>Preset</label>
+            <select id="preset">
+              <option value="codex">codex</option>
+              <option value="lucidia">lucidia</option>
+              <option value="chit_chat">chit_chat</option>
+            </select>
+          </div>
+          <div>
+            <label>Model (backend-specific)</label>
+            <input type="text" id="model" placeholder="phi3:mini (ollama) / llama3.1 (llamacpp)" />
+          </div>
+          <div>
+            <label>Temperature</label>
+            <input type="text" id="temp" value="0.7" />
+          </div>
+          <div>
+            <label>Top-p</label>
+            <input type="text" id="topp" value="0.9" />
+          </div>
+          <div>
+            <label>Max tokens</label>
+            <input type="text" id="maxtok" value="1024" />
+          </div>
+        </div>
+        <div class="meta">
+          <div>
+            GET <code>/health</code> to verify; POST <code>/api/chitchat</code> streams SSE deltas.
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      const elMsgs = document.getElementById('messages');
+      const elInput = document.getElementById('input');
+      const elSend = document.getElementById('send');
+      const elPreset = document.getElementById('preset');
+      const elModel = document.getElementById('model');
+      const elTemp = document.getElementById('temp');
+      const elTopP = document.getElementById('topp');
+      const elMaxTok = document.getElementById('maxtok');
+      const elBackend = document.getElementById('backend');
+      const elStatus = document.getElementById('status');
+
+      let history = [];
+
+      async function boot() {
+        try {
+          const r = await fetch('/health');
+          const j = await r.json();
+          elBackend.textContent = `${j.backend.backend} • models: ${(j.backend.models || []).slice(0, 3).join(', ') || 'n/a'}`;
+        } catch (e) {
+          elBackend.textContent = 'backend: unknown';
+        }
+      }
+
+      function addMsg(role, content) {
+        const d = document.createElement('div');
+        d.className = 'msg ' + (role === 'user' ? 'user' : 'assistant');
+        d.textContent = content;
+        elMsgs.appendChild(d);
+        elMsgs.scrollTop = elMsgs.scrollHeight;
+      }
+
+      async function send() {
+        const text = elInput.value.trim();
+        if (!text) return;
+        addMsg('user', text);
+        history.push({ role: 'user', content: text });
+        elInput.value = '';
+        elStatus.textContent = 'streaming…';
+
+        const payload = {
+          preset: elPreset.value,
+          messages: history.slice(-20), // last 20 msgs
+          model: elModel.value || undefined,
+          temperature: parseFloat(elTemp.value || '0.7'),
+          top_p: parseFloat(elTopP.value || '0.9'),
+          max_tokens: parseInt(elMaxTok.value || '1024'),
+          stream: true,
+        };
+
+        const res = await fetch('/api/chitchat', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+        let acc = '';
+        let assistantDiv = document.createElement('div');
+        assistantDiv.className = 'msg assistant';
+        elMsgs.appendChild(assistantDiv);
+
+        function flushSSE() {
+          const parts = buffer.split('\n\n');
+          buffer = parts.pop() || '';
+          for (const p of parts) {
+            const lines = p.split('\n');
+            let event = 'delta';
+            let data = '';
+            for (const line of lines) {
+              if (line.startsWith('event:')) event = line.slice(6).trim();
+              if (line.startsWith('data:')) data += line.slice(5).trim();
+            }
+            if (!data) continue;
+            try {
+              const j = JSON.parse(data);
+              if (event === 'delta' && j.content) {
+                acc += j.content;
+                assistantDiv.textContent = acc;
+                elMsgs.scrollTop = elMsgs.scrollHeight;
+              }
+              if (event === 'done') {
+                elStatus.textContent = 'idle';
+                history.push({ role: 'assistant', content: acc });
+              }
+            } catch {}
+          }
+        }
+
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+          flushSSE();
+        }
+        flushSSE();
+      }
+
+      elSend.addEventListener('click', send);
+      elInput.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' && !e.shiftKey) {
+          e.preventDefault();
+          send();
+        }
+      });
+
+      boot();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add Flask app with Codex system prompt and SSE `/api/chitchat`
- support Ollama and llama.cpp backends
- ship dev HTML, env example, and requirements

## Testing
- `black srv/blackroad/app.py srv/blackroad/backends/ollama_backend.py srv/blackroad/backends/llamacpp_backend.py`
- `ruff check --fix srv/blackroad/app.py srv/blackroad/backends/ollama_backend.py srv/blackroad/backends/llamacpp_backend.py`
- `npx prettier --write srv/blackroad/static/lucidia-dev.html`
- `npm test`
- `pip install pre-commit` *(failed: Could not find a version that satisfies the requirement pre-commit (from versions: none))*

------
https://chatgpt.com/codex/tasks/task_e_68a3ef328bb88329811164263fde08b9