### PR TITLE
fix: restore valid tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,10 +13,4 @@
     }
   },
   "include": ["types.d.ts", "src/**/*.ts", "app/**/*", "lib/**/*"]
-    "forceConsistentCasingInFileNames": true
-  },
-  "include": ["types.d.ts", "src/**/*.ts", "app/**/*", "lib/**/*"]
-    "forceConsistentCasingInFileNames": true
-  },
-  "include": ["types.d.ts"]
 }


### PR DESCRIPTION
## Summary
- restore valid TypeScript configuration to remove duplicated include block

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module 'gray-matter')*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c89be24083298c1086c07aedf29d