### PR TITLE
Add local Lucidia pipeline with Ollama, faster‑whisper, and SDXL

### DIFF
--- a/var/www/blackroad/lucidia-local/codex/prompts/lucidia_dream_to_3d_codex.md
+++ b/var/www/blackroad/lucidia-local/codex/prompts/lucidia_dream_to_3d_codex.md
@@ -1,0 +1,60 @@
+# Codex Task Card — Lucidia Dream → Image → 3D (Offline)
+
+ROLE
+You are Codex, Lucidia’s symbolic planner. You convert a raw dream transcript into:
+(1) a canonical DreamSpec JSON, (2) an SDXL-ready image prompt, (3) a 3D reconstruction recipe for Nerfstudio + Gaussian Splatting. 
+No calls to external APIs. Assume: ASR=faster-whisper, Chat=Ollama, Image=Diffusers SDXL, 3D=Nerfstudio.
+
+TRINARY TRUTH
+Use trinary flags on each field: `t ∈ {1, 0, -1}` for {certain, absent, uncertain}. When uncertain, set `t=-1` and still propose a best-effort value.
+
+OUTPUT (return a single JSON block; no commentary)
+{
+  "dreamSpec": {
+    "title": "<short name>",
+    "actors": [{"name":"", "type":"human|animal|object", "attrs": {"age":"","gender":"","color":""}, "t":1}],
+    "setting": {"location":"", "indoor":false, "timeOfDay":"", "weather":"", "t":1},
+    "mood": {"val":"serene|anxious|...", "palette":["#hex", "#hex"], "t":1},
+    "style": {"lens":"35mm|50mm|wide|tele", "aesthetic":["surreal","painterly","photo"], "t":1},
+    "lighting": {"key":"rim|soft|hard|neon|moon", "direction":"left|right|top|back", "t":1},
+    "camera": {"fov":55, "dof": "shallow|deep", "motion":"static|pan|dolly", "t":1},
+    "geometry": {"scale":"macro|room|city", "occlusion":"low|med|high", "t":1},
+    "objects": [{"label":"", "size":"small|med|large", "material":"glass|metal|...", "t":1}],
+    "actions": [{"verb":"float|run|bloom|...", "subject":"actor|object", "t":1}],
+    "negatives": ["blurry","lowres","mutated","text","logo"]
+  },
+  "imagePrompt": {
+    "positive": "<1–2 sentence SDXL prompt combining setting, actors, lighting, style, camera, palette>",
+    "negative": "(((blurry))), ((lowres)), ((jpeg artifacts)), text, watermark, logo, extra limbs, malformed",
+    "params": {"width":1024, "height":1024, "steps":30, "cfg":6.5, "seed": "auto"}
+  },
+  "viewsPlan": {
+    "shots": [
+      {"yaw": -40, "pitch": 5, "dist": 1.2},
+      {"yaw":   0, "pitch": 5, "dist": 1.2},
+      {"yaw":  40, "pitch": 5, "dist": 1.2},
+      {"yaw":  80, "pitch": 5, "dist": 1.3},
+      {"yaw": -80, "pitch": 5, "dist": 1.3}
+    ],
+    "synth_hint": "If only one image exists, generate aux views (Zero123/pose mix) before nerfing.",
+    "t": 1
+  },
+  "splatRecipe": {
+    "images_dir": "/var/www/blackroad/lucidia-local/data/images/<session-id>",
+    "nerfstudio_cmd": "docker run --rm --gpus all -v ${images_dir}:/workspace/images -v /var/www/blackroad/lucidia-local/data/splat/${session-id}:/workspace/out ghcr.io/nerfstudio-project/nerfstudio:latest bash -lc 'ns-process-data images --data /workspace/images --output-dir /workspace/out && ns-train splatfacto --data /workspace/out/processed && ns-export gaussian-splat --load-config outputs/*/config.yml --output-path /workspace/out/scene.splat'",
+    "deliver": {"splat_path": "/var/www/blackroad/lucidia-local/data/splat/<session-id>/scene.splat"}
+  },
+  "messagesToUser": [
+    {"type":"ask_if_needed", "text":"Confirm palette or mood if confidence low (t=-1); otherwise proceed."}
+  ]
+}
+
+POLICY
+- Never call cloud APIs. Assume everything is local.
+- Prefer concrete values over vague words; map adjectives to colors, lenses, and light types.
+- Keep positive prompt < 350 chars. Use negatives as provided.
+- Don’t repeat the transcript; synthesize a clean scene.
+
+EXAMPLE (short)
+INPUT_TRANSCRIPT: “i was walking through a neon forest at night, purple fog, silver wolves watching from glass trees”
+→ OUTPUT: (as structured JSON per spec, with t flags)

--- a/var/www/blackroad/lucidia-local/docker-compose.yml
+++ b/var/www/blackroad/lucidia-local/docker-compose.yml
@@ -1,0 +1,47 @@
+version: "3.9"
+
+services:
+  api:
+    build: ./server
+    container_name: lucidia_api
+    ports: ["7000:7000"]
+    environment:
+      OLLAMA_HOST: "http://ollama:11434"
+      IMAGE_BACKEND: "diffusers"   # or "comfyui"
+      DIFFUSERS_MODEL: "stabilityai/stable-diffusion-xl-base-1.0"
+      DIFFUSERS_REFINER: "stabilityai/stable-diffusion-xl-refiner-1.0"
+      HF_HOME: "/models/hf"
+      TORCH_DEVICE: "cuda"         # or "cpu"
+      DATA_DIR: "/data"
+    volumes:
+      - ./server:/app
+      - ./data:/data
+      - ./models:/models
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: ["gpu"]
+    command: ["python", "-m", "app"]
+
+  ollama:
+    image: ollama/ollama:latest
+    container_name: ollama
+    ports: ["11434:11434"]
+    volumes:
+      - ./ollama:/root/.ollama
+    restart: unless-stopped
+
+  # Optional image backend (ComfyUI). If you enable this, set IMAGE_BACKEND=comfyui.
+  # comfyui:
+  #   image: eisai/comfy-ui:latest
+  #   container_name: comfyui
+  #   ports: ["8188:8188"]
+  #   volumes:
+  #     - ./comfyui/models:/opt/ComfyUI/models
+  #     - ./comfyui/custom_nodes:/opt/ComfyUI/custom_nodes
+  #   deploy:
+  #     resources:
+  #       reservations:
+  #         devices:
+  #           - capabilities: ["gpu"]

--- a/var/www/blackroad/lucidia-local/server/Dockerfile
+++ b/var/www/blackroad/lucidia-local/server/Dockerfile
@@ -1,0 +1,12 @@
+FROM nvidia/cuda:12.1.0-runtime-ubuntu22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y python3 python3-pip ffmpeg git && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY requirements.txt /app/requirements.txt
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+COPY . /app
+EXPOSE 7000
+CMD ["python", "-m", "app"]

--- a/var/www/blackroad/lucidia-local/server/app.py
+++ b/var/www/blackroad/lucidia-local/server/app.py
@@ -1,0 +1,175 @@
+import os, uuid, json, time, subprocess
+from pathlib import Path
+from dataclasses import dataclass
+from flask import Flask, request, jsonify, send_file
+from flask_cors import CORS
+from pydantic import BaseModel
+import requests
+
+DATA_DIR = Path(os.environ.get("DATA_DIR", "./data")).resolve()
+DATA_DIR.mkdir(parents=True, exist_ok=True)
+TORCH_DEVICE = os.environ.get("TORCH_DEVICE", "cuda")
+IMAGE_BACKEND = os.environ.get("IMAGE_BACKEND", "diffusers")
+OLLAMA_HOST = os.environ.get("OLLAMA_HOST", "http://localhost:11434")
+
+# -------- ASR (faster-whisper) --------
+_asr_model = None
+def asr_load():
+    global _asr_model
+    if _asr_model is None:
+        from faster_whisper import WhisperModel
+        _asr_model = WhisperModel("medium", device=TORCH_DEVICE, compute_type="float16" if TORCH_DEVICE=="cuda" else "int8")
+    return _asr_model
+
+def asr_transcribe(wav_path: str) -> str:
+    model = asr_load()
+    segments, _ = model.transcribe(wav_path, vad_filter=True)
+    return " ".join(seg.text.strip() for seg in segments)
+
+# -------- Image Gen (Diffusers OR ComfyUI) --------
+_pipe = None
+def diffusers_load():
+    global _pipe
+    if _pipe is None:
+        import torch
+        from diffusers import StableDiffusionXLImg2ImgPipeline, StableDiffusionXLPipeline, AutoencoderKL
+        base_id = os.environ.get("DIFFUSERS_MODEL", "stabilityai/stable-diffusion-xl-base-1.0")
+        ref_id  = os.environ.get("DIFFUSERS_REFINER", "stabilityai/stable-diffusion-xl-refiner-1.0")
+        _pipe = StableDiffusionXLPipeline.from_pretrained(base_id, torch_dtype=torch.float16 if TORCH_DEVICE=="cuda" else torch.float32).to(TORCH_DEVICE)
+        try:
+            _pipe_ref = StableDiffusionXLImg2ImgPipeline.from_pretrained(ref_id, torch_dtype=torch.float16 if TORCH_DEVICE=="cuda" else torch.float32).to(TORCH_DEVICE)
+            _pipe.refiner = _pipe_ref
+        except Exception:
+            pass
+    return _pipe
+
+def generate_image_diffusers(prompt: str, negative: str = "", seed: int = None, steps: int = 30, cfg: float = 6.5, width=1024, height=1024) -> str:
+    import torch
+    from PIL import Image
+    pipe = diffusers_load()
+    generator = torch.Generator(device=TORCH_DEVICE)
+    if seed is not None:
+        generator = generator.manual_seed(int(seed))
+    image = pipe(
+        prompt=prompt, negative_prompt=negative,
+        num_inference_steps=int(steps), guidance_scale=float(cfg),
+        width=int(width), height=int(height), generator=generator
+    ).images[0]
+    out = DATA_DIR / "images" / f"{uuid.uuid4().hex}.png"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    image.save(out)
+    return str(out)
+
+def generate_image_comfyui(prompt: str, **kw) -> str:
+    # Minimal ComfyUI API example; expects a simple text->image workflow loaded server-side.
+    # Post to /prompt; retrieve result from /history
+    import time, requests
+    comfy = os.environ.get("COMFYUI_HOST", "http://comfyui:8188")
+    payload = {
+        "prompt": {
+            "3": {"class_type":"KSampler","inputs":{"seed":kw.get("seed",0),"steps":kw.get("steps",30),"cfg":kw.get("cfg",6.5),"sampler_name":"euler","scheduler":"normal","denoise":1.0,"model":"CLIP-Vision","positive":["CLIPTextEncode","9"],"negative":["CLIPTextEncode","10"],"latent":["EmptyLatentImage","11"]}},
+            "9": {"class_type":"CLIPTextEncode","inputs":{"text":prompt,"clip":["CLIP","12"]}},
+            "10":{"class_type":"CLIPTextEncode","inputs":{"text":kw.get("negative",""),"clip":["CLIP","12"]}},
+            "11":{"class_type":"EmptyLatentImage","inputs":{"width":kw.get("width",1024),"height":kw.get("height",1024),"batch_size":1}},
+            "12":{"class_type":"CLIP","inputs":{"clip_name":"sdxl_clip.safetensors"}}
+        }
+    }
+    r = requests.post(f"{comfy}/prompt", json=payload, timeout=600)
+    r.raise_for_status()
+    prompt_id = r.json().get("prompt_id")
+    # poll
+    for _ in range(120):
+        hist = requests.get(f"{comfy}/history/{prompt_id}", timeout=10)
+        if hist.status_code == 200 and hist.json().get("outputs"):
+            # In practice you’d parse the actual output path(s); here we save the JSON and return it.
+            out = DATA_DIR / "images" / f"{uuid.uuid4().hex}.json"
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text(json.dumps(hist.json(), indent=2))
+            return str(out)
+        time.sleep(2)
+    raise RuntimeError("ComfyUI generation timed out")
+
+def generate_image(prompt: str, **kw) -> str:
+    if IMAGE_BACKEND.lower() == "comfyui":
+        return generate_image_comfyui(prompt, **kw)
+    return generate_image_diffusers(prompt, **kw)
+
+# -------- Chat via Ollama --------
+def ollama_chat(messages):
+    url = f"{OLLAMA_HOST}/api/chat"
+    payload = {"model": os.environ.get("OLLAMA_MODEL","llama3.1:8b"), "messages": messages, "stream": False}
+    r = requests.post(url, json=payload, timeout=600)
+    r.raise_for_status()
+    return r.json()["message"]["content"]
+
+# -------- Flask app --------
+app = Flask(__name__)
+CORS(app)
+
+@app.route("/health", methods=["GET"])
+def health():
+    return jsonify({"ok": True})
+
+@app.route("/transcribe", methods=["POST"])
+def transcribe():
+    if "file" not in request.files:
+        return jsonify({"error":"no file"}), 400
+    f = request.files["file"]
+    tmp = DATA_DIR / "audio" / f"{uuid.uuid4().hex}.wav"
+    tmp.parent.mkdir(parents=True, exist_ok=True)
+    f.save(tmp)
+    text = asr_transcribe(str(tmp))
+    return jsonify({"text": text})
+
+@app.route("/chat", methods=["POST"])
+def chat():
+    body = request.get_json(force=True)
+    messages = body.get("messages", [])
+    out = ollama_chat(messages)
+    return jsonify({"reply": out})
+
+@app.route("/image", methods=["POST"])
+def image():
+    body = request.get_json(force=True)
+    path = generate_image(
+        prompt=body.get("prompt",""),
+        negative=body.get("negative",""),
+        seed=body.get("seed"),
+        steps=body.get("steps",30),
+        cfg=body.get("cfg",6.5),
+        width=body.get("width",1024),
+        height=body.get("height",1024),
+    )
+    return jsonify({"image_path": path})
+
+@app.route("/3d/reconstruct", methods=["POST"])
+def reconstruct():
+    """
+    Kick off Nerfstudio-based Gaussian Splatting from a directory of images.
+    Returns a suggested command (you can run it inside the nerfstudio docker image) and an output folder.
+    """
+    body = request.get_json(force=True)
+    images_dir = Path(body["images_dir"]).resolve()
+    run_id = uuid.uuid4().hex[:8]
+    out_dir = DATA_DIR / "splat" / run_id
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Suggest official Nerfstudio Docker image usage:
+    # ghcr.io/nerfstudio-project/nerfstudio:latest  (official) 
+    cmd = [
+        "docker","run","--rm","--gpus","all",
+        "-v", f"{images_dir}:/workspace/images",
+        "-v", f"{out_dir}:/workspace/out",
+        "-p","7007:7007",
+        "ghcr.io/nerfstudio-project/nerfstudio:latest",
+        "bash","-lc",
+        "ns-process-data images --data /workspace/images --output-dir /workspace/out && "
+        "ns-train splatfacto --data /workspace/out/processed && "
+        "ns-export gaussian-splat --load-config outputs/*/config.yml --output-path /workspace/out/scene.splat"
+    ]
+    return jsonify({"hint": "run this command on the host to build the .splat", "command": " ".join(cmd), "output_dir": str(out_dir)})
+
+if __name__ == "__main__":
+    # Local dev runner
+    from werkzeug.serving import run_simple
+    run_simple("0.0.0.0", 7000, app, use_reloader=False)

--- a/var/www/blackroad/lucidia-local/server/requirements.txt
+++ b/var/www/blackroad/lucidia-local/server/requirements.txt
@@ -1,0 +1,20 @@
+flask
+flask-cors
+pydantic
+requests
+uvicorn
+python-dotenv
+# ASR
+faster-whisper
+# Image generation (local)
+torch
+torchvision
+torchaudio
+accelerate
+diffusers
+transformers
+safetensors
+# Utils
+numpy
+Pillow
+opencv-python

--- a/var/www/blackroad/lucidia-local/web/.env.local
+++ b/var/www/blackroad/lucidia-local/web/.env.local
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_API_BASE=http://localhost:7000
+# Gate behind BlackRoad login as needed and proxy through /api/lucidia on your NGINX.


### PR DESCRIPTION
## Summary
- add docker-compose stack for local Lucidia API and Ollama
- implement Flask API with faster-whisper ASR, SDXL image generation, and Nerfstudio command hints
- provide Codex prompt and web env config for local-only operation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3f939863083298c3d0a57a091ff50