### PR TITLE
feat: scaffold blackroad sync script

### DIFF
--- a/codex/jobs/blackroad_sync.py
+++ b/codex/jobs/blackroad_sync.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""
+BlackRoad sync/deploy scaffolding.
+
+This module provides a high-level entrypoint that describes the steps needed
+for a full end-to-end sync from Codex to the live BlackRoad.io deployment.
+Actual connector, Working Copy, and Droplet implementations are intentionally
+left as placeholders; they can be expanded as infrastructure is built out.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import subprocess
+from pathlib import Path
+from typing import Sequence
+
+log = logging.getLogger(__name__)
+
+
+def run(cmd: Sequence[str], cwd: Path | None = None) -> None:
+    """Run a command, raising if it fails."""
+    log.debug("Running %s", " ".join(cmd))
+    subprocess.run(cmd, check=True, cwd=cwd)
+
+
+def git_push() -> None:
+    """Push local commits to the configured Git remote."""
+    run(["git", "push"])
+
+
+def refresh_working_copy() -> None:
+    """Placeholder for refreshing the Working Copy iOS app."""
+    log.info("Refreshing Working Copy (placeholder)")
+
+
+def deploy_droplet() -> None:
+    """Placeholder for pulling and deploying on the droplet."""
+    log.info("Deploying to droplet (placeholder)")
+
+
+def sync_connectors() -> None:
+    """Placeholder for syncing Salesforce/Airtable/Slack/Linear."""
+    log.info("Syncing connectors (placeholder)")
+
+
+ACTIONS = {
+    "push": git_push,
+    "refresh": refresh_working_copy,
+    "deploy": deploy_droplet,
+    "sync": sync_connectors,
+}
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="BlackRoad sync/deploy helper")
+    parser.add_argument("action", choices=sorted(ACTIONS), help="operation to run")
+    args = parser.parse_args(argv)
+    logging.basicConfig(level=logging.INFO)
+    ACTIONS[args.action]()
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add `blackroad_sync` job as a placeholder CLI for Git push, working copy refresh, droplet deploy and connector sync

## Testing
- `python codex/jobs/blackroad_sync.py sync`
- `pre-commit run --files codex/jobs/blackroad_sync.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1930c32c832984b78fcb042d6491