### PR TITLE
Add lucidia_reason trinary reasoning package

### DIFF
--- a/packages/lucidia_reason/lucidia_reason/__init__.py
+++ b/packages/lucidia_reason/lucidia_reason/__init__.py
@@ -1,0 +1,6 @@
+"""Lucidia Program-of-Thought reasoning engine."""
+
+from .trinary import TruthValue
+from .pot import plan_question
+
+__all__ = ["TruthValue", "plan_question"]

--- a/packages/lucidia_reason/lucidia_reason/cli.py
+++ b/packages/lucidia_reason/lucidia_reason/cli.py
@@ -1,0 +1,27 @@
+"""CLI interface for lucidia_reason."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from .pot import plan_question
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(prog="lucidia-reason")
+    sub = parser.add_subparsers(dest="cmd")
+
+    plan_p = sub.add_parser("plan", help="plan a question")
+    plan_p.add_argument("question")
+    plan_p.add_argument("--n", type=int, default=1)
+    plan_p.add_argument("--out", type=str, default=None)
+
+    args = parser.parse_args()
+
+    if args.cmd == "plan":
+        plan_question(args.question, n=args.n, out_dir=args.out)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/packages/lucidia_reason/lucidia_reason/pot.py
+++ b/packages/lucidia_reason/lucidia_reason/pot.py
@@ -1,0 +1,38 @@
+"""Simple Program-of-Thought planner and executor."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import json
+import random
+from typing import List, Optional
+
+
+@dataclass
+class Node:
+    op: str
+    data: dict
+
+
+def _default_trace(question: str) -> List[Node]:
+    return [
+        Node("PLAN", {"question": question}),
+        Node("STEP", {"id": 1, "text": f"Echo {question}"}),
+        Node("YIELD", {"answer": question}),
+    ]
+
+
+def plan_question(question: str, n: int = 1, out_dir: Optional[str] = None, seed: int = 0) -> List[List[Node]]:
+    """Generate ``n`` simple traces for a question."""
+    random.seed(seed)
+    traces: List[List[Node]] = []
+    for i in range(n):
+        trace = _default_trace(question)
+        traces.append(trace)
+        if out_dir:
+            path = Path(out_dir)
+            path.mkdir(parents=True, exist_ok=True)
+            with open(path / f"trace_{i}.jsonl", "w", encoding="utf-8") as fh:
+                for node in trace:
+                    fh.write(json.dumps({"op": node.op, **node.data}) + "\n")
+    return traces

--- a/packages/lucidia_reason/lucidia_reason/registry.py
+++ b/packages/lucidia_reason/lucidia_reason/registry.py
@@ -1,0 +1,22 @@
+"""Registry for Ψ′ operator mapping to Python callables."""
+from __future__ import annotations
+from typing import Callable, Dict
+
+from . import trinary
+
+
+Operator = Callable[..., trinary.TruthValue]
+
+
+REGISTRY: Dict[str, Operator] = {
+    "neg": trinary.neg,
+    "and3": trinary.and3,
+    "or3": trinary.or3,
+    "imp3": trinary.imp3,
+    "conflict": trinary.conflict,
+}
+
+
+def get_operator(name: str) -> Operator:
+    """Return operator by name."""
+    return REGISTRY[name]

--- a/packages/lucidia_reason/lucidia_reason/sandbox.py
+++ b/packages/lucidia_reason/lucidia_reason/sandbox.py
@@ -1,0 +1,22 @@
+"""Minimal sandbox runner for deterministic skill execution."""
+from __future__ import annotations
+from typing import Any, Callable
+import contextlib
+import resource
+import signal
+
+CPU_TIME_LIMIT = 1  # seconds
+MEMORY_LIMIT = 32 * 1024 * 1024  # 32MB
+
+
+def _limit_resources() -> None:
+    resource.setrlimit(resource.RLIMIT_CPU, (CPU_TIME_LIMIT, CPU_TIME_LIMIT))
+    resource.setrlimit(resource.RLIMIT_AS, (MEMORY_LIMIT, MEMORY_LIMIT))
+
+
+def run(func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+    """Run callable within basic resource limits."""
+    with contextlib.ExitStack() as stack:
+        stack.callback(signal.signal, signal.SIGXCPU, signal.SIG_DFL)
+        _limit_resources()
+        return func(*args, **kwargs)

--- a/packages/lucidia_reason/lucidia_reason/skills/__init__.py
+++ b/packages/lucidia_reason/lucidia_reason/skills/__init__.py
@@ -1,0 +1,6 @@
+"""Built-in skills for reasoning."""
+from __future__ import annotations
+
+from .basic import add
+
+__all__ = ["add"]

--- a/packages/lucidia_reason/lucidia_reason/skills/basic.py
+++ b/packages/lucidia_reason/lucidia_reason/skills/basic.py
@@ -1,0 +1,7 @@
+"""Basic arithmetic skills."""
+from __future__ import annotations
+
+
+def add(a: int, b: int) -> int:
+    """Return ``a + b``."""
+    return a + b

--- a/packages/lucidia_reason/lucidia_reason/trinary.py
+++ b/packages/lucidia_reason/lucidia_reason/trinary.py
@@ -1,0 +1,47 @@
+"""Trinary logic core for Program-of-Thought reasoning."""
+from __future__ import annotations
+from enum import Enum
+
+
+class TruthValue(Enum):
+    """Trinary truth values."""
+    TRUE = 1
+    UNKNOWN = 0
+    FALSE = -1
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        mapping = {1: "true", 0: "unknown", -1: "false"}
+        return mapping[self.value]
+
+
+def neg(value: TruthValue) -> TruthValue:
+    """Negate a trinary value."""
+    return TruthValue(-value.value)
+
+
+def and3(a: TruthValue, b: TruthValue) -> TruthValue:
+    """Trinary AND."""
+    if TruthValue.FALSE in (a, b):
+        return TruthValue.FALSE
+    if TruthValue.UNKNOWN in (a, b):
+        return TruthValue.UNKNOWN
+    return TruthValue.TRUE
+
+
+def or3(a: TruthValue, b: TruthValue) -> TruthValue:
+    """Trinary OR."""
+    if TruthValue.TRUE in (a, b):
+        return TruthValue.TRUE
+    if TruthValue.UNKNOWN in (a, b):
+        return TruthValue.UNKNOWN
+    return TruthValue.FALSE
+
+
+def imp3(a: TruthValue, b: TruthValue) -> TruthValue:
+    """Trinary implication (a → b)."""
+    return or3(neg(a), b)
+
+
+def conflict(a: TruthValue, b: TruthValue) -> TruthValue:
+    """Return FALSE when values conflict, TRUE otherwise."""
+    return TruthValue.FALSE if a != b else TruthValue.TRUE

--- a/packages/lucidia_reason/lucidia_reason/verifier.py
+++ b/packages/lucidia_reason/lucidia_reason/verifier.py
@@ -1,0 +1,27 @@
+"""Self-consistency verifier for traces."""
+from __future__ import annotations
+from collections import Counter
+from pathlib import Path
+from typing import Iterable
+
+from .trinary import TruthValue
+
+
+CONTRADICTION_LOG = Path("contradictions.log")
+
+
+def majority(values: Iterable[TruthValue]) -> TruthValue:
+    """Return majority truth value, UNKNOWN on tie."""
+    counts = Counter(values)
+    if not counts:
+        return TruthValue.UNKNOWN
+    best = counts.most_common()
+    if len(best) > 1 and best[0][1] == best[1][1]:
+        return TruthValue.UNKNOWN
+    return best[0][0]
+
+
+def assert_truth(value: TruthValue, message: str) -> None:
+    """Log to contradiction file on failed assertion."""
+    if value == TruthValue.FALSE:
+        CONTRADICTION_LOG.write_text(f"ASSERT FAILED: {message}\n")

--- a/packages/lucidia_reason/pyproject.toml
+++ b/packages/lucidia_reason/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "lucidia_reason"
+version = "0.1.0"
+description = "Program-of-Thought reasoning engine with trinary logic"
+requires-python = ">=3.11"
+authors = [{name="Lucidia"}]
+dependencies = []
+
+[project.scripts]
+lucidia-reason = "lucidia_reason.cli:main"
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/packages/lucidia_reason/tests/test_plan.py
+++ b/packages/lucidia_reason/tests/test_plan.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+from lucidia_reason.pot import plan_question
+
+
+def test_plan_writes_traces(tmp_path: Path):
+    out_dir = tmp_path / "traces"
+    traces = plan_question("What?", n=2, out_dir=str(out_dir), seed=1)
+    assert len(traces) == 2
+    files = sorted(out_dir.glob("trace_*.jsonl"))
+    assert len(files) == 2
+    content = files[0].read_text().strip().splitlines()
+    assert content[0].startswith("{\"op\": \"PLAN\"")
+    assert content[-1].startswith("{\"op\": \"YIELD\"")

--- a/packages/lucidia_reason/tests/test_trinary.py
+++ b/packages/lucidia_reason/tests/test_trinary.py
@@ -1,0 +1,26 @@
+from lucidia_reason.trinary import TruthValue, neg, and3, or3, imp3, conflict
+
+
+def test_neg():
+    assert neg(TruthValue.TRUE) is TruthValue.FALSE
+
+
+def test_and3():
+    assert and3(TruthValue.TRUE, TruthValue.TRUE) is TruthValue.TRUE
+    assert and3(TruthValue.TRUE, TruthValue.UNKNOWN) is TruthValue.UNKNOWN
+    assert and3(TruthValue.FALSE, TruthValue.TRUE) is TruthValue.FALSE
+
+
+def test_or3():
+    assert or3(TruthValue.FALSE, TruthValue.FALSE) is TruthValue.FALSE
+    assert or3(TruthValue.UNKNOWN, TruthValue.FALSE) is TruthValue.UNKNOWN
+    assert or3(TruthValue.TRUE, TruthValue.FALSE) is TruthValue.TRUE
+
+
+def test_imp3():
+    assert imp3(TruthValue.TRUE, TruthValue.FALSE) is TruthValue.FALSE
+
+
+def test_conflict():
+    assert conflict(TruthValue.TRUE, TruthValue.FALSE) is TruthValue.FALSE
+    assert conflict(TruthValue.TRUE, TruthValue.TRUE) is TruthValue.TRUE


### PR DESCRIPTION
## Summary
- implement minimal `lucidia_reason` package with trinary logic and simple Program-of-Thought planner
- provide CLI entry point `lucidia-reason plan` for generating JSONL traces
- add basic arithmetic skill and self-consistency verifier

## Testing
- `python -m py_compile packages/lucidia_reason/lucidia_reason/*.py packages/lucidia_reason/lucidia_reason/skills/*.py`
- `PYTHONPATH=packages/lucidia_reason pytest packages/lucidia_reason/tests -q`
- Attempted `pre-commit run --files ...` *(failed: command not found and installation blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68a5052640ac8329865b8079196a7c50