### PR TITLE
docs: streamline hybrid deploy for site and API

### DIFF
--- a/.github/workflows/prism-ssh-deploy.yml
+++ b/.github/workflows/prism-ssh-deploy.yml
@@ -1,12 +1,11 @@
 name: Prism — SSH Deploy to blackroad.io
+# Requires secrets: DEPLOY_HOST, DEPLOY_USER, DEPLOY_KEY
 on:
   push:
     branches: [ main ]
     paths:
-      - "frontend/**"
-      - "sites/blackroad/**"
       - "services/api/**"
-      - "nginx/blackroad.io.conf"
+      - "ops/nginx/**"
       - "systemd/**"
       - ".github/workflows/prism-ssh-deploy.yml"
   workflow_dispatch: {}
@@ -34,12 +33,6 @@ jobs:
           cache: npm
           cache-dependency-path: "${{ steps.site.outputs.dir }}/package-lock.json"
 
-      - name: Build site
-        working-directory: ${{ steps.site.outputs.dir }}
-        run: |
-          npm ci
-          npm run build
-
       - name: Install SSH key
         uses: webfactory/ssh-agent@v0.9.0
         with:
@@ -50,18 +43,14 @@ jobs:
           mkdir -p ~/.ssh
           ssh-keyscan -H ${{ secrets.DEPLOY_HOST }} >> ~/.ssh/known_hosts
 
-      - name: Rsync site
-        run: |
-          rsync -avz --delete --rsync-path="sudo rsync" ${{ steps.site.outputs.dir }}/dist/ ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/var/www/blackroad/
-
       - name: Rsync API source
         run: |
           rsync -avz --delete --rsync-path="sudo rsync" services/api/ ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/opt/blackroad/api/
-
+      
       - name: Upload config files
         run: |
-          scp nginx/blackroad.io.conf ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/tmp/blackroad.io.conf
-          scp systemd/blackroad-api.service ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/tmp/blackroad-api.service
+          scp ops/nginx/blackroad.io.conf ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/tmp/blackroad.io.conf
+          scp systemd/*.service ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/tmp/
 
       - name: Remote activate
         run: |
@@ -71,7 +60,7 @@ jobs:
           sudo ln -sf /etc/nginx/sites-available/blackroad.io /etc/nginx/sites-enabled/blackroad.io
           sudo nginx -t
           sudo systemctl reload nginx
-          sudo mv /tmp/blackroad-api.service /etc/systemd/system/blackroad-api.service
+          sudo mv /tmp/*.service /etc/systemd/system/
           sudo systemctl daemon-reload
           sudo systemctl enable --now blackroad-api
           sudo systemctl status blackroad-api --no-pager

--- a/.github/workflows/site-build.yml
+++ b/.github/workflows/site-build.yml
@@ -42,4 +42,5 @@ jobs:
     steps:
       - id: deployment
         uses: actions/deploy-pages@v4
+      - run: echo "Deployed to ${{ steps.deployment.outputs.page_url }}" >> "$GITHUB_STEP_SUMMARY"
 

--- a/README-OPS.md
+++ b/README-OPS.md
@@ -1,2 +1,17 @@
 # Ops quickstart
 Bridge runs on :4000; nginx routes /api and /ws
+
+## Hybrid Deploy
+
+Static site is served via GitHub Pages at https://blackroad.io.
+API and NGINX configs deploy over SSH with `.github/workflows/prism-ssh-deploy.yml`.
+Actions require secrets `DEPLOY_HOST`, `DEPLOY_USER`, and `DEPLOY_KEY`.
+
+API health check: http://127.0.0.1:4000/api/health
+
+On the server you can run:
+
+```sh
+scripts/nginx-ensure-and-health.sh
+scripts/nginx-enable-tls.sh   # optional TLS helper
+```

--- a/sites/blackroad/README.md
+++ b/sites/blackroad/README.md
@@ -3,22 +3,29 @@ BlackRoad.io — Site
 Static Vite + React + Tailwind site served at / on blackroad.io.
 NGINX proxies /api to the backend and /ws for WebSockets.
 
-Local dev
+## Local dev
 
 cd sites/blackroad
 npm i
 npm run dev
 # open http://localhost:5173
 
-Build
+## Build
 
 npm run build   # outputs to sites/blackroad/dist
 
-Preview
+## Preview
 
 npm run preview # http://localhost:5174
 
-Production is served by the repository’s NGINX/Caddy configs. Artifacts are also uploaded from CI.
+## Deployment
+
+GitHub Pages builds and deploys `dist` on every push to `main` via `.github/workflows/site-build.yml`.
+Pages URL: https://blackroad.io
+
+To switch to Vercel or Cloudflare Pages, add the respective project tokens as repository
+secrets and enable the `pr-preview-vercel.yml` or `pr-preview-cloudflare.yml` workflows.
+Production is served by the repository’s NGINX/Caddy configs; GitHub Pages hosts the static assets.
 
 ⸻
 


### PR DESCRIPTION
## Summary
- print GitHub Pages URL after site deploy
- scope SSH deploy to API and ops config only
- document Pages workflow and hybrid deploy flow

## Testing
- `cd sites/blackroad && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8bd6c7fb88329918ce666590e228c