### PR TITLE
feat: add interactive portal code editor

### DIFF
--- a/sites/blackroad/src/pages/Portal.jsx
+++ b/sites/blackroad/src/pages/Portal.jsx
@@ -1,21 +1,35 @@
-export default function Portal() {
-  return (
-    <div className="card">
-      <h2 className="text-xl font-semibold mb-2">Portal</h2>
-      <p>Interactive coding portal coming soon.</p>
-    </div>
-  );
+import { useState } from 'react'
 import { t } from '../lib/i18n.ts'
+
 export default function Portal(){
+  const [code, setCode] = useState('console.log("Hello, BlackRoad")')
+  const [output, setOutput] = useState('')
+
+  const runCode = () => {
+    try {
+      const logs = []
+      const originalLog = console.log
+      console.log = (...args) => logs.push(args.join(' '))
+      const result = eval(code)
+      console.log = originalLog
+      if (result !== undefined) logs.push(String(result))
+      setOutput(logs.join('\n'))
+    } catch (err) {
+      setOutput(String(err))
+    }
+  }
+
   return (
     <div className="card">
       <h2 className="text-xl font-semibold mb-2">{t('navPortal')}</h2>
-      <p className="opacity-80">Co-coding portal coming soon.</p>
-export default function Portal(){
-  return (
-    <div className="card">
-      <h2 className="text-xl font-semibold mb-2">Portal</h2>
-      <p>Content coming soon.</p>
+      <textarea
+        value={code}
+        onChange={e => setCode(e.target.value)}
+        className="w-full h-40 font-mono p-2 border rounded"
+      />
+      <button onClick={runCode} className="btn mt-2">Run</button>
+      <pre className="mt-2 p-2 bg-black text-white rounded h-40 overflow-auto">{output}</pre>
     </div>
   )
 }
+


### PR DESCRIPTION
## Summary
- replace placeholder with interactive co-coding portal
- allow running JavaScript snippets and capturing output

## Testing
- `npm run lint` (fails: SyntaxError: Unexpected identifier 'js')
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6b0b72ee883299b44cd4d4af19e1e