### PR TITLE
Fix import issue in Codex issue opener

### DIFF
--- a/codex/agents/issue_opener.py
+++ b/codex/agents/issue_opener.py
@@ -16,10 +16,15 @@ Reads:
 Emits:
   repo.issues.opened
 """
-import os, re, json, base64, time
-from pathlib import Path
+import json
+import os
+import re
+import time
 from datetime import datetime
-import urllib.request, urllib.error
+from pathlib import Path
+import urllib.error
+import urllib.parse
+import urllib.request
 
 BASE = Path("codex")
 EVENTS = BASE/"runtime"/"events"


### PR DESCRIPTION
## Summary
- ensure urllib.parse is imported in Codex GitHub issue opener
- tidy imports by removing unused base64

## Testing
- `python3 -m py_compile codex/agents/issue_opener.py`
- `python3 -m py_compile codex/agents/webhook_notifier.py codex/agents/codex_operator.py codex/agents/merge_agent.py`
- `pytest` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9eba308688329b0def30af169aa36