### PR TITLE
feat(chat): add file read tool

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,10 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { chatOllama, type Msg } from "@/lib/providers/ollama";
 import { codexInfinityPrompt } from "@/lib/prompts/codex-infinity";
-import { searchFiles } from "@/lib/tools/files";
+import { searchFiles, readFile } from "@/lib/tools/files";
 
 type Mode = "machine" | "chit-chat";
-interface In { messages: { role: "user" | "assistant"; content: string }[]; mode?: Mode; }
+interface In {
+  messages: { role: "user" | "assistant"; content: string }[];
+  mode?: Mode;
+}
 
 export const runtime = "nodejs";
 
@@ -29,6 +32,10 @@ export async function POST(req: NextRequest) {
       if (name === "files.search") {
         const q = String(args.query || "");
         toolResult = { ok: true, hits: searchFiles(q) };
+      } else if (name === "files.read") {
+        const p = String(args.path || "");
+        const text = readFile(p);
+        toolResult = text != null ? { ok: true, path: p, text } : { ok: false, error: "file not found" };
       } else {
         toolResult = { ok: false, error: `unknown tool: ${name}` };
       }
@@ -53,107 +60,11 @@ export async function POST(req: NextRequest) {
   }
 }
 
-function tryJson(s: string) { try { return JSON.parse(s); } catch { return null; } }
-import { NextRequest } from "next/server";
-import { streamText } from "ai";
-import { getModel } from "@/lib/ai/models";
-
-type Mode = "machine" | "chit-chat";
-interface In { messages: { role: "user" | "assistant"; content: string }[]; mode?: Mode; }
-
-export const runtime = "nodejs";
-
-export async function POST(req: NextRequest) {
+function tryJson(s: string) {
   try {
-    const { messages, mode: modeIn }: In = await req.json();
-    let mode: Mode = (modeIn || (process.env.DEFAULT_MODE as Mode) || "machine");
-    const last = messages?.at(-1)?.content ?? "";
-    if (/chit\s*chat\s*cadillac/i.test(last)) mode = "chit-chat";
-
-    const system: Msg = { role: "system", content: codexInfinityPrompt(mode) };
-    const convo: Msg[] = [system, ...messages];
-
-    // Pass 1
-    const first = await chatOllama(convo);
-    const parsed1 = tryJson(first);
-
-    if (parsed1?.type === "tool") {
-      const { name = "", args = {} } = parsed1;
-      let toolResult: unknown;
-
-      if (name === "files.search") {
-        const q = String(args.query || "");
-        toolResult = { ok: true, hits: searchFiles(q) };
-      } else {
-        toolResult = { ok: false, error: `unknown tool: ${name}` };
-      }
-
-      const followup: Msg[] = [
-        system,
-        ...messages,
-        { role: "tool", content: JSON.stringify({ name, result: toolResult }) },
-        { role: "user", content: "Return the final user message JSON now." }
-      ];
-
-      const second = await chatOllama(followup);
-      const parsed2 = tryJson(second);
-      if (parsed2?.type === "message") return NextResponse.json(parsed2);
-      return NextResponse.json({ type: "message", mode, content: second });
-    }
-
-    if (parsed1?.type === "message") return NextResponse.json(parsed1);
-    return NextResponse.json({ type: "message", mode, content: first });
-  } catch (e: any) {
-    return NextResponse.json({ error: String(e?.message || e) }, { status: 500 });
+    return JSON.parse(s);
+  } catch {
+    return null;
   }
 }
 
-function tryJson(s: string) { try { return JSON.parse(s); } catch { return null; } }
-export const runtime = "edge";
-
-export async function POST(req: NextRequest) {
-  try {
-    const { messages, mode: modeIn }: In = await req.json();
-    let mode: Mode = (modeIn || (process.env.DEFAULT_MODE as Mode) || "machine");
-    const last = messages?.at(-1)?.content ?? "";
-    if (/chit\s*chat\s*cadillac/i.test(last)) mode = "chit-chat";
-
-    const system: Msg = { role: "system", content: codexInfinityPrompt(mode) };
-    const convo: Msg[] = [system, ...messages];
-
-    // Pass 1
-    const first = await chatOllama(convo);
-    const parsed1 = tryJson(first);
-
-    if (parsed1?.type === "tool") {
-      const { name = "", args = {} } = parsed1;
-      let toolResult: unknown;
-
-      if (name === "files.search") {
-        const q = String(args.query || "");
-        toolResult = { ok: true, hits: searchFiles(q) };
-      } else {
-        toolResult = { ok: false, error: `unknown tool: ${name}` };
-      }
-
-      const followup: Msg[] = [
-        system,
-        ...messages,
-        { role: "tool", content: JSON.stringify({ name, result: toolResult }) },
-        { role: "user", content: "Return the final user message JSON now." }
-      ];
-
-      const second = await chatOllama(followup);
-      const parsed2 = tryJson(second);
-      if (parsed2?.type === "message") return NextResponse.json(parsed2);
-      return NextResponse.json({ type: "message", mode, content: second });
-    }
-
-    if (parsed1?.type === "message") return NextResponse.json(parsed1);
-    return NextResponse.json({ type: "message", mode, content: first });
-  } catch (e: any) {
-    return NextResponse.json({ error: String(e?.message || e) }, { status: 500 });
-  }
-}
-
-function tryJson(s: string) { try { return JSON.parse(s); } catch { return null; } }

--- a/lib/tools/files.ts
+++ b/lib/tools/files.ts
@@ -41,6 +41,13 @@ export function searchFiles(query: string, limit = 4) {
   return scores.filter(s => s.score > 0).sort((a, b) => b.score - a.score).slice(0, limit);
 }
 
+export function readFile(relPath: string): string | null {
+  const full = path.resolve(ROOT, relPath);
+  if (!full.startsWith(ROOT)) return null;
+  if (!fs.existsSync(full) || !fs.statSync(full).isFile()) return null;
+  return fs.readFileSync(full, "utf8");
+}
+
 function tokenize(s: string) {
   return s.toLowerCase().replace(/[^a-z0-9\s]+/g, " ").split(/\s+/).filter(Boolean);
 }


### PR DESCRIPTION
## Summary
- consolidate chat API route and support a new `files.read` tool
- add safe file reading helper for knowledge base

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a63b73ce0483299c77b21e9e7f2cc5