### PR TITLE
feat: add dry-run mode to cleanup bot

### DIFF
--- a/agents/cleanup_bot.py
+++ b/agents/cleanup_bot.py
@@ -4,20 +4,43 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import subprocess
+from subprocess import CalledProcessError
 from typing import List
 
 
 @dataclass
 class CleanupBot:
-    """Delete local and remote branches after merges."""
+    """Delete local and remote branches after merges.
+
+    Args:
+        branches: Branch names to delete.
+        dry_run: If True, print commands instead of executing them.
+    """
 
     branches: List[str]
+    dry_run: bool = False
+
+    def _run(self, *cmd: str) -> None:
+        """Run a command unless in dry-run mode."""
+        if self.dry_run:
+            print("DRY-RUN:", " ".join(cmd))
+            return
+        subprocess.run(cmd, check=True)
 
     def cleanup(self) -> None:
-        """Remove the configured branches locally and remotely."""
+        """Remove the configured branches locally and remotely.
+
+        Skips branches that are missing locally or remotely.
+        """
         for branch in self.branches:
-            subprocess.run(["git", "branch", "-D", branch], check=True)
-            subprocess.run(["git", "push", "origin", "--delete", branch], check=True)
+            try:
+                self._run("git", "branch", "-D", branch)
+            except CalledProcessError:
+                print(f"Local branch {branch} not found; skipping")
+            try:
+                self._run("git", "push", "origin", "--delete", branch)
+            except CalledProcessError:
+                print(f"Remote branch {branch} not found; skipping")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow CleanupBot to optionally dry-run branch deletions
- skip missing local or remote branches with helpful messages

## Testing
- `python -m py_compile agents/*.py`
- `python agents/auto_novel_agent.py`
- `pre-commit run --files agents/cleanup_bot.py` *(fails: command not found, proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ebebcb90832981df16e461d8d772