### PR TITLE
Add local ES CartPole training utilities

### DIFF
--- a/README_LOCAL.md
+++ b/README_LOCAL.md
@@ -1,0 +1,45 @@
+# Local ES Starter
+
+This directory provides a local-first workflow for experimenting with
+Evolution Strategies on the classic CartPole control task.  It avoids the
+AWS-specific tooling of the original project and runs entirely on a laptop.
+
+## Setup
+
+```bash
+bash scripts/setup_local.sh
+```
+
+This creates `.venv`, installs dependencies from `requirements-local.txt` and
+verifies the environment.  MuJoCo is skipped by default.  To enable it later:
+
+```bash
+pip install mujoco gymnasium[mujoco]
+```
+
+## Train
+
+```bash
+bash scripts/run_local.sh train --iterations 50
+```
+
+Checkpoints are written to `checkpoints/es_cartpole/` and TensorBoard logs to
+`runs/es_local`.
+
+## TensorBoard
+
+```bash
+bash scripts/run_local.sh tb
+```
+
+## Logs
+
+```bash
+bash scripts/run_local.sh logs
+```
+
+## Extending
+
+The code under `local/` is modular and torch-only, making it easy to plug in new
+environments or policies.  MuJoCo or Atari environments can be added by
+installing the appropriate extras and modifying `run_cartpole.py`.

--- a/local/es_core.py
+++ b/local/es_core.py
@@ -1,0 +1,47 @@
+"""Core utilities for Evolution Strategies."""
+from __future__ import annotations
+
+import gymnasium as gym
+import torch
+from torch import nn
+from typing import Tuple
+
+from .models import unflatten_params
+
+
+def perturb(params: torch.Tensor, noise: torch.Tensor, sigma: float) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Return positive and negative perturbations of parameters."""
+    return params + sigma * noise, params - sigma * noise
+
+
+def evaluate(env_name: str, model: nn.Module, params: torch.Tensor, episodes: int = 1, seed: int | None = None) -> float:
+    """Evaluate a policy with given parameters and return average reward."""
+    unflatten_params(model, params)
+    env = gym.make(env_name)
+    total_reward = 0.0
+    for ep in range(episodes):
+        obs, _ = env.reset(seed=None if seed is None else seed + ep)
+        done = False
+        while not done:
+            obs_t = torch.as_tensor(obs, dtype=torch.float32)
+            action = model.act(obs_t)
+            obs, reward, terminated, truncated, _ = env.step(action)
+            done = terminated or truncated
+            total_reward += reward
+    env.close()
+    return total_reward / episodes
+
+
+def estimate_gradient(noises: torch.Tensor, rewards_pos: torch.Tensor, rewards_neg: torch.Tensor, sigma: float) -> torch.Tensor:
+    """Estimate gradient using antithetic sampling."""
+    advantages = rewards_pos - rewards_neg
+    grad = (advantages.unsqueeze(1) * noises).mean(0) / sigma
+    return grad
+
+
+def update(params: torch.Tensor, grad: torch.Tensor, lr: float, weight_decay: float) -> torch.Tensor:
+    """Apply gradient ascent step with weight decay."""
+    return params + lr * (grad - weight_decay * params)
+
+
+__all__ = ["perturb", "evaluate", "estimate_gradient", "update"]

--- a/local/models.py
+++ b/local/models.py
@@ -1,0 +1,45 @@
+"""Models for local ES experiments."""
+from __future__ import annotations
+
+
+import torch
+from torch import nn
+
+
+class MLPPolicy(nn.Module):
+    """Simple MLP policy producing action logits."""
+
+    def __init__(self, obs_dim: int, act_dim: int) -> None:
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(obs_dim, 64),
+            nn.Tanh(),
+            nn.Linear(64, 64),
+            nn.Tanh(),
+            nn.Linear(64, act_dim),
+        )
+
+    def forward(self, obs: torch.Tensor) -> torch.Tensor:
+        return self.net(obs)
+
+    def act(self, obs: torch.Tensor) -> int:
+        with torch.no_grad():
+            logits = self.forward(obs)
+            return int(torch.argmax(logits).item())
+
+
+def flatten_params(model: nn.Module) -> torch.Tensor:
+    """Flatten model parameters into a single 1-D tensor."""
+    return torch.cat([p.detach().view(-1) for p in model.parameters()])
+
+
+def unflatten_params(model: nn.Module, flat: torch.Tensor) -> None:
+    """Load parameters from a flat tensor back into the model."""
+    pointer = 0
+    for p in model.parameters():
+        numel = p.numel()
+        p.data.copy_(flat[pointer:pointer + numel].view_as(p))
+        pointer += numel
+
+
+__all__ = ["MLPPolicy", "flatten_params", "unflatten_params"]

--- a/local/run_cartpole.py
+++ b/local/run_cartpole.py
@@ -1,0 +1,123 @@
+"""Local ES training on CartPole."""
+from __future__ import annotations
+
+import json
+import logging
+import random
+import signal
+import sys
+import time
+from pathlib import Path
+
+import click
+import gymnasium
+import numpy as np
+import torch
+from torch.utils.tensorboard import SummaryWriter
+
+from .es_core import perturb, evaluate, estimate_gradient, update
+from .models import MLPPolicy, flatten_params, unflatten_params
+
+
+@click.command()
+@click.option("--iterations", default=200, type=int, help="Number of ES iterations")
+@click.option("--timesteps", default=None, type=int, help="Alias for --iterations")
+@click.option("--popsize", default=64, type=int, help="Population size")
+@click.option("--sigma", default=0.1, type=float, help="Noise standard deviation")
+@click.option("--lr", default=0.02, type=float, help="Learning rate")
+@click.option("--seed", default=0, type=int, help="Random seed")
+@click.option("--eval-episodes", default=5, type=int, help="Evaluation episodes")
+@click.option("--resume", type=click.Path(exists=True), default=None, help="Resume from checkpoint")
+@click.option("--checkpoint-interval", default=10, type=int, help="Checkpoint interval")
+def main(iterations: int, timesteps: int | None, popsize: int, sigma: float, lr: float, seed: int,
+         eval_episodes: int, resume: str | None, checkpoint_interval: int) -> None:
+    if timesteps is not None:
+        iterations = timesteps
+
+    run_dir = Path("runs/es_local")
+    run_dir.mkdir(parents=True, exist_ok=True)
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        handlers=[
+            logging.StreamHandler(sys.stdout),
+            logging.FileHandler(run_dir / "train.log"),
+        ],
+    )
+    logger = logging.getLogger("es")
+
+    writer = SummaryWriter(str(run_dir))
+
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    generator = torch.Generator().manual_seed(seed)
+
+    env_name = "CartPole-v1"
+    env = gymnasium.make(env_name)
+    obs_dim = env.observation_space.shape[0]
+    act_dim = env.action_space.n
+    env.close()
+
+    model = MLPPolicy(obs_dim, act_dim)
+    params = flatten_params(model)
+    start_iter = 0
+    if resume is not None:
+        ckpt = torch.load(resume)
+        params = ckpt["params"]
+        start_iter = ckpt.get("iteration", 0)
+        unflatten_params(model, params)
+        logger.info(f"Resumed from {resume} at iteration {start_iter}")
+
+    ckpt_dir = Path("checkpoints/es_cartpole")
+    ckpt_dir.mkdir(parents=True, exist_ok=True)
+
+    stop = False
+
+    def handle_sigint(sig, frame):  # type: ignore[unused-argument]
+        nonlocal stop
+        stop = True
+        logger.info("SIGINT received, will save checkpoint and exit")
+
+    signal.signal(signal.SIGINT, handle_sigint)
+
+    num_params = params.numel()
+
+    for iteration in range(start_iter, iterations):
+        start = time.time()
+        noises = torch.randn(popsize, num_params, generator=generator)
+        rewards_pos = torch.zeros(popsize)
+        rewards_neg = torch.zeros(popsize)
+
+        for i in range(popsize):
+            pos_params, neg_params = perturb(params, noises[i], sigma)
+            rewards_pos[i] = evaluate(env_name, model, pos_params, episodes=1, seed=seed + i * 2)
+            rewards_neg[i] = evaluate(env_name, model, neg_params, episodes=1, seed=seed + i * 2 + 1)
+
+        grad = estimate_gradient(noises, rewards_pos, rewards_neg, sigma)
+        params = update(params, grad, lr, weight_decay=0.005)
+        unflatten_params(model, params)
+
+        avg_reward = evaluate(env_name, model, params, episodes=eval_episodes, seed=seed + 1234 + iteration)
+        duration = time.time() - start
+        writer.add_scalar("reward/average", avg_reward, iteration)
+        writer.add_scalar("hyper/lr", lr, iteration)
+        writer.add_scalar("hyper/sigma", sigma, iteration)
+        writer.add_scalar("time/iteration", duration, iteration)
+        logger.info(f"iter {iteration} avg_reward={avg_reward:.2f} time={duration:.2f}s")
+
+        if iteration % checkpoint_interval == 0 or iteration == iterations - 1 or stop:
+            ckpt_path = ckpt_dir / f"iter_{iteration:05d}.pt"
+            torch.save({"params": params, "iteration": iteration}, ckpt_path)
+            with open(ckpt_path.with_suffix(".json"), "w") as f:
+                json.dump({"iteration": iteration, "avg_reward": float(avg_reward)}, f)
+            torch.save({"params": params, "iteration": iteration}, ckpt_dir / "latest.pt")
+        if stop:
+            break
+
+    writer.close()
+    logger.info("training complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/local/test_vectorization.py
+++ b/local/test_vectorization.py
@@ -1,0 +1,12 @@
+import torch
+
+from .models import MLPPolicy, flatten_params, unflatten_params
+
+
+def test_round_trip() -> None:
+    model = MLPPolicy(4, 2)
+    flat = flatten_params(model)
+    new = torch.randn_like(flat)
+    unflatten_params(model, new)
+    flat2 = flatten_params(model)
+    assert torch.allclose(flat2, new)

--- a/requirements-local.txt
+++ b/requirements-local.txt
@@ -1,0 +1,9 @@
+numpy==1.24.4
+scipy==1.10.1
+gymnasium[classic-control]==0.29.1
+torch==2.1.0
+tensorboard==2.14.0
+tqdm==4.66.1
+click==8.1.7
+cloudpickle==2.2.1
+mpi4py==3.1.5

--- a/scripts/run_local.sh
+++ b/scripts/run_local.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -e
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+LOGDIR="$ROOT/runs/es_local"
+
+case "$1" in
+  train)
+    shift
+    source "$ROOT/.venv/bin/activate"
+    python "$ROOT/local/run_cartpole.py" "$@"
+    ;;
+  tb)
+    shift
+    source "$ROOT/.venv/bin/activate"
+    tensorboard --logdir "$LOGDIR" --port 6006 "$@"
+    ;;
+  logs)
+    tail -n 20 "$LOGDIR/train.log"
+    ;;
+  *)
+    echo "Usage: $0 {train|tb|logs} [args]"
+    exit 1
+    ;;
+esac

--- a/scripts/setup_local.sh
+++ b/scripts/setup_local.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$ROOT"
+
+if [ ! -d .venv ]; then
+    python3 -m venv .venv
+fi
+
+source .venv/bin/activate
+python -m pip install --upgrade pip
+pip install -r requirements-local.txt
+
+echo "Skipping MuJoCo installation. To enable later: pip install mujoco gymnasium[mujoco]"
+
+python - <<'PY'
+import numpy, scipy, gymnasium, torch, tensorboard, tqdm, click, cloudpickle
+print('✅ READY')
+PY


### PR DESCRIPTION
## Summary
- add local-only ES training loop for CartPole with checkpoints and TensorBoard logging
- provide local setup and run scripts with pinned dependencies
- document local workflow in README_LOCAL

## Testing
- `bash scripts/setup_local.sh` *(fails: Could not find a version that satisfies the requirement numpy==1.24.4)*
- `pytest local/test_vectorization.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68a4e6101d488329ae495dd360b83995