### PR TITLE
Add BlackRoad site build workflow and update docs

### DIFF
--- a/.github/workflows/site-build.yml
+++ b/.github/workflows/site-build.yml
@@ -1,0 +1,45 @@
+name: Build BlackRoad Site
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - "sites/blackroad/**"
+      - ".github/workflows/site-build.yml"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sites/blackroad
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: actions/setup-node@v4
+        with: { node-version: 20, cache: npm, cache-dependency-path: "sites/blackroad/package-lock.json" }
+      - name: Install
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: sites/blackroad/dist
+
+  deploy:
+    needs: build
+    if: github.repository_owner == 'blackboxprogramming'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4
+

--- a/sites/blackroad/README.md
+++ b/sites/blackroad/README.md
@@ -1,17 +1,24 @@
-# BlackRoad.io — Ops
+BlackRoad.io — Site
 
-**Deploy commands (ChatOps):**
-- `/deploy blackroad pages` — GitHub Pages
-- `/deploy blackroad vercel` — Vercel (needs `VERCEL_*` secrets)
-- `/deploy blackroad cloudflare` — Cloudflare Pages (needs `CF_*` + `CF_PAGES_PROJECT`)
+Static Vite + React + Tailwind site served at / on blackroad.io.
+NGINX proxies /api to the backend and /ws for WebSockets.
 
-**Useful:**
-- `/site status` — quick HTTP code check
-- `/site url` — prints configured URL
-- `/urls` — lists primary, GH Pages, and status.json URLs
+Local dev
 
-**Status page:** available at `/status` (reads `sites/blackroad/public/status.json`, updated every 30 minutes by workflow).
+cd sites/blackroad
+npm i
+npm run dev
+# open http://localhost:5173
 
-**Lucidia video generation:** site now exposes a `video` worker at
-`sites/blackroad/api/video.ts` that forwards requests for basic animated
-GIF creation powered by Lucidia's new `/video` API.
+Build
+
+npm run build   # outputs to sites/blackroad/dist
+
+Preview
+
+npm run preview # http://localhost:5174
+
+Production is served by the repository’s NGINX/Caddy configs. Artifacts are also uploaded from CI.
+
+⸻
+

--- a/sites/blackroad/public/_redirects
+++ b/sites/blackroad/public/_redirects
@@ -1,1 +1,6 @@
-/*    /index.html   200
+(for static hosts that support Netlify-style redirects)
+
+send all SPA routes to index
+
+/*   /index.html   200
+

--- a/sites/blackroad/public/robots.txt
+++ b/sites/blackroad/public/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
 Allow: /
+Sitemap: https://blackroad.io/sitemap.xml
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and deploy the BlackRoad site
- document site setup and usage in README
- include sitemap reference and redirects for static hosts

## Testing
- ⚠️ `npm install` (403 Forbidden fetching @playwright/test)
- ✅ `npm test`
- ⚠️ `npm run lint` (ESLint configuration error)


------
https://chatgpt.com/codex/tasks/task_e_68a6b619e86c8329b11df2f2691088e7