### PR TITLE
fix: deploy blackroad via rsync

### DIFF
--- a/.github/workflows/prism-ssh-deploy.yml
+++ b/.github/workflows/prism-ssh-deploy.yml
@@ -3,8 +3,9 @@ on:
   push:
     branches: [ main ]
     paths:
-      - "sites/blackroad/"
-      - "services/api/"
+      - "frontend/**"
+      - "sites/blackroad/**"
+      - "services/api/**"
       - "nginx/blackroad.io.conf"
       - "systemd/**"
       - ".github/workflows/prism-ssh-deploy.yml"
@@ -13,67 +14,67 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    env:
-      SITE_DIR: sites/blackroad
-      API_DIR: services/api
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Determine site directory
+        id: site
+        run: |
+          if [ -d sites/blackroad ]; then
+            echo "dir=sites/blackroad" >> "$GITHUB_OUTPUT"
+          else
+            echo "dir=frontend" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
-          cache-dependency-path: "${{ env.SITE_DIR }}/package-lock.json"
+          cache-dependency-path: "${{ steps.site.outputs.dir }}/package-lock.json"
 
-      # -------- Build site (Vite) --------
-      - name: Install site deps
-        working-directory: ${{ env.SITE_DIR }}
-        run: npm ci
       - name: Build site
-        working-directory: ${{ env.SITE_DIR }}
-        run: npm run build
-      - name: Tar site artifact
-        run: tar -C $SITE_DIR -czf site-dist.tgz dist
+        working-directory: ${{ steps.site.outputs.dir }}
+        run: |
+          npm ci
+          npm run build
 
-      # -------- Prepare API (no build step needed) --------
-      - name: Tar API
-        run: tar -C $API_DIR -czf api-src.tgz .
-
-      # -------- SSH: upload + activate --------
       - name: Install SSH key
         uses: webfactory/ssh-agent@v0.9.0
         with:
-          ssh-private-key: ${{ secrets.DEPLOY_SSH_KEY }}
+          ssh-private-key: ${{ secrets.DEPLOY_KEY }}
+
       - name: Add host to known_hosts
         run: |
           mkdir -p ~/.ssh
           ssh-keyscan -H ${{ secrets.DEPLOY_HOST }} >> ~/.ssh/known_hosts
 
-      - name: Upload bundles
+      - name: Rsync site
         run: |
-          scp -q site-dist.tgz ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/tmp/site-dist.tgz
-          scp -q api-src.tgz  ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/tmp/api-src.tgz
-          scp -q nginx/blackroad.io.conf  ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/tmp/blackroad.io.conf
-          scp -q systemd/blackroad-api.service ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/tmp/blackroad-api.service
+          rsync -avz --delete --rsync-path="sudo rsync" ${{ steps.site.outputs.dir }}/dist/ ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/var/www/blackroad/
+
+      - name: Rsync API source
+        run: |
+          rsync -avz --delete --rsync-path="sudo rsync" services/api/ ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/opt/blackroad/api/
+
+      - name: Upload config files
+        run: |
+          scp nginx/blackroad.io.conf ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/tmp/blackroad.io.conf
+          scp systemd/blackroad-api.service ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/tmp/blackroad-api.service
 
       - name: Remote activate
         run: |
           ssh -tt ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} <<'EOS'
           set -euo pipefail
-          sudo mkdir -p /var/www/blackroad
-          sudo tar -xzf /tmp/site-dist.tgz -C /var/www/blackroad --strip-components=1
-          sudo mkdir -p /opt/blackroad/api
-          sudo tar -xzf /tmp/api-src.tgz -C /opt/blackroad/api
-          # Systemd service for API
-          sudo mv /tmp/blackroad-api.service /etc/systemd/system/blackroad-api.service
-          sudo systemctl daemon-reload
-          sudo systemctl enable --now blackroad-api
-          # NGINX config
           sudo mv /tmp/blackroad.io.conf /etc/nginx/sites-available/blackroad.io
           sudo ln -sf /etc/nginx/sites-available/blackroad.io /etc/nginx/sites-enabled/blackroad.io
           sudo nginx -t
           sudo systemctl reload nginx
-          echo "Deploy OK"
+          sudo mv /tmp/blackroad-api.service /etc/systemd/system/blackroad-api.service
+          sudo systemctl daemon-reload
+          sudo systemctl enable --now blackroad-api
+          sudo systemctl status blackroad-api --no-pager
+          curl http://127.0.0.1:4000/api/health
+          curl -I http://localhost
           EOS


### PR DESCRIPTION
## Summary
- build site from `frontend` or `sites/blackroad`
- rsync site and API to server using DEPLOY_* secrets
- install nginx + systemd configs and run health checks

## Testing
- `pre-commit run --files .github/workflows/prism-ssh-deploy.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a88e7e5b488329a0b36116922bdd14