### PR TITLE
Add Atlas export tools and route

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ openai==1.30.1
 streamlit==1.35.0
 torch
 whisper
+pyarrow==16.1.0

--- a/sites/blackroad/src/pages/Atlas.jsx
+++ b/sites/blackroad/src/pages/Atlas.jsx
@@ -1,0 +1,15 @@
+import { useEffect } from 'react'
+
+export default function Atlas() {
+  useEffect(() => {
+    // TODO: enforce RBAC so only admins can access this route
+  }, [])
+
+  return (
+    <div className="card">
+      <h2 className="text-xl font-semibold mb-2">Atlas (Local)</h2>
+      <p className="opacity-80">Embedding explorer loading…</p>
+      <div id="atlas-root" className="h-[80vh] border mt-4" />
+    </div>
+  )
+}

--- a/sites/blackroad/src/router.jsx
+++ b/sites/blackroad/src/router.jsx
@@ -10,6 +10,7 @@ import Contact from './pages/Contact.jsx'
 import Tutorials from './pages/Tutorials.jsx'
 import Roadmap from './pages/Roadmap.jsx'
 import Changelog from './pages/Changelog.jsx'
+import Atlas from './pages/Atlas.jsx'
 import Blog from './pages/Blog.jsx'
 import Post from './pages/Post.jsx'
 import NotFound from './pages/NotFound.jsx'
@@ -26,6 +27,7 @@ export const router = createBrowserRouter([
       { path: 'snapshot', element: <SnapshotPage /> },
       { path: 'portal', element: <Portal /> },
       { path: 'playground', element: <Playground /> },
+      { path: 'atlas', element: <Atlas /> },
       { path: 'contact', element: <Contact /> },
       { path: 'tutorials', element: <Tutorials /> },
       { path: 'roadmap', element: <Roadmap /> },
@@ -42,6 +44,7 @@ export const router = createBrowserRouter([
     { path: 'snapshot', element: <SnapshotPage /> },
     { path: 'portal', element: <Portal /> },
     { path: 'playground', element: <Playground /> },
+    { path: 'atlas', element: <Atlas /> },
     { path: 'contact', element: <Contact /> },
     { path: 'tutorials', element: <Tutorials /> },
     { path: 'roadmap', element: <Roadmap /> },

--- a/tools/export_embeddings.py
+++ b/tools/export_embeddings.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Export Lucidia embeddings to Embedding Atlas compatible Parquet.
+
+Writes a Parquet file with the schema required by the Embedding Atlas
+viewer. The script performs a light redaction pass to strip secrets or
+email-like strings from textual metadata before serialization.
+
+Example:
+    python tools/export_embeddings.py --out data/atlas.parquet
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import re
+from typing import Iterable, Dict, Any
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+
+RE_EMAIL = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+RE_TOKEN = re.compile(r"[A-Za-z0-9_\-]{32,}")
+
+
+def redact(text: str) -> str:
+    """Redact obvious secrets from text fields."""
+    text = RE_EMAIL.sub("[redacted]", text)
+    text = RE_TOKEN.sub("[redacted]", text)
+    return text
+
+
+def records() -> Iterable[Dict[str, Any]]:
+    """Yield embedding records.
+
+    In a real deployment this function would stream data from Lucidia's
+    memory store. Here we emit a tiny synthetic example so the exporter
+    can run in isolation.
+    """
+    yield {
+        "id": "demo-0",
+        "embedding": [0.0, 0.1, 0.2],
+        "projection_2d": [0.0, 0.0],
+        "text": "hello world",
+        "source_uri": "/demo",
+        "agent": "guardian",
+        "doc_type": "chat",
+        "truth_state": 0,
+        "contradiction_level": 0.0,
+        "ps_sha_inf": "deadbeef",
+        "timestamp": dt.datetime.now(dt.timezone.utc),
+        "tags": ["demo"],
+    }
+
+
+def build_table(rows: Iterable[Dict[str, Any]]) -> pa.Table:
+    schema = pa.schema([
+        pa.field("id", pa.string()),
+        pa.field("embedding", pa.list_(pa.float32())),
+        pa.field("projection_2d", pa.list_(pa.float32())),
+        pa.field("text", pa.string()),
+        pa.field("source_uri", pa.string()),
+        pa.field("agent", pa.string()),
+        pa.field("doc_type", pa.string()),
+        pa.field("truth_state", pa.int8()),
+        pa.field("contradiction_level", pa.float32()),
+        pa.field("ps_sha_inf", pa.string()),
+        pa.field("timestamp", pa.timestamp("ms")),
+        pa.field("tags", pa.list_(pa.string())),
+    ])
+
+    cleaned = []
+    for r in rows:
+        r = r.copy()
+        r["text"] = redact(r.get("text", ""))
+        r["source_uri"] = redact(r.get("source_uri", ""))
+        cleaned.append(r)
+
+    return pa.Table.from_pylist(cleaned, schema=schema)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", default="data/atlas.parquet", help="Output Parquet file")
+    args = parser.parse_args()
+
+    table = build_table(records())
+    pq.write_table(table, args.out)
+    print(f"wrote {table.num_rows} rows to {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `export_embeddings.py` to create Embedding Atlas compatible Parquet with redaction
- stub `/atlas` React page and wire route
- pin `pyarrow` dependency for exporter

## Testing
- `npm test`
- `pytest tests/test_tokenize_url.py`


------
https://chatgpt.com/codex/tasks/task_e_68a505c1cf9483298cb13743b2a0afa8