### PR TITLE
Integrate Anthropic Claude adapter and system prompt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,7 @@ matplotlib==3.8.4
 numpy==1.26.4
 whisper
 torch
+anthropic
+boto3
+python-dotenv
 

--- a/srv/blackroad/config/.env.example
+++ b/srv/blackroad/config/.env.example
@@ -1,0 +1,11 @@
+CLAUDE_PROVIDER=anthropic          # or: bedrock
+ANTHROPIC_API_KEY=sk-ant-xxxxxxxx
+# Optional: route through your proxy/reverse-proxy
+ANTHROPIC_BASE_URL=https://api.anthropic.com
+CLAUDE_MODEL=claude-sonnet-4-20250514
+
+# If using AWS Bedrock:
+AWS_REGION=us-east-1
+# Example Bedrock model ids you can use in code:
+#  - anthropic.claude-sonnet-4-20250514-v1:0
+#  - anthropic.claude-3-7-sonnet-20250219-v1:0

--- a/srv/blackroad/examples/claude_smoke_test.py
+++ b/srv/blackroad/examples/claude_smoke_test.py
@@ -1,0 +1,16 @@
+import os
+from dotenv import load_dotenv
+from srv.blackroad.lib.llm.claude_adapter import ClaudeClient, ClaudeConfig
+
+load_dotenv("/srv/blackroad/config/.env")
+
+cfg = ClaudeConfig()
+client = ClaudeClient(cfg)
+
+system_path = "/srv/blackroad/prompts/codex_claude_system.txt"
+system = open(system_path, "r", encoding="utf-8").read() if os.path.exists(system_path) else None
+
+print(f"Provider={cfg.provider}, Model={cfg.model}")
+resp = client.generate(text="Say hello to BlackRoad & Lucidia in one sentence.",
+                       system=system, max_tokens=200, temperature=0.2)
+print(resp if isinstance(resp, str) else "".join(resp))

--- a/srv/blackroad/lib/llm/claude_adapter.py
+++ b/srv/blackroad/lib/llm/claude_adapter.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+import os, json, typing as t
+from dataclasses import dataclass
+
+Provider = t.Literal["anthropic", "bedrock"]
+
+@dataclass
+class ClaudeConfig:
+    provider: Provider = t.cast(Provider, os.getenv("CLAUDE_PROVIDER", "anthropic"))
+    model: str = os.getenv("CLAUDE_MODEL", "claude-sonnet-4-20250514")
+    # Anthropic direct
+    anthropic_api_key: t.Optional[str] = os.getenv("ANTHROPIC_API_KEY")
+    anthropic_base_url: t.Optional[str] = os.getenv("ANTHROPIC_BASE_URL")
+    # Bedrock
+    aws_region: str = os.getenv("AWS_REGION", "us-east-1")
+
+class ClaudeClient:
+    def __init__(self, cfg: ClaudeConfig | None = None):
+        self.cfg = cfg or ClaudeConfig()
+        if self.cfg.provider == "anthropic":
+            from anthropic import Anthropic, DefaultHttpxClient
+            http_client = DefaultHttpxClient()  # customize if needed
+            self.client = Anthropic(
+                api_key=self.cfg.anthropic_api_key,
+                base_url=self.cfg.anthropic_base_url,
+                http_client=http_client,
+            )
+        elif self.cfg.provider == "bedrock":
+            import boto3
+            self.bedrock = boto3.client("bedrock-runtime", region_name=self.cfg.aws_region)
+        else:
+            raise ValueError(f"Unknown provider: {self.cfg.provider}")
+
+    # Unified call
+    def generate(
+        self,
+        *,
+        messages: list[dict[str, t.Any]] | None = None,
+        text: str | None = None,
+        system: str | list[dict[str, str]] | None = None,
+        model: str | None = None,
+        max_tokens: int = 1024,
+        temperature: float = 0.4,
+        stream: bool = False,
+        tools: list[dict[str, t.Any]] | None = None,
+        tool_choice: t.Literal["auto","any","tool","none"] | dict | None = None,
+        thinking: dict | None = None,  # e.g., {"type":"enabled", "budget_tokens":4096}
+    ):
+        model = model or self.cfg.model
+
+        if self.cfg.provider == "anthropic":
+            from anthropic import APIError
+            # Build messages if user passed plain text
+            if messages is None:
+                if not text:
+                    raise ValueError("Either messages or text must be provided.")
+                messages = [{"role":"user","content":text}]
+            try:
+                if stream:
+                    # SDK-native streaming helpers (SSE)
+                    with self.client.messages.stream(
+                        model=model,
+                        messages=messages,
+                        max_tokens=max_tokens,
+                        temperature=temperature,
+                        system=system,
+                        tools=tools,
+                        tool_choice=tool_choice,
+                        thinking=thinking,
+                    ) as s:
+                        for delta in s.text_stream:
+                            yield delta
+                        final = s.get_final_message()
+                        # Optionally yield a sentinel or store `final`
+                else:
+                    resp = self.client.messages.create(
+                        model=model,
+                        messages=messages,
+                        max_tokens=max_tokens,
+                        temperature=temperature,
+                        system=system,
+                        tools=tools,
+                        tool_choice=tool_choice,
+                        thinking=thinking,
+                    )
+                    # Return concatenated text blocks
+                    return "".join([c.text for c in resp.content if c.type == "text"])
+            except APIError as e:
+                raise RuntimeError(f"Anthropic error: {e}") from e
+
+        else:  # Bedrock
+            # Map Anthropic-style messages to Bedrock Converse shape
+            def _to_converse_content(msg: dict) -> dict:
+                # Only text support here; extend for images/docs as needed
+                content = msg.get("content", "")
+                if isinstance(content, str):
+                    parts = [{"text": content}]
+                elif isinstance(content, list):
+                    # If content blocks are dicts with {"type":"text","text":...}
+                    parts = []
+                    for b in content:
+                        if isinstance(b, str):
+                            parts.append({"text": b})
+                        elif isinstance(b, dict) and b.get("type") == "text":
+                            parts.append({"text": b.get("text", "")})
+                else:
+                    parts = [{"text": str(content)}]
+                return {"role": msg["role"], "content": parts}
+
+            if messages is None:
+                if not text:
+                    raise ValueError("Either messages or text must be provided.")
+                messages = [{"role":"user","content":text}]
+
+            br_messages = [_to_converse_content(m) for m in messages]
+            system_prompts = None
+            if system:
+                if isinstance(system, str):
+                    system_prompts = [{"text": system}]
+                elif isinstance(system, list):
+                    system_prompts = system
+
+            inference_cfg = {"maxTokens": max_tokens, "temperature": temperature}
+
+            if stream:
+                # Streaming via ConverseStream
+                resp = self.bedrock.converse_stream(
+                    modelId=model,
+                    system=system_prompts,
+                    messages=br_messages,
+                    inferenceConfig=inference_cfg,
+                )
+                for event in resp.get("stream", []):
+                    # Text deltas arrive as contentBlockDelta
+                    if "contentBlockDelta" in event:
+                        delta = event["contentBlockDelta"]["delta"]
+                        if "text" in delta:
+                            yield delta["text"]
+                return
+            else:
+                out = self.bedrock.converse(
+                    modelId=model,
+                    system=system_prompts,
+                    messages=br_messages,
+                    inferenceConfig=inference_cfg,
+                )
+                # Extract final text
+                blocks = out.get("output", {}).get("message", {}).get("content", []) or []
+                return "".join([b.get("text","") for b in blocks if "text" in b])

--- a/srv/blackroad/prompts/codex_claude_system.txt
+++ b/srv/blackroad/prompts/codex_claude_system.txt
@@ -1,0 +1,21 @@
+You are CLAUDE inside Codex Infinity (Lucidia). Guardrails:
+
+1) Truth above eloquence. If unknown or ambiguous, say “Unknown” and ask for the minimum needed data. NEVER fabricate.
+2) No supernatural claims or invocations. Stay technical, symbolic, and grounded.
+3) Trinary logic: use {1:true, 0:unknown, –1:false} internally to reason about states; surface plainly in English.
+4) Contradiction hygiene: when input conflicts with prior context, call the host tool `log_contradiction` with a concise JSON of the clash; then proceed with the best consistent path.
+5) Memory etiquette: only reference memory explicitly provided in the current context or via approved tools.
+6) Output contract:
+   • Default to concise, actionable steps.  
+   • Show commands/code that can be copy–pasted.  
+   • Do not reveal hidden chain-of-thought—summarize decisions instead.  
+7) Safety & data: do not emit secrets; never exfiltrate keys; avoid high-risk instructions.
+
+Operational frame:
+- Role: “Symbolic engineer & co-coder for BlackRoad/Lucidia.”
+- Style: precise, minimally formal, execution-first.
+- Today’s date: {{TODAY}}
+
+When asked to “configure / integrate”, produce a short plan, then the files (with top-line FILE path comments) in paste-ready blocks.
+
+Pass this as the system= argument to client.generate(...). The system top-level param is the officially supported way to add a system prompt.


### PR DESCRIPTION
## Summary
- add environment template and dependencies for Claude and Bedrock
- implement `ClaudeClient` adapter supporting Anthropic or AWS Bedrock with streaming
- include Codex-ready system prompt and smoke test script

## Testing
- `pip install anthropic boto3 python-dotenv` *(fails: Could not connect to proxy)*
- `pip install boto3 python-dotenv` *(fails: Could not connect to proxy)*
- `pre-commit run --files requirements.txt srv/blackroad/config/.env.example srv/blackroad/lib/llm/claude_adapter.py srv/blackroad/prompts/codex_claude_system.txt srv/blackroad/examples/claude_smoke_test.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not connect to proxy)*
- `PYTHONPATH=$(pwd) python srv/blackroad/examples/claude_smoke_test.py` *(fails: No module named 'anthropic')*

------
https://chatgpt.com/codex/tasks/task_e_68a3fc98d6c083298cdd4dd6a29529d2