### PR TITLE
Add basic Lucidia coding portal

### DIFF
--- a/lucidia/app.py
+++ b/lucidia/app.py
@@ -1,11 +1,35 @@
+"""Simple coding portal for executing Python snippets."""
+
+import io
 import os
-from flask import Flask
+from contextlib import redirect_stdout
+
+from flask import Flask, jsonify, render_template, request
 
 app = Flask(__name__)
 
-@app.route('/')
-def index():
-    return 'Lucidia alive'
 
-if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=int(os.getenv('PORT', 8080)))
+@app.route("/")
+def index():
+    """Serve the main page."""
+    return render_template("index.html")
+
+
+@app.post("/run")
+def run_code():
+    """Execute user-supplied Python code and return the output."""
+    data = request.get_json(silent=True) or {}
+    code = data.get("code", "")
+    local_vars: dict[str, object] = {}
+    stdout = io.StringIO()
+    try:
+        with redirect_stdout(stdout):
+            exec(code, {"__builtins__": {"print": print}}, local_vars)
+        output = stdout.getvalue()
+    except Exception as exc:  # noqa: BLE001 - broad for user feedback
+        output = f"Error: {exc}"
+    return jsonify({"output": output})
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=int(os.getenv("PORT", 8080)))

--- a/lucidia/templates/index.html
+++ b/lucidia/templates/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Lucidia Co Coding Portal</title>
+  </head>
+  <body>
+    <h1>Lucidia Co Coding Portal</h1>
+    <form id="code-form">
+      <textarea id="code" rows="10" cols="80" placeholder="print('Hello')"></textarea><br />
+      <button type="submit">Run</button>
+    </form>
+    <pre id="output"></pre>
+    <script>
+      document.getElementById('code-form').addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const code = document.getElementById('code').value;
+        const response = await fetch('/run', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ code }),
+        });
+        const data = await response.json();
+        document.getElementById('output').textContent = data.output;
+      });
+    </script>
+  </body>
+</html>

--- a/lucidia/test_app.py
+++ b/lucidia/test_app.py
@@ -1,0 +1,15 @@
+from lucidia.app import app
+
+
+def test_index():
+    client = app.test_client()
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert b"Lucidia Co Coding Portal" in resp.data
+
+
+def test_run_code():
+    client = app.test_client()
+    resp = client.post("/run", json={"code": "print('hi')"})
+    assert resp.status_code == 200
+    assert "hi" in resp.get_json()["output"]


### PR DESCRIPTION
## Summary
- add Flask backend with endpoint to execute Python snippets
- serve a simple HTML interface for submitting code
- test basic portal routes and execution flow

## Testing
- `ruff check lucidia/app.py lucidia/test_app.py`
- `pytest lucidia/test_app.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7d6bbf2608329bd2e040b70690d1e