### PR TITLE
feat: add site build agent and blog post

### DIFF
--- a/agents/build_blackroad_site_agent.py
+++ b/agents/build_blackroad_site_agent.py
@@ -1,0 +1,31 @@
+"""Agent that builds the BlackRoad.io website using npm."""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def build_site() -> int:
+    """Run the npm build for the BlackRoad.io site.
+
+    Returns the exit code from the npm process. If npm is unavailable or the
+    build fails, a non-zero code is returned and a message is printed.
+    """
+    site_dir = Path(__file__).resolve().parent.parent / "sites" / "blackroad"
+    try:
+        result = subprocess.run(
+            ["npm", "run", "build"],
+            cwd=site_dir,
+            check=True,
+        )
+        return result.returncode
+    except FileNotFoundError:
+        print("npm is not installed or not on PATH.")
+        return 1
+    except subprocess.CalledProcessError as exc:
+        print("Site build failed:", exc)
+        return exc.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(build_site())

--- a/sites/blackroad/content/blog/bots-build-blackroad.md
+++ b/sites/blackroad/content/blog/bots-build-blackroad.md
@@ -1,0 +1,9 @@
+---
+title: "Bots Build BlackRoad"
+date: "2025-02-14"
+tags: [bots, automation]
+description: "Introducing agents that automatically build the BlackRoad.io website."
+---
+
+Our new build agent can run `npm run build` for the BlackRoad.io site, enabling
+bots to keep the website up to date with minimal human oversight.


### PR DESCRIPTION
## Summary
- add build_blackroad_site_agent to run npm build for the BlackRoad site
- document automation with a blog post about bots building the website

## Testing
- `python -m py_compile *.py` *(fails: simulator_agent.py - SyntaxError: unterminated triple-quoted string literal)*
- `python auto_novel_agent.py`
- `python build_blackroad_site_agent.py` *(fails: npm error code EJSONPARSE)*
- `npm test` *(fails: npm error code EJSONPARSE)*

------
https://chatgpt.com/codex/tasks/task_e_68a64c722b6c83298100534de8bc435d