### PR TITLE
Add skeleton for L-ADLS crate with WebSocket example

### DIFF
--- a/packages/Cargo.toml
+++ b/packages/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [
+members = [ "ladls",
     "lucidia-geodesy",
     "lucidia-geodesy-ffi"
 ]

--- a/packages/ladls/Cargo.toml
+++ b/packages/ladls/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "ladls"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+
+[dependencies]
+thiserror = "1"
+zeroize = "1"
+
+[dev-dependencies]
+anyhow = "1"
+futures = "0.3"
+tokio = { version = "1", features = ["rt", "macros"] }
+tokio-tungstenite = "0.21"
+url = "2"

--- a/packages/ladls/examples/ws_tunnel.rs
+++ b/packages/ladls/examples/ws_tunnel.rs
@@ -1,0 +1,19 @@
+use anyhow::Result;
+use futures::{SinkExt, StreamExt};
+use ladls::{SecurityAssociation, Session};
+use tokio_tungstenite::{connect_async, tungstenite::Message};
+use url::Url;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let url = Url::parse("ws://localhost:9001")?;
+    let (mut ws, _) = connect_async(url).await?;
+    let sa = SecurityAssociation::new(0x42);
+    let mut tx = Session::new_tx(sa);
+    let frame = tx.seal(0, &[], b"ping")?;
+    ws.send(Message::Binary(frame)).await?;
+    if let Some(msg) = ws.next().await {
+        println!("Received: {:?}", msg);
+    }
+    Ok(())
+}

--- a/packages/ladls/src/aead.rs
+++ b/packages/ladls/src/aead.rs
@@ -1,0 +1,21 @@
+//! AEAD helpers (stub).
+
+use crate::error::LadlsError;
+
+pub fn seal(
+    _key: &[u8],
+    _nonce: &[u8],
+    _plaintext: &[u8],
+    _ad: &[u8],
+) -> Result<Vec<u8>, LadlsError> {
+    Err(LadlsError::NotImplemented)
+}
+
+pub fn open(
+    _key: &[u8],
+    _nonce: &[u8],
+    _ciphertext: &[u8],
+    _ad: &[u8],
+) -> Result<Vec<u8>, LadlsError> {
+    Err(LadlsError::NotImplemented)
+}

--- a/packages/ladls/src/error.rs
+++ b/packages/ladls/src/error.rs
@@ -1,0 +1,9 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum LadlsError {
+    #[error("not implemented")]
+    NotImplemented,
+    #[error("parse error")]
+    Parse,
+}

--- a/packages/ladls/src/frame.rs
+++ b/packages/ladls/src/frame.rs
@@ -1,0 +1,35 @@
+#[derive(Debug, Clone)]
+pub struct LAdlsHeader {
+    pub version: u8,
+    pub msg_type: u8,
+    pub spi: u32,
+    pub sn: u64,
+    pub flags: u8,
+    pub ad_len: u16,
+}
+
+impl LAdlsHeader {
+    pub const VERSION: u8 = 1;
+
+    pub fn new(msg_type: u8, spi: u32, sn: u64, flags: u8, ad_len: u16) -> Self {
+        Self {
+            version: Self::VERSION,
+            msg_type,
+            spi,
+            sn,
+            flags,
+            ad_len,
+        }
+    }
+
+    pub fn encode(&self) -> [u8; 17] {
+        let mut buf = [0u8; 17];
+        buf[0] = self.version;
+        buf[1] = self.msg_type;
+        buf[2..6].copy_from_slice(&self.spi.to_be_bytes());
+        buf[6..14].copy_from_slice(&self.sn.to_be_bytes());
+        buf[14] = self.flags;
+        buf[15..17].copy_from_slice(&self.ad_len.to_be_bytes());
+        buf
+    }
+}

--- a/packages/ladls/src/kdf.rs
+++ b/packages/ladls/src/kdf.rs
@@ -1,0 +1,5 @@
+//! HKDF-based key derivation (stub).
+
+pub fn derive_sa(_master_key: &[u8]) {
+    // to be implemented
+}

--- a/packages/ladls/src/lib.rs
+++ b/packages/ladls/src/lib.rs
@@ -1,0 +1,27 @@
+pub mod aead;
+pub mod error;
+pub mod frame;
+pub mod kdf;
+pub mod nonce;
+pub mod rekey;
+pub mod sa;
+pub mod session;
+
+pub use error::LadlsError;
+pub use frame::LAdlsHeader;
+pub use sa::SecurityAssociation;
+pub use session::Session;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip() {
+        let sa = SecurityAssociation::new(1);
+        let mut tx = Session::new_tx(sa.clone());
+        let frame = tx.seal(0, &[], b"hello").unwrap();
+        let mut rx = Session::new_rx(sa);
+        let (_header, _ad, _pt) = rx.open(&frame).unwrap();
+    }
+}

--- a/packages/ladls/src/nonce.rs
+++ b/packages/ladls/src/nonce.rs
@@ -1,0 +1,5 @@
+//! Nonce utilities (stub).
+
+pub fn nonce_from_prefix(_prefix: &[u8; 16], _sn: u64) -> [u8; 24] {
+    todo!("nonce derivation not implemented");
+}

--- a/packages/ladls/src/rekey.rs
+++ b/packages/ladls/src/rekey.rs
@@ -1,0 +1,5 @@
+//! Rekey policy helpers (stub).
+
+pub fn should_rekey(age_secs: u64, frame_count: u64) -> bool {
+    age_secs >= 24 * 60 * 60 || frame_count >= 1_000_000
+}

--- a/packages/ladls/src/sa.rs
+++ b/packages/ladls/src/sa.rs
@@ -1,0 +1,10 @@
+#[derive(Clone, Debug)]
+pub struct SecurityAssociation {
+    pub spi: u32,
+}
+
+impl SecurityAssociation {
+    pub fn new(spi: u32) -> Self {
+        Self { spi }
+    }
+}

--- a/packages/ladls/src/session.rs
+++ b/packages/ladls/src/session.rs
@@ -1,0 +1,47 @@
+use crate::{error::LadlsError, frame::LAdlsHeader, sa::SecurityAssociation};
+
+#[derive(Clone)]
+pub struct Session {
+    sa: SecurityAssociation,
+    sn: u64,
+}
+
+impl Session {
+    pub fn new_tx(sa: SecurityAssociation) -> Self {
+        Self { sa, sn: 0 }
+    }
+
+    pub fn new_rx(sa: SecurityAssociation) -> Self {
+        Self { sa, sn: 0 }
+    }
+
+    pub fn seal(
+        &mut self,
+        msg_type: u8,
+        _ad: &[u8],
+        _plaintext: &[u8],
+    ) -> Result<Vec<u8>, LadlsError> {
+        let header = LAdlsHeader::new(msg_type, self.sa.spi, self.sn, 0, 0);
+        self.sn = self.sn.wrapping_add(1);
+        Ok(header.encode().to_vec())
+    }
+
+    pub fn open(&mut self, frame: &[u8]) -> Result<(LAdlsHeader, Vec<u8>, Vec<u8>), LadlsError> {
+        if frame.len() < 17 {
+            return Err(LadlsError::Parse);
+        }
+        let header = LAdlsHeader {
+            version: frame[0],
+            msg_type: frame[1],
+            spi: u32::from_be_bytes(frame[2..6].try_into().unwrap()),
+            sn: u64::from_be_bytes(frame[6..14].try_into().unwrap()),
+            flags: frame[14],
+            ad_len: u16::from_be_bytes(frame[15..17].try_into().unwrap()),
+        };
+        Ok((header, Vec::new(), Vec::new()))
+    }
+
+    pub fn request_rekey(&mut self) {
+        // placeholder
+    }
+}


### PR DESCRIPTION
## Summary
- add new `ladls` Rust crate for link-layer security scaffolding
- stub modules for headers, sessions, AEAD, and utility helpers
- include example WebSocket tunnel using L‑ADLS framing

## Testing
- `cargo test -p ladls` *(fails: failed to download from `https://index.crates.io/config.json` — [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*

------
https://chatgpt.com/codex/tasks/task_e_68a50b0a04d48329b68563a208fac200