### PR TITLE
feat: add blackroad API bridge

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -1,0 +1,25 @@
+name: API Bridge CI
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - "services/api/**"
+      - ".github/workflows/api-ci.yml"
+  workflow_dispatch: {}
+jobs:
+  lint-and-boot:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: services/api
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm install
+      - name: Boot health probe
+        run: |
+          node server.mjs & sleep 1
+          node healthcheck.mjs

--- a/Makefile
+++ b/Makefile
@@ -170,3 +170,17 @@ sbom: ; bash scripts/review.sh --sbom
 lock: ; bash scripts/review.sh --lock
 gen: ; python scripts/ai_codegen.py --task "$(t)"
 docs: ; python scripts/ai_docs.py --from-diff
+
+
+.PHONY: api-dev api-up api-logs site-up-all
+api-dev:
+	cd services/api && npm i && npm run dev
+
+api-up:
+	docker compose -f docker-compose.prism.yml up -d api
+
+api-logs:
+	docker compose -f docker-compose.prism.yml logs -f api
+
+site-up-all:
+	docker compose -f docker-compose.prism.yml up -d

--- a/docker-compose.prism.yml
+++ b/docker-compose.prism.yml
@@ -1,0 +1,27 @@
+version: "3.9"
+services:
+  api:
+    image: node:20-alpine
+    container_name: blackroad-api
+    working_dir: /app
+    restart: unless-stopped
+    environment:
+      - PORT=4000
+      - NODE_ENV=production
+    volumes:
+      - ./services/api:/app:ro
+    command: ["node", "server.mjs"]
+    ports:
+      - "4000:4000"
+
+  site:
+    image: caddy:2.8-alpine
+    container_name: blackroad-site
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./sites/blackroad/dist:/srv:ro
+      - ./sites/blackroad/Caddyfile:/etc/caddy/Caddyfile:ro
+    depends_on:
+      - api

--- a/services/api/healthcheck.mjs
+++ b/services/api/healthcheck.mjs
@@ -1,0 +1,18 @@
+import http from "node:http";
+const req = http.request(
+  { host: "127.0.0.1", port: process.env.PORT || 4000, path: "/api/health.json", method: "GET" },
+  (res) => {
+    if (res.statusCode === 200) {
+      process.stdout.write("OK\n");
+      process.exit(0);
+    } else {
+      process.stderr.write(`BAD ${res.statusCode}\n`);
+      process.exit(1);
+    }
+  }
+);
+req.on("error", (e) => {
+  process.stderr.write(String(e) + "\n");
+  process.exit(2);
+});
+req.end();

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "blackroad-api-bridge",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "node --watch server.mjs",
+    "start": "node server.mjs",
+    "health": "node healthcheck.mjs"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.19.2",
+    "morgan": "^1.10.0",
+    "ws": "^8.18.0"
+  }
+}

--- a/services/api/server.mjs
+++ b/services/api/server.mjs
@@ -1,0 +1,47 @@
+import express from "express";
+import cors from "cors";
+import morgan from "morgan";
+import { WebSocketServer } from "ws";
+
+const PORT = process.env.PORT || 4000;
+const app = express();
+
+app.use(cors());
+app.use(morgan("tiny"));
+app.use(express.json());
+
+/**
+ * Health + metadata for the BlackRoad bridge.
+ * NGINX/Caddy proxies /api/* → this service (see existing configs).
+ */
+app.get("/api/health.json", (_req, res) => {
+  res.json({
+    status: "ok",
+    service: "blackroad-api-bridge",
+    time: new Date().toISOString(),
+    upstreams: {
+      ws: "/ws",
+    },
+  });
+});
+
+// Simple echo for diagnostics
+app.post("/api/echo", (req, res) => {
+  res.json({ ok: true, received: req.body ?? null });
+});
+
+const server = app.listen(PORT, "0.0.0.0", () => {
+  console.log(`BlackRoad API bridge listening on :${PORT}`);
+});
+
+/**
+ * WebSocket channel (diagnostic)
+ * NGINX should map /ws → this server (HTTP/1.1 Upgrade).
+ */
+const wss = new WebSocketServer({ server, path: "/ws" });
+wss.on("connection", (socket) => {
+  socket.send(JSON.stringify({ hello: "blackroad", t: Date.now() }));
+  socket.on("message", (msg) => {
+    socket.send(JSON.stringify({ echo: msg.toString(), t: Date.now() }));
+  });
+});

--- a/sites/blackroad/src/App.jsx
+++ b/sites/blackroad/src/App.jsx
@@ -11,16 +11,22 @@ const portals = [
 ];
 
 function Status() {
-  const [state, setState] = useState({ ok: null, error: null });
+  const [state, setState] = useState({ ok: null, error: null, info: '' });
 
   useEffect(() => {
     let canceled = false;
     (async () => {
       try {
         const res = await fetch('/api/health.json', { cache: 'no-store' });
-        if (!canceled) setState({ ok: res.ok, error: null });
+        const text = await res.text();
+        let info = '';
+        try {
+          const json = JSON.parse(text);
+          info = `${json.service || ''} • ${json.time || ''}`;
+        } catch {}
+        if (!canceled) setState({ ok: res.ok, error: null, info });
       } catch (e) {
-        if (!canceled) setState({ ok: false, error: String(e) });
+        if (!canceled) setState({ ok: false, error: String(e), info: '' });
       }
     })();
     return () => {
@@ -42,6 +48,7 @@ function Status() {
   return (
     <p className={`mt-3 text-sm ${tone}`}>
       {label}
+      {state.info && <span className="ml-2 text-neutral-400">{state.info}</span>}
       {state.error && <span className="ml-2">{state.error}</span>}
     </p>
   );


### PR DESCRIPTION
## Summary
- add Node-based API bridge with health check and WebSocket echo
- wire up docker compose, Makefile targets, and CI workflow
- surface API health info in site Status component

## Testing
- `pre-commit run --files services/api/package.json services/api/server.mjs services/api/healthcheck.mjs docker-compose.prism.yml Makefile .github/workflows/api-ci.yml sites/blackroad/src/App.jsx` *(fails: command not found)*
- `pip install pre-commit` *(fails: proxy 403 Forbidden)*
- `npm install --package-lock-only` *(fails: 403 Forbidden from registry)*
- `node services/api/server.mjs` *(fails: Cannot find package 'express')*


------
https://chatgpt.com/codex/tasks/task_e_68a6b9260d7883298e9f09919b38a49e