### PR TITLE
feat: add offline meteoroid environment module

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,8 @@
+This project includes an independent implementation of concepts from:
+
+Moorhead, A. V., et al. "Modeling the meteoroid environment far from the
+ ecliptic plane / MEM 3.1-alpha." Journal of Geophysical Research: Planets
+ (2014).
+
+The equations have been rederived and implemented from the publication; no
+source code from that work or from NASA/JPL projects has been used.

--- a/examples/meteoroid_demo.ipynb
+++ b/examples/meteoroid_demo.ipynb
@@ -1,0 +1,43 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Meteoroid environment demo\n",
+    "This notebook demonstrates the offline `astro.meteoroid_env` module."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lucidia.astro.meteoroid_env import OrbitalElements, TargetPoint, number_density, encounter_velocities\n",
+    "from lucidia.astro.meteoroid_env.units import AU, ms_to_kms\n",
+    "\n",
+    "elements = OrbitalElements(a=AU, e=0.1, i=0.3)\n",
+    "point = TargetPoint(AU, 0.0, 0.0)\n",
+    "\n",
+    "n = number_density(elements, point)\n",
+    "vels = encounter_velocities(elements, point)\n",
+    "vels_kms = ms_to_kms(vels)\n",
+    "n, vels_kms"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/lucidia/__init__.py
+++ b/lucidia/__init__.py
@@ -1,0 +1,1 @@
+"""Lucidia namespace package."""

--- a/lucidia/astro/__init__.py
+++ b/lucidia/astro/__init__.py
@@ -1,0 +1,1 @@
+"""Astrophysics utilities for Lucidia."""

--- a/lucidia/astro/meteoroid_env/__init__.py
+++ b/lucidia/astro/meteoroid_env/__init__.py
@@ -1,0 +1,15 @@
+"""Minimal meteoroid environment module.
+
+This package provides simple, fully offline estimators for meteoroid number
+density and encounter velocities in heliocentric space.  It is intentionally
+small and self-contained so it can be embedded within agents without pulling
+in large external dependencies or network resources.
+"""
+from .api import OrbitalElements, TargetPoint, encounter_velocities, number_density
+
+__all__ = [
+    "OrbitalElements",
+    "TargetPoint",
+    "number_density",
+    "encounter_velocities",
+]

--- a/lucidia/astro/meteoroid_env/api.py
+++ b/lucidia/astro/meteoroid_env/api.py
@@ -1,0 +1,55 @@
+"""Public façade for the meteoroid environment module."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .kernels import encounter_velocities_kernel, number_density_kernel
+
+__all__ = [
+    "OrbitalElements",
+    "TargetPoint",
+    "number_density",
+    "encounter_velocities",
+]
+
+
+@dataclass
+class OrbitalElements:
+    """Elliptic orbital elements."""
+
+    a: float  # semi-major axis [m]
+    e: float  # eccentricity [0..1)
+    i: float  # inclination [rad]
+
+
+@dataclass
+class TargetPoint:
+    """Cartesian heliocentric position."""
+
+    x: float
+    y: float
+    z: float
+
+
+def number_density(elements: OrbitalElements, point: TargetPoint) -> float:
+    """Return meteoroid number density at ``point`` [1/m^3]."""
+
+    r_vec = np.array([point.x, point.y, point.z], dtype=float)
+    return float(number_density_kernel(r_vec))
+
+
+def encounter_velocities(
+    elements: OrbitalElements, point: TargetPoint
+) -> NDArray[np.float64]:
+    """Return encounter velocity vectors for the given configuration.
+
+    The result may contain from zero to four vectors depending on whether the
+    geometry admits valid solutions.  Each row is one 3D velocity in [m/s].
+    """
+
+    r_vec = np.array([point.x, point.y, point.z], dtype=float)
+    return encounter_velocities_kernel(elements.a, elements.e, elements.i, r_vec)

--- a/lucidia/astro/meteoroid_env/kernels.py
+++ b/lucidia/astro/meteoroid_env/kernels.py
@@ -1,0 +1,171 @@
+"""Physics kernels for the meteoroid environment module.
+
+The routines here implement a small subset of orbital mechanics required for
+estimating meteoroid encounter velocities and number densities.  The
+implementation is self-contained and based on equations described by
+Moorhead et al., *Modeling the meteoroid environment far from the ecliptic
+plane / MEM 3.1-alpha*.  No code from that work is used here – only the
+published mathematical relationships.
+
+All functions operate purely on NumPy arrays and float types; no external
+state is touched.  Constants are defined locally to keep the module
+self-contained.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List
+
+import numpy as np
+from numpy.typing import NDArray
+
+__all__ = [
+    "GM_SUN",
+    "vis_viva",
+    "number_density_kernel",
+    "encounter_velocities_kernel",
+]
+
+# Standard gravitational parameter of the Sun [m^3/s^2].  This value is
+# published by the International Astronomical Union and is widely available in
+# scientific literature.
+GM_SUN: float = 1.327_124_400_18e20
+
+
+def vis_viva(a: float, r: float, gm: float = GM_SUN) -> float:
+    """Velocity magnitude for an object in an ellipse.
+
+    Parameters
+    ----------
+    a : float
+        Semi-major axis [m]. Must be positive.
+    r : float
+        Heliocentric distance of the object [m]. Must be positive.
+    gm : float, optional
+        Gravitational parameter [m^3/s^2]; defaults to :data:`GM_SUN`.
+
+    Returns
+    -------
+    float
+        Orbital speed [m/s].
+    """
+    if a <= 0 or r <= 0:
+        raise ValueError("Semi-major axis and radius must be positive")
+    return np.sqrt(gm * (2.0 / r - 1.0 / a))
+
+
+# --- Number density -------------------------------------------------------
+# The model is intentionally simple: a power-law radial falloff combined with a
+# vertical exponential scale height.  This mirrors the qualitative behaviour
+# described by Moorhead et al. without reproducing any proprietary constants.
+
+_N0 = 1.0e-6  # number density at 1 au in the ecliptic [1/m^3]
+_R0 = 1.495_978_707e11  # 1 au in metres
+_ALPHA = 1.3
+_H = 0.1 * _R0  # vertical scale height
+
+
+def number_density_kernel(r_vec: NDArray[np.float64]) -> float:
+    """Estimate meteoroid number density at a heliocentric point.
+
+    Parameters
+    ----------
+    r_vec : array-like, shape (3,)
+        Cartesian heliocentric position [m].
+
+    Returns
+    -------
+    float
+        Number density [1/m^3].
+    """
+    r = np.linalg.norm(r_vec)
+    if r == 0.0:
+        raise ValueError("Target point cannot be at the solar centre")
+    z = abs(r_vec[2])
+    radial = (_R0 / r) ** _ALPHA
+    vertical = np.exp(-z / _H)
+    return _N0 * radial * vertical
+
+
+# --- Encounter velocity geometry -----------------------------------------
+
+def _plane_normals(r_vec: NDArray[np.float64], incl: float) -> List[NDArray[np.float64]]:
+    """Return all orbital plane normals for an orbit of inclination `incl` passing
+    through position `r_vec`.
+
+    The method follows the geometric construction described by Moorhead et
+    al., yielding up to two possible plane orientations.
+    """
+    r_hat = r_vec / np.linalg.norm(r_vec)
+    k_hat = np.array([0.0, 0.0, 1.0])
+    # construct basis vectors spanning the plane perpendicular to r
+    if np.allclose(r_hat, k_hat) or np.allclose(r_hat, -k_hat):
+        temp = np.array([1.0, 0.0, 0.0])
+    else:
+        temp = k_hat
+    u = np.cross(temp, r_hat)
+    u /= np.linalg.norm(u)
+    v = np.cross(r_hat, u)
+
+    A = u[2]
+    B = v[2]
+    C = np.hypot(A, B)
+    cos_i = np.cos(incl)
+    if C == 0:
+        return []
+    if abs(cos_i) > C + 1e-12:
+        return []
+    phi = np.arctan2(B, A)
+    delta = np.arccos(np.clip(cos_i / C, -1.0, 1.0))
+    normals = []
+    for alpha in (phi + delta, phi - delta):
+        n = u * np.cos(alpha) + v * np.sin(alpha)
+        normals.append(n / np.linalg.norm(n))
+    # Deduplicate normals that may be effectively the same (e.g. incl ~0)
+    unique: List[NDArray[np.float64]] = []
+    for n in normals:
+        if not any(np.allclose(n, m) for m in unique):
+            unique.append(n)
+    return unique
+
+
+def encounter_velocities_kernel(
+    a: float, e: float, incl: float, r_vec: NDArray[np.float64]
+) -> NDArray[np.float64]:
+    """Compute all feasible encounter velocity vectors.
+
+    Parameters
+    ----------
+    a, e, incl : float
+        Orbital elements (semi-major axis [m], eccentricity, inclination [rad]).
+    r_vec : array-like, shape (3,)
+        Target heliocentric position [m].
+
+    Returns
+    -------
+    ndarray, shape (N, 3)
+        Velocity vectors [m/s], one per valid solution (up to four).
+    """
+    r = np.linalg.norm(r_vec)
+    if not 0 <= e < 1:
+        raise ValueError("Eccentricity must be in [0,1)")
+    p = a * (1.0 - e**2)
+    cos_f = (p / r - 1.0) / e if e > 0 else 1.0
+    if abs(cos_f) > 1.0:
+        return np.zeros((0, 3))
+    sin_f_mag = np.sqrt(max(0.0, 1.0 - cos_f**2))
+    normals = _plane_normals(r_vec, incl)
+    if not normals:
+        return np.zeros((0, 3))
+    k = np.sqrt(GM_SUN / p)
+    r_hat = r_vec / r
+    velocities: List[NDArray[np.float64]] = []
+    for n in normals:
+        t_hat = np.cross(n, r_hat)
+        t_hat /= np.linalg.norm(t_hat)
+        for sin_f in (sin_f_mag, -sin_f_mag):
+            v_r = k * e * sin_f
+            v_t = k * (1.0 + e * cos_f)
+            v = v_r * r_hat + v_t * t_hat
+            velocities.append(v)
+    return np.array(velocities)

--- a/lucidia/astro/meteoroid_env/units.py
+++ b/lucidia/astro/meteoroid_env/units.py
@@ -1,0 +1,31 @@
+"""Unit conversion helpers for the meteoroid environment module.
+
+All calculations internally use SI units (meters, seconds). The helpers
+here provide convenience conversions to and from astronomical units (au)
+and kilometres per second (km/s).
+"""
+from __future__ import annotations
+
+__all__ = ["AU", "au_to_m", "m_to_au", "kms_to_ms", "ms_to_kms"]
+
+AU: float = 149_597_870_700.0  # [m]
+
+
+def au_to_m(au: float) -> float:
+    """Convert astronomical units to meters."""
+    return au * AU
+
+
+def m_to_au(meters: float) -> float:
+    """Convert meters to astronomical units."""
+    return meters / AU
+
+
+def kms_to_ms(km_per_s: float) -> float:
+    """Convert kilometres per second to meters per second."""
+    return km_per_s * 1_000.0
+
+
+def ms_to_kms(m_per_s: float) -> float:
+    """Convert meters per second to kilometres per second."""
+    return m_per_s / 1_000.0

--- a/tests/test_meteoroid_env.py
+++ b/tests/test_meteoroid_env.py
@@ -1,0 +1,43 @@
+import numpy as np
+from numpy.testing import assert_allclose
+
+from lucidia.astro.meteoroid_env import (
+    OrbitalElements,
+    TargetPoint,
+    encounter_velocities,
+    number_density,
+)
+from lucidia.astro.meteoroid_env.kernels import GM_SUN, vis_viva
+from lucidia.astro.meteoroid_env.units import AU
+
+
+def test_number_density_radial_and_vertical_scaling():
+    elements = OrbitalElements(a=AU, e=0.1, i=0.1)
+    p0 = TargetPoint(AU, 0.0, 0.0)
+    p1 = TargetPoint(2 * AU, 0.0, 0.0)
+    p2 = TargetPoint(AU, 0.0, 0.1 * AU)
+
+    n0 = number_density(elements, p0)
+    n1 = number_density(elements, p1)
+    n2 = number_density(elements, p2)
+
+    assert_allclose(n1, n0 / 2 ** 1.3, rtol=1e-6)
+    assert_allclose(n2, n0 * np.exp(-1.0), rtol=1e-6)
+
+
+def test_encounter_velocities_geometry():
+    elements = OrbitalElements(a=AU, e=0.1, i=0.3)
+    point = TargetPoint(AU, 0.0, 0.0)
+    vels = encounter_velocities(elements, point)
+
+    assert vels.shape[1] == 3
+    assert 1 <= vels.shape[0] <= 4
+
+    r_vec = np.array([point.x, point.y, point.z])
+    r = np.linalg.norm(r_vec)
+    speed = vis_viva(elements.a, r)
+    for v in vels:
+        assert_allclose(np.linalg.norm(v), speed, rtol=1e-6)
+        h = np.cross(r_vec, v)
+        n_hat = h / np.linalg.norm(h)
+        assert_allclose(abs(n_hat[2]), np.cos(elements.i), atol=1e-6)


### PR DESCRIPTION
## Summary
- implement offline meteoroid environment physics kernels
- provide unit converters and API dataclasses
- add regression tests and demo notebook

## Testing
- `pre-commit run --files NOTICE examples/meteoroid_demo.ipynb lucidia/__init__.py lucidia/astro/__init__.py lucidia/astro/meteoroid_env/__init__.py lucidia/astro/meteoroid_env/kernels.py lucidia/astro/meteoroid_env/units.py lucidia/astro/meteoroid_env/api.py tests/test_meteoroid_env.py` *(fails: command not found: pre-commit)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pytest tests/test_meteoroid_env.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68a4f974a3388329ac633d129e40e8af