### PR TITLE
chore: add LMC skeleton

### DIFF
--- a/lmc/README.md
+++ b/lmc/README.md
@@ -1,0 +1,13 @@
+# Lucidia Metadata & Catalog (LMC)
+
+This directory contains an early skeleton for the Lucidia/BlackRoad metadata management system.
+
+## Layout
+
+- `docker-compose.yml` – local development stack (Postgres, Fuseki, API).
+- `services/api` – FastAPI service exposing REST and GraphQL stubs.
+- `schemas` – placeholder JSON Schemas (DCAT 3.0, STAC 1.0, UMM).
+- `web` – React admin UI stub.
+
+The implementation is intentionally minimal and independent from NASA CMR
+or Earthdata services.  It serves as a starting point for further work.

--- a/lmc/docker-compose.yml
+++ b/lmc/docker-compose.yml
@@ -1,0 +1,39 @@
+version: '3.9'
+
+services:
+  postgres:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: lmc
+      POSTGRES_PASSWORD: lmc
+      POSTGRES_DB: lmc
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  fuseki:
+    image: stain/jena-fuseki:4.10.0
+    restart: unless-stopped
+    environment:
+      - ADMIN_PASSWORD=admin
+    ports:
+      - "3030:3030"
+    volumes:
+      - fuseki_data:/fuseki
+
+  api:
+    build: ./services/api
+    environment:
+      DATABASE_URL: postgresql://lmc:lmc@postgres:5432/lmc
+      FUSEKI_URL: http://fuseki:3030
+    ports:
+      - "8000:8000"
+    depends_on:
+      - postgres
+      - fuseki
+
+volumes:
+  postgres_data:
+  fuseki_data:

--- a/lmc/schemas/dcat_3_0.json
+++ b/lmc/schemas/dcat_3_0.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DCAT 3.0 Placeholder",
+  "description": "Simplified placeholder for the DCAT 3.0 JSON schema.",
+  "type": "object",
+  "properties": {}
+}

--- a/lmc/schemas/stac_1_0.json
+++ b/lmc/schemas/stac_1_0.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "STAC 1.0 Placeholder",
+  "description": "Simplified placeholder for the STAC 1.0 JSON schema.",
+  "type": "object",
+  "properties": {}
+}

--- a/lmc/schemas/umm_placeholder.json
+++ b/lmc/schemas/umm_placeholder.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "UMM Placeholder",
+  "description": "Placeholder for a UMM schema without NASA dependencies.",
+  "type": "object",
+  "properties": {}
+}

--- a/lmc/services/api/main.py
+++ b/lmc/services/api/main.py
@@ -1,0 +1,28 @@
+from fastapi import FastAPI
+
+app = FastAPI(title="LMC API")
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    """Simple health check."""
+    return {"status": "ok"}
+
+
+@app.get("/schemas")
+def list_schemas() -> list[dict]:
+    """Return available metadata schemas.
+
+    The implementation is a placeholder; in the future this will query the
+    schema registry stored in Postgres.
+    """
+    return []
+
+
+@app.post("/schemas")
+def create_schema(schema: dict) -> dict:
+    """Store a new metadata schema.
+
+    This endpoint performs no validation yet; it merely echoes the payload.
+    """
+    return schema

--- a/lmc/services/api/pyproject.toml
+++ b/lmc/services/api/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "lmc-api"
+version = "0.1.0"
+description = "Lucidia Metadata & Catalog API service"
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi",
+    "uvicorn[standard]"
+]
+
+[project.optional-dependencies]
+dev = ["pytest"]

--- a/lmc/web/package.json
+++ b/lmc/web/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "lmc-web",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/lmc/web/src/App.tsx
+++ b/lmc/web/src/App.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function App() {
+  return <div>Lucidia Metadata & Catalog Admin</div>;
+}


### PR DESCRIPTION
## Summary
- scaffold Lucidia Metadata & Catalog directory with docker-compose
- add FastAPI API stub and placeholder schemas
- include minimal React admin UI

## Testing
- `pre-commit run --files lmc/README.md lmc/docker-compose.yml lmc/services/api/main.py lmc/services/api/pyproject.toml lmc/schemas/dcat_3_0.json lmc/schemas/stac_1_0.json lmc/schemas/umm_placeholder.json lmc/web/package.json lmc/web/src/App.tsx` *(failed: command not found)*
- `pip install pre-commit` *(failed: Could not find a version that satisfies the requirement pre-commit)*
- `pytest` *(failed: ModuleNotFoundError: No module named 'anthropic')*
- `pip install anthropic` *(failed: Could not find a version that satisfies the requirement anthropic)*
- `npm test` *(failed: Invalid package.json: JSONParseError)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fbd0716083298b4c4273157d72bd