### PR TITLE
feat: add earthdata adapter scaffold

### DIFF
--- a/services/earthdata-adapter/main.py
+++ b/services/earthdata-adapter/main.py
@@ -1,0 +1,56 @@
+"""Earthdata Adapter FastAPI service scaffold.
+
+This service proxies AppEEARS job information and provides basic COG tiling.
+The implementation is guarded by the FEATURE_EARTHDATA_ADAPTER environment
+variable, which defaults to disabled. Real credentials and network calls are
+intentionally omitted in this scaffold.
+"""
+
+from typing import Any, Dict
+import os
+
+from fastapi import FastAPI, HTTPException
+
+app = FastAPI()
+
+FEATURE_EARTHDATA_ADAPTER = os.getenv("FEATURE_EARTHDATA_ADAPTER", "false").lower() == "true"
+
+
+def _feature_guard() -> None:
+    """Raise an HTTP error if the adapter feature is disabled."""
+    if not FEATURE_EARTHDATA_ADAPTER:
+        raise HTTPException(status_code=503, detail="earthdata adapter disabled")
+
+
+@app.get("/health")
+def health() -> Dict[str, Any]:
+    """Health check endpoint."""
+    return {"status": "ok", "feature_enabled": FEATURE_EARTHDATA_ADAPTER}
+
+
+@app.post("/appeears/jobs:list")
+def list_jobs() -> Dict[str, Any]:
+    """Return a placeholder list of AppEEARS jobs."""
+    _feature_guard()
+    return {"jobs": []}
+
+
+@app.get("/appeears/jobs/{job_id}")
+def get_job(job_id: str) -> Dict[str, Any]:
+    """Return placeholder metadata for a specific job."""
+    _feature_guard()
+    return {"id": job_id, "status": "unknown"}
+
+
+@app.get("/appeears/jobs/{job_id}/assets")
+def get_job_assets(job_id: str) -> Dict[str, Any]:
+    """Return a stub STAC item for job assets."""
+    _feature_guard()
+    return {"id": job_id, "assets": []}
+
+
+@app.get("/cog/tiles/{z}/{x}/{y}")
+def cog_tiles(z: int, x: int, y: int) -> Dict[str, Any]:
+    """Return placeholder tile coordinates for a COG."""
+    _feature_guard()
+    return {"tile": [z, x, y]}

--- a/services/earthdata-adapter/stac_indexer.py
+++ b/services/earthdata-adapter/stac_indexer.py
@@ -1,0 +1,26 @@
+"""Minimal STAC indexer worker.
+
+This placeholder illustrates how AppEEARS outputs or self-hosted products could
+be converted into STAC items with COG assets.
+"""
+from typing import Any, Dict
+
+
+def index_stac_item(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Create a minimal STAC item from provided metadata.
+
+    Parameters
+    ----------
+    data: Dict[str, Any]
+        Input dictionary containing at least an ``id`` and optional ``assets``.
+
+    Returns
+    -------
+    Dict[str, Any]
+        A STAC item representation.
+    """
+    return {
+        "id": data.get("id", "unknown"),
+        "type": "Feature",
+        "assets": data.get("assets", []),
+    }


### PR DESCRIPTION
## Summary
- scaffold optional Earthdata Adapter FastAPI service with feature flag
- add minimal STAC indexer worker

## Testing
- `python -m py_compile services/earthdata-adapter/*.py`
- `pytest services/earthdata-adapter`


------
https://chatgpt.com/codex/tasks/task_e_68a4fa9ddf68832994e89cbf6f35fdf2