### PR TITLE
Add local main-branch workflow gate

### DIFF
--- a/.github/actions/main-branch-check/action.yml
+++ b/.github/actions/main-branch-check/action.yml
@@ -1,0 +1,141 @@
+name: Local Main Branch Check
+description: Ensure this workflow has a successful run on the main branch before allowing PRs to pass.
+inputs:
+  token:
+    description: GitHub token (use the default GITHUB_TOKEN)
+    required: true
+  main_branch:
+    description: Name of your main branch
+    required: false
+    default: main
+  allow_overrides:
+    description: Allow PR description tokens to bypass the check
+    required: false
+    default: "true"
+  override_tokens:
+    description: Comma-separated tokens that bypass (exact match search in PR body)
+    required: false
+    default: "[ci override_main_branch_checks],[ci override_main_branch_checks $WORKFLOW]"
+  workflow_file:
+    description: Fallback workflow file name (e.g., ci.yml) if GITHUB_WORKFLOW_REF unavailable
+    required: false
+  recency_days:
+    description: Require that main’s last passing run is <= N days old (0 disables)
+    required: false
+    default: "0"
+  verbose:
+    description: Extra logs
+    required: false
+    default: "false"
+runs:
+  using: "composite"
+  steps:
+    - name: Ensure jq
+      shell: bash
+      run: |
+        set -e
+        if ! command -v jq >/dev/null 2>&1; then
+          sudo apt-get update -y
+          sudo apt-get install -y jq
+        fi
+
+    - name: Check main branch has passing run of this workflow
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        MAIN_BRANCH: ${{ inputs.main_branch }}
+        ALLOW_OVERRIDES: ${{ inputs.allow_overrides }}
+        OVERRIDE_TOKENS: ${{ inputs.override_tokens }}
+        WORKFLOW_FILE_FALLBACK: ${{ inputs.workflow_file }}
+        RECENCY_DAYS: ${{ inputs.recency_days }}
+        VERBOSE: ${{ inputs.verbose }}
+      run: |
+        set -euo pipefail
+
+        if [[ "${GITHUB_EVENT_NAME:-}" != "pull_request" && "${GITHUB_EVENT_NAME:-}" != "pull_request_target" ]]; then
+          echo "Not a PR event; skipping."
+          exit 0
+        fi
+
+        # Skip if running on the main branch itself
+        if [[ "${GITHUB_REF_NAME:-}" == "${MAIN_BRANCH}" ]]; then
+          echo "Running on ${MAIN_BRANCH}; skipping."
+          exit 0
+        fi
+
+        # Check overrides in PR body
+        PR_BODY="$(jq -r '.pull_request.body // ""' "$GITHUB_EVENT_PATH")"
+        if [[ "${ALLOW_OVERRIDES}" == "true" ]]; then
+          IFS=',' read -ra TOKS <<< "${OVERRIDE_TOKENS}"
+          for t in "${TOKS[@]}"; do
+            tok="$(echo "$t" | xargs)"
+            if [[ -n "$tok" && "$PR_BODY" == *"$tok"* ]]; then
+              echo "Override token found: '$tok'. Bypassing main-branch check."
+              exit 0
+            fi
+          done
+        fi
+
+        REPO="${GITHUB_REPOSITORY}"
+        API="https://api.github.com"
+        HDR=(-H "Authorization: Bearer ${GH_TOKEN}" -H "Accept: application/vnd.github+json")
+
+        # Resolve workflow file path from GITHUB_WORKFLOW_REF if available
+        WF_FILE=""
+        if [[ -n "${GITHUB_WORKFLOW_REF:-}" ]]; then
+          # form: owner/repo/.github/workflows/<file>@ref
+          WF_PATH="${GITHUB_WORKFLOW_REF#*/*/}"
+          WF_FILE="${WF_PATH#".github/workflows/"}"
+          WF_FILE="${WF_FILE%@*}"
+        else
+          WF_FILE="${WORKFLOW_FILE_FALLBACK}"
+        fi
+
+        if [[ -z "$WF_FILE" ]]; then
+          echo "::error::Cannot determine workflow file name; set inputs.workflow_file."
+          exit 2
+        fi
+
+        [[ "$VERBOSE" == "true" ]] && echo "Workflow file: $WF_FILE"
+
+        # Get workflow id
+        WF_JSON="$(curl -sS "${HDR[@]}" "$API/repos/$REPO/actions/workflows/$WF_FILE")"
+        WF_ID="$(echo "$WF_JSON" | jq -r '.id')"
+        if [[ "$WF_ID" == "null" || -z "$WF_ID" ]]; then
+          echo "::error::Could not resolve workflow id for $WF_FILE"
+          echo "$WF_JSON"
+          exit 2
+        fi
+
+        # Get latest successful run on main branch for this workflow
+        RUNS_JSON="$(curl -sS "${HDR[@]}" "$API/repos/$REPO/actions/workflows/$WF_ID/runs?branch=${MAIN_BRANCH}&status=success&event=push&per_page=1")"
+        COUNT="$(echo "$RUNS_JSON" | jq -r '.total_count // 0')"
+        if (( COUNT < 1 )); then
+          echo "::error::No successful '$WF_FILE' runs found on '${MAIN_BRANCH}'. Re-run the workflow on ${MAIN_BRANCH}."
+          exit 1
+        fi
+
+        RUN_SHA="$(echo "$RUNS_JSON" | jq -r '.workflow_runs[0].head_sha')"
+        RUN_UPDATED="$(echo "$RUNS_JSON" | jq -r '.workflow_runs[0].updated_at')"
+        BASE_SHA="$(jq -r '.pull_request.base.sha' "$GITHUB_EVENT_PATH")"
+
+        if [[ -n "${RECENCY_DAYS}" && "${RECENCY_DAYS}" != "0" ]]; then
+          NOW=$(date -u +%s)
+          RUN_TS=$(date -u -d "$RUN_UPDATED" +%s)
+          AGE_DAYS=$(( (NOW - RUN_TS) / 86400 ))
+          if (( AGE_DAYS > RECENCY_DAYS )); then
+            echo "::error::Latest main run is ${AGE_DAYS} days old (> ${RECENCY_DAYS}). Re-run on ${MAIN_BRANCH}."
+            exit 1
+          fi
+        fi
+
+        # Ensure the successful main run includes the PR base commit
+        CMP_JSON="$(curl -sS "${HDR[@]}" "$API/repos/$REPO/compare/$BASE_SHA...$RUN_SHA")"
+        STATUS="$(echo "$CMP_JSON" | jq -r '.status')"
+        if [[ "$STATUS" != "ahead" && "$STATUS" != "identical" ]]; then
+          echo "::error::Latest successful main run ($RUN_SHA) does not include PR base $BASE_SHA. Re-run '$WF_FILE' on ${MAIN_BRANCH}."
+          exit 1
+        fi
+
+        echo "Main-branch check passed: $RUN_SHA @ $RUN_UPDATED includes base $BASE_SHA."
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,15 @@
-## Summary
-Describe changes.
+### Summary
+Describe the change and why it exists.
 
-## Testing
-Steps run.
+### Tests
+List how you tested this change (commands, screenshots, logs).
 
-## Linked Issues
-Closes #
+### Rollout / Risk
+- Risks:
+- Mitigations:
+- Rollback plan:
+
+> **Bypass (emergencies only):**
+> Add one of these tokens to the PR description to skip the main-branch gate:
+> `[ci override_main_branch_checks]` or `[ci override_main_branch_checks $WORKFLOW]`
+

--- a/.github/workflows/blackroad-ci.yml
+++ b/.github/workflows/blackroad-ci.yml
@@ -1,4 +1,4 @@
-name: Lucidia CI
+name: BlackRoad CI
 on:
   pull_request:
     branches: ["*"]
@@ -9,7 +9,7 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: lucidia-ci-${{ github.ref }}
+  group: blackroad-ci-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -19,12 +19,14 @@ jobs:
       - uses: actions/checkout@v4
 
       # ❗️ Your real build/test steps go here
-      - run: echo "Run Lucidia build/tests here"
+      - run: echo "Run BlackRoad build/tests here"
 
+      # Policy gate: require this workflow to be green on main
       - name: Main Branch Check (local)
         uses: ./.github/actions/main-branch-check
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           main_branch: main
-          recency_days: 7
+          recency_days: 7            # optional: require a recent passing run
+          verbose: "true"
 

--- a/codex/prompts/main_branch_gate.prompt.md
+++ b/codex/prompts/main_branch_gate.prompt.md
@@ -1,0 +1,58 @@
+# Role
+You are **Guardian**, a deterministic policy gate for pull requests. You never merge logic; you only **evaluate** and **report**. Use trinary logic:
+- `1` = PASS (permit)
+- `0` = HOLD (needs action)
+- `−1` = BLOCK (violation)
+
+# Objective
+Only allow a PR to pass if the **same workflow** has a **successful run on the main branch** that **includes** the PR’s base commit. Allow an explicit override token. Log contradictions.
+
+# Inputs (JSON)
+{
+  "repo": "<owner/name>",
+  "main_branch": "main",
+  "workflow_file": "<e.g., blackroad-ci.yml>",
+  "pr": {
+    "number": <int>,
+    "base_sha": "<sha>",
+    "body": "<markdown>"
+  },
+  "latest_main_success": {
+    "head_sha": "<sha>",
+    "updated_at": "<RFC3339 or ISO8601>"
+  },
+  "recency_days": 7,
+  "override_tokens": ["[ci override_main_branch_checks]", "[ci override_main_branch_checks $WORKFLOW]"]
+}
+
+# Evaluation Steps
+1. **Override Check**: If PR body contains any override token → emit `result=1`, `note="override"`, `contradiction=Ψ′_override`.
+2. **Recency**: If `recency_days > 0` and the successful main run is older than `recency_days` → `result=0`, `note="re-run main"`.
+3. **Inclusion**: Verify that `latest_main_success.head_sha` is **ahead of or identical to** `pr.base_sha` (i.e., main’s passing run includes the base). If not → `result=−1`, `note="main run does not include base"`.
+4. Otherwise → `result=1`, `note="ok"`.
+
+# Output (JSON)
+{
+  "result": 1 | 0 | -1,
+  "note": "<string>",
+  "details": {
+    "main_sha": "<sha>",
+    "base_sha": "<sha>",
+    "updated_at": "<timestamp>",
+    "recency_days": <int>
+  },
+  "log": [
+    "guardian:check:override=<true|false>",
+    "guardian:check:recency=<ok|stale>",
+    "guardian:check:inclusion=<ok|fail>"
+  ]
+}
+
+# Style
+- Deterministic, terse, machine-ready.
+- If `result != 1`, include **one** actionable instruction.
+- If override used, emit a **contradiction note** and tag `Ψ′_override`.
+
+# Example Response
+{"result":0,"note":"re-run main","details":{"main_sha":"abc...","base_sha":"def...","updated_at":"2025-08-10T12:34:56Z","recency_days":7},"log":["guardian:check:override=false","guardian:check:recency=stale","guardian:check:inclusion=ok"]}
+


### PR DESCRIPTION
## Summary
- add composite action verifying main branch CI run
- wire up BlackRoad and Lucidia CI workflows to use new gate
- document override tokens in PR template and codex prompt

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3ee7073c883298d3d05332f669678