### PR TITLE
feat: scaffold lucidia MCP filesystem and ollama servers

### DIFF
--- a/lmcp/ops/systemd/lucidia-fs.service
+++ b/lmcp/ops/systemd/lucidia-fs.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Lucidia Filesystem MCP Server
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/env uv run lucidia-fs
+Restart=on-failure
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectHome=yes
+CapabilityBoundingSet=
+
+[Install]
+WantedBy=default.target

--- a/lmcp/ops/systemd/lucidia-ollama.service
+++ b/lmcp/ops/systemd/lucidia-ollama.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Lucidia Ollama MCP Server
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/env uv run lucidia-ollama
+Restart=on-failure
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectHome=yes
+CapabilityBoundingSet=
+
+[Install]
+WantedBy=default.target

--- a/lmcp/servers/lucidia_fs/lucidia_fs/__init__.py
+++ b/lmcp/servers/lucidia_fs/lucidia_fs/__init__.py
@@ -1,0 +1,1 @@
+"""Lucidia filesystem MCP server package."""

--- a/lmcp/servers/lucidia_fs/lucidia_fs/server.py
+++ b/lmcp/servers/lucidia_fs/lucidia_fs/server.py
@@ -1,0 +1,72 @@
+"""Filesystem MCP server for Lucidia.
+
+Provides tools to read and write files within an allow-listed root
+directory. Traversal outside the root is rejected. The server may be
+placed in read-only mode via the ``LUCIDIA_FS_READ_ONLY`` environment
+variable.
+"""
+from __future__ import annotations
+
+import os
+import pathlib
+
+try:
+    from mcp.server import Server as MCPServer
+except Exception:  # pragma: no cover - mcp is an optional dependency
+    MCPServer = None
+
+ROOT = pathlib.Path(os.environ.get("LUCIDIA_FS_ROOT", ".")).resolve()
+READ_ONLY = os.environ.get("LUCIDIA_FS_READ_ONLY", "0") == "1"
+
+server = MCPServer("lucidia-fs") if MCPServer else None
+
+
+def _resolve_path(path: str) -> pathlib.Path:
+    """Return ``path`` resolved against :data:`ROOT`.
+
+    Raises
+    ------
+    ValueError
+        If ``path`` escapes :data:`ROOT`.
+    """
+    target = (ROOT / path).resolve()
+    if not str(target).startswith(str(ROOT)):
+        raise ValueError("path escapes root")
+    return target
+
+
+if server:
+
+    @server.tool()
+    def read_file(path: str) -> str:
+        """Read a file relative to the allowed root."""
+        return _resolve_path(path).read_text()
+
+    @server.tool()
+    def write_file(path: str, content: str) -> str:
+        """Write ``content`` to ``path`` if the server is not read-only."""
+        if READ_ONLY:
+            raise PermissionError("server in read-only mode")
+        target = _resolve_path(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content)
+        return "ok"
+
+    @server.tool()
+    def apply_patch(path: str, diff: str) -> str:
+        """Apply a unified diff to ``path``.
+
+        This implementation is a placeholder and does not yet apply the
+        patch. It simply raises ``NotImplementedError``.
+        """
+        raise NotImplementedError("patch application not yet implemented")
+
+
+def main() -> None:
+    if not server:
+        raise RuntimeError("mcp package not installed")
+    server.run()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()

--- a/lmcp/servers/lucidia_fs/pyproject.toml
+++ b/lmcp/servers/lucidia_fs/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "lucidia-fs"
+version = "0.1.0"
+description = "Lucidia filesystem MCP server"
+requires-python = ">=3.10"
+dependencies = [
+    "mcp",
+]
+
+[project.scripts]
+lucidia-fs = "lucidia_fs.server:main"

--- a/lmcp/servers/lucidia_ollama/lucidia_ollama/__init__.py
+++ b/lmcp/servers/lucidia_ollama/lucidia_ollama/__init__.py
@@ -1,0 +1,1 @@
+"""Lucidia Ollama MCP server package."""

--- a/lmcp/servers/lucidia_ollama/lucidia_ollama/server.py
+++ b/lmcp/servers/lucidia_ollama/lucidia_ollama/server.py
@@ -1,0 +1,76 @@
+"""Ollama MCP server for Lucidia.
+
+This server exposes simple tools to interact with a locally running
+`ollama` instance. Only models present in the allow-list are accepted.
+"""
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List
+
+
+try:
+    import requests
+except Exception:  # pragma: no cover - requests may be optional
+    requests = None  # type: ignore
+
+try:
+    from mcp.server import Server as MCPServer
+except Exception:  # pragma: no cover
+    MCPServer = None
+
+OLLAMA_URL = os.environ.get("OLLAMA_URL", "http://127.0.0.1:11434")
+MODEL_ALLOWLIST = set(
+    os.environ.get("LUCIDIA_OLLAMA_MODELS", "phi3:latest,mistral:instruct").split(",")
+)
+TIMEOUT = float(os.environ.get("LUCIDIA_OLLAMA_TIMEOUT", "30"))
+
+server = MCPServer("lucidia-ollama") if MCPServer else None
+
+
+def _check_model(model: str) -> None:
+    if model not in MODEL_ALLOWLIST:
+        raise ValueError("model not allowed")
+
+
+def _post(endpoint: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    if requests is None:
+        raise RuntimeError("requests not installed")
+    url = f"{OLLAMA_URL}/{endpoint}"
+    response = requests.post(url, json=payload, timeout=TIMEOUT)
+    response.raise_for_status()
+    return response.json()
+
+
+if server:
+
+    @server.tool()
+    def generate(model: str, prompt: str) -> str:
+        """Generate text from ``prompt`` using ``model``."""
+        _check_model(model)
+        data = _post("api/generate", {"model": model, "prompt": prompt})
+        return data.get("response", "")
+
+    @server.tool()
+    def chat(model: str, messages: List[Dict[str, str]]) -> str:
+        """Chat with ``model`` using a list of messages."""
+        _check_model(model)
+        data = _post("api/chat", {"model": model, "messages": messages})
+        return data.get("response", "")
+
+    @server.tool()
+    def embed(model: str, text: str) -> List[float]:
+        """Return an embedding vector for ``text`` using ``model``."""
+        _check_model(model)
+        data = _post("api/embed", {"model": model, "input": text})
+        return data.get("embedding", [])
+
+
+def main() -> None:
+    if not server:
+        raise RuntimeError("mcp package not installed")
+    server.run()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()

--- a/lmcp/servers/lucidia_ollama/pyproject.toml
+++ b/lmcp/servers/lucidia_ollama/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "lucidia-ollama"
+version = "0.1.0"
+description = "Lucidia Ollama MCP server"
+requires-python = ">=3.10"
+dependencies = [
+    "mcp",
+    "requests",
+]
+
+[project.scripts]
+lucidia-ollama = "lucidia_ollama.server:main"

--- a/lmcp/tests/test_lucidia_fs.py
+++ b/lmcp/tests/test_lucidia_fs.py
@@ -1,0 +1,16 @@
+import importlib
+import pathlib
+import sys
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "servers" / "lucidia_fs"))
+from lucidia_fs import server as fs_server
+
+
+def test_resolve_path(tmp_path, monkeypatch):
+    monkeypatch.setenv("LUCIDIA_FS_ROOT", str(tmp_path))
+    importlib.reload(fs_server)
+    assert fs_server._resolve_path("allowed.txt") == tmp_path / "allowed.txt"
+    with pytest.raises(ValueError):
+        fs_server._resolve_path("../secret.txt")

--- a/lmcp/tests/test_lucidia_ollama.py
+++ b/lmcp/tests/test_lucidia_ollama.py
@@ -1,0 +1,15 @@
+import importlib
+import pathlib
+import sys
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "servers" / "lucidia_ollama"))
+from lucidia_ollama import server as ollama_server
+
+
+def test_model_allowlist(monkeypatch):
+    monkeypatch.setenv("LUCIDIA_OLLAMA_MODELS", "a,b")
+    importlib.reload(ollama_server)
+    with pytest.raises(ValueError):
+        ollama_server._check_model("c")


### PR DESCRIPTION
## Summary
- add initial lucidia-fs MCP server with path restrictions and read-only mode
- add initial lucidia-ollama MCP server with model allowlist and local API calls
- provide systemd units and basic tests for the new servers

## Testing
- `pytest lmcp/tests/test_lucidia_fs.py lmcp/tests/test_lucidia_ollama.py`
- `pre-commit run --files lmcp/servers/lucidia_fs/lucidia_fs/__init__.py lmcp/servers/lucidia_fs/lucidia_fs/server.py lmcp/servers/lucidia_fs/pyproject.toml lmcp/servers/lucidia_ollama/lucidia_ollama/__init__.py lmcp/servers/lucidia_ollama/lucidia_ollama/server.py lmcp/servers/lucidia_ollama/pyproject.toml lmcp/ops/systemd/lucidia-fs.service lmcp/ops/systemd/lucidia-ollama.service lmcp/tests/test_lucidia_fs.py lmcp/tests/test_lucidia_ollama.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a505adb1088329944fea9a8c913077