### PR TITLE
docs: allow bot and agent issue workflows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,8 @@ Thank you for your interest in contributing to this project!
 
 We appreciate your time and look forward to your contributions.
 - Open an issue first for large changes.
+- Bots and agents may open issues they discover and submit pull requests resolving them.
 - Use conventional commits (feat:, fix:, chore:).
 - For docs-only PRs, add label `docs` to allow auto-merge.
-- To ask bots to remediate:  
+- To ask bots to remediate:
   `/codex apply .github/prompts/codex-fix-anything.md`

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -4,6 +4,7 @@ If you have questions or need help with the project, please use the following re
 
 - **Questions and discussions:** [GitHub Discussions](https://github.com/blackroad-dev/prism-console/discussions)
 - **Bug reports and feature requests:** [GitHub Issues](https://github.com/blackroad-dev/prism-console/issues)
+- Automated bots and AI agents may also open issues and submit pull requests to resolve them.
 - **Email support:** reach out to [support@blackroad.dev](mailto:support@blackroad.dev)
 
 Please avoid filing security-related reports in public channels. Instead, follow the instructions in [SECURITY.md](SECURITY.md).


### PR DESCRIPTION
## Summary
- clarify that bots and agents may open issues and follow through with PRs
- note in support docs that automated agents can report issues and resolve them

## Testing
- `npm test`
- `pre-commit run --files CONTRIBUTING.md SUPPORT.md` *(fails: command not found then installation blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a768ff6d4c8329bbe63fbbc8f7cd04