### PR TITLE
Add Consul gateway routes and lucidia canary deployment

### DIFF
--- a/k8s/apps/blackroad-ui.yaml
+++ b/k8s/apps/blackroad-ui.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: blackroad-ui
+  namespace: blackroad
+spec:
+  selector:
+    app: blackroad-ui
+  ports:
+    - name: http
+      port: 3000
+      targetPort: 3000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: blackroad-ui
+  namespace: blackroad
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: blackroad-ui
+  template:
+    metadata:
+      labels:
+        app: blackroad-ui
+      annotations:
+        consul.hashicorp.com/connect-inject: "true"
+        consul.hashicorp.com/connect-service: "blackroad-ui"
+        consul.hashicorp.com/transparent-proxy: "true"
+        consul.hashicorp.com/connect-service-upstreams: "lucidia-api.svc:9000"
+    spec:
+      containers:
+        - name: ui
+          image: ghcr.io/yourorg/blackroad-ui:latest
+          ports:
+            - containerPort: 3000
+          env:
+            - name: LUCIDIA_API_URL
+              value: "http://127.0.0.1:9000"

--- a/k8s/apps/lucidia-api-canary.yaml
+++ b/k8s/apps/lucidia-api-canary.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: lucidia-api-canary
+  namespace: blackroad
+spec:
+  selector:
+    app: lucidia-api
+    track: canary
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lucidia-api-canary
+  namespace: blackroad
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: lucidia-api
+      track: canary
+  template:
+    metadata:
+      labels:
+        app: lucidia-api
+        track: canary
+      annotations:
+        consul.hashicorp.com/connect-inject: "true"
+        consul.hashicorp.com/connect-service: "lucidia-api-canary"
+        consul.hashicorp.com/transparent-proxy: "true"
+    spec:
+      containers:
+        - name: api
+          image: ghcr.io/yourorg/lucidia-api:latest
+          ports:
+            - containerPort: 8080
+          env:
+            - name: PORT
+              value: "8080"

--- a/k8s/apps/lucidia-api.yaml
+++ b/k8s/apps/lucidia-api.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: lucidia-api
+  namespace: blackroad
+spec:
+  selector:
+    app: lucidia-api
+    track: stable
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lucidia-api
+  namespace: blackroad
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: lucidia-api
+      track: stable
+  template:
+    metadata:
+      labels:
+        app: lucidia-api
+        track: stable
+      annotations:
+        consul.hashicorp.com/connect-inject: "true"
+        consul.hashicorp.com/connect-service: "lucidia-api"
+        consul.hashicorp.com/transparent-proxy: "true"
+    spec:
+      containers:
+        - name: api
+          image: ghcr.io/yourorg/lucidia-api:latest
+          ports:
+            - containerPort: 8080
+          env:
+            - name: PORT
+              value: "8080"

--- a/k8s/consul/install.sh
+++ b/k8s/consul/install.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+kubectl create namespace consul --dry-run=client -o yaml | kubectl apply -f -
+helm repo add hashicorp https://helm.releases.hashicorp.com
+helm repo update
+helm upgrade --install consul hashicorp/consul \
+  --namespace consul \
+  -f k8s/consul/values-lucidia-dev.yaml

--- a/k8s/consul/intentions.yaml
+++ b/k8s/consul/intentions.yaml
@@ -1,0 +1,23 @@
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ServiceIntentions
+metadata:
+  name: lucidia-api
+  namespace: blackroad
+spec:
+  destination:
+    name: lucidia-api
+  sources:
+    - name: blackroad-ui
+      action: allow
+---
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ServiceIntentions
+metadata:
+  name: lucidia-api-canary
+  namespace: blackroad
+spec:
+  destination:
+    name: lucidia-api-canary
+  sources:
+    - name: blackroad-ui
+      action: allow

--- a/k8s/consul/proxy-defaults.yaml
+++ b/k8s/consul/proxy-defaults.yaml
@@ -1,0 +1,6 @@
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ProxyDefaults
+metadata:
+  name: global
+spec:
+  mode: transparent

--- a/k8s/consul/service-defaults.yaml
+++ b/k8s/consul/service-defaults.yaml
@@ -1,0 +1,23 @@
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ServiceDefaults
+metadata:
+  name: lucidia-api
+  namespace: blackroad
+spec:
+  protocol: http
+---
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ServiceDefaults
+metadata:
+  name: lucidia-api-canary
+  namespace: blackroad
+spec:
+  protocol: http
+---
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ServiceDefaults
+metadata:
+  name: blackroad-ui
+  namespace: blackroad
+spec:
+  protocol: http

--- a/k8s/consul/values-lucidia-dev.yaml
+++ b/k8s/consul/values-lucidia-dev.yaml
@@ -1,0 +1,29 @@
+global:
+  name: consul
+  datacenter: br-dc1
+  tls:
+    enabled: true
+    httpsOnly: true
+  acls:
+    manageSystemACLs: true
+
+server:
+  replicas: 1
+
+ui:
+  enabled: true
+  service:
+    enabled: true
+    type: LoadBalancer
+
+syncCatalog:
+  enabled: true
+
+connectInject:
+  enabled: true
+  default: true
+  transparentProxy:
+    defaultEnabled: true
+  apiGateway:
+    # Consul API Gateway is installed with the chart; CRDs can be managed here.
+    manageExternalCRDs: true

--- a/k8s/gateway/gateway.yaml
+++ b/k8s/gateway/gateway.yaml
@@ -1,0 +1,11 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: br-public
+  namespace: consul
+spec:
+  gatewayClassName: consul
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80

--- a/k8s/gateway/gatewayclass.yaml
+++ b/k8s/gateway/gatewayclass.yaml
@@ -1,0 +1,18 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: GatewayClass
+metadata:
+  name: consul
+spec:
+  controllerName: hashicorp.com/consul-api-gateway-controller
+  parametersRef:
+    group: api-gateway.consul.hashicorp.com
+    kind: GatewayClassConfig
+    name: consul-gwc
+---
+apiVersion: api-gateway.consul.hashicorp.com/v1alpha1
+kind: GatewayClassConfig
+metadata:
+  name: consul-gwc
+spec:
+  serviceType: LoadBalancer
+  logLevel: info

--- a/k8s/gateway/httproute.yaml
+++ b/k8s/gateway/httproute.yaml
@@ -1,0 +1,38 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: br-public-routes
+  namespace: consul
+spec:
+  parentRefs:
+    - name: br-public
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api
+      backendRefs:
+        - name: lucidia-api
+          namespace: blackroad
+          port: 8080
+          weight: 80
+        - name: lucidia-api-canary
+          namespace: blackroad
+          port: 8080
+          weight: 20
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v2
+      backendRefs:
+        - name: lucidia-api
+          namespace: blackroad
+          port: 8080
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: blackroad-ui
+          namespace: blackroad
+          port: 3000

--- a/k8s/gateway/refgrant-blackroad.yaml
+++ b/k8s/gateway/refgrant-blackroad.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-consul-to-blackroad-services
+  namespace: blackroad
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: consul
+  to:
+    - group: ""
+      kind: Service

--- a/k8s/namespaces/blackroad.yaml
+++ b/k8s/namespaces/blackroad.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: blackroad
+  labels:
+    consul.hashicorp.com/transparent-proxy: "true"


### PR DESCRIPTION
## Summary
- deploy Consul with mTLS and ACLs enabled
- expose BlackRoad UI and Lucidia API through Consul API Gateway
- add canary deployment for lucidia-api with weighted routing and global transparent proxy defaults

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3f87dd8888329a9c9a7e8ffa4519c