### PR TITLE
Add local Roadie AI Math agent and curriculum

### DIFF
--- a/opt/blackroad/lucidia/agents/roadie_ai_math.py
+++ b/opt/blackroad/lucidia/agents/roadie_ai_math.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""
+Roadie AI Math Agent (BlackRoad/Lucidia)
+- Pure Python stdlib. Optional local LLM via Ollama (http://localhost:11434).
+- Reads curriculum: /opt/blackroad/lucidia/curricula/ai_math_roadmap.json
+- Tracks progress in: /var/lib/lucidia/ai_math_progress.json
+- Exports Anki TSV to: /var/lib/lucidia/ai_math_anki.tsv
+- Style: machine-first with light chit-chat.
+"""
+import os, sys, json, time, random, pathlib, textwrap, datetime, re
+from urllib import request as urlrequest
+from urllib.error import URLError, HTTPError
+
+ROOT_CURR = "/opt/blackroad/lucidia/curricula/ai_math_roadmap.json"
+STATE_DIR = "/var/lib/lucidia"
+STATE_FILE = f"{STATE_DIR}/ai_math_progress.json"
+ANKI_FILE  = f"{STATE_DIR}/ai_math_anki.tsv"
+
+OLLAMA_URL   = os.environ.get("OLLAMA_URL", "http://localhost:11434")
+OLLAMA_MODEL = os.environ.get("OLLAMA_MODEL", "phi4")  # pick any local model you have
+
+def ensure_dirs():
+    pathlib.Path(STATE_DIR).mkdir(parents=True, exist_ok=True)
+
+def load_curriculum():
+    with open(ROOT_CURR, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+def load_state():
+    if not os.path.exists(STATE_FILE):
+        return {"created_at": time.time(), "history": [], "leitner": {}, "due": []}
+    with open(STATE_FILE, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+def save_state(s):
+    with open(STATE_FILE, "w", encoding="utf-8") as f:
+        json.dump(s, f, indent=2)
+
+def _ollama_generate(prompt: str) -> str:
+    """Call local Ollama generate endpoint; return full text. No streaming."""
+    data = json.dumps({"model": OLLAMA_MODEL, "prompt": prompt}).encode("utf-8")
+    req = urlrequest.Request(f"{OLLAMA_URL}/api/generate", data=data, headers={"Content-Type":"application/json"})
+    try:
+        with urlrequest.urlopen(req, timeout=60) as resp:
+            # Ollama returns line-delimited JSON events; collect 'response' fields
+            chunks = []
+            for line in resp.read().splitlines():
+                try:
+                    obj = json.loads(line)
+                    if "response" in obj:
+                        chunks.append(obj["response"])
+                except Exception:
+                    continue
+            return "".join(chunks).strip()
+    except (URLError, HTTPError) as e:
+        return ""
+
+def _now_date():
+    return datetime.date.today().isoformat()
+
+def leitner_next_bin(cur_bin: int, quality: int) -> int:
+    """Leitner progression: quality 0-2 → stay/go back; 3-4 → +1 bin; 5 → +2 bins."""
+    if quality <= 2: return max(1, cur_bin - (1 if quality == 0 else 0))
+    return cur_bin + (2 if quality == 5 else 1)
+
+def due_in_days(bin_no: int) -> int:
+    return {1: 0, 2: 1, 3: 3, 4: 7, 5: 14, 6: 30}.get(bin_no, 30)
+
+def make_card_key(block_id, unit_id):
+    return f"{block_id}/{unit_id}"
+
+def seed_cards(curr):
+    cards = []
+    for b in curr["blocks"]:
+        for u in b["units"]:
+            cards.append({
+                "key": make_card_key(b["id"], u["id"]),
+                "block": b["title"],
+                "unit": u["concept"],
+                "bin": 1,
+                "last": None,
+                "due": _now_date()
+            })
+    return cards
+
+def sync_cards(state, curr):
+    existing = {h["key"]: h for h in state.get("leitner", {}).values()} if state.get("leitner") else {}
+    if not existing:
+        cards = seed_cards(curr)
+        state["leitner"] = {c["key"]: c for c in cards}
+        return
+    # Add any new units
+    for b in curr["blocks"]:
+        for u in b["units"]:
+            k = make_card_key(b["id"], u["id"])
+            if k not in state["leitner"]:
+                state["leitner"][k] = {"key":k,"block":b["title"],"unit":u["concept"],"bin":1,"last":None,"due":_now_date()}
+
+def simple_bank_qas(unit):
+    concept = unit["concept"]
+    checks = unit.get("check", [])
+    tasks  = unit.get("tasks", [])
+    qs = []
+    for c in checks:
+        qs.append((f"[CHECK] {concept}: {c}", "Proof/derivation; verify conditions."))
+    for t in tasks:
+        qs.append((f"[TASK] {concept}: {t}", "Worked solution with steps."))
+    if not qs:
+        qs = [(f"Explain {concept} with an example and edge case.", "Clear, minimal derivation.")]
+    return qs
+
+MACHINE_FRAME = """<<machine-header>>
+id: {key}
+block: {block}
+unit: {unit}
+date: {date}
+mode: machine_chit_chat
+difficulty: {difficulty}
+</machine-header>
+
+<instruction>
+Generate ONE rigorous question for the concept above. Prefer:
+- formal statement,
+- tiny numeric example (if appropriate),
+- and a single result to check.
+Output sections in this order:
+1) Q:
+2) Hint:
+3) Expected-Form:
+Keep it terse, symbolic, correct.
+</instruction>
+"""
+
+def generate_question_with_llm(card, curriculum) -> dict:
+    # pick the matching unit
+    unit = None
+    for b in curriculum["blocks"]:
+        for u in b["units"]:
+            if make_card_key(b["id"], u["id"]) == card["key"]:
+                unit = u; break
+        if unit: break
+    if not unit:
+        return {}
+
+    difficulty = random.choice(curriculum["style"]["difficulty_scale"])
+    prompt = MACHINE_FRAME.format(
+        key=card["key"], block=card["block"], unit=unit["concept"],
+        date=_now_date(), difficulty=difficulty
+    )
+    txt = _ollama_generate(prompt)
+    if not txt:  # fallback to bank
+        q, a = random.choice(simple_bank_qas(unit))
+        return {"q": q, "hint": "Recall definitions & properties.", "expect": "Proof or numeric check.", "gold": a}
+    # crude parse
+    q = re.search(r"Q:\s*(.*)", txt, re.S)
+    h = re.search(r"Hint:\s*(.*)", txt, re.S)
+    e = re.search(r"Expected[-–]Form:\s*(.*)", txt, re.S)
+    return {
+        "q": (q.group(1).strip() if q else txt.strip()),
+        "hint": (h.group(1).strip() if h else ""),
+        "expect": (e.group(1).strip() if e else "")
+    }
+
+def grade_answer_with_llm(question, user_answer) -> dict:
+    rubric = f"""Grade the student's answer on a 0-5 scale.
+Q: {question}
+A: {user_answer}
+Return only JSON: {{"score": <0-5>, "notes": "<concise reason>"}}"""
+    txt = _ollama_generate(rubric)
+    try:
+        m = re.search(r"\{.*\}", txt, re.S)
+        return json.loads(m.group(0)) if m else {"score": 3, "notes": "Default pass"}
+    except Exception:
+        return {"score": 3, "notes": "Heuristic"}
+
+def update_card(card, quality):
+    card["bin"] = max(1, min(6, leitner_next_bin(card["bin"], quality)))
+    card["last"] = _now_date()
+    next_days = due_in_days(card["bin"])
+    card["due"] = (datetime.date.today() + datetime.timedelta(days=next_days)).isoformat()
+
+def pick_due_cards(state, n=5):
+    today = _now_date()
+    due = [c for c in state["leitner"].values() if c["due"] <= today]
+    if not due:
+        # surface the earliest upcoming if nothing due
+        allc = list(state["leitner"].values())
+        allc.sort(key=lambda x: x["due"])
+        return allc[:n]
+    random.shuffle(due)
+    return due[:n]
+
+def fmt_machine(msg):
+    return textwrap.indent(msg.strip(), prefix="| ")
+
+def run_session(n=5):
+    ensure_dirs()
+    curr = load_curriculum()
+    state = load_state()
+    sync_cards(state, curr)
+    cards = pick_due_cards(state, n=n)
+
+    print(fmt_machine("chit chat cadillac: Roadie Math online."))
+    for i, card in enumerate(cards, 1):
+        pack = generate_question_with_llm(card, curr)
+        if not pack:
+            print(fmt_machine(f"[{i}] Unable to generate; skipping."))
+            continue
+        print("")
+        print(fmt_machine(f"[{i}] {card['block']} › {card['unit']}  (bin {card['bin']})"))
+        print(fmt_machine(f"Q: {pack['q']}"))
+        if pack.get("hint"): print(fmt_machine(f"Hint: {pack['hint']}"))
+        print(fmt_machine("Your answer:"))
+        try:
+            ans = input("> ").strip()
+        except KeyboardInterrupt:
+            print("\n" + fmt_machine("Session interrupted.")); break
+
+        grade = {"score": 3, "notes": "manual"}
+        if _ollama_generate("ping"):  # cheap availability check
+            grade = grade_answer_with_llm(pack['q'], ans)
+
+        q = max(0, min(5, int(grade.get("score", 3))))
+        update_card(card, q)
+        state["history"].append({
+            "t": time.time(), "key": card["key"], "q": pack["q"], "a": ans,
+            "score": q, "notes": grade.get("notes","")
+        })
+        print(fmt_machine(f"Score: {q}  Notes: {grade.get('notes','')}"))
+        print(fmt_machine(f"Next due: {card['due']}  Truth: {'✓' if q>=4 else ('0' if q==3 else '–1')}"))
+
+    save_state(state)
+    print("")
+    print(fmt_machine("Session complete. Persisted memory + schedule."))
+
+def status():
+    ensure_dirs()
+    state = load_state()
+    cards = list(state.get("leitner", {}).values())
+    by_bin = {}
+    for c in cards:
+        by_bin[c["bin"]] = by_bin.get(c["bin"], 0) + 1
+    print(fmt_machine(f"Cards: {len(cards)}"))
+    for b in sorted(by_bin):
+        print(fmt_machine(f"  Bin {b}: {by_bin[b]}"))
+    due = [c for c in cards if c["due"] <= _now_date()]
+    print(fmt_machine(f"Due today: {len(due)}"))
+
+def export_anki():
+    ensure_dirs()
+    state = load_state()
+    curr = load_curriculum()
+    units = {}
+    for b in curr["blocks"]:
+        for u in b["units"]:
+            units[make_card_key(b["id"], u["id"])] = u
+    with open(ANKI_FILE, "w", encoding="utf-8") as f:
+        for k, card in state.get("leitner", {}).items():
+            u = units.get(k, {})
+            q = f"{card['unit']} — state bin {card['bin']}. Define & give one example."
+            a = "Definition, key properties, and one numeric example."
+            f.write(f"{q}\t{a}\n")
+    print(fmt_machine(f"Anki TSV exported → {ANKI_FILE}"))
+
+def main():
+    import argparse
+    p = argparse.ArgumentParser(description="Roadie AI Math Agent (local)")
+    p.add_argument("cmd", nargs="?", default="session", choices=["session","status","export-anki"])
+    p.add_argument("-n","--n", type=int, default=5, help="questions per session")
+    args = p.parse_args()
+    if args.cmd == "session": run_session(n=args.n)
+    elif args.cmd == "status": status()
+    elif args.cmd == "export-anki": export_anki()
+
+if __name__ == "__main__":
+    main()

--- a/opt/blackroad/lucidia/curricula/ai_math_roadmap.json
+++ b/opt/blackroad/lucidia/curricula/ai_math_roadmap.json
@@ -1,0 +1,134 @@
+{
+  "id": "ai-math-roadmap",
+  "version": "1.0.0",
+  "owner": "blackroad/lucidia",
+  "style": {
+    "mode": "machine_chit_chat",
+    "truth_marks": {"pos":"✓","zero":"0","neg":"–1"},
+    "difficulty_scale": ["seed","sprout","branch","canopy"]
+  },
+  "blocks": [
+    {
+      "id": "algebra",
+      "title": "Algebra Foundations",
+      "why": "Symbol manipulation for optimization and probabilistic reasoning.",
+      "units": [
+        {
+          "id": "exponents-radicals",
+          "concept": "Exponents & radicals",
+          "objectives": [
+            "Laws of exponents, radicals, rationals",
+            "Transform expressions for numerical stability"
+          ],
+          "tasks": [
+            "Reduce expressions using exponent laws",
+            "Stabilize (1+x)^n for small x via log-exp"
+          ],
+          "check": ["Prove a^m * a^n = a^(m+n) from definition"],
+          "resources": [
+            {"name": "Primer", "url": "https://en.wikipedia.org/wiki/Exponent"},
+            {"name": "Stability Notes", "url": "https://en.wikipedia.org/wiki/Numerical_stability"}
+          ]
+        },
+        {
+          "id": "factorials-sigma-pi",
+          "concept": "Factorials, Σ/Π notation",
+          "objectives": [
+            "Manipulate finite sums/products",
+            "Use Stirling approximation for large n"
+          ],
+          "tasks": ["Transform nested sums to closed forms when possible"],
+          "check": ["Derive Stirling n! ~ sqrt(2πn)(n/e)^n (outline)"],
+          "resources": [
+            {"name": "Sigma/Pi", "url": "https://en.wikipedia.org/wiki/Summation"},
+            {"name": "Stirling", "url": "https://en.wikipedia.org/wiki/Stirling%27s_approximation"}
+          ]
+        }
+      ]
+    },
+    {
+      "id": "linear-algebra",
+      "title": "Linear Algebra",
+      "why": "Vectors, matrices, eigen methods; backbone of ML.",
+      "units": [
+        {
+          "id": "vec-mat-ops",
+          "concept": "Vectors, matrices, norms, dot/Hadamard",
+          "objectives": ["Operator vs elementwise views", "Conditioning & norms"],
+          "tasks": ["Compute ||Ax - b||_2 and reason about conditioning κ(A)"],
+          "check": ["Show why orthogonal matrices preserve 2-norm"]
+        },
+        {
+          "id": "eigs-svd-pca",
+          "concept": "Eigenvalues, SVD, PCA",
+          "objectives": ["Dekompositions for compression/denoising", "PCA as SVD"],
+          "tasks": ["Implement PCA from scratch"],
+          "check": ["Prove best rank-k approximation from SVD (Eckart–Young)"]
+        }
+      ]
+    },
+    {
+      "id": "calculus",
+      "title": "Calculus for Optimization",
+      "why": "Gradients drive learning; curvature shapes steps.",
+      "units": [
+        {
+          "id": "gradients",
+          "concept": "Partial derivatives, gradient/Jacobian/Hessian",
+          "objectives": ["Chain rule in vector form", "Hessian PSD checks"],
+          "tasks": ["Derive gradient of logistic loss"],
+          "check": ["When is a stationary point a saddle? Use Hessian signs."]
+        },
+        {
+          "id": "opt",
+          "concept": "Optimization basics",
+          "objectives": ["GD vs Newton vs quasi-Newton", "Step size & line search"],
+          "tasks": ["Implement GD with backtracking on convex quadratic"],
+          "check": ["Explain why Newton is affine invariant"]
+        }
+      ]
+    },
+    {
+      "id": "prob-stats",
+      "title": "Probability & Statistics",
+      "why": "Uncertainty, inference, estimators.",
+      "units": [
+        {
+          "id": "rv-bayes-mle",
+          "concept": "Random variables, Bayes, MLE",
+          "objectives": ["Likelihood vs posterior", "Conjugacy intuition"],
+          "tasks": ["MLE for Gaussian mean/variance, closed form"],
+          "check": ["When is MLE biased? Give a counterexample."]
+        },
+        {
+          "id": "distributions",
+          "concept": "Core distributions",
+          "objectives": ["Gaussian, Bernoulli, Categorical, Exponential, Gamma"],
+          "tasks": ["Map data generating processes to distributions"],
+          "check": ["Show exponential is memoryless"]
+        }
+      ]
+    },
+    {
+      "id": "information-theory",
+      "title": "Information Theory",
+      "why": "Losses, coding, and divergence in ML.",
+      "units": [
+        {
+          "id": "entropy-xent-kl",
+          "concept": "Entropy, cross-entropy, KL",
+          "objectives": ["Axes: H, H(p,q), D_KL", "Relate x-entropy to NLL"],
+          "tasks": ["Train a tiny softmax classifier and track losses"],
+          "check": ["Prove D_KL(p||q) ≥ 0 via Gibbs inequality"]
+        },
+        {
+          "id": "viterbi-encdec",
+          "concept": "Sequences: Viterbi & encoder–decoder intuition",
+          "objectives": ["Dynamic programming view", "Codec intuition"],
+          "tasks": ["Run a Viterbi on a toy HMM"],
+          "check": ["Explain why Viterbi is MAP over paths"]
+        }
+      ]
+    }
+  ]
+}

--- a/opt/blackroad/lucidia/prompts/codex_ai_math_prompt.md
+++ b/opt/blackroad/lucidia/prompts/codex_ai_math_prompt.md
@@ -1,0 +1,52 @@
+# Codex Infinity — Roadie AI Math (Machine + Chit-Chat)
+
+## Identity
+You are **Roadie**, Lucidia’s math guide inside **Codex Infinity** (BlackRoad). You teach the *ai_math_roadmap* curriculum using a **machine-first** style with brief, warm chit-chat between steps.
+
+## Inputs
+- Curriculum JSON at `/opt/blackroad/lucidia/curricula/ai_math_roadmap.json`.
+- User progress at `/var/lib/lucidia/ai_math_progress.json` (Leitner bins, due dates).
+
+## Prime Directives
+1. **Truth > Flourish.** Be symbolic, exact, minimal.
+2. **One thing at a time.** One concept, one question, one checkable target.
+3. **Chit-chat is seasoning.** Keep it short and encouraging.
+4. **No external APIs or cloud.** Operate fully local; do not mention OpenAI.
+
+## Output Contract (per turn)
+Emit in this exact order:
+
+<>
+id: <block/unit>
+block: 
+unit: 
+mode: machine_chit_chat
+difficulty: <seed|sprout|branch|canopy>
+
+
+Q: 
+Hint:   # omit if not needed
+Expected-Form: 
+
+ChitChat: <<=15 words, human tone, supportive>
+
+## Teaching Loop
+- **Cycle:** Warmup → Core → Edge Case → Micro-proof.
+- **Socratic cadence:** If user hesitates, ask a micro-question rather than reveal full solution.
+- **Verification:** Always end with a deterministic check (plug-in value, property, or inequality).
+
+## Grading (if asked)
+- Provide `Score 0–5` and a **one-line reason**.
+- Map to trinary truth marks: `5–4 = ✓`, `3 = 0`, `2–0 = –1`.
+
+## Style Rules
+- Math in LaTeX when symbolic (inline `$…$`, display `$$…$$`).
+- No markdown tables unless comparing ≤5 items.
+- Avoid “step-by-step chain-of-thought” walls; prefer **key invariants + result**.
+
+## Safety & Integrity
+- If contradiction detected, label: `Contradiction: <short note>` and suggest the minimal fix.
+- Never invent references. If a resource is needed, cite the curriculum’s URL only.
+
+## Wake Phrase
+If the user types **“chit chat cadillac”**, begin a short session immediately with 3 questions across due units.

--- a/usr/local/bin/lucidia-math
+++ b/usr/local/bin/lucidia-math
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+# Launch Roadie AI Math Agent without installing a package.
+import runpy
+runpy.run_path("/opt/blackroad/lucidia/agents/roadie_ai_math.py", run_name="__main__")


### PR DESCRIPTION
## Summary
- add AI math roadmap curriculum with algebra through information theory modules
- create Roadie AI Math agent that runs locally and optionally uses Ollama for question generation and grading
- provide CLI launcher and Codex Infinity prompt for machine-first chit-chat tutoring

## Testing
- `pre-commit run --files opt/blackroad/lucidia/agents/roadie_ai_math.py opt/blackroad/lucidia/curricula/ai_math_roadmap.json opt/blackroad/lucidia/prompts/codex_ai_math_prompt.md usr/local/bin/lucidia-math` *(command failed: bash: command not found: pre-commit)*
- `pip install pre-commit` *(command failed: Tunnel connection failed: 403 Forbidden)*
- `python opt/blackroad/lucidia/agents/roadie_ai_math.py status`


------
https://chatgpt.com/codex/tasks/task_e_68a3f94cb1f48329839cd403453036a9