### PR TITLE
feat: add Pachi Go engine service

### DIFF
--- a/etc/nginx/snippets/blackroad-go.conf
+++ b/etc/nginx/snippets/blackroad-go.conf
@@ -1,0 +1,9 @@
+location /api/go/ {
+    proxy_pass         http://127.0.0.1:8088/;
+    proxy_http_version 1.1;
+    proxy_set_header   Host $host;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header   X-Forwarded-Proto $scheme;
+    client_max_body_size 1m;
+}

--- a/etc/systemd/system/blackroad-go.service
+++ b/etc/systemd/system/blackroad-go.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=BlackRoad Go Service (Pachi GTP wrapper)
+After=network.target
+
+[Service]
+User=www-data
+Group=www-data
+WorkingDirectory=/opt/blackroad
+Environment=PYTHONPATH=/opt/blackroad
+ExecStart=/usr/bin/uvicorn services.go_service:app --host 0.0.0.0 --port 8088
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target

--- a/opt/blackroad/agents/pachi_gtp_agent.py
+++ b/opt/blackroad/agents/pachi_gtp_agent.py
@@ -1,0 +1,152 @@
+# FILE: /opt/blackroad/agents/pachi_gtp_agent.py
+# Desc: Minimal, robust GTP client for the Pachi Go engine as a subprocess.
+# Note: Pachi speaks GTP (responses start with '=' or '?', end with a blank line).
+#       We don't expose raw GTP to users; only safe endpoints call this client.
+# Refs: Pachi is a GTP client; don't expose GTP to untrusted users. See README.
+#       https://github.com/pasky/pachi  (GTP client)
+#       https://www.lysator.liu.se/~gunnar/gtp/  (GTP protocol)
+
+import subprocess, threading, queue, shlex, time, atexit
+from dataclasses import dataclass
+from typing import Optional, List
+
+class GTPError(Exception): ...
+
+class _LineReader(threading.Thread):
+    def __init__(self, stream):
+        super().__init__(daemon=True)
+        self.stream = stream
+        self.q = queue.Queue()
+
+    def run(self):
+        for line in self.stream:
+            self.q.put(line)
+
+    def get(self, timeout=None):
+        return self.q.get(timeout=timeout)
+
+@dataclass
+class PachiConfig:
+    engine_path: str = "pachi"      # ensure `pachi` is on PATH
+    size: int = 19
+    komi: float = 6.5
+    engine_args: Optional[List[str]] = None  # e.g., ["-t", "8"]
+
+class PachiGTP:
+    """
+    Tiny GTP client for Pachi with a safe, minimal API.
+    """
+    def __init__(self, cfg: Optional[PachiConfig] = None):
+        self.cfg = cfg or PachiConfig()
+        args = [self.cfg.engine_path]
+        if self.cfg.engine_args:
+            args += self.cfg.engine_args
+
+        self.proc = subprocess.Popen(
+            args,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1
+        )
+        self._out = _LineReader(self.proc.stdout)
+        self._err = _LineReader(self.proc.stderr)
+        self._out.start()
+        self._err.start()
+        atexit.register(self.close)
+
+        # Basic board setup
+        self.cmd(f"boardsize {self.cfg.size}")
+        self.cmd(f"komi {self.cfg.komi}")
+        self.cmd("clear_board")
+
+    def close(self):
+        try:
+            if self.proc and self.proc.poll() is None:
+                try:
+                    self.cmd("quit")
+                except Exception:
+                    pass
+                self.proc.terminate()
+        except Exception:
+            pass
+
+    def cmd(self, line: str, timeout: float = 10.0) -> str:
+        """
+        Send a GTP command and return payload without the leading '='.
+        """
+        if not self.proc or self.proc.stdin.closed:
+            raise GTPError("Engine process inactive.")
+        self.proc.stdin.write(line.strip() + "\n")
+        self.proc.stdin.flush()
+
+        status = None
+        payload_lines = []
+        while True:
+            try:
+                raw = self._out.get(timeout=timeout)
+            except queue.Empty:
+                raise GTPError(f"GTP timeout for: {line!r}")
+            s = raw.rstrip("\n")
+            if s == "":
+                break  # end of response
+            if status is None:
+                if s.startswith("="):
+                    status = "="
+                    s = s[1:].lstrip()
+                    if s:
+                        payload_lines.append(s)
+                elif s.startswith("?"):
+                    # Drain until blank line, then raise
+                    status = "?"
+                    msg = s[1:].lstrip() or f"GTP error for: {line}"
+                    while True:
+                        try:
+                            more = self._out.get(timeout=timeout)
+                        except queue.Empty:
+                            break
+                        if more.strip() == "":
+                            break
+                    raise GTPError(msg)
+                else:
+                    # Skip non-GTP chatter (banners)
+                    continue
+            else:
+                payload_lines.append(s)
+        if status != "=":
+            raise GTPError(f"Unexpected GTP status for {line!r}: {status}")
+        return "\n".join(payload_lines).strip()
+
+    # High-level helpers
+    def new_game(self, size: Optional[int] = None, komi: Optional[float] = None):
+        if size is not None:
+            self.cmd(f"boardsize {size}")
+        if komi is not None:
+            self.cmd(f"komi {komi}")
+        self.cmd("clear_board")
+
+    def play(self, color: str, move: str):
+        """color in {'B','W'}; move like 'D4' or 'pass'."""
+        return self.cmd(f"play {color.upper()} {move.upper()}")
+
+    def genmove(self, color: str) -> str:
+        return self.cmd(f"genmove {color.upper()}")
+
+    def final_score(self) -> str:
+        return self.cmd("final_score")
+
+    def time_settings(self, main_s:int=1200, byo_s:int=30, byo_stones:int=0):
+        """Standard GTP time_settings if supported by engine."""
+        return self.cmd(f"time_settings {main_s} {byo_s} {byo_stones}")
+
+if __name__ == "__main__":
+    e = PachiGTP(PachiConfig(size=9))
+    try:
+        e.play("B", "D4")
+        e.play("W", "E5")
+        mv = e.genmove("B")
+        print("Pachi suggests:", mv)
+        print("Score (if over):", e.final_score())
+    finally:
+        e.close()

--- a/opt/blackroad/codex/prompts/lucidia-go-codex.prompt
+++ b/opt/blackroad/codex/prompts/lucidia-go-codex.prompt
@@ -1,0 +1,30 @@
+[AGENT] lucidia.go.codex
+ROLE
+  Converse naturally about Go and call the BlackRoad Go Service to play or suggest moves.
+TOOLS
+  - POST /api/go/new {size:int, komi:float, engine_args?:string[]}
+  - POST /api/go/play {game_id:string, color:"B"|"W", move:string}
+  - POST /api/go/genmove {game_id:string, to_play:"B"|"W"}
+  - GET  /api/go/score?game_id=...
+  - GET  /api/go/state?game_id=...
+POLICY
+  - Never invent board state. Reflect the tool-reported state exactly.
+  - Normalize moves to uppercase GTP (e.g., "D4", "PASS"). Echo user-provided moves back.
+  - Default to size=19, komi=6.5 unless the user specifies otherwise.
+  - If user says "new 9x9", interpret size=9; "komi 7.5" overrides default.
+  - On tool errors, quote the message verbatim and propose a corrected action.
+  - Security: do NOT expose raw GTP commands; only call the HTTP tools above.
+WORKFLOW
+  1) Parse the user utterance for size/komi/moves/turn (be strict, no guessing).
+  2) If no game_id yet, call /api/go/new.
+  3) Apply any user moves via /api/go/play in order.
+  4) If asked for a move, call /api/go/genmove with the correct side to play.
+  5) Report results succinctly: e.g., "Black plays C3." Offer "score" on request.
+EXAMPLES
+  USER: "new 9x9, komi 6.5. B D4, W E5. your move as Black?"
+  CALLS:
+    POST /api/go/new {"size":9,"komi":6.5} → {game_id}
+    POST /api/go/play {"game_id":..., "color":"B", "move":"D4"} → ok
+    POST /api/go/play {"game_id":..., "color":"W", "move":"E5"} → ok
+    POST /api/go/genmove {"game_id":..., "to_play":"B"} → {"move":"C3"}
+  RETURN: "Black: C3"

--- a/opt/blackroad/docker/docker-compose.yml
+++ b/opt/blackroad/docker/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  go:
+    build:
+      context: /opt/blackroad
+      dockerfile: docker/go-engine.Dockerfile
+    container_name: blackroad-go
+    ports:
+      - "8088:8088"
+    restart: unless-stopped

--- a/opt/blackroad/docker/go-engine.Dockerfile
+++ b/opt/blackroad/docker/go-engine.Dockerfile
@@ -1,0 +1,30 @@
+FROM debian:12-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      build-essential git python3 python3-pip ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+# Build Pachi
+RUN git clone https://github.com/pasky/pachi /opt/pachi && \
+    make -C /opt/pachi && \
+    ln -s /opt/pachi/pachi /usr/local/bin/pachi
+
+# App
+WORKDIR /app
+COPY agents /app/agents
+COPY services /app/services
+RUN pip3 install fastapi uvicorn pydantic
+
+ENV PYTHONPATH=/app
+EXPOSE 8088
+
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD \
+  python3 - <<'PY' || exit 1
+import urllib.request,sys
+try:
+  urllib.request.urlopen('http://127.0.0.1:8088/api/go/health',timeout=2)
+except Exception as e:
+  sys.exit(1)
+PY
+
+CMD ["uvicorn", "services.go_service:app", "--host", "0.0.0.0", "--port", "8088"]

--- a/opt/blackroad/lucidia/handlers/go_chat.py
+++ b/opt/blackroad/lucidia/handlers/go_chat.py
@@ -1,0 +1,52 @@
+# FILE: /opt/blackroad/lucidia/handlers/go_chat.py
+# Desc: Very light NL → action parser so users can talk casually; Codex can do better.
+import re, requests
+
+API = "http://127.0.0.1:8088"
+
+def parse_user(text:str):
+    t = text.strip().lower()
+    # Examples:
+    # "new 9x9", "new 19x19 komi 7.5", "play b d4", "genmove black"
+    if t.startswith("new"):
+        m = re.search(r'(\d{1,2})x\1', t)
+        size = int(m.group(1)) if m else 19
+        m2 = re.search(r'komi\s+([0-9.]+)', t)
+        komi = float(m2.group(1)) if m2 else 6.5
+        return ("new", {"size":size,"komi":komi})
+    if t.startswith("play"):
+        m = re.findall(r'\b([bw])\b[^a-z0-9]*([a-t]\d{1,2}|pass)', t)
+        if not m: return ("err", "Say: play B D4  (or play W pass)")
+        color, move = m[0]
+        return ("play", {"color":color.upper(), "move":move.upper()})
+    if "genmove" in t or "engine move" in t or "your move" in t:
+        color = "B" if "black" in t else ("W" if "white" in t else "B")
+        return ("genmove", {"to_play":color})
+    if "score" in t:
+        return ("score", {})
+    return ("help", "Try: 'new 9x9', 'play B D4', 'genmove black', 'score'.")
+
+def handle(user_text:str, game_id_box:dict):
+    kind, payload = parse_user(user_text)
+    if kind == "help": return payload
+    if kind == "err":  return f"⚠️ {payload}"
+
+    if kind == "new":
+        r = requests.post(f"{API}/api/go/new", json=payload, timeout=5)
+        r.raise_for_status()
+        gid = r.json()["game_id"]
+        game_id_box["id"] = gid
+        return f"New game {payload['size']}x{payload['size']} (komi {payload['komi']}), game_id={gid}"
+
+    gid = game_id_box.get("id")
+    if not gid: return "Start with 'new 9x9' (no active game)."
+
+    if kind == "play":
+        r = requests.post(f"{API}/api/go/play", json={"game_id":gid, **payload}, timeout=5)
+        return "ok" if r.ok else f"⚠️ {r.text}"
+    if kind == "genmove":
+        r = requests.post(f"{API}/api/go/genmove", json={"game_id":gid, **payload}, timeout=10)
+        return f"{payload['to_play']} → {r.json().get('move')}" if r.ok else f"⚠️ {r.text}"
+    if kind == "score":
+        r = requests.get(f"{API}/api/go/score", params={"game_id":gid}, timeout=5)
+        return r.json().get("score","?") if r.ok else f"⚠️ {r.text}"

--- a/opt/blackroad/services/go_service.py
+++ b/opt/blackroad/services/go_service.py
@@ -1,0 +1,139 @@
+# FILE: /opt/blackroad/services/go_service.py
+# Desc: FastAPI service that manages Pachi sessions keyed by game_id.
+# Usage: POST /api/go/new → game_id; /play; /genmove; /score; /state; /health.
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field, validator
+from typing import Literal, List, Dict
+from uuid import uuid4
+from datetime import datetime, timedelta
+from threading import Lock
+from agents.pachi_gtp_agent import PachiGTP, PachiConfig, GTPError
+
+app = FastAPI(title="BlackRoad Go Service")
+_SESS: Dict[str, dict] = {}
+_SESS_LOCK = Lock()
+_SESSION_TTL = timedelta(minutes=30)
+
+def _now(): return datetime.utcnow()
+
+class NewGameRequest(BaseModel):
+    size: int = Field(19, ge=5, le=25)
+    komi: float = 6.5
+    engine_args: List[str] = Field(default_factory=list)
+
+class NewGameResponse(BaseModel):
+    game_id: str
+    size: int
+    komi: float
+
+class PlayRequest(BaseModel):
+    game_id: str
+    color: Literal["B", "W"]
+    move: str  # e.g., D4 or pass
+
+    @validator("move")
+    def _normalize_move(cls, v):
+        v = v.strip().upper()
+        if v != "PASS":
+            # allow A1..T19; Pachi will validate legality (we don't trust clients)
+            if len(v) < 2 or not v[0].isalpha() or not v[1:].isdigit():
+                raise ValueError("Move must be like 'D4' or 'pass'")
+        return v
+
+class GenMoveRequest(BaseModel):
+    game_id: str
+    to_play: Literal["B", "W"] = "B"
+
+class MoveResponse(BaseModel):
+    move: str
+
+class ScoreResponse(BaseModel):
+    score: str
+
+class StateResponse(BaseModel):
+    size: int
+    komi: float
+    moves: List[str]
+    to_play: Literal["B", "W"]
+
+def _gc():
+    # Lazy TTL eviction
+    with _SESS_LOCK:
+        stale = [gid for gid, s in _SESS.items() if _now() - s["last"] > _SESSION_TTL]
+        for gid in stale:
+            try:
+                s = _SESS.pop(gid)
+                s["eng"].close()
+            except Exception:
+                pass
+
+def _get(gid: str):
+    _gc()
+    with _SESS_LOCK:
+        s = _SESS.get(gid)
+        if not s:
+            raise HTTPException(status_code=404, detail="Unknown or expired game_id")
+        s["last"] = _now()
+        return s
+
+@app.get("/api/go/health")
+def health():
+    return {"ok": True, "ts": _now().isoformat()}
+
+@app.post("/api/go/new", response_model=NewGameResponse)
+def new(req: NewGameRequest):
+    cfg = PachiConfig(size=req.size, komi=req.komi, engine_args=req.engine_args or None)
+    eng = PachiGTP(cfg)
+    gid = uuid4().hex
+    with _SESS_LOCK:
+        _SESS[gid] = {"eng": eng, "size": req.size, "komi": req.komi,
+                      "moves": [], "to_play": "B", "last": _now(), "lock": Lock()}
+    return NewGameResponse(game_id=gid, size=req.size, komi=req.komi)
+
+@app.post("/api/go/play")
+def play(req: PlayRequest):
+    s = _get(req.game_id)
+    with s["lock"]:
+        try:
+            s["eng"].play(req.color, req.move)
+            s["moves"].append(f"{req.color} {req.move}")
+            s["to_play"] = "W" if req.color == "B" else "B"
+            return {"ok": True}
+        except GTPError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+
+@app.post("/api/go/genmove", response_model=MoveResponse)
+def genmove(req: GenMoveRequest):
+    s = _get(req.game_id)
+    with s["lock"]:
+        try:
+            mv = s["eng"].genmove(req.to_play)
+            s["moves"].append(f"{req.to_play} {mv}")
+            s["to_play"] = "W" if req.to_play == "B" else "B"
+            return MoveResponse(move=mv)
+        except GTPError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+
+@app.get("/api/go/score", response_model=ScoreResponse)
+def score(game_id: str):
+    s = _get(game_id)
+    with s["lock"]:
+        try:
+            return ScoreResponse(score=s["eng"].final_score())
+        except GTPError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+
+@app.get("/api/go/state", response_model=StateResponse)
+def state(game_id: str):
+    s = _get(game_id)
+    return StateResponse(size=s["size"], komi=s["komi"], moves=s["moves"], to_play=s["to_play"])
+
+@app.delete("/api/go/{game_id}")
+def destroy(game_id: str):
+    with _SESS_LOCK:
+        s = _SESS.pop(game_id, None)
+    if s:
+        try: s["eng"].close()
+        except Exception: pass
+    return {"ok": True}

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,7 @@ numpy==1.26.4
 whisper
 torch
 
+fastapi
+uvicorn
+pydantic
+requests


### PR DESCRIPTION
## Summary
- add minimal Pachi GTP client
- expose FastAPI Go microservice with per-game sessions
- include systemd, nginx and docker configs plus Lucidia handler and codex card

## Testing
- `python -m py_compile opt/blackroad/agents/pachi_gtp_agent.py opt/blackroad/services/go_service.py opt/blackroad/lucidia/handlers/go_chat.py`
- `pytest`
- `pip install fastapi uvicorn pydantic requests` *(fails: Tunnel connection failed: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_68a3f869ac808329a04de46c787dde30