### PR TITLE
Add dry-run mode and error handling to CleanupBot

### DIFF
--- a/agents/cleanup_bot.py
+++ b/agents/cleanup_bot.py
@@ -4,20 +4,44 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import subprocess
+from subprocess import CalledProcessError
 from typing import List
 
 
 @dataclass
 class CleanupBot:
-    """Delete local and remote branches after merges."""
+    """Delete local and remote branches after merges.
+
+    Parameters
+    ----------
+    branches:
+        A list of branch names to remove.
+    dry_run:
+        When ``True`` no commands are executed and planned actions are
+        printed instead. This is helpful for verifying branch names before
+        actual deletion.
+    """
 
     branches: List[str]
+    dry_run: bool = False
 
     def cleanup(self) -> None:
         """Remove the configured branches locally and remotely."""
         for branch in self.branches:
-            subprocess.run(["git", "branch", "-D", branch], check=True)
-            subprocess.run(["git", "push", "origin", "--delete", branch], check=True)
+            if self.dry_run:
+                print(f"Would delete branch '{branch}' locally and remotely")
+                continue
+            try:
+                subprocess.run(["git", "branch", "-D", branch], check=True)
+            except CalledProcessError:
+                print(f"Failed to delete local branch '{branch}'")
+            try:
+                subprocess.run(
+                    ["git", "push", "origin", "--delete", branch],
+                    check=True,
+                )
+            except CalledProcessError:
+                print(f"Failed to delete remote branch '{branch}'")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add optional `dry_run` flag to skip branch deletion commands
- wrap git operations in error handling to surface failures gracefully

## Testing
- `python -m py_compile agents/*.py`
- `python agents/auto_novel_agent.py`
- `pre-commit run --files agents/cleanup_bot.py` *(fails: command not found)*
- `pytest` *(fails: missing dependencies such as cargo)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e94461048329a503395b5500551f