### PR TITLE
Cache Whisper model and clean up audio handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,12 +2,16 @@ import streamlit as st
 from openai import OpenAI
 import numpy as np
 import matplotlib.pyplot as plt
-from mpl_toolkits.mplot3d import Axes3D
 import io
 import os
-import base64
 import tempfile
 import whisper
+
+
+@st.cache_resource
+def load_whisper_model():
+    """Load the Whisper model once and reuse across reruns."""
+    return whisper.load_model("base")
 
 client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
@@ -29,8 +33,9 @@ if audio_file is not None:
     with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as temp_audio:
         temp_audio.write(audio_file.read())
         temp_audio_path = temp_audio.name
-    model = whisper.load_model("base")
+    model = load_whisper_model()
     result = model.transcribe(temp_audio_path)
+    os.unlink(temp_audio_path)
     user_input = result["text"]
     st.markdown(f"**You said:** {user_input}")
 else:


### PR DESCRIPTION
## Summary
- cache Whisper model via `st.cache_resource`
- remove unused imports and clean up temporary audio files

## Testing
- `python -m py_compile main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9e9faed0883298cd86c2d10a50a2d