### PR TITLE
Configure pytest path for local modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,6 @@ dependencies = [
   "rich>=13"
 ]
 
+
+[tool.pytest.ini_options]
+pythonpath = ["."]


### PR DESCRIPTION
## Summary
- configure pytest to include project root on PYTHONPATH so `lib` modules import in tests

## Testing
- `pytest tests/test_symbolic.py -q`
- `node tests/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a401162ce48329852f517887a68b6b