### PR TITLE
Add vision service proto and gRPC server skeleton

### DIFF
--- a/proto/vision_service.proto
+++ b/proto/vision_service.proto
@@ -1,0 +1,101 @@
+syntax = "proto3";
+
+package lucidia.vision.v1;
+
+option go_package   = "github.com/lucidia/vision/gen/go;visionpb";
+option java_package = "com.lucidia.vision.v1";
+
+// General image container (PNG or GeoTIFF by default).
+message Image {
+  bytes data   = 1;            // Raw image bytes.
+  string format = 2;           // "png" or "tiff".
+  uint32 width  = 3;
+  uint32 height = 4;
+}
+
+// Common projection info (EPSG codes).
+message Projection {
+  int32 epsg = 1;              // e.g., 4326 for WGS84, 3857 for WebMercator.
+}
+
+// ReprojectImage -------------------------------------------------------------
+message ReprojectImageRequest {
+  Image input          = 1;
+  Projection src_proj  = 2;
+  Projection dst_proj  = 3;
+}
+message ReprojectImageResponse {
+  Image output = 1;
+}
+
+// TilePyramid ----------------------------------------------------------------
+message TilePyramidRequest {
+  Image input          = 1;
+  Projection proj      = 2;
+  uint32 tile_size     = 3;     // e.g., 256.
+  uint32 min_zoom      = 4;
+  uint32 max_zoom      = 5;
+}
+message TilePyramidResponse {
+  repeated Image tiles = 1;     // XYZ tiles concatenated in z/x/y order.
+}
+
+// Mosaic ---------------------------------------------------------------------
+message MosaicRequest {
+  repeated Image inputs = 1;
+  Projection proj       = 2;
+}
+message MosaicResponse {
+  Image output = 1;
+}
+
+// Hillshade ------------------------------------------------------------------
+message HillshadeRequest {
+  Image dem            = 1;
+  Projection proj      = 2;
+  double sun_azimuth   = 3;     // degrees.
+  double sun_elevation = 4;     // degrees.
+}
+message HillshadeResponse {
+  Image output = 1;
+}
+
+// OrthorectifyDEM ------------------------------------------------------------
+message OrthorectifyDEMRequest {
+  Image dem       = 1;
+  Image texture   = 2;
+  Projection proj = 3;
+}
+message OrthorectifyDEMResponse {
+  Image output = 1;
+}
+
+// Resample -------------------------------------------------------------------
+message ResampleRequest {
+  Image input  = 1;
+  uint32 width = 2;
+  uint32 height = 3;
+}
+message ResampleResponse {
+  Image output = 1;
+}
+
+// ColorMap -------------------------------------------------------------------
+message ColorMapRequest {
+  Image input  = 1;
+  string palette = 2;           // e.g., "viridis", "terrain".
+}
+message ColorMapResponse {
+  Image output = 1;
+}
+
+// Service --------------------------------------------------------------------
+service VisionService {
+  rpc ReprojectImage   (ReprojectImageRequest)   returns (ReprojectImageResponse);
+  rpc TilePyramid      (TilePyramidRequest)      returns (TilePyramidResponse);
+  rpc Mosaic           (MosaicRequest)           returns (MosaicResponse);
+  rpc Hillshade        (HillshadeRequest)        returns (HillshadeResponse);
+  rpc OrthorectifyDEM  (OrthorectifyDEMRequest)  returns (OrthorectifyDEMResponse);
+  rpc Resample         (ResampleRequest)         returns (ResampleResponse);
+  rpc ColorMap         (ColorMapRequest)         returns (ColorMapResponse);
+}

--- a/services/lucidia-vision/server.cc
+++ b/services/lucidia-vision/server.cc
@@ -1,0 +1,79 @@
+#include <grpcpp/grpcpp.h>
+#include "proto/vision_service.grpc.pb.h"
+
+using lucidia::vision::v1::VisionService;
+using lucidia::vision::v1::*;  // import request/response messages
+
+class VisionServiceImpl final : public VisionService::Service {
+ public:
+  grpc::Status ReprojectImage(grpc::ServerContext*,
+                              const ReprojectImageRequest* req,
+                              ReprojectImageResponse* res) override {
+    // TODO: invoke VW reprojection, enforce quotas.
+    (void)req; (void)res;
+    return grpc::Status::OK;
+  }
+
+  grpc::Status TilePyramid(grpc::ServerContext*,
+                           const TilePyramidRequest* req,
+                           TilePyramidResponse* res) override {
+    // TODO: VW quadtree tiling.
+    (void)req; (void)res;
+    return grpc::Status::OK;
+  }
+
+  grpc::Status Mosaic(grpc::ServerContext*,
+                      const MosaicRequest* req,
+                      MosaicResponse* res) override {
+    // TODO: VW mosaic.
+    (void)req; (void)res;
+    return grpc::Status::OK;
+  }
+
+  grpc::Status Hillshade(grpc::ServerContext*,
+                         const HillshadeRequest* req,
+                         HillshadeResponse* res) override {
+    // TODO: VW hillshade.
+    (void)req; (void)res;
+    return grpc::Status::OK;
+  }
+
+  grpc::Status OrthorectifyDEM(grpc::ServerContext*,
+                               const OrthorectifyDEMRequest* req,
+                               OrthorectifyDEMResponse* res) override {
+    // TODO: VW orthorectification.
+    (void)req; (void)res;
+    return grpc::Status::OK;
+  }
+
+  grpc::Status Resample(grpc::ServerContext*,
+                        const ResampleRequest* req,
+                        ResampleResponse* res) override {
+    // TODO: VW resample.
+    (void)req; (void)res;
+    return grpc::Status::OK;
+  }
+
+  grpc::Status ColorMap(grpc::ServerContext*,
+                        const ColorMapRequest* req,
+                        ColorMapResponse* res) override {
+    // TODO: VW color mapping.
+    (void)req; (void)res;
+    return grpc::Status::OK;
+  }
+};
+
+int main(int argc, char** argv) {
+  (void)argc; (void)argv;
+  std::string server_address("0.0.0.0:50051");
+  VisionServiceImpl service;
+
+  grpc::ServerBuilder builder;
+  builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
+  builder.RegisterService(&service);
+
+  std::unique_ptr<grpc::Server> server(builder.BuildAndStart());
+  std::cout << "VisionService listening on " << server_address << std::endl;
+  server->Wait();
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add VisionService proto with RPC definitions for geospatial operations
- scaffold C++ gRPC server exposing VisionService with stubbed handlers

## Testing
- `pre-commit run --files proto/vision_service.proto services/lucidia-vision/server.cc` *(fails: command not found)*
- `pip install pre-commit` *(fails: Tunnel connection failed: 403 Forbidden)*
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fa6756bc8329b44250f93251bae6