### PR TITLE
feat: add pipeline-based Lucidia brain

### DIFF
--- a/lucidia/brain.py
+++ b/lucidia/brain.py
@@ -1,0 +1,52 @@
+"""Core cognitive primitives for Lucidia.
+
+This module defines a tiny `LucidiaBrain` class that can register
+processing steps and execute them sequentially.  It acts as a very small
+placeholder for more sophisticated reasoning engines.
+"""
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, List
+
+
+class LucidiaBrain:
+    """Simple pipeline-based brain for Lucidia.
+
+    Functions registered via :meth:`register` are called in the order they
+    were added when :meth:`think` is invoked.  Each function receives the
+    current value and returns the next value.
+    """
+
+    def __init__(self) -> None:
+        self._steps: List[Callable[[Any], Any]] = []
+
+    def register(self, func: Callable[[Any], Any]) -> None:
+        """Register a processing step.
+
+        Parameters
+        ----------
+        func:
+            A callable that accepts a single argument and returns the
+            transformed value.
+        """
+
+        self._steps.append(func)
+
+    def think(self, value: Any) -> Any:
+        """Run the registered steps on ``value``.
+
+        Parameters
+        ----------
+        value:
+            Initial input to the pipeline.
+
+        Returns
+        -------
+        Any
+            The result after all steps have been applied.
+        """
+
+        for step in self._steps:
+            value = step(value)
+        return value

--- a/tests/test_lucidia_brain.py
+++ b/tests/test_lucidia_brain.py
@@ -1,0 +1,8 @@
+from lucidia.brain import LucidiaBrain
+
+
+def test_pipeline_executes_in_order():
+    brain = LucidiaBrain()
+    brain.register(lambda x: x + 1)
+    brain.register(lambda x: x * 2)
+    assert brain.think(3) == 8


### PR DESCRIPTION
## Summary
- add `LucidiaBrain` class implementing a simple processing pipeline
- test that pipeline executes registered steps sequentially

## Testing
- `pytest tests/test_lucidia_brain.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6b1d60c9c83298a7bc734f8ccfd2d