### PR TITLE
Add Manifesto portal and backend routes

### DIFF
--- a/backend/manifesto.pdf
+++ b/backend/manifesto.pdf
@@ -1,0 +1,32 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 44 >>
+stream
+BT /F1 24 Tf 100 100 Td (Manifesto) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /Name /F1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000061 00000 n 
+0000000112 00000 n 
+0000000245 00000 n 
+0000000328 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+399
+%%EOF

--- a/backend/server.js
+++ b/backend/server.js
@@ -103,6 +103,16 @@ app.post('/api/notes', authMiddleware(JWT_SECRET), (req, res)=>{
   res.json({ ok: true });
 });
 
+app.get('/api/manifesto', (req, res)=>{
+  const content = `<h1>Manifesto</h1><p>The BlackRoad manifesto outlines our vision.</p><h2>Principles</h2><ul><li>Openness</li><li>Autonomy</li><li>Resilience</li></ul><blockquote>Stay curious.</blockquote><p>Use <code>npm run build</code> to compile.</p>`;
+  res.json({ content });
+});
+
+app.get('/api/manifesto/download', (req, res)=>{
+  const file = path.join(__dirname, 'manifesto.pdf');
+  res.sendFile(file);
+});
+
 // Actions
 app.post('/api/actions/run', authMiddleware(JWT_SECRET), (req,res)=>{
   const item = addTimeline({ type: 'action', text: 'Run triggered', by: req.user.username });

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import Tasks from './components/Tasks.jsx'
 import Commits from './components/Commits.jsx'
 import AgentStack from './components/AgentStack.jsx'
 import Login from './components/Login.jsx'
+import Manifesto from './components/Manifesto.jsx'
 
 export default function App(){
   const [user, setUser] = useState(null)
@@ -21,6 +22,7 @@ export default function App(){
   const [notes, setNotesState] = useState('')
   const [socket, setSocket] = useState(null)
   const [stream, setStream] = useState(true)
+  const path = window.location.pathname
 
   // bootstrap auth from localstorage
   useEffect(()=>{
@@ -80,12 +82,13 @@ export default function App(){
             </div>
 
             <nav className="space-y-1">
-              <NavItem icon={<LayoutGrid size={18} />} text="Workspace" />
+              <NavItem icon={<LayoutGrid size={18} />} text="Workspace" href="/" />
               <NavItem icon={<SquareDashedMousePointer size={18} />} text="Projects" />
               <NavItem icon={<Brain size={18} />} text="Agents" />
               <NavItem icon={<Database size={18} />} text="Datasets" />
               <NavItem icon={<ShieldCheck size={18} />} text="Models" />
               <NavItem icon={<Settings size={18} />} text="Integrations" />
+              <NavItem icon={<Rocket size={18} />} text="Manifesto" href="/manifesto" />
             </nav>
 
             <button className="btn w-full text-white font-semibold">Start Co‑Coding</button>
@@ -104,20 +107,26 @@ export default function App(){
           {/* Main */}
           <main className="flex-1 px-6 py-4 grid grid-cols-12 gap-6">
             <section className="col-span-8">
-              <header className="flex items-center gap-8 border-b border-slate-800 mb-4">
-                <Tab onClick={()=>setTab('timeline')} active={tab==='timeline'}>Timeline</Tab>
-                <Tab onClick={()=>setTab('tasks')} active={tab==='tasks'}>Tasks</Tab>
-                <Tab onClick={()=>setTab('commits')} active={tab==='commits'}>Commits</Tab>
-                <div className="ml-auto flex items-center gap-2 py-3">
-                  <button className="badge" onClick={()=>onAction('run')}>Run</button>
-                  <button className="badge" onClick={()=>onAction('revert')}>Revert</button>
-                  <button className="badge" onClick={()=>onAction('mint')}><Wallet size={14}/> Mint</button>
-                </div>
-              </header>
+              {path === '/manifesto' ? (
+                <Manifesto />
+              ) : (
+                <>
+                  <header className="flex items-center gap-8 border-b border-slate-800 mb-4">
+                    <Tab onClick={()=>setTab('timeline')} active={tab==='timeline'}>Timeline</Tab>
+                    <Tab onClick={()=>setTab('tasks')} active={tab==='tasks'}>Tasks</Tab>
+                    <Tab onClick={()=>setTab('commits')} active={tab==='commits'}>Commits</Tab>
+                    <div className="ml-auto flex items-center gap-2 py-3">
+                      <button className="badge" onClick={()=>onAction('run')}>Run</button>
+                      <button className="badge" onClick={()=>onAction('revert')}>Revert</button>
+                      <button className="badge" onClick={()=>onAction('mint')}><Wallet size={14}/> Mint</button>
+                    </div>
+                  </header>
 
-              {tab==='timeline' && <Timeline items={timeline} />}
-              {tab==='tasks' && <Tasks items={tasks} />}
-              {tab==='commits' && <Commits items={commits} />}
+                  {tab==='timeline' && <Timeline items={timeline} />}
+                  {tab==='tasks' && <Tasks items={tasks} />}
+                  {tab==='commits' && <Commits items={commits} />}
+                </>
+              )}
             </section>
 
             {/* Right bar */}
@@ -131,11 +140,12 @@ export default function App(){
   )
 }
 
-function NavItem({ icon, text }){
+function NavItem({ icon, text, href }){
+  const Comp = href ? 'a' : 'div'
   return (
-    <div className="flex items-center gap-3 px-2 py-2 rounded-xl hover:bg-slate-900 cursor-pointer">
+    <Comp href={href} className="flex items-center gap-3 px-2 py-2 rounded-xl hover:bg-slate-900 cursor-pointer">
       {icon}<span>{text}</span>
-    </div>
+    </Comp>
   )
 }
 

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -53,4 +53,9 @@ export async function action(name){
   return data
 }
 
+export async function fetchManifesto(){
+  const { data } = await axios.get(`${API_BASE}/api/manifesto`)
+  return data.content
+}
+
 export { API_BASE }

--- a/frontend/src/components/Manifesto.jsx
+++ b/frontend/src/components/Manifesto.jsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useRef, useState } from 'react'
+import { fetchManifesto } from '../api'
+
+export default function Manifesto(){
+  const [content, setContent] = useState('')
+  const [toc, setToc] = useState([])
+  const contentRef = useRef(null)
+
+  useEffect(()=>{
+    (async()=>{
+      const html = await fetchManifesto()
+      setContent(html)
+    })()
+  }, [])
+
+  useEffect(()=>{
+    if(!contentRef.current) return
+    const headers = contentRef.current.querySelectorAll('h1, h2, h3')
+    const items = []
+    headers.forEach(h=>{
+      const id = h.id || h.textContent.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$|/g, '')
+      h.id = id
+      items.push({ id, text: h.textContent, level: Number(h.tagName[1]) })
+    })
+    setToc(items)
+  }, [content])
+
+  return (
+    <div className="relative">
+      <button
+        className="px-3 py-1.5 rounded-xl text-white"
+        style={{ backgroundColor: 'var(--accent)' }}
+        onClick={()=>{ window.open('/api/manifesto/download', '_blank') }}
+      >
+        Download PDF
+      </button>
+      <div className="flex mt-10">
+        <nav className="w-48 mr-6 sticky top-4 self-start">
+          <ul className="space-y-1 text-sm">
+            {toc.map(item => (
+              <li key={item.id} style={{ marginLeft: (item.level-1)*8 }}>
+                <a href={`#${item.id}`} className="link">
+                  {item.text}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </nav>
+        <article ref={contentRef} className="manifesto flex-1">
+          <div dangerouslySetInnerHTML={{ __html: content }} />
+        </article>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,6 +4,9 @@
 
 :root {
   --panel: 15 15 30;
+  --accent: #FF4FD8;
+  --accent-2: #0096FF;
+  --accent-3: #FDBA2D;
 }
 
 .card {
@@ -20,4 +23,28 @@
 }
 .link {
   @apply text-slate-300 hover:text-white underline underline-offset-4;
+}
+
+.manifesto h1 {
+  @apply text-4xl font-bold mb-6;
+}
+.manifesto h2 {
+  @apply text-2xl font-semibold mt-8 mb-4;
+}
+.manifesto p {
+  @apply mb-4 leading-relaxed;
+}
+.manifesto ul {
+  @apply list-disc pl-6 mb-4;
+}
+.manifesto blockquote {
+  @apply mb-4 italic text-slate-300;
+  border-left: 4px solid var(--accent);
+  padding-left: 1rem;
+}
+.manifesto code {
+  background-color: #1e293b;
+  border-radius: 4px;
+  padding: 0 4px;
+  color: var(--accent-2);
 }


### PR DESCRIPTION
## Summary
- Add Manifesto page with table of contents, PDF download, and brand palette styling
- Introduce backend endpoints to serve manifesto HTML and downloadable PDF
- Wire up frontend to fetch and display manifesto content

## Testing
- `npm test` (backend)
- `npm test` (frontend, fails: Missing script "test")
- `curl -s http://localhost:4000/api/manifesto`
- `curl -s -I http://localhost:4000/api/manifesto/download`


------
https://chatgpt.com/codex/tasks/task_e_68a8deb146b88329b9acd502785857e7