### PR TITLE
Add Nginx config for blackroad.io reverse proxy

### DIFF
--- a/nginx/blackroad.io.conf
+++ b/nginx/blackroad.io.conf
@@ -1,0 +1,40 @@
+server {
+  listen 80;
+  listen [::]:80;
+  server_name blackroad.io www.blackroad.io;
+  return 301 https://$host$request_uri;
+}
+
+server {
+  listen 443 ssl http2;
+  listen [::]:443 ssl http2;
+  server_name blackroad.io www.blackroad.io;
+
+  ssl_certificate /etc/letsencrypt/live/blackroad.io/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/blackroad.io/privkey.pem;
+  include /etc/letsencrypt/options-ssl-nginx.conf;
+  ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+  root /var/www/blackroad;
+  index index.html;
+
+  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
+  location / {
+    try_files $uri /index.html;
+  }
+
+  location /api/ {
+    proxy_pass http://127.0.0.1:4000/;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+  }
+
+  location /ws {
+    proxy_pass http://127.0.0.1:4000/ws;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+  }
+}


### PR DESCRIPTION
## Summary
- add Nginx configuration for blackroad.io with HTTPS, API, and WS proxies

## Testing
- `curl -I https://blackroad.io`
- `nginx -t -c nginx/blackroad.io.conf` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*
- `npm test`
- `python -m py_compile agents/*.py`
- `python agents/auto_novel_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_68a654699f588329aa3a0034457759c7