### PR TITLE
feat: add optional quantum ml module

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,3 +541,14 @@ Pass a specific date if needed:
 ```bash
 python scripts/lucidia_awaken_code.py --date 2025-08-19
 ```
+
+## Quantum ML (optional)
+
+An experimental `lucidia.quantum` module provides local Qiskit-based
+neural networks and quantum kernel methods. It is disabled by default
+and can be enabled via the environment variable `LUCIDIA_QML=on`.
+
+Pinned versions:
+
+- `qiskit-machine-learning==0.8.3`
+- `qiskit-aer==0.17.1`

--- a/blackroad/api/quantum.py
+++ b/blackroad/api/quantum.py
@@ -1,0 +1,51 @@
+"""Quantum Lab API routes."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from lucidia.quantum import is_enabled
+
+router = APIRouter(prefix="/api/quantum")
+
+
+def _require_enabled() -> None:
+    if not is_enabled():
+        raise HTTPException(status_code=503, detail="Quantum disabled")
+
+
+class TrainRequest(BaseModel):
+    data: list[list[float]]
+    labels: list[int]
+
+
+@router.post("/qnn/train")
+def train_qnn(req: TrainRequest) -> dict[str, str]:
+    _require_enabled()
+    # In a real implementation this would enqueue a training job.
+    return {"status": "queued"}
+
+
+class PredictRequest(BaseModel):
+    data: list[list[float]]
+
+
+@router.post("/qnn/predict")
+def predict_qnn(req: PredictRequest) -> dict[str, list[int]]:
+    _require_enabled()
+    # Placeholder deterministic prediction
+    preds = [0 for _ in req.data]
+    return {"status": "ok", "prediction": preds}
+
+
+class KernelRequest(BaseModel):
+    data: list[list[float]]
+    labels: list[int]
+
+
+@router.post("/kernel/qsvc")
+def kernel_qsvc(req: KernelRequest) -> dict[str, list[int]]:
+    _require_enabled()
+    # Stubbed kernel-based classifier
+    return {"status": "ok", "prediction": req.labels}

--- a/blackroad/ui/quantum-lab/index.html
+++ b/blackroad/ui/quantum-lab/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Quantum Lab</title>
+</head>
+<body>
+<h1>Quantum Lab</h1>
+<p>This panel is gated behind the <code>LUCIDIA_QML</code> feature flag and
+is intended for experimenting with local quantum machine learning models.</p>
+</body>
+</html>

--- a/compliance/third_party/qiskit-ml/NOTICE.md
+++ b/compliance/third_party/qiskit-ml/NOTICE.md
@@ -1,0 +1,11 @@
+# Qiskit Machine Learning
+
+- Version: 0.8.3
+- Source: https://github.com/Qiskit/qiskit-machine-learning
+- License: Apache-2.0
+
+# Qiskit Aer
+
+- Version: 0.17.1
+- Source: https://github.com/Qiskit/qiskit-aer
+- License: Apache-2.0

--- a/lucidia/quantum/__init__.py
+++ b/lucidia/quantum/__init__.py
@@ -1,0 +1,44 @@
+"""Quantum ML module for Lucidia.
+
+This package is optional and guarded by the ``LUCIDIA_QML`` environment
+variable. Only local simulators are used; remote providers are disabled
+when ``LUCIDIA_QML_REMOTE`` is unset or false.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, Type
+
+from .backends import AerCPUBackend, QuantumBackend
+
+_QML_ENABLED = os.getenv("LUCIDIA_QML", "off").lower() in {"1", "true", "on"}
+_REMOTE_OK = os.getenv("LUCIDIA_QML_REMOTE", "false").lower() in {"1", "true", "on"}
+
+# Registry of available backends
+_BACKENDS: Dict[str, Type[QuantumBackend]] = {"aer_cpu": AerCPUBackend}
+
+
+def is_enabled() -> bool:
+    """Return True if the Quantum ML feature flag is on."""
+
+    return _QML_ENABLED
+
+
+def get_backend(name: str = "aer_cpu") -> QuantumBackend:
+    """Instantiate and return a backend by name.
+
+    Parameters
+    ----------
+    name:
+        Registered backend key. Defaults to ``aer_cpu``.
+    """
+
+    if not _QML_ENABLED:
+        raise RuntimeError("Quantum ML disabled")
+    if not _REMOTE_OK and name not in _BACKENDS:
+        raise RuntimeError("Remote backends are disabled")
+    backend_cls = _BACKENDS.get(name)
+    if backend_cls is None:
+        raise ValueError(f"Unknown backend '{name}'")
+    return backend_cls()

--- a/lucidia/quantum/backends.py
+++ b/lucidia/quantum/backends.py
@@ -1,0 +1,50 @@
+"""Backend interfaces for Quantum ML.
+
+Currently only the local Aer CPU simulator is implemented. GPU support is
+stubbed out and disabled unless ``LUCIDIA_QML_GPU`` is set.
+"""
+
+from __future__ import annotations
+
+import os
+from abc import ABC, abstractmethod
+from typing import Any
+
+from qiskit import QuantumCircuit
+
+
+class QuantumBackend(ABC):
+    """Abstract quantum backend."""
+
+    @abstractmethod
+    def run(self, circuit: QuantumCircuit, shots: int = 1024, seed: int | None = None) -> Any:
+        """Execute a circuit and return the raw result."""
+
+
+class AerCPUBackend(QuantumBackend):
+    """Qiskit Aer CPU simulator backend."""
+
+    def __init__(self) -> None:
+        from qiskit_aer import AerSimulator
+
+        self.simulator = AerSimulator(method="automatic")
+
+    def run(self, circuit: QuantumCircuit, shots: int = 1024, seed: int | None = None) -> Any:
+        if seed is not None:
+            circuit = circuit.copy()
+            circuit.seed_simulator(seed)
+        job = self.simulator.run(circuit, shots=shots)
+        return job.result()
+
+
+class AerGPUBackend(AerCPUBackend):
+    """Stub GPU backend. Requires CUDA and qiskit-aer-gpu."""
+
+    def __init__(self) -> None:
+        if os.getenv("LUCIDIA_QML_GPU", "off").lower() not in {"1", "true", "on"}:
+            raise RuntimeError("GPU backend disabled")
+        super().__init__()
+        try:
+            self.simulator.set_options(device="GPU")  # type: ignore[attr-defined]
+        except Exception as exc:  # pragma: no cover - fallback path
+            raise RuntimeError("GPU backend not available") from exc

--- a/lucidia/quantum/kernels.py
+++ b/lucidia/quantum/kernels.py
@@ -1,0 +1,26 @@
+"""Quantum kernel utilities."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import numpy as np
+from qiskit_machine_learning.algorithms import PegasosQSVC
+from qiskit_machine_learning.kernels import QuantumKernel
+
+from .backends import AerCPUBackend, QuantumBackend
+
+
+def fit_qsvc(
+    x: np.ndarray,
+    y: np.ndarray,
+    kernel_opts: Optional[dict[str, Any]] = None,
+    backend: Optional[QuantumBackend] = None,
+) -> PegasosQSVC:
+    """Train a PegasosQSVC on the given data using a local quantum kernel."""
+
+    backend = backend or AerCPUBackend()
+    kernel = QuantumKernel(quantum_instance=backend.simulator, **(kernel_opts or {}))
+    model = PegasosQSVC(quantum_kernel=kernel)
+    model.fit(x, y)
+    return model

--- a/lucidia/quantum/policies.py
+++ b/lucidia/quantum/policies.py
@@ -1,0 +1,18 @@
+"""Resource policies for quantum execution."""
+
+from __future__ import annotations
+
+from qiskit import QuantumCircuit
+
+MAX_QUBITS = 8
+MAX_DEPTH = 40
+MAX_SHOTS = 1024
+
+
+def validate_circuit(circuit: QuantumCircuit) -> None:
+    """Raise ``ValueError`` if the circuit exceeds policy limits."""
+
+    if circuit.num_qubits > MAX_QUBITS:
+        raise ValueError("too many qubits")
+    if circuit.depth() > MAX_DEPTH:
+        raise ValueError("circuit too deep")

--- a/lucidia/quantum/qnn.py
+++ b/lucidia/quantum/qnn.py
@@ -1,0 +1,58 @@
+"""Helper builders for Qiskit EstimatorQNN and SamplerQNN."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from qiskit import QuantumCircuit
+from qiskit.circuit import ParameterVector
+from qiskit_machine_learning.neural_networks import EstimatorQNN, SamplerQNN
+
+from .backends import AerCPUBackend, QuantumBackend
+
+
+def build_estimator_qnn(
+    feature_map: QuantumCircuit,
+    ansatz: QuantumCircuit,
+    observable: QuantumCircuit | None,
+    input_size: int,
+    weight_size: int,
+    backend: Optional[QuantumBackend] = None,
+) -> EstimatorQNN:
+    """Construct an :class:`EstimatorQNN` with gradients enabled."""
+
+    backend = backend or AerCPUBackend()
+    input_params = ParameterVector("x", length=input_size)
+    weight_params = ParameterVector("w", length=weight_size)
+    return EstimatorQNN(
+        feature_map=feature_map,
+        ansatz=ansatz,
+        observable=observable,
+        input_params=input_params,
+        weight_params=weight_params,
+        backend=backend.simulator,
+        input_gradients=True,
+    )
+
+
+def build_sampler_qnn(
+    feature_map: QuantumCircuit,
+    ansatz: QuantumCircuit,
+    input_size: int,
+    weight_size: int,
+    num_classes: int,
+    backend: Optional[QuantumBackend] = None,
+) -> SamplerQNN:
+    """Construct a probabilistic :class:`SamplerQNN`."""
+
+    backend = backend or AerCPUBackend()
+    input_params = ParameterVector("x", length=input_size)
+    weight_params = ParameterVector("w", length=weight_size)
+    return SamplerQNN(
+        feature_map=feature_map,
+        ansatz=ansatz,
+        input_params=input_params,
+        weight_params=weight_params,
+        output_shape=num_classes,
+        backend=backend.simulator,
+    )

--- a/lucidia/quantum/tests/test_qml.py
+++ b/lucidia/quantum/tests/test_qml.py
@@ -1,0 +1,51 @@
+"""Basic tests for the Quantum ML module."""
+
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("qiskit")
+pytest.importorskip("qiskit_machine_learning")
+
+import torch
+from qiskit.circuit.library import RealAmplitudes, ZZFeatureMap
+
+import lucidia.quantum as qml
+from lucidia.quantum.kernels import fit_qsvc
+from lucidia.quantum.qnn import build_sampler_qnn
+from lucidia.quantum.torch_bridge import QModule
+
+
+def test_feature_flag_off(monkeypatch):
+    monkeypatch.setenv("LUCIDIA_QML", "off")
+    importlib.reload(qml)
+    assert not qml.is_enabled()
+    with pytest.raises(RuntimeError):
+        qml.get_backend()
+
+
+def test_sampler_qnn_gradients(monkeypatch):
+    monkeypatch.setenv("LUCIDIA_QML", "on")
+    importlib.reload(qml)
+    feature_map = ZZFeatureMap(2)
+    ansatz = RealAmplitudes(2, reps=1)
+    qnn = build_sampler_qnn(feature_map, ansatz, input_size=2, weight_size=ansatz.num_parameters, num_classes=2)
+    module = QModule(qnn, seed=1)
+    x = torch.zeros((1, 2), requires_grad=True)
+    out = module(x)
+    out.backward(torch.ones_like(out))
+    assert torch.all(torch.isfinite(x.grad))
+
+
+def test_qsvc_training(monkeypatch):
+    monkeypatch.setenv("LUCIDIA_QML", "on")
+    importlib.reload(qml)
+    x = np.array([[0, 0], [1, 1]])
+    y = np.array([0, 1])
+    model = fit_qsvc(x, y)
+    preds = model.predict(x)
+    assert preds.shape == (2,)

--- a/lucidia/quantum/torch_bridge.py
+++ b/lucidia/quantum/torch_bridge.py
@@ -1,0 +1,37 @@
+"""PyTorch bridge for Quantum Neural Networks."""
+
+from __future__ import annotations
+
+import os
+import random
+from typing import Any
+
+import numpy as np
+import torch
+from qiskit_machine_learning.connectors import TorchConnector
+from qiskit_machine_learning.neural_networks import NeuralNetwork
+
+
+class QModule(torch.nn.Module):
+    """Wrap a Qiskit ``NeuralNetwork`` as a ``torch.nn.Module``."""
+
+    def __init__(self, qnn: NeuralNetwork, seed: int | None = 42) -> None:
+        super().__init__()
+        if seed is not None:
+            random.seed(seed)
+            np.random.seed(seed)
+            torch.manual_seed(seed)
+        self.qnn = qnn
+        self.connector = TorchConnector(neural_network=self.qnn)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if not isinstance(x, torch.Tensor):  # pragma: no cover - defensive
+            raise TypeError("expected torch.Tensor")
+        return self.connector(x)
+
+    def to(self, device: Any) -> "QModule":  # type: ignore[override]
+        if device not in {"cpu", torch.device("cpu")}:  # pragma: no cover - gpu path
+            if os.getenv("LUCIDIA_QML_GPU", "off").lower() not in {"1", "true", "on"}:
+                raise RuntimeError("GPU disabled")
+        self.connector.to(device)
+        return super().to(device)

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,6 @@ openai==1.30.1
 streamlit==1.35.0
 torch
 whisper
+
+qiskit-machine-learning==0.8.3
+qiskit-aer==0.17.1


### PR DESCRIPTION
## Summary
- add gated `lucidia.quantum` package with Aer simulator backend and QNN/kernels helpers
- expose placeholder FastAPI routes for quantum training and prediction
- document optional Quantum ML support and pin qiskit dependencies

## Testing
- `python -m py_compile lucidia/quantum/__init__.py lucidia/quantum/backends.py lucidia/quantum/qnn.py lucidia/quantum/torch_bridge.py lucidia/quantum/kernels.py lucidia/quantum/policies.py blackroad/api/quantum.py`
- `pytest lucidia/quantum/tests -q` *(skipped: torch, qiskit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a506283c288329800586d66a2809a0