### PR TITLE
feat(portals): add simple RoadView video gallery

### DIFF
--- a/apps/portals/app/roadview/page.tsx
+++ b/apps/portals/app/roadview/page.tsx
@@ -1,9 +1,42 @@
 import { Card } from "../../components/ui/card";
 
+interface Video {
+  title: string;
+  description: string;
+  url: string;
+}
+
+const videos: Video[] = [
+  {
+    title: "Welcome to RoadView",
+    description: "Introductory clip about the RoadView portal.",
+    url: "https://www.w3schools.com/html/mov_bbb.mp4",
+  },
+  {
+    title: "Road Infrastructure Update",
+    description: "A short look at the latest RoadChain upgrade.",
+    url: "https://www.w3schools.com/html/movie.mp4",
+  },
+];
+
 export default function RoadViewPage() {
   return (
-    <div className="flex min-h-screen items-center justify-center">
-      <Card className="p-8">RoadView coming soon.</Card>
-    </div>
+    <main className="mx-auto max-w-5xl space-y-4 p-4">
+      <h1 className="text-2xl font-bold">RoadView</h1>
+      <div className="grid gap-4 md:grid-cols-2">
+        {videos.map((video) => (
+          <Card key={video.title} className="p-4">
+            <div
+              className="mb-2 w-full overflow-hidden rounded bg-black"
+              style={{ aspectRatio: "16 / 9" }}
+            >
+              <video className="h-full w-full" controls src={video.url} />
+            </div>
+            <h2 className="text-lg font-semibold">{video.title}</h2>
+            <p className="text-sm text-gray-400">{video.description}</p>
+          </Card>
+        ))}
+      </div>
+    </main>
   );
 }


### PR DESCRIPTION
## Summary
- add RoadView page displaying sample video gallery

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install --no-audit --no-fund` *(fails: 403 Forbidden for @ai-sdk/openai)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8dc59788c8329a017bdf5dcc5855b