### PR TITLE
feat: add billing dashboard and API

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,13 @@
   "type": "module",
   "scripts": {
     "build:lucidia-create": "npx tsc -p packages/lucidia-create/tsconfig.json --noEmit false --outDir packages/lucidia-create/dist",
-    "test": "npm run build:lucidia-create && node tests/smoke.test.js && node --test tests/*.mjs"
+    "test": "npm run build:lucidia-create && node tests/smoke.test.js && node --test tests/*.mjs",
+    "test:unit": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "react": "^18.2.0",
+    "react-test-renderer": "^18.2.0",
+    "supertest": "^6.3.3"
   }
 }

--- a/src/components/BillingCard.tsx
+++ b/src/components/BillingCard.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export interface BillingInfo {
+  plan: string;
+  amountDue: number;
+  nextBillingDate: string;
+}
+
+export function BillingCard({ plan, amountDue, nextBillingDate }: BillingInfo) {
+  return (
+    <div className="p-4 rounded-lg bg-[var(--bg-elev-1)] border border-[var(--border)] shadow-[var(--shadow-md)]">
+      <h3 className="text-lg font-semibold mb-2">Billing</h3>
+      <div className="flex justify-between"><span>Plan</span><span>{plan}</span></div>
+      <div className="flex justify-between"><span>Amount Due</span><span>${amountDue}</span></div>
+      <div className="flex justify-between"><span>Next Billing</span><span>{nextBillingDate}</span></div>
+    </div>
+  );
+}

--- a/src/components/UserDashboard.tsx
+++ b/src/components/UserDashboard.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from 'react';
+import { BillingCard, BillingInfo } from './BillingCard';
+
+interface Deployment {
+  id: string;
+  name: string;
+  date: string;
+}
+
+export function UserDashboard() {
+  const [billing, setBilling] = useState<BillingInfo | null>(null);
+  const [deployments, setDeployments] = useState<Deployment[]>([]);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch('/api/billing');
+        const data = await res.json();
+        setBilling(data.billing);
+        setDeployments(data.deployments || []);
+      } catch (err) {
+        console.error('Failed to load billing info', err);
+      }
+    }
+    load();
+  }, []);
+
+  return (
+    <div className="p-6 space-y-6">
+      {billing && <BillingCard {...billing} />}
+      <div>
+        <h3 className="text-lg font-semibold mb-2">Recent Deployments</h3>
+        <ul className="space-y-1">
+          {deployments.map((d) => (
+            <li key={d.id} className="flex justify-between border-b border-[var(--border)] py-1">
+              <span>{d.name}</span>
+              <span className="text-sm text-gray-500">{d.date}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/components/__tests__/BillingCard.test.js
+++ b/src/components/__tests__/BillingCard.test.js
@@ -1,0 +1,15 @@
+const React = require('react');
+const renderer = require('react-test-renderer');
+const { BillingCard } = require('../BillingCard');
+
+test('renders billing information', () => {
+  const component = renderer.create(
+    React.createElement(BillingCard, {
+      plan: 'Pro',
+      amountDue: 42,
+      nextBillingDate: '2025-09-01'
+    })
+  );
+  const tree = component.toJSON();
+  expect(tree).toBeDefined();
+});

--- a/var/www/blackroad/server/index.js
+++ b/var/www/blackroad/server/index.js
@@ -4,6 +4,7 @@ const ai = require('./routes/ai');
 const agent = require('./routes/agent');
 const git = require('./routes/git');
 const term = require('./routes/term');
+const billing = require('./routes/billing');
 
 const app = express();
 app.use(cors());
@@ -14,6 +15,7 @@ app.post('/api/agent/task', agent.runTask);
 app.post('/api/git/apply', git.applyPatches);
 app.post('/api/term/propose', term.propose);
 app.post('/api/term/approve', term.approve);
+app.get('/api/billing', billing.getBilling);
 
 const PORT = process.env.PORT || 9000;
 app.listen(

--- a/var/www/blackroad/server/routes/__tests__/billing.test.js
+++ b/var/www/blackroad/server/routes/__tests__/billing.test.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const request = require('supertest');
+const billing = require('../billing');
+
+test('returns billing information', async () => {
+  const app = express();
+  app.get('/api/billing', billing.getBilling);
+  const res = await request(app).get('/api/billing');
+  expect(res.status).toBe(200);
+  expect(res.body.billing).toBeDefined();
+  expect(Array.isArray(res.body.deployments)).toBe(true);
+});

--- a/var/www/blackroad/server/routes/billing.js
+++ b/var/www/blackroad/server/routes/billing.js
@@ -1,0 +1,14 @@
+async function getBilling(_req, res){
+  const billing = {
+    plan: 'Pro',
+    amountDue: 42,
+    nextBillingDate: '2025-09-01'
+  };
+  const deployments = [
+    { id: 'dep1', name: 'Initial Deploy', date: '2025-08-01' },
+    { id: 'dep2', name: 'Hotfix #1', date: '2025-08-15' }
+  ];
+  res.json({ billing, deployments });
+}
+
+module.exports = { getBilling };


### PR DESCRIPTION
## Summary
- add BillingCard and UserDashboard React components
- expose `/api/billing` Express route
- scaffold Jest tests for new UI and API

## Testing
- `npm test`
- `npx jest` *(fails: 403 Forbidden - GET http://verdaccio.internal:4873/jest)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d5a662108329b5c1df65b50f2667