### PR TITLE
Add offline meteoroid environment endpoint and UI

### DIFF
--- a/lucidia-dev.html
+++ b/lucidia-dev.html
@@ -12,6 +12,94 @@
   </div>
   <pre id="aider-console" style="max-height:260px;overflow:auto;background:#f7f7f7;padding:.5rem;"></pre>
 </section>
+<section id="meteoroid-panel" style="max-width:920px;margin:24px auto;padding:16px;border:1px solid #e5e7eb;border-radius:16px">
+  <h2 style="margin:0 0 12px 0;font-size:20px;">Meteoroid Environment (Offline)</h2>
+  <p style="margin:0 0 12px 0;opacity:.8">Compute number density and up to four encounter-velocity branches at a heliocentric point.</p>
+
+  <div style="display:grid;grid-template-columns:repeat(6,1fr);gap:10px;align-items:end">
+    <label style="display:flex;flex-direction:column;font-size:12px">a
+      <input id="in-a" type="number" step="any" placeholder="1"
+             style="padding:8px;border:1px solid #e5e7eb;border-radius:10px">
+    </label>
+    <label style="display:flex;flex-direction:column;font-size:12px">e
+      <input id="in-e" type="number" step="any" min="0" max="0.999" placeholder="0.0167"
+             style="padding:8px;border:1px solid #e5e7eb;border-radius:10px">
+    </label>
+    <label style="display:flex;flex-direction:column;font-size:12px">i (rad)
+      <input id="in-i" type="number" step="any" min="0" max="3.14159" placeholder="0.0"
+             style="padding:8px;border:1px solid #e5e7eb;border-radius:10px">
+    </label>
+    <label style="display:flex;flex-direction:column;font-size:12px">x
+      <input id="in-x" type="number" step="any" placeholder="1"
+             style="padding:8px;border:1px solid #e5e7eb;border-radius:10px">
+    </label>
+    <label style="display:flex;flex-direction:column;font-size:12px">y
+      <input id="in-y" type="number" step="any" placeholder="0"
+             style="padding:8px;border:1px solid #e5e7eb;border-radius:10px">
+    </label>
+    <label style="display:flex;flex-direction:column;font-size:12px">z
+      <input id="in-z" type="number" step="any" placeholder="0"
+             style="padding:8px;border:1px solid #e5e7eb;border-radius:10px">
+    </label>
+  </div>
+
+  <div style="display:flex;gap:12px;align-items:center;margin-top:12px">
+    <label style="font-size:12px">Units
+      <select id="in-units" style="padding:8px;border:1px solid #e5e7eb;border-radius:10px">
+        <option value="astro" selected>astro (a,x,y,z in AU; v in km/s)</option>
+        <option value="SI">SI (a,x,y,z in m; v in m/s)</option>
+      </select>
+    </label>
+    <button id="btn-run" style="padding:10px 14px;border:0;border-radius:12px;background:#111827;color:white;cursor:pointer">
+      Compute
+    </button>
+    <span id="status" style="font-size:12px;opacity:.7"></span>
+  </div>
+
+  <div id="out" style="margin-top:16px;white-space:pre-wrap;font-family:ui-monospace, SFMono-Regular, Menlo, monospace;font-size:12px;background:#f9fafb;border:1px solid #e5e7eb;border-radius:12px;padding:12px"></div>
+
+  <script>
+    const AU = 1.0; // purely indicative for placeholders
+    const $ = id => document.getElementById(id);
+    const fmt = n => (Math.abs(n) >= 1e4 || Math.abs(n) < 1e-3) ? n.toExponential(6) : n.toFixed(6);
+
+    $('btn-run').addEventListener('click', async () => {
+      const body = {
+        a: parseFloat($('in-a').value),
+        e: parseFloat($('in-e').value),
+        i: parseFloat($('in-i').value),
+        x: parseFloat($('in-x').value),
+        y: parseFloat($('in-y').value),
+        z: parseFloat($('in-z').value),
+        units: $('in-units').value
+      };
+      $('status').textContent = 'running…';
+      $('out').textContent = '';
+      try {
+        const r = await fetch('/api/astro/meteoroid/solve', {
+          method: 'POST',
+          headers: {'Content-Type':'application/json'},
+          body: JSON.stringify(body)
+        });
+        if (!r.ok) {
+          const err = await r.json().catch(()=>({detail:`HTTP ${r.status}`}));
+          throw new Error(err.detail || `HTTP ${r.status}`);
+        }
+        const data = await r.json();
+        const rows = [];
+        rows.push(`density: ${fmt(data.density_astro)}  [1/AU^3]   | ${fmt(data.density_SI)}  [1/m^3]`);
+        rows.push(`branches: ${data.branch_count}`);
+        data.velocities_astro.forEach((v, k) => rows.push(`v${k+1} (km/s): [${fmt(v[0])}, ${fmt(v[1])}, ${fmt(v[2])}]`));
+        data.velocities_SI.forEach((v, k) => rows.push(`v${k+1} (m/s) : [${fmt(v[0])}, ${fmt(v[1])}, ${fmt(v[2])}]`));
+        $('out').textContent = rows.join('\n');
+        $('status').textContent = 'ok';
+      } catch (e) {
+        $('status').textContent = 'error';
+        $('out').textContent = 'ERROR: ' + e.message;
+      }
+    });
+  </script>
+</section>
 <script>
 (async function(){
   const $ = (id) => document.getElementById(id);

--- a/opt/blackroad/api/__init__.py
+++ b/opt/blackroad/api/__init__.py
@@ -1,0 +1,5 @@
+from fastapi import APIRouter
+from .astro_meteoroid import router as astro_meteoroid_router
+
+api_router = APIRouter()
+api_router.include_router(astro_meteoroid_router)

--- a/opt/blackroad/api/astro_meteoroid.py
+++ b/opt/blackroad/api/astro_meteoroid.py
@@ -1,0 +1,74 @@
+# FastAPI router: offline meteoroid environment compute endpoint
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field, confloat
+import numpy as np
+
+from lucidia.astro.meteoroid_env.api import (
+    number_density,
+    encounter_velocities,
+    OrbitalElements,
+    TargetPoint,
+)
+from lucidia.astro.meteoroid_env.units import (
+    au_to_m,
+)
+
+router = APIRouter(prefix="/api/astro/meteoroid", tags=["astro"])
+
+
+class SolveRequest(BaseModel):
+    a: confloat(gt=0)
+    e: confloat(ge=0, lt=1)
+    i: confloat(ge=0, le=float(np.pi))   # radians
+    x: float
+    y: float
+    z: float
+    units: str = Field("SI", pattern="^(SI|astro)$")
+
+
+class SolveResponse(BaseModel):
+    density_SI: float          # 1/m^3
+    density_astro: float       # 1/AU^3
+    velocities_SI: list[list[float]]     # m/s
+    velocities_astro: list[list[float]]  # km/s
+    branch_count: int
+
+
+@router.post("/solve", response_model=SolveResponse)
+def solve(req: SolveRequest) -> SolveResponse:
+    # Convert positions/semi-major axis to SI if provided in astro units
+    if req.units == "astro":
+        a_m = au_to_m(req.a)
+        x_m = au_to_m(req.x); y_m = au_to_m(req.y); z_m = au_to_m(req.z)
+    else:
+        a_m = float(req.a)
+        x_m = float(req.x); y_m = float(req.y); z_m = float(req.z)
+
+    # Security/sanity bounds (offline guardrails)
+    AU_M = au_to_m(1.0)
+    if not (-100*AU_M <= x_m <= 100*AU_M and -100*AU_M <= y_m <= 100*AU_M and -10*AU_M <= z_m <= 10*AU_M):
+        raise HTTPException(status_code=400, detail="TargetPoint out of safe bounds.")
+    if not (au_to_m(0.05) <= a_m <= au_to_m(40.0)):
+        raise HTTPException(status_code=400, detail="Semi-major axis out of safe bounds.")
+
+    elems = OrbitalElements(a=a_m, e=float(req.e), i=float(req.i))
+    tp = TargetPoint(x=x_m, y=y_m, z=z_m)
+
+    try:
+        rho = number_density(elems, tp)                 # 1/m^3
+        V = encounter_velocities(elems, tp)             # (N,3) m/s
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    density_SI = float(rho)
+    density_astro = density_SI * (AU_M ** 3)           # 1/AU^3
+    velocities_SI = V.tolist()
+    velocities_astro = (V / 1000.0).tolist()           # km/s
+
+    return SolveResponse(
+        density_SI=density_SI,
+        density_astro=density_astro,
+        velocities_SI=velocities_SI,
+        velocities_astro=velocities_astro,
+        branch_count=len(velocities_SI),
+    )

--- a/opt/blackroad/lucidia/astro/__init__.py
+++ b/opt/blackroad/lucidia/astro/__init__.py
@@ -1,0 +1,1 @@
+# Astro package for Lucidia utilities

--- a/opt/blackroad/lucidia/astro/meteoroid_env/__init__.py
+++ b/opt/blackroad/lucidia/astro/meteoroid_env/__init__.py
@@ -1,0 +1,1 @@
+"""Meteoroid environment utilities."""

--- a/opt/blackroad/lucidia/astro/meteoroid_env/api.py
+++ b/opt/blackroad/lucidia/astro/meteoroid_env/api.py
@@ -1,0 +1,46 @@
+"""Simple meteoroid environment computation utilities.
+
+This module is a lightweight placeholder to support the offline
+API used in tests. The physics is not intended to be accurate.
+"""
+from dataclasses import dataclass
+import numpy as np
+
+
+@dataclass
+class OrbitalElements:
+    a: float  # semi-major axis in meters
+    e: float  # eccentricity
+    i: float  # inclination in radians
+
+
+@dataclass
+class TargetPoint:
+    x: float
+    y: float
+    z: float
+
+
+def number_density(elems: OrbitalElements, tp: TargetPoint) -> float:
+    """Return a toy number density in 1/m^3.
+
+    The model simply scales inversely with distance from the origin and
+    semi-major axis to provide deterministic, non-zero values.
+    """
+    r = np.sqrt(tp.x ** 2 + tp.y ** 2 + tp.z ** 2) + 1e-9
+    return 1e-6 * (1.0 + elems.e) / (r * (elems.a / 1e11))
+
+
+def encounter_velocities(elems: OrbitalElements, tp: TargetPoint) -> np.ndarray:
+    """Return a set of encounter velocity vectors in m/s.
+
+    For demonstration we return a single branch pointing from the origin
+    to the target point with a magnitude of 1 km/s.
+    """
+    vec = np.array([tp.x, tp.y, tp.z], dtype=float)
+    norm = np.linalg.norm(vec)
+    if norm == 0:
+        vec = np.array([1.0, 0.0, 0.0])
+    else:
+        vec = vec / norm
+    return vec[np.newaxis, :] * 1000.0  # 1 km/s

--- a/opt/blackroad/lucidia/astro/meteoroid_env/units.py
+++ b/opt/blackroad/lucidia/astro/meteoroid_env/units.py
@@ -1,0 +1,7 @@
+"""Unit conversion utilities for the meteoroid environment module."""
+
+AU_IN_M = 149597870700.0  # meters
+
+def au_to_m(au: float) -> float:
+    """Convert astronomical units to meters."""
+    return au * AU_IN_M

--- a/opt/blackroad/main.py
+++ b/opt/blackroad/main.py
@@ -1,0 +1,6 @@
+# Minimal app hook-up (if you don't already have one)
+from fastapi import FastAPI
+from api import api_router
+
+app = FastAPI(title="BlackRoad API", docs_url="/_docs")
+app.include_router(api_router)

--- a/opt/blackroad/requirements.txt
+++ b/opt/blackroad/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn[standard]
+pydantic
+numpy

--- a/tests/test_api_meteoroid.py
+++ b/tests/test_api_meteoroid.py
@@ -1,0 +1,54 @@
+import socket
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+# Ensure the app and modules can be imported
+ROOT = Path(__file__).resolve().parents[1] / "opt" / "blackroad"
+sys.path.insert(0, str(ROOT))
+from main import app  # type: ignore  # noqa:E402
+
+
+@pytest.fixture(autouse=True)
+def no_network(monkeypatch):
+    """Fail tests if any code tries to access the network."""
+    def fail(*args, **kwargs):  # pragma: no cover - simple guard
+        raise RuntimeError("Network access disabled during tests")
+
+    monkeypatch.setattr(socket.socket, "connect", fail, raising=True)
+
+
+client = TestClient(app)
+
+
+def test_solve_ok():
+    payload = {
+        "a": 1.0,
+        "e": 0.0167,
+        "i": 0.0,
+        "x": 1.0,
+        "y": 0.0,
+        "z": 0.0,
+        "units": "astro",
+    }
+    res = client.post("/api/astro/meteoroid/solve", json=payload)
+    assert res.status_code == 200
+    data = res.json()
+    assert data["branch_count"] == len(data["velocities_SI"]) == len(data["velocities_astro"]) > 0
+    assert "density_SI" in data and "density_astro" in data
+
+
+def test_out_of_bounds():
+    payload = {
+        "a": 1.0,
+        "e": 0.0,
+        "i": 0.0,
+        "x": 150.0,  # beyond safe bounds
+        "y": 0.0,
+        "z": 0.0,
+        "units": "astro",
+    }
+    res = client.post("/api/astro/meteoroid/solve", json=payload)
+    assert res.status_code == 400


### PR DESCRIPTION
## Summary
- add HTML panel for offline meteoroid environment computations
- expose FastAPI `/api/astro/meteoroid/solve` endpoint with validation and unit handling
- stub meteoroid environment module and unit conversions
- add tests covering API response schema and bounds

## Testing
- `pytest tests/test_api_meteoroid.py` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fabf49448329b30745e21cd3779e