### PR TITLE
feat: add prompt request page

### DIFF
--- a/sites/blackroad/api/prompt.ts
+++ b/sites/blackroad/api/prompt.ts
@@ -1,0 +1,17 @@
+addEventListener('fetch', (event) => {
+  event.respondWith(handle(event.request))
+})
+
+async function handle(req: Request): Promise<Response> {
+  if (req.method === 'POST') {
+    try {
+      const data = await req.json()
+      console.log('Prompt request', data)
+    } catch (err) {
+      console.log('Prompt request parse error')
+    }
+  }
+  return new Response(JSON.stringify({ ok: true }), {
+    headers: { 'content-type': 'application/json' }
+  })
+}

--- a/sites/blackroad/src/pages/PromptRequest.jsx
+++ b/sites/blackroad/src/pages/PromptRequest.jsx
@@ -1,0 +1,43 @@
+import { useState } from 'react'
+
+export default function PromptRequest() {
+  const [text, setText] = useState('')
+  const [status, setStatus] = useState('')
+
+  async function submit(e) {
+    e.preventDefault()
+    try {
+      const res = await fetch('/api/prompt', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ prompt: text })
+      })
+      setStatus(res.ok ? 'Request sent!' : 'Request failed')
+      if (res.ok) setText('')
+    } catch {
+      setStatus('Request failed')
+    }
+  }
+
+  return (
+    <div className="card">
+      <h2 className="text-xl font-semibold mb-2">Request a Code Prompt</h2>
+      <form onSubmit={submit} className="space-y-2">
+        <textarea
+          className="w-full p-2 rounded bg-white/5 border border-white/10"
+          rows="4"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder="Describe the code you need..."
+        />
+        <button
+          type="submit"
+          className="px-3 py-1 rounded bg-blue-600 hover:bg-blue-700"
+        >
+          Send
+        </button>
+      </form>
+      {status && <p className="mt-2 text-sm">{status}</p>}
+    </div>
+  )
+}

--- a/sites/blackroad/src/router.jsx
+++ b/sites/blackroad/src/router.jsx
@@ -14,6 +14,7 @@ import Blog from './pages/Blog.jsx'
 import Post from './pages/Post.jsx'
 import QuantumLab from './pages/QuantumLab.jsx'
 import NotFound from './pages/NotFound.jsx'
+import PromptRequest from './pages/PromptRequest.jsx'
 
 export const router = createBrowserRouter([
   {
@@ -33,6 +34,7 @@ export const router = createBrowserRouter([
       { path: 'roadmap', element: <Roadmap /> },
       { path: 'changelog', element: <Changelog /> },
       { path: 'blog', element: <Blog /> },
+      { path: 'prompts', element: <PromptRequest /> },
       { path: 'blog/:slug', element: <Post /> },
       { path: '*', element: <NotFound /> }
     ]
@@ -50,6 +52,7 @@ export const router = createBrowserRouter([
     { path: 'roadmap', element: <Roadmap /> },
     { path: 'changelog', element: <Changelog /> },
     { path: 'blog', element: <Blog /> },
+    { path: 'prompts', element: <PromptRequest /> },
     { path: 'blog/:slug', element: <Post /> },
     { path: '*', element: <NotFound /> }
   ] }

--- a/sites/blackroad/src/ui/Layout.jsx
+++ b/sites/blackroad/src/ui/Layout.jsx
@@ -23,6 +23,7 @@ const links = [
   { to: '/math', label: 'MathLab' },
   { to: '/uncertainty', label: 'Uncertainty' },
   { to: '/geodesic', label: 'Geodesic' },
+  { to: '/prompts', label: 'Prompts' },
 ];
 
 function navigate(e, to) {
@@ -102,6 +103,7 @@ export default function Layout() {
               <Tab to="/changelog">{t('navChangelog')}</Tab>
               <Tab to="/blog">{t('navBlog')}</Tab>
               <Tab to="/contact">{t('navContact')}</Tab>
+              <Tab to="/prompts">Prompts</Tab>
               <LanguageSwitcher />
             </nav>
           </header>


### PR DESCRIPTION
## Summary
- add Prompt Request page and API endpoint
- wire new page into router and navigation

## Testing
- `npm test`
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6426144bc832989bb1e2a9ce5ef54