### PR TITLE
Add scaffold script for BlackRoad sync pipeline

### DIFF
--- a/scripts/blackroad_sync.sh
+++ b/scripts/blackroad_sync.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Scaffold script for BlackRoad.io end-to-end sync and deployment.
+# This is a placeholder that outlines the desired flow.
+
+set -euo pipefail
+
+# 1. GitHub integration
+# TODO: auto-commit and push changes, handle branches, trigger downstream syncs.
+
+# 2. Connector jobs (Salesforce, Airtable, Slack, Linear, etc.)
+# TODO: provide OAuth scaffolding and webhook listeners.
+# TODO: enable background jobs to synchronize metadata and assets.
+# TODO: post status updates to Slack.
+
+# 3. Working Copy automation
+# TODO: automate pull/push to refresh local state on iOS devices.
+
+# 4. Droplet deployment
+# TODO: auto-pull latest code, run migrations, and restart services.
+# TODO: expose /health and /deploy/status endpoints.
+
+# 5. BlackRoad.io live refresh
+# TODO: verify SPA and backend refresh after deployment.
+# TODO: ensure logs/errors flow back for debugging.
+
+# 6. Resilience and manual override
+# TODO: support forced refresh, retry, or rollback on failure.
+# TODO: log all actions for traceability.
+
+printf "BlackRoad sync scaffold: implementation pending.\n"


### PR DESCRIPTION
## Summary
- scaffold `blackroad_sync.sh` outlining GitHub, connector, working copy, droplet, and live refresh steps for future implementation

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa199342088329a443c4b05e73fa16