### PR TITLE
chore(blackroad): list all portals

### DIFF
--- a/sites/blackroad/lighthouserc.json
+++ b/sites/blackroad/lighthouserc.json
@@ -1,7 +1,19 @@
 {
   "ci": {
     "collect": {
-      "url": ["https://blackroad.io/", "https://blackroad.io/portal", "https://blackroad.io/status"],
+      "url": [
+        "https://blackroad.io/",
+        "https://blackroad.io/portal",
+        "https://blackroad.io/status",
+        "https://blackroad.io/portal/roadbook",
+        "https://blackroad.io/portal/roadview",
+        "https://blackroad.io/portal/lucidia",
+        "https://blackroad.io/portal/roadcode",
+        "https://blackroad.io/portal/roadcoin",
+        "https://blackroad.io/portal/roadchain",
+        "https://blackroad.io/portal/radius",
+        "https://blackroad.io/portal/bot"
+      ],
       "numberOfRuns": 1
     },
     "assert": {

--- a/sites/blackroad/public/sitemap.xml
+++ b/sites/blackroad/public/sitemap.xml
@@ -12,5 +12,6 @@
   <url><loc>https://blackroad.io/portal/roadcoin</loc></url>
   <url><loc>https://blackroad.io/portal/roadchain</loc></url>
   <url><loc>https://blackroad.io/portal/radius</loc></url>
+  <url><loc>https://blackroad.io/portal/bot</loc></url>
 </urlset>
 


### PR DESCRIPTION
## Summary
- include every portal route in Lighthouse config
- expose bot portal in sitemap

## Testing
- `npm test`
- `npm run e2e` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8da61dadc83299fc9c4f4120ed7c0