### PR TITLE
Expose backend server on 0.0.0.0

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -155,6 +155,7 @@ io.on('connection', (socket)=>{
 });
 
 const PORT = process.env.PORT || 4000;
-server.listen(PORT, ()=>{
-  console.log(`Backend listening on http://localhost:${PORT}`);
+const HOST = '0.0.0.0';
+server.listen(PORT, HOST, () => {
+  console.log(`Backend listening on http://${HOST}:${PORT}`);
 });


### PR DESCRIPTION
## Summary
- listen on all network interfaces for backend server

## Testing
- `npm test`
- `curl -sS http://127.0.0.1:4000/api/auth/login -H 'content-type: application/json' -d '{"username":"root","password":"Codex2025"}'`


------
https://chatgpt.com/codex/tasks/task_e_68a6890af0fc8329875a4bab7462b372