### PR TITLE
Codex/add blackroad dashboard for audio clips

### DIFF
--- a/tests/git-route.test.js
+++ b/tests/git-route.test.js
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { applyPatches } from '../var/www/blackroad/server/routes/git.js';
+
+const tempFile = 'tmp-applyPatches.txt';
+const abs = path.join(process.cwd(), tempFile);
+
+await fs.writeFile(abs, 'old\n');
+const diff = [
+  `--- ${tempFile}`,
+  `+++ ${tempFile}`,
+  '@@ -1 +1 @@',
+  '-old',
+  '+new',
+  ''
+].join('\n');
+
+const req = { body: { patches: [{ path: tempFile, diff }] } };
+const res = {
+  statusCode: 200,
+  status(c) { this.statusCode = c; return this; },
+  json(obj) { this.body = obj; }
+};
+
+await applyPatches(req, res);
+assert.equal(res.body.applied[tempFile], 'ok');
+const content = await fs.readFile(abs, 'utf8');
+assert.equal(content, 'new\n');
+await fs.unlink(abs);
+

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -1,2 +1,3 @@
 import assert from 'node:assert';
+import './git-route.test.js';
 assert.ok(true);

--- a/var/www/blackroad/server/routes/git.js
+++ b/var/www/blackroad/server/routes/git.js
@@ -1,8 +1,58 @@
-// TODO: replace with real unified diff apply that edits files safely.
-async function applyPatches(req, res){
+import { spawn } from 'node:child_process';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const repoRoot = process.cwd();
+
+function sanitizeDiff(diff, filePath) {
+  const lines = diff.split('\n');
+  let i = lines.findIndex(l => l.startsWith('--- '));
+  if (i !== -1) lines[i] = `--- ${filePath}`;
+  i = lines.findIndex(l => l.startsWith('+++ '));
+  if (i !== -1) lines[i] = `+++ ${filePath}`;
+  return lines.join('\n');
+}
+
+async function applyPatch(patch) {
+  const { path: filePath, diff } = patch || {};
+  if (typeof filePath !== 'string' || typeof diff !== 'string') {
+    throw new Error('invalid patch format');
+  }
+  const absPath = path.resolve(repoRoot, filePath);
+  if (!absPath.startsWith(repoRoot + path.sep)) {
+    throw new Error('invalid path');
+  }
+  await fs.mkdir(path.dirname(absPath), { recursive: true });
+  const sanitized = sanitizeDiff(diff, filePath);
+  await new Promise((resolve, reject) => {
+    const child = spawn('patch', ['-p0', '--silent'], {
+      cwd: repoRoot,
+      stdio: ['pipe', 'ignore', 'pipe'],
+    });
+    let err = '';
+    child.stderr.on('data', d => (err += d));
+    child.on('close', code => {
+      if (code === 0) resolve();
+      else reject(new Error(err.trim() || `patch exited ${code}`));
+    });
+    child.stdin.end(sanitized);
+  });
+  return 'ok';
+}
+
+export async function applyPatches(req, res) {
   const { patches } = req.body || {};
-  if(!Array.isArray(patches)) return res.status(400).json({ error: 'patches[] required' });
-  const applied = Object.fromEntries(patches.map(p=>[p.path,'ok']));
+  if (!Array.isArray(patches)) {
+    return res.status(400).json({ error: 'patches[] required' });
+  }
+  const applied = {};
+  for (const p of patches) {
+    try {
+      applied[p.path] = await applyPatch(p);
+    } catch (err) {
+      applied[p.path] = String(err.message || err);
+    }
+  }
   res.json({ applied });
 }
-module.exports = { applyPatches };
+


### PR DESCRIPTION
# Summary

What does this change?

# Testing
- Local build passes
- `npm run build` (site) / API boots
- E2E (Playwright) green

# Checklist
- Docs/README updated if needed
- No secrets committed
- Labels added (area/site, area/api, etc.)
