### PR TITLE
chore: add auto build workflow

### DIFF
--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -1,0 +1,17 @@
+name: Bot Auto Build
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - name: Run automated build
+        run: bash scripts/auto-build.sh

--- a/scripts/auto-build.sh
+++ b/scripts/auto-build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Simple automation script to install dependencies and build the project.
+# Allows automated agents to trigger builds regularly.
+set -euo pipefail
+
+pnpm install --frozen-lockfile
+pnpm build


### PR DESCRIPTION
## Summary
- add automation script to install dependencies and build project
- schedule GitHub action to run automated build daily

## Testing
- `pre-commit run --files scripts/auto-build.sh .github/workflows/auto-build.yml` *(fails: command not found)*
- `bash scripts/auto-build.sh` *(fails: ERR_PNPM_JSON_PARSE in apps/portals/package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7595a9e1c8329a188007f614a52ca