### PR TITLE
feat: add express sqlite api server

### DIFF
--- a/srv/blackroad-api/server_full.js
+++ b/srv/blackroad-api/server_full.js
@@ -1,0 +1,230 @@
+/* BlackRoad API — Express + SQLite + Socket.IO + LLM bridge
+   Runs behind Nginx on port 4000 with cookie-session auth.
+   Env (optional):
+     PORT=4000
+     SESSION_SECRET=change_me
+     DB_PATH=/srv/blackroad-api/blackroad.db
+     LLM_URL=http://127.0.0.1:8000/chat
+     ALLOW_SHELL=false
+*/
+
+const http = require('http');
+const os = require('os');
+const path = require('path');
+const fs = require('fs');
+
+const express = require('express');
+const compression = require('compression');
+const morgan = require('morgan');
+const cookieSession = require('cookie-session');
+const Database = require('better-sqlite3');
+const { Server: SocketIOServer } = require('socket.io');
+const { exec } = require('child_process');
+
+// --- Config
+const PORT = parseInt(process.env.PORT || '4000', 10);
+const SESSION_SECRET = process.env.SESSION_SECRET || 'dev-secret-change-me';
+const DB_PATH = process.env.DB_PATH || '/srv/blackroad-api/blackroad.db';
+const LLM_URL = process.env.LLM_URL || 'http://127.0.0.1:8000/chat';
+const ALLOW_SHELL = String(process.env.ALLOW_SHELL || 'false').toLowerCase() === 'true';
+
+// Ensure DB dir exists
+fs.mkdirSync(path.dirname(DB_PATH), { recursive: true });
+
+// --- App & server
+const app = express();
+const server = http.createServer(app);
+const io = new SocketIOServer(server, {
+  path: '/socket.io',
+  serveClient: false,
+  cors: { origin: false }, // same-origin via Nginx
+});
+
+// --- Middleware
+app.disable('x-powered-by');
+app.use(compression());
+app.use(express.json({ limit: '2mb' }));
+app.use(morgan('tiny'));
+app.use(cookieSession({
+  name: 'brsess',
+  keys: [SESSION_SECRET],
+  httpOnly: true,
+  sameSite: 'lax',
+  maxAge: 1000 * 60 * 60 * 8, // 8h
+}));
+
+// --- Health
+app.head('/api/health', (_, res) => res.status(200).end());
+app.get('/api/health', (_, res) =>
+  res.json({ ok: true, service: 'blackroad-api', time: new Date().toISOString() })
+);
+
+// --- Auth (cookie-session)
+function requireAuth(req, res, next) {
+  if (req.session && req.session.user) return next();
+  return res.status(401).json({ error: 'unauthorized' });
+}
+app.get('/api/session', (req, res) => {
+  res.json({ user: req.session?.user || null });
+});
+app.post('/api/login', (req, res) => {
+  const { username, password } = req.body || {};
+  // dev defaults: root / Codex2025 (can be replaced with real auth)
+  if ((username === 'root' && password === 'Codex2025') || process.env.BYPASS_LOGIN === 'true') {
+    req.session.user = { username, role: 'dev' };
+    return res.json({ ok: true, user: req.session.user });
+  }
+  return res.status(401).json({ error: 'invalid_credentials' });
+});
+app.post('/api/logout', (req, res) => {
+  req.session = null;
+  res.json({ ok: true });
+});
+
+// --- SQLite bootstrap
+const db = new Database(DB_PATH);
+db.pragma('journal_mode = WAL');
+db.pragma('synchronous = NORMAL');
+
+const TABLES = ['projects', 'agents', 'datasets', 'models', 'integrations'];
+for (const t of TABLES) {
+  db.prepare(`
+    CREATE TABLE IF NOT EXISTS ${t} (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+      meta JSON
+    )
+  `).run();
+}
+
+// Helpers
+function listRows(t) {
+  return db.prepare(`SELECT id, name, updated_at, meta FROM ${t} ORDER BY datetime(updated_at) DESC`).all();
+}
+function createRow(t, name, meta = null) {
+  const stmt = db.prepare(`INSERT INTO ${t} (name, updated_at, meta) VALUES (?, datetime('now'), ?)`);
+  const info = stmt.run(name, meta ? JSON.stringify(meta) : null);
+  return info.lastInsertRowid;
+}
+function updateRow(t, id, name, meta = null) {
+  const stmt = db.prepare(`UPDATE ${t} SET name = COALESCE(?, name), meta = COALESCE(?, meta), updated_at = datetime('now') WHERE id = ?`);
+  stmt.run(name ?? null, meta ? JSON.stringify(meta) : null, id);
+}
+function deleteRow(t, id) {
+  db.prepare(`DELETE FROM ${t} WHERE id = ?`).run(id);
+}
+function validKind(kind) { return TABLES.includes(kind); }
+
+
+// --- CRUD routes (guard with auth once you’re ready)
+app.get('/api/:kind', requireAuth, (req, res) => {
+  const { kind } = req.params;
+  if (!validKind(kind)) return res.status(404).json({ error: 'unknown_kind' });
+  try { res.json(listRows(kind)); }
+  catch (e) { res.status(500).json({ error: 'db_list_failed', detail: String(e) }); }
+});
+app.post('/api/:kind', requireAuth, (req, res) => {
+  const { kind } = req.params;
+  const { name, meta } = req.body || {};
+  if (!validKind(kind)) return res.status(404).json({ error: 'unknown_kind' });
+  if (!name) return res.status(400).json({ error: 'name_required' });
+  try {
+    const id = createRow(kind, name, meta);
+    res.json({ ok: true, id });
+  } catch (e) { res.status(500).json({ error: 'db_create_failed', detail: String(e) }); }
+});
+app.post('/api/:kind/:id', requireAuth, (req, res) => {
+  const { kind, id } = req.params;
+  const { name, meta } = req.body || {};
+  if (!validKind(kind)) return res.status(404).json({ error: 'unknown_kind' });
+  try {
+    updateRow(kind, Number(id), name, meta);
+    res.json({ ok: true });
+  } catch (e) { res.status(500).json({ error: 'db_update_failed', detail: String(e) }); }
+});
+app.delete('/api/:kind/:id', requireAuth, (req, res) => {
+  const { kind, id } = req.params;
+  if (!validKind(kind)) return res.status(404).json({ error: 'unknown_kind' });
+  try { deleteRow(kind, Number(id)); res.json({ ok: true }); }
+  catch (e) { res.status(500).json({ error: 'db_delete_failed', detail: String(e) }); }
+});
+
+// --- LLM bridge (/api/llm/chat)
+// Forwards body to FastAPI (LLM_URL) and streams raw text back to the client.
+app.post('/api/llm/chat', requireAuth, async (req, res) => {
+  try {
+    const upstream = await fetch(LLM_URL, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify(req.body || {}),
+    });
+
+    // Stream if possible
+    if (upstream.ok && upstream.body) {
+      res.status(200);
+      res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+      res.setHeader('Transfer-Encoding', 'chunked');
+
+      const reader = upstream.body.getReader();
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        // passthrough raw bytes (FastAPI may send plain text or SSE-like chunks)
+        res.write(Buffer.from(value));
+      }
+      return res.end();
+    }
+
+    // Non-stream fallback
+    const txt = await upstream.text().catch(() => '');
+    // try to unwrap {text: "..."}
+    let out = txt;
+    try { const j = JSON.parse(txt); if (j && typeof j.text === 'string') out = j.text; } catch {}
+    res.status(upstream.ok ? 200 : upstream.status).type('text/plain').send(out || '(no content)');
+  } catch (e) {
+    res.status(502).type('text/plain').send('(llm upstream error)');
+  }
+});
+
+// --- Optional shell exec (disabled by default)
+app.post('/api/exec', requireAuth, (req, res) => {
+  if (!ALLOW_SHELL) return res.status(403).json({ error: 'exec_disabled' });
+  const cmd = (req.body && req.body.cmd || '').trim();
+  if (!cmd) return res.status(400).json({ error: 'cmd_required' });
+  exec(cmd, { timeout: 20000 }, (err, stdout, stderr) => {
+    if (err) return res.status(500).json({ error: 'exec_failed', detail: String(err), stderr });
+    res.json({ out: stdout, stderr });
+  });
+});
+
+// --- Actions (stubs)
+app.post('/api/actions/mint', requireAuth, (req, res) => {
+  // TODO: integrate wallet; for now echo a stub tx id
+  res.json({ ok: true, minted: Number(req.body?.amount || 1), tx: 'rc_' + Math.random().toString(36).slice(2, 10) });
+});
+
+// --- Socket.IO presence (metrics)
+io.on('connection', (socket) => {
+  socket.emit('hello', { ok: true, t: Date.now() });
+});
+setInterval(() => {
+  const total = os.totalmem(), free = os.freemem();
+  const payload = {
+    t: Date.now(),
+    load: os.loadavg()[0],
+    mem: { total, free, used: total - free, pct: (1 - free / total) },
+    cpuCount: os.cpus()?.length || 1,
+    host: os.hostname(),
+  };
+  io.emit('metrics', payload);
+}, 2000);
+
+// --- Start
+server.listen(PORT, () => {
+  console.log(`[blackroad-api] listening on ${PORT} (db: ${DB_PATH}, llm: ${LLM_URL}, shell: ${ALLOW_SHELL})`);
+});
+
+// --- Safety
+process.on('unhandledRejection', (e) => console.error('UNHANDLED', e));
+process.on('uncaughtException', (e) => console.error('UNCAUGHT', e));


### PR DESCRIPTION
## Summary
- add standalone Express server with SQLite persistence, LLM bridge and Socket.IO metrics

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6d8f761148329b058abd31ac9e821