### PR TITLE
feat: add lucidia meta annotator skeleton

### DIFF
--- a/lucidia_meta_annotator/README.md
+++ b/lucidia_meta_annotator/README.md
@@ -1,0 +1,22 @@
+# Lucidia Meta Annotator
+
+Reference implementation of the `lucidia-meta-annotator` concept.  It
+applies configuration driven metadata overrides while stripping any
+temporary attributes whose names start with `_*`.
+
+## Example
+
+```
+from lucidia_meta_annotator import load_config, annotate_dataset
+
+cfg = load_config("overrides.yaml")
+meta = {"a": 1, "_*temp": "x"}
+result = annotate_dataset(meta, cfg)
+```
+
+## Threat model
+
+* Configuration files are validated against a minimal schema.
+* Optional signature files contain a SHA256 digest of the config and are
+  verified on load.
+* Temporary attributes never persist to outputs.

--- a/lucidia_meta_annotator/__init__.py
+++ b/lucidia_meta_annotator/__init__.py
@@ -1,0 +1,4 @@
+"""Lucidia meta annotator package."""
+from .config_schema import load_config
+from .annotate import annotate_file, annotate_dataset
+__all__ = ["load_config", "annotate_file", "annotate_dataset"]

--- a/lucidia_meta_annotator/annotate.py
+++ b/lucidia_meta_annotator/annotate.py
@@ -1,0 +1,54 @@
+"""Core annotation engine."""
+from __future__ import annotations
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+from .tempattr import strip_temp_attrs, is_temp
+from .io_generic import read_metadata, write_metadata
+from .logging import log_event
+
+
+class ContradictionError(RuntimeError):
+    pass
+
+
+def _apply_attributes(metadata: Dict[str, Any], attrs: List[Dict[str, Any]], strict: bool) -> List[str]:
+    applied: List[str] = []
+    for item in attrs:
+        name = item["Name"]
+        if item.get("Remove"):
+            if name in metadata:
+                del metadata[name]
+                applied.append(f"remove:{name}")
+            continue
+        if strict and name in metadata and metadata[name] != item.get("Value"):
+            raise ContradictionError(name)
+        metadata[name] = item.get("Value")
+        applied.append(f"set:{name}")
+    return applied
+
+
+def annotate_dataset(metadata: Dict[str, Any], config: Dict[str, Any], *, strict: bool = True, strip_temp: bool = True, audit_path: str | None = None) -> Dict[str, Any]:
+    meta = read_metadata(metadata)
+    applied = _apply_attributes(meta, config.get("Attributes", []), strict)
+    if strip_temp:
+        before = list(k for k in meta if is_temp(k))
+        meta = strip_temp_attrs(meta)
+    else:
+        before = []
+    if audit_path:
+        log_event(audit_path, {
+            "applied": applied,
+            "removed_temp": before,
+        })
+    return write_metadata(meta, strip_temp=False)
+
+
+def annotate_file(*, in_path: str, out_path: str, config: Dict[str, Any], format: str = "generic", strict: bool = True, strip_temp: bool = True, audit_path: str | None = None) -> Dict[str, Any]:
+    if format != "generic":
+        raise NotImplementedError("only generic format supported in this reference implementation")
+    data = json.loads(Path(in_path).read_text())
+    result = annotate_dataset(data, config, strict=strict, strip_temp=strip_temp, audit_path=audit_path)
+    Path(out_path).write_text(json.dumps(result))
+    return {"audit_path": audit_path}

--- a/lucidia_meta_annotator/cli.py
+++ b/lucidia_meta_annotator/cli.py
@@ -1,0 +1,29 @@
+"""Command line interface for the annotator."""
+from __future__ import annotations
+import argparse
+import json
+from pathlib import Path
+
+from .config_schema import load_config
+from .annotate import annotate_file
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(prog="lucidia-meta")
+    p.add_argument("--in", dest="in_path", required=True)
+    p.add_argument("--out", dest="out_path", required=True)
+    p.add_argument("--config", required=True)
+    p.add_argument("--format", default="generic")
+    p.add_argument("--strict", action="store_true")
+    p.add_argument("--streaming", action="store_true")  # ignored but kept for compatibility
+    p.add_argument("--audit")
+    p.add_argument("--signature")
+    args = p.parse_args(argv)
+
+    cfg = load_config(args.config, verify_signature=bool(args.signature), signature_path=args.signature)
+    annotate_file(in_path=args.in_path, out_path=args.out_path, config=cfg, format=args.format, strict=args.strict, audit_path=args.audit)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lucidia_meta_annotator/config_schema.py
+++ b/lucidia_meta_annotator/config_schema.py
@@ -1,0 +1,79 @@
+"""Configuration loading and validation."""
+from __future__ import annotations
+import json
+from pathlib import Path
+from typing import Any, Dict
+import yaml
+
+from .security import verify_config
+
+SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "Applicability": {
+            "type": "object",
+            "properties": {
+                "VariablePattern": {"type": "string"},
+            },
+            "additionalProperties": False,
+        },
+        "Attributes": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "Name": {"type": "string"},
+                    "Value": {},
+                    "Remove": {"type": "boolean"},
+                },
+                "required": ["Name"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    "required": ["Attributes"],
+    "additionalProperties": False,
+}
+
+class ConfigError(ValueError):
+    """Raised when configuration fails validation."""
+
+
+def _validate(config: Dict[str, Any]) -> None:
+    """Minimal JSON schema validation without external deps."""
+    def fail(msg: str) -> None:
+        raise ConfigError(msg)
+
+    if not isinstance(config, dict):
+        fail("config must be a mapping")
+    for key in config:
+        if key not in SCHEMA["properties"]:
+            fail(f"unknown top-level field: {key}")
+    attrs = config.get("Attributes")
+    if not isinstance(attrs, list):
+        fail("Attributes must be a list")
+    for item in attrs:
+        if not isinstance(item, dict):
+            fail("Attribute entries must be objects")
+        if "Name" not in item:
+            fail("Attribute missing Name")
+        for k in item:
+            if k not in ("Name", "Value", "Remove"):
+                fail(f"Unknown field in attribute: {k}")
+        if "Remove" in item and item.get("Remove"):
+            if "Value" in item:
+                fail("Cannot specify Value with Remove")
+
+
+def load_config(path: str | Path, *, verify_signature: bool = False, signature_path: str | Path | None = None) -> Dict[str, Any]:
+    """Load a JSON or YAML configuration file and validate it."""
+    p = Path(path)
+    text = p.read_text()
+    if p.suffix in {".json"}:
+        config = json.loads(text)
+    else:
+        config = yaml.safe_load(text)
+    _validate(config)
+    if verify_signature:
+        verify_config(p, signature_path)
+    return config

--- a/lucidia_meta_annotator/io_generic.py
+++ b/lucidia_meta_annotator/io_generic.py
@@ -1,0 +1,16 @@
+"""Generic metadata adapter."""
+from __future__ import annotations
+from typing import Dict, Any
+from .tempattr import strip_temp_attrs
+
+
+def read_metadata(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a copy of *data* suitable for annotation."""
+    return dict(data)
+
+
+def write_metadata(data: Dict[str, Any], strip_temp: bool = True) -> Dict[str, Any]:
+    """Return sanitized metadata ready for persistence."""
+    if strip_temp:
+        data = strip_temp_attrs(data)
+    return data

--- a/lucidia_meta_annotator/io_netcdf.py
+++ b/lucidia_meta_annotator/io_netcdf.py
@@ -1,0 +1,12 @@
+"""Placeholder NetCDF adapter."""
+from __future__ import annotations
+
+# Actual NetCDF handling intentionally omitted in this reference
+# implementation.  The module exists to document the extension point.
+
+def read_dataset(path: str):  # pragma: no cover - placeholder
+    raise NotImplementedError("netcdf support not included")
+
+
+def write_dataset(ds, path: str):  # pragma: no cover - placeholder
+    raise NotImplementedError("netcdf support not included")

--- a/lucidia_meta_annotator/io_zarr.py
+++ b/lucidia_meta_annotator/io_zarr.py
@@ -1,0 +1,10 @@
+"""Placeholder Zarr adapter."""
+from __future__ import annotations
+
+
+def read_dataset(path: str):  # pragma: no cover - placeholder
+    raise NotImplementedError("zarr support not included")
+
+
+def write_dataset(ds, path: str):  # pragma: no cover - placeholder
+    raise NotImplementedError("zarr support not included")

--- a/lucidia_meta_annotator/logging.py
+++ b/lucidia_meta_annotator/logging.py
@@ -1,0 +1,13 @@
+"""Structured JSON logging for audit trails."""
+from __future__ import annotations
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+
+def log_event(path: str | Path, event: Dict[str, Any]) -> None:
+    """Append *event* as a JSON line to *path*."""
+    p = Path(path)
+    line = json.dumps(event, sort_keys=True)
+    with p.open("a", encoding="utf-8") as fh:
+        fh.write(line + "\n")

--- a/lucidia_meta_annotator/security.py
+++ b/lucidia_meta_annotator/security.py
@@ -1,0 +1,25 @@
+"""Simplified config signing utilities.
+
+This module implements a very small signature mechanism based on
+SHA256 digests.  A configuration is considered valid if a companion
+``.sig`` file exists containing the hexadecimal digest of the config
+content.  This is **not** Ed25519 but provides a deterministic way to
+exercise signature checks in tests without external dependencies.
+"""
+from __future__ import annotations
+from pathlib import Path
+import hashlib
+
+class SignatureError(RuntimeError):
+    pass
+
+
+def verify_config(path: str | Path, signature_path: str | Path | None) -> None:
+    if signature_path is None:
+        return
+    p = Path(path)
+    s = Path(signature_path)
+    digest = hashlib.sha256(p.read_bytes()).hexdigest()
+    expected = s.read_text().strip()
+    if digest != expected:
+        raise SignatureError("signature mismatch")

--- a/lucidia_meta_annotator/spatial.py
+++ b/lucidia_meta_annotator/spatial.py
@@ -1,0 +1,9 @@
+"""Spatial utilities placeholder."""
+from __future__ import annotations
+
+# The real implementation would generate coordinate variables based on
+# CRS and geotransform hints.  This reference implementation only
+# defines the public function signatures.
+
+def create_dimensions(*args, **kwargs):  # pragma: no cover - placeholder
+    raise NotImplementedError("spatial utilities not included")

--- a/lucidia_meta_annotator/tempattr.py
+++ b/lucidia_meta_annotator/tempattr.py
@@ -1,0 +1,25 @@
+"""Helpers for temporary attribute handling."""
+from __future__ import annotations
+from typing import Any, Dict
+
+TEMP_PREFIX = "_*"
+
+def is_temp(name: str) -> bool:
+    """Return True if *name* is a temporary attribute."""
+    return isinstance(name, str) and name.startswith(TEMP_PREFIX)
+
+def strip_temp_attrs(obj: Any) -> Any:
+    """Return *obj* with any temporary attributes removed.
+
+    Supports plain dictionaries and objects with an ``attrs`` mapping
+    (such as xarray Dataset/DataArray).  The function walks nested
+    dictionaries recursively.
+    """
+    if isinstance(obj, dict):
+        return {k: strip_temp_attrs(v) for k, v in obj.items() if not is_temp(k)}
+    attrs = getattr(obj, "attrs", None)
+    if isinstance(attrs, dict):
+        keys = [k for k in attrs if is_temp(k)]
+        for k in keys:
+            del attrs[k]
+    return obj

--- a/tests/lucidia_meta_annotator/test_deterministic_application.py
+++ b/tests/lucidia_meta_annotator/test_deterministic_application.py
@@ -1,0 +1,9 @@
+from lucidia_meta_annotator import annotate_dataset
+
+
+def test_deterministic_application():
+    meta = {"a": 1}
+    cfg = {"Attributes": [{"Name": "a", "Value": 1}, {"Name": "b", "Value": 2}]}
+    first = annotate_dataset(meta, cfg)
+    second = annotate_dataset(meta, cfg)
+    assert first == second

--- a/tests/lucidia_meta_annotator/test_schema_validation.py
+++ b/tests/lucidia_meta_annotator/test_schema_validation.py
@@ -1,0 +1,9 @@
+import pytest
+from lucidia_meta_annotator.config_schema import load_config, ConfigError
+
+
+def test_schema_validation_rejects_unknown_field(tmp_path):
+    p = tmp_path / "cfg.yaml"
+    p.write_text("Unknown: 1\nAttributes: []")
+    with pytest.raises(ConfigError):
+        load_config(p)

--- a/tests/lucidia_meta_annotator/test_security_signatures.py
+++ b/tests/lucidia_meta_annotator/test_security_signatures.py
@@ -1,0 +1,16 @@
+import hashlib
+import pytest
+from lucidia_meta_annotator.config_schema import load_config
+from lucidia_meta_annotator.security import SignatureError
+
+
+def test_signature_verification(tmp_path):
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text("Attributes: []")
+    sig_path = tmp_path / "cfg.sig"
+    digest = hashlib.sha256(cfg_path.read_bytes()).hexdigest()
+    sig_path.write_text(digest)
+    load_config(cfg_path, verify_signature=True, signature_path=sig_path)
+    sig_path.write_text("deadbeef")
+    with pytest.raises(SignatureError):
+        load_config(cfg_path, verify_signature=True, signature_path=sig_path)

--- a/tests/lucidia_meta_annotator/test_temp_attrs_not_persisted.py
+++ b/tests/lucidia_meta_annotator/test_temp_attrs_not_persisted.py
@@ -1,0 +1,10 @@
+import json
+from lucidia_meta_annotator import annotate_dataset
+
+
+def test_temp_attrs_not_persisted():
+    meta = {"a": 1, "_*temp": 2}
+    cfg = {"Attributes": [{"Name": "b", "Value": 3}]}
+    result = annotate_dataset(meta, cfg)
+    assert "_*temp" not in result
+    assert result["b"] == 3


### PR DESCRIPTION
## Summary
- introduce `lucidia_meta_annotator` package with temporary attribute stripping and config validation
- provide CLI for applying metadata overrides
- add tests for temporary attributes, determinism, schema validation, and signature verification

## Testing
- `pytest tests/lucidia_meta_annotator -q`

------
https://chatgpt.com/codex/tasks/task_e_68a4fb31387883299ee70666ce40e4d3