### PR TITLE
Add 10 additional automation bots

### DIFF
--- a/agents/cleanup_bot.py
+++ b/agents/cleanup_bot.py
@@ -1,0 +1,24 @@
+"""Bot for cleaning up merged Git branches."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import subprocess
+from typing import List
+
+
+@dataclass
+class CleanupBot:
+    """Delete local and remote branches after merges."""
+
+    branches: List[str]
+
+    def cleanup(self) -> None:
+        """Remove the configured branches locally and remotely."""
+        for branch in self.branches:
+            subprocess.run(["git", "branch", "-D", branch], check=True)
+            subprocess.run(["git", "push", "origin", "--delete", branch], check=True)
+
+
+if __name__ == "__main__":
+    print("CleanupBot ready to delete branches.")

--- a/agents/comment_bot.py
+++ b/agents/comment_bot.py
@@ -1,0 +1,33 @@
+"""Bot for posting comments on GitHub issues and pull requests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from typing import Optional
+import requests
+
+
+@dataclass
+class CommentBot:
+    """Automate posting comments using the GitHub API."""
+
+    repo: str
+    token: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if self.token is None:
+            self.token = os.getenv("GITHUB_TOKEN")
+
+    def comment(self, issue_number: int, body: str) -> dict:
+        """Post a comment on the specified issue or pull request."""
+        url = f"https://api.github.com/repos/{self.repo}/issues/{issue_number}/comments"
+        headers = {"Authorization": f"token {self.token}"} if self.token else {}
+        payload = {"body": body}
+        response = requests.post(url, json=payload, headers=headers, timeout=10)
+        response.raise_for_status()
+        return response.json()
+
+
+if __name__ == "__main__":
+    print("CommentBot ready to post comments.")

--- a/agents/deploy_bot.py
+++ b/agents/deploy_bot.py
@@ -1,0 +1,25 @@
+"""Bot for deploying services via shell commands."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import subprocess
+from typing import List
+
+
+@dataclass
+class DeployBot:
+    """Automate service deployments using subprocess calls."""
+
+    commands: List[List[str]] = field(
+        default_factory=lambda: [["echo", "deploy"], ["echo", "verify"]]
+    )
+
+    def deploy(self) -> None:
+        """Run configured deployment commands sequentially."""
+        for cmd in self.commands:
+            subprocess.run(cmd, check=True)
+
+
+if __name__ == "__main__":
+    print("DeployBot ready to run deployments.")

--- a/agents/issue_bot.py
+++ b/agents/issue_bot.py
@@ -1,0 +1,42 @@
+"""Bot for automating GitHub issue creation and management."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from typing import Optional
+import requests
+
+
+@dataclass
+class IssueBot:
+    """Automate creation and closing of GitHub issues."""
+
+    repo: str
+    token: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if self.token is None:
+            self.token = os.getenv("GITHUB_TOKEN")
+
+    def create_issue(self, title: str, body: str = "") -> dict:
+        """Create a new issue on GitHub."""
+        url = f"https://api.github.com/repos/{self.repo}/issues"
+        headers = {"Authorization": f"token {self.token}"} if self.token else {}
+        payload = {"title": title, "body": body}
+        response = requests.post(url, json=payload, headers=headers, timeout=10)
+        response.raise_for_status()
+        return response.json()
+
+    def close_issue(self, issue_number: int) -> dict:
+        """Close an existing GitHub issue."""
+        url = f"https://api.github.com/repos/{self.repo}/issues/{issue_number}"
+        headers = {"Authorization": f"token {self.token}"} if self.token else {}
+        payload = {"state": "closed"}
+        response = requests.patch(url, json=payload, headers=headers, timeout=10)
+        response.raise_for_status()
+        return response.json()
+
+
+if __name__ == "__main__":
+    print("IssueBot ready to manage issues.")

--- a/agents/label_bot.py
+++ b/agents/label_bot.py
@@ -1,0 +1,42 @@
+"""Bot for managing GitHub labels."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from typing import Optional
+import requests
+
+
+@dataclass
+class LabelBot:
+    """Automate adding or removing labels on issues and pull requests."""
+
+    repo: str
+    token: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if self.token is None:
+            self.token = os.getenv("GITHUB_TOKEN")
+
+    def add_labels(self, issue_number: int, labels: list[str]) -> dict:
+        """Add labels to a GitHub issue or pull request."""
+        url = f"https://api.github.com/repos/{self.repo}/issues/{issue_number}/labels"
+        headers = {"Authorization": f"token {self.token}"} if self.token else {}
+        payload = {"labels": labels}
+        response = requests.post(url, json=payload, headers=headers, timeout=10)
+        response.raise_for_status()
+        return response.json()
+
+    def remove_label(self, issue_number: int, label: str) -> None:
+        """Remove a label from a GitHub issue or pull request."""
+        url = (
+            f"https://api.github.com/repos/{self.repo}/issues/{issue_number}/labels/{label}"
+        )
+        headers = {"Authorization": f"token {self.token}"} if self.token else {}
+        response = requests.delete(url, headers=headers, timeout=10)
+        response.raise_for_status()
+
+
+if __name__ == "__main__":
+    print("LabelBot ready to manage labels.")

--- a/agents/merge_bot.py
+++ b/agents/merge_bot.py
@@ -1,0 +1,35 @@
+"""Bot for merging GitHub pull requests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from typing import Optional
+import requests
+
+
+@dataclass
+class MergeBot:
+    """Automate merging of pull requests when conditions are met."""
+
+    repo: str
+    token: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if self.token is None:
+            self.token = os.getenv("GITHUB_TOKEN")
+
+    def merge_pull_request(self, pr_number: int, commit_message: str | None = None) -> dict:
+        """Merge a pull request using the GitHub API."""
+        url = f"https://api.github.com/repos/{self.repo}/pulls/{pr_number}/merge"
+        headers = {"Authorization": f"token {self.token}"} if self.token else {}
+        payload: dict[str, str] = {}
+        if commit_message:
+            payload["commit_message"] = commit_message
+        response = requests.put(url, json=payload, headers=headers, timeout=10)
+        response.raise_for_status()
+        return response.json()
+
+
+if __name__ == "__main__":
+    print("MergeBot ready to merge pull requests.")

--- a/agents/milestone_bot.py
+++ b/agents/milestone_bot.py
@@ -1,0 +1,42 @@
+"""Bot for automating GitHub milestone management."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from typing import Optional
+import requests
+
+
+@dataclass
+class MilestoneBot:
+    """Create and close GitHub milestones."""
+
+    repo: str
+    token: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if self.token is None:
+            self.token = os.getenv("GITHUB_TOKEN")
+
+    def create_milestone(self, title: str, description: str = "") -> dict:
+        """Create a new milestone."""
+        url = f"https://api.github.com/repos/{self.repo}/milestones"
+        headers = {"Authorization": f"token {self.token}"} if self.token else {}
+        payload = {"title": title, "description": description}
+        response = requests.post(url, json=payload, headers=headers, timeout=10)
+        response.raise_for_status()
+        return response.json()
+
+    def close_milestone(self, milestone_number: int) -> dict:
+        """Close an existing milestone."""
+        url = f"https://api.github.com/repos/{self.repo}/milestones/{milestone_number}"
+        headers = {"Authorization": f"token {self.token}"} if self.token else {}
+        payload = {"state": "closed"}
+        response = requests.patch(url, json=payload, headers=headers, timeout=10)
+        response.raise_for_status()
+        return response.json()
+
+
+if __name__ == "__main__":
+    print("MilestoneBot ready to manage milestones.")

--- a/agents/notification_bot.py
+++ b/agents/notification_bot.py
@@ -1,0 +1,30 @@
+"""Bot for sending notifications to a webhook endpoint."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from typing import Optional
+import requests
+
+
+@dataclass
+class NotificationBot:
+    """Send messages to an HTTP webhook such as Slack."""
+
+    webhook_url: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if self.webhook_url is None:
+            self.webhook_url = os.getenv("WEBHOOK_URL")
+
+    def send(self, message: str) -> None:
+        """Post ``message`` to the configured webhook."""
+        if not self.webhook_url:
+            raise ValueError("webhook_url not configured")
+        response = requests.post(self.webhook_url, json={"text": message}, timeout=10)
+        response.raise_for_status()
+
+
+if __name__ == "__main__":
+    print("NotificationBot ready to send messages.")

--- a/agents/pull_request_bot.py
+++ b/agents/pull_request_bot.py
@@ -1,0 +1,46 @@
+"""Bot for automating GitHub pull request updates."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from typing import Optional
+import requests
+
+
+@dataclass
+class PullRequestBot:
+    """Automate creation and updating of GitHub pull requests."""
+
+    repo: str
+    token: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if self.token is None:
+            self.token = os.getenv("GITHUB_TOKEN")
+
+    def update_pull_request(self, pr_number: int, title: str | None = None, body: str | None = None) -> dict:
+        """Update the title or body of an existing pull request."""
+        url = f"https://api.github.com/repos/{self.repo}/pulls/{pr_number}"
+        headers = {"Authorization": f"token {self.token}"} if self.token else {}
+        payload: dict[str, str] = {}
+        if title is not None:
+            payload["title"] = title
+        if body is not None:
+            payload["body"] = body
+        response = requests.patch(url, json=payload, headers=headers, timeout=10)
+        response.raise_for_status()
+        return response.json()
+
+    def create_pull_request(self, title: str, head: str, base: str, body: str = "") -> dict:
+        """Create a new pull request on GitHub."""
+        url = f"https://api.github.com/repos/{self.repo}/pulls"
+        headers = {"Authorization": f"token {self.token}"} if self.token else {}
+        payload = {"title": title, "head": head, "base": base, "body": body}
+        response = requests.post(url, json=payload, headers=headers, timeout=10)
+        response.raise_for_status()
+        return response.json()
+
+
+if __name__ == "__main__":
+    print("PullRequestBot ready to manage pull requests.")

--- a/agents/release_bot.py
+++ b/agents/release_bot.py
@@ -1,0 +1,33 @@
+"""Bot for creating GitHub releases."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from typing import Optional
+import requests
+
+
+@dataclass
+class ReleaseBot:
+    """Automate creation of GitHub releases."""
+
+    repo: str
+    token: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if self.token is None:
+            self.token = os.getenv("GITHUB_TOKEN")
+
+    def create_release(self, tag: str, name: str, body: str = "") -> dict:
+        """Create a release for the given tag."""
+        url = f"https://api.github.com/repos/{self.repo}/releases"
+        headers = {"Authorization": f"token {self.token}"} if self.token else {}
+        payload = {"tag_name": tag, "name": name, "body": body}
+        response = requests.post(url, json=payload, headers=headers, timeout=10)
+        response.raise_for_status()
+        return response.json()
+
+
+if __name__ == "__main__":
+    print("ReleaseBot ready to create releases.")

--- a/agents/review_bot.py
+++ b/agents/review_bot.py
@@ -1,0 +1,35 @@
+"""Bot for requesting GitHub code reviews."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from typing import List, Optional
+import requests
+
+
+@dataclass
+class ReviewBot:
+    """Automate requesting reviews on pull requests."""
+
+    repo: str
+    token: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if self.token is None:
+            self.token = os.getenv("GITHUB_TOKEN")
+
+    def request_review(self, pr_number: int, reviewers: List[str]) -> dict:
+        """Request reviews from the specified users."""
+        url = (
+            f"https://api.github.com/repos/{self.repo}/pulls/{pr_number}/requested_reviewers"
+        )
+        headers = {"Authorization": f"token {self.token}"} if self.token else {}
+        payload = {"reviewers": reviewers}
+        response = requests.post(url, json=payload, headers=headers, timeout=10)
+        response.raise_for_status()
+        return response.json()
+
+
+if __name__ == "__main__":
+    print("ReviewBot ready to request reviews.")

--- a/agents/status_bot.py
+++ b/agents/status_bot.py
@@ -1,0 +1,36 @@
+"""Bot for checking GitHub workflow run status."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from typing import Optional
+import requests
+
+
+@dataclass
+class StatusBot:
+    """Fetch status of GitHub Actions workflow runs."""
+
+    repo: str
+    token: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if self.token is None:
+            self.token = os.getenv("GITHUB_TOKEN")
+
+    def latest_status(self, workflow: str) -> str:
+        """Return the status of the most recent workflow run."""
+        url = f"https://api.github.com/repos/{self.repo}/actions/workflows/{workflow}/runs"
+        headers = {"Authorization": f"token {self.token}"} if self.token else {}
+        response = requests.get(url, headers=headers, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+        runs = data.get("workflow_runs", [])
+        if not runs:
+            return "unknown"
+        return runs[0].get("conclusion") or runs[0].get("status", "unknown")
+
+
+if __name__ == "__main__":
+    print("StatusBot ready to check workflow runs.")

--- a/agents/website_bot.py
+++ b/agents/website_bot.py
@@ -1,0 +1,30 @@
+"""Bot for automating site deployments and cache operations."""
+
+from dataclasses import dataclass, field
+import subprocess
+from typing import List
+
+
+@dataclass
+class WebsiteBot:
+    """Automate website deployment and cache management."""
+
+    deploy_cmd: List[str] = field(default_factory=lambda: ["/deploy", "blackroad", "pages"])
+    cache_purge_cmd: List[str] = field(default_factory=lambda: ["/cache", "purge"])
+    cache_warm_cmd: List[str] = field(default_factory=lambda: ["/cache", "warm"])
+
+    def deploy(self) -> None:
+        """Deploy the website using the configured command."""
+        subprocess.run(self.deploy_cmd, check=True)
+
+    def purge_cache(self) -> None:
+        """Purge the website cache."""
+        subprocess.run(self.cache_purge_cmd, check=True)
+
+    def warm_cache(self) -> None:
+        """Warm the website cache."""
+        subprocess.run(self.cache_warm_cmd, check=True)
+
+
+if __name__ == "__main__":
+    print("WebsiteBot ready to deploy and manage cache.")


### PR DESCRIPTION
## Summary
- add IssueBot for managing issues
- add ReviewBot to request code reviews
- add LabelBot for label management
- add MilestoneBot to create or close milestones
- add ReleaseBot for publishing releases
- add DeployBot to run deployment commands
- add CommentBot for posting comments
- add CleanupBot to delete merged branches
- add StatusBot to check workflow run status
- add NotificationBot to send webhook messages

## Testing
- `python -m py_compile *.py`
- `python auto_novel_agent.py`
- `python issue_bot.py`
- `python review_bot.py`
- `python label_bot.py`
- `python milestone_bot.py`
- `python release_bot.py`
- `python deploy_bot.py`
- `python comment_bot.py`
- `python cleanup_bot.py`
- `python status_bot.py`
- `python notification_bot.py`
- `python pull_request_bot.py`
- `python merge_bot.py`
- `python website_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68a64bc04c508329bab101b99f628689