### PR TITLE
feat: list supported game engines

### DIFF
--- a/agents/auto_novel_agent.py
+++ b/agents/auto_novel_agent.py
@@ -1,5 +1,7 @@
 """Simple auto novel agent example with game creation abilities."""
+
 from dataclasses import dataclass
+from typing import ClassVar, List
 
 
 @dataclass
@@ -7,24 +9,31 @@ class AutoNovelAgent:
     """A toy agent that can deploy itself and create simple games."""
 
     name: str = "AutoNovelAgent"
+    SUPPORTED_ENGINES: ClassVar[set[str]] = {"unity", "unreal"}
 
     def deploy(self) -> None:
         """Deploy the agent by printing a greeting."""
         print(f"{self.name} deployed and ready to generate novels!")
 
     def create_game(self, engine: str, include_weapons: bool = False) -> None:
-        """Create a basic game using Unity or Unreal without weapons.
+        """Create a basic game using a supported engine without weapons.
 
         Args:
-            engine: Game engine to use ("unity" or "unreal").
-            include_weapons: If True, raise a ValueError because weapons are not allowed.
+            engine: Game engine to use.
+            include_weapons: If True, raise a ``ValueError`` because weapons are not
+                allowed.
         """
         engine_lower = engine.lower()
-        if engine_lower not in {"unity", "unreal"}:
-            raise ValueError("Unsupported engine. Choose 'unity' or 'unreal'.")
+        if engine_lower not in self.SUPPORTED_ENGINES:
+            supported = ", ".join(sorted(self.SUPPORTED_ENGINES))
+            raise ValueError(f"Unsupported engine. Choose one of: {supported}.")
         if include_weapons:
             raise ValueError("Weapons are not allowed in generated games.")
         print(f"Creating a {engine_lower.capitalize()} game without weapons...")
+
+    def list_supported_engines(self) -> List[str]:
+        """Return a list of supported game engines."""
+        return sorted(self.SUPPORTED_ENGINES)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- track allowed game engines in `SUPPORTED_ENGINES`
- expose `list_supported_engines` helper
- improve validation and error messages in `create_game`

## Testing
- `python -m py_compile *.py`
- `python auto_novel_agent.py`
- `pre-commit run --files agents/auto_novel_agent.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ebdc3f508329ba69807b0f56da07