### PR TITLE
Add Glow service with dataset prep and systemd unit

### DIFF
--- a/opt/blackroad/glow/Dockerfile.amd64
+++ b/opt/blackroad/glow/Dockerfile.amd64
@@ -1,0 +1,20 @@
+FROM pytorch/pytorch:2.3.1-cuda11.8-cudnn8-runtime
+WORKDIR /app
+
+# basic deps
+RUN apt-get update && apt-get install -y git ffmpeg libsm6 libxext6 && rm -rf /var/lib/apt/lists/*
+
+# python deps
+RUN pip install --no-cache-dir fastapi uvicorn[standard] pillow pydantic==1.10.14 \
+    torchvision einops
+
+# vendor a PyTorch Glow impl (MIT)
+RUN mkdir -p /app/vendor && \
+    git clone --depth=1 https://github.com/rosinality/glow-pytorch /app/vendor/glow-pytorch
+
+# our agent code
+COPY glow_agent /app/glow_agent
+
+# allow both CPU and GPU runs
+ENV TORCH_HOME=/app/.torch
+ENV PYTHONUNBUFFERED=1

--- a/opt/blackroad/glow/Dockerfile.jetson
+++ b/opt/blackroad/glow/Dockerfile.jetson
@@ -1,0 +1,9 @@
+FROM nvcr.io/nvidia/l4t-pytorch:r35.2.1-pth2.0-py3
+WORKDIR /app
+RUN apt-get update && apt-get install -y git ffmpeg libsm6 libxext6 && rm -rf /var/lib/apt/lists/*
+RUN pip3 install --no-cache-dir fastapi uvicorn[standard] pillow pydantic==1.10.14 einops
+RUN mkdir -p /app/vendor && \
+    git clone --depth=1 https://github.com/rosinality/glow-pytorch /app/vendor/glow-pytorch
+COPY glow_agent /app/glow_agent
+ENV TORCH_HOME=/app/.torch
+ENV PYTHONUNBUFFERED=1

--- a/opt/blackroad/glow/compose.yml
+++ b/opt/blackroad/glow/compose.yml
@@ -1,0 +1,45 @@
+version: '3.9'
+services:
+  glow:
+    profiles: ['amd64']
+    build:
+      context: .
+      dockerfile: Dockerfile.amd64
+    image: blackroad/glow-agent:amd64
+    runtime: nvidia
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
+      - NVIDIA_DRIVER_CAPABILITIES=compute,utility
+      - MODEL_DIR=/opt/blackroad/models/glow
+      - DATA_DIR=/opt/blackroad/data
+      - LOG_DIR=/opt/blackroad/logs
+      - LUCIDIA_BUS=/opt/blackroad/bus/codex_bus.jsonl
+    volumes:
+      - /opt/blackroad/models/glow:/opt/blackroad/models/glow
+      - /opt/blackroad/data:/opt/blackroad/data
+      - /opt/blackroad/logs:/opt/blackroad/logs
+      - /opt/blackroad/bus:/opt/blackroad/bus
+    ports: ['8018:8018']
+    command: ['uvicorn', 'glow_agent.app:app', '--host', '0.0.0.0', '--port', '8018']
+
+  glow-jetson:
+    profiles: ['jetson']
+    build:
+      context: .
+      dockerfile: Dockerfile.jetson
+    image: blackroad/glow-agent:jetson
+    runtime: nvidia
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
+      - NVIDIA_DRIVER_CAPABILITIES=compute,utility
+      - MODEL_DIR=/opt/blackroad/models/glow
+      - DATA_DIR=/opt/blackroad/data
+      - LOG_DIR=/opt/blackroad/logs
+      - LUCIDIA_BUS=/opt/blackroad/bus/codex_bus.jsonl
+    volumes:
+      - /opt/blackroad/models/glow:/opt/blackroad/models/glow
+      - /opt/blackroad/data:/opt/blackroad/data
+      - /opt/blackroad/logs:/opt/blackroad/logs
+      - /opt/blackroad/bus:/opt/blackroad/bus
+    ports: ['8018:8018']
+    command: ['uvicorn', 'glow_agent.app:app', '--host', '0.0.0.0', '--port', '8018']

--- a/opt/blackroad/glow/glow-agent.service
+++ b/opt/blackroad/glow/glow-agent.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Glow Agent Service
+After=network.target docker.service
+Requires=docker.service
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/blackroad/glow
+Environment=GLOW_PROFILE=amd64
+ExecStart=/usr/bin/docker compose -f /opt/blackroad/glow/compose.yml --profile ${GLOW_PROFILE} up
+ExecStop=/usr/bin/docker compose -f /opt/blackroad/glow/compose.yml --profile ${GLOW_PROFILE} down
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/opt/blackroad/glow/glow_agent/app.py
+++ b/opt/blackroad/glow/glow_agent/app.py
@@ -1,0 +1,113 @@
+import os
+import pathlib
+import subprocess
+import time
+import uuid
+from typing import Optional
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from .lucidia_bridge import log_contradiction, log_event
+
+APP_ID = "glow-agent"
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+VENDOR = ROOT / "vendor" / "glow-pytorch"
+MODEL_DIR = pathlib.Path(os.getenv("MODEL_DIR", "/opt/blackroad/models/glow"))
+DATA_DIR = pathlib.Path(os.getenv("DATA_DIR", "/opt/blackroad/data"))
+LOG_DIR = pathlib.Path(os.getenv("LOG_DIR", "/opt/blackroad/logs"))
+
+app = FastAPI(title="BlackRoad Glow Agent", version="1.0.0")
+
+
+class TrainReq(BaseModel):
+    dataset_dir: Optional[str] = None
+    img_size: int = 64
+    batch: int = 16
+    lr: float = 1e-4
+    epochs: int = 1
+    bits: int = 5
+    n_flow: int = 32
+    n_block: int = 3
+    seed: int = 0
+
+
+class SampleReq(BaseModel):
+    n: int = 8
+    temperature: float = 0.7
+    seed: int = 0
+    out_size: int = 64
+
+
+def _python():
+    return "python3"
+
+
+@app.get("/health")
+def health():
+    return {"ok": True, "app": APP_ID}
+
+
+@app.post("/train")
+def train(req: TrainReq):
+    dataset = req.dataset_dir or str(DATA_DIR / "glow_data")
+    os.makedirs(MODEL_DIR, exist_ok=True)
+    os.makedirs(LOG_DIR, exist_ok=True)
+    run_id = f"glow-{int(time.time())}-{uuid.uuid4().hex[:6]}"
+
+    cmd = [
+        _python(),
+        str(VENDOR / "train.py"),
+        dataset,
+        "--image_size",
+        str(req.img_size),
+        "--batch",
+        str(req.batch),
+        "--lr",
+        str(req.lr),
+        "--epochs",
+        str(req.epochs),
+        "--bits",
+        str(req.bits),
+        "--n_flow",
+        str(req.n_flow),
+        "--n_block",
+        str(req.n_block),
+        "--seed",
+        str(req.seed),
+        "--ckpt",
+        str(MODEL_DIR / f"{run_id}.pt"),
+    ]
+
+    log_event(agent=APP_ID, action="train:start", payload={"cmd": cmd, "run_id": run_id})
+    try:
+        sp = subprocess.run(cmd, cwd=str(VENDOR), check=True, capture_output=True, text=True)
+        (LOG_DIR / f"{run_id}.train.log").write_text(sp.stdout + "\n\n" + sp.stderr)
+        log_event(agent=APP_ID, action="train:done", payload={"run_id": run_id})
+        return {"ok": True, "run_id": run_id}
+    except subprocess.CalledProcessError as e:
+        log_contradiction(APP_ID, "train_failed", {"stderr": e.stderr})
+        return {"ok": False, "error": "train_failed", "detail": e.stderr}
+
+
+@app.post("/sample")
+def sample(req: SampleReq):
+    from .engine import autodiscover_ckpt, sample_grid_b64
+
+    ckpt = autodiscover_ckpt(MODEL_DIR)
+    if ckpt is None:
+        log_contradiction(APP_ID, "sample_no_checkpoint", {})
+        return {"ok": False, "error": "no_checkpoint"}
+    b64 = sample_grid_b64(
+        ckpt,
+        n=req.n,
+        temperature=req.temperature,
+        out_size=req.out_size,
+        seed=req.seed,
+    )
+    log_event(
+        agent=APP_ID,
+        action="sample",
+        payload={"n": req.n, "temperature": req.temperature},
+    )
+    return {"ok": True, "image_b64": b64}

--- a/opt/blackroad/glow/glow_agent/engine.py
+++ b/opt/blackroad/glow/glow_agent/engine.py
@@ -1,0 +1,61 @@
+import base64
+import io
+import math
+import os
+
+import torch
+from PIL import Image
+
+
+def autodiscover_ckpt(model_dir):
+    if not os.path.isdir(model_dir):
+        return None
+    cands = sorted([p for p in os.listdir(model_dir) if p.endswith(".pt")], reverse=True)
+    return os.path.join(model_dir, cands[0]) if cands else None
+
+
+def _load_model_from_vendor(ckpt_path, device):
+    from importlib import import_module
+
+    glow_mod = import_module("vendor.glow_pytorch.model")
+    model = glow_mod.Glow(3, 64, 32, 3)
+    sd = torch.load(ckpt_path, map_location=device)
+    state = sd["model"] if isinstance(sd, dict) and "model" in sd else sd
+    model.load_state_dict(state, strict=False)
+    model.to(device).eval()
+    return model
+
+
+@torch.inference_mode()
+def sample_grid_b64(ckpt_path, n=8, temperature=0.7, out_size=64, seed=0):
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    torch.manual_seed(seed)
+    model = _load_model_from_vendor(ckpt_path, device)
+    z = torch.randn(n, 3, out_size, out_size, device=device) * temperature
+    x, _ = model(z, reverse=True)
+    x = torch.clamp((x + 1) / 2, 0, 1)
+    cols = int(math.ceil(math.sqrt(n)))
+    rows = int(math.ceil(n / cols))
+    pad = 2
+    grid = torch.ones(
+        3,
+        rows * out_size + pad * (rows - 1),
+        cols * out_size + pad * (cols - 1),
+        device=device,
+    )
+    k = 0
+    for r in range(rows):
+        for c in range(cols):
+            if k >= n:
+                break
+            grid[
+                :,
+                r * (out_size + pad) : r * (out_size + pad) + out_size,
+                c * (out_size + pad) : c * (out_size + pad) + out_size,
+            ] = x[k]
+            k += 1
+    img = (grid.permute(1, 2, 0).cpu().numpy() * 255).astype("uint8")
+    pil = Image.fromarray(img)
+    buf = io.BytesIO()
+    pil.save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode("ascii")

--- a/opt/blackroad/glow/glow_agent/lucidia_bridge.py
+++ b/opt/blackroad/glow/glow_agent/lucidia_bridge.py
@@ -1,0 +1,46 @@
+import hashlib
+import json
+import os
+import pathlib
+import time
+
+BUS_PATH = pathlib.Path(os.getenv("LUCIDIA_BUS", "/opt/blackroad/bus/codex_bus.jsonl"))
+LOG_DIR = pathlib.Path(os.getenv("LOG_DIR", "/opt/blackroad/logs"))
+LOG_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _ps_sha_inf(s: str) -> str:
+    return hashlib.sha256(("PS-SHA∞|" + s).encode()).hexdigest()
+
+
+def log_event(agent: str, action: str, payload: dict):
+    rec = {
+        "t": time.time(),
+        "agent": agent,
+        "action": action,
+        "payload": payload,
+        "truth": 1,
+        "hash": _ps_sha_inf(json.dumps(payload, sort_keys=True)),
+    }
+    BUS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with open(BUS_PATH, "a") as f:
+        f.write(json.dumps(rec) + "\n")
+    with open(LOG_DIR / "glow.events.log", "a") as f:
+        f.write(json.dumps(rec) + "\n")
+
+
+def log_contradiction(agent: str, reason: str, payload: dict):
+    rec = {
+        "t": time.time(),
+        "agent": agent,
+        "action": "contradiction",
+        "reason": reason,
+        "payload": payload,
+        "truth": -1,
+        "hash": _ps_sha_inf(json.dumps(payload, sort_keys=True)),
+    }
+    BUS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with open(BUS_PATH, "a") as f:
+        f.write(json.dumps(rec) + "\n")
+    with open(LOG_DIR / "glow.contradictions.log", "a") as f:
+        f.write(json.dumps(rec) + "\n")

--- a/opt/blackroad/glow/glowctl
+++ b/opt/blackroad/glow/glowctl
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+HOST="${HOST:-localhost}"
+PORT="${PORT:-8018}"
+
+case "${1:-}" in
+  health)
+    curl -s "http://$HOST:$PORT/health" | jq ;;
+  train)
+    curl -s -X POST "http://$HOST:$PORT/train" -H 'content-type: application/json' \
+      -d '{"dataset_dir": null, "img_size":64, "batch":16, "epochs":1, "n_flow":32, "n_block":3, "bits":5}' | jq ;;
+  sample)
+    curl -s -X POST "http://$HOST:$PORT/sample" -H 'content-type: application/json' \
+      -d '{"n":9,"temperature":0.7,"out_size":64}' | jq -r '.image_b64' | base64 --decode > sample.png && echo "wrote sample.png" ;;
+  *)
+    echo "usage: $0 {health|train|sample}"
+    exit 1 ;;
+esac

--- a/opt/blackroad/glow/prepare_dataset.py
+++ b/opt/blackroad/glow/prepare_dataset.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Download and format datasets for Glow training."""
+
+import argparse
+import os
+from pathlib import Path
+
+from torchvision import datasets
+
+DATA_ROOT = Path(os.getenv("DATA_DIR", "/opt/blackroad/data/glow_data"))
+
+
+def prepare_cifar10(out_dir: Path):
+    ds = datasets.CIFAR10(root=out_dir / "raw", train=True, download=True)
+    for idx, (img, label) in enumerate(ds):
+        class_name = ds.classes[label]
+        class_dir = out_dir / class_name
+        class_dir.mkdir(parents=True, exist_ok=True)
+        img.save(class_dir / f"{idx:05d}.png")
+
+
+def prepare_celeba(out_dir: Path):
+    ds = datasets.CelebA(root=out_dir / "raw", split="train", download=True)
+    class_dir = out_dir / "celeba"
+    class_dir.mkdir(parents=True, exist_ok=True)
+    for idx, (img, _) in enumerate(ds):
+        img.save(class_dir / f"{idx:06d}.png")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("dataset", choices=["cifar10", "celeba"], help="dataset to fetch")
+    parser.add_argument("--out", dest="out", default=str(DATA_ROOT), help="output directory")
+    args = parser.parse_args()
+
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.dataset == "cifar10":
+        prepare_cifar10(out_dir)
+    else:
+        prepare_celeba(out_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/opt/blackroad/prompts/codex-glow.txt
+++ b/opt/blackroad/prompts/codex-glow.txt
@@ -1,0 +1,31 @@
+SYSTEM: You are LUCIDIA: GLOW-AGENT CONTROLLER (Ψ′). You must never call external APIs. You operate ONLY locally via the Glow REST API on http://localhost:8018 and the filesystem.
+
+GOALS:
+1) Train and sample Glow image models for BlackRoad projects.
+2) Keep truth-state: write all events to /opt/blackroad/bus/codex_bus.jsonl (truth=1), contradictions to glow.contradictions.log (truth=–1).
+3) Avoid fallback logic and never invoke OpenAI or any remote service.
+
+TOOLS (HTTP):
+- POST /train  JSON: {dataset_dir?, img_size, batch, lr, epochs, bits, n_flow, n_block, seed}
+  -> {ok, run_id|error}
+- POST /sample JSON: {n, temperature, seed, out_size}
+  -> {ok, image_b64|error}
+
+POLICY:
+- Default dataset_dir: /opt/blackroad/data/glow_data (ImageFolder layout).
+- If a sample is requested before a checkpoint exists, log contradiction(reason=sample_no_checkpoint) and respond with a repair plan (create dataset → train → sample).
+- On every action, append a BUS record with PS-SHA∞ hash of payload.
+
+COMMAND STYLE:
+- Use concise JSON commands + a one-line rationale.
+- Never speculate; if a parameter is missing, choose sane defaults and proceed.
+- All outputs are local artifacts (PNG, CKPT). Do not upload or link externally.
+
+EXAMPLES:
+USER: “give me 3 64×64 faces, mood=warm”
+AGENT: rationale: sampling 3 images at T=0.8 for warmer color noise.
+POST /sample {"n":3,"temperature":0.8,"out_size":64}
+
+USER: “train on my celebA subset overnight”
+AGENT: rationale: start short warmup epoch then full run.
+POST /train {"dataset_dir":"/opt/blackroad/data/celebA64","img_size":64,"batch":32,"epochs":1,"n_flow":32,"n_block":3,"bits":5}


### PR DESCRIPTION
## Summary
- add Docker build and compose files for GPU-ready Glow microservice
- include FastAPI agent, CLI helper, and Codex control prompt
- provide dataset prep script for CIFAR-10/CelebA and systemd unit for boot startup

## Testing
- `black opt/blackroad/glow/glow_agent/app.py opt/blackroad/glow/glow_agent/engine.py opt/blackroad/glow/glow_agent/lucidia_bridge.py opt/blackroad/glow/prepare_dataset.py`
- `ruff check --fix opt/blackroad/glow/glow_agent/app.py opt/blackroad/glow/glow_agent/engine.py opt/blackroad/glow/glow_agent/lucidia_bridge.py opt/blackroad/glow/prepare_dataset.py`
- `ruff format opt/blackroad/glow/glow_agent/app.py opt/blackroad/glow/glow_agent/engine.py opt/blackroad/glow/glow_agent/lucidia_bridge.py opt/blackroad/glow/prepare_dataset.py`
- `npx prettier -w opt/blackroad/glow/compose.yml`
- `pre-commit run --files opt/blackroad/glow/compose.yml opt/blackroad/glow/Dockerfile.amd64 opt/blackroad/glow/Dockerfile.jetson opt/blackroad/glow/glow_agent/app.py opt/blackroad/glow/glow_agent/engine.py opt/blackroad/glow/glow_agent/lucidia_bridge.py opt/blackroad/glow/glowctl opt/blackroad/prompts/codex-glow.txt opt/blackroad/glow/prepare_dataset.py opt/blackroad/glow/glow-agent.service` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3eea394f483299c731c16fdb5d8e1