### PR TITLE
feat: add music clip dashboard tile

### DIFF
--- a/index.html
+++ b/index.html
@@ -513,6 +513,24 @@
                 <span>🎯 Live</span><span>📊 85%</span><span>⏰ now</span>
               </div>
             </article>
+
+            <article class="card" id="clipsCard">
+              <span class="status s-active">New</span>
+              <h3>Generated Clips</h3>
+              <div
+                id="clipList"
+                style="
+                  margin-top: 8px;
+                  display: flex;
+                  flex-direction: column;
+                  gap: 8px;
+                  max-height: 200px;
+                  overflow: auto;
+                "
+              >
+                <p style="color: var(--muted)">Loading…</p>
+              </div>
+            </article>
           </div>
 
           <div class="editor card">
@@ -833,6 +851,29 @@
         renderChat();
       };
       renderChat();
+
+      /* ---------------- Audio clips ---------------- */
+      async function loadClips() {
+        try {
+          const res = await fetch('/api/music/clips', { cache: 'no-cache' });
+          const data = await res.json();
+          const list = $('#clipList');
+          list.innerHTML = '';
+          if (!data.files || !data.files.length) {
+            list.innerHTML = '<p style="color: var(--muted)">No clips yet.</p>';
+            return;
+          }
+          data.files.forEach((f) => {
+            const div = document.createElement('div');
+            div.innerHTML = `<audio controls src="/media/${encodeURIComponent(f)}" style="width:100%"></audio>`;
+            list.appendChild(div);
+          });
+        } catch (err) {
+          console.error(err);
+          $('#clipList').innerHTML = '<p style="color: var(--muted)">Failed to load clips</p>';
+        }
+      }
+      loadClips();
 
       /* ---------------- Search box acts as command palette too ---------------- */
       $('#q').addEventListener('keydown', (e) => {

--- a/src/routes/music.js
+++ b/src/routes/music.js
@@ -1,0 +1,17 @@
+import express from 'express';
+import fs from 'node:fs';
+
+const router = express.Router();
+const MUSIC_DIR = process.env.MUSIC_OUT || '/opt/blackroad/data/outputs';
+
+router.get('/clips', (_req, res) => {
+  fs.readdir(MUSIC_DIR, (err, files = []) => {
+    if (err) {
+      return res.json({ files: [] });
+    }
+    const audio = files.filter((f) => /\.(wav|mp3|ogg)$/i.test(f));
+    res.json({ files: audio });
+  });
+});
+
+export default router;

--- a/src/server.js
+++ b/src/server.js
@@ -1,10 +1,14 @@
 /* FILE: /var/www/blackroad/src/server.js */
 import express from 'express';
 import aiderRouter from './routes/aider.js';
+import musicRouter from './routes/music.js';
 
 const app = express();
 app.get('/health', (_req, res) => res.json({ ok: true }));
 app.use('/api/aider', aiderRouter);
+const MUSIC_DIR = process.env.MUSIC_OUT || '/opt/blackroad/data/outputs';
+app.use('/api/music', musicRouter);
+app.use('/media', express.static(MUSIC_DIR));
 
 const PORT = process.env.PORT || 8000;
 app.listen(PORT, () => console.log(`[server] listening on :${PORT}`));


### PR DESCRIPTION
## Summary
- add route and static media serving for generated music clips
- show "Generated Clips" tile on dashboard with inline audio players

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pre-commit run --files src/routes/music.js src/server.js index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ee5d0278832988325984111901c0