### PR TITLE
Add Lucidia GEMM module

### DIFF
--- a/opt/blackroad/lucidia_gemm/CMakeLists.txt
+++ b/opt/blackroad/lucidia_gemm/CMakeLists.txt
@@ -1,0 +1,97 @@
+cmake_minimum_required(VERSION 3.20)
+project(lucidia_gemm LANGUAGES CXX CUDA)
+
+# ---------- Options ----------
+option(USE_FETCHCONTENT_CUTLASS "Fetch CUTLASS with CMake if CUTLASS_DIR not set" ON)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CUDA_STANDARD 17)
+set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
+
+# Target Orin (Ampere SM 8.7). Add others if you like: 80;86;89;90
+set(CMAKE_CUDA_ARCHITECTURES 87)
+
+# ---------- Dependencies ----------
+find_package(Python3 REQUIRED COMPONENTS Interpreter Development.Module)
+find_package(pybind11 REQUIRED)
+find_package(Torch REQUIRED)
+find_package(CUDAToolkit REQUIRED)
+
+# CUTLASS: either provide CUTLASS_DIR to a local checkout, or fetch it.
+if(DEFINED CUTLASS_DIR)
+  message(STATUS "Using CUTLASS from ${CUTLASS_DIR}")
+  set(CUTLASS_INCLUDE_DIR "${CUTLASS_DIR}/include" CACHE PATH "" FORCE)
+else()
+  if(USE_FETCHCONTENT_CUTLASS)
+    include(FetchContent)
+    FetchContent_Declare(
+      cutlass
+      GIT_REPOSITORY https://github.com/NVIDIA/cutlass.git
+      GIT_TAG v3.5.1
+    )
+    FetchContent_MakeAvailable(cutlass)
+    set(CUTLASS_INCLUDE_DIR "${cutlass_SOURCE_DIR}/include" CACHE PATH "" FORCE)
+  else()
+    message(FATAL_ERROR "CUTLASS_DIR not set and USE_FETCHCONTENT_CUTLASS=OFF")
+  endif()
+endif()
+
+# ---------- Sources ----------
+set(LUCIDIA_GEMM_SOURCES
+  src/lucidia_gemm_cutlass.cu
+  src/lucidia_gemm_cublaslt.cpp
+  python/bindings.cpp
+)
+
+add_library(lucidia_gemm MODULE ${LUCIDIA_GEMM_SOURCES})
+
+target_include_directories(lucidia_gemm PRIVATE
+  ${CUTLASS_INCLUDE_DIR}
+  ${TORCH_INCLUDE_DIRS}
+  ${Python3_INCLUDE_DIRS}
+  ${CUDAToolkit_INCLUDE_DIRS}
+  include
+)
+
+target_link_libraries(lucidia_gemm PRIVATE
+  pybind11::module
+  ${TORCH_LIBRARIES}
+  CUDA::cudart
+  CUDA::cublas
+  CUDA::cublasLt
+)
+
+# Disable prefix "lib" and ensure correct python module suffix
+set_target_properties(lucidia_gemm PROPERTIES
+  PREFIX ""
+  SUFFIX "${Python3_EXTENSION_SUFFIX}"
+)
+
+# Compile flags
+target_compile_definitions(lucidia_gemm PRIVATE
+  -D_GLIBCXX_USE_CXX11_ABI=$<IF:$<BOOL:${GLIBCXX_USE_CXX11_ABI}>,1,1>
+  -DLUCIDIA_GEMM_VERSION=\"0.1.0\"
+)
+
+target_compile_options(lucidia_gemm PRIVATE
+  $<$<COMPILE_LANGUAGE:CUDA>:
+    --expt-relaxed-constexpr
+    --expt-extended-lambda
+    --use_fast_math
+    -O3
+  >
+  $<$<COMPILE_LANGUAGE:CXX>:
+    -O3
+    -fno-exceptions
+  >
+)
+
+# RPATH so the module finds Torch/ CUDA at runtime
+if(APPLE)
+  # not needed
+else()
+  set_property(TARGET lucidia_gemm PROPERTY INSTALL_RPATH_USE_LINK_PATH TRUE)
+endif()
+
+message(STATUS "Torch includes: ${TORCH_INCLUDE_DIRS}")
+message(STATUS "CUTLASS includes: ${CUTLASS_INCLUDE_DIR}")

--- a/opt/blackroad/lucidia_gemm/examples/use_in_lucidia.py
+++ b/opt/blackroad/lucidia_gemm/examples/use_in_lucidia.py
@@ -1,0 +1,8 @@
+import torch, os
+os.environ.setdefault("LUCIDIA_GEMM_BACKEND", "cutlass")
+import lucidia_gemm as lg
+
+def mlp_linear(a_fp16, W_fp16, bias_fp32=None, activation="gelu"):
+    # a: [B, K], W: [K, N]  -> [B, N]
+    out = lg.gemm(a_fp16, W_fp16, bias=bias_fp32, activation=activation, out_dtype="fp16")
+    return out

--- a/opt/blackroad/lucidia_gemm/include/lucidia_gemm/common.h
+++ b/opt/blackroad/lucidia_gemm/include/lucidia_gemm/common.h
@@ -1,0 +1,51 @@
+#pragma once
+#include <cstdint>
+#include <stdexcept>
+#include <cuda_runtime.h>
+
+#define LUCIDIA_CHECK_CUDA(expr)                                                   \
+  do {                                                                             \
+    cudaError_t _err = (expr);                                                     \
+    if (_err != cudaSuccess) {                                                     \
+      throw std::runtime_error(std::string("CUDA error: ") +                       \
+        cudaGetErrorString(_err) + " at " + __FILE__ + ":" + std::to_string(__LINE__)); \
+    }                                                                              \
+  } while (0)
+
+#define LUCIDIA_CHECK_CUDART()                                                     \
+  do {                                                                             \
+    cudaError_t _err = cudaGetLastError();                                         \
+    if (_err != cudaSuccess) {                                                     \
+      throw std::runtime_error(std::string("CUDA kernel error: ") +                \
+        cudaGetErrorString(_err) + " at " + __FILE__ + ":" + std::to_string(__LINE__)); \
+    }                                                                              \
+  } while (0)
+
+enum class Activation : int32_t { None = 0, ReLU = 1, GELU = 2 };
+
+// fast GELU (tanh approximation)
+__device__ __forceinline__ float gelu_fast(float x) {
+  const float kAlpha = 0.7978845608028654f;   // sqrt(2/pi)
+  const float kBeta  = 0.044715f;
+  float x3 = x * x * x;
+  float inner = kAlpha * (x + kBeta * x3);
+  return 0.5f * x * (1.0f + tanhf(inner));
+}
+
+// post-processing kernel: add column-wise bias[N] then activation
+__global__ void bias_activation_kernel(float* __restrict__ C,
+                                       const float* __restrict__ bias, // nullable
+                                       int M, int N, Activation act) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int size = M * N;
+  if (idx >= size) return;
+  int col = idx % N;
+  float v = C[idx];
+  if (bias) v += bias[col];
+  if (act == Activation::ReLU) {
+    v = v > 0.f ? v : 0.f;
+  } else if (act == Activation::GELU) {
+    v = gelu_fast(v);
+  }
+  C[idx] = v;
+}

--- a/opt/blackroad/lucidia_gemm/python/bindings.cpp
+++ b/opt/blackroad/lucidia_gemm/python/bindings.cpp
@@ -1,0 +1,148 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <torch/extension.h>
+#include <ATen/cuda/CUDAContext.h>
+#include "lucidia_gemm/common.h"
+
+namespace py = pybind11;
+
+namespace lucidia_gemm {
+  // cutlass backend
+  void run_cutlass_fp16fp32RowRowRow(const void* A, const void* B, void* C,
+                                     int64_t M, int64_t N, int64_t K,
+                                     int64_t lda, int64_t ldb, int64_t ldc,
+                                     float alpha, float beta, cudaStream_t stream);
+  // cublasLt backend
+  void run_cublaslt_fp16fp32RowRowRow(const void* A, const void* B, void* C,
+                                      int64_t M, int64_t N, int64_t K,
+                                      int64_t lda, int64_t ldb, int64_t ldc,
+                                      float alpha, float beta, cudaStream_t stream);
+}
+
+static Activation parse_activation(const std::string& s) {
+  std::string t = s;
+  for (auto &c : t) c = std::tolower(c);
+  if (t == "none" || t.empty()) return Activation::None;
+  if (t == "relu") return Activation::ReLU;
+  if (t == "gelu") return Activation::GELU;
+  throw std::invalid_argument("activation must be one of: none, relu, gelu");
+}
+
+static bool prefer_cutlass(int64_t M, int64_t N, int64_t K) {
+  const char* env = std::getenv("LUCIDIA_GEMM_BACKEND");
+  if (env) {
+    std::string s(env);
+    for (auto &c : s) c = std::tolower(c);
+    if (s == "cutlass") return true;
+    if (s == "cublaslt") return false;
+  }
+  // Heuristic: CUTLASS usually wins on small-M
+  return M <= 128;
+}
+
+torch::Tensor gemm(torch::Tensor A, torch::Tensor B,
+                   c10::optional<torch::Tensor> bias_opt,
+                   const std::string& activation = "none",
+                   bool transa = false, bool transb = false,
+                   double alpha_d = 1.0, double beta_d = 0.0,
+                   const std::string& out_dtype = "fp16") {
+  TORCH_CHECK(A.is_cuda() && B.is_cuda(), "A and B must be CUDA tensors");
+  TORCH_CHECK(A.dtype() == torch::kHalf && B.dtype() == torch::kHalf,
+              "A and B must be float16");
+  TORCH_CHECK(A.is_contiguous() && B.is_contiguous(),
+              "A and B must be contiguous (row-major)");
+
+  int64_t M = transa ? A.size(1) : A.size(0);
+  int64_t K_a = transa ? A.size(0) : A.size(1);
+  int64_t K_b = transb ? B.size(1) : B.size(0);
+  int64_t N = transb ? B.size(0) : B.size(1);
+  TORCH_CHECK(K_a == K_b, "Inner dimensions must match: got ", K_a, " vs ", K_b);
+  int64_t K = K_a;
+
+  // output as FP32 for compute, optionally cast to FP16 at the end
+  auto optsF32 = A.options().dtype(torch::kFloat);
+  auto C32 = torch::empty({M, N}, optsF32);
+
+  float alpha = static_cast<float>(alpha_d);
+  float beta  = static_cast<float>(beta_d);
+
+  // Leading dimensions for row-major
+  int64_t lda = transa ? M : K;
+  int64_t ldb = transb ? K : N;
+  int64_t ldc = N;
+
+  // CUDA stream
+  cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
+  const void* A_ptr = A.data_ptr();
+  const void* B_ptr = B.data_ptr();
+  void* C_ptr = C32.data_ptr();
+
+  // Back-end selection
+  if (prefer_cutlass(M, N, K)) {
+    // CUTLASS expects row-major arguments as provided
+    lucidia_gemm::run_cutlass_fp16fp32RowRowRow(
+      A_ptr, B_ptr, C_ptr, M, N, K, lda, ldb, ldc, alpha, beta, stream);
+  } else {
+    // cuBLASLt
+    lucidia_gemm::run_cublaslt_fp16fp32RowRowRow(
+      A_ptr, B_ptr, C_ptr, M, N, K, lda, ldb, ldc, alpha, beta, stream);
+  }
+
+  // Optional bias + activation (post-process)
+  Activation act = parse_activation(activation);
+  const float* bias_ptr = nullptr;
+  if (bias_opt.has_value()) {
+    auto bias = bias_opt.value();
+    TORCH_CHECK(bias.is_cuda(), "bias must be CUDA tensor");
+    TORCH_CHECK(bias.dtype() == torch::kFloat || bias.dtype() == torch::kHalf,
+                "bias must be float32 or float16");
+    TORCH_CHECK(bias.numel() == N, "bias must be length N");
+    if (bias.dtype() == torch::kHalf) bias = bias.to(torch::kFloat);
+    bias_ptr = bias.data_ptr<float>();
+  }
+
+  int total = static_cast<int>(M * N);
+  int block = 256;
+  int grid = (total + block - 1) / block;
+  bias_activation_kernel<<<grid, block, 0, stream>>>(
+    C32.data_ptr<float>(), bias_ptr, (int)M, (int)N, act);
+  LUCIDIA_CHECK_CUDART();
+
+  // Output dtype
+  std::string t = out_dtype;
+  for (auto &c : t) c = std::tolower(c);
+  if (t == "fp16" || t == "half") {
+    return C32.to(torch::kHalf);
+  } else if (t == "fp32" || t == "float") {
+    return C32;
+  } else {
+    throw std::invalid_argument("out_dtype must be 'fp16' or 'fp32'");
+  }
+}
+
+PYBIND11_MODULE(lucidia_gemm, m) {
+  m.doc() = "Lucidia GEMM (CUTLASS + cuBLASLt), FP16->FP32 with optional bias/activation";
+  m.def("gemm", &gemm,
+        py::arg("A"), py::arg("B"),
+        py::arg("bias") = py::none(),
+        py::arg("activation") = "none",
+        py::arg("transa") = false,
+        py::arg("transb") = false,
+        py::arg("alpha") = 1.0,
+        py::arg("beta")  = 0.0,
+        py::arg("out_dtype") = "fp16",
+        R"doc(
+Compute C = alpha * A @ B + beta * C0  (C0 initialized to zeros here),
+then (optional) add column-wise bias and apply activation (none|relu|gelu).
+
+Arguments:
+  A: torch.cuda.HalfTensor [M, K] (row-major, contiguous)
+  B: torch.cuda.HalfTensor [K, N] (row-major, contiguous)
+  bias: optional torch.cuda.(Half|Float)Tensor [N]
+  activation: "none" | "relu" | "gelu"
+  transa, transb: if True, treat A/B as transposed without copying
+  alpha, beta: scalars
+  out_dtype: "fp16" or "fp32"
+)doc");
+  m.attr("__version__") = LUCIDIA_GEMM_VERSION;
+}

--- a/opt/blackroad/lucidia_gemm/setup.sh
+++ b/opt/blackroad/lucidia_gemm/setup.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Simple builder for the lucidia_gemm module
+# Requirements: CUDA Toolkit >= 11.8, cuBLASLt, Python3 dev, pybind11, CMake >= 3.20, LibTorch (PyTorch C++)
+
+# Optional: vendor CUTLASS locally (recommended for reproducibility)
+#   git submodule add https://github.com/NVIDIA/cutlass.git third_party/cutlass
+#   export CUTLASS_DIR="$(pwd)/third_party/cutlass"
+
+if [[ -z "${BUILD_DIR:-}" ]]; then BUILD_DIR="build"; fi
+mkdir -p "${BUILD_DIR}"
+cd "${BUILD_DIR}"
+
+cmake -DCMAKE_BUILD_TYPE=Release \
+      -DCUTLASS_DIR="${CUTLASS_DIR:-}" \
+      -DUSE_FETCHCONTENT_CUTLASS=ON \
+      ..
+
+cmake --build . -j
+
+# Copy module near tests for quick import, or install into your PYTHONPATH
+MOD=$(ls lucidia_gemm.*.so)
+echo "Built module: ${MOD}"
+echo "To use: export PYTHONPATH=$(pwd):$PYTHONPATH"

--- a/opt/blackroad/lucidia_gemm/src/lucidia_gemm_cublaslt.cpp
+++ b/opt/blackroad/lucidia_gemm/src/lucidia_gemm_cublaslt.cpp
@@ -1,0 +1,97 @@
+#include <cublasLt.h>
+#include <cuda_runtime.h>
+#include <stdexcept>
+#include "lucidia_gemm/common.h"
+
+namespace lucidia_gemm {
+
+static inline cublasLtHandle_t& lt_handle() {
+  static cublasLtHandle_t handle = []{
+    cublasLtHandle_t h;
+    if (cublasLtCreate(&h) != CUBLAS_STATUS_SUCCESS) {
+      throw std::runtime_error("cublasLtCreate failed");
+    }
+    return h;
+  }();
+  return handle;
+}
+
+void run_cublaslt_fp16fp32RowRowRow(const void* A, const void* B, void* C,
+                                    int64_t M, int64_t N, int64_t K,
+                                    int64_t lda, int64_t ldb, int64_t ldc,
+                                    float alpha, float beta, cudaStream_t stream) {
+  auto& handle = lt_handle();
+
+  cublasOperation_t transA = CUBLAS_OP_N;
+  cublasOperation_t transB = CUBLAS_OP_N;
+
+  cublasComputeType_t computeType = CUBLAS_COMPUTE_32F;
+  cudaDataType_t scaleType = CUDA_R_32F;
+
+  cublasLtMatmulDesc_t matmulDesc;
+  cublasLtMatrixLayout_t aDesc, bDesc, cDesc, dDesc;
+
+  if (cublasLtMatmulDescCreate(&matmulDesc, computeType, scaleType) != CUBLAS_STATUS_SUCCESS)
+    throw std::runtime_error("cublasLtMatmulDescCreate failed");
+
+  cublasLtMatmulDescSetAttribute(matmulDesc, CUBLASLT_MATMUL_DESC_TRANSA, &transA, sizeof(transA));
+  cublasLtMatmulDescSetAttribute(matmulDesc, CUBLASLT_MATMUL_DESC_TRANSB, &transB, sizeof(transB));
+
+  if (cublasLtMatrixLayoutCreate(&aDesc, CUDA_R_16F, K, M, lda) != CUBLAS_STATUS_SUCCESS)
+    throw std::runtime_error("a layout failed");
+  if (cublasLtMatrixLayoutCreate(&bDesc, CUDA_R_16F, N, K, ldb) != CUBLAS_STATUS_SUCCESS)
+    throw std::runtime_error("b layout failed");
+  if (cublasLtMatrixLayoutCreate(&cDesc, CUDA_R_32F, N, M, ldc) != CUBLAS_STATUS_SUCCESS)
+    throw std::runtime_error("c layout failed");
+  if (cublasLtMatrixLayoutCreate(&dDesc, CUDA_R_32F, N, M, ldc) != CUBLAS_STATUS_SUCCESS)
+    throw std::runtime_error("d layout failed");
+
+  cublasLtMatmulPreference_t preference;
+  cublasLtMatmulPreferenceCreate(&preference);
+  size_t workspaceLimit = 1ULL << 26; // 64MB
+  cublasLtMatmulPreferenceSetAttribute(preference, CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES, &workspaceLimit, sizeof(workspaceLimit));
+
+  // Choose heuristic
+  cublasLtMatmulHeuristicResult_t heuristic;
+  int returnedResults = 0;
+  if (cublasLtMatmulAlgoGetHeuristic(handle, matmulDesc, aDesc, bDesc, cDesc, dDesc,
+                                     preference, 1, &heuristic, &returnedResults) != CUBLAS_STATUS_SUCCESS
+      || returnedResults == 0) {
+    cublasLtMatmulPreferenceDestroy(preference);
+    cublasLtMatrixLayoutDestroy(aDesc);
+    cublasLtMatrixLayoutDestroy(bDesc);
+    cublasLtMatrixLayoutDestroy(cDesc);
+    cublasLtMatrixLayoutDestroy(dDesc);
+    cublasLtMatmulDescDestroy(matmulDesc);
+    throw std::runtime_error("cublasLt heuristic selection failed");
+  }
+
+  cublasLtEpilogue_t epi = CUBLASLT_EPILOGUE_DEFAULT; // we post-process ourselves
+  cublasLtMatmulDescSetAttribute(matmulDesc, CUBLASLT_MATMUL_DESC_EPILOGUE, &epi, sizeof(epi));
+
+  cublasStatus_t status = cublasLtMatmul(
+      handle,
+      matmulDesc,
+      &alpha,
+      B, bDesc,    // Note: RowMajor with lt uses col-major semantics; swapping roles keeps row-major logical
+      A, aDesc,
+      &beta,
+      C, cDesc,
+      C, dDesc,
+      &heuristic.algo,
+      nullptr, 0,
+      stream);
+
+  cublasLtMatmulPreferenceDestroy(preference);
+  cublasLtMatrixLayoutDestroy(aDesc);
+  cublasLtMatrixLayoutDestroy(bDesc);
+  cublasLtMatrixLayoutDestroy(cDesc);
+  cublasLtMatrixLayoutDestroy(dDesc);
+  cublasLtMatmulDescDestroy(matmulDesc);
+
+  if (status != CUBLAS_STATUS_SUCCESS) {
+    throw std::runtime_error("cublasLtMatmul failed");
+  }
+}
+
+} // namespace lucidia_gemm

--- a/opt/blackroad/lucidia_gemm/src/lucidia_gemm_cutlass.cu
+++ b/opt/blackroad/lucidia_gemm/src/lucidia_gemm_cutlass.cu
@@ -1,0 +1,66 @@
+#include <cutlass/cutlass.h>
+#include <cutlass/half.h>
+#include <cutlass/layout/matrix.h>
+#include <cutlass/arch/arch.h>
+#include <cutlass/gemm/device/gemm.h>
+#include <cutlass/gemm/threadblock/default_mma_core_sm80.h>
+#include <cutlass/epilogue/thread/linear_combination.h>
+
+#include <cuda_runtime.h>
+#include <stdexcept>
+#include "lucidia_gemm/common.h"
+
+namespace lucidia_gemm {
+
+// FP16 inputs, FP32 accumulate, FP32 output
+using ElementInputA = cutlass::half_t;
+using ElementInputB = cutlass::half_t;
+using ElementAccumulator = float;
+using ElementOutput = float;
+
+using LayoutA = cutlass::layout::RowMajor;
+using LayoutB = cutlass::layout::RowMajor;
+using LayoutC = cutlass::layout::RowMajor;
+
+using EpilogueOp = cutlass::epilogue::thread::LinearCombination<
+    ElementOutput, /*ElementsPerAccess*/ 4, ElementAccumulator, ElementAccumulator>;
+
+using Gemm = cutlass::gemm::device::Gemm<
+    ElementInputA, LayoutA,
+    ElementInputB, LayoutB,
+    ElementOutput,  LayoutC,
+    ElementAccumulator,
+    cutlass::arch::OpClassTensorOp,
+    cutlass::arch::Sm80, // valid for SM80+ (Orin SM87 compatible)
+    cutlass::gemm::GemmShape<128, 64, 64>,      // Threadblock tile
+    cutlass::gemm::GemmShape<64, 64, 64>,       // Warp tile
+    cutlass::gemm::GemmShape<16, 8, 8>,         // MMA op tile (Tensor Cores)
+    EpilogueOp,
+    cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>,
+    2 // stages
+>;
+
+void run_cutlass_fp16fp32RowRowRow(const void* A, const void* B, void* C,
+                                   int64_t M, int64_t N, int64_t K,
+                                   int64_t lda, int64_t ldb, int64_t ldc,
+                                   float alpha, float beta, cudaStream_t stream) {
+  typename Gemm::Arguments args(
+      {int(M), int(N), int(K)},
+      {reinterpret_cast<ElementInputA const*>(A), int(lda)},
+      {reinterpret_cast<ElementInputB const*>(B), int(ldb)},
+      {reinterpret_cast<ElementOutput const*>(C), int(ldc)}, // C source for beta
+      {reinterpret_cast<ElementOutput*>(C), int(ldc)},
+      {alpha, beta});
+
+  Gemm op;
+  cutlass::Status st = op.initialize(args, stream);
+  if (st != cutlass::Status::kSuccess) {
+    throw std::runtime_error("CUTLASS initialize failed");
+  }
+  st = op(stream);
+  if (st != cutlass::Status::kSuccess) {
+    throw std::runtime_error("CUTLASS run failed");
+  }
+}
+
+} // namespace lucidia_gemm

--- a/opt/blackroad/lucidia_gemm/tests/test_gemm.py
+++ b/opt/blackroad/lucidia_gemm/tests/test_gemm.py
@@ -1,0 +1,57 @@
+import torch, os, time, math
+
+def check_one(M, N, K, act="none"):
+    A = torch.randn(M, K, device="cuda", dtype=torch.float16)
+    B = torch.randn(K, N, device="cuda", dtype=torch.float16)
+    bias = torch.randn(N, device="cuda", dtype=torch.float32)
+
+    import lucidia_gemm as lg
+    C = lg.gemm(A, B, bias=bias, activation=act, out_dtype="fp32")
+    # Reference
+    C_ref = (A.float() @ B.float())
+    if bias is not None:
+        C_ref = C_ref + bias
+    if act == "relu":
+        C_ref = torch.nn.functional.relu(C_ref)
+    elif act == "gelu":
+        C_ref = torch.nn.functional.gelu(C_ref, approximate="tanh")
+
+    err = (C - C_ref).abs().max().item()
+    print(f"M={M} N={N} K={K} act={act} max|err|={err:.3e}")
+    assert err < 2e-2, f"excess error {err}"
+
+def bench(M, N, K, repeats=50):
+    A = torch.randn(M, K, device="cuda", dtype=torch.float16)
+    B = torch.randn(K, N, device="cuda", dtype=torch.float16)
+    import lucidia_gemm as lg
+    # warmup
+    for _ in range(5):
+        lg.gemm(A, B, activation="none", out_dtype="fp16")
+    torch.cuda.synchronize()
+
+    t0 = time.time()
+    for _ in range(repeats):
+        lg.gemm(A, B, activation="none", out_dtype="fp16")
+    torch.cuda.synchronize()
+    dt = (time.time() - t0) / repeats
+    tflops = (2.0 * M * N * K) / (dt * 1e12)
+    print(f"[lucidia_gemm] {M}x{N}x{K}: {dt*1e3:.3f} ms, {tflops:.2f} TFLOP/s")
+
+    # cuBLAS reference for comparison
+    t0 = time.time()
+    for _ in range(repeats):
+        (A.float() @ B.float()).half()
+    torch.cuda.synchronize()
+    dt2 = (time.time() - t0) / repeats
+    tflops2 = (2.0 * M * N * K) / (dt2 * 1e12)
+    print(f"[torch matmul] {M}x{N}x{K}: {dt2*1e3:.3f} ms, {tflops2:.2f} TFLOP/s")
+
+if __name__ == "__main__":
+    torch.backends.cuda.matmul.allow_tf32 = True
+    os.environ.setdefault("LUCIDIA_GEMM_BACKEND", "cutlass")
+    for act in ["none", "relu", "gelu"]:
+        for M in [16, 32, 64, 128]:
+            for N in [1024, 2048]:
+                for K in [1024, 2048]:
+                    check_one(M, N, K, act=act)
+    bench(64, 2048, 2048)


### PR DESCRIPTION
## Summary
- add CMake build for lucidia_gemm with CUTLASS and cuBLASLt backends
- expose torch-friendly gemm API with optional bias and activation
- include setup script, tests, and usage example

## Testing
- `pre-commit run --files opt/blackroad/lucidia_gemm/CMakeLists.txt opt/blackroad/lucidia_gemm/include/lucidia_gemm/common.h opt/blackroad/lucidia_gemm/src/lucidia_gemm_cutlass.cu opt/blackroad/lucidia_gemm/src/lucidia_gemm_cublaslt.cpp opt/blackroad/lucidia_gemm/python/bindings.cpp opt/blackroad/lucidia_gemm/setup.sh opt/blackroad/lucidia_gemm/tests/test_gemm.py opt/blackroad/lucidia_gemm/examples/use_in_lucidia.py` (fail: command not found)
- `cd opt/blackroad/lucidia_gemm && bash ./setup.sh` (fail: Failed to find nvcc)
- `python opt/blackroad/lucidia_gemm/tests/test_gemm.py` (fail: Found no NVIDIA driver)


------
https://chatgpt.com/codex/tasks/task_e_68a3f853ae9c8329824d7700e3e805c7