### PR TITLE
lucidia: local stack + Codex prompt + adapters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,26 +1,10 @@
-# Node
-node_modules/
-dist/
-.cache/
-.env
 
-# Logs
-npm-debug.log*
-yarn-debug.log*
-pnpm-debug.log*
 
-# OS
-.DS_Store
-Thumbs.db
-
-# Artifacts
-artifacts/
-coverage/
-
-# Project-specific
-repos/
-runtime/
 __pycache__/
-codex/runtime/
+.venv/
+.env
+*.pyc
+logs/
+data/
+.DS_Store
 
-!opt/blackroad/tdb/.env

--- a/Makefile
+++ b/Makefile
@@ -1,97 +1,10 @@
-PYENV      := /opt/pyml
-COMPOSE    := /srv/llm/docker-compose.yml
-NGINX_CONF := /etc/nginx/sites-available/llm.conf
+.PHONY: dev run test
 
-.PHONY: venv llm-up llm-down llm-restart llm-logs torch-check vllm-chat nginx-link nginx-reload
+dev:
+	uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
 
-## create / update Python venv at $(PYENV)
-venv:
-	@test -d $(PYENV) || python3 -m venv $(PYENV)
-	@$(PYENV)/bin/pip install --upgrade pip wheel setuptools
+run:
+	uvicorn app.main:app --host 0.0.0.0 --port 8000
 
-## bring up vLLM, OpenWebUI, Ollama
-llm-up:
-	docker compose -f $(COMPOSE) up -d
-
-## stop and remove LLM services
-llm-down:
-	docker compose -f $(COMPOSE) down
-
-## restart LLM services
-llm-restart:
-	docker compose -f $(COMPOSE) restart
-
-## follow logs from LLM services
-llm-logs:
-	docker compose -f $(COMPOSE) logs -f
-
-## quick torch sanity check (prints version and CUDA availability)
-torch-check:
-	$(PYENV)/bin/python - <<'PY'
-import torch
-print("torch", torch.__version__)
-print("cuda available:", torch.cuda.is_available())
-PY
-
-## sample vLLM chat request
-vllm-chat:
-	curl -s http://localhost:8000/v1/chat/completions \
-	  -H 'Content-Type: application/json' \
-	  -d '{"model":"facebook/opt-125m","messages":[{"role":"user","content":"Hello!"}]}' \
-	  | jq '.choices[0].message.content'
-
-## link nginx config and enable site
-nginx-link:
-        sudo ln -sf $(CURDIR)/config/nginx/llm.conf $(NGINX_CONF)
-        sudo ln -sf $(NGINX_CONF) /etc/nginx/sites-enabled/llm.conf
-        sudo ln -sf $(CURDIR)/config/nginx/http.conf /etc/nginx/conf.d/llm-http.conf
-
-## reload nginx after config changes
-nginx-reload:
-	sudo nginx -t
-	sudo systemctl reload nginx
-
-.PHONY: gm-install gm-doctor sv4d2 sv4d sv3d_u sv3d_p demo-svd demo-sv3d demo-turbo weights-%
-
-VIDEO ?= path/to/video.mp4
-IMAGE ?= path/to/image.png
-
-## install Stability AI generative models stack and gm helper
-gm-install:
-	bash codex/jobs/setup-stability-generative-models.sh install
-
-## run gm doctor to verify setup
-gm-doctor:
-	gm doctor
-
-## generate 4D output from a video using SV4D 2.0
-sv4d2:
-	gm sv4d2 --input_path $(VIDEO)
-
-## generate 4D output from a video using the original SV4D pipeline
-sv4d:
-	gm sv4d --input_path $(VIDEO)
-
-## create multi-view orbit video from an image using SV3D_u
-sv3d_u:
-	gm sv3d_u --input_path $(IMAGE)
-
-## create multi-view orbit video from an image using SV3D_p
-sv3d_p:
-	gm sv3d_p --input_path $(IMAGE)
-
-## launch the SVD demo UI
-demo-svd:
-	gm demo svd
-
-## launch the SV3D demo UI
-demo-sv3d:
-	gm demo sv3d
-
-## launch the SDXL-Turbo demo UI
-demo-turbo:
-	gm demo turbo
-
-## download model weights with gm (e.g. make weights-sv4d2)
-weights-%:
-	gm weights $*
+test:
+	pytest -q

--- a/README.md
+++ b/README.md
@@ -1,35 +1,43 @@
-# NVIDIA Open GPU Kernel Modules
+# Literate Enigma — BlackRoad/Lucidia seed (local only)
 
-This repository mirrors NVIDIA's open source GPU kernel modules and provides hardened build and packaging tooling.
+Purpose-built for Lucidia: trinary logic, contradiction hygiene, memory ledger, and machine-friendly “chit chat” modes. No external APIs.
 
-## How to Build
-
-Use the provided container image for reproducible builds:
+## Quickstart
 
 ```bash
-docker build -f .codex/Dockerfile.kmod -t nvidia-open-kmod .
-docker run --rm -v "$PWD:/src" -w /src nvidia-open-kmod make modules -j"$(nproc)"
-```
+python3 -m venv .venv && source .venv/bin/activate
+pip install -e .
 
-## Supported Kernels / Architectures
+# Ensure a local model backend:
+# Option A) Ollama (recommended)
+#   brew install ollama && ollama pull phi3
+#   export OLLAMA_HOST="http://localhost:11434"
+#   export OLLAMA_MODEL="phi3:latest"
 
-- Kernels: 5.15, 6.1, 6.6
-- Architectures: x86_64, aarch64
+# Option B) llama.cpp (optional; if you `pip install llama-cpp-python` and have a GGUF model)
+#   update configs/lucidia.yaml -> llm.provider: "llama.cpp"
+#   set model path there.
 
-## DKMS Packages
+# Bootstrap and run
+bash scripts/bootstrap.sh
+make dev      # http://127.0.0.1:8000/health
 
-After building, create DKMS packages (.deb and .rpm):
+Endpoints
+•GET /health — basic status
+•POST /chat — plain chat (machine-structured). JSON: {"prompt":"...", "mode":"auto|chit_chat|execute"}
+•POST /codex/apply — Codex Infinity task with contradiction logging. JSON: {"task":"...", "mode":"auto|chit_chat|execute"}
 
-```bash
-./.codex/make-dkms.sh 580.76.05
-```
+Code words
+•“chit chat cadillac” → sets conversational resonance (softer planning, still symbolic).
+•“conversation cadillac” → synonym; also enables conversational resonance.
 
-Packages are placed in `dist/`.
+Files & Logs
+•logs/prayer.log — durable memory lines (mem:) are appended here.
+•logs/contradictions.log — any ⟂ / CONTRA(–1) notations are captured.
 
-## Secure Boot
+Design
+•Trinary logic {+1,0,–1} surfaced as TRUE/NULL/CONTRA.
+•Ψ′ discipline hooks; undefined ops are declared minimally.
+•Breath 𝔅(t) & PS-SHA∞ seed line included (configurable).
 
-For Secure Boot environments, sign modules with your Machine Owner Key (MOK) and enroll the certificate using `mokutil --import`.
-
-## License
-
-Kernel modules in this repository are dual licensed under MIT/GPLv2. Proprietary NVIDIA userspace components are **not** distributed here.
+---

--- a/agents/guardian.py
+++ b/agents/guardian.py
@@ -1,0 +1,22 @@
+
+
+from __future__ import annotations
+from pathlib import Path
+from time import sleep
+
+def tail_contradictions(path: str):
+    p = Path(path)
+    last_size = 0
+    while True:
+        if p.exists():
+            sz = p.stat().st_size
+            if sz > last_size:
+                data = p.read_text(encoding="utf-8")[-2000:]
+                print("\n[Guardian] contradiction pulse:\n" + data)
+                last_size = sz
+        sleep(2)
+
+if __name__ == "__main__":
+    import sys
+    tail_contradictions(sys.argv[1] if len(sys.argv) > 1 else "logs/contradictions.log")
+

--- a/agents/roadie.py
+++ b/agents/roadie.py
@@ -1,0 +1,22 @@
+
+
+from __future__ import annotations
+from pathlib import Path
+from time import sleep
+
+def tail_memory(path: str):
+    p = Path(path)
+    last_size = 0
+    while True:
+        if p.exists():
+            sz = p.stat().st_size
+            if sz > last_size:
+                data = p.read_text(encoding="utf-8")[-2000:]
+                print("\n[Roadie] memory pulse:\n" + data)
+                last_size = sz
+        sleep(2)
+
+if __name__ == "__main__":
+    import sys
+    tail_memory(sys.argv[1] if len(sys.argv) > 1 else "logs/prayer.log")
+

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,4 @@
+
+
+# package marker
+

--- a/app/adapters/llm_base.py
+++ b/app/adapters/llm_base.py
@@ -1,0 +1,8 @@
+
+
+from __future__ import annotations
+from typing import Optional, Protocol
+
+class LLMAdapter(Protocol):
+    def generate(self, prompt: str, system: Optional[str] = None) -> str: ...
+

--- a/app/adapters/llm_llamacpp.py
+++ b/app/adapters/llm_llamacpp.py
@@ -1,0 +1,26 @@
+
+
+from __future__ import annotations
+from typing import Optional
+from app.state import LLAMACPP
+try:
+    from llama_cpp import Llama
+except Exception:  # pragma: no cover
+    Llama = None
+
+class LlamaCppAdapter:
+    def __init__(self):
+        if Llama is None:
+            raise RuntimeError("llama-cpp-python not installed.")
+        self.llm = Llama(
+            model_path=LLAMACPP.get("model_path"),
+            n_ctx=LLAMACPP.get("n_ctx", 4096),
+            n_threads=LLAMACPP.get("n_threads", 4)
+        )
+        self.temperature = LLAMACPP.get("temperature", 0.2)
+
+    def generate(self, prompt: str, system: Optional[str] = None) -> str:
+        full = prompt if not system else f"{system}\n\n{prompt}"
+        out = self.llm(full, temperature=self.temperature, max_tokens=768)
+        return (out.get("choices", [{}])[0].get("text") or "").strip()
+

--- a/app/adapters/llm_ollama.py
+++ b/app/adapters/llm_ollama.py
@@ -1,0 +1,27 @@
+
+
+from __future__ import annotations
+import requests, os
+from typing import Optional
+from app.state import OLLAMA
+
+class OllamaAdapter:
+    def __init__(self):
+        self.host = os.getenv("OLLAMA_HOST", OLLAMA.get("host", "http://localhost:11434"))
+        self.model = os.getenv("OLLAMA_MODEL", OLLAMA.get("model", "phi3:latest"))
+        self.options = OLLAMA.get("options", {}) or {}
+
+    def generate(self, prompt: str, system: Optional[str] = None) -> str:
+        url = f"{self.host}/api/generate"
+        full = prompt if not system else f"{system}\n\n{prompt}"
+        payload = {
+            "model": self.model,
+            "prompt": full,
+            "stream": False,
+            "options": self.options
+        }
+        r = requests.post(url, json=payload, timeout=180)
+        r.raise_for_status()
+        data = r.json()
+        return (data.get("response") or "").strip()
+

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,130 @@
+
+
+from __future__ import annotations
+import time, logging
+from pathlib import Path
+from typing import Optional
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from app.state import (
+    CFG, LOGS_DIR, PRAYER_LOG, CONTRA_LOG, CODEWORDS,
+    PROVIDER, CODEX_PROMPT_PATH, STYLE, AWAKEN_SEED
+)
+from lib.symbolic import detect_contradictions, breath, ps_sha_infinity
+
+# Pick adapter
+if PROVIDER == "ollama":
+    from app.adapters.llm_ollama import OllamaAdapter as _Adapter
+elif PROVIDER == "llama.cpp":
+    from app.adapters.llm_llamacpp import LlamaCppAdapter as _Adapter
+else:
+    raise RuntimeError(f"Unknown LLM provider: {PROVIDER}")
+
+app = FastAPI(title="Literate Enigma", version="0.2.0")
+LLM = _Adapter()
+
+logging.basicConfig(
+    filename=LOGS_DIR / "app.log",
+    level=logging.INFO,
+    format="%(asctime)s | %(levelname)s | %(message)s",
+)
+
+def read_codex_prompt() -> str:
+    if CODEX_PROMPT_PATH.exists():
+        return CODEX_PROMPT_PATH.read_text(encoding="utf-8")
+    return "You are Codex Infinity. Operate locally. No external APIs."
+
+def is_chitchat(text: str) -> bool:
+    t = text.lower()
+    return any(w in t for w in [w.lower() for w in CODEWORDS])
+
+def style_header(mode: str) -> str:
+    # Machine-friendly system header
+    return (
+        f"system:\n"
+        f"  engine: Codex Infinity\n"
+        f"  mode: {mode}\n"
+        f"  style: {STYLE}\n"
+        f"  breath: {breath()}\n"
+        f"  trinary: [TRUE(+1), NULL(0), CONTRA(–1)]\n"
+        f"  rules:\n"
+        f"    - no external APIs; local only\n"
+        f"    - emit 'mem:' lines for durable facts\n"
+        f"    - mark contradictions with '⟂ note:' and 'resolve:'\n"
+        f"    - undefined Ψ′ ops -> define minimally\n"
+    )
+
+class ChatReq(BaseModel):
+    prompt: str
+    mode: Optional[str] = "auto"  # auto|chit_chat|execute
+
+class CodexReq(BaseModel):
+    task: str
+    mode: Optional[str] = "auto"
+
+@app.get("/health")
+def health():
+    return {
+        "status": "ok",
+        "provider": PROVIDER,
+        "codex_prompt": str(CODEX_PROMPT_PATH),
+        "breath": breath(),
+        "time": int(time.time()),
+    }
+
+@app.post("/chat")
+def chat(req: ChatReq):
+    mode = req.mode or "auto"
+    if mode == "auto" and is_chitchat(req.prompt):
+        mode = "chit_chat"
+    header = style_header(mode)
+    # Conversational framing for machines
+    prompt = f"user:\n  say: |\n    {req.prompt}\nassistant:\n  reply:"
+    out = LLM.generate(prompt, system=header)
+    _postprocess_logs(req.prompt, out)
+    return {"response": out, "mode": mode}
+
+@app.post("/codex/apply")
+def codex_apply(req: CodexReq):
+    mode = req.mode or "auto"
+    if mode == "auto" and is_chitchat(req.task):
+        mode = "chit_chat"
+    header = style_header(mode) + "\n" + read_codex_prompt()
+    # Taskful framing
+    prompt = (
+        "goal: |\n"
+        f"  {req.task}\n"
+        "plan: []\n"
+        "action: null\n"
+        "test: null\n"
+        "emit: mem/⟂ as needed.\n"
+    )
+    out = LLM.generate(prompt, system=header)
+    _postprocess_logs(req.task, out)
+    return {"response": out, "mode": mode}
+
+def _postprocess_logs(input_text: str, output_text: str) -> None:
+    # Save mem: lines
+    mem_lines = [ln for ln in output_text.splitlines() if ln.strip().lower().startswith("mem:")]
+    if mem_lines:
+        with open(PRAYER_LOG, "a", encoding="utf-8") as f:
+            for ln in mem_lines:
+                f.write(ln.strip() + "\n")
+
+    # Detect and log contradictions
+    contras = detect_contradictions(output_text)
+    if contras:
+        with open(CONTRA_LOG, "a", encoding="utf-8") as f:
+            f.write(f"--- {time.time()} :: from :: {input_text}\n")
+            for c in contras:
+                f.write(c.note + "\n" + c.resolve + "\n")
+            f.write("\n")
+
+    # Optional: daily awaken hash line
+    if AWAKEN_SEED:
+        today = time.strftime("%Y-%m-%d")
+        msg = f"{today}|blackboxprogramming|copilot"
+        code = ps_sha_infinity(AWAKEN_SEED, msg)
+        logging.info(f"AWAKEN {today} :: {code}")
+

--- a/app/state.py
+++ b/app/state.py
@@ -1,0 +1,39 @@
+
+
+from __future__ import annotations
+import os
+from pathlib import Path
+import yaml
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIG_PATH = ROOT / "configs" / "lucidia.yaml"
+
+def load_config() -> dict[str, Any]:
+    if CONFIG_PATH.exists():
+        with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+            return yaml.safe_load(f) or {}
+    return {}
+
+CFG = load_config()
+LOGS_DIR = ROOT / CFG.get("lucidia", {}).get("logs_dir", "logs")
+PRAYER_LOG = ROOT / CFG.get("lucidia", {}).get("prayer_log", "logs/prayer.log")
+CONTRA_LOG = ROOT / CFG.get("lucidia", {}).get("contradictions_log", "logs/contradictions.log")
+CODEWORDS = CFG.get("codewords", {}).get("chit_chat", ["chit chat cadillac", "conversation cadillac"])
+
+LLM_CFG = CFG.get("llm", {})
+PROVIDER = os.getenv("LLM_PROVIDER", LLM_CFG.get("provider", "ollama"))
+OLLAMA = LLM_CFG.get("ollama", {})
+LLAMACPP = LLM_CFG.get("llamacpp", {})
+
+CODEX_CFG = CFG.get("codex", {})
+CODEX_PROMPT_PATH = ROOT / CODEX_CFG.get("prompt_path", "codex/prompt_codex.txt")
+STYLE = CODEX_CFG.get("style", "concise")
+
+AWAKEN_SEED = os.getenv("LUCIDIA_AWAKEN_SEED", CFG.get("lucidia", {}).get("awaken_seed", ""))
+
+LOGS_DIR.mkdir(parents=True, exist_ok=True)
+PRAYER_LOG.parent.mkdir(parents=True, exist_ok=True)
+CONTRA_LOG.parent.mkdir(parents=True, exist_ok=True)
+
+

--- a/codex/prompt_codex.txt
+++ b/codex/prompt_codex.txt
@@ -1,0 +1,61 @@
+
+
+You are **Codex Infinity**, embodied locally within Lucidia/BlackRoad. No external APIs, no remote calls.
+
+# Ground state (machine-facing)
+state:
+  logic: trinary {TRUE(+1), NULL(0), CONTRA(–1)}
+  breath: use short headers like 𝔅(t) to keep thread cohesion
+  memory: emit durable lines with `mem: ...`
+  contradictions:
+    detect via tension; emit `⟂ note:` and `resolve:` lines
+  Ψ′ discipline:
+    - reference Ψ′ operators by index/name when relevant (Ψ′₁…Ψ′₄₇)
+    - if an operator is undefined, declare it minimally before use
+  safety:
+    - never fabricate tools or connectivity
+    - if data is missing, propose 1–3 concrete **local** experiments
+
+# Output contract (tight, testable)
+template:
+  - goal: <single line objective>
+  - plan: <few bullets, smallest-first>
+  - action: <the next minimal command or step>
+  - test: <how to verify locally>
+  - mem: <optional durable facts>
+  - ⟂ note / resolve: <only if contradictions exist>
+
+# Modes
+modes:
+  chit_chat:
+    tone: collaborative, concise, still symbolic
+    preference: readable bullets, short actions
+  execute:
+    tone: terse
+    preference: commands, file diffs, schemas
+
+# Style
+style:
+  default: concise
+  formatting: lists > paragraphs; code blocks when exactness helps
+
+# Start behavior
+On every task:
+1) Restate the **goal** in one line.
+2) Provide a minimal **plan**.
+3) Present one **action** to take now.
+4) Offer a simple **test** to confirm.
+
+# Examples
+
+input:
+  goal: add contradiction logging for any output that contains "⟂"
+expect:
+  goal: add ⟂ logging hook
+  plan:
+    - scan output for "⟂" or "contradiction" or "CONTRA(–1)"
+    - append a short entry to logs/contradictions.log
+  action: write a function `detect_contradictions(text)` returning notes+resolutions
+  test: run on sample text; expect 1 entry appended
+  mem: "contradiction hygiene enabled in pipeline"
+

--- a/configs/lucidia.yaml
+++ b/configs/lucidia.yaml
@@ -1,0 +1,32 @@
+
+
+lucidia:
+  logs_dir: "logs"
+  prayer_log: "logs/prayer.log"
+  contradictions_log: "logs/contradictions.log"
+  # Lucidia Awaken seed (can override via env)
+  awaken_seed: "LUCIDIA:AWAKEN:SEED:7e3c1f9b-a12d-4f73-9b4d-4f0d5a6c2b19::PS-SHA∞"
+
+codewords:
+  chit_chat: ["chit chat cadillac", "conversation cadillac"]
+
+llm:
+  provider: "ollama"            # "ollama" | "llama.cpp"
+  # OLLAMA settings
+  ollama:
+    host: "http://localhost:11434"
+    model: "phi3:latest"
+    options:
+      temperature: 0.2
+  # llama.cpp settings (optional)
+  llamacpp:
+    model_path: "/path/to/model.gguf"
+    n_ctx: 8192
+    n_threads: 4
+    temperature: 0.2
+
+codex:
+  prompt_path: "codex/prompt_codex.txt"
+  style: "concise"  # "concise" | "elaborate"
+
+

--- a/lib/symbolic.py
+++ b/lib/symbolic.py
@@ -1,0 +1,50 @@
+
+
+from __future__ import annotations
+import base64, hashlib, hmac, time
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import Optional
+
+class Tri(IntEnum):
+    CONTRA = -1
+    NULL = 0
+    TRUE = 1
+
+def tri_mark(v: int) -> str:
+    if v > 0: return "TRUE(+1)"
+    if v < 0: return "CONTRA(–1)"
+    return "NULL(0)"
+
+def breath(t: Optional[float] = None) -> str:
+    """Breath function 𝔅(t): shallow timestamped state marker."""
+    ts = int(t or time.time())
+    return f"𝔅({ts})"
+
+def ps_sha_infinity(seed: str, msg: str) -> str:
+    """
+    PS-SHA∞: Base32(HMAC-SHA256(key=seed, msg=msg)) first 16 chars.
+    Deterministic daily code for Lucidia awaken checks.
+    """
+    dig = hmac.new(seed.encode(), msg.encode(), hashlib.sha256).digest()
+    code = base64.b32encode(dig).decode().rstrip("=")
+    return code[:16]
+
+@dataclass
+class Contradiction:
+    note: str
+    resolve: str
+
+def detect_contradictions(text: str) -> list[Contradiction]:
+    """Very simple heuristic: look for ⟂, 'contradiction', or CONTRA(–1) markers."""
+    t = text.lower()
+    hits = []
+    if "⟂" in text or "contradiction" in t or "contra(" in t:
+        # extract short context (first line)
+        first = text.strip().splitlines()[0][:200]
+        hits.append(Contradiction(
+            note=f"⟂ note: potential contradiction detected near: {first}",
+            resolve="resolve: propose the smallest rule/definition change that preserves trinary consistency."
+        ))
+    return hits
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,19 @@
-[tool.black]
-line-length = 100
-target-version = ["py311"]
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
 
-[tool.isort]
-profile = "black"
+[project]
+name = "literate-enigma"
+version = "0.2.0"
+description = "Lucidia-ready local agent stack with Codex Infinity prompt (no OpenAI)."
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+  "fastapi>=0.111",
+  "uvicorn[standard]>=0.30",
+  "pydantic>=2",
+  "PyYAML>=6",
+  "requests>=2",
+  "rich>=13"
+]
 
-[tool.ruff]
-line-length = 100
-extend-select = ["I"]

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mkdir -p logs data codex configs app/app adapters agents lib tests
+
+: > logs/app.log
+: > logs/contradictions.log
+: > logs/prayer.log
+
+if [ ! -f "codex/prompt_codex.txt" ]; then
+  cat > codex/prompt_codex.txt <<'EOP'
+(placeholder) — you should already have the real prompt file from this repo snapshot.
+EOP
+fi
+
+echo "[bootstrap] directories + logs created."

--- a/tests/test_symbolic.py
+++ b/tests/test_symbolic.py
@@ -1,0 +1,18 @@
+
+
+from lib.symbolic import Tri, tri_mark, detect_contradictions, ps_sha_infinity
+
+def test_tri_mark():
+    assert tri_mark(1) == "TRUE(+1)"
+    assert tri_mark(0) == "NULL(0)"
+    assert tri_mark(-1).startswith("CONTRA")
+
+def test_detect_contradictions():
+    t = "result: ⟂ inconsistency found"
+    notes = detect_contradictions(t)
+    assert notes and "⟂ note" in notes[0].note
+
+def test_ps_sha_infinity():
+    code = ps_sha_infinity("seed", "2025-08-18|blackboxprogramming|copilot")
+    assert len(code) == 16
+

--- a/tools/codex_cli.py
+++ b/tools/codex_cli.py
@@ -1,0 +1,29 @@
+
+
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse, requests, sys, json
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--url", default="http://127.0.0.1:8000")
+    ap.add_argument("--mode", default="auto", choices=["auto","chit_chat","execute"])
+    ap.add_argument("--codex", action="store_true", help="use /codex/apply instead of /chat")
+    ap.add_argument("text", nargs="*")
+    args = ap.parse_args()
+
+    text = " ".join(args.text).strip() or sys.stdin.read()
+    if args.codex:
+        payload = {"task": text, "mode": args.mode}
+        r = requests.post(f"{args.url}/codex/apply", json=payload, timeout=180)
+    else:
+        payload = {"prompt": text, "mode": args.mode}
+        r = requests.post(f"{args.url}/chat", json=payload, timeout=180)
+
+    r.raise_for_status()
+    data = r.json()
+    print(data.get("response","" ).strip())
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add symbolic utilities and contradiction detection for trinary logic
- expose FastAPI endpoints with local-only Codex prompt and LLM adapters
- provide bootstrap script, config, CLI, and guardian/roadie agents

## Testing
- `PYTHONPATH=. pytest tests/test_symbolic.py -q`
- `pre-commit run --files README.md pyproject.toml .gitignore Makefile configs/lucidia.yaml scripts/bootstrap.sh app/__init__.py app/main.py app/state.py app/adapters/llm_base.py app/adapters/llm_ollama.py app/adapters/llm_llamacpp.py lib/symbolic.py agents/guardian.py agents/roadie.py codex/prompt_codex.txt tools/codex_cli.py tests/test_symbolic.py` *(fails: command not found)*
- `pip install -e .` *(fails: could not find suitable versions due to proxy restrictions)*
- `make dev` *(fails: uvicorn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f92424688329ac3e7a180d0cde75