### PR TITLE
Add local ES training utilities

### DIFF
--- a/README_LOCAL.md
+++ b/README_LOCAL.md
@@ -1,0 +1,23 @@
+# Local Evolution Strategies
+
+This directory provides a local-first pathway for running the Evolution Strategies starter without AWS.
+
+## Setup
+
+```bash
+bash scripts/setup_local.sh
+```
+
+## Training CartPole
+
+```bash
+bash scripts/run_local.sh
+```
+
+TensorBoard will be available on [http://localhost:6006](http://localhost:6006).
+
+Checkpoints are saved under `checkpoints/es_cartpole/`.
+
+## Extending
+
+The code is structured to make it easy to swap environments or models. To enable MuJoCo or Atari later, install the relevant `gymnasium` extras and update `run_cartpole.py`.

--- a/local/es_core.py
+++ b/local/es_core.py
@@ -1,0 +1,48 @@
+# mypy: ignore-errors
+"""Core Evolution Strategies utilities for local training."""
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor
+
+
+def evaluate(env, model, params: Tensor, episodes: int, seed: int) -> float:
+    """Evaluate a policy with given parameters and return mean reward."""
+    from .models import vector_to_params
+
+    vector_to_params(params, model)
+    total_reward = 0.0
+    for ep in range(episodes):
+        obs, _ = env.reset(seed=seed + ep)
+        done = False
+        while not done:
+            obs_t = torch.as_tensor(obs, dtype=torch.float32)
+            logits = model(obs_t)
+            action = int(torch.argmax(logits).item())
+            obs, reward, terminated, truncated, _ = env.step(action)
+            total_reward += reward
+            done = terminated or truncated
+    return total_reward / episodes
+
+
+def sample_noise(generator: torch.Generator, size: int) -> Tensor:
+    """Sample Gaussian noise."""
+    return torch.randn(size, generator=generator)
+
+
+def estimate_gradient(
+    noises: Tensor,
+    rewards_pos: Tensor,
+    rewards_neg: Tensor,
+    sigma: float,
+) -> Tensor:
+    """Estimate gradient using antithetic sampling."""
+    returns = rewards_pos - rewards_neg
+    grad = (returns[:, None] * noises).mean(dim=0) / (2 * sigma)
+    return grad
+
+
+def update(params: Tensor, grad: Tensor, lr: float, weight_decay: float) -> Tensor:
+    """Apply gradient update with weight decay."""
+    return params + lr * grad - weight_decay * params

--- a/local/models.py
+++ b/local/models.py
@@ -1,0 +1,44 @@
+# mypy: ignore-errors
+"""Model definitions for local ES training."""
+
+from __future__ import annotations
+
+import torch
+from torch import nn, Tensor
+
+
+class MLPPolicy(nn.Module):
+    """Simple MLP policy network."""
+
+    def __init__(self, obs_dim: int, act_dim: int) -> None:
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(obs_dim, 64),
+            nn.Tanh(),
+            nn.Linear(64, 64),
+            nn.Tanh(),
+            nn.Linear(64, act_dim),
+        )
+
+    def forward(self, obs: Tensor) -> Tensor:
+        return self.net(obs)
+
+
+def params_to_vector(model: nn.Module) -> Tensor:
+    """Flatten model parameters to a 1D tensor."""
+    return torch.nn.utils.parameters_to_vector(model.parameters())
+
+
+def vector_to_params(vec: Tensor, model: nn.Module) -> None:
+    """Load a 1D tensor into a model's parameters."""
+    torch.nn.utils.vector_to_parameters(vec, model.parameters())
+
+
+def num_params(model: nn.Module) -> int:
+    """Return number of parameters in the model."""
+    return sum(p.numel() for p in model.parameters())
+
+
+def perturb_params(params: Tensor, noise: Tensor, sigma: float) -> Tensor:
+    """Apply noise to parameter vector."""
+    return params + sigma * noise

--- a/local/run_cartpole.py
+++ b/local/run_cartpole.py
@@ -1,0 +1,128 @@
+# mypy: ignore-errors
+"""Run Evolution Strategies training on CartPole-v1 locally."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import random
+import signal
+import time
+from pathlib import Path
+
+import gymnasium as gym
+import numpy as np
+import torch
+from torch.utils.tensorboard import SummaryWriter
+
+from .es_core import estimate_gradient, evaluate, update
+from .models import MLPPolicy, params_to_vector, vector_to_params
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="ES CartPole")
+    parser.add_argument("--iterations", type=int, default=200, help="training iterations")
+    parser.add_argument("--timesteps", type=int, help="alias for --iterations")
+    parser.add_argument("--popsize", type=int, default=64, help="population size (even)")
+    parser.add_argument("--sigma", type=float, default=0.1, help="noise stddev")
+    parser.add_argument("--lr", type=float, default=0.02, help="learning rate")
+    parser.add_argument("--weight-decay", type=float, default=0.005, help="weight decay")
+    parser.add_argument("--seed", type=int, default=0, help="random seed")
+    parser.add_argument("--eval-episodes", type=int, default=5, help="episodes for evaluation")
+    parser.add_argument("--save-interval", type=int, default=10, help="checkpoint interval")
+    parser.add_argument("--resume", type=str, default=None, help="path to checkpoint to resume")
+    return parser.parse_args()
+
+
+def save_checkpoint(directory: Path, iteration: int, params: torch.Tensor, args: argparse.Namespace, name: str | None = None) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    name = name or f"iter_{iteration}"
+    state_path = directory / f"{name}_state_dict.pt"
+    meta_path = directory / f"{name}.json"
+    torch.save({"iteration": iteration, "params": params}, state_path)
+    with open(meta_path, "w", encoding="utf-8") as f:
+        json.dump({"iteration": iteration, "args": vars(args)}, f, indent=2)
+    torch.save({"iteration": iteration, "params": params}, directory / "latest.pt")
+    with open(directory / "latest.json", "w", encoding="utf-8") as f:
+        json.dump({"iteration": iteration, "args": vars(args)}, f, indent=2)
+
+
+def main() -> None:
+    args = parse_args()
+    if args.timesteps is not None:
+        args.iterations = args.timesteps
+
+    if args.popsize % 2 != 0:
+        raise ValueError("popsize must be even for antithetic sampling")
+
+    torch.manual_seed(args.seed)
+    np.random.seed(args.seed)
+    random.seed(args.seed)
+
+    env = gym.make("CartPole-v1")
+    obs_dim = env.observation_space.shape[0]
+    act_dim = env.action_space.n
+    policy = MLPPolicy(obs_dim, act_dim)
+    params = params_to_vector(policy)
+    start_iter = 0
+    if args.resume is not None:
+        ckpt = torch.load(args.resume)
+        params = ckpt["params"]
+        start_iter = int(ckpt.get("iteration", 0))
+        vector_to_params(params, policy)
+
+    log_dir = Path("runs/es_local")
+    log_dir.mkdir(parents=True, exist_ok=True)
+    writer = SummaryWriter(log_dir)
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(message)s",
+        handlers=[
+            logging.StreamHandler(),
+            logging.FileHandler(log_dir / "train.log"),
+        ],
+    )
+
+    checkpoint_dir = Path("checkpoints/es_cartpole")
+    generator = torch.Generator().manual_seed(args.seed)
+
+    stop = {"flag": False}
+
+    def handle_sigint(signum, frame):
+        stop["flag"] = True
+
+    signal.signal(signal.SIGINT, handle_sigint)
+
+    for iteration in range(start_iter, args.iterations):
+        t0 = time.time()
+        noises = torch.randn(args.popsize // 2, params.numel(), generator=generator)
+        rewards_pos = torch.empty(args.popsize // 2)
+        rewards_neg = torch.empty(args.popsize // 2)
+        for i, noise in enumerate(noises):
+            base_seed = args.seed + iteration * args.popsize + i * 2
+            r_pos = evaluate(env, policy, params + args.sigma * noise, 1, base_seed)
+            r_neg = evaluate(env, policy, params - args.sigma * noise, 1, base_seed + 1)
+            rewards_pos[i] = r_pos
+            rewards_neg[i] = r_neg
+        grad = estimate_gradient(noises, rewards_pos, rewards_neg, args.sigma)
+        params = update(params, grad, args.lr, args.weight_decay)
+        vector_to_params(params, policy)
+        avg_reward = evaluate(env, policy, params, args.eval_episodes, args.seed + iteration)
+        step_time = time.time() - t0
+        writer.add_scalar("avg_reward", avg_reward, iteration)
+        writer.add_scalar("lr", args.lr, iteration)
+        writer.add_scalar("sigma", args.sigma, iteration)
+        writer.add_scalar("step_time", step_time, iteration)
+        logging.info("iter %d avg_reward %.2f", iteration, avg_reward)
+        if (iteration + 1) % args.save_interval == 0:
+            save_checkpoint(checkpoint_dir, iteration + 1, params, args)
+        if stop["flag"]:
+            logging.info("SIGINT received, saving checkpoint and exiting")
+            save_checkpoint(checkpoint_dir, iteration + 1, params, args, name="interrupted")
+            break
+    writer.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/local/test_vectorization.py
+++ b/local/test_vectorization.py
@@ -1,0 +1,17 @@
+# mypy: ignore-errors
+"""Tests for parameter vector utilities."""
+
+from __future__ import annotations
+
+import torch
+
+from .models import MLPPolicy, params_to_vector, vector_to_params
+
+
+def test_vector_round_trip() -> None:
+    policy = MLPPolicy(4, 2)
+    vec = params_to_vector(policy)
+    perturbed = vec + torch.randn_like(vec)
+    vector_to_params(perturbed, policy)
+    new_vec = params_to_vector(policy)
+    assert torch.allclose(perturbed, new_vec)

--- a/patches/non_aws_cleanup.patch
+++ b/patches/non_aws_cleanup.patch
@@ -1,0 +1,13 @@
+diff --git a/remote.py b/remote.py
+index 1111111..2222222 100644
+--- a/remote.py
++++ b/remote.py
+@@
+-    parser.add_argument('--ec2', action='store_true', help='launch on EC2')
++    parser.add_argument('--ec2', action='store_true', help='launch on EC2 (disabled locally)')
+@@
+-    if args.ec2:
+-        launch_ec2()
+-        return
++    if args.ec2:
++        raise RuntimeError('EC2 launching is disabled for local usage. Run without --ec2.')

--- a/requirements-local.txt
+++ b/requirements-local.txt
@@ -1,0 +1,10 @@
+numpy==1.26.4
+scipy==1.11.4
+gymnasium==0.29.1
+gymnasium[classic-control]==0.29.1
+torch==2.1.2
+tensorboard==2.15.1
+tqdm==4.66.1
+click==8.1.7
+cloudpickle==2.2.1
+mpi4py==3.1.5

--- a/scripts/run_local.sh
+++ b/scripts/run_local.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck disable=SC1091
+source .venv/bin/activate
+
+mkdir -p runs/es_local
+
+tensorboard --logdir runs/es_local --port 6006 &
+TB_PID=$!
+
+tail -n 20 -F runs/es_local/train.log &
+TAIL_PID=$!
+
+python -m local.run_cartpole "$@"
+
+kill $TB_PID $TAIL_PID 2>/dev/null || true

--- a/scripts/setup_local.sh
+++ b/scripts/setup_local.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create virtual environment
+if [ ! -d ".venv" ]; then
+  python3 -m venv .venv
+fi
+# shellcheck disable=SC1091
+source .venv/bin/activate
+
+python -m pip install --upgrade pip
+pip install -r requirements-local.txt
+
+cat <<'MSG'
+MuJoCo dependencies are skipped. To enable MuJoCo later, install mujoco and gymnasium[mujoco].
+MSG
+
+python - <<'PY'
+import importlib
+mods = ["numpy", "scipy", "gymnasium", "torch", "tensorboard", "tqdm", "click", "cloudpickle"]
+for m in mods:
+    importlib.import_module(m)
+print("\N{white heavy check mark} READY")
+PY


### PR DESCRIPTION
## Summary
- add local requirements and setup script
- implement CartPole ES training loop with logging and checkpoints
- provide docs and helper scripts for local execution

## Testing
- `pre-commit run --files requirements-local.txt README_LOCAL.md scripts/setup_local.sh scripts/run_local.sh local/models.py local/es_core.py local/run_cartpole.py local/test_vectorization.py patches/non_aws_cleanup.patch` *(fails: command not found)*
- `python -m pip install pre-commit` *(fails: Could not connect to proxy)*
- `pytest local/test_vectorization.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68a4e95fee4c8329b955e77bfb4d639d