### PR TITLE
Add NGINX setup and health check scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,5 +178,12 @@ site-blackroad-build:
 site-blackroad-caddy:
 	docker compose -f docker-compose.site.yml up -d
 
-site-blackroad-up: site-blackroad-build site-blackroad-caddy
-	@echo "Site running at http://localhost:8080"
+.PHONY: nginx-ensure nginx-health tls
+nginx-ensure:
+	bash scripts/nginx-ensure-and-health.sh
+
+nginx-health:
+	bash scripts/nginx-ensure-and-health.sh
+
+tls:
+	bash scripts/nginx-enable-tls.sh blackroad.io you@example.com

--- a/scripts/nginx-enable-tls.sh
+++ b/scripts/nginx-enable-tls.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Optional: enable HTTPS with Let's Encrypt (requires DNS -> server)
+# Usage: bash scripts/nginx-enable-tls.sh blackroad.io admin@example.com
+set -euo pipefail
+DOMAIN="${1:-blackroad.io}"
+EMAIL="${2:-admin@example.com}"
+
+apt-get update -y
+apt-get install -y certbot python3-certbot-nginx
+certbot --nginx -d "$DOMAIN" -d "www.$DOMAIN" --agree-tos -m "$EMAIL" --redirect -n
+systemctl reload nginx
+echo "TLS enabled on https://$DOMAIN"

--- a/scripts/nginx-ensure-and-health.sh
+++ b/scripts/nginx-ensure-and-health.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Purpose: Ensure NGINX is correctly serving BlackRoad.io and proxying /api + /ws,
+# then run full health checks for site, API, and WebSocket.
+
+set -euo pipefail
+
+SITE_ROOT="/var/www/blackroad"
+NGX_AVAIL="/etc/nginx/sites-available/blackroad.io"
+NGX_ENABLED="/etc/nginx/sites-enabled/blackroad.io"
+API_URL="http://127.0.0.1:4000"
+SITE_URL_LOCAL="http://127.0.0.1"
+SITE_URL_EXT="http://blackroad.io"   # DNS must already point here
+
+echo "==> Install nginx if missing"
+if ! command -v nginx >/dev/null 2>&1; then
+  apt-get update -y
+  apt-get install -y nginx
+fi
+
+echo "==> Ensure site artifacts exist"
+mkdir -p "$SITE_ROOT"
+# If CI already synced a build, this is a no-op. Otherwise drop a minimal index
+[ -f "$SITE_ROOT/index.html" ] || cat > "$SITE_ROOT/index.html" <<'HTML'
+<!doctype html><meta charset="utf-8"><title>BlackRoad.io</title>
+<body style="background:#0b0b10;color:#e8e8f0;font:16px system-ui;-webkit-font-smoothing:antialiased">
+<h1>BlackRoad.io</h1><p>Serving static root from /var/www/blackroad</p>
+</body>
+HTML
+
+echo "==> Write nginx vhost config (proxy /api + /ws, SPA fallback)"
+cat > "$NGX_AVAIL" <<'NGINX'
+server {
+  listen 80;
+  listen [::]:80;
+  server_name blackroad.io www.blackroad.io;
+
+  root /var/www/blackroad;
+  index index.html;
+
+  # Single-page app fallback (keeps /status, /portal working)
+  location / {
+    try_files $uri /index.html;
+  }
+
+  # API proxy to Node bridge on :4000
+  location /api/ {
+    proxy_pass http://127.0.0.1:4000/;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
+  # WebSocket proxy to /ws (HTTP/1.1 Upgrade)
+  location /ws {
+    proxy_pass http://127.0.0.1:4000/ws;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+  }
+}
+NGINX
+
+echo "==> Enable vhost"
+ln -sf "$NGX_AVAIL" "$NGX_ENABLED"
+
+echo "==> Config test + reload"
+nginx -t
+systemctl reload nginx || systemctl restart nginx
+
+echo "==> Basic service status"
+systemctl is-active nginx || (echo "nginx not active"; exit 1)
+
+echo "==> API health probe (bridge must be running on :4000)"
+if curl -fsS "$API_URL/api/health.json" >/dev/null; then
+  echo "API OK @ $API_URL/api/health.json"
+else
+  echo "WARN: API not responding on $API_URL"
+fi
+
+echo "==> Site root probe (local loopback)"
+curl -fsS -I "$SITE_URL_LOCAL" | head -1
+
+echo "==> Site essential routes (static & SPA)"
+for p in "/" "/status" "/portal" "/docs"; do
+  code=$(curl -o /dev/null -s -w "%{http_code}" "$SITE_URL_LOCAL$p")
+  printf "  %-8s -> %s\n" "$p" "$code"
+
+done
+
+echo "==> External hostname (requires DNS):"
+code_ext=$(curl -o /dev/null -s -w "%{http_code}" "$SITE_URL_EXT" || true)
+echo "  $SITE_URL_EXT -> ${code_ext:-NA}"
+
+echo "==> WebSocket handshake probe"
+# Minimal HTTP/1.1 upgrade request using curl
+WS_HEADERS=$(cat <<'HDR'
+GET /ws HTTP/1.1
+Host: 127.0.0.1
+Connection: Upgrade
+Upgrade: websocket
+Sec-WebSocket-Key: x3JJHMbDL1EzLkh9GBhXDw==
+Sec-WebSocket-Version: 13
+
+HDR
+)
+# Use netcat or /dev/tcp to send the handshake
+if command -v nc >/dev/null 2>&1; then
+  printf "%s" "$WS_HEADERS" | nc 127.0.0.1 80 -w 2 | head -3 || true
+else
+  exec 3<>/dev/tcp/127.0.0.1/80 || true
+  printf "%s" "$WS_HEADERS" >&3 || true
+  head -3 <&3 || true
+  exec 3<&- 3>&- || true
+fi
+
+echo "==> Tail last nginx error lines (if any)"
+tail -n 50 /var/log/nginx/error.log || true
+
+echo "==> Done. If any probe failed, check the API service and DNS."

--- a/scripts/prism-full-check.sh
+++ b/scripts/prism-full-check.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# One-button: check API systemd, nginx config, and all public routes.
+set -euo pipefail
+echo "== systemd: blackroad-api =="
+systemctl status blackroad-api --no-pager || true
+echo "== nginx test =="
+nginx -t
+echo "== Routes =="
+for p in "/" "/status" "/portal" "/docs" "/api/health.json"; do
+  code=$(curl -o /dev/null -s -w "%{http_code}" "http://127.0.0.1$p" || true)
+  printf "  %-16s %s\n" "$p" "$code"
+done


### PR DESCRIPTION
## Summary
- add script to install and verify NGINX and probe API/WebSocket endpoints
- add optional TLS enabling script via certbot
- add prism full check helper and Makefile targets

## Testing
- `bash -n scripts/nginx-ensure-and-health.sh`
- `bash -n scripts/nginx-enable-tls.sh`
- `bash -n scripts/prism-full-check.sh`
- `pre-commit run --files Makefile scripts/nginx-enable-tls.sh scripts/nginx-ensure-and-health.sh scripts/prism-full-check.sh` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a6bcd58cc48329972ce33b27d21ef2