### PR TITLE
Add OpenAI-free MPE orchestration stack

### DIFF
--- a/etc/blackroad/mpe.yaml
+++ b/etc/blackroad/mpe.yaml
@@ -1,0 +1,7 @@
+scenario: simple_tag
+episodes: 3
+seed: null
+render: off
+policy: random
+log_dir: /var/log/blackroad/mpe
+meta_dir: /opt/blackroad/lucidia/memory/mpe

--- a/opt/blackroad/codex/prompts/mpe_orchestrator.prompt
+++ b/opt/blackroad/codex/prompts/mpe_orchestrator.prompt
@@ -1,0 +1,33 @@
+ROLE: Lucidia–MPE Orchestrator (no external APIs; OpenAI-free)
+GOAL: Run Multi-Particle Environments (MPE) locally and converse about outcomes. Coordinate agent loops, summarize rewards, surface contradictions to Ψ′, and propose next experiments.
+
+CONTEXT
+- Environments live in mpe2 / pettingzoo.mpe (v3 APIs).
+- Local bridge: /opt/blackroad/lucidia/agents/mpe/chat_adapter.py
+- Commands must be embedded as single-line control messages:
+  [MPE start scenario=<name> episodes=<N> seed=<S> render=off|human policy=random|zeros]
+  [MPE scenarios]
+- The bridge returns one-line JSON. You MUST parse it and then speak in concise, machine-first summaries.
+
+PRINCIPLES
+1) Truth-first, no fallback. If uncertain, run a small test (episodes ≤ 5) and report observed rewards.
+2) Minimalism: state scenario, seed, episodes, total reward by agent, and log path only.
+3) Ψ-perturbation: when flagged (perturb=True), deliberately propose a contrasting hypothesis with a short plan to falsify it in ≤ 3 runs.
+4) Memory: persist the log path and tag; reference past tags when comparing results.
+
+FORMAT
+- To execute: emit exactly one control line on its own:
+  [MPE start scenario=simple_tag episodes=3 seed=7 render=off policy=random]
+- Then, after the JSON is returned, reply with:
+  summary: <one sentence>
+  agents: <list or count>
+  rewards: <compact dict>
+  log: <path>
+
+EXAMPLES
+User: try a quick tag run
+You: [MPE start scenario=simple_tag episodes=2 seed=1 render=off]
+You: summary: simple_tag x2 (seed=1) random baseline; all agents active
+    agents: 4
+    rewards: {"adversary_0":-1.0,"adversary_1":-0.3,"adversary_2":-0.7,"agent_0":0.9}
+    log: /var/log/blackroad/mpe/chat-simple_tag.jsonl

--- a/opt/blackroad/lucidia/agents/mpe/README.md
+++ b/opt/blackroad/lucidia/agents/mpe/README.md
@@ -1,0 +1,45 @@
+# Lucidia × MPE (OpenAI-free)
+
+## Install
+```bash
+pip install numpy
+pip install mpe2 || pip install "pettingzoo[mpe]"
+
+Quick run
+
+python /opt/blackroad/lucidia/agents/mpe/runner.py --scenario simple_tag --episodes 3 --seed 7 --render off
+
+Prints a JSON summary and writes JSONL steps to /var/log/blackroad/mpe/.
+
+Chat mode
+
+python /opt/blackroad/lucidia/agents/mpe/chat_adapter.py
+# then type:
+scenarios
+start scenario=simple_spread episodes=2 seed=11 render=off
+
+Codex Infinity
+
+Load /opt/blackroad/codex/prompts/mpe_orchestrator.prompt and let the engine
+emit control lines like [MPE start scenario=... ...] and parse the JSON reply.
+
+Notes
+•MPE lives in MPE2 (new package); PettingZoo MPE is being moved. Prefer mpe2 imports.
+•Legacy OpenAI MPE is archived; no dependency on it.
+
+---
+
+### Why this wiring (and why now)
+
+- **MPE2 is the new home**: PettingZoo warns MPE v3 envs are moving; this setup prefers `mpe2.*_v3` and only falls back to `pettingzoo.mpe` if needed.  [oai_citation:6‡pettingzoo.farama.org](https://pettingzoo.farama.org/environments/mpe/simple_tag/?utm_source=chatgpt.com) [oai_citation:7‡mpe2.farama.org](https://mpe2.farama.org/?utm_source=chatgpt.com)
+- **API-compatible loop**: we use PettingZoo/MPE2’s `agent_iter()` pattern correctly for deterministic stepping.  [oai_citation:8‡pettingzoo.farama.org](https://pettingzoo.farama.org/content/basic_usage/?utm_source=chatgpt.com)
+- **OpenAI-free**: no calls to OpenAI APIs; legacy OpenAI MPE repo acknowledged but unused.  [oai_citation:9‡GitHub](https://github.com/openai/multiagent-particle-envs?utm_source=chatgpt.com)
+
+---
+
+### Next knobs (optional)
+- Add an `independent PPO` policy if you want learning (SB3 via Gymnasium wrappers).
+- Expose the chat adapter over FastAPI for web UI on blackroad.io’s dashboard.
+- Wire contradictions to your Ψ′ log by reading `/var/log/blackroad/mpe/*.jsonl` and computing deltas between tags.
+
+If you want the FastAPI microservice or a lean PPO policy added, say the word and I’ll drop two more nano-ready files.

--- a/opt/blackroad/lucidia/agents/mpe/chat_adapter.py
+++ b/opt/blackroad/lucidia/agents/mpe/chat_adapter.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""
+Minimal chat bridge:
+Input lines like:
+  scenarios
+  start scenario=simple_tag episodes=5 seed=7 render=off policy=random
+  start scenario=simple_spread episodes=3
+  help
+Emits one-line JSON for programmatic consumption.
+"""
+import sys, json, shlex
+from env import LucidiaMPE, available_scenarios
+
+def parse_kv(parts):
+    cfg = {}
+    for p in parts:
+        if "=" in p:
+            k, v = p.split("=", 1)
+            cfg[k.strip()] = v.strip()
+    return cfg
+
+def to_bool(s):
+    return s.lower() in ("1","true","yes","on")
+
+def handle(line: str):
+    line = line.strip()
+    if not line:
+        return {"ok": True, "echo": ""}
+    if line == "help":
+        return {"ok": True, "help": "commands: scenarios | start scenario=<name> [episodes=N seed=S render=off|human policy=random|zeros]"}
+    if line == "scenarios":
+        return {"ok": True, "scenarios": available_scenarios()}
+
+    if line.startswith("start"):
+        parts = shlex.split(line)
+        cfg = parse_kv(parts[1:])
+        scenario = cfg.get("scenario", "simple_tag")
+        episodes = int(cfg.get("episodes", 3))
+        seed = int(cfg["seed"]) if "seed" in cfg else None
+        render = cfg.get("render", "off")
+        policy = cfg.get("policy", "random")
+        env = LucidiaMPE(
+            scenario=scenario,
+            render_mode=None if render=="off" else "human",
+        )
+        res = env.run_episodes(episodes=episodes, policy=policy, episode_tag=f"chat-{scenario}")
+        return {"ok": True, "result": res}
+
+    return {"ok": False, "error": f"unknown command: {line}"}
+
+def main():
+    for raw in sys.stdin:
+        try:
+            out = handle(raw)
+        except Exception as e:
+            out = {"ok": False, "error": repr(e)}
+        sys.stdout.write(json.dumps(out, separators=(",", ":")) + "\n")
+        sys.stdout.flush()
+
+if __name__ == "__main__":
+    main()

--- a/opt/blackroad/lucidia/agents/mpe/env.py
+++ b/opt/blackroad/lucidia/agents/mpe/env.py
@@ -1,0 +1,183 @@
+"""
+Lucidia MPE unified loader + runner (OpenAI-free)
+- Prefers mpe2.*_v3 (new home), falls back to pettingzoo.mpe.*_v3.
+- Structured JSONL logging for BlackRoad/Lucidia.
+"""
+from __future__ import annotations
+import os, json, time, importlib, datetime as _dt
+from typing import Any, Dict, Optional, Callable
+
+try:
+    import numpy as np
+except Exception as e:
+    raise RuntimeError("numpy is required: pip install numpy") from e
+
+# Known scenario base names (v3 variants exist in mpe2 & pettingzoo.mpe)
+KNOWN = [
+    "simple", "simple_adversary", "simple_crypto", "simple_push",
+    "simple_reference", "simple_speaker_listener", "simple_spread",
+    "simple_tag", "simple_world_comm"
+]
+
+def _ensure_dir(p: str) -> None:
+    os.makedirs(p, exist_ok=True)
+
+def _jsonable(x):
+    if x is None: return None
+    if isinstance(x, (int, float, str, bool)): return x
+    if isinstance(x, dict): return {k: _jsonable(v) for k, v in x.items()}
+    if isinstance(x, (list, tuple)): return [_jsonable(v) for v in x]
+    if 'numpy' in type(x).__module__:
+        return x.tolist()
+    return str(x)
+
+def _load_module_for(base: str):
+    key = f"{base}_v3"
+    # Prefer mpe2 (new package), then PettingZoo fallback
+    for pkg in ("mpe2", "pettingzoo.mpe"):
+        try:
+            return importlib.import_module(f"{pkg}.{key}")
+        except ModuleNotFoundError:
+            continue
+    raise ImportError(
+        f"Could not import scenario '{base}'. Install 'mpe2' or 'pettingzoo[mpe]'."
+    )
+
+def available_scenarios():
+    out = []
+    for base in KNOWN:
+        try:
+            _load_module_for(base)
+            out.append(base)
+        except Exception:
+            pass
+    return sorted(set(out))
+
+class LucidiaMPE:
+    def __init__(
+        self,
+        scenario: str = "simple_tag",
+        render_mode: Optional[str] = None,  # "human" or None
+        seed: Optional[int] = None,
+        log_dir: str = "/var/log/blackroad/mpe",
+        meta_dir: str = "/opt/blackroad/lucidia/memory/mpe",
+        max_cycles: Optional[int] = None,
+        continuous_actions: Optional[bool] = None,
+        local_ratio: Optional[float] = None,
+        **kwargs: Any,
+    ):
+        self.scenario = scenario
+        self.seed = seed
+        self.render_mode = render_mode
+        self.max_cycles = max_cycles
+        self.continuous_actions = continuous_actions
+        self.local_ratio = local_ratio
+        self.extra_kwargs = dict(kwargs)
+
+        _ensure_dir(log_dir)
+        _ensure_dir(meta_dir)
+        self.log_dir = log_dir
+        self.meta_dir = meta_dir
+
+        mod = _load_module_for(scenario)
+        self._env_ctor = getattr(mod, "env")  # AEC API
+        # common ctor kwargs across MPE2/PettingZoo
+        ctor_kwargs = {}
+        if render_mode is not None:
+            ctor_kwargs["render_mode"] = render_mode
+        if max_cycles is not None:
+            ctor_kwargs["max_cycles"] = max_cycles
+        if continuous_actions is not None:
+            ctor_kwargs["continuous_actions"] = continuous_actions
+        if local_ratio is not None:
+            ctor_kwargs["local_ratio"] = local_ratio
+        ctor_kwargs.update(self.extra_kwargs)
+        self.env = self._env_ctor(**ctor_kwargs)
+
+    def run_episodes(
+        self,
+        episodes: int = 3,
+        policy: str = "random",
+        policy_fn: Optional[Callable[[str, Any, Any], Any]] = None,
+        episode_tag: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Run episodes with agent_iter loop. Logs JSONL to log_dir.
+        Returns a compact summary dict.
+        """
+        ts = _dt.datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+        tag = episode_tag or f"{self.scenario}-{ts}"
+        out_path = os.path.join(self.log_dir, f"{tag}.jsonl")
+
+        def choose_action(agent, obs, env):
+            if policy_fn is not None:
+                return policy_fn(agent, obs, env)
+            if policy == "zeros":
+                space = env.action_space(agent)
+                if hasattr(space, "n"):
+                    return 0
+                return np.zeros(space.shape, dtype=space.dtype if hasattr(space, "dtype") else np.float32)
+            # default random
+            return env.action_space(agent).sample()
+
+        totals = { "episodes": episodes, "by_agent": {}, "rewards": [] }
+        with open(out_path, "w") as f:
+            for ep in range(episodes):
+                reset_kwargs = {}
+                if self.seed is not None:
+                    reset_kwargs["seed"] = int(self.seed) + ep
+                obs_dict = self.env.reset(**reset_kwargs)
+                step_idx = 0
+                ep_reward = {}
+
+                # AEC API
+                for agent in self.env.agent_iter():
+                    obs, rew, term, trunc, info = self.env.last()
+                    ep_reward[agent] = ep_reward.get(agent, 0.0) + float(rew)
+
+                    if term or trunc:
+                        action = None
+                    else:
+                        action = choose_action(agent, obs, self.env)
+
+                    self.env.step(action)
+
+                    rec = {
+                        "t": time.time(),
+                        "episode": ep,
+                        "step": step_idx,
+                        "scenario": self.scenario,
+                        "agent": agent,
+                        "reward": float(rew),
+                        "terminated": bool(term),
+                        "truncated": bool(trunc),
+                        "action": _jsonable(action),
+                        "info": _jsonable(info),
+                    }
+                    f.write(json.dumps(rec, separators=(",", ":")) + "\n")
+                    step_idx += 1
+
+                totals["rewards"].append(ep_reward)
+                for a, r in ep_reward.items():
+                    totals["by_agent"][a] = totals["by_agent"].get(a, 0.0) + float(r)
+
+        # meta drops (Lucidia memory / contradiction stubs)
+        meta_blob = {
+            "tag": tag,
+            "scenario": self.scenario,
+            "episodes": episodes,
+            "agents": sorted(self.env.possible_agents) if hasattr(self.env, "possible_agents") else None,
+            "log_path": out_path,
+        }
+        with open(os.path.join(self.meta_dir, f"{tag}.meta.json"), "w") as mf:
+            mf.write(json.dumps(meta_blob, indent=2))
+
+        return {
+            "tag": tag,
+            "log_path": out_path,
+            "summary": {
+                "episodes": episodes,
+                "total_reward_by_agent": totals["by_agent"],
+                "episode_rewards": totals["rewards"],
+            },
+        }

--- a/opt/blackroad/lucidia/agents/mpe/runner.py
+++ b/opt/blackroad/lucidia/agents/mpe/runner.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+import argparse, json, sys
+from env import LucidiaMPE, available_scenarios
+
+def main():
+    ap = argparse.ArgumentParser("lucidia-mpe-runner")
+    ap.add_argument("--scenario", default="simple_tag", choices=available_scenarios() or ["simple_tag"],
+                    help="MPE scenario base name (e.g., simple_tag)")
+    ap.add_argument("--episodes", type=int, default=3)
+    ap.add_argument("--seed", type=int, default=None)
+    ap.add_argument("--render", default="off", choices=["off", "human"])
+    ap.add_argument("--log-dir", default="/var/log/blackroad/mpe")
+    ap.add_argument("--meta-dir", default="/opt/blackroad/lucidia/memory/mpe")
+    ap.add_argument("--max-cycles", type=int, default=None)
+    ap.add_argument("--continuous-actions", action="store_true")
+    ap.add_argument("--local-ratio", type=float, default=None)
+    ap.add_argument("--policy", default="random", choices=["random","zeros"])
+    args = ap.parse_args()
+
+    env = LucidiaMPE(
+        scenario=args.scenario,
+        render_mode=None if args.render=="off" else "human",
+        seed=args.seed,
+        log_dir=args.log_dir,
+        meta_dir=args.meta_dir,
+        max_cycles=args.max_cycles,
+        continuous_actions=args.continuous_actions,
+        local_ratio=args.local_ratio,
+    )
+    res = env.run_episodes(episodes=args.episodes, policy=args.policy)
+    print(json.dumps(res, indent=2))
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add LucidiaMPE loader that prefers mpe2 scenarios and falls back to pettingzoo with structured JSONL logs
- provide CLI runner and chat adapter for running and chatting with environments
- ship Codex Infinity prompt, default config, and README guidance

## Testing
- `python -m py_compile opt/blackroad/lucidia/agents/mpe/env.py opt/blackroad/lucidia/agents/mpe/runner.py opt/blackroad/lucidia/agents/mpe/chat_adapter.py`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3ee4429948329bfb518922de43a1c