### PR TITLE
feat(ui): scaffold vite react router app

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -1,0 +1,37 @@
+name: UI
+
+on:
+  push:
+    paths:
+      - 'apps/blackroad-web/**'
+      - '.github/workflows/ui.yml'
+  pull_request:
+    paths:
+      - 'apps/blackroad-web/**'
+      - '.github/workflows/ui.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/blackroad-web
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9
+      - name: Install
+        run: pnpm install --frozen-lockfile
+      - name: Lint
+        run: pnpm run lint
+      - name: Test
+        run: pnpm run test
+      - name: Build
+        run: pnpm run build
+      - name: Audit
+        run: pnpm audit --audit-level=high || true
+      - name: SBOM
+        uses: CycloneDX/gh-node-module@v1
+        with:
+          path: apps/blackroad-web

--- a/apps/blackroad-web/Dockerfile
+++ b/apps/blackroad-web/Dockerfile
@@ -1,0 +1,13 @@
+# Build stage
+FROM node:20-slim AS build
+WORKDIR /app
+COPY package.json tsconfig.json vite.config.ts index.html ./
+COPY src ./src
+RUN npm ci && npm run build
+
+# Runtime stage
+FROM gcr.io/distroless/nodejs20
+WORKDIR /app
+COPY --from=build /app/dist ./dist
+EXPOSE 3000
+CMD ["node", "./dist/server/entry.mjs"]

--- a/apps/blackroad-web/MIGRATION.md
+++ b/apps/blackroad-web/MIGRATION.md
@@ -1,0 +1,8 @@
+# Migration from CRA
+
+This project was initialized without Create React App. To migrate an existing CRA codebase:
+
+1. Remove `react-scripts` and related dependencies.
+2. Copy source files into `src/` and update environment variables to use the `VITE_` prefix.
+3. Replace testing utilities with Vitest and React Testing Library.
+4. Verify the strict Content-Security-Policy and TypeScript settings.

--- a/apps/blackroad-web/SECURITY.md
+++ b/apps/blackroad-web/SECURITY.md
@@ -1,0 +1,9 @@
+# Security
+
+This UI enforces a strict Content-Security-Policy:
+
+```
+default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://api.blackroad.io wss://api.blackroad.io; img-src 'self' data:; frame-ancestors 'none'
+```
+
+TypeScript is configured with `strict`, `noUncheckedIndexedAccess`, `noImplicitOverride`, and `exactOptionalPropertyTypes` for safer code. Secrets are injected at build time via environment variables and `.env` files are never committed.

--- a/apps/blackroad-web/index.html
+++ b/apps/blackroad-web/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://api.blackroad.io wss://api.blackroad.io; img-src 'self' data:; frame-ancestors 'none'" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>BlackRoad Web</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/blackroad-web/package.json
+++ b/apps/blackroad-web/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "blackroad-web",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint .",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.0.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^7.0.0",
+    "zustand": "^4.5.2"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.2",
+    "@types/react-dom": "^18.3.0",
+    "@typescript-eslint/eslint-plugin": "^7.0.0",
+    "@typescript-eslint/parser": "^7.0.0",
+    "@vitejs/plugin-react": "^4.2.1",
+    "autoprefixer": "^10.4.17",
+    "eslint": "^8.57.0",
+    "postcss": "^8.4.33",
+    "tailwindcss": "^3.4.4",
+    "typescript": "^5.4.5",
+    "vite": "^5.1.0",
+    "vitest": "^1.6.0"
+  }
+}

--- a/apps/blackroad-web/postcss.config.cjs
+++ b/apps/blackroad-web/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/blackroad-web/src/index.css
+++ b/apps/blackroad-web/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/apps/blackroad-web/src/main.tsx
+++ b/apps/blackroad-web/src/main.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
+import Home from "./routes/Home";
+import "./index.css";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<Home />} />
+      </Routes>
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/apps/blackroad-web/src/routes/Home.tsx
+++ b/apps/blackroad-web/src/routes/Home.tsx
@@ -1,0 +1,7 @@
+export default function Home() {
+  return (
+    <main className="p-4">
+      <h1 className="text-xl font-bold">BlackRoad</h1>
+    </main>
+  );
+}

--- a/apps/blackroad-web/tailwind.config.ts
+++ b/apps/blackroad-web/tailwind.config.ts
@@ -1,0 +1,9 @@
+import type { Config } from "tailwindcss";
+
+export default {
+  content: ["./index.html", "./src/**/*.{ts,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+} satisfies Config;

--- a/apps/blackroad-web/tsconfig.json
+++ b/apps/blackroad-web/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "exactOptionalPropertyTypes": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/apps/blackroad-web/vite.config.ts
+++ b/apps/blackroad-web/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    sourcemap: false
+  },
+  server: {
+    headers: {
+      "Content-Security-Policy":
+        "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://api.blackroad.io wss://api.blackroad.io; img-src 'self' data:; frame-ancestors 'none'"
+    }
+  }
+});

--- a/ops/ui-self-host.md
+++ b/ops/ui-self-host.md
@@ -1,0 +1,11 @@
+# UI Self-Host Runbook
+
+1. Build the Docker image:
+   ```bash
+   docker build -t blackroad-web apps/blackroad-web
+   ```
+2. Run the container:
+   ```bash
+   docker run -p 3000:3000 blackroad-web
+   ```
+3. Access the UI at `http://localhost:3000`.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@blackroad/ui",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@blackroad/utils",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - "apps/*"
+  - "packages/*"


### PR DESCRIPTION
## Summary
- scaffold Vite + React Router web app with strict CSP and TS settings
- add CI workflow and self-host runbook
- set up pnpm workspace with placeholder ui/utils packages

## Testing
- `npm test`
- `npm audit`
- `pip install pre-commit` *(fails: Could not connect to proxy)*
- `pre-commit run --files pnpm-workspace.yaml apps/blackroad-web/package.json apps/blackroad-web/tsconfig.json apps/blackroad-web/vite.config.ts apps/blackroad-web/index.html apps/blackroad-web/src/main.tsx apps/blackroad-web/src/routes/Home.tsx apps/blackroad-web/src/index.css apps/blackroad-web/tailwind.config.ts apps/blackroad-web/postcss.config.cjs apps/blackroad-web/SECURITY.md apps/blackroad-web/MIGRATION.md apps/blackroad-web/Dockerfile packages/ui/package.json packages/utils/package.json ops/ui-self-host.md .github/workflows/ui.yml` *(fails: command not found)*
- `osv-scanner --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a505e82f40832997a5fa8146d7257d