### PR TITLE
Add Codex sync and deploy scaffold

### DIFF
--- a/scripts/codex_build.py
+++ b/scripts/codex_build.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Codex end-to-end sync and deploy scaffold.
+
+This module provides a lightweight scaffold for an automated flow:
+Codex -> GitHub -> Connectors -> Working Copy -> Droplet -> BlackRoad.io.
+Each component is represented by a small class with placeholder methods so
+future agents can implement the full behaviour.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import subprocess
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+# --------------------------- GitHub integration ---------------------------
+
+@dataclass
+class GitHubIntegration:
+    """Minimal wrapper around git commands."""
+
+    repo_path: str = "."
+
+    def commit_and_push(self, message: str) -> None:
+        """Commit staged changes and push to origin."""
+        logger.info("Committing and pushing changes")
+        subprocess.check_call(["git", "commit", "-am", message])
+        subprocess.check_call(["git", "push", "origin", "HEAD"])
+
+    def pull_rebase(self) -> None:
+        """Fetch latest changes and rebase."""
+        logger.info("Pulling latest changes with rebase")
+        subprocess.check_call(["git", "pull", "--rebase"])
+
+
+# --------------------------- Connector jobs ---------------------------
+
+@dataclass
+class ConnectorManager:
+    """Placeholder for Salesforce/Airtable/Slack/Linear connectors."""
+
+    def sync(self) -> None:
+        logger.info("Running connector sync stub")
+        # Future implementation: OAuth flows, webhooks and background jobs
+
+
+# --------------------------- Working Copy automation ---------------------------
+
+@dataclass
+class WorkingCopyManager:
+    """Represent iOS Working Copy automation hooks."""
+
+    path: str = "."
+
+    def refresh(self) -> None:
+        logger.info("Refreshing Working Copy stub")
+        # Future implementation: integrate with Working Copy's x-callback-url
+
+
+# --------------------------- Droplet deployment ---------------------------
+
+@dataclass
+class DropletDeployment:
+    """Placeholder for remote droplet deployment logic."""
+
+    def deploy(self) -> None:
+        logger.info("Deploying to droplet stub")
+        # Future implementation: git pull, migrations, service restarts
+
+
+# --------------------------- Chat control surface ---------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Unified Codex build script scaffold for BlackRoad.io"
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    sub.add_parser("push", help="Commit and push changes to GitHub")
+    sub.add_parser("pull", help="Pull and rebase from origin")
+    sub.add_parser("deploy", help="Deploy latest code to droplet")
+    sub.add_parser("refresh", help="Sync connectors and Working Copy")
+
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO)
+
+    git = GitHubIntegration()
+    connectors = ConnectorManager()
+    working_copy = WorkingCopyManager()
+    droplet = DropletDeployment()
+
+    if args.command == "push":
+        git.commit_and_push("codex automation update")
+        connectors.sync()
+    elif args.command == "pull":
+        git.pull_rebase()
+    elif args.command == "deploy":
+        droplet.deploy()
+    elif args.command == "refresh":
+        connectors.sync()
+        working_copy.refresh()
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- scaffold a unified Codex build script providing placeholders for GitHub, connectors, working copy and droplet deployment
- expose simple chat-style CLI commands for push, pull, deploy and refresh

## Testing
- `python -m py_compile scripts/codex_build.py`
- `python scripts/codex_build.py --help`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa1960fe688329b872745ae30ad4ec