### PR TITLE
Bind Blackroad API server to all network interfaces

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -11,4 +11,8 @@ app.use('/api/music', musicRouter);
 app.use('/media', express.static(MUSIC_DIR));
 
 const PORT = process.env.PORT || 8000;
-app.listen(PORT, () => console.log(`[server] listening on :${PORT}`));
+app.listen(
+  PORT,
+  '0.0.0.0',
+  () => console.log(`[server] listening on 0.0.0.0:${PORT}`)
+);

--- a/var/www/blackroad/server/index.js
+++ b/var/www/blackroad/server/index.js
@@ -16,4 +16,8 @@ app.post('/api/term/propose', term.propose);
 app.post('/api/term/approve', term.approve);
 
 const PORT = process.env.PORT || 9000;
-app.listen(PORT, ()=> console.log(`[lucidia-dev] server listening on :${PORT}`));
+app.listen(
+  PORT,
+  '0.0.0.0',
+  () => console.log(`[lucidia-dev] server listening on 0.0.0.0:${PORT}`)
+);


### PR DESCRIPTION
## Summary
- expose Express server on all interfaces in src/server.js
- expose lucidia-dev server on all interfaces in var/www/blackroad/server/index.js

## Testing
- `npm test`
- `ss -ltnp | grep :4000` *(fails: command not found)*
- `curl -sS http://127.0.0.1:4000/api/login -H 'content-type: application/json' -d '{"username":"root","password":"Codex2025"}'` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a688ee25b483299afe7c28c01125ea