### PR TITLE
feat: add lucidia chat page and api route

### DIFF
--- a/apps/portals/app/api/lucidia/route.ts
+++ b/apps/portals/app/api/lucidia/route.ts
@@ -1,0 +1,20 @@
+// FILE: app/api/lucidia/route.ts
+import { streamText, convertToModelMessages } from 'ai';
+import { openai } from '@ai-sdk/openai';
+
+export const maxDuration = 30;
+
+export async function POST(req: Request) {
+  const { messages } = await req.json();
+  const modelId = process.env.LUCIDIA_MODEL ?? 'gpt-4o-mini';
+  const result = streamText({
+    model: openai(modelId),
+    messages: convertToModelMessages(messages),
+  });
+
+  return result.toUIMessageStreamResponse({
+    onError(error) {
+      return error instanceof Error ? error.message : String(error);
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- add `/api/lucidia` Next.js endpoint streaming responses via OpenAI provider
- implement interactive Lucidia chat page using `useChat`

## Testing
- `npm test` *(fails: Invalid package.json: Expected ',' or '}' after property value)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e133c4888329b06334800b9b927e