### PR TITLE
feat: add self-hosted stack skeleton

### DIFF
--- a/BACKUP_POLICY.md
+++ b/BACKUP_POLICY.md
@@ -1,0 +1,8 @@
+<!-- FILE: /BACKUP_POLICY.md -->
+# Backup Policy
+
+- **RPO:** 1 hour
+- **RTO:** 4 hours
+- Daily restic backups to MinIO bucket `lucidia-backups`.
+- Weekly verify using `restic check`.
+- Quarterly full restore rehearsal using `ops/backup/restore_example.md`.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,0 +1,24 @@
+<!-- FILE: /RUNBOOK.md -->
+# BlackRoad Stack Runbook
+
+## Bootstrap
+1. `bash infra/provision.sh`
+2. Access Gitea at `https://blackroad.io`.
+
+## Rotate
+- Update images via CI and redeploy with `docker compose pull && docker compose up -d`.
+
+## Failover
+- Promote Postgres replica: `docker exec postgres-replica repmgr standby promote`.
+
+## Restore
+1. Retrieve backup from MinIO using restic.
+2. `restic restore latest --target /restore`.
+
+## Site Down Checklist
+- Run `ops/health/check.sh`.
+- Inspect `docker compose ps`.
+
+## DNS and Tor
+- Deploy NSD with `infra/dns/deploy.sh` on ns1/ns2.
+- Tor service uses `/infra/tor/torrc`; start with `tor -f torrc`.

--- a/SECURITY_BASELINE.md
+++ b/SECURITY_BASELINE.md
@@ -1,0 +1,8 @@
+<!-- FILE: /SECURITY_BASELINE.md -->
+# Security Baseline
+
+- Enforce SSH key authentication; passwords disabled.
+- UFW allows 22/tcp from admin IPs, 80/443/tcp, WireGuard UDP 51820.
+- Vault stores all secrets; no plaintext in repos.
+- Images signed with cosign before deployment.
+- Monthly key rotation and vulnerability scans in CI.

--- a/apps/lucidia/agents/dockerfile
+++ b/apps/lucidia/agents/dockerfile
@@ -1,0 +1,5 @@
+# <!-- FILE: /apps/lucidia/agents/dockerfile -->
+FROM python:3.12-slim
+WORKDIR /app
+COPY worker.py ./
+CMD ["python", "worker.py"]

--- a/apps/lucidia/agents/worker.py
+++ b/apps/lucidia/agents/worker.py
@@ -1,0 +1,6 @@
+# <!-- FILE: /apps/lucidia/agents/worker.py -->
+import time
+
+while True:
+    print("lucidia agent heartbeat", flush=True)
+    time.sleep(30)

--- a/apps/lucidia/api/dockerfile
+++ b/apps/lucidia/api/dockerfile
@@ -1,0 +1,8 @@
+# <!-- FILE: /apps/lucidia/api/dockerfile -->
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json ./
+RUN npm install --production
+COPY server.js ./
+EXPOSE 8080
+CMD ["node", "server.js"]

--- a/apps/lucidia/api/package.json
+++ b/apps/lucidia/api/package.json
@@ -1,0 +1,9 @@
+# <!-- FILE: /apps/lucidia/api/package.json -->
+{
+  "name": "lucidia-api",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/apps/lucidia/api/server.js
+++ b/apps/lucidia/api/server.js
@@ -1,0 +1,9 @@
+// <!-- FILE: /apps/lucidia/api/server.js -->
+import express from 'express';
+const app = express();
+
+app.get('/health', (_, res) => res.send('ok'));
+app.get('/', (_, res) => res.json({status: 'lucidia api'}));
+
+const port = process.env.PORT || 8080;
+app.listen(port, () => console.log(`API listening on ${port}`));

--- a/apps/lucidia/systemd/lucidia-agents.service
+++ b/apps/lucidia/systemd/lucidia-agents.service
@@ -1,0 +1,14 @@
+# <!-- FILE: /apps/lucidia/systemd/lucidia-agents.service -->
+[Unit]
+Description=Lucidia Agents
+After=docker.service
+Requires=docker.service
+
+[Service]
+Restart=always
+WatchdogSec=30
+ExecStart=/usr/local/bin/docker compose -f /srv/blackroad/stack/docker-compose.yml up -d lucidia-agents
+ExecStop=/usr/local/bin/docker compose -f /srv/blackroad/stack/docker-compose.yml stop lucidia-agents
+
+[Install]
+WantedBy=multi-user.target

--- a/apps/lucidia/systemd/lucidia-api.service
+++ b/apps/lucidia/systemd/lucidia-api.service
@@ -1,0 +1,14 @@
+# <!-- FILE: /apps/lucidia/systemd/lucidia-api.service -->
+[Unit]
+Description=Lucidia API
+After=docker.service
+Requires=docker.service
+
+[Service]
+Restart=always
+WatchdogSec=30
+ExecStart=/usr/local/bin/docker compose -f /srv/blackroad/stack/docker-compose.yml up -d lucidia-api
+ExecStop=/usr/local/bin/docker compose -f /srv/blackroad/stack/docker-compose.yml stop lucidia-api
+
+[Install]
+WantedBy=multi-user.target

--- a/apps/lucidia/systemd/lucidia-web.service
+++ b/apps/lucidia/systemd/lucidia-web.service
@@ -1,0 +1,14 @@
+# <!-- FILE: /apps/lucidia/systemd/lucidia-web.service -->
+[Unit]
+Description=Lucidia Web
+After=docker.service
+Requires=docker.service
+
+[Service]
+Restart=always
+WatchdogSec=30
+ExecStart=/usr/local/bin/docker compose -f /srv/blackroad/stack/docker-compose.yml up -d lucidia-web
+ExecStop=/usr/local/bin/docker compose -f /srv/blackroad/stack/docker-compose.yml stop lucidia-web
+
+[Install]
+WantedBy=multi-user.target

--- a/apps/lucidia/web/dockerfile
+++ b/apps/lucidia/web/dockerfile
@@ -1,0 +1,3 @@
+# <!-- FILE: /apps/lucidia/web/dockerfile -->
+FROM nginx:1.27-alpine
+COPY index.html /usr/share/nginx/html/index.html

--- a/apps/lucidia/web/index.html
+++ b/apps/lucidia/web/index.html
@@ -1,0 +1,11 @@
+<!-- FILE: /apps/lucidia/web/index.html -->
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Lucidia</title>
+  </head>
+  <body>
+    <h1>Lucidia Web</h1>
+  </body>
+</html>

--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -1,0 +1,22 @@
+# <!-- FILE: /infra/caddy/Caddyfile -->
+{
+  admin off
+}
+
+blackroad.io {
+  encode gzip
+  reverse_proxy lucidia-web:80
+  header {
+    Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
+    X-Content-Type-Options nosniff
+    X-Frame-Options DENY
+    Referrer-Policy no-referrer
+  }
+}
+
+*.internal.blackroad.io {
+  tls {
+    ca http://stepca:9000
+  }
+  reverse_proxy {"{http.request.host}":8080}
+}

--- a/infra/dns/deploy.sh
+++ b/infra/dns/deploy.sh
@@ -1,0 +1,5 @@
+# <!-- FILE: /infra/dns/deploy.sh -->
+#!/usr/bin/env bash
+set -euo pipefail
+
+nsd-control reconfig

--- a/infra/dns/nsd.conf
+++ b/infra/dns/nsd.conf
@@ -1,0 +1,6 @@
+# <!-- FILE: /infra/dns/nsd.conf -->
+server:
+  ip-address: 0.0.0.0
+zone:
+  name: blackroad.io
+  zonefile: /etc/nsd/zone/blackroad.io.zone

--- a/infra/dns/zone/blackroad.io.zone
+++ b/infra/dns/zone/blackroad.io.zone
@@ -1,0 +1,14 @@
+# <!-- FILE: /infra/dns/zone/blackroad.io.zone -->
+$ORIGIN blackroad.io.
+@ 3600 IN SOA ns1.blackroad.io. admin.blackroad.io. (
+  2024010101 ; serial
+  3600       ; refresh
+  900        ; retry
+  604800     ; expire
+  86400 )    ; minimum
+
+@ 3600 IN NS ns1.blackroad.io.
+@ 3600 IN NS ns2.blackroad.io.
+ns1 3600 IN A 192.0.2.1
+ns2 3600 IN A 192.0.2.2
+@   3600 IN A 198.51.100.10

--- a/infra/hardening/audit.sh
+++ b/infra/hardening/audit.sh
@@ -1,0 +1,9 @@
+# <!-- FILE: /infra/hardening/audit.sh -->
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Checking SSH config"
+sshd -T | grep -E 'passwordauthentication|permitrootlogin'
+
+echo "Checking UFW"
+ufw status verbose

--- a/infra/hardening/secure-ssh.sh
+++ b/infra/hardening/secure-ssh.sh
@@ -1,0 +1,8 @@
+# <!-- FILE: /infra/hardening/secure-ssh.sh -->
+#!/usr/bin/env bash
+set -euo pipefail
+
+sed -i 's/^#PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config
+sed -i 's/^#PermitRootLogin prohibit-password/PermitRootLogin no/' /etc/ssh/sshd_config
+systemctl restart ssh
+apt-get update && apt-get install -y fail2ban

--- a/infra/hardening/ufw.sh
+++ b/infra/hardening/ufw.sh
@@ -1,0 +1,12 @@
+# <!-- FILE: /infra/hardening/ufw.sh -->
+#!/usr/bin/env bash
+set -euo pipefail
+
+ufw default deny incoming
+ufw default allow outgoing
+ufw allow 22/tcp
+ufw allow 80/tcp
+ufw allow 443/tcp
+ufw allow 51820/udp
+ufw allow from 127.0.0.1 proto tcp to any port 9100
+ufw --force enable

--- a/infra/provision.sh
+++ b/infra/provision.sh
@@ -1,0 +1,26 @@
+# <!-- FILE: /infra/provision.sh -->
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v docker >/dev/null; then
+  apt-get update && apt-get install -y ca-certificates curl gnupg lsb-release
+  install -m 0755 -d /etc/apt/keyrings
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+  echo "deb [arch=\$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \$(. /etc/os-release && echo \$VERSION_CODENAME) stable" > /etc/apt/sources.list.d/docker.list
+  apt-get update && apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+fi
+
+if ! command -v docker-compose >/dev/null; then
+  curl -L "https://github.com/docker/compose/releases/download/v2.20.3/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+  chmod +x /usr/local/bin/docker-compose
+fi
+
+cd "$(dirname "$0")/../stack"
+DOCKER_COMPOSE=docker-compose.yml
+if [ -f .env ]; then
+  export $(grep -v '^#' .env | xargs)
+fi
+
+/usr/local/bin/docker-compose -f "$DOCKER_COMPOSE" up -d
+
+echo "Stack deployed. Access Caddy on port 80/443."

--- a/infra/step-ca/bootstrap.sh
+++ b/infra/step-ca/bootstrap.sh
@@ -1,0 +1,5 @@
+# <!-- FILE: /infra/step-ca/bootstrap.sh -->
+#!/usr/bin/env bash
+set -euo pipefail
+
+step ca init --name "BlackRoad CA" --dns "stepca" --address ":9000" --provisioner "admin" --password-file <(echo "changeit")

--- a/infra/tor/torrc
+++ b/infra/tor/torrc
@@ -1,0 +1,3 @@
+# <!-- FILE: /infra/tor/torrc -->
+HiddenServiceDir /var/lib/tor/lucidia/
+HiddenServicePort 80 lucidia-web:80

--- a/infra/wireguard/ADD_NODE_CHECKLIST.md
+++ b/infra/wireguard/ADD_NODE_CHECKLIST.md
@@ -1,0 +1,7 @@
+<!-- FILE: /infra/wireguard/ADD_NODE_CHECKLIST.md -->
+# Add Node Checklist
+
+1. Run `infra/wireguard/gen-peers.sh peer1`.
+2. Append peer config to `wg0.conf` on existing nodes.
+3. Copy generated files to new node and start WireGuard.
+4. Apply `infra/hardening/secure-ssh.sh` and `infra/hardening/ufw.sh`.

--- a/infra/wireguard/gen-peers.sh
+++ b/infra/wireguard/gen-peers.sh
@@ -1,0 +1,10 @@
+# <!-- FILE: /infra/wireguard/gen-peers.sh -->
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${1:-}" ]; then
+  echo "usage: $0 peer_name" >&2
+  exit 1
+fi
+
+wg genkey | tee "$1.key" | wg pubkey > "$1.pub"

--- a/infra/wireguard/wg0.conf.template
+++ b/infra/wireguard/wg0.conf.template
@@ -1,0 +1,11 @@
+# <!-- FILE: /infra/wireguard/wg0.conf.template -->
+[Interface]
+Address = 10.10.0.1/32
+ListenPort = 51820
+PrivateKey = AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+
+# Peer example
+#[Peer]
+#PublicKey = BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=
+#AllowedIPs = 10.10.0.2/32
+#Endpoint = peer.example.com:51820

--- a/ops/backup/backup.service
+++ b/ops/backup/backup.service
@@ -1,0 +1,8 @@
+# <!-- FILE: /ops/backup/backup.service -->
+[Unit]
+Description=Restic backup
+
+[Service]
+Type=oneshot
+EnvironmentFile=/srv/blackroad/ops/backup/restic.env
+ExecStart=/usr/local/bin/restic backup /srv/blackroad

--- a/ops/backup/backup.timer
+++ b/ops/backup/backup.timer
@@ -1,0 +1,10 @@
+# <!-- FILE: /ops/backup/backup.timer -->
+[Unit]
+Description=Daily restic backup
+
+[Timer]
+OnCalendar=daily
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/ops/backup/restic.env
+++ b/ops/backup/restic.env
@@ -1,0 +1,5 @@
+# <!-- FILE: /ops/backup/restic.env -->
+RESTIC_REPOSITORY=s3:http://minio:9000/lucidia-backups
+RESTIC_PASSWORD=restic_pass
+AWS_ACCESS_KEY_ID=minio
+AWS_SECRET_ACCESS_KEY=minio123

--- a/ops/backup/restic_setup.sh
+++ b/ops/backup/restic_setup.sh
@@ -1,0 +1,10 @@
+# <!-- FILE: /ops/backup/restic_setup.sh -->
+#!/usr/bin/env bash
+set -euo pipefail
+
+export RESTIC_REPOSITORY="s3:http://minio:9000/lucidia-backups"
+export RESTIC_PASSWORD="restic_pass"
+export AWS_ACCESS_KEY_ID="minio"
+export AWS_SECRET_ACCESS_KEY="minio123"
+
+restic init || true

--- a/ops/backup/restore_example.md
+++ b/ops/backup/restore_example.md
@@ -1,0 +1,7 @@
+<!-- FILE: /ops/backup/restore_example.md -->
+# Restore Example
+
+```bash
+source restic.env
+restic restore latest --target /tmp/restore-test
+```

--- a/ops/ci/pipeline.yml
+++ b/ops/ci/pipeline.yml
@@ -1,0 +1,13 @@
+# <!-- FILE: /ops/ci/pipeline.yml -->
+name: build
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build image
+        run: |
+          docker build -t harbor/blackroad/lucidia-api:$(git rev-parse --short HEAD) apps/lucidia/api
+          cosign sign --key cosign.key harbor/blackroad/lucidia-api:$(git rev-parse --short HEAD)
+          docker push harbor/blackroad/lucidia-api:$(git rev-parse --short HEAD)

--- a/ops/health/check.sh
+++ b/ops/health/check.sh
@@ -1,0 +1,5 @@
+# <!-- FILE: /ops/health/check.sh -->
+#!/usr/bin/env bash
+set -e
+
+curl -sf http://localhost:8080/health >/dev/null && echo "API ok" || echo "API down"

--- a/ops/scripts/pg-failover.sh
+++ b/ops/scripts/pg-failover.sh
@@ -1,0 +1,5 @@
+# <!-- FILE: /ops/scripts/pg-failover.sh -->
+#!/usr/bin/env bash
+set -euo pipefail
+
+docker exec postgres-replica repmgr standby promote

--- a/ops/scripts/switch_traffic.sh
+++ b/ops/scripts/switch_traffic.sh
@@ -1,0 +1,13 @@
+# <!-- FILE: /ops/scripts/switch_traffic.sh -->
+#!/usr/bin/env bash
+set -euo pipefail
+
+# usage: switch_traffic.sh new_service old_service
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 new_service old_service" >&2
+  exit 1
+fi
+
+compose=/srv/blackroad/stack/docker-compose.yml
+/usr/local/bin/docker compose -f "$compose" up -d "$1"
+/usr/local/bin/docker compose -f "$compose" stop "$2"

--- a/ops/scripts/test-restore.sh
+++ b/ops/scripts/test-restore.sh
@@ -1,0 +1,6 @@
+# <!-- FILE: /ops/scripts/test-restore.sh -->
+#!/usr/bin/env bash
+set -euo pipefail
+
+source ../backup/restic.env
+restic restore latest --target /tmp/restore-test

--- a/stack/docker-compose.yml
+++ b/stack/docker-compose.yml
@@ -1,0 +1,214 @@
+# <!-- FILE: /stack/docker-compose.yml -->
+version: "3.8"
+
+services:
+  caddy:
+    image: caddy:2-alpine
+    container_name: caddy
+    restart: always
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ../infra/caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      - stepca
+
+  stepca:
+    image: smallstep/step-ca:0.27.4
+    container_name: stepca
+    restart: always
+    volumes:
+      - ../infra/step-ca:/home/step
+    environment:
+      STEP_CA_INIT_NAME: "BlackRoad CA"
+      STEP_CA_INIT_DNS_NAMES: "stepca"
+      STEP_CA_INIT_PASSWORD: "changeit"
+    ports:
+      - "9000:9000"
+
+  vault:
+    image: hashicorp/vault:1.15
+    container_name: vault
+    restart: always
+    cap_add:
+      - IPC_LOCK
+    environment:
+      VAULT_LOCAL_CONFIG: '{"backend":{"file":{"path":"/vault/file"}},"listener":{"tcp":{"address":"0.0.0.0:8200","tls_disable":1}},"default_lease_ttl":"168h","max_lease_ttl":"720h"}'
+    volumes:
+      - vault_data:/vault/file
+    ports:
+      - "8200:8200"
+
+  gitea:
+    image: gitea/gitea:1.21.0
+    container_name: gitea
+    restart: always
+    environment:
+      - USER_UID=1000
+      - USER_GID=1000
+      - GITEA__database__DB_TYPE=postgres
+      - GITEA__database__HOST=postgres-primary:5432
+      - GITEA__database__NAME=gitea
+      - GITEA__database__USER=gitea
+      - GITEA__database__PASSWD=gitea_pass
+    depends_on:
+      - postgres-primary
+    volumes:
+      - gitea_data:/data
+    ports:
+      - "3000:3000"
+      - "2222:22"
+
+  gitea-runner:
+    image: gitea/act_runner:0.2.6
+    container_name: gitea-runner
+    restart: always
+    environment:
+      - GITEA_INSTANCE_URL=http://gitea:3000
+      - GITEA_RUNNER_REGISTRATION_TOKEN=changeme
+    depends_on:
+      - gitea
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  harbor:
+    image: goharbor/harbor-core:v2.9.0
+    container_name: harbor
+    restart: always
+    environment:
+      - POSTGRESQL_HOST=postgres-primary
+      - POSTGRESQL_USERNAME=harbor
+      - POSTGRESQL_PASSWORD=harbor_pass
+      - POSTGRESQL_DATABASE=harbor
+      - REGISTRY_STORAGE_PROVIDER_NAME=s3
+      - REGISTRY_STORAGE_PROVIDER_CONFIG=/{"region":"us-east-1","bucket":"harbor-registry","accesskey":"minio","secretkey":"minio123","regionendpoint":"http://minio:9000","encrypt":false}
+    depends_on:
+      - postgres-primary
+      - minio
+    volumes:
+      - harbor_data:/harbor
+    ports:
+      - "8443:8443"
+
+  minio:
+    image: minio/minio:RELEASE.2024-01-18T22-51-28Z
+    container_name: minio
+    restart: always
+    environment:
+      - MINIO_ROOT_USER=minio
+      - MINIO_ROOT_PASSWORD=minio123
+    command: server /data --console-address ":9001"
+    volumes:
+      - minio_data:/data
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+
+  postgres-primary:
+    image: bitnami/postgresql-repmgr:16
+    container_name: postgres-primary
+    restart: always
+    environment:
+      - POSTGRESQL_POSTGRES_PASSWORD=supersecret
+      - POSTGRESQL_USERNAME=blackroad
+      - POSTGRESQL_PASSWORD=blackroad_pass
+      - POSTGRESQL_DATABASE=blackroad
+      - REPMGR_PRIMARY_ROLE=primary
+      - REPMGR_PARTNER_NODES=postgres-primary,postgres-replica
+      - REPMGR_PASSWORD=repmgr_pass
+      - REPMGR_PRIMARY_HOST=postgres-primary
+      - REPMGR_NODE_NAME=postgres-primary
+      - REPMGR_NODE_NETWORK_NAME=postgres-primary
+    volumes:
+      - pg_primary:/bitnami/postgresql
+    ports:
+      - "5432:5432"
+
+  postgres-replica:
+    image: bitnami/postgresql-repmgr:16
+    container_name: postgres-replica
+    restart: always
+    environment:
+      - POSTGRESQL_POSTGRES_PASSWORD=supersecret
+      - POSTGRESQL_USERNAME=blackroad
+      - POSTGRESQL_PASSWORD=blackroad_pass
+      - POSTGRESQL_DATABASE=blackroad
+      - REPMGR_PRIMARY_ROLE=replica
+      - REPMGR_PARTNER_NODES=postgres-primary,postgres-replica
+      - REPMGR_PASSWORD=repmgr_pass
+      - REPMGR_PRIMARY_HOST=postgres-primary
+      - REPMGR_NODE_NAME=postgres-replica
+      - REPMGR_NODE_NETWORK_NAME=postgres-replica
+    depends_on:
+      - postgres-primary
+    volumes:
+      - pg_replica:/bitnami/postgresql
+
+  redis-cluster:
+    image: bitnami/redis-cluster:7.2
+    container_name: redis-cluster
+    restart: always
+    environment:
+      - REDIS_PASSWORD=redispass
+      - REDISCLI_AUTH=redispass
+    ports:
+      - "7000-7005:7000-7005"
+
+  meilisearch:
+    image: getmeili/meilisearch:v1.6
+    container_name: meilisearch
+    restart: always
+    environment:
+      - MEILI_MASTER_KEY=meili_master
+    ports:
+      - "7700:7700"
+    volumes:
+      - meili_data:/meili_data
+
+  lucidia-api:
+    build: ../apps/lucidia/api
+    container_name: lucidia-api
+    restart: always
+    environment:
+      - NODE_ENV=production
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    depends_on:
+      - postgres-primary
+      - redis-cluster
+
+  lucidia-agents:
+    build: ../apps/lucidia/agents
+    container_name: lucidia-agents
+    restart: always
+    environment:
+      - NODE_ENV=production
+    depends_on:
+      - lucidia-api
+      - redis-cluster
+
+  lucidia-web:
+    build: ../apps/lucidia/web
+    container_name: lucidia-web
+    restart: always
+    ports:
+      - "8080:80"
+    depends_on:
+      - lucidia-api
+
+volumes:
+  caddy_data:
+  caddy_config:
+  vault_data:
+  gitea_data:
+  harbor_data:
+  minio_data:
+  pg_primary:
+  pg_replica:
+  meili_data:


### PR DESCRIPTION
## Summary
- add docker compose stack with core self-hosted services
- add provisioning, hardening, and backup scripts for local infrastructure
- document runbook, backup policy, and security baseline

## Testing
- `pre-commit run --files $(git ls-files --others --exclude-standard)` *(fails: command not found)*
- `pip install pre-commit` *(fails: Tunnel connection failed: 403 Forbidden)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e84f655883299acc1ba99220ba71