### PR TITLE
Add initial infrastructure skeleton

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,15 @@
+# Infrastructure Skeleton
+
+This directory contains an initial skeleton for provisioning a self-hosted Lucidia stack on
+BlackRoad-controlled infrastructure. The layout uses Ansible playbooks to configure a
+highly-available k3s cluster backed by Longhorn for storage and MinIO for object
+hosting. All playbooks are currently placeholders awaiting implementation.
+
+## Structure
+- `bootstrap.sh` – convenience script to run the full Ansible bootstrap.
+- `ansible/` – Ansible inventory, playbooks, and roles.
+  - `playbooks/` – entry points for each major component.
+  - `roles/` – component roles with placeholder tasks.
+
+Customize `ansible/inventory.ini` with hostnames or IPs for your environment before
+running the bootstrap script.

--- a/infra/ansible/inventory.ini
+++ b/infra/ansible/inventory.ini
@@ -1,0 +1,13 @@
+[controllers]
+controller1 ansible_host=10.0.0.11
+controller2 ansible_host=10.0.0.12
+controller3 ansible_host=10.0.0.13
+
+[workers]
+worker1 ansible_host=10.0.0.21
+worker2 ansible_host=10.0.0.22
+worker3 ansible_host=10.0.0.23
+
+[k3s_cluster:children]
+controllers
+workers

--- a/infra/ansible/playbooks/bootstrap.yml
+++ b/infra/ansible/playbooks/bootstrap.yml
@@ -1,0 +1,6 @@
+---
+# Master playbook chaining all component playbooks
+- import_playbook: wireguard.yml
+- import_playbook: k3s-ha.yml
+- import_playbook: longhorn.yml
+- import_playbook: minio.yml

--- a/infra/ansible/playbooks/k3s-ha.yml
+++ b/infra/ansible/playbooks/k3s-ha.yml
@@ -1,0 +1,10 @@
+---
+- hosts: controllers
+  become: true
+  roles:
+    - { role: k3s, k3s_role: controller }
+
+- hosts: workers
+  become: true
+  roles:
+    - { role: k3s, k3s_role: worker }

--- a/infra/ansible/playbooks/longhorn.yml
+++ b/infra/ansible/playbooks/longhorn.yml
@@ -1,0 +1,5 @@
+---
+- hosts: controllers
+  become: true
+  roles:
+    - longhorn

--- a/infra/ansible/playbooks/minio.yml
+++ b/infra/ansible/playbooks/minio.yml
@@ -1,0 +1,5 @@
+---
+- hosts: controllers
+  become: true
+  roles:
+    - minio

--- a/infra/ansible/playbooks/wireguard.yml
+++ b/infra/ansible/playbooks/wireguard.yml
@@ -1,0 +1,5 @@
+---
+- hosts: all
+  become: true
+  roles:
+    - wireguard

--- a/infra/ansible/roles/common/tasks/main.yml
+++ b/infra/ansible/roles/common/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Base system preparation placeholder
+  debug:
+    msg: "Common baseline tasks would run here"

--- a/infra/ansible/roles/k3s/tasks/main.yml
+++ b/infra/ansible/roles/k3s/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Install k3s {{ k3s_role }} (placeholder)
+  debug:
+    msg: "k3s would be installed in {{ k3s_role }} mode"

--- a/infra/ansible/roles/longhorn/tasks/main.yml
+++ b/infra/ansible/roles/longhorn/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Deploy Longhorn (placeholder)
+  debug:
+    msg: "Longhorn deployment would be orchestrated here"

--- a/infra/ansible/roles/minio/tasks/main.yml
+++ b/infra/ansible/roles/minio/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Deploy MinIO (placeholder)
+  debug:
+    msg: "MinIO cluster would be deployed and configured here"

--- a/infra/ansible/roles/wireguard/tasks/main.yml
+++ b/infra/ansible/roles/wireguard/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Configure WireGuard mesh (placeholder)
+  debug:
+    msg: "WireGuard configuration would be applied here"

--- a/infra/bootstrap.sh
+++ b/infra/bootstrap.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run the full bootstrap playbook which chains all component playbooks.
+ANSIBLE_INVENTORY=${ANSIBLE_INVENTORY:-ansible/inventory.ini}
+
+ansible-playbook -i "$ANSIBLE_INVENTORY" ansible/playbooks/bootstrap.yml


### PR DESCRIPTION
## Summary
- scaffold infrastructure directory with Ansible inventory, playbooks, and roles
- include bootstrap.sh to run full provisioning sequence
- document usage and structure in infra/README.md

## Testing
- `npm run lint` *(fails: Invalid package.json: JSONParseError: Expected ',' or '}' after property value in JSON)*
- `npm run typecheck` *(fails: Invalid package.json: JSONParseError: Expected ',' or '}' after property value in JSON)*
- `npm test` *(fails: Invalid package.json: JSONParseError: Expected ',' or '}' after property value in JSON)*
- `npm run build` *(fails: Invalid package.json: JSONParseError: Expected ',' or '}' after property value in JSON)*
- `node scripts/healthcheck.js` *(fails: Error: Invalid package config /workspace/blackroad-prism-console/package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4eab613448329a6ffcc89d4dbc89f