### PR TITLE
fix: prioritize chat route in nginx config

### DIFF
--- a/nginx/conf.d/lucidia-sites.conf
+++ b/nginx/conf.d/lucidia-sites.conf
@@ -47,47 +47,6 @@ server {
     proxy_set_header X-Forwarded-Proto $scheme;
   }
 
-    location /api/ {
-      limit_req zone=api burst=20 nodelay;
-      proxy_pass http://blackroad_app;
-      proxy_http_version 1.1;
-      proxy_set_header Host $host;
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header X-Forwarded-Proto $scheme;
-      proxy_set_header Upgrade $http_upgrade;
-      proxy_set_header Connection $connection_upgrade;
-      proxy_read_timeout 60s;
-    }
-
-    location /api/chat {
-      proxy_pass http://127.0.0.1:3000;
-      proxy_http_version 1.1;
-      proxy_set_header Connection "";
-      proxy_buffering off;
-      proxy_cache off;
-    }
-
-    location /api/ {
-      limit_req zone=api burst=20 nodelay;
-      proxy_pass http://blackroad_app;
-      proxy_http_version 1.1;
-      proxy_set_header Host $host;
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header X-Forwarded-Proto $scheme;
-      proxy_set_header Upgrade $http_upgrade;
-      proxy_set_header Connection $connection_upgrade;
-      proxy_read_timeout 60s;
-    }
-
-    location /api/chat {
-      proxy_pass http://127.0.0.1:3000;
-      proxy_http_version 1.1;
-      proxy_set_header Connection "";
-      proxy_buffering off;
-      proxy_cache off;
-    }
   location /api/chat {
     proxy_pass http://127.0.0.1:3000;
     proxy_http_version 1.1;
@@ -147,47 +106,6 @@ server {
   add_header X-XSS-Protection "1; mode=block" always;
   include snippets/job_applier.conf;
 
-    location /api/ {
-      limit_req zone=api burst=20 nodelay;
-      proxy_pass http://blackroadinc_app;
-      proxy_http_version 1.1;
-      proxy_set_header Host $host;
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header X-Forwarded-Proto $scheme;
-      proxy_set_header Upgrade $http_upgrade;
-      proxy_set_header Connection $connection_upgrade;
-      proxy_read_timeout 60s;
-    }
-
-    location /api/chat {
-      proxy_pass http://127.0.0.1:3000;
-      proxy_http_version 1.1;
-      proxy_set_header Connection "";
-      proxy_buffering off;
-      proxy_cache off;
-    }
-
-    location /api/ {
-      limit_req zone=api burst=20 nodelay;
-      proxy_pass http://blackroadinc_app;
-      proxy_http_version 1.1;
-      proxy_set_header Host $host;
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header X-Forwarded-Proto $scheme;
-      proxy_set_header Upgrade $http_upgrade;
-      proxy_set_header Connection $connection_upgrade;
-      proxy_read_timeout 60s;
-    }
-
-    location /api/chat {
-      proxy_pass http://127.0.0.1:3000;
-      proxy_http_version 1.1;
-      proxy_set_header Connection "";
-      proxy_buffering off;
-      proxy_cache off;
-    }
   location /api/chat {
     proxy_pass http://127.0.0.1:3000;
     proxy_http_version 1.1;


### PR DESCRIPTION
## Summary
- ensure /api/chat blocks precede generic /api routes for blackroad.io and blackroadinc.us

## Testing
- `apt-get update` *(fails: repository InRelease not signed, 403 Forbidden)*
- `apt-get install -y nginx` *(fails: Unable to locate package nginx)*
- `nginx -t -c nginx/nginx.conf` *(fails: command not found: nginx)*
- `pre-commit run --files nginx/conf.d/lucidia-sites.conf` *(fails: command not found: pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68a771fa75d4832989840e9c584319f9