### PR TITLE
Add bot portal to display task stats

### DIFF
--- a/sites/blackroad/public/portal/bot/index.html
+++ b/sites/blackroad/public/portal/bot/index.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Bot Portal | BlackRoad.io</title>
+    <style>
+      :root { color-scheme: dark; }
+      body { margin:0; font:14px/1.5 system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif; background:#0b0b10; color:#e8e8f0; }
+      .wrap { max-width: 900px; margin:40px auto; padding:24px; border-radius:16px; background:#14141d; box-shadow:0 10px 30px rgba(0,0,0,.35); }
+      h1 { margin:0 0 12px; font-size:22px; }
+      table { width:100%; border-collapse:collapse; margin-top:20px; }
+      th, td { border:1px solid #23232c; padding:8px 10px; }
+      th { background:#1c1c27; text-align:left; }
+      .muted { color:#a3a3ad; }
+    </style>
+  </head>
+  <body>
+    <div class="wrap" role="main">
+      <strong><a href="/">BlackRoad.io</a></strong>
+      <h1>Bot Portal</h1>
+      <p class="muted">Task states and CSV stats.</p>
+      <div id="summary" class="muted"></div>
+      <table id="tasks">
+        <thead>
+          <tr><th>Task</th><th>Status</th><th>Progress</th></tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
+    <script>
+      async function load(){
+        try {
+          const res = await fetch('tasks.csv');
+          const text = await res.text();
+          const lines = text.trim().split('\n');
+          const tasks = lines.slice(1).map(line => {
+            const [id,title,status,progress] = line.split(',');
+            return { id, title, status, progress: Number(progress) };
+          });
+          const tbody = document.querySelector('#tasks tbody');
+          tasks.forEach(t => {
+            const tr = document.createElement('tr');
+            tr.innerHTML = `<td>${t.title}</td><td>${t.status}</td><td>${(t.progress*100).toFixed(0)}%</td>`;
+            tbody.appendChild(tr);
+          });
+          const counts = tasks.reduce((acc,t)=>{ acc[t.status]=(acc[t.status]||0)+1; return acc; },{});
+          document.getElementById('summary').textContent = 'Counts: ' + Object.entries(counts).map(([k,v])=>`${k}: ${v}`).join(', ');
+        } catch(err){
+          document.getElementById('summary').textContent = 'Error loading tasks';
+        }
+      }
+      load();
+    </script>
+  </body>
+</html>

--- a/sites/blackroad/public/portal/bot/tasks.csv
+++ b/sites/blackroad/public/portal/bot/tasks.csv
@@ -1,0 +1,4 @@
+id,title,status,progress
+1,Wire GPUs to agents,In Progress,0.3
+2,Policy/secret scan checks,Queued,0.0
+3,Implement streaming SSE,Done,1.0

--- a/sites/blackroad/public/portal/index.html
+++ b/sites/blackroad/public/portal/index.html
@@ -41,6 +41,7 @@
         { name: "Roadcoin",  desc: "Wallet, staking, and token economy.", href: "/portal/roadcoin" },
         { name: "Roadchain", desc: "On-chain proofs, explorer, and indexer.", href: "/portal/roadchain" },
         { name: "Radius",    desc: "Local meetups and events nearby.", href: "/portal/radius" },
+        { name: "Bot",       desc: "Task states and stats dashboard.", href: "/portal/bot" },
       ];
       const el = document.getElementById('grid');
       el.innerHTML = portals.map(p => `


### PR DESCRIPTION
## Summary
- add static bot portal page that reads a CSV of task stats and shows status counts
- list bot portal link alongside other portals

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7d72826388329903b8b335d40fbc1