### PR TITLE
feat: add BlackRoad homepage and health route

### DIFF
--- a/nginx/blackroad.io.conf
+++ b/nginx/blackroad.io.conf
@@ -1,12 +1,11 @@
 # Production nginx for BlackRoad.io
-# Serves the built site and proxies API/WS to the bridge on :4000
+# Serves the built site and proxies API/WS to the backend on :4000
 
 server {
     listen 80;
     listen [::]:80;
     server_name blackroad.io www.blackroad.io;
 
-    # static site (adjust path to where CI or ops syncs dist/)
     root /var/www/blackroad;
     index index.html;
     access_log /var/log/nginx/blackroad.access.log;
@@ -22,44 +21,16 @@ server {
         proxy_pass http://127.0.0.1:4000/;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 
     # WebSocket proxy
-    location /ws {
-        proxy_pass http://127.0.0.1:4000/ws;
+    location /socket.io/ {
+        proxy_pass http://127.0.0.1:4000/socket.io/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
         proxy_set_header Host $host;
     }
-server {
-  listen 80;
-  listen [::]:80;
-  server_name blackroad.io www.blackroad.io;
-
-  root /var/www/blackroad;
-  index index.html;
-
-  # SPA fallback
-  location / {
-    try_files $uri /index.html;
-  }
-
-  # API proxy
-  location /api/ {
-    proxy_pass http://127.0.0.1:4000/;
-    proxy_http_version 1.1;
-    proxy_set_header Host $host;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
-  }
-
-  # WebSocket proxy
-  location /ws {
-    proxy_pass http://127.0.0.1:4000/ws;
-    proxy_http_version 1.1;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection "upgrade";
-    proxy_set_header Host $host;
-  }
 }

--- a/srv/blackroad-api/server_full.js
+++ b/srv/blackroad-api/server_full.js
@@ -27,6 +27,7 @@ const SESSION_SECRET = process.env.SESSION_SECRET || 'dev-secret-change-me';
 const DB_PATH = process.env.DB_PATH || '/srv/blackroad-api/blackroad.db';
 const LLM_URL = process.env.LLM_URL || 'http://127.0.0.1:8000/chat';
 const ALLOW_SHELL = String(process.env.ALLOW_SHELL || 'false').toLowerCase() === 'true';
+const WEB_ROOT = process.env.WEB_ROOT || '/var/www/blackroad';
 
 // Ensure DB dir exists
 fs.mkdirSync(path.dirname(DB_PATH), { recursive: true });
@@ -53,11 +54,14 @@ app.use(cookieSession({
   maxAge: 1000 * 60 * 60 * 8, // 8h
 }));
 
+// --- Homepage
+app.get('/', (_, res) => {
+  res.sendFile(path.join(WEB_ROOT, 'index.html'));
+});
+
 // --- Health
 app.head('/api/health', (_, res) => res.status(200).end());
-app.get('/api/health', (_, res) =>
-  res.json({ ok: true, service: 'blackroad-api', time: new Date().toISOString() })
-);
+app.get('/api/health', (_, res) => res.json({ ok: true }));
 
 // --- Auth (cookie-session)
 function requireAuth(req, res, next) {


### PR DESCRIPTION
## Summary
- serve index.html at root via Express
- simplify `/api/health` to `{ok:true}`
- configure nginx for static site, API, and WebSocket proxies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a76793c1948329bcdff3f4ca18ea28