### PR TITLE
feat: add unified sync script for BlackRoad.io

### DIFF
--- a/docs/github-droplet-sync.md
+++ b/docs/github-droplet-sync.md
@@ -52,3 +52,19 @@ This guide outlines how to keep a GitHub repository, your local working copy, an
 - Verify the droplet's SSH fingerprint `SHA256:b3uikwBkwnxpMTZjWBFaNgscsWXHRRG3Snj9QYke+ok=` on first connection.
 - Use SSH keys instead of passwords whenever possible.
 
+## Unified sync & deploy
+
+For one-step push or refresh use `scripts/blackroad_sync.sh`:
+
+```bash
+# Commit and push local changes, then redeploy on the droplet
+scripts/blackroad_sync.sh push "commit message"
+
+# Pull latest from GitHub and redeploy without committing
+scripts/blackroad_sync.sh refresh
+```
+
+The script expects SSH access to the droplet (`$DROPLET_HOST`) and
+optionally posts status events via `WEBHOOK_URL` to connected systems
+like Slack or Airtable.
+

--- a/scripts/blackroad_sync.sh
+++ b/scripts/blackroad_sync.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# blackroad_sync.sh - Unified sync & deploy for BlackRoad.io
+#
+# This script pushes local changes to GitHub, propagates updates to
+# connected services, syncs the working copy on the droplet, and
+# restarts services so updates are live on BlackRoad.io.
+#
+# Usage:
+#   scripts/blackroad_sync.sh push "commit message"  # commit & push local changes
+#   scripts/blackroad_sync.sh refresh                 # pull & redeploy latest
+#
+# The script uses environment variables for remote access:
+#   GIT_REMOTE (default: origin)
+#   DROPLET_HOST (e.g. user@1.2.3.4)
+#   DROPLET_REPO (default: /srv/blackroad)
+#   WEBHOOK_URL (optional webhook for Slack/Airtable/etc.)
+#
+set -euo pipefail
+
+REMOTE="${GIT_REMOTE:-origin}"
+DROPLET="${DROPLET_HOST:-}"
+DROPLET_REPO="${DROPLET_REPO:-/srv/blackroad}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+notify(){
+  if [[ -n "${WEBHOOK_URL:-}" ]]; then
+    "${SCRIPT_DIR}/webhook-notify.py" "$1" "$2" || true
+  fi
+}
+
+commit_and_push(){
+  msg=${1:-"update"}
+  git add -A
+  if git diff --cached --quiet; then
+    echo "No changes to commit."
+  else
+    git commit -m "$msg"
+  fi
+  git push "$REMOTE" HEAD
+  notify "git_push" "$msg"
+}
+
+pull_and_rebase(){
+  git fetch "$REMOTE"
+  git rebase "$REMOTE/main" || {
+    echo "Auto rebase failed; attempting merge" >&2
+    git merge --no-edit "$REMOTE/main" || true
+  }
+  notify "git_sync" "rebase"
+}
+
+sync_droplet(){
+  [[ -n "$DROPLET" ]] || { echo "DROPLET_HOST not set" >&2; return 1; }
+  ssh "$DROPLET" "set -euo pipefail; cd '$DROPLET_REPO'; git fetch --all; git reset --hard '$REMOTE/main'; npm ci --omit=dev || npm install; pm2 restart all || systemctl restart blackroad-api || true" && notify "droplet_sync" "$DROPLET"
+}
+
+case "${1:-}" in
+  push)
+    commit_and_push "${2:-update}"
+    sync_droplet
+    ;;
+  refresh)
+    pull_and_rebase
+    sync_droplet
+    ;;
+  *)
+    echo "Usage: $0 [push <msg>|refresh]" >&2
+    exit 1
+    ;;
+ esac


### PR DESCRIPTION
## Summary
- add `blackroad_sync.sh` to push changes, rebase, and redeploy to the droplet with optional connector webhooks
- document one-step sync in `github-droplet-sync.md`

## Testing
- `bash -n scripts/blackroad_sync.sh`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa18fb09388329a73589918bce9b00