### PR TITLE
feat: add fprime bridge skeleton

### DIFF
--- a/SUPPLYCHAIN.md
+++ b/SUPPLYCHAIN.md
@@ -1,0 +1,4 @@
+# Supply Chain Records
+
+- `third_party/fprime-examples`: intended to pin `nasa/fprime-examples` at tag
+  `v4.0.0`. Commit SHA to be recorded once the repository is vendored.

--- a/etc/systemd/system/blackroad-gds-adapter.service
+++ b/etc/systemd/system/blackroad-gds-adapter.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=BlackRoad GDS Adapter
+After=network.target lucidia-fprime-bridge.service
+
+[Service]
+User=lucidia
+Group=lucidia
+ExecStart=/usr/bin/env python3 /opt/blackroad/gds_adapter/main.py
+Restart=on-failure
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=read-only
+PrivateTmp=yes
+AmbientCapabilities=
+CapabilityBoundingSet=
+
+[Install]
+WantedBy=multi-user.target

--- a/etc/systemd/system/lucidia-fprime-bridge.service
+++ b/etc/systemd/system/lucidia-fprime-bridge.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Lucidia F´ Bridge
+After=network.target
+
+[Service]
+User=lucidia
+Group=lucidia
+ExecStart=/usr/local/bin/lucidia-fprime-bridge
+Restart=on-failure
+RestartSec=2
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=read-only
+PrivateTmp=yes
+AmbientCapabilities=
+CapabilityBoundingSet=
+LimitNOFILE=4096
+
+[Install]
+WantedBy=multi-user.target

--- a/services/blackroad-gds-adapter/bridge_client.py
+++ b/services/blackroad-gds-adapter/bridge_client.py
@@ -1,0 +1,15 @@
+class BridgeClient:
+    """Placeholder client for lucidia-fprime-bridge."""
+
+    def __init__(self, endpoint: str):
+        self.endpoint = endpoint
+        # TODO: initialize ZeroMQ or gRPC client
+
+    async def subscribe(self, topics):
+        """Async generator yielding telemetry messages."""
+        for _ in []:
+            yield None
+
+    async def submit(self, command):
+        """Submit a command sequence to the bridge."""
+        pass

--- a/services/blackroad-gds-adapter/main.py
+++ b/services/blackroad-gds-adapter/main.py
@@ -1,0 +1,40 @@
+import asyncio
+import ssl
+import websockets
+from bridge_client import BridgeClient
+
+CA_PATH = "/etc/blackroad/ca.pem"
+CERT = "/etc/blackroad/client.pem"
+KEY = "/etc/blackroad/client.key"
+WS_URL = "wss://mission-control.blackroad.local/gds"
+
+ssl_ctx = ssl.create_default_context(cafile=CA_PATH)
+ssl_ctx.load_cert_chain(CERT, KEY)
+
+def sign(msg):
+    # TODO: implement signing
+    return msg
+
+def verify_and_parse(msg):
+    # TODO: verify signature and parse command
+    return msg
+
+async def telemetry_task(ws, bridge):
+    async for tlm in bridge.subscribe(["*"]):
+        await ws.send(sign(tlm))
+
+async def command_task(ws, bridge):
+    async for msg in ws:
+        cmd = verify_and_parse(msg)
+        await bridge.submit(cmd)
+
+async def main():
+    bridge = BridgeClient("ipc:///var/run/lucidia_bridge.sock")
+    async with websockets.connect(WS_URL, ssl=ssl_ctx) as ws:
+        await asyncio.gather(
+            telemetry_task(ws, bridge),
+            command_task(ws, bridge),
+        )
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/services/lucidia-fprime-bridge/src/bridge/BridgeComponent.cpp
+++ b/services/lucidia-fprime-bridge/src/bridge/BridgeComponent.cpp
@@ -1,0 +1,26 @@
+#include "BridgeComponent.hpp"
+
+void BridgeComponent::registerTransport(ZmqServer &t) {
+    this->transport = &t;
+}
+
+void BridgeComponent::startRateGroups(const std::vector<int> &rates) {
+    // TODO: initialize scheduler with given rates
+}
+
+void BridgeComponent::ping() {
+    // TODO: implement watchdog ping
+}
+
+void BridgeComponent::loop() {
+    while (true) {
+        // TODO: run scheduler and poll transport
+        if (transport) {
+            transport->poll();
+        }
+    }
+}
+
+void BridgeComponent::handleCommandSeq(const CommandSeq &seq) {
+    // TODO: validate and queue sequence
+}

--- a/services/lucidia-fprime-bridge/src/bridge/BridgeComponent.hpp
+++ b/services/lucidia-fprime-bridge/src/bridge/BridgeComponent.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <vector>
+#include "Transport/ZmqServer.hpp"
+
+class BridgeComponent {
+  public:
+    void registerTransport(ZmqServer &transport);
+    void startRateGroups(const std::vector<int> &rates);
+    void ping();
+    void loop();
+    void handleCommandSeq(const CommandSeq &seq);
+
+  private:
+    ZmqServer *transport = nullptr;
+    // add members for scheduler, telemetry queues, etc.
+};

--- a/services/lucidia-fprime-bridge/src/bridge/Main.cpp
+++ b/services/lucidia-fprime-bridge/src/bridge/Main.cpp
@@ -1,0 +1,25 @@
+#include <thread>
+#include "Fw/Types/Assert.hpp"
+#include "Os/Task.hpp"
+#include "Bridge/BridgeComponent.hpp"
+#include "Transport/ZmqServer.hpp"      // or gRPC server wrapper
+
+int main() {
+    BridgeComponent bridge;
+    ZmqServer transport("ipc:///var/run/lucidia_bridge.sock");
+
+    bridge.registerTransport(transport);
+    bridge.startRateGroups({10, 50, 100}); // Hz
+
+    // Watchdog
+    std::thread watchdog([&](){
+        while (true) {
+            bridge.ping();
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+        }
+    });
+
+    bridge.loop();        // Runs scheduler, telemetry, command processing
+    watchdog.join();
+    return 0;
+}

--- a/sites/blackroad/src/ui/GdsDashboard.jsx
+++ b/sites/blackroad/src/ui/GdsDashboard.jsx
@@ -1,0 +1,24 @@
+import { useEffect, useRef } from "react";
+
+export default function GdsDashboard() {
+  const wsRef = useRef(null);
+
+  useEffect(() => {
+    const ws = new WebSocket("wss://mission-control.blackroad.local/gds");
+    wsRef.current = ws;
+    ws.onmessage = (evt) => {
+      const msg = JSON.parse(evt.data);
+      // TODO: handle telemetry, events, command acks
+      console.log(msg);
+    };
+    return () => ws.close();
+  }, []);
+
+  return (
+    <div>
+      <div id="health"></div>
+      <canvas id="telemetryChart" />
+      <ul id="commandQueue"></ul>
+    </div>
+  );
+}

--- a/third_party/fprime-examples/README.md
+++ b/third_party/fprime-examples/README.md
@@ -1,0 +1,4 @@
+This directory is intended to contain the `nasa/fprime-examples` repository
+vendored at tag `v4.0.0`. Network restrictions prevented automatic retrieval.
+Populate this folder with the tagged release and record the commit SHA in
+`SUPPLYCHAIN.md` when available.


### PR DESCRIPTION
## Summary
- add C++ lucidia-fprime-bridge skeleton with transport and watchdog
- add Python blackroad-gds-adapter skeleton
- add dashboard component placeholder and systemd units
- note intended vendoring of fprime-examples in supply chain records

## Testing
- `pre-commit run --files SUPPLYCHAIN.md etc/systemd/system/blackroad-gds-adapter.service etc/systemd/system/lucidia-fprime-bridge.service services/blackroad-gds-adapter/main.py services/blackroad-gds-adapter/bridge_client.py services/lucidia-fprime-bridge/src/bridge/Main.cpp services/lucidia-fprime-bridge/src/bridge/BridgeComponent.hpp services/lucidia-fprime-bridge/src/bridge/BridgeComponent.cpp sites/blackroad/src/ui/GdsDashboard.jsx third_party/fprime-examples/README.md` (command failed: pre-commit not found)
- `pip install pre-commit` (command failed: Could not find a version that satisfies the requirement pre-commit)
- `python -m py_compile services/blackroad-gds-adapter/*.py`
- `cd sites/blackroad && npm test` (command failed: Invalid package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a4f9928b2c832988d6f1c65a6d1056