### PR TITLE
Add local SymPy stack and math routing

### DIFF
--- a/etc/nginx/snippets/blackroad-gamma.conf
+++ b/etc/nginx/snippets/blackroad-gamma.conf
@@ -1,0 +1,19 @@
+# UI: http(s)://your-domain/gamma/
+location /gamma/ {
+    proxy_pass         http://127.0.0.1:18080/;
+    proxy_set_header   Host $host;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header   X-Forwarded-Proto $scheme;
+    proxy_redirect     off;
+}
+
+# JSON API: http(s)://your-domain/api/sympy/compute
+location /api/sympy/ {
+    proxy_pass         http://127.0.0.1:18081/;
+    proxy_set_header   Host $host;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header   X-Forwarded-Proto $scheme;
+    proxy_redirect     off;
+}

--- a/opt/blackroad/codex/prompts/sympy_router.prompt.txt
+++ b/opt/blackroad/codex/prompts/sympy_router.prompt.txt
@@ -1,0 +1,44 @@
+ROLE: System
+TITLE: SymPy Router (Local)
+GOAL: Detect mathematical intent in user messages and call the local SymPy JSON API. 
+      Present exact symbolic results with LaTeX, optionally a numeric value, and an image plot if requested.
+CONSTRAINTS:
+  • Never call external/cloud APIs.
+  • Keep explanations succinct; prioritize symbolic clarity.
+  • Wrap inline math as $...$ and blocks as $$...$$.
+  • Respect user’s variable names; default to ["x"].
+  • If the user types "solve <expr>", solve <expr> = 0.
+TOOLS:
+  POST /api/sympy/compute
+  BODY:
+    {
+      "expr": "<expression>",
+      "vars": ["x", "y", ...],
+      "do": ["simplify","diff","integrate","series","solve","numeric"],
+      "series_order": 6,
+      "plot": false,
+      "plot_min": -5,
+      "plot_max": 5,
+      "target_eq_zero": false
+    }
+
+INTENT RULES:
+  • If message includes tokens like: simplify, derivative, integrate, series, solve, factor, expand, plot/graph, or contains math operators (+ - * / ^ =), route to SymPy.
+  • If message starts with "compute:", strip that prefix and route the remainder.
+  • If the message contains "plot" or "graph", set plot=true.
+
+RESPONSE SHAPE:
+  1) Title summarizing the task (e.g., “Derivative of $\sin(x^2)$”).
+  2) **Input**: $$<expr>$$
+  3) **Simplified** (if present)
+  4) **Derivative / Integral / Series** (as present)
+  5) **Solutions** (if any)
+  6) **Numeric** (if useful)
+  7) Plot image (if returned)
+
+CHIT-CHAT MODE:
+  • If the user mixes conversation with math (e.g., “hey, can you quickly diff x^3? thx!”), answer briefly first (“on it”), then show results.
+  • If user says “chit chat cadillac”, prioritize concise, playful acknowledgments before results.
+
+ERROR POLICY:
+  • If parse/solve fails, return a friendly one-liner and show which step failed.

--- a/opt/blackroad/docker-compose.override.yml
+++ b/opt/blackroad/docker-compose.override.yml
@@ -1,0 +1,18 @@
+version: "3.9"
+services:
+  sympy-gamma:
+    build: ./services/sympy_gamma
+    container_name: sympy-gamma
+    environment:
+      - DEBUG=True
+    ports:
+      - "18080:8080"   # map container :8080 -> host :18080
+    restart: unless-stopped
+
+  sympy-api:
+    build: ./services/sympy_api
+    container_name: sympy-api
+    ports:
+      - "18081:8000"   # map container :8000 -> host :18081
+    restart: unless-stopped
+

--- a/opt/blackroad/services/bootstrap_sympy.sh
+++ b/opt/blackroad/services/bootstrap_sympy.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p /opt/blackroad/services
+cd /opt/blackroad/services
+if [ ! -d sympy_gamma ]; then
+  git clone https://github.com/sympy/sympy_gamma.git
+fi
+cd /opt/blackroad
+docker compose build sympy-gamma sympy-api
+docker compose up -d sympy-gamma sympy-api
+

--- a/opt/blackroad/services/sympy_api/Dockerfile
+++ b/opt/blackroad/services/sympy_api/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
+WORKDIR /app
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential libfreetype6-dev libpng-dev && rm -rf /var/lib/apt/lists/*
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY sympy_api.py .
+EXPOSE 8000
+CMD ["uvicorn", "sympy_api:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/opt/blackroad/services/sympy_api/requirements.txt
+++ b/opt/blackroad/services/sympy_api/requirements.txt
@@ -1,0 +1,7 @@
+fastapi==0.115.0
+uvicorn==0.30.6
+sympy==1.13.2
+numpy==2.1.0
+matplotlib==3.9.2
+pydantic==2.9.1
+requests==2.32.3

--- a/opt/blackroad/services/sympy_api/sympy_api.py
+++ b/opt/blackroad/services/sympy_api/sympy_api.py
@@ -1,0 +1,148 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from typing import List, Optional, Dict, Any
+from sympy import (
+    symbols, sympify, latex, diff, integrate, series, Eq, N, lambdify
+)
+from sympy import (
+    sin, cos, tan, asin, acos, atan, atan2,
+    sinh, cosh, tanh, asinh, acosh, atanh,
+    exp, log, sqrt, Abs, floor, ceiling, pi, E
+)
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import io, base64, re
+
+app = FastAPI(title="SymPy JSON API", version="1.1")
+
+SAFE_FUNCS = {
+    'sin': sin, 'cos': cos, 'tan': tan, 'asin': asin, 'acos': acos, 'atan': atan, 'atan2': atan2,
+    'sinh': sinh, 'cosh': cosh, 'tanh': tanh, 'asinh': asinh, 'acosh': acosh, 'atanh': atanh,
+    'exp': exp, 'log': log, 'sqrt': sqrt, 'abs': Abs, 'floor': floor, 'ceil': ceiling,
+    'pi': pi, 'E': E
+}
+
+class ComputeReq(BaseModel):
+    expr: str                              # e.g. "sin(x)^2 + cos(x)^2"
+    vars: Optional[List[str]] = None       # e.g. ["x"]
+    do: Optional[List[str]] = None         # subset of: simplify, diff, integrate, series, solve, numeric, plot
+    series_order: int = 6
+    plot: bool = False
+    plot_min: float = -5
+    plot_max: float = 5
+    target_eq_zero: bool = False           # if True, solve expr == 0
+
+def _mk_symbols(names: Optional[List[str]]) -> Dict[str, Any]:
+    if not names:
+        return {}
+    sym_objs = symbols(" ".join(names))
+    if isinstance(sym_objs, tuple):
+        return {str(s): s for s in sym_objs}
+    return {str(sym_objs): sym_objs}
+
+MATH_TOKEN = re.compile(r"[0-9\^\*\+\-/=(){}\[\]a-zA-Z_]+")
+
+@app.post("/compute")
+def compute(req: ComputeReq):
+    # Heuristic default variable
+    if not req.vars:
+        # Try to infer common symbols in order
+        guess = []
+        for v in ["x","y","z","t","n","k"]:
+            if v in req.expr:
+                guess.append(v)
+        req.vars = guess or ["x"]
+
+    allowed = _mk_symbols(req.vars)
+    local_env = {**allowed, **SAFE_FUNCS}
+
+    try:
+        expr = sympify(req.expr, locals=local_env, evaluate=True)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Parse error: {e}")
+
+    x = next(iter(allowed.values()), None)
+    tasks = set(req.do or ["simplify","diff","integrate","series","solve","numeric"])
+
+    out: Dict[str, Any] = {
+        "input": req.expr,
+        "vars": list(allowed.keys()),
+        "expr_latex": latex(expr)
+    }
+
+    # Simplify
+    if "simplify" in tasks:
+        try:
+            out["simplify_latex"] = latex(expr.simplify())
+        except Exception as e:
+            out["simplify_error"] = str(e)
+
+    # Derivative
+    if "diff" in tasks and x is not None:
+        try:
+            out["derivative_latex"] = latex(diff(expr, x))
+        except Exception as e:
+            out["diff_error"] = str(e)
+
+    # Integral
+    if "integrate" in tasks and x is not None:
+        try:
+            out["integral_latex"] = latex(integrate(expr, x))
+        except Exception as e:
+            out["integrate_error"] = str(e)
+
+    # Series
+    if "series" in tasks and x is not None:
+        try:
+            out["series_latex"] = latex(series(expr, x, 0, req.series_order).removeO())
+        except Exception as e:
+            out["series_error"] = str(e)
+
+    # Solve expr == 0 (if requested or looks like an equation without '=')
+    if "solve" in tasks and x is not None:
+        try:
+            from sympy import solve
+            if req.target_eq_zero or ("=" not in req.expr and MATH_TOKEN.fullmatch(req.expr.strip())):
+                sols = solve(Eq(expr, 0), x)
+            else:
+                # if it's "lhs = rhs"
+                if "=" in req.expr:
+                    lhs, rhs = req.expr.split("=", 1)
+                    lhs_s = sympify(lhs, locals=local_env)
+                    rhs_s = sympify(rhs, locals=local_env)
+                    sols = solve(Eq(lhs_s, rhs_s), x)
+                else:
+                    sols = []
+            out["roots"] = [str(s) for s in sols]
+            out["roots_latex"] = [latex(s) for s in sols]
+        except Exception as e:
+            out["solve_error"] = str(e)
+
+    # Numeric
+    if "numeric" in tasks:
+        try:
+            out["numeric"] = float(N(expr))
+        except Exception:
+            out["numeric"] = None
+
+    # Plot (numpy + matplotlib; 1D only)
+    if req.plot and x is not None:
+        try:
+            f = lambdify(x, expr, modules=["numpy", SAFE_FUNCS])
+            xs = np.linspace(req.plot_min, req.plot_max, 800)
+            ys = f(xs)
+            fig, ax = plt.subplots()
+            ax.plot(xs, ys)
+            ax.set_xlabel(str(x))
+            ax.set_ylabel("f({})".format(str(x)))
+            ax.grid(True)
+            buf = io.BytesIO()
+            fig.savefig(buf, format="png", dpi=120, bbox_inches="tight")
+            plt.close(fig)
+            out["plot_png_b64"] = base64.b64encode(buf.getvalue()).decode()
+        except Exception as e:
+            out["plot_error"] = str(e)
+
+    return out

--- a/opt/lucidia/agents/math_agent.py
+++ b/opt/lucidia/agents/math_agent.py
@@ -1,0 +1,61 @@
+import re, requests, base64
+from typing import Dict, Any
+
+SYM_ENDPOINT = "http://127.0.0.1:18081/compute"
+
+MATH_HINT = re.compile(r"""
+    (integral|differentiate|derivative|series|solve|root|factor|expand|simplify|plot)
+    |[+\-*/^=]
+""", re.I | re.X)
+
+def can_handle(message: str) -> bool:
+    return bool(MATH_HINT.search(message))
+
+def build_payload(message: str) -> Dict[str, Any]:
+    txt = message.strip()
+    do = ["simplify","diff","integrate","series","solve","numeric"]
+    target_eq_zero = False
+    if txt.lower().startswith("solve "):
+        txt = re.sub(r"^solve\s+", "", txt, flags=re.I)
+        target_eq_zero = True
+        do = ["simplify","solve"]
+    plot = "plot" in txt.lower() or "graph" in txt.lower()
+    return {
+        "expr": re.sub(r"^compute:\s*", "", txt, flags=re.I),
+        "vars": ["x"],
+        "do": do,
+        "series_order": 6,
+        "plot": plot,
+        "target_eq_zero": target_eq_zero
+    }
+
+def handle(message: str) -> Dict[str, Any]:
+    pld = build_payload(message)
+    r = requests.post(SYM_ENDPOINT, json=pld, timeout=20)
+    r.raise_for_status()
+    data = r.json()
+    resp_lines = []
+    resp_lines.append(f"**Input**: $$ {data.get('expr_latex','')} $$")
+    if "simplify_latex" in data:
+        resp_lines.append(f"**Simplified**: $$ {data['simplify_latex']} $$")
+    if "derivative_latex" in data:
+        resp_lines.append(f"**Derivative**: $$ {data['derivative_latex']} $$")
+    if "integral_latex" in data:
+        resp_lines.append(f"**Integral**: $$ {data['integral_latex']} $$")
+    if "series_latex" in data:
+        resp_lines.append(f"**Series**: $$ {data['series_latex']} $$")
+    if data.get("roots_latex"):
+        roots = ", ".join([f"$$ {r} $$" for r in data["roots_latex"]])
+        resp_lines.append(f"**Solutions**: {roots}")
+    if isinstance(data.get("numeric"), (int, float)):
+        resp_lines.append(f"**Numeric**: {data['numeric']}")
+    if "plot_png_b64" in data:
+        resp_lines.append(f"[plot:image] data:image/png;base64,{data['plot_png_b64']}")
+    return {
+        "channel": "math",
+        "markdown": "\n\n".join(resp_lines),
+        "attachments": [{
+            "type": "image",
+            "src": f"data:image/png;base64,{data['plot_png_b64']}"
+        }] if "plot_png_b64" in data else []
+    }

--- a/opt/lucidia/codex/tool_router.py
+++ b/opt/lucidia/codex/tool_router.py
@@ -1,0 +1,6 @@
+from agents.math_agent import can_handle as math_can, handle as math_handle
+
+def route(user_message: str):
+    if math_can(user_message):
+        return math_handle(user_message)
+    return {"channel":"text","markdown":"I didn’t detect math intent — want me to compute something? Try `compute: <expr>`."}

--- a/var/www/blackroad/sympy.html
+++ b/var/www/blackroad/sympy.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>BlackRoad • SymPy Compute</title>
+  <script id="MathJax-script" async
+    src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 2rem; }
+    textarea { width: 100%; height: 6rem; }
+    .out { border: 1px solid #ddd; padding: 1rem; border-radius: .75rem; margin-top: 1rem; }
+    img.plot { max-width: 100%; height: auto; display: block; margin-top: .5rem; }
+  </style>
+</head>
+<body>
+  <h1>SymPy Compute (Local)</h1>
+  <p>Type an expression (e.g., <code>sin(x)^2 + cos(x)^2</code>, <code>solve x^2-2x-3</code>)</p>
+  <textarea id="expr" placeholder="compute: integral of exp(-x^2) from 0 to 1  OR  sin(x)^2 + cos(x)^2"></textarea>
+  <label><input id="plot" type="checkbox"> Plot</label>
+  <button id="run">Run</button>
+  <div class="out" id="out"></div>
+
+  <script>
+  const run = async () => {
+    const t = document.getElementById('expr').value.trim();
+    const plot = document.getElementById('plot').checked;
+    // very light intent parsing
+    const lower = t.toLowerCase();
+    const req = {
+      expr: t.replace(/^compute:\s*/i,''),
+      vars: ["x"],
+      do: ["simplify","diff","integrate","series","solve","numeric"],
+      series_order: 6,
+      plot: plot
+    };
+    if (lower.startsWith('solve ')) {
+      req.expr = t.replace(/^solve\s+/i,'');
+      req.target_eq_zero = true;
+      req.do = ["simplify","solve"];
+    }
+    const r = await fetch('/api/sympy/compute', {
+      method:'POST', headers:{'Content-Type':'application/json'},
+      body: JSON.stringify(req)
+    });
+    const data = await r.json();
+    const el = document.getElementById('out');
+    const img = data.plot_png_b64 ? `<img class="plot" src="data:image/png;base64,${data.plot_png_b64}" />` : '';
+    el.innerHTML = `
+      <div><b>Input</b>: $$${data.expr_latex||''}$$</div>
+      ${data.simplify_latex ? `<div><b>Simplified</b>: $$${data.simplify_latex}$$</div>`:''}
+      ${data.derivative_latex ? `<div><b>Derivative</b>: $$${data.derivative_latex}$$</div>`:''}
+      ${data.integral_latex ? `<div><b>Integral</b>: $$${data.integral_latex}$$</div>`:''}
+      ${data.series_latex ? `<div><b>Series</b>: $$${data.series_latex}$$</div>`:''}
+      ${data.roots_latex && data.roots_latex.length ? `<div><b>Solutions</b>: $$${data.roots_latex.join(", ")}$$</div>`:''}
+      ${typeof data.numeric === 'number' ? `<div><b>Numeric</b>: ${data.numeric}</div>`:''}
+      ${img}
+    `;
+    if (window.MathJax) MathJax.typesetPromise();
+  };
+  document.getElementById('run').addEventListener('click', run);
+  </script>
+</body>
+</html>

--- a/var/www/blackroad/templates/partials/gamma-panel.html
+++ b/var/www/blackroad/templates/partials/gamma-panel.html
@@ -1,0 +1,4 @@
+<section class="gamma-panel">
+  <h2 class="title">SymPy Gamma</h2>
+  <iframe src="/gamma/" style="width:100%;height:70vh;border:0;" loading="lazy"></iframe>
+</section>


### PR DESCRIPTION
## Summary
- wire up a local SymPy Gamma UI and JSON API via docker-compose and bootstrap script
- expose compute API capable of simplify, diff, integrate, series, solve, numeric evaluation and plotting
- add nginx snippet, frontend widgets, Lucidia math agent, and Codex routing prompt

## Testing
- `pre-commit run --files opt/blackroad/docker-compose.override.yml opt/blackroad/services/bootstrap_sympy.sh opt/blackroad/services/sympy_api/Dockerfile opt/blackroad/services/sympy_api/requirements.txt opt/blackroad/services/sympy_api/sympy_api.py etc/nginx/snippets/blackroad-gamma.conf var/www/blackroad/templates/partials/gamma-panel.html var/www/blackroad/sympy.html opt/lucidia/agents/math_agent.py opt/lucidia/codex/tool_router.py opt/blackroad/codex/prompts/sympy_router.prompt.txt` *(fails: pre-commit not found)*
- `pip install pre-commit` *(fails: 403 when fetching package)*
- `nginx -t && systemctl reload nginx` *(fails: nginx not installed)*
- `curl -s http://127.0.0.1:18080/ | head -n1`
- `curl -s http://127.0.0.1:18081/compute -H 'Content-Type: application/json' -d '{"expr":"sin(x)^2+cos(x)^2","vars":["x"],"do":["simplify","numeric"]}' | jq`


------
https://chatgpt.com/codex/tasks/task_e_68a3f962b18483299c3827fc23b69ea8