### PR TITLE
feat: add lucidia presence workspace skeleton

### DIFF
--- a/lucidia-presence/Cargo.toml
+++ b/lucidia-presence/Cargo.toml
@@ -1,0 +1,13 @@
+[workspace]
+members = [
+    "presence_core",
+    "presence_net",
+    "presence_sandbox",
+    "presence_host_desktop",
+    "presence_host_web",
+]
+resolver = "2"
+
+[workspace.package]
+edition = "2021"
+license = "MIT OR Apache-2.0"

--- a/lucidia-presence/presence_core/Cargo.toml
+++ b/lucidia-presence/presence_core/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "presence_core"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+bevy = { version = "0.13", default-features = false, features = ["bevy_winit", "x11"] }
+wgpu = "0.19"
+bevy_egui = "0.24"
+rapier3d = { version = "0.26", features = ["dim3", "simd-stable"] }
+serde = { version = "1", features = ["derive"] }
+
+[lib]
+path = "src/lib.rs"

--- a/lucidia-presence/presence_core/src/lib.rs
+++ b/lucidia-presence/presence_core/src/lib.rs
@@ -1,0 +1,15 @@
+#![forbid(unsafe_code)]
+
+use bevy::prelude::*;
+
+pub struct PresenceCorePlugin;
+
+impl Plugin for PresenceCorePlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Startup, setup);
+    }
+}
+
+fn setup(mut commands: Commands) {
+    commands.spawn(Camera3dBundle::default());
+}

--- a/lucidia-presence/presence_host_desktop/Cargo.toml
+++ b/lucidia-presence/presence_host_desktop/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "presence_host_desktop"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+tauri = { version = "1", features = ["api-all"] }
+
+[dependencies.presence_core]
+path = "../presence_core"
+
+[dependencies.presence_net]
+path = "../presence_net"
+
+[[bin]]
+name = "presence_host_desktop"
+path = "src/main.rs"

--- a/lucidia-presence/presence_host_desktop/src/main.rs
+++ b/lucidia-presence/presence_host_desktop/src/main.rs
@@ -1,0 +1,16 @@
+#![forbid(unsafe_code)]
+
+use presence_core::PresenceCorePlugin;
+
+fn main() {
+    tauri::Builder::default()
+        .setup(|_app| {
+            // Initialize Bevy app inside Tauri
+            let mut app = bevy::prelude::App::new();
+            app.add_plugins(bevy::DefaultPlugins);
+            app.add_plugins(PresenceCorePlugin);
+            Ok(())
+        })
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
+}

--- a/lucidia-presence/presence_host_web/Cargo.toml
+++ b/lucidia-presence/presence_host_web/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "presence_host_web"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+path = "src/lib.rs"
+
+[dependencies]
+wasm-bindgen = "0.2"
+console_error_panic_hook = { version = "0.1", optional = true }
+
+[dependencies.presence_core]
+path = "../presence_core"
+
+[dependencies.presence_net]
+path = "../presence_net"
+
+[features]
+default = []
+wee_alloc = []

--- a/lucidia-presence/presence_host_web/src/lib.rs
+++ b/lucidia-presence/presence_host_web/src/lib.rs
@@ -1,0 +1,12 @@
+#![forbid(unsafe_code)]
+
+use presence_core::PresenceCorePlugin;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen(start)]
+pub fn run() {
+    console_error_panic_hook::set_once();
+    let mut app = bevy::prelude::App::new();
+    app.add_plugins(bevy::DefaultPlugins);
+    app.add_plugins(PresenceCorePlugin);
+}

--- a/lucidia-presence/presence_net/Cargo.toml
+++ b/lucidia-presence/presence_net/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "presence_net"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+quinn = "0.11"
+webrtc = "0.10"
+
+[lib]
+path = "src/lib.rs"

--- a/lucidia-presence/presence_net/src/lib.rs
+++ b/lucidia-presence/presence_net/src/lib.rs
@@ -1,0 +1,13 @@
+#![forbid(unsafe_code)]
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AgentState {
+    pub id: String,
+    pub memory_heat: f32,
+}
+
+pub fn encode_state(state: &AgentState) -> serde_json::Result<String> {
+    serde_json::to_string(state)
+}

--- a/lucidia-presence/presence_sandbox/Cargo.toml
+++ b/lucidia-presence/presence_sandbox/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "presence_sandbox"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+wasmtime = "17"
+
+[lib]
+path = "src/lib.rs"

--- a/lucidia-presence/presence_sandbox/src/lib.rs
+++ b/lucidia-presence/presence_sandbox/src/lib.rs
@@ -1,0 +1,5 @@
+#![forbid(unsafe_code)]
+
+pub fn load_wasm(_bytes: &[u8]) {
+    // Placeholder for sandboxed plugin loader
+}


### PR DESCRIPTION
## Summary
- scaffold lucidia-presence Rust workspace with core, networking, sandbox, desktop, and web crates
- include minimal Bevy plugin, network message type, sandbox loader stub, and host entry points

## Testing
- `pre-commit run --files lucidia-presence/Cargo.toml`: command not found
- `pip install pre-commit`: could not find a version due to proxy 403
- `cargo check`: failed to download bevy (CONNECT tunnel failed, response 403)


------
https://chatgpt.com/codex/tasks/task_e_68a50612613483299e6113b3d35d5096