### PR TITLE
feat: add guardian security portal

### DIFF
--- a/backend/data.js
+++ b/backend/data.js
@@ -13,6 +13,12 @@ const store = {
   ],
   contradictions: { issues: 2 },
   sessionNotes: "",
+  guardian: {
+    status: { secure: true, mfa: true, encryption: true, lastScan: '2025-08-20' },
+    alerts: [
+      { id: uuidv4(), type: 'Unauthorized login', severity: 'high', time: new Date().toISOString(), status: 'active' }
+    ]
+  },
   tasks: [
     { id: uuidv4(), title: "Calculus HW 3", course: "Math 201", status: "todo", due: "2025-08-25", reward: 12, progress: 0.2 },
     { id: uuidv4(), title: "Lab: Sorting", course: "CS 101", status: "inprogress", due: "2025-08-23", reward: 20, progress: 0.55 },

--- a/backend/server.js
+++ b/backend/server.js
@@ -103,6 +103,22 @@ app.post('/api/notes', authMiddleware(JWT_SECRET), (req, res)=>{
   res.json({ ok: true });
 });
 
+// Guardian endpoints
+app.get('/api/guardian/status', authMiddleware(JWT_SECRET), (req, res)=>{
+  res.json(store.guardian.status);
+});
+
+app.get('/api/guardian/alerts', authMiddleware(JWT_SECRET), (req, res)=>{
+  res.json({ alerts: store.guardian.alerts });
+});
+
+app.post('/api/guardian/alerts/:id/resolve', authMiddleware(JWT_SECRET), (req, res)=>{
+  const alert = store.guardian.alerts.find(a=>a.id === req.params.id);
+  if (!alert) return res.status(404).json({ error: 'not found' });
+  alert.status = req.body?.status || 'resolved';
+  res.json({ ok: true, alert });
+});
+
 // Actions
 app.post('/api/actions/run', authMiddleware(JWT_SECRET), (req,res)=>{
   const item = addTimeline({ type: 'action', text: 'Run triggered', by: req.user.username });

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import io from 'socket.io-client'
 import { API_BASE, setToken, login, me, fetchTimeline, fetchTasks, fetchCommits, fetchAgents, fetchWallet, fetchContradictions, getNotes, setNotes, action } from './api'
+import Guardian from './Guardian.jsx'
 import { Activity, Brain, Cpu, Database, GitCommit, LayoutGrid, Rocket, Settings, ShieldCheck, SquareDashedMousePointer, Wallet } from 'lucide-react'
 import Timeline from './components/Timeline.jsx'
 import Tasks from './components/Tasks.jsx'
@@ -21,6 +22,7 @@ export default function App(){
   const [notes, setNotesState] = useState('')
   const [socket, setSocket] = useState(null)
   const [stream, setStream] = useState(true)
+  const route = window.location.pathname
 
   // bootstrap auth from localstorage
   useEffect(()=>{
@@ -103,22 +105,26 @@ export default function App(){
 
           {/* Main */}
           <main className="flex-1 px-6 py-4 grid grid-cols-12 gap-6">
-            <section className="col-span-8">
-              <header className="flex items-center gap-8 border-b border-slate-800 mb-4">
-                <Tab onClick={()=>setTab('timeline')} active={tab==='timeline'}>Timeline</Tab>
-                <Tab onClick={()=>setTab('tasks')} active={tab==='tasks'}>Tasks</Tab>
-                <Tab onClick={()=>setTab('commits')} active={tab==='commits'}>Commits</Tab>
-                <div className="ml-auto flex items-center gap-2 py-3">
-                  <button className="badge" onClick={()=>onAction('run')}>Run</button>
-                  <button className="badge" onClick={()=>onAction('revert')}>Revert</button>
-                  <button className="badge" onClick={()=>onAction('mint')}><Wallet size={14}/> Mint</button>
-                </div>
-              </header>
+            {route === '/guardian' ? (
+              <Guardian />
+            ) : (
+              <section className="col-span-8">
+                <header className="flex items-center gap-8 border-b border-slate-800 mb-4">
+                  <Tab onClick={()=>setTab('timeline')} active={tab==='timeline'}>Timeline</Tab>
+                  <Tab onClick={()=>setTab('tasks')} active={tab==='tasks'}>Tasks</Tab>
+                  <Tab onClick={()=>setTab('commits')} active={tab==='commits'}>Commits</Tab>
+                  <div className="ml-auto flex items-center gap-2 py-3">
+                    <button className="badge" onClick={()=>onAction('run')}>Run</button>
+                    <button className="badge" onClick={()=>onAction('revert')}>Revert</button>
+                    <button className="badge" onClick={()=>onAction('mint')}><Wallet size={14}/> Mint</button>
+                  </div>
+                </header>
 
-              {tab==='timeline' && <Timeline items={timeline} />}
-              {tab==='tasks' && <Tasks items={tasks} />}
-              {tab==='commits' && <Commits items={commits} />}
-            </section>
+                {tab==='timeline' && <Timeline items={timeline} />}
+                {tab==='tasks' && <Tasks items={tasks} />}
+                {tab==='commits' && <Commits items={commits} />}
+              </section>
+            )}
 
             {/* Right bar */}
             <section className="col-span-4 flex flex-col gap-4">

--- a/frontend/src/Guardian.jsx
+++ b/frontend/src/Guardian.jsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useState } from 'react'
+import { fetchGuardianStatus, fetchGuardianAlerts, resolveGuardianAlert } from './api'
+
+export default function Guardian(){
+  const [status, setStatus] = useState({ secure: true, mfa: true, encryption: true, lastScan: '' })
+  const [alerts, setAlerts] = useState([])
+
+  useEffect(()=>{ (async ()=>{
+    const s = await fetchGuardianStatus()
+    setStatus(s)
+    const a = await fetchGuardianAlerts()
+    setAlerts(a)
+  })() }, [])
+
+  async function updateAlert(id, newStatus){
+    const alert = await resolveGuardianAlert(id, newStatus)
+    setAlerts(prev=>prev.map(a=>a.id===id? alert : a))
+  }
+
+  return (
+    <section className="col-span-8 space-y-6">
+      <header className="text-2xl font-semibold">Guardian</header>
+      <div className="flex items-center gap-3">
+        <span>System Status:</span>
+        <span className={status.secure? 'text-green-400':'text-red-500'}>
+          {status.secure? 'Secure':'Alert'}
+        </span>
+      </div>
+
+      <div className="grid grid-cols-3 gap-4">
+        <div className="card p-4">
+          <div className="text-slate-400 text-sm">MFA Status</div>
+          <div className="text-xl font-semibold" style={{color:'var(--accent-2)'}}>{status.mfa? 'Enabled':'Disabled'}</div>
+        </div>
+        <div className="card p-4">
+          <div className="text-slate-400 text-sm">Encryption</div>
+          <div className="text-xl font-semibold" style={{color:'var(--accent-3)'}}>{status.encryption? 'Enabled':'Disabled'}</div>
+        </div>
+        <div className="card p-4">
+          <div className="text-slate-400 text-sm">Last Scan</div>
+          <div className="text-xl font-semibold" style={{color:'var(--accent)'}}>{status.lastScan}</div>
+        </div>
+      </div>
+
+      <div>
+        <h2 className="text-xl mb-2">Active Alerts</h2>
+        <div className="space-y-2">
+          {alerts.map(a=>(
+            <div key={a.id} className="card p-3 flex items-center justify-between">
+              <div>
+                <div className="font-semibold">{a.type}</div>
+                <div className="text-xs text-slate-400">{a.severity} · {a.time}</div>
+              </div>
+              <div className="space-x-2">
+                {a.status !== 'acknowledged' && (
+                  <button className="badge" style={{backgroundColor:'var(--accent-3)'}} onClick={()=>updateAlert(a.id, 'acknowledged')}>Acknowledge</button>
+                )}
+                {a.status !== 'resolved' && (
+                  <button className="badge" style={{backgroundColor:'var(--accent-2)'}} onClick={()=>updateAlert(a.id, 'resolved')}>Resolve</button>
+                )}
+              </div>
+            </div>
+          ))}
+          {!alerts.length && <div className="text-slate-400">No active alerts</div>}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -53,4 +53,19 @@ export async function action(name){
   return data
 }
 
+export async function fetchGuardianStatus(){
+  const { data } = await axios.get(`${API_BASE}/api/guardian/status`)
+  return data
+}
+
+export async function fetchGuardianAlerts(){
+  const { data } = await axios.get(`${API_BASE}/api/guardian/alerts`)
+  return data.alerts
+}
+
+export async function resolveGuardianAlert(id, status='resolved'){
+  const { data } = await axios.post(`${API_BASE}/api/guardian/alerts/${id}/resolve`, { status })
+  return data.alert
+}
+
 export { API_BASE }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,6 +4,9 @@
 
 :root {
   --panel: 15 15 30;
+  --accent: #FF4FD8;
+  --accent-2: #0096FF;
+  --accent-3: #FDBA2D;
 }
 
 .card {


### PR DESCRIPTION
## Summary
- add Guardian security dashboard and API endpoints
- wire frontend route `/guardian` with status cards and alert actions
- expose backend guardian status and alert update routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8dee450f883298880a2ad5815659a