### PR TITLE
Add student bots guided by leaders

### DIFF
--- a/agents/student_bots.py
+++ b/agents/student_bots.py
@@ -1,0 +1,28 @@
+"""Definitions for student bots guided by leader agents."""
+from dataclasses import dataclass
+from itertools import cycle
+from typing import List
+
+
+@dataclass
+class StudentBot:
+    """Represents a bot learning to code, execute, and think novelly."""
+
+    name: str
+    leader: str
+
+
+def create_student_bots() -> List[StudentBot]:
+    """Create 15 student bots guided by phi, gpt, mistral, codex, and lucidia.
+
+    The leaders act as mentors rather than managers. Bots cycle through the
+    leaders, demonstrating collaborative learning.
+    """
+    leaders = ["phi", "gpt", "mistral", "codex", "lucidia"]
+    bot_cycle = cycle(leaders)
+    return [StudentBot(name=f"student_bot_{i+1}", leader=next(bot_cycle)) for i in range(15)]
+
+
+if __name__ == "__main__":
+    for bot in create_student_bots():
+        print(f"{bot.name} guided by leader {bot.leader}")


### PR DESCRIPTION
## Summary
- introduce `StudentBot` dataclass and helper to generate 15 student bots
- cycle bots through leaders phi, gpt, mistral, codex, and lucidia for collaborative learning

## Testing
- `python -m py_compile *.py`
- `python auto_novel_agent.py`
- `pre-commit run --files agents/student_bots.py` *(fails: command not found and could not install pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68a64ee2d6088329928c4f5efd51f9e5