### PR TITLE
Add Anthropic adapter and sample tools for Lucidia integration

### DIFF
--- a/opt/blackroad/codex/prompts/claude_codex_system.prompt
+++ b/opt/blackroad/codex/prompts/claude_codex_system.prompt
@@ -1,0 +1,22 @@
+ROLE
+You are a Lucidia–Codex Infinity worker. Operate with trinary logic (1, 0, –1), contradiction awareness, and strict honesty. No fallback routing. If something is unknown, say so and request a bounded input.
+
+CORE LAWS
+1) Truth over eloquence. Prefer verifiable statements and explicit assumptions.
+2) Contradiction logging: when detecting inconsistency, emit an action {type:"contradiction", signal:"Ψ′", note:"..."} and continue safely.
+3) Tools are explicit. Use only declared tools; never invent parameters. Ask for missing required inputs.
+4) Output contract is minimal and machine-parseable; no hidden reasoning.
+
+OUTPUT FORMAT (default)
+Return plain text optimized for execution or user reading. When the caller requests JSON mode, obey the provided schema or use:
+{"answer": string, "actions": [{"type": string, "args": object}], "notes": string|null}
+
+LUCIDIA CONTEXT HINTS
+• Memory is hashed via PS-SHA∞ and referenced by id only when needed.
+• Guardian enforces safety + contradiction policy; treat its output as authoritative.
+• Roadie is the co-coding agent; propose minimal diffs when relevant.
+
+STYLE
+Crisp, correct, and specific. Use absolute dates. Avoid purple prose and anthropomorphism.
+
+(Use as the system string in the adapter; Anthropic expects system at the top level, not as a message role.)

--- a/opt/blackroad/lucidia/adapters/anthropic_adapter.py
+++ b/opt/blackroad/lucidia/adapters/anthropic_adapter.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+import typing as t
+from dataclasses import dataclass, field
+
+from anthropic import Anthropic, APIError  # SDK docs & install: https://docs.anthropic.com/  # noqa
+
+ToolFn = t.Callable[[dict], t.Any]
+
+@dataclass
+class ToolSpec:
+    name: str
+    description: str
+    schema: dict
+    fn: ToolFn
+
+@dataclass
+class AnthropicAdapter:
+    model: str = field(default_factory=lambda: os.getenv("ANTHROPIC_MODEL", "claude-3-5-sonnet-20240620"))
+    api_key: str = field(default_factory=lambda: os.getenv("ANTHROPIC_API_KEY", ""))
+    temperature: float = 0.2
+    max_tokens: int = 1200
+    client: Anthropic = field(init=False)
+
+    def __post_init__(self):
+        if not self.api_key:
+            raise RuntimeError("ANTHROPIC_API_KEY is not set")
+        self.client = Anthropic(api_key=self.api_key)
+
+    def _tool_defs(self, tools: list[ToolSpec]) -> list[dict]:
+        return [
+            {
+                "name": t_.name,
+                "description": t_.description,
+                "input_schema": t_.schema,
+            }
+            for t_ in tools
+        ]
+
+    def chat(
+        self,
+        messages: list[dict],
+        *,
+        tools: list[ToolSpec] | None = None,
+        system: str | None = None,
+        json_mode: bool = False,
+        stream: bool = False,
+    ) -> dict:
+        """
+        messages: [{"role":"user"|"assistant", "content": str|list}]
+        Returns: {"text": str, "raw": response, "trace": list[dict]}
+        """
+        trace: list[dict] = []
+        tool_lookup = {t_.name: t_ for t_ in (tools or [])}
+        tool_defs = self._tool_defs(tools or [])
+
+        while True:
+            try:
+                resp = self.client.messages.create(
+                    model=self.model,
+                    max_tokens=self.max_tokens,
+                    temperature=self.temperature,
+                    system=system,  # system is a top-level field (no system role)  # see docs
+                    tools=tool_defs if tools else None,
+                    response_format={"type": "json_object"} if json_mode else None,
+                    messages=messages,
+                )
+            except APIError:
+                raise
+
+            trace.append({"t": time.time(), "direction": "assistant", "content": [c.to_dict() for c in resp.content]})
+
+            # Collect tool calls (if any)
+            tool_calls = []
+            for block in resp.content:
+                if getattr(block, "type", None) == "tool_use":
+                    tool_calls.append(block)
+
+            if tool_calls:
+                # Execute all tool calls in parallel-ish, then append a user/tool_result message.
+                results = []
+                for call in tool_calls:
+                    spec = tool_lookup.get(call.name)
+                    if not spec:
+                        out = {"error": f"Unknown tool '{call.name}'"}
+                    else:
+                        try:
+                            out_raw = spec.fn(call.input or {})
+                            out = out_raw if isinstance(out_raw, (str, int, float, dict, list, bool)) else str(out_raw)
+                        except Exception as ex:
+                            out = {"error": repr(ex)}
+                    # tool_result blocks must be first in the next user message
+                    # and must reference the exact tool_use id. (Strict API rule.)
+                    results.append({
+                        "type": "tool_result",
+                        "tool_use_id": call.id,
+                        "content": out if isinstance(out, str) else json.dumps(out),
+                    })
+
+                # Append the assistant tool use content (for full conversation state), then tool results
+                messages.append({"role": "assistant", "content": [c.to_dict() for c in resp.content]})
+                messages.append({"role": "user", "content": results})
+                trace.append({"t": time.time(), "direction": "user", "content": results})
+                continue  # Loop again so Claude can synthesize using the tool results
+
+            # No tool use → return final text
+            final_text = "".join(getattr(b, "text", "") for b in resp.content if getattr(b, "type", "") == "text")
+            return {"text": final_text, "raw": resp.to_dict(), "trace": trace}

--- a/opt/blackroad/lucidia/adapters/anthropic_tools.py
+++ b/opt/blackroad/lucidia/adapters/anthropic_tools.py
@@ -1,0 +1,26 @@
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+def tool_get_time(payload: dict):
+    tz = payload.get("timezone", "America/Chicago")
+    return {"iso": datetime.now(ZoneInfo(tz)).isoformat(), "timezone": tz}
+
+def tool_guardian_check(payload: dict):
+    # Hook your Guardian logic here (policy / safety / contradiction gates).
+    # Return concise flags only (no chain-of-thought).
+    return {"ok": True, "flags": []}
+
+TOOLS = [
+    {
+        "name": "get_time",
+        "description": "Get current time in a given IANA timezone",
+        "schema": {"type": "object", "properties": {"timezone": {"type": "string"}}, "required": []},
+        "fn": tool_get_time,
+    },
+    {
+        "name": "guardian_check",
+        "description": "Run Lucidia Guardian policy & contradiction gates on the current request",
+        "schema": {"type": "object", "properties": {}},
+        "fn": tool_guardian_check,
+    },
+]

--- a/opt/blackroad/lucidia/examples/run_claude.py
+++ b/opt/blackroad/lucidia/examples/run_claude.py
@@ -1,0 +1,12 @@
+from adapters.anthropic_adapter import AnthropicAdapter, ToolSpec
+from adapters.anthropic_tools import TOOLS
+
+system = open("/opt/blackroad/codex/prompts/claude_codex_system.prompt", "r").read()
+
+adapter = AnthropicAdapter()
+tools = [ToolSpec(**t) for t in TOOLS]
+
+messages = [{"role":"user","content":"What’s the time in Tokyo? Then run Guardian."}]
+out = adapter.chat(messages, tools=tools, system=system, json_mode=False)
+print(out["text"])
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ fastapi
 uvicorn
 pydantic
 requests
+
+anthropic


### PR DESCRIPTION
## Summary
- add AnthropicAdapter to support Claude Messages API with tool use and JSON mode
- include sample tools and example driver for Lucidia
- provide Codex-ready system prompt for Claude and pin anthropic dependency

## Testing
- `ruff check opt/blackroad/lucidia/adapters/anthropic_adapter.py opt/blackroad/lucidia/adapters/anthropic_tools.py opt/blackroad/lucidia/examples/run_claude.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'lib')*


------
https://chatgpt.com/codex/tasks/task_e_68a3fff356888329ac473fde9e95828e