### PR TITLE
refactor: cache whisper model and cleanup temp files

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,10 +2,8 @@ import streamlit as st
 import openai
 import numpy as np
 import matplotlib.pyplot as plt
-from mpl_toolkits.mplot3d import Axes3D
 import io
 import os
-import base64
 import tempfile
 import whisper
 
@@ -24,13 +22,20 @@ st.markdown("""
 """)
 
 # Audio input
+@st.cache_resource
+def load_whisper_model():
+    """Load Whisper model once and cache for subsequent requests."""
+    return whisper.load_model("base")
+
+
 audio_file = st.file_uploader("Upload your voice (mp3 or wav)", type=["mp3", "wav"])
 if audio_file is not None:
     with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as temp_audio:
         temp_audio.write(audio_file.read())
         temp_audio_path = temp_audio.name
-    model = whisper.load_model("base")
+    model = load_whisper_model()
     result = model.transcribe(temp_audio_path)
+    os.remove(temp_audio_path)
     user_input = result["text"]
     st.markdown(f"**You said:** {user_input}")
 else:


### PR DESCRIPTION
## Summary
- cache Whisper model with `st.cache_resource`
- remove temporary audio files after transcription
- drop unused imports

## Testing
- `python -m py_compile main.py`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9ec278be88329bb23f1d5ff922d3a