### PR TITLE
feat: add constrained latent flow matching prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ secrets/
 /tests/_codex_autogen/
 .tmp/
 *.out.md
+# Allow random field datasets
+!lucidia/modules/random_fields/datasets/
+!lucidia/modules/random_fields/datasets/*.py
+lucidia/modules/random_fields/datasets/__pycache__/

--- a/blackroad/analytics/clfm_bridge.py
+++ b/blackroad/analytics/clfm_bridge.py
@@ -1,0 +1,36 @@
+"""Utilities for applying CLFM to BlackRoad analytics data."""
+
+from __future__ import annotations
+
+import pandas as pd
+import torch
+
+from lucidia.modules.random_fields.clfm_engine import CLFMEngine
+from lucidia.modules.random_fields.functional_vae import FunctionalVAE
+
+
+def dataframe_to_field(df: pd.DataFrame) -> tuple[torch.Tensor, torch.Tensor]:
+    """Convert a one‑column DataFrame to ``(values, coords)`` tensors."""
+
+    if df.shape[1] != 1:
+        raise ValueError("dataframe must have a single column")
+    values = torch.tensor(df.iloc[:, 0].to_numpy(), dtype=torch.float32)
+    coords = torch.linspace(0, 1, len(df)).unsqueeze(-1)
+    return values, coords
+
+
+def impute_missing(df: pd.DataFrame) -> pd.Series:
+    """Run a dummy CLFM sampler to produce an imputed series.
+
+    This is a minimal placeholder implementation.  In a real deployment the
+    engine would be pre‑trained and loaded from disk.
+    """
+
+    values, coords = dataframe_to_field(df.fillna(0.0))
+    vae = FunctionalVAE(x_dim=len(values), z_dim=4, coord_dim=1)
+    engine = CLFMEngine(vae)
+    samples = engine.sample(coords, n_samples=1)
+    return pd.Series(samples.squeeze().numpy(), index=df.index)
+
+
+__all__ = ["dataframe_to_field", "impute_missing"]

--- a/docs/clfm.md
+++ b/docs/clfm.md
@@ -1,0 +1,23 @@
+# Constrained Latent Flow Matching (C-LFM)
+
+This document summarises the minimal C-LFM prototype implemented in this
+repository.  C-LFM combines a functional variational auto-encoder with a flow
+model operating in the latent space.  Physical or statistical constraints are
+injected during VAE pre-training via residual loss terms.
+
+## Modules
+
+- `lucidia.modules.random_fields.functional_vae` – VAE with DeepONet-style
+  function decoder.
+- `lucidia.modules.random_fields.constraints` – pluggable constraint API.
+- `lucidia.modules.random_fields.clfm_engine` – training and sampling engine.
+- `lucidia.modules.random_fields.datasets.synthetic_gp` – toy dataset.
+
+## Usage
+
+```
+python lucidia/cli/clfm_train.py --epochs 2
+python lucidia/cli/clfm_sample.py --samples 3
+```
+
+The code is dependency-light (PyTorch only) and avoids vendoring any NASA code.

--- a/lucidia/cli/clfm_sample.py
+++ b/lucidia/cli/clfm_sample.py
@@ -1,0 +1,28 @@
+"""Sample fields from a trained CLFM model."""
+
+from __future__ import annotations
+
+import argparse
+
+import torch
+
+from lucidia.modules.random_fields.clfm_engine import CLFMEngine
+from lucidia.modules.random_fields.functional_vae import FunctionalVAE
+from lucidia.modules.random_fields.datasets.synthetic_gp import SyntheticGPDataset
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Sample from trained model")
+    parser.add_argument("--samples", type=int, default=1)
+    args = parser.parse_args()
+
+    ds = SyntheticGPDataset(n_samples=1, n_points=32)
+    coords = ds.coords
+    vae = FunctionalVAE(x_dim=32, z_dim=8, coord_dim=1)
+    engine = CLFMEngine(vae)
+    fields = engine.sample(coords, n_samples=args.samples)
+    print(fields)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/lucidia/cli/clfm_train.py
+++ b/lucidia/cli/clfm_train.py
@@ -1,0 +1,30 @@
+"""CLI for training the CLFM engine on a synthetic dataset."""
+
+from __future__ import annotations
+
+import argparse
+
+import torch
+
+from lucidia.modules.random_fields.clfm_engine import CLFMEngine, TrainConfig
+from lucidia.modules.random_fields.constraints import MeanConstraint
+from lucidia.modules.random_fields.datasets.synthetic_gp import SyntheticGPDataset
+from lucidia.modules.random_fields.functional_vae import FunctionalVAE
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train C-LFM on synthetic data")
+    parser.add_argument("--epochs", type=int, default=1)
+    args = parser.parse_args()
+
+    ds = SyntheticGPDataset(n_samples=64, n_points=32)
+    vae = FunctionalVAE(x_dim=32, z_dim=8, coord_dim=1)
+    engine = CLFMEngine(vae)
+    mean_const = MeanConstraint(lambda c: torch.zeros_like(c))
+    engine.pretrain_vae(ds, constraints=(mean_const,), config=TrainConfig(epochs=args.epochs))
+    engine.train_flow(ds, config=TrainConfig(epochs=args.epochs))
+    print("training complete")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/lucidia/cli/clfm_validate.py
+++ b/lucidia/cli/clfm_validate.py
@@ -1,0 +1,32 @@
+"""Validate constraint satisfaction for a trained CLFM model."""
+
+from __future__ import annotations
+
+import argparse
+
+import torch
+
+from lucidia.modules.random_fields.clfm_engine import CLFMEngine
+from lucidia.modules.random_fields.constraints import MeanConstraint
+from lucidia.modules.random_fields.datasets.synthetic_gp import SyntheticGPDataset
+from lucidia.modules.random_fields.functional_vae import FunctionalVAE
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Validate CLFM constraints")
+    parser.add_argument("--samples", type=int, default=10)
+    args = parser.parse_args()
+
+    ds = SyntheticGPDataset(n_samples=64, n_points=32)
+    coords = ds.coords
+    vae = FunctionalVAE(x_dim=32, z_dim=8, coord_dim=1)
+    engine = CLFMEngine(vae)
+    mean_const = MeanConstraint(lambda c: torch.zeros_like(c))
+    engine.pretrain_vae(ds, constraints=(mean_const,))
+    fields = engine.sample(coords, n_samples=args.samples)
+    mean_res = mean_const.residual(fields, coords)
+    print({"mean_residual": float(mean_res)})
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/lucidia/modules/random_fields/clfm_engine.py
+++ b/lucidia/modules/random_fields/clfm_engine.py
@@ -1,0 +1,126 @@
+"""Minimal Constrained Latent Flow Matching engine.
+
+This module provides a light‑weight implementation of the training stages
+outlined in the C‑LFM paper:
+
+1. Pre‑train a :class:`FunctionalVAE` with optional constraints.
+2. Train a latent vector field using conditional flow matching.
+3. Sample new fields by solving an ODE in the latent space and decoding
+   through the VAE's function decoder.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader
+
+from .functional_vae import FunctionalVAE
+
+
+class LatentVectorField(nn.Module):
+    """Simple MLP representing ``v(z, t)``."""
+
+    def __init__(self, z_dim: int, hidden: int = 128) -> None:
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(z_dim + 1, hidden),
+            nn.SiLU(),
+            nn.Linear(hidden, hidden),
+            nn.SiLU(),
+            nn.Linear(hidden, z_dim),
+        )
+
+    def forward(self, z: torch.Tensor, t: torch.Tensor) -> torch.Tensor:
+        if t.dim() == 1:
+            t = t.unsqueeze(-1)
+        inp = torch.cat([z, t.expand_as(z[:, :1])], dim=-1)
+        return self.net(inp)
+
+
+@dataclass
+class TrainConfig:
+    lr: float = 1e-3
+    epochs: int = 1
+    batch_size: int = 16
+
+
+class CLFMEngine:
+    """Encapsulates VAE and latent flow training."""
+
+    def __init__(self, vae: FunctionalVAE, device: str | torch.device = "cpu") -> None:
+        self.vae = vae.to(device)
+        self.device = device
+        self.z_dim = vae.encoder[-1].out_features // 2
+        self.vfield = LatentVectorField(self.z_dim).to(device)
+
+    # ------------------------------------------------------------------
+    def pretrain_vae(
+        self,
+        dataset,
+        constraints: Sequence = (),
+        config: TrainConfig | None = None,
+    ) -> None:
+        config = config or TrainConfig()
+        self.vae.train()
+        loader = DataLoader(dataset, batch_size=config.batch_size, shuffle=True)
+        opt = torch.optim.Adam(self.vae.parameters(), lr=config.lr)
+        mse = nn.MSELoss()
+        for _ in range(config.epochs):
+            for x, xi in loader:
+                x = x.to(self.device)
+                xi = xi.to(self.device)
+                f_hat, losses = self.vae(x, xi, constraints)
+                recon = mse(f_hat.squeeze(), x)
+                loss = recon + losses["kld"] + losses["cres"]
+                opt.zero_grad()
+                loss.backward()
+                opt.step()
+
+    # ------------------------------------------------------------------
+    def train_flow(self, dataset, config: TrainConfig | None = None) -> None:
+        config = config or TrainConfig()
+        self.vae.eval()
+        loader = DataLoader(dataset, batch_size=config.batch_size, shuffle=True)
+        opt = torch.optim.Adam(self.vfield.parameters(), lr=config.lr)
+        for _ in range(config.epochs):
+            for x, _ in loader:
+                x = x.to(self.device)
+                with torch.no_grad():
+                    mu, _ = self.vae.encode(x)
+                z1 = mu
+                z0 = torch.randn_like(z1)
+                t = torch.rand(z1.size(0), device=self.device)
+                zt = (1 - t[:, None]) * z0 + t[:, None] * z1
+                v_target = z1 - z0
+                v_pred = self.vfield(zt, t)
+                loss = (v_pred - v_target).pow(2).mean()
+                opt.zero_grad()
+                loss.backward()
+                opt.step()
+
+    # ------------------------------------------------------------------
+    def sample(
+        self, coords: torch.Tensor, n_samples: int = 1, steps: int = 20
+    ) -> torch.Tensor:
+        """Generate ``n_samples`` fields evaluated at ``coords``."""
+
+        self.vae.eval()
+        self.vfield.eval()
+        device = self.device
+        coords = coords.to(device)
+        dt = 1.0 / steps
+        z = torch.randn(n_samples, self.z_dim, device=device)
+        for i in range(steps):
+            t = torch.full((n_samples,), i * dt, device=device)
+            v = self.vfield(z, t)
+            z = z + v * dt
+        with torch.no_grad():
+            f = self.vae.decoder(z, coords)
+        return f.squeeze(-1)
+
+
+__all__ = ["CLFMEngine", "LatentVectorField", "TrainConfig"]

--- a/lucidia/modules/random_fields/constraints.py
+++ b/lucidia/modules/random_fields/constraints.py
@@ -1,0 +1,72 @@
+"""Constraint abstractions for random field modeling.
+
+This module defines a base :class:`Constraint` along with example
+implementations such as :class:`MeanConstraint` and :class:`PoissonResidual`.
+The API is intentionally light‑weight so that new constraint types can be
+plugged in by implementing the :meth:`Constraint.residual` method.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Optional
+
+import torch
+
+
+class Constraint(ABC):
+    """Abstract base class for constraints.
+
+    Subclasses implement :meth:`residual` which should return a tensor of
+    residual values to be added to the training loss.  Each constraint has a
+    ``weight`` used when aggregating the total constraint loss.
+    """
+
+    name: str = "base"
+
+    def __init__(self, weight: float = 1.0) -> None:
+        self.weight = float(weight)
+
+    @abstractmethod
+    def residual(
+        self, f_hat: torch.Tensor, coords: torch.Tensor, aux: Optional[dict] = None
+    ) -> torch.Tensor:
+        """Compute the residual for the constraint."""
+
+
+class MeanConstraint(Constraint):
+    """Penalise deviation from a target mean ``mu_fn`` evaluated at ``coords``."""
+
+    name = "mean"
+
+    def __init__(self, mu_fn, weight: float = 1.0) -> None:
+        super().__init__(weight)
+        self.mu_fn = mu_fn
+
+    def residual(
+        self, f_hat: torch.Tensor, coords: torch.Tensor, aux: Optional[dict] = None
+    ) -> torch.Tensor:
+        target = self.mu_fn(coords)
+        return (f_hat - target).pow(2).mean()
+
+
+class PoissonResidual(Constraint):
+    """Enforce ``Δf = s(coords)`` weakly via collocation points."""
+
+    name = "poisson"
+
+    def __init__(self, source_fn, weight: float = 1.0) -> None:
+        super().__init__(weight)
+        self.s = source_fn
+
+    def residual(
+        self, f_hat: torch.Tensor, coords: torch.Tensor, aux: Optional[dict] = None
+    ) -> torch.Tensor:
+        grads = torch.autograd.grad(f_hat.sum(), coords, create_graph=True)[0]
+        lap = torch.autograd.grad(grads.sum(), coords, create_graph=True)[0]
+        lap = lap.sum(dim=-1, keepdim=True)
+        target = self.s(coords)
+        return (lap - target).pow(2).mean()
+
+
+__all__ = ["Constraint", "MeanConstraint", "PoissonResidual"]

--- a/lucidia/modules/random_fields/datasets/synthetic_gp.py
+++ b/lucidia/modules/random_fields/datasets/synthetic_gp.py
@@ -1,0 +1,35 @@
+"""Synthetic 1D field dataset for quick tests.
+
+Each sample is generated from ``f(x) = a*sin(πx) + b*cos(πx)`` with random
+coefficients ``a`` and ``b``.  Coordinates are fixed on ``[0, 1]``.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import torch
+from torch.utils.data import Dataset
+
+
+class SyntheticGPDataset(Dataset):
+    """Simple analytic dataset mimicking a Gaussian process."""
+
+    def __init__(self, n_samples: int = 100, n_points: int = 32, seed: int = 0):
+        super().__init__()
+        g = torch.Generator().manual_seed(seed)
+        self.n_samples = n_samples
+        self.coords = torch.linspace(0, 1, n_points).unsqueeze(-1)
+        self.coeffs = torch.randn(n_samples, 2, generator=g)
+
+    def __len__(self) -> int:  # noqa: D401 - short doc
+        return self.n_samples
+
+    def __getitem__(self, idx: int) -> Tuple[torch.Tensor, torch.Tensor]:
+        a, b = self.coeffs[idx]
+        x = self.coords
+        field = a * torch.sin(torch.pi * x) + b * torch.cos(torch.pi * x)
+        return field.squeeze(-1), x
+
+
+__all__ = ["SyntheticGPDataset"]

--- a/lucidia/modules/random_fields/functional_vae.py
+++ b/lucidia/modules/random_fields/functional_vae.py
@@ -1,0 +1,103 @@
+"""Variational auto‑encoder with a function decoder.
+
+The decoder follows the DeepONet paradigm where coordinates (``xi``) are
+processed by a trunk network and latent variables (``z``) by a branch network.
+Their interaction yields a predicted field value ``f_hat``.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+
+class Trunk(nn.Module):
+    """Network processing spatial/temporal coordinates."""
+
+    def __init__(self, in_dim: int = 2, width: int = 128, depth: int = 4) -> None:
+        super().__init__()
+        layers = []
+        d = in_dim
+        for _ in range(depth):
+            layers.extend([nn.Linear(d, width), nn.SiLU()])
+            d = width
+        self.net = nn.Sequential(*layers)
+
+    def forward(self, xi: torch.Tensor) -> torch.Tensor:  # noqa: D401 - short doc
+        return self.net(xi)
+
+
+class Branch(nn.Module):
+    """Network processing the latent code ``z``."""
+
+    def __init__(self, z_dim: int = 32, width: int = 128, depth: int = 2) -> None:
+        super().__init__()
+        layers = []
+        d = z_dim
+        for _ in range(depth):
+            layers.extend([nn.Linear(d, width), nn.SiLU()])
+            d = width
+        self.net = nn.Sequential(*layers)
+
+    def forward(self, z: torch.Tensor) -> torch.Tensor:  # noqa: D401 - short doc
+        return self.net(z)
+
+
+class FunctionDecoder(nn.Module):
+    """DeepONet-style function decoder ``f_hat(xi; z)``."""
+
+    def __init__(self, z_dim: int = 32, coord_dim: int = 2, width: int = 128) -> None:
+        super().__init__()
+        self.trunk = Trunk(coord_dim, width)
+        self.branch = Branch(z_dim, width)
+        self.out = nn.Sequential(nn.Linear(width, width), nn.SiLU(), nn.Linear(width, 1))
+
+    def forward(self, z: torch.Tensor, xi: torch.Tensor) -> torch.Tensor:
+        phi_t = self.trunk(xi)  # (N, W)
+        phi_b = self.branch(z)  # (B, W)
+        if phi_b.dim() == 2:
+            phi_b = phi_b.unsqueeze(1)  # (B, 1, W)
+        return self.out(phi_t * phi_b)
+
+
+class FunctionalVAE(nn.Module):
+    """Simple VAE with functional decoder and optional constraints."""
+
+    def __init__(self, x_dim: int, z_dim: int = 32, coord_dim: int = 2) -> None:
+        super().__init__()
+        self.encoder = nn.Sequential(
+            nn.Linear(x_dim, 256),
+            nn.SiLU(),
+            nn.Linear(256, 2 * z_dim),
+        )
+        self.decoder = FunctionDecoder(z_dim=z_dim, coord_dim=coord_dim)
+
+    def encode(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        h = self.encoder(x)
+        mu, logvar = torch.chunk(h, 2, dim=-1)
+        return mu, logvar
+
+    def reparam(self, mu: torch.Tensor, logvar: torch.Tensor) -> torch.Tensor:
+        eps = torch.randn_like(mu)
+        return mu + eps * torch.exp(0.5 * logvar)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        xi: torch.Tensor,
+        constraints: tuple = (),
+    ) -> tuple[torch.Tensor, dict]:
+        mu, logvar = self.encode(x)
+        z = self.reparam(mu, logvar)
+        f_hat = self.decoder(z, xi)
+        kld = -0.5 * (1 + logvar - mu.pow(2) - logvar.exp()).mean()
+        cres = sum(c.weight * c.residual(f_hat, xi) for c in constraints)
+        return f_hat, {"kld": kld, "cres": cres}
+
+
+__all__ = [
+    "Trunk",
+    "Branch",
+    "FunctionDecoder",
+    "FunctionalVAE",
+]

--- a/tests/random_fields/test_clfm_basic.py
+++ b/tests/random_fields/test_clfm_basic.py
@@ -1,0 +1,26 @@
+"""Basic tests for the CLFM components."""
+
+from __future__ import annotations
+
+import torch
+
+from lucidia.modules.random_fields.clfm_engine import CLFMEngine, TrainConfig
+from lucidia.modules.random_fields.constraints import MeanConstraint
+from lucidia.modules.random_fields.datasets.synthetic_gp import SyntheticGPDataset
+from lucidia.modules.random_fields.functional_vae import FunctionalVAE
+
+
+def test_end_to_end_training_and_sampling() -> None:
+    ds = SyntheticGPDataset(n_samples=32, n_points=16, seed=1)
+    vae = FunctionalVAE(x_dim=16, z_dim=4, coord_dim=1)
+    engine = CLFMEngine(vae)
+    mean_const = MeanConstraint(lambda c: torch.zeros_like(c))
+
+    engine.pretrain_vae(ds, constraints=(mean_const,), config=TrainConfig(epochs=1))
+    engine.train_flow(ds, config=TrainConfig(epochs=1))
+
+    coords = ds.coords
+    fields = engine.sample(coords, n_samples=2, steps=5)
+    assert fields.shape == (2, 16)
+    res = mean_const.residual(fields, coords)
+    assert torch.isfinite(res)


### PR DESCRIPTION
## Summary
- add functional VAE with DeepONet-style decoder
- implement minimal constrained latent flow matching engine and synthetic dataset
- expose CLFM CLIs, analytics bridge, docs and tests

## Testing
- `pre-commit run --files lucidia/modules/random_fields/constraints.py lucidia/modules/random_fields/functional_vae.py lucidia/modules/random_fields/clfm_engine.py lucidia/modules/random_fields/datasets/synthetic_gp.py lucidia/cli/clfm_train.py lucidia/cli/clfm_sample.py lucidia/cli/clfm_validate.py tests/random_fields/test_clfm_basic.py blackroad/analytics/clfm_bridge.py docs/clfm.md` *(fail: command not found)*
- `pip install pre-commit` *(fail: no matching distribution / network 403)*
- `pytest tests/random_fields/test_clfm_basic.py` *(fail: ModuleNotFoundError: No module named 'torch')*
- `pip install torch --no-index --find-links /usr/share/pip-wheels` *(fail: no matching distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fb1b733c83299424f35f913000f0