### PR TITLE
feat: add blackroad site health endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,3 +170,13 @@ sbom: ; bash scripts/review.sh --sbom
 lock: ; bash scripts/review.sh --lock
 gen: ; python scripts/ai_codegen.py --task "$(t)"
 docs: ; python scripts/ai_docs.py --from-diff
+
+.PHONY: site-blackroad-build site-blackroad-caddy site-blackroad-up
+site-blackroad-build:
+	cd sites/blackroad && npm run build
+
+site-blackroad-caddy:
+	docker compose -f docker-compose.site.yml up -d
+
+site-blackroad-up: site-blackroad-build site-blackroad-caddy
+	@echo "Site running at http://localhost:8080"

--- a/docker-compose.site.yml
+++ b/docker-compose.site.yml
@@ -1,0 +1,21 @@
+version: "3.9"
+services:
+  blackroad-site:
+    image: caddy:2.8-alpine
+    container_name: blackroad-site
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    volumes:
+      # built site goes here after npm run build
+      - ./sites/blackroad/dist:/srv:ro
+      - ./sites/blackroad/Caddyfile:/etc/caddy/Caddyfile:ro
+
+  # (optional) mock backend so /api resolves locally
+  mock-api:
+    image: ghcr.io/underscoreio/http-echo:latest
+    container_name: blackroad-mock-api
+    command: ["-listen", ":4000", "-text", "{\"status\":\"ok\",\"message\":\"mock backend\"}"]
+    restart: unless-stopped
+    ports:
+      - "4000:4000"

--- a/sites/blackroad/Caddyfile
+++ b/sites/blackroad/Caddyfile
@@ -1,5 +1,51 @@
-:8080
-root * /srv
-encode zstd gzip
-file_server
-try_files {path} /index.html
+{
+    auto_https off
+}
+
+:8080 {
+    root * /srv
+    encode zstd gzip
+
+    handle /api/health {
+        file_server
+    }
+
+    handle_path /api/* {
+        reverse_proxy 127.0.0.1:4000
+    }
+
+    handle_path /ws* {
+        reverse_proxy 127.0.0.1:4000 {
+            header_up Connection {>Connection}
+            header_up Upgrade {>Upgrade}
+        }
+    }
+
+    # Single Page App fallback (keeps /portal, /status working client-side)
+    try_files {path} /index.html
+    file_server
+}
+
+# Production (enable when deployed with TLS)
+blackroad.io, www.blackroad.io {
+    root * /srv
+    encode zstd gzip
+
+    handle /api/health {
+        file_server
+    }
+
+    handle_path /api/* {
+        reverse_proxy 127.0.0.1:4000
+    }
+
+    handle_path /ws* {
+        reverse_proxy 127.0.0.1:4000 {
+            header_up Connection {>Connection}
+            header_up Upgrade {>Upgrade}
+        }
+    }
+
+    try_files {path} /index.html
+    file_server
+}

--- a/sites/blackroad/public/api/health.json
+++ b/sites/blackroad/public/api/health.json
@@ -1,0 +1,4 @@
+{
+  "status": "ok",
+  "message": "dev health stub (served from /public). In production, NGINX proxies /api to the backend."
+}


### PR DESCRIPTION
## Summary
- expand BlackRoad Caddyfile with API and WS proxies plus `/api/health` static route
- add health check JSON and Docker Compose file for running the site
- provide Makefile helpers to build and launch Caddy

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6b764376c8329ad40c0e87c4e60d0