### PR TITLE
feat: add lucidia api service

### DIFF
--- a/services/lucidia_api/app/__init__.py
+++ b/services/lucidia_api/app/__init__.py
@@ -1,0 +1,2 @@
+"""Lucidia API application package."""
+

--- a/services/lucidia_api/app/deps.py
+++ b/services/lucidia_api/app/deps.py
@@ -1,0 +1,13 @@
+import os
+from redis.asyncio import Redis
+
+_redis: Redis | None = None
+
+
+async def get_redis() -> Redis:
+    """Return a singleton Redis client."""
+    global _redis
+    if _redis is None:
+        url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+        _redis = Redis.from_url(url)
+    return _redis

--- a/services/lucidia_api/app/routes.py
+++ b/services/lucidia_api/app/routes.py
@@ -1,0 +1,63 @@
+import json
+import os
+from typing import Any, Dict
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import StreamingResponse
+
+from .deps import get_redis
+from redis.asyncio import Redis
+
+router = APIRouter()
+
+
+@router.get("/health")
+async def health() -> Dict[str, bool]:
+    return {"ok": True}
+
+
+@router.post("/chat")
+async def chat(payload: Dict[str, Any]) -> StreamingResponse:
+    messages = payload.get("messages", [])
+    if not isinstance(messages, list):
+        raise HTTPException(status_code=400, detail="messages must be a list")
+
+    async def event_stream():
+        async with httpx.AsyncClient(timeout=None) as client:
+            async with client.stream(
+                "POST",
+                "http://localhost:11434/api/chat",
+                json={"model": "mistral:7b", "messages": messages, "stream": True},
+            ) as response:
+                async for line in response.aiter_lines():
+                    if line:
+                        yield f"data: {line}\n\n"
+
+    return StreamingResponse(event_stream(), media_type="text/event-stream")
+
+
+@router.post("/embed")
+async def embed(payload: Dict[str, Any], redis: Redis = Depends(get_redis)) -> Dict[str, Any]:
+    text = payload.get("text")
+    if not isinstance(text, str) or not text.strip():
+        raise HTTPException(status_code=400, detail="text is required")
+    if len(text) > 8000:
+        raise HTTPException(status_code=400, detail="text too long")
+    key = f"embed:{hash(text)}"
+    cached = await redis.get(key)
+    if cached:
+        return {"embedding": json.loads(cached)}
+
+    headers = {"Authorization": f"Bearer {os.getenv('OPENAI_API_KEY', '')}"}
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            "https://api.openai.com/v1/embeddings",
+            headers=headers,
+            json={"model": "text-embedding-3-large", "input": text},
+        )
+        resp.raise_for_status()
+        embedding = resp.json()["data"][0]["embedding"]
+
+    await redis.set(key, json.dumps(embedding))
+    return {"embedding": embedding}

--- a/services/lucidia_api/main.py
+++ b/services/lucidia_api/main.py
@@ -1,0 +1,29 @@
+import os
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from app.routes import router
+
+
+def create_app() -> FastAPI:
+    app = FastAPI()
+    origin = os.getenv("ORIGIN", "")
+    if origin:
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=[origin],
+            allow_credentials=True,
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
+    app.include_router(router)
+    return app
+
+
+app = create_app()
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run("main:app", host="0.0.0.0", port=8000)

--- a/services/lucidia_api/pyproject.toml
+++ b/services/lucidia_api/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "lucidia_api"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+  "fastapi",
+  "uvicorn[standard]",
+  "httpx",
+  "redis",
+]
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+addopts = "-q"

--- a/services/lucidia_api/tests/test_health.py
+++ b/services/lucidia_api/tests/test_health.py
@@ -1,0 +1,18 @@
+import pathlib
+import sys
+
+import pytest
+from httpx import AsyncClient
+
+ROOT = pathlib.Path(__file__).resolve().parents[3]
+sys.path.append(str(ROOT))
+
+from services.lucidia_api.main import app
+
+
+@pytest.mark.asyncio
+async def test_health() -> None:
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        resp = await ac.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}


### PR DESCRIPTION
## Summary
- scaffold FastAPI lucidia_api service with chat, embed, and health endpoints
- configure redis caching and CORS from ORIGIN env
- add basic health endpoint test

## Testing
- `python -m py_compile services/lucidia_api/main.py services/lucidia_api/app/__init__.py services/lucidia_api/app/deps.py services/lucidia_api/app/routes.py`
- `pytest services/lucidia_api/tests/test_health.py -q` *(fails: ModuleNotFoundError: No module named 'fastapi', pip install blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e50f96148329aad4eb6d8bc18546