### PR TITLE
fix: correct ssh command formatting

### DIFF
--- a/codex/tools/codex_repo_discover.py
+++ b/codex/tools/codex_repo_discover.py
@@ -131,13 +131,18 @@ def merge_into_repos_json(new_entries, base_dir: Path, default_branch="main"):
 
 def build_git_env(cfg):
     env = os.environ.copy()
-    key = os.path.expanduser(cfg.get("git_ssh_key","~/.ssh/id_ed25519"))
+    key = os.path.expanduser(cfg.get("git_ssh_key", "~/.ssh/id_ed25519"))
     # Reuse your wizard’s strict host key policy if known_hosts is already prepared.
     known_hosts = Path("codex/secrets/known_hosts")
     if known_hosts.exists():
-        env["GIT_SSH_COMMAND"] = f"ssh -i {shlex.quote(key)} -o UserKnownHostsFile={shlex.quote(str(known_hosts))} -o StrictHostKeyChecking=yes"
+        env["GIT_SSH_COMMAND"] = (
+            f"ssh -i {shlex.quote(key)} -o UserKnownHostsFile={shlex.quote(str(known_hosts))} "
+            "-o StrictHostKeyChecking=yes"
+        )
     else:
-        env["GIT_SSH_COMMAND"] = f"ssh -i {shlex.quote(key)} -o StrictHostKeyChecking=accept-new"
+        env["GIT_SSH_COMMAND"] = (
+            f"ssh -i {shlex.quote(key)} -o StrictHostKeyChecking=accept-new"
+        )
     return env
 
 def repo_state(repo_dir: Path):

--- a/codex/tools/codex_repo_wizard.py
+++ b/codex/tools/codex_repo_wizard.py
@@ -126,9 +126,14 @@ def build_git_env(ssh_key_path: str, strict: bool):
     env = os.environ.copy()
     key = os.path.expanduser(ssh_key_path)
     if strict:
-        env["GIT_SSH_COMMAND"] = f"ssh -i {shlex.quote(key)} -o UserKnownHostsFile={shlex.quote(str(KNOWN_HOSTS_PATH))} -o StrictHostKeyChecking=yes"
+        env["GIT_SSH_COMMAND"] = (
+            f"ssh -i {shlex.quote(key)} -o UserKnownHostsFile={shlex.quote(str(KNOWN_HOSTS_PATH))} "
+            "-o StrictHostKeyChecking=yes"
+        )
     else:
-        env["GIT_SSH_COMMAND"] = f"ssh -i {shlex.quote(key)} -o StrictHostKeyChecking=accept-new"
+        env["GIT_SSH_COMMAND"] = (
+            f"ssh -i {shlex.quote(key)} -o StrictHostKeyChecking=accept-new"
+        )
     return env
 
 def tokenize_url(url, token):


### PR DESCRIPTION
## Summary
- fix `GIT_SSH_COMMAND` construction to avoid line breaks that caused malformed strings
- restore packages lockfile

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'libcst')*
- `python -m py_compile codex/tools/codex_repo_discover.py codex/tools/codex_repo_wizard.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9ec184c308329907dd5e35f0b8a18