### PR TITLE
chore: fix vite config and add postcss

### DIFF
--- a/sites/blackroad/.gitignore
+++ b/sites/blackroad/.gitignore
@@ -1,3 +1,7 @@
-node_modules/
-dist/
+node_modules
+dist
 .env
+.DS_Store
+*.log
+.cache
+.temp

--- a/sites/blackroad/postcss.config.js
+++ b/sites/blackroad/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/sites/blackroad/vite.config.js
+++ b/sites/blackroad/vite.config.js
@@ -1,12 +1,17 @@
 import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
+// Vite config for the static BlackRoad site.
+// NGINX/Caddy in the repo will serve the built /dist at runtime.
 export default defineConfig({
-  esbuild: { jsxFactory: 'React.createElement', jsxFragment: 'React.Fragment' },
-  build: { outDir: 'dist' },
-export default defineConfig({
-  esbuild: {
-    jsx: 'automatic',
-    jsxImportSource: 'react',
+  plugins: [react()],
+  root: '.',
+  build: {
+    outDir: 'dist',
+    sourcemap: false,
+    emptyOutDir: true,
   },
-  base: '/',
+  server: {
+    host: true,
+  },
 });


### PR DESCRIPTION
## Summary
- add postcss config for Tailwind
- clean up Vite config and React plugin
- expand site gitignore patterns

## Testing
- `npm --prefix sites/blackroad test`
- `npm --prefix sites/blackroad run build` *(fails: Cannot find module 'gray-matter')*


------
https://chatgpt.com/codex/tasks/task_e_68a6b5ac22f88329a1372e62bea4a16a