### PR TITLE
Expose removed temporary metadata

### DIFF
--- a/lucidia_meta_annotator/README.md
+++ b/lucidia_meta_annotator/README.md
@@ -11,7 +11,7 @@ from lucidia_meta_annotator import load_config, annotate_dataset
 
 cfg = load_config("overrides.yaml")
 meta = {"a": 1, "_*temp": "x"}
-result = annotate_dataset(meta, cfg)
+result, removed = annotate_dataset(meta, cfg)
 ```
 
 ## Threat model

--- a/tests/lucidia_meta_annotator/test_deterministic_application.py
+++ b/tests/lucidia_meta_annotator/test_deterministic_application.py
@@ -4,6 +4,7 @@ from lucidia_meta_annotator import annotate_dataset
 def test_deterministic_application():
     meta = {"a": 1}
     cfg = {"Attributes": [{"Name": "a", "Value": 1}, {"Name": "b", "Value": 2}]}
-    first = annotate_dataset(meta, cfg)
-    second = annotate_dataset(meta, cfg)
+    first, removed_first = annotate_dataset(meta, cfg)
+    second, removed_second = annotate_dataset(meta, cfg)
     assert first == second
+    assert removed_first == removed_second

--- a/tests/lucidia_meta_annotator/test_temp_attrs_not_persisted.py
+++ b/tests/lucidia_meta_annotator/test_temp_attrs_not_persisted.py
@@ -5,6 +5,7 @@ from lucidia_meta_annotator import annotate_dataset
 def test_temp_attrs_not_persisted():
     meta = {"a": 1, "_*temp": 2}
     cfg = {"Attributes": [{"Name": "b", "Value": 3}]}
-    result = annotate_dataset(meta, cfg)
+    result, removed = annotate_dataset(meta, cfg)
     assert "_*temp" not in result
+    assert "_*temp" in removed
     assert result["b"] == 3


### PR DESCRIPTION
## Summary
- return list of stripped temporary attributes from `annotate_dataset`
- include removed temp attributes in `annotate_file` results and documentation
- update tests for new return values

## Testing
- `pytest tests/lucidia_meta_annotator/test_temp_attrs_not_persisted.py tests/lucidia_meta_annotator/test_deterministic_application.py tests/lucidia_meta_annotator/test_schema_validation.py tests/lucidia_meta_annotator/test_security_signatures.py`
- `pre-commit run --files lucidia_meta_annotator/annotate.py lucidia_meta_annotator/README.md tests/lucidia_meta_annotator/test_temp_attrs_not_persisted.py tests/lucidia_meta_annotator/test_deterministic_application.py` *(failed: command not found: pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68a507b35a4083298490ce868d5ecdb3