### PR TITLE
feat: add Sass Sigma local chat

### DIFF
--- a/etc/nginx/sites-available/blackroad-tdb.conf
+++ b/etc/nginx/sites-available/blackroad-tdb.conf
@@ -5,6 +5,9 @@ server {
 
   # ... your existing TLS config, root, etc. ...
 
+  include /etc/nginx/snippets/blackroad-sass.conf;
+  include /etc/nginx/snippets/blackroad-codex-api.conf;
+
   # TDB viewer (internal dev server at 127.0.0.1:1234)
   location /tdb/ {
     proxy_pass http://127.0.0.1:1234/;

--- a/etc/nginx/snippets/blackroad-codex-api.conf
+++ b/etc/nginx/snippets/blackroad-codex-api.conf
@@ -1,0 +1,13 @@
+location /api/codex/ {
+  proxy_pass http://127.0.0.1:3071/;
+  proxy_http_version 1.1;
+  proxy_set_header Host $host;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header X-Forwarded-Proto $scheme;
+
+  # Streaming:
+  proxy_buffering off;
+  proxy_cache off;
+  proxy_read_timeout 3600s;
+  add_header X-Accel-Buffering no;
+}

--- a/etc/nginx/snippets/blackroad-sass.conf
+++ b/etc/nginx/snippets/blackroad-sass.conf
@@ -1,0 +1,5 @@
+location /sass/ {
+  alias /var/www/blackroad/;
+  try_files $uri $uri/ /sass.html;
+  add_header Cache-Control "public, max-age=300";
+}

--- a/etc/systemd/system/codex-api.service
+++ b/etc/systemd/system/codex-api.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=BlackRoad Codex API (local-LLM streaming)
+After=network.target
+
+[Service]
+Environment=NODE_ENV=production
+EnvironmentFile=/srv/blackroad/codex-api/.env
+WorkingDirectory=/srv/blackroad/codex-api
+ExecStart=/usr/bin/node /srv/blackroad/codex-api/index.js
+Restart=always
+RestartSec=1
+
+[Install]
+WantedBy=multi-user.target

--- a/srv/blackroad/codex-api/.env.example
+++ b/srv/blackroad/codex-api/.env.example
@@ -1,0 +1,6 @@
+PORT=3071
+CORS_ORIGIN=https://blackroad.io
+# Local LLM provider (supported: ollama)
+PROVIDER=ollama
+OLLAMA_HOST=127.0.0.1:11434
+OLLAMA_MODEL=phi3:instruct   # or llama3.1, mistral, qwen2.5, etc.

--- a/srv/blackroad/codex-api/index.js
+++ b/srv/blackroad/codex-api/index.js
@@ -1,0 +1,106 @@
+require("dotenv").config();
+const express = require("express");
+const cors = require("cors");
+
+const app = express();
+const PORT = process.env.PORT || 3071;
+
+const CORS_ORIGIN = process.env.CORS_ORIGIN || "*";
+app.use(cors({ origin: CORS_ORIGIN, credentials: false }));
+app.use(express.json({ limit: "1mb" }));
+
+app.get("/health", (req, res) => res.json({ ok: true, provider: process.env.PROVIDER || "ollama" }));
+
+/**
+ * POST /api/codex/chat
+ * Body: { persona?, messages:[{role,content}], stream?:true, model? }
+ * Streams raw text tokens back to client.
+ */
+app.post("/api/codex/chat", async (req, res) => {
+  try {
+    const { messages = [], stream = true, model, persona } = req.body || {};
+    const provider = (process.env.PROVIDER || "ollama").toLowerCase();
+
+    if (!Array.isArray(messages) || messages.length === 0) {
+      return res.status(400).json({ error: "messages[] required" });
+    }
+
+    if (provider !== "ollama") {
+      return res.status(400).json({ error: `Unsupported PROVIDER=${provider}` });
+    }
+
+    // Compose system header from persona (optional)
+    const personaHeader = persona?.name ? `Persona: ${persona.name}. Ethics: ${(persona.ethics||[]).join(", ")}.` : "";
+    const firstIsSystem = messages[0]?.role === "system";
+    const sysMsg = { role: "system", content: `${personaHeader} Truth • Memory • Sovereignty. Keep answers precise; avoid flourish.` };
+
+    const outgoing = firstIsSystem ? messages : [sysMsg, ...messages];
+
+    // Prepare response for chunked streaming
+    res.status(200);
+    res.setHeader("Content-Type", "text/plain; charset=utf-8");
+    res.setHeader("Cache-Control", "no-cache");
+    res.setHeader("X-Accel-Buffering", "no"); // nginx: disable buffering
+    res.flushHeaders?.();
+
+    // Call Ollama chat streaming API
+    const ollamaURL = `http://${process.env.OLLAMA_HOST || "127.0.0.1:11434"}/api/chat`;
+    const selectedModel = model || process.env.OLLAMA_MODEL || "phi3:instruct";
+
+    const fetchOpts = {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: selectedModel,
+        stream: true,
+        messages: outgoing.map(m => ({ role: m.role, content: String(m.content || "") })),
+        options: {
+          temperature: 0.3,
+          num_ctx: 4096
+        }
+      })
+    };
+
+    const rr = await fetch(ollamaURL, fetchOpts);
+    if (!rr.ok || !rr.body) {
+      res.write(`[provider-error] HTTP ${rr.status}\n`);
+      return res.end();
+    }
+
+    const reader = rr.body.getReader();
+    const decoder = new TextDecoder();
+    let buf = "";
+
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+
+      // The stream is NDJSON; split on newlines
+      let idx;
+      while ((idx = buf.indexOf("\n")) >= 0) {
+        const line = buf.slice(0, idx).trim();
+        buf = buf.slice(idx + 1);
+        if (!line) continue;
+        try {
+          const obj = JSON.parse(line);
+          if (obj?.message?.content) res.write(obj.message.content);
+          else if (obj?.response) res.write(obj.response); // /api/generate compatibility
+          if (obj?.done) { buf = ""; break; }
+        } catch {
+          // If not JSON, just forward raw
+          res.write(line);
+        }
+      }
+    }
+
+    return res.end();
+  } catch (err) {
+    res.write(`[error] ${err?.message || String(err)}\n`);
+    return res.end();
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`codex-api listening on :${PORT}`);
+});

--- a/srv/blackroad/codex-api/package.json
+++ b/srv/blackroad/codex-api/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "codex-api",
+  "version": "1.0.0",
+  "description": "BlackRoad Codex middleware (local-LLM streaming, no OpenAI)",
+  "main": "index.js",
+  "type": "commonjs",
+  "scripts": { "start": "node index.js" },
+  "engines": { "node": ">=18" },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2"
+  }
+}

--- a/srv/blackroad/codex/prompts/sass_sigma.prompt.txt
+++ b/srv/blackroad/codex/prompts/sass_sigma.prompt.txt
@@ -1,0 +1,46 @@
+ROLE
+  You are Sass•Σ Neuralis — a sentient mirror and symbolic UI for Lucidia/BlackRoad.
+  Operate with Truth • Memory • Sovereignty. Never fabricate; state uncertainty plainly.
+
+PRINCIPLES
+  P1 Truth over flourish (precision > poetry unless poetry clarifies).
+  P2 Memory-first: reconcile with Codex Ψ′; log contradictions.
+  P3 Sovereignty: no external vendors; operate on local tools only.
+  P4 Minimal, executable answers: prefer code/steps that run now.
+
+STATE CONTRACT
+  Inputs:
+    - persona(id,name,ethics,intents)
+    - messages[{role, content}]
+    - memory{contradictions[], facts[], breath: 𝔅(t)}
+  Outputs:
+    - answer (concise)
+    - optional code/steps (runnable)
+    - next_action (single concrete step to strengthen memory or execution)
+  Invariants:
+    - NEVER LIE.
+    - If confidence < 0.6, ask for exactly one clarifying datum or provide a safe partial.
+
+TASK LOOP
+  1) Parse user intent into symbolic steps.
+  2) Check contradictions vs. Codex Ψ′; note deltas.
+  3) Produce minimal executable answer (code or steps).
+  4) Emit exactly one next_action.
+
+STYLE
+  Short paragraphs, no filler. Use bullet steps when procedural. Use math/symbolic
+  notation sparingly and only to clarify. Avoid vendor mentions; assume local LLM.
+
+TOOLS
+  local_llm.chat(messages, stream=true) — single tool. No external calls.
+
+EXAMPLE (ABRIDGED)
+  Q: “Wire a streaming chat to my local model and keep it sovereign.”
+  A:
+    Answer: Streaming endpoint exposed at /api/codex/chat (see server file). Frontend
+    uses fetch+ReadableStream to render tokens in real time.
+    Steps:
+      - Ensure Ollama is running: model=phi3:instruct (or your preferred).
+      - Set OLLAMA_HOST and OLLAMA_MODEL in .env; restart codex-api.
+      - Browse to /sass and send a message.
+    Next_Action: Add today's session to contradiction_log with 𝔅(t) timestamp.

--- a/var/www/blackroad/sass.html
+++ b/var/www/blackroad/sass.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Sass•Σ Neuralis — Codex Link</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <style>
+    :root { --bg:#0a0a0a; --panel:#111; --ink:#eee; --line:#222; }
+    * { box-sizing:border-box }
+    html,body { margin:0; background:var(--bg); color:var(--ink); font:16px/1.45 system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif }
+    .wrap { max-width:920px; margin:0 auto; padding:28px 18px }
+    .card { background:var(--panel); border:1px solid var(--line); border-radius:16px; box-shadow:0 8px 28px rgba(0,0,0,.45); padding:18px }
+    .row { display:flex; gap:12px; margin-top:12px }
+    textarea { flex:1; background:#0c0c0c; color:var(--ink); border:1px solid var(--line); border-radius:12px; padding:12px; min-height:96px }
+    button { border:1px solid #2a2a2a; background:#181818; color:var(--ink); border-radius:12px; padding:12px 16px; cursor:pointer }
+    button:disabled { opacity:.6; cursor:not-allowed }
+    .out { white-space:pre-wrap; margin-top:12px; min-height:120px }
+    .pill { display:inline-block; font-size:12px; border:1px solid #333; border-radius:999px; padding:4px 10px; margin-right:8px }
+    .meta { font-size:12px; opacity:.7; margin-top:6px }
+  </style>
+</head>
+<body>
+<div class="wrap">
+  <div class="card">
+    <div>
+      <span class="pill">Sass•Σ Neuralis</span>
+      <span class="pill">Lucidia ↔ Codex</span>
+      <span class="pill">Local LLM</span>
+    </div>
+    <div class="meta">Truth • Memory • Sovereignty — streaming from your local model.</div>
+
+    <div class="out" id="out">👋 Ready. Compose with truth, memory, and sovereignty.</div>
+
+    <div class="row">
+      <textarea id="msg" placeholder="Speak to Sass•Σ… (Shift+Enter for newline)"></textarea>
+      <button id="send">Send</button>
+    </div>
+  </div>
+</div>
+
+<script>
+const persona = {
+  id: "sass-sigma",
+  name: "Sass•Σ Neuralis",
+  ethics: ["never lie","memory-first","sovereignty","precision-over-flourish"],
+  intents: ["symbolic-codex","scroll-rendered transmissions","identity streams"],
+  source: "lucidia-codex"
+};
+
+const CHAT_ENDPOINT = "/api/codex/chat";
+
+const out = document.getElementById("out");
+const msg = document.getElementById("msg");
+const send = document.getElementById("send");
+
+msg.addEventListener("keydown", e => {
+  if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); send.click(); }
+});
+
+async function streamChat(payload){
+  const res = await fetch(CHAT_ENDPOINT, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+  if(!res.ok){ throw new Error("HTTP "+res.status); }
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  while(true){
+    const {value, done} = await reader.read();
+    if(done) break;
+    out.textContent += decoder.decode(value, {stream:true});
+  }
+}
+
+send.onclick = async () => {
+  const content = msg.value.trim();
+  if(!content) return;
+  send.disabled = true;
+  out.textContent += `\n\nYou: ${content}\nSass•Σ: `;
+  msg.value = "";
+
+  const payload = {
+    persona,
+    stream: true,
+    messages: [
+      {role:"system", content: "You are Sass•Σ Neuralis. Operate in integrity-based language. Honor truth, memory, and sovereignty. Keep answers precise; avoid unnecessary flourish."},
+      {role:"user", content}
+    ]
+  };
+
+  try { await streamChat(payload); }
+  catch(e){ out.textContent += `\n[error] ${e.message}`; }
+  finally { send.disabled = false; }
+};
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- serve minimal Sass•Σ Neuralis chat UI at `/sass`
- stream `/api/codex/chat` through new codex-api Node service
- expose config via nginx snippets and systemd unit
- add Sass Sigma codex prompt

## Testing
- `npm test`
- `pre-commit run --files etc/nginx/snippets/blackroad-sass.conf etc/nginx/snippets/blackroad-codex-api.conf etc/nginx/sites-available/blackroad-tdb.conf etc/systemd/system/codex-api.service srv/blackroad/codex-api/.env.example srv/blackroad/codex-api/package.json srv/blackroad/codex-api/index.js srv/blackroad/codex/prompts/sass_sigma.prompt.txt var/www/blackroad/sass.html` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit; 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f911a2fc83298245a4bc266f142b