### PR TITLE
Add Codex pipeline scaffold script

### DIFF
--- a/tools/codex_pipeline.py
+++ b/tools/codex_pipeline.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Codex pipeline scaffold for BlackRoad.io.
+
+This CLI provides placeholder commands that outline an end-to-end
+synchronisation flow:
+
+* Commit and push local code to GitHub.
+* Refresh iOS Working Copy state.
+* Redeploy the BlackRoad droplet.
+* Trigger external connector jobs (Salesforce, Airtable, etc.).
+
+Each step contains TODO markers where project-specific logic should be
+implemented. The script is intended as a starting point for a full CI/CD
+solution rather than a complete deployment utility.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+
+
+def run(cmd: str) -> None:
+    """Run a shell command and stream output."""
+    print(f"[cmd] {cmd}")
+    subprocess.run(cmd, shell=True, check=True)
+
+
+def push_latest() -> None:
+    """Push local commits to GitHub."""
+    # TODO: handle authentication, branching, conflict resolution, and
+    # downstream webhook notifications.
+    run("git push origin HEAD")
+
+
+def refresh_working_copy() -> None:
+    """Placeholder for refreshing iOS Working Copy app."""
+    # TODO: use Working Copy automation or URL schemes to pull latest changes.
+    print("TODO: implement Working Copy refresh")
+
+
+def redeploy_droplet() -> None:
+    """Placeholder for redeploying the BlackRoad droplet."""
+    # TODO: SSH into droplet, pull latest code, run migrations, restart services.
+    print("TODO: implement droplet redeploy")
+
+
+def sync_connectors() -> None:
+    """Placeholder for syncing external connectors."""
+    # TODO: add OAuth flows, webhook listeners, and Slack notifications.
+    print("TODO: implement connector sync")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="BlackRoad Codex pipeline scaffold",
+    )
+    sub = parser.add_subparsers(dest="command")
+    sub.add_parser("push", help="Push latest to BlackRoad.io")
+    sub.add_parser("refresh", help="Refresh working copy and redeploy")
+    sub.add_parser("rebase", help="Rebase branch and update site")
+    sub.add_parser("sync", help="Sync Salesforce → Airtable → Droplet")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "push":
+        push_latest()
+        redeploy_droplet()
+    elif args.command == "refresh":
+        push_latest()
+        refresh_working_copy()
+        redeploy_droplet()
+    elif args.command == "rebase":
+        run("git pull --rebase")
+        push_latest()
+        redeploy_droplet()
+    elif args.command == "sync":
+        sync_connectors()
+    else:
+        parser.print_help()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
## Summary
- scaffold a `codex_pipeline` CLI outlining end-to-end sync steps from GitHub to droplet and external connectors

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa197341f4832988a4ca370a0e0540