### PR TITLE
test: add About page coverage to blackroad site

### DIFF
--- a/sites/blackroad/content/blog/about-page-coverage.md
+++ b/sites/blackroad/content/blog/about-page-coverage.md
@@ -1,0 +1,8 @@
+---
+title: "About Page Coverage"
+date: "2025-08-22"
+tags: [testing, about]
+description: "Adding an end-to-end test to verify the About page renders correctly."
+---
+
+We expanded the route coverage in our Playwright suite to include the `/about` page, ensuring visitors can always learn about BlackRoad.

--- a/sites/blackroad/tests/e2e.spec.ts
+++ b/sites/blackroad/tests/e2e.spec.ts
@@ -12,6 +12,7 @@ const routes = [
   '/roadmap',
   '/changelog',
   '/blog',
+  '/about',
 ];
 
 for (const r of routes) {


### PR DESCRIPTION
## Summary
- expand Playwright route list to cover `/about`
- document the new coverage with an accompanying blog post

## Testing
- `npm --prefix sites/blackroad test`
- `npm --prefix sites/blackroad run e2e` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8dce98f8c8329b95ce9dc6565a772