### PR TITLE
feat: add dashboard and personal portals

### DIFF
--- a/backend/data.js
+++ b/backend/data.js
@@ -3,7 +3,7 @@ const { v4: uuidv4 } = require('uuid');
 
 const store = {
   users: [
-    { id: 'u-root', username: 'root', displayName: 'Root', role: 'owner' }
+    { id: 'u-root', username: 'root', displayName: 'Root', role: 'owner', plan: 'free', lastLogin: new Date().toISOString() }
   ],
   wallet: { rc: 1.2 },
   agents: [
@@ -22,6 +22,9 @@ const store = {
   commits: [
     { id: 'c1', hash: 'd1f6e52', author: 'Mistral agent', message: 'Revert last commit', time: new Date(Date.now()-3600e3).toISOString() },
     { id: 'c2', hash: 'a9c1b02', author: 'User', message: 'Add print("Hello, world!")', time: new Date(Date.now()-1800e3).toISOString() }
+  ],
+  projects: [
+    { id: uuidv4(), name: 'Demo Project', status: 'active' }
   ],
   timeline: [
     { id: uuidv4(), type: 'agent', agent: 'Phi', text: "created a branch `main`", time: new Date().toISOString() },

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,13 +1,15 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import io from 'socket.io-client'
 import { API_BASE, setToken, login, me, fetchTimeline, fetchTasks, fetchCommits, fetchAgents, fetchRoadcoinWallet, fetchContradictions, getNotes, setNotes, action } from './api'
-import { Activity, Brain, Cpu, Database, GitCommit, LayoutGrid, Rocket, Settings, ShieldCheck, SquareDashedMousePointer, Wallet } from 'lucide-react'
+import { Activity, Brain, Cpu, Database, GitCommit, LayoutGrid, Rocket, Settings, ShieldCheck, SquareDashedMousePointer, Wallet, User } from 'lucide-react'
 import Timeline from './components/Timeline.jsx'
 import Tasks from './components/Tasks.jsx'
 import Commits from './components/Commits.jsx'
 import AgentStack from './components/AgentStack.jsx'
 import Login from './components/Login.jsx'
 import RoadCoin from './components/RoadCoin.jsx'
+import Dashboard from './components/Dashboard.jsx'
+import You from './components/You.jsx'
 
 export default function App(){
   const [user, setUser] = useState(null)
@@ -18,12 +20,14 @@ export default function App(){
   const [agents, setAgents] = useState([])
   const [wallet, setWallet] = useState({ rc: 0 })
   const [contradictions, setContradictions] = useState({ issues: 0 })
-  const [system, setSystem] = useState({ cpu: 0, mem: 0, gpu: 0 })
+  const [system, setSystem] = useState({ cpu: 0, mem: 0, gpu: 0, net: 0 })
   const [notes, setNotesState] = useState('')
   const [socket, setSocket] = useState(null)
   const [stream, setStream] = useState(true)
   const path = window.location.pathname
   const isRoadcoin = path === '/roadcoin'
+  const isDashboard = path === '/dashboard'
+  const isYou = path === '/you'
 
   // bootstrap auth from localstorage
   useEffect(()=>{
@@ -83,7 +87,9 @@ export default function App(){
             </div>
 
             <nav className="space-y-1">
-              <NavItem icon={<LayoutGrid size={18} />} text="Workspace" />
+              <NavItem icon={<Activity size={18} />} text="Dashboard" href="/dashboard" />
+              <NavItem icon={<User size={18} />} text="You" href="/you" />
+              <NavItem icon={<LayoutGrid size={18} />} text="Workspace" href="/" />
               <NavItem icon={<SquareDashedMousePointer size={18} />} text="Projects" />
               <NavItem icon={<Brain size={18} />} text="Agents" />
               <NavItem icon={<Database size={18} />} text="Datasets" />
@@ -108,7 +114,9 @@ export default function App(){
           {/* Main */}
           <main className="flex-1 px-6 py-4 grid grid-cols-12 gap-6">
             <section className="col-span-8">
-              {!isRoadcoin && (
+              {isDashboard && <Dashboard />}
+              {isYou && <You />}
+              {!isDashboard && !isYou && !isRoadcoin && (
                 <>
                   <header className="flex items-center gap-8 border-b border-slate-800 mb-4">
                     <Tab onClick={()=>setTab('timeline')} active={tab==='timeline'}>Timeline</Tab>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -63,4 +63,19 @@ export async function action(name){
   return data
 }
 
+export async function fetchDashboardSystem(){
+  const { data } = await axios.get(`${API_BASE}/api/dashboard/system`)
+  return data
+}
+
+export async function fetchDashboardFeed(){
+  const { data } = await axios.get(`${API_BASE}/api/dashboard/feed`)
+  return data.events
+}
+
+export async function fetchProfile(){
+  const { data } = await axios.get(`${API_BASE}/api/you/profile`)
+  return data
+}
+
 export { API_BASE }

--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -1,0 +1,60 @@
+import React, { useEffect, useState } from 'react'
+import { fetchDashboardSystem, fetchDashboardFeed, fetchAgents } from '../api'
+
+function MetricCard({ label, value }){
+  return (
+    <div className="card p-4 text-center" style={{ borderColor: 'var(--accent)' }}>
+      <div className="text-sm text-slate-400">{label}</div>
+      <div className="text-2xl font-bold">{value}%</div>
+    </div>
+  )
+}
+
+export default function Dashboard(){
+  const [metrics, setMetrics] = useState({ cpu:0, gpu:0, memory:0, network:0 })
+  const [feed, setFeed] = useState([])
+  const [agents, setAgents] = useState([])
+
+  useEffect(()=>{
+    (async ()=>{
+      const m = await fetchDashboardSystem()
+      setMetrics(m)
+      const f = await fetchDashboardFeed()
+      setFeed(f)
+      const ag = await fetchAgents()
+      setAgents(ag)
+    })()
+  }, [])
+
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-4 gap-4">
+        <MetricCard label="CPU" value={metrics.cpu} />
+        <MetricCard label="GPU" value={metrics.gpu} />
+        <MetricCard label="Memory" value={metrics.memory} />
+        <MetricCard label="Network" value={metrics.network} />
+      </div>
+
+      <section>
+        <h2 className="font-semibold mb-2">Activity Feed</h2>
+        <ul className="space-y-2 max-h-64 overflow-auto">
+          {feed.map(e => (
+            <li key={e.id} className="card p-2 text-sm">{e.text || e.type}</li>
+          ))}
+        </ul>
+      </section>
+
+      <section>
+        <h2 className="font-semibold mb-2">Agents</h2>
+        <div className="grid grid-cols-3 gap-4">
+          {agents.map(a => (
+            <div key={a.id} className="card p-4">
+              <div className="font-medium">{a.name}</div>
+              <div className="text-xs text-slate-400">{a.status}</div>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/frontend/src/components/You.jsx
+++ b/frontend/src/components/You.jsx
@@ -1,0 +1,56 @@
+import React, { useEffect, useState } from 'react'
+import { fetchProfile, getNotes, setNotes } from '../api'
+
+export default function You(){
+  const [profile, setProfile] = useState(null)
+  const [notes, setNotesState] = useState('')
+
+  useEffect(()=>{
+    (async ()=>{
+      const p = await fetchProfile()
+      setProfile(p)
+      const n = await getNotes()
+      setNotesState(n || '')
+    })()
+  }, [])
+
+  if(!profile) return null
+
+  return (
+    <div className="space-y-6">
+      <section className="card p-4">
+        <div className="font-semibold text-lg">{profile.username}</div>
+        <div className="text-sm text-slate-400">Plan: {profile.plan}</div>
+        <div className="text-sm text-slate-400">Last login: {new Date(profile.lastLogin).toLocaleString()}</div>
+        {profile.plan === 'free' && (
+          <button className="mt-4 px-3 py-1.5 rounded-xl text-white" style={{ backgroundColor: 'var(--accent-2)' }}>
+            Upgrade Plan
+          </button>
+        )}
+      </section>
+
+      <section>
+        <h2 className="font-semibold mb-2">Tasks</h2>
+        <ul className="space-y-2">
+          {profile.tasks.map(t => (
+            <li key={t.id} className="card p-2 text-sm">{t.title}</li>
+          ))}
+        </ul>
+      </section>
+
+      <section>
+        <h2 className="font-semibold mb-2">Projects</h2>
+        <ul className="space-y-2">
+          {profile.projects.map(p => (
+            <li key={p.id} className="card p-2 text-sm">{p.name}</li>
+          ))}
+        </ul>
+      </section>
+
+      <section>
+        <h2 className="font-semibold mb-2">Notes</h2>
+        <textarea className="input w-full h-32" value={notes} onChange={e=>setNotesState(e.target.value)} onBlur={()=>setNotes(notes)} />
+      </section>
+    </div>
+  )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,6 +4,9 @@
 
 :root {
   --panel: 15 15 30;
+  --accent: #FF4FD8;
+  --accent-2: #0096FF;
+  --accent-3: #FDBA2D;
 }
 
 .card {


### PR DESCRIPTION
## Summary
- add `/dashboard` and `/you` routes with shared navigation and sidebars
- provide backend APIs for system metrics, activity feed, and user profile
- apply brand color palette and wire up dashboard and profile views

## Testing
- `npm test` (backend)
- `npm --prefix frontend run build` *(fails: Cannot find package '@vitejs/plugin-react')*


------
https://chatgpt.com/codex/tasks/task_e_68a8df741bc0832998a6ede575d26e57