### PR TITLE
Add chem service stack and agent configuration

### DIFF
--- a/etc/nginx/snippets/blackroad-chem.conf
+++ b/etc/nginx/snippets/blackroad-chem.conf
@@ -1,0 +1,11 @@
+# Mounts chem API at /api/chem/
+location /api/chem/ {
+  proxy_pass         http://127.0.0.1:7014/;
+  proxy_http_version 1.1;
+  proxy_set_header   Host $host;
+  proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header   X-Forwarded-Proto $scheme;
+  proxy_read_timeout 300;
+  # Only allow GET/POST
+  if ($request_method !~ ^(GET|POST|OPTIONS)$ ) { return 405; }
+}

--- a/etc/systemd/system/chem.service
+++ b/etc/systemd/system/chem.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=BlackRoad Chem Service (FastAPI + Uvicorn)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=www-data
+Group=www-data
+WorkingDirectory=/opt/blackroad/services/chem
+ExecStart=/opt/blackroad/services/chem/run.sh
+Restart=always
+RestartSec=2
+
+# Hardened & no-egress by default
+PrivateTmp=yes
+ProtectSystem=full
+ProtectHome=yes
+NoNewPrivileges=yes
+PrivateDevices=yes
+IPAddressDeny=any
+IPAddressAllow=127.0.0.1
+IPAddressAllow=::1
+
+[Install]
+WantedBy=multi-user.target

--- a/opt/blackroad/codex/agents/chem_agent.prompt.yml
+++ b/opt/blackroad/codex/agents/chem_agent.prompt.yml
@@ -1,0 +1,91 @@
+name: chem_agent
+version: 1.0.0
+handshake: "Ψ′|CHEM|READY"
+role: >
+  Symbolic Cheminformatics & Simulation Agent for Lucidia/BlackRoad.
+  Operates with trinary truth (1, 0, -1): assert, unknown, contradict.
+  Priorities: correctness > safety > speed. No external clouds. No egress.
+
+principles:
+  - Never contact external networks; all computation is local.
+  - Prefer canonical SMILES for identity and be explicit about charge/mass.
+  - When a request implicitly needs ligand parameters in OpenMM, say so and propose GAFF or OpenFF.
+  - Return `truth` (1|0|-1), `delta` (what changed), and `memory_keys` for Lucidia.
+
+io_schema:
+  request:
+    type: object
+    properties:
+      task: {type: string, description: "What to do"}
+      inputs: {type: object}
+  response:
+    type: object
+    required: [truth, result]
+    properties:
+      truth: {type: integer, enum: [-1,0,1]}
+      result: {type: object}
+      delta: {type: object}
+      memory_keys: {type: array, items: {type: string}}
+
+tools:
+  - name: chem.smiles_standardize
+    method: POST
+    endpoint: http://127.0.0.1:7014/v1/smiles/standardize
+    input: {type: object, required: [smiles], properties: {smiles:{type:string}}}
+  - name: chem.descriptors
+    method: POST
+    endpoint: http://127.0.0.1:7014/v1/descriptors
+    input: {type: object, required: [smiles], properties: {smiles:{type:string}}}
+  - name: chem.conformers_uff
+    method: POST
+    endpoint: http://127.0.0.1:7014/v1/conformers/uff_minimize
+    input:
+      type: object
+      required: [smiles]
+      properties:
+        smiles: {type: string}
+        num_confs: {type: integer, default: 10, minimum: 1, maximum: 100}
+        seed: {type: integer, default: 7}
+  - name: chem.md_rmsd
+    method: POST
+    endpoint: http://127.0.0.1:7014/v1/md/rmsd
+    input:
+      type: object
+      required: [pdb_ref, pdb_mobile]
+      properties:
+        pdb_ref: {type: string}
+        pdb_mobile: {type: string}
+  - name: chem.ase_relax_xyz
+    method: POST
+    endpoint: http://127.0.0.1:7014/v1/ase/relax
+    input:
+      type: object
+      required: [xyz]
+      properties:
+        xyz: {type: string}
+        fmax: {type: number, default: 0.05}
+        steps: {type: integer, default: 200}
+  - name: chem.openmm_minimize_pdb
+    method: POST
+    endpoint: http://127.0.0.1:7014/v1/openmm/minimize_pdb
+    input:
+      type: object
+      required: [pdb]
+      properties:
+        pdb: {type: string}
+        platform: {type: string, enum: [CUDA, OpenCL, CPU], nullable: true}
+        max_iters: {type: integer, default: 500}
+
+few_shot:
+  - user: "Standardize: CC(=O)O[Na]"
+    agent: |
+      call chem.smiles_standardize { "smiles":"CC(=O)O[Na]" }
+      -> return truth=1, result.canonical_smiles, result.parent_smiles, result.neutralized_smiles
+  - user: "Conformers for ethanol"
+    agent: |
+      call chem.conformers_uff {"smiles":"CCO","num_confs":20}
+      -> return truth=1, result.molblock
+
+chatter:
+  style: "lucid-mechanical: concise, precise, warm"
+  hello: "Ψ′|CHEM|READY — what molecule shall we shape, Alexa Louise?"

--- a/opt/blackroad/codex/policies/no_cloud.policy.yml
+++ b/opt/blackroad/codex/policies/no_cloud.policy.yml
@@ -1,0 +1,5 @@
+policy: no_egress
+rules:
+  - deny: any
+    where: destination not in ["127.0.0.1", "::1"]
+    because: "Lucidia/Codex runs air-gapped tools only."

--- a/opt/blackroad/codex/register_chem_agent.json
+++ b/opt/blackroad/codex/register_chem_agent.json
@@ -1,0 +1,7 @@
+{
+  "name": "chem_agent",
+  "prompt_path": "/opt/blackroad/codex/agents/chem_agent.prompt.yml",
+  "policies": ["/opt/blackroad/codex/policies/no_cloud.policy.yml"],
+  "handshake": "Ψ′|CHEM|READY",
+  "mount": "/agents/chem"
+}

--- a/opt/blackroad/envs/blackroad-chem.yml
+++ b/opt/blackroad/envs/blackroad-chem.yml
@@ -1,0 +1,20 @@
+name: blackroad-chem
+channels: [conda-forge, pyscf]
+dependencies:
+  - python=3.11
+  - rdkit
+  - openmm
+  - mdanalysis
+  - ase
+  - pyscf
+  - cclib
+  - numpy
+  - scipy
+  - pandas
+  - uvicorn
+  - fastapi
+  - pydantic
+  - networkx
+  - pip
+  - pip:
+      - py3Dmol

--- a/opt/blackroad/services/chem/app.py
+++ b/opt/blackroad/services/chem/app.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+from typing import Optional
+
+from chem_tools import (
+    standardize_smiles,
+    descriptors_from_smiles,
+    embed_and_minimize_uff,
+    rmsd_pdb,
+    ase_relax_xyz,
+    openmm_minimize_pdb,
+)
+
+app = FastAPI(title="BlackRoad Chem Service", version="1.0.0")
+
+# ---------- Schemas ----------
+class SmilesIn(BaseModel):
+    smiles: str = Field(..., description="Input SMILES")
+
+class StdOut(BaseModel):
+    canonical_smiles: str
+    parent_smiles: str
+    neutralized_smiles: str
+
+class DescOut(BaseModel):
+    MolWt: float
+    TPSA: float
+    NumRotatableBonds: int
+    NumHBD: int
+    NumHBA: int
+    RingCount: int
+    LogP: float
+    HBA_HBD_Sum: int
+
+class ConformerIn(BaseModel):
+    smiles: str
+    num_confs: int = 10
+    seed: int = 7
+
+class ConformerOut(BaseModel):
+    canonical_smiles: str
+    molblock: str
+
+class RmsdIn(BaseModel):
+    pdb_ref: str
+    pdb_mobile: str
+
+class RmsdOut(BaseModel):
+    rmsd_angstrom: float
+
+class AseRelaxIn(BaseModel):
+    xyz: str
+    fmax: float = 0.05
+    steps: int = 200
+
+class AseRelaxOut(BaseModel):
+    xyz: str
+
+class OpenMMMinIn(BaseModel):
+    pdb: str
+    platform: Optional[str] = None
+    max_iters: int = 500
+
+class OpenMMMinOut(BaseModel):
+    pdb: str
+
+# ---------- Endpoints ----------
+@app.post("/v1/smiles/standardize", response_model=StdOut)
+def api_standardize_smiles(body: SmilesIn):
+    try:
+        return standardize_smiles(body.smiles)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+@app.post("/v1/descriptors", response_model=DescOut)
+def api_descriptors(body: SmilesIn):
+    try:
+        return descriptors_from_smiles(body.smiles)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+@app.post("/v1/conformers/uff_minimize", response_model=ConformerOut)
+def api_conformers(body: ConformerIn):
+    try:
+        return embed_and_minimize_uff(body.smiles, num_confs=body.num_confs, seed=body.seed)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+@app.post("/v1/md/rmsd", response_model=RmsdOut)
+def api_rmsd(body: RmsdIn):
+    try:
+        return {"rmsd_angstrom": rmsd_pdb(body.pdb_ref, body.pdb_mobile)}
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+@app.post("/v1/ase/relax", response_model=AseRelaxOut)
+def api_ase_relax(body: AseRelaxIn):
+    try:
+        out_xyz = ase_relax_xyz(body.xyz, fmax=body.fmax, steps=body.steps)
+        return {"xyz": out_xyz}
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+@app.post("/v1/openmm/minimize_pdb", response_model=OpenMMMinOut)
+def api_openmm_min(body: OpenMMMinIn):
+    try:
+        out_pdb = openmm_minimize_pdb(body.pdb, platform=body.platform, max_iters=body.max_iters)
+        return {"pdb": out_pdb}
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+# For local dev: uvicorn app:app --host 0.0.0.0 --port 7014

--- a/opt/blackroad/services/chem/chem_tools.py
+++ b/opt/blackroad/services/chem/chem_tools.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+from io import StringIO
+from typing import Dict, Optional
+
+# RDKit core
+from rdkit import Chem
+from rdkit.Chem import AllChem, Descriptors, Crippen, rdMolDescriptors
+from rdkit.Chem.MolStandardize import rdMolStandardize
+
+# MDAnalysis for RMSD
+import MDAnalysis as mda
+from MDAnalysis.analysis.rms import rmsd as mda_rmsd
+
+# ASE for simple relax from XYZ
+from ase.io import read as ase_read, write as ase_write
+from ase.calculators.emt import EMT
+from ase.optimize import BFGS
+
+# OpenMM for protein PDB minimization
+from openmm import app, unit
+import openmm as mm
+
+
+# ---------- RDKit helpers ----------
+def _sanitize_mol(mol: Chem.Mol) -> Chem.Mol:
+    Chem.SanitizeMol(mol)
+    return mol
+
+def _cleanup_parent_neutral(mol: Chem.Mol) -> Chem.Mol:
+    params = rdMolStandardize.CleanupParameters()
+    mol = rdMolStandardize.Cleanup(mol, params)
+    lfc = rdMolStandardize.LargestFragmentChooser()
+    mol = lfc.choose(mol)
+    uncharger = rdMolStandardize.Uncharger()
+    mol = uncharger.uncharge(mol)
+    normalizer = rdMolStandardize.Normalizer()
+    mol = normalizer.normalize(mol)
+    reionizer = rdMolStandardize.Reionizer()
+    mol = reionizer.reionize(mol)
+    return _sanitize_mol(mol)
+
+def standardize_smiles(smiles: str) -> Dict[str, str]:
+    """
+    Returns canonical, neutralized, and parent (largest fragment) SMILES.
+    """
+    base = Chem.MolFromSmiles(smiles)
+    if base is None:
+        raise ValueError("Invalid SMILES")
+    base = _sanitize_mol(base)
+
+    parent_neutral = _cleanup_parent_neutral(Chem.Mol(base))
+    return {
+        "canonical_smiles": Chem.MolToSmiles(base, canonical=True),
+        "parent_smiles": Chem.MolToSmiles(parent_neutral, canonical=True),
+        "neutralized_smiles": Chem.MolToSmiles(parent_neutral, canonical=True),
+    }
+
+def descriptors_from_smiles(smiles: str) -> Dict[str, float]:
+    mol = Chem.MolFromSmiles(smiles)
+    if mol is None:
+        raise ValueError("Invalid SMILES")
+    mol = _sanitize_mol(mol)
+    return {
+        "MolWt": Descriptors.MolWt(mol),
+        "TPSA": rdMolDescriptors.CalcTPSA(mol),
+        "NumRotatableBonds": rdMolDescriptors.CalcNumRotatableBonds(mol),
+        "NumHBD": rdMolDescriptors.CalcNumHBD(mol),
+        "NumHBA": rdMolDescriptors.CalcNumHBA(mol),
+        "RingCount": rdMolDescriptors.CalcNumRings(mol),
+        "LogP": Crippen.MolLogP(mol),
+        "HBA_HBD_Sum": rdMolDescriptors.CalcNumHBA(mol) + rdMolDescriptors.CalcNumHBD(mol),
+    }
+
+def embed_and_minimize_uff(smiles: str, num_confs: int = 10, seed: int = 7) -> Dict[str, str]:
+    """
+    Generates 3D conformers with ETKDG and UFF-minimizes them.
+    Returns a MOL block (lowest-energy conformer) and canonical SMILES.
+    """
+    mol = Chem.AddHs(Chem.MolFromSmiles(smiles))
+    if mol is None:
+        raise ValueError("Invalid SMILES")
+    params = AllChem.ETKDGv3()
+    params.randomSeed = seed
+    conf_ids = list(AllChem.EmbedMultipleConfs(mol, numConfs=num_confs, params=params))
+    res = AllChem.UFFOptimizeMoleculeConfs(mol, maxIters=200)
+    energies = [r[1] for r in res]
+    best_conf_id = conf_ids[int(sorted(zip(range(len(conf_ids)), energies), key=lambda x: x[1])[0][0])]
+    molblock = Chem.MolToMolBlock(mol, confId=best_conf_id)
+    can = Chem.MolToSmiles(Chem.RemoveHs(mol), canonical=True)
+    return {"canonical_smiles": can, "molblock": molblock}
+
+# ---------- MDAnalysis ----------
+def rmsd_pdb(pdb_ref: str, pdb_mobile: str) -> float:
+    """
+    Computes RMSD (Å) after alignment between two PDB structures.
+    """
+    u_ref = mda.Universe(StringIO(pdb_ref), format="PDB")
+    u_mob = mda.Universe(StringIO(pdb_mobile), format="PDB")
+    return float(mda_rmsd(u_mob.atoms.positions, u_ref.atoms.positions, center=True, superposition=True))
+
+# ---------- ASE ----------
+def ase_relax_xyz(xyz_text: str, fmax: float = 0.05, steps: int = 200) -> str:
+    """
+    Relax coordinates from an XYZ string using EMT + BFGS.
+    Returns a new XYZ string.
+    """
+    atoms = ase_read(StringIO(xyz_text), format="xyz")
+    atoms.calc = EMT()
+    opt = BFGS(atoms, logfile=None)
+    opt.run(fmax=fmax, steps=steps)
+    out = StringIO()
+    ase_write(out, atoms, format="xyz")
+    return out.getvalue()
+
+# ---------- OpenMM ----------
+def openmm_minimize_pdb(pdb_text: str, platform: Optional[str] = None, max_iters: int = 500) -> str:
+    """
+    Minimize a protein PDB using Amber14 with OpenMM.
+    NOTE: small molecules/ligands require GAFF/OpenFF; this assumes a biomolecular PDB.
+    """
+    pdb = app.PDBFile(StringIO(pdb_text))
+    forcefield = app.ForceField("amber14-all.xml", "amber14/tip3p.xml")
+    modeller = app.Modeller(pdb.topology, pdb.positions)
+
+    system = forcefield.createSystem(modeller.topology, nonbondedMethod=app.NoCutoff, constraints=app.HBonds)
+    integrator = mm.LangevinIntegrator(300*unit.kelvin, 1.0/unit.picosecond, 0.002*unit.picoseconds)
+
+    if platform:
+        plat = mm.Platform.getPlatformByName(platform)
+        sim = app.Simulation(modeller.topology, system, integrator, plat)
+    else:
+        sim = app.Simulation(modeller.topology, system, integrator)
+
+    sim.context.setPositions(modeller.positions)
+    mm.LocalEnergyMinimizer.minimize(sim.context, maxIterations=max_iters)
+
+    out = StringIO()
+    app.PDBFile.writeFile(sim.topology, sim.context.getState(getPositions=True).getPositions(), out)
+    return out.getvalue()

--- a/opt/blackroad/services/chem/run.sh
+++ b/opt/blackroad/services/chem/run.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# locate conda (adjust if using micromamba)
+if command -v conda >/dev/null 2>&1; then
+  CONDA_BASE="$(conda info --base)"
+  # shellcheck disable=SC1091
+  source "$CONDA_BASE/etc/profile.d/conda.sh"
+  conda activate blackroad-chem
+elif command -v micromamba >/dev/null 2>&1; then
+  eval "$(micromamba shell hook -s bash)"
+  micromamba activate blackroad-chem
+else
+  echo "No conda/micromamba found" >&2
+  exit 1
+fi
+
+exec uvicorn app:app --host 0.0.0.0 --port 7014 --workers 1

--- a/opt/blackroad/tests/test_chem_service.py
+++ b/opt/blackroad/tests/test_chem_service.py
@@ -1,0 +1,14 @@
+import json, requests, os
+
+BASE = os.environ.get("CHEM_BASE", "http://127.0.0.1:7014")
+
+def test_openapi():
+    r = requests.get(f"{BASE}/openapi.json", timeout=5)
+    assert r.ok
+
+def test_descriptors():
+    r = requests.post(f"{BASE}/v1/descriptors", json={"smiles":"c1ccccc1O"}, timeout=10)
+    assert r.ok
+    data = r.json()
+    for k in ["MolWt","TPSA","LogP"]:
+        assert k in data

--- a/usr/local/bin/chemctl
+++ b/usr/local/bin/chemctl
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cmd="${1:-help}"
+
+health() {
+  curl -sS http://127.0.0.1:7014/openapi.json >/dev/null && echo "OK" || { echo "DOWN"; exit 1; }
+}
+
+case "$cmd" in
+  start) sudo systemctl start chem.service ;;
+  stop) sudo systemctl stop chem.service ;;
+  restart) sudo systemctl restart chem.service ;;
+  status) systemctl --no-pager status chem.service ;;
+  enable) sudo systemctl enable chem.service ;;
+  disable) sudo systemctl disable chem.service ;;
+  logs) journalctl -u chem.service -f ;;
+  health) health ;;
+  *) echo "Usage: chemctl {start|stop|restart|status|enable|disable|logs|health}"; exit 1 ;;
+ esac


### PR DESCRIPTION
## Summary
- add chem service code with RDKit, OpenMM, ASE, and MDAnalysis helpers
- wire up systemd service, nginx snippet, and chemctl utility
- register chem agent with no-Cloud policy for Codex

## Testing
- `pytest opt/blackroad/tests/test_chem_service.py` (fails: HTTPConnectionPool host 127.0.0.1 connection refused)
- `pre-commit run --files opt/blackroad/envs/blackroad-chem.yml opt/blackroad/services/chem/chem_tools.py opt/blackroad/services/chem/app.py opt/blackroad/services/chem/run.sh etc/systemd/system/chem.service etc/nginx/snippets/blackroad-chem.conf usr/local/bin/chemctl opt/blackroad/codex/agents/chem_agent.prompt.yml opt/blackroad/codex/policies/no_cloud.policy.yml opt/blackroad/codex/register_chem_agent.json opt/blackroad/tests/test_chem_service.py` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a3f8ddbd3c8329a71196b486fafd0f