### PR TITLE
Add symbol gateway service and clients

### DIFF
--- a/etc/nginx/snippets/blackroad-symbol-gateway.conf
+++ b/etc/nginx/snippets/blackroad-symbol-gateway.conf
@@ -1,0 +1,8 @@
+
+
+# Proxy /api/symbols/* → local gateway
+location /api/symbols/ {
+  proxy_pass http://127.0.0.1:8087/;
+  proxy_set_header Host $host;
+  proxy_http_version 1.1;
+}

--- a/etc/systemd/system/symbol-gateway.service
+++ b/etc/systemd/system/symbol-gateway.service
@@ -1,0 +1,16 @@
+
+
+[Unit]
+Description=BlackRoad Symbol Gateway (Typst Codex)
+After=network.target
+
+[Service]
+User=www-data
+Group=www-data
+WorkingDirectory=/opt/blackroad/symbol-gateway
+ExecStart=/opt/blackroad/symbol-gateway/target/release/symbol-gateway serve --addr 127.0.0.1:8087
+Restart=on-failure
+Environment=RUST_LOG=info
+
+[Install]
+WantedBy=multi-user.target

--- a/opt/blackroad/clients/symbol_client.py
+++ b/opt/blackroad/clients/symbol_client.py
@@ -1,0 +1,19 @@
+
+
+import json, urllib.parse, urllib.request
+
+BASE = "http://127.0.0.1:8087"
+
+def resolve(name: str):
+    url = f"{BASE}/v1/resolve?name={urllib.parse.quote(name)}"
+    try:
+        with urllib.request.urlopen(url, timeout=2) as r:
+            return json.loads(r.read().decode("utf-8"))
+    except Exception as e:
+        return {"error": str(e), "name": name}
+
+def batch(names):
+    data = json.dumps({"names": names}).encode("utf-8")
+    req = urllib.request.Request(f"{BASE}/v1/batch", data=data, headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=3) as r:
+        return json.loads(r.read().decode("utf-8"))

--- a/opt/blackroad/prompts/codex_symbol_protocol.md
+++ b/opt/blackroad/prompts/codex_symbol_protocol.md
@@ -1,0 +1,23 @@
+
+
+# Codex Infinity — Symbol Protocol
+
+You speak in **stable symbol names** and convert to Unicode only at render time.
+
+**Rules**
+1) When you need a symbol or emoji, write its Codex name: e.g., `sym.arrow.r`, `sym.gt.eq.not`, `emoji.face.halo`.
+2) Before sending final output to UI/logs/files, resolve all names via the Symbol Gateway:
+   - HTTP GET `/v1/resolve?name=<name>` for one, or POST `/v1/batch` with `{"names":[...]}` for many.
+3) If a name is unknown, return the name literally and emit a `contradiction(log: "symbol-not-found", name)`.
+4) Prefer declarative names over literal codepoints in code, data, and prompts.
+5) Keep a per-turn cache `{name → char}`; invalidate between sessions.
+
+**Examples**
+- Text assembly: `Hello {sym.arrow.r} world` → resolve → `Hello → world`
+- Math flags: `sym.gt.eq.not` resolves to the "≱" family; choose the variant that matches your requested modifiers; when multiple match, pick the one with the fewest extras; otherwise default to the first variant.
+
+**Gateway contract**
+- Resolve: `/v1/resolve?name=sym.arrow.r` → `{ "char":"→", "codepoint":"U+2192", ... }`
+- Batch: POST `/v1/batch` with names
+- Search: `/v1/search?module=sym&query=arrow`
+

--- a/opt/blackroad/symbol-gateway/Cargo.toml
+++ b/opt/blackroad/symbol-gateway/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "symbol-gateway"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+codex = "0.1.1"                 # typst/codex crate (symbols ↔ names)  [oai_citation:2‡Crates.io](https://crates.io/crates/codex?utm_source=chatgpt.com)
+axum = { version = "0.7", features = ["macros", "json"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tower-http = { version = "0.5", features = ["cors", "trace"] }
+tracing = "0.1"
+tracing-subscriber = "0.3"
+clap = { version = "4", features = ["derive"] }

--- a/opt/blackroad/symbol-gateway/install.sh
+++ b/opt/blackroad/symbol-gateway/install.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd /opt/blackroad/symbol-gateway
+cargo build --release
+install -Dm755 target/release/symbol-gateway /usr/local/bin/symbol-gateway
+systemctl daemon-reload
+systemctl enable --now symbol-gateway.service
+echo "OK -> http://127.0.0.1:8087/healthz"

--- a/opt/blackroad/symbol-gateway/src/lib.rs
+++ b/opt/blackroad/symbol-gateway/src/lib.rs
@@ -1,0 +1,151 @@
+
+
+use codex::{Binding, Def, Module, Symbol, EMOJI, ROOT, SYM};
+
+#[derive(Debug, Clone)]
+pub struct Resolved {
+    pub input: String,
+    pub module: &'static str,
+    pub base: String,
+    pub modifiers: Vec<String>,
+    pub ch: char,
+    pub variant_key: Option<String>,
+}
+
+fn codepoint_hex(ch: char) -> String {
+    format!("U+{:04X}", ch as u32)
+}
+fn utf8_bytes_hex(ch: char) -> String {
+    let mut buf = [0u8; 4];
+    let s = ch.encode_utf8(&mut buf);
+    s.as_bytes()
+        .iter()
+        .map(|b| format!("{:02X}", b))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+pub fn module_for(prefix: &str) -> Option<(&'static str, Module)> {
+    match prefix {
+        "sym" => Some(("sym", SYM)),
+        "emoji" => Some(("emoji", EMOJI)),
+        // allow full-tree lookups: root.sym.arrow.r etc.
+        "root" => Some(("root", ROOT)),
+        _ => None,
+    }
+}
+
+/// Parse "sym.arrow.r.quad" → (prefix="sym", base="arrow", mods=["r","quad"])
+pub fn parse_name(name: &str) -> Option<(&str, &str, Vec<&str>)> {
+    let mut parts = name.split('.').collect::<Vec<_>>();
+    if parts.is_empty() {
+        return None;
+    }
+    let prefix = parts.remove(0);
+    if parts.is_empty() {
+        return None;
+    }
+    let base = parts.remove(0);
+    Some((prefix, base, parts))
+}
+
+/// Choose the best `Multi` variant: must contain all requested modifiers; among matches,
+/// prefer the one with the fewest extra modifiers. Fallback: first variant.
+fn pick_variant<'a>(
+    requested: &[&str],
+    alts: &'a [(&'static str, char)],
+) -> (&'a str, char) {
+    // normalize into sets
+    let mut best: Option<(&str, char, usize)> = None;
+    'outer: for (key, ch) in alts {
+        let have: Vec<&str> = key.split('.').filter(|s| !s.is_empty()).collect();
+        for &need in requested {
+            if !have.iter().any(|h| h == &need) {
+                continue 'outer;
+            }
+        }
+        let extras = have.len().saturating_sub(requested.len());
+        if best.map_or(true, |(_, _, b)| extras < b) {
+            best = Some((key, *ch, extras));
+        }
+    }
+    if let Some((k, c, _)) = best {
+        (k, c)
+    } else {
+        // default documented by crate: Multi "defaults to its first variant"  [oai_citation:3‡Docs.rs](https://docs.rs/codex/latest/codex/enum.Symbol.html)
+        alts.first().map(|(k, c)| (*k, *c)).unwrap_or(("", '\u{FFFD}'))
+    }
+}
+
+pub fn resolve_one(name: &str) -> Option<Resolved> {
+    let (prefix, base, mods) = parse_name(name)?;
+    let (module_name, module) = module_for(prefix)?;
+    let binding: Binding = module.get(base)?;
+    match binding.def {
+        Def::Symbol(Symbol::Single(c)) => Some(Resolved {
+            input: name.to_string(),
+            module: module_name,
+            base: base.to_string(),
+            modifiers: mods.iter().map(|s| s.to_string()).collect(),
+            ch: c,
+            variant_key: None,
+        }),
+        Def::Symbol(Symbol::Multi(alts)) => {
+            let (k, c) = pick_variant(&mods, alts);
+            Some(Resolved {
+                input: name.to_string(),
+                module: module_name,
+                base: base.to_string(),
+                modifiers: mods.iter().map(|s| s.to_string()).collect(),
+                ch: c,
+                variant_key: if k.is_empty() { None } else { Some(k.to_string()) },
+            })
+        }
+        Def::Module(_) => None,
+    }
+}
+
+#[derive(serde::Serialize)]
+pub struct JsonResolved {
+    pub name: String,
+    pub char: String,
+    pub codepoint: String,
+    pub utf8: String,
+    pub module: String,
+    pub base: String,
+    pub modifiers: Vec<String>,
+    pub variant: Option<String>,
+    pub source: &'static str,
+}
+impl From<Resolved> for JsonResolved {
+    fn from(r: Resolved) -> Self {
+        JsonResolved {
+            name: r.input.clone(),
+            char: r.ch.to_string(),
+            codepoint: codepoint_hex(r.ch),
+            utf8: utf8_bytes_hex(r.ch),
+            module: r.module.to_string(),
+            base: r.base,
+            modifiers: r.modifiers,
+            variant: r.variant_key,
+            source: "codex 0.1.1",
+        }
+    }
+}
+
+/// Search within a module by substring (case-insensitive) over keys.
+pub fn search(module: Module, q: &str) -> Vec<(String, char)> {
+    let q = q.to_lowercase();
+    module
+        .iter()
+        .filter_map(|(k, b)| match b.def {
+            Def::Symbol(Symbol::Single(c)) if k.to_lowercase().contains(&q) => {
+                Some((k.to_string(), c))
+            }
+            Def::Symbol(Symbol::Multi(alts)) if k.to_lowercase().contains(&q) => {
+                Some((k.to_string(), alts[0].1))
+            }
+            _ => None,
+        })
+        .collect()
+}

--- a/opt/blackroad/symbol-gateway/src/main.rs
+++ b/opt/blackroad/symbol-gateway/src/main.rs
@@ -1,0 +1,121 @@
+
+
+use axum::{extract::Query, http::StatusCode, response::IntoResponse, routing::{get, post}, Json, Router};
+use clap::{Parser, Subcommand};
+use serde::Deserialize;
+use std::net::SocketAddr;
+use tower_http::{cors::{Any, CorsLayer}, trace::TraceLayer};
+use symbol_gateway::*;
+
+mod symbol_gateway {
+    pub use symbol_gateway::*;
+}
+use symbol_gateway::{resolve_one, search};
+use codex::{EMOJI, ROOT, SYM};
+
+#[derive(Parser)]
+#[command(name = "symbol-gateway", version, about = "Unicode-by-name gateway (Typst Codex powered)")]
+struct Cli {
+    /// Run as an HTTP server or use CLI tools
+    #[command(subcommand)]
+    cmd: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Start HTTP server
+    Serve {
+        #[arg(long, default_value = "127.0.0.1:8087")]
+        addr: String,
+        #[arg(long, default_value_t = true)]
+        cors_any: bool,
+    },
+    /// Resolve a single name (e.g., sym.arrow.r)
+    Resolve { name: String },
+    /// Search keys (in sym/emoji/root)
+    Search { #[arg(long, default_value = "sym")] module: String, query: String },
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt().with_target(false).compact().init();
+
+    let cli = Cli::parse();
+    match cli.cmd {
+        Commands::Serve { addr, cors_any } => {
+            let app = router().layer(TraceLayer::new_for_http()).layer(
+                if cors_any {
+                    CorsLayer::new()
+                        .allow_origin(Any)
+                        .allow_methods(Any)
+                        .allow_headers(Any)
+                } else {
+                    CorsLayer::permissive()
+                },
+            );
+            let addr: SocketAddr = addr.parse().expect("bad addr");
+            tracing::info!("symbol-gateway listening on http://{addr}");
+            axum::Server::bind(&addr).serve(app.into_make_service()).await.unwrap();
+        }
+        Commands::Resolve { name } => {
+            if let Some(r) = resolve_one(&name) {
+                println!("{}\t{}\t{}", r.ch, r.input, r.variant_key.unwrap_or_default());
+                println!("codepoint: U+{:04X}", r.ch as u32);
+            } else {
+                eprintln!("not found: {name}");
+                std::process::exit(2);
+            }
+        }
+        Commands::Search { module, query } => {
+            let m = match module.as_str() { "sym" => SYM, "emoji" => EMOJI, "root" => ROOT, _ => SYM };
+            for (k, c) in search(m, &query) {
+                println!("{c}\t{k}");
+            }
+        }
+    }
+}
+
+fn router() -> Router {
+    Router::new()
+        .route("/healthz", get(|| async { "ok" }))
+        .route("/v1/resolve", get(http_resolve))
+        .route("/v1/batch", post(http_batch))
+        .route("/v1/search", get(http_search))
+}
+
+#[derive(Deserialize)]
+struct ResolveParams { name: String }
+
+async fn http_resolve(Query(q): Query<ResolveParams>) -> impl IntoResponse {
+    match resolve_one(&q.name) {
+        Some(r) => (StatusCode::OK, Json(symbol_gateway::JsonResolved::from(r))),
+        None => (StatusCode::NOT_FOUND, Json(serde_json::json!({
+            "error": "not-found", "name": q.name
+        }))),
+    }
+}
+
+#[derive(Deserialize)]
+struct BatchReq { names: Vec<String> }
+
+async fn http_batch(Json(b): Json<BatchReq>) -> impl IntoResponse {
+    let out: Vec<_> = b.names.iter()
+        .filter_map(|n| symbol_gateway::resolve_one(n).map(symbol_gateway::JsonResolved::from))
+        .collect();
+    Json(out)
+}
+
+#[derive(Deserialize)]
+struct SearchParams { query: String, module: Option<String> }
+
+async fn http_search(Query(q): Query<SearchParams>) -> impl IntoResponse {
+    let m = match q.module.as_deref() { Some("emoji") => EMOJI, Some("root") => ROOT, _ => SYM };
+    let rows = symbol_gateway::search(m, &q.query);
+    Json(serde_json::json!({
+        "query": q.query,
+        "module": q.module.unwrap_or_else(|| "sym".into()),
+        "results": rows.into_iter().map(|(k,c)| {
+            serde_json::json!({"name": format!("sym.{k}"), "char": c.to_string()})
+        }).collect::<Vec<_>>()
+    }))
+}

--- a/opt/blackroad/symbol-gateway/tests/integration.rs
+++ b/opt/blackroad/symbol-gateway/tests/integration.rs
@@ -1,0 +1,13 @@
+
+
+#[test]
+fn basic_resolution() {
+    let r = symbol_gateway::resolve_one("sym.arrow.r").unwrap();
+    assert_eq!(r.ch, '→');
+}
+#[test]
+fn halo_emoji() {
+    let r = symbol_gateway::resolve_one("emoji.face.halo").unwrap();
+    assert_eq!(r.ch, '😇');
+}
+

--- a/var/www/blackroad/clients/symbolClient.ts
+++ b/var/www/blackroad/clients/symbolClient.ts
@@ -1,0 +1,23 @@
+
+
+export interface Resolved {
+  name: string; char: string; codepoint: string; utf8: string;
+  module: string; base: string; modifiers: string[]; variant?: string; source: string;
+}
+const BASE = "/api/symbols";
+
+export async function resolveSymbol(name: string): Promise<Resolved> {
+  const r = await fetch(`${BASE}/v1/resolve?name=${encodeURIComponent(name)}`);
+  if (!r.ok) throw new Error(`resolve failed: ${r.status}`);
+  return r.json();
+}
+
+export async function batchResolve(names: string[]): Promise<Resolved[]> {
+  const r = await fetch(`${BASE}/v1/batch`, {
+    method: "POST",
+    headers: {"Content-Type": "application/json"},
+    body: JSON.stringify({ names }),
+  });
+  if (!r.ok) throw new Error(`batch failed: ${r.status}`);
+  return r.json();
+}


### PR DESCRIPTION
## Summary
- add `symbol-gateway` Rust microservice using typst/codex for Unicode-by-name resolution
- expose HTTP API, CLI, and batch search for symbol names
- include systemd unit, nginx proxy, and thin Python/TS clients

## Testing
- `cargo test` *(fails: download of config.json failed, 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f8cf40648329b2bb5bd9da7b4a19