### PR TITLE
feat: add deploy-site workflow

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -1,0 +1,63 @@
+name: deploy-site
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - "sites/blackroad/**"
+      - "nginx/blackroad.io.conf"
+      - ".github/workflows/deploy-site.yml"
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: sites/blackroad/package-lock.json
+
+      - name: Install & Build (sites/blackroad)
+        working-directory: sites/blackroad
+        run: |
+          npm ci
+          npm run build
+
+      - name: Deploy via rsync to /var/www/blackroad
+        uses: Burnett01/rsync-deployments@6.0
+        with:
+          switches: -avz --delete
+          path: sites/blackroad/dist/
+          remote_path: /var/www/blackroad/
+          remote_host: ${{ secrets.DEPLOY_HOST }}
+          remote_user: ${{ secrets.DEPLOY_USER }}
+          remote_key:  ${{ secrets.DEPLOY_KEY }}
+
+      - name: Install Nginx config & reload
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_KEY }}
+          script: |
+            sudo mkdir -p /etc/nginx/sites-available /etc/nginx/sites-enabled
+            # Ensure the active config points to /var/www/blackroad
+            if grep -q "/var/www/prism" /srv/blackroad/nginx/blackroad.io.conf; then
+              sudo sed -i 's#/var/www/prism#/var/www/blackroad#g' /srv/blackroad/nginx/blackroad.io.conf
+            fi
+            sudo cp /srv/blackroad/nginx/blackroad.io.conf /etc/nginx/sites-available/blackroad.io
+            sudo ln -sf /etc/nginx/sites-available/blackroad.io /etc/nginx/sites-enabled/blackroad.io
+            sudo nginx -t && sudo systemctl reload nginx
+
+            # Optional: make sure API is up (expected at :4000)
+            sudo systemctl enable --now blackroad-api || true
+            curl -fsS http://127.0.0.1:4000/api/health || exit 1
+
+            # Basic site check
+            curl -I -s https://blackroad.io | head -n 1
+


### PR DESCRIPTION
## Summary
- add GitHub Action to build and deploy blackroad site via rsync and Nginx reload

## Testing
- `pre-commit run --files .github/workflows/deploy-site.yml` *(fails: command not found)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a88dec63508329ba63dc51e9bd7d60