### PR TITLE
Allow IPv6 localhost connections

### DIFF
--- a/services/quantum_lab/app.py
+++ b/services/quantum_lab/app.py
@@ -16,13 +16,15 @@ from .puzzles import simulate_chsh
 # Block outbound network access except localhost
 import socket
 
+ALLOWED_HOSTS = {"127.0.0.1", "localhost", "::1"}
+
 
 def _guard_network() -> None:
     real_create = socket.create_connection
 
     def guarded(address, *args, **kwargs):
         host, *_ = address
-        if host not in {"127.0.0.1", "localhost"}:
+        if host not in ALLOWED_HOSTS:
             raise RuntimeError("Network access disabled")
         return real_create(address, *args, **kwargs)
 


### PR DESCRIPTION
## Summary
- permit IPv6 loopback (::1) in Quantum Lab network guard to avoid false connection errors

## Testing
- `python -m py_compile services/quantum_lab/app.py`
- `pytest tests/test_quantum_lab.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7725b30b88329991eb261cdae24dc