### PR TITLE
feat: add roadview portal

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -103,6 +103,14 @@ app.post('/api/notes', authMiddleware(JWT_SECRET), (req, res)=>{
   res.json({ ok: true });
 });
 
+// RoadView sample streams
+app.get('/api/roadview/list', authMiddleware(JWT_SECRET), (req, res)=>{
+  res.json({ streams: [
+    { id: 'cam-1', name: 'Main Street', status: 'offline' },
+    { id: 'cam-2', name: 'Downtown', status: 'offline' }
+  ]});
+});
+
 // Actions
 app.post('/api/actions/run', authMiddleware(JWT_SECRET), (req,res)=>{
   const item = addTimeline({ type: 'action', text: 'Run triggered', by: req.user.username });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "axios": "^1.7.2",
+    "react-router-dom": "^6.23.0",
     "lucide-react": "^0.460.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,12 +1,11 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import io from 'socket.io-client'
+import { Routes, Route, NavLink } from 'react-router-dom'
 import { API_BASE, setToken, login, me, fetchTimeline, fetchTasks, fetchCommits, fetchAgents, fetchWallet, fetchContradictions, getNotes, setNotes, action } from './api'
-import { Activity, Brain, Cpu, Database, GitCommit, LayoutGrid, Rocket, Settings, ShieldCheck, SquareDashedMousePointer, Wallet } from 'lucide-react'
-import Timeline from './components/Timeline.jsx'
-import Tasks from './components/Tasks.jsx'
-import Commits from './components/Commits.jsx'
-import AgentStack from './components/AgentStack.jsx'
+import { Activity, Brain, Database, LayoutGrid, Settings, ShieldCheck, SquareDashedMousePointer } from 'lucide-react'
 import Login from './components/Login.jsx'
+import Dashboard from './pages/Dashboard.jsx'
+import RoadView from './pages/RoadView.jsx'
 
 export default function App(){
   const [user, setUser] = useState(null)
@@ -19,7 +18,6 @@ export default function App(){
   const [contradictions, setContradictions] = useState({ issues: 0 })
   const [system, setSystem] = useState({ cpu: 0, mem: 0, gpu: 0 })
   const [notes, setNotesState] = useState('')
-  const [socket, setSocket] = useState(null)
   const [stream, setStream] = useState(true)
 
   // bootstrap auth from localstorage
@@ -51,7 +49,6 @@ export default function App(){
     s.on('timeline:new', d => setTimeline(prev => [d.item, ...prev]))
     s.on('wallet:update', w => setWallet(w))
     s.on('notes:update', n => setNotesState(n || ''))
-    setSocket(s)
   }
 
   async function handleLogin(usr, pass){
@@ -80,50 +77,22 @@ export default function App(){
             </div>
 
             <nav className="space-y-1">
-              <NavItem icon={<LayoutGrid size={18} />} text="Workspace" />
-              <NavItem icon={<SquareDashedMousePointer size={18} />} text="Projects" />
-              <NavItem icon={<Brain size={18} />} text="Agents" />
-              <NavItem icon={<Database size={18} />} text="Datasets" />
-              <NavItem icon={<ShieldCheck size={18} />} text="Models" />
-              <NavItem icon={<Settings size={18} />} text="Integrations" />
+              <NavItem to="/" icon={<Activity size={18} />} text="Chat" />
+              <NavItem to="/projects" icon={<SquareDashedMousePointer size={18} />} text="Projects" />
+              <NavItem to="/agents" icon={<Brain size={18} />} text="Agents" />
+              <NavItem to="/datasets" icon={<Database size={18} />} text="Datasets" />
+              <NavItem to="/models" icon={<ShieldCheck size={18} />} text="Models" />
+              <NavItem to="/integrations" icon={<Settings size={18} />} text="Integrations" />
+              <NavItem to="/roadview" icon={<LayoutGrid size={18} />} text="RoadView" />
             </nav>
-
-            <button className="btn w-full text-white font-semibold">Start Co‑Coding</button>
-
-            <div className="pt-8">
-              <div className="uppercase text-[11px] text-slate-400 tracking-widest mb-2">Workspace</div>
-              <div className="space-y-2">
-                <div className="flex items-center justify-between"><span>Projects</span><span className="badge">12</span></div>
-                <div>Agents</div>
-                <div>Sessions</div>
-                <div>Datasets</div>
-              </div>
-            </div>
           </aside>
 
           {/* Main */}
           <main className="flex-1 px-6 py-4 grid grid-cols-12 gap-6">
-            <section className="col-span-8">
-              <header className="flex items-center gap-8 border-b border-slate-800 mb-4">
-                <Tab onClick={()=>setTab('timeline')} active={tab==='timeline'}>Timeline</Tab>
-                <Tab onClick={()=>setTab('tasks')} active={tab==='tasks'}>Tasks</Tab>
-                <Tab onClick={()=>setTab('commits')} active={tab==='commits'}>Commits</Tab>
-                <div className="ml-auto flex items-center gap-2 py-3">
-                  <button className="badge" onClick={()=>onAction('run')}>Run</button>
-                  <button className="badge" onClick={()=>onAction('revert')}>Revert</button>
-                  <button className="badge" onClick={()=>onAction('mint')}><Wallet size={14}/> Mint</button>
-                </div>
-              </header>
-
-              {tab==='timeline' && <Timeline items={timeline} />}
-              {tab==='tasks' && <Tasks items={tasks} />}
-              {tab==='commits' && <Commits items={commits} />}
-            </section>
-
-            {/* Right bar */}
-            <section className="col-span-4 flex flex-col gap-4">
-              <AgentStack stream={stream} setStream={setStream} system={system} wallet={wallet} contradictions={contradictions} notes={notes} setNotes={async (v)=>{ setNotesState(v); await setNotes(v); }} />
-            </section>
+            <Routes>
+              <Route path="/" element={<Dashboard tab={tab} setTab={setTab} timeline={timeline} tasks={tasks} commits={commits} onAction={onAction} stream={stream} setStream={setStream} system={system} wallet={wallet} contradictions={contradictions} notes={notes} setNotes={async (v)=>{ setNotesState(v); await setNotes(v); }} />} />
+              <Route path="/roadview" element={<RoadView agents={agents} stream={stream} setStream={setStream} system={system} wallet={wallet} contradictions={contradictions} notes={notes} setNotes={async (v)=>{ setNotesState(v); await setNotes(v); }} />} />
+            </Routes>
           </main>
         </>
       )}
@@ -131,18 +100,10 @@ export default function App(){
   )
 }
 
-function NavItem({ icon, text }){
+function NavItem({ icon, text, to }){
   return (
-    <div className="flex items-center gap-3 px-2 py-2 rounded-xl hover:bg-slate-900 cursor-pointer">
+    <NavLink to={to} className={({isActive})=>`flex items-center gap-3 px-2 py-2 rounded-xl hover:bg-slate-900 ${isActive?'text-white':'text-slate-300'}`}>
       {icon}<span>{text}</span>
-    </div>
-  )
-}
-
-function Tab({ children, active, onClick }){
-  return (
-    <button onClick={onClick} className={`py-3 border-b-2 ${active?'border-indigo-500 text-white':'border-transparent text-slate-400 hover:text-slate-200'}`}>
-      {children}
-    </button>
+    </NavLink>
   )
 }

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,6 +1,6 @@
 import axios from 'axios'
 
-const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:4000'
+const API_BASE = import.meta.env.VITE_API_BASE || ''
 
 export function setToken(token){
   axios.defaults.headers.common['Authorization'] = token ? `Bearer ${token}` : ''
@@ -51,6 +51,11 @@ export async function setNotes(notes){
 export async function action(name){
   const { data } = await axios.post(`${API_BASE}/api/actions/${name}`)
   return data
+}
+
+export async function fetchRoadviewStreams(){
+  const { data } = await axios.get(`${API_BASE}/api/roadview/list`)
+  return data.streams
 }
 
 export { API_BASE }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,6 +4,9 @@
 
 :root {
   --panel: 15 15 30;
+  --accent: #FF4FD8;
+  --accent-2: #0096FF;
+  --accent-3: #FDBA2D;
 }
 
 .card {

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,10 +1,13 @@
 import React from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import App from './App.jsx'
 import './index.css'
 
 createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>
 )

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { Wallet } from 'lucide-react'
+import Timeline from '../components/Timeline.jsx'
+import Tasks from '../components/Tasks.jsx'
+import Commits from '../components/Commits.jsx'
+import AgentStack from '../components/AgentStack.jsx'
+
+export default function Dashboard({ tab, setTab, timeline, tasks, commits, onAction, stream, setStream, system, wallet, contradictions, notes, setNotes }){
+  return (
+    <>
+      <section className="col-span-8">
+        <header className="flex items-center gap-8 border-b border-slate-800 mb-4">
+          <Tab onClick={()=>setTab('timeline')} active={tab==='timeline'}>Timeline</Tab>
+          <Tab onClick={()=>setTab('tasks')} active={tab==='tasks'}>Tasks</Tab>
+          <Tab onClick={()=>setTab('commits')} active={tab==='commits'}>Commits</Tab>
+          <div className="ml-auto flex items-center gap-2 py-3">
+            <button className="badge" onClick={()=>onAction('run')}>Run</button>
+            <button className="badge" onClick={()=>onAction('revert')}>Revert</button>
+            <button className="badge" onClick={()=>onAction('mint')}><Wallet size={14}/> Mint</button>
+          </div>
+        </header>
+        {tab==='timeline' && <Timeline items={timeline} />}
+        {tab==='tasks' && <Tasks items={tasks} />}
+        {tab==='commits' && <Commits items={commits} />}
+      </section>
+      <section className="col-span-4 flex flex-col gap-4">
+        <AgentStack stream={stream} setStream={setStream} system={system} wallet={wallet} contradictions={contradictions} notes={notes} setNotes={setNotes} />
+      </section>
+    </>
+  )
+}
+
+function Tab({ children, active, onClick }){
+  return (
+    <button onClick={onClick} className={`py-3 border-b-2 ${active?'border-indigo-500 text-white':'border-transparent text-slate-400 hover:text-slate-200'}`}>{children}</button>
+  )
+}

--- a/frontend/src/pages/RoadView.jsx
+++ b/frontend/src/pages/RoadView.jsx
@@ -1,0 +1,30 @@
+import React, { useEffect, useState } from 'react'
+import AgentStack from '../components/AgentStack.jsx'
+import { fetchRoadviewStreams } from '../api'
+
+const colors = ['var(--accent)', 'var(--accent-2)', 'var(--accent-3)']
+
+export default function RoadView({ agents, stream, setStream, system, wallet, contradictions, notes, setNotes }){
+  const [streams, setStreams] = useState([])
+  useEffect(()=>{ (async()=>{ try{ const s = await fetchRoadviewStreams(); setStreams(s) } catch{} })() }, [])
+  return (
+    <>
+      <section className="col-span-8">
+        <h1 className="text-xl font-semibold mb-4">RoadView</h1>
+        <div className="grid grid-cols-2 gap-4">
+          {streams.map(s => (
+            <div key={s.id} className="card flex items-center justify-center h-40 text-slate-400">Coming Soon</div>
+          ))}
+        </div>
+        <div className="flex items-center gap-2 mt-4">
+          {agents.map((a,i)=>(
+            <div key={a.id||i} title={a.name||a.username} className="w-3 h-3 rounded-full" style={{ backgroundColor: colors[i%colors.length] }}></div>
+          ))}
+        </div>
+      </section>
+      <section className="col-span-4 flex flex-col gap-4">
+        <AgentStack stream={stream} setStream={setStream} system={system} wallet={wallet} contradictions={contradictions} notes={notes} setNotes={setNotes} />
+      </section>
+    </>
+  )
+}

--- a/nginx/conf.d/lucidia-sites.conf
+++ b/nginx/conf.d/lucidia-sites.conf
@@ -68,6 +68,19 @@ server {
     proxy_read_timeout 60s;
   }
 
+  location /roadview {
+    limit_req zone=general burst=10 nodelay;
+    proxy_pass http://blackroad_app;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    proxy_read_timeout 60s;
+  }
+
   location / {
     limit_req zone=general burst=10 nodelay;
     proxy_pass http://blackroad_app;
@@ -116,6 +129,19 @@ server {
 
   location /api/ {
     limit_req zone=api burst=20 nodelay;
+    proxy_pass http://blackroadinc_app;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    proxy_read_timeout 60s;
+  }
+
+  location /roadview {
+    limit_req zone=general burst=10 nodelay;
     proxy_pass http://blackroadinc_app;
     proxy_http_version 1.1;
     proxy_set_header Host $host;


### PR DESCRIPTION
## Summary
- add `/api/roadview/list` endpoint returning sample streams
- integrate React Router and new RoadView page with placeholder tiles and agent presence
- proxy `/roadview` paths through nginx

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8dd7dc50c83298defee0669c1b101