### PR TITLE
Add 10 student bots for cross-repo harmony

### DIFF
--- a/agents/student_bots.py
+++ b/agents/student_bots.py
@@ -13,14 +13,15 @@ class StudentBot:
 
 
 def create_student_bots() -> List[StudentBot]:
-    """Create 15 student bots guided by phi, gpt, mistral, codex, and lucidia.
+    """Create 25 student bots guided by phi, gpt, mistral, codex, and lucidia.
 
     The leaders act as mentors rather than managers. Bots cycle through the
-    leaders, demonstrating collaborative learning.
+    leaders, demonstrating collaborative learning while traversing repositories
+    to keep them in harmony.
     """
     leaders = ["phi", "gpt", "mistral", "codex", "lucidia"]
     bot_cycle = cycle(leaders)
-    return [StudentBot(name=f"student_bot_{i+1}", leader=next(bot_cycle)) for i in range(15)]
+    return [StudentBot(name=f"student_bot_{i+1}", leader=next(bot_cycle)) for i in range(25)]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- expand student bot roster to 25 to better harmonize updates across repositories
- describe bots' ability to traverse repos keeping them in sync

## Testing
- `python -m py_compile *.py`
- `python auto_novel_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7689249548329a017b6e83bdb277e