### PR TITLE
feat: add Codex sync pipeline script

### DIFF
--- a/docs/codex-sync.md
+++ b/docs/codex-sync.md
@@ -1,0 +1,24 @@
+# Codex Sync Pipeline
+
+`scripts/codex_sync.py` offers a chat-style entry point for moving code from Codex all the way to the live BlackRoad.io instance.
+
+## Features
+
+- Auto-commit and push to GitHub with rebase handling.
+- Invokes connector stubs and Slack notifications.
+- Refreshes an optional iOS Working Copy checkout (`WORKING_COPY_PATH`) and redeploys the droplet via `scripts/prism_sync_build.sh`.
+- Minimal FastAPI server with OAuth/webhook placeholders (`webhook-server`).
+
+## Usage
+
+```bash
+python scripts/codex_sync.py "Push latest to BlackRoad.io"
+python scripts/codex_sync.py "Refresh working copy and redeploy"
+python scripts/codex_sync.py "Rebase branch and update site"
+python scripts/codex_sync.py "Sync Salesforce to Airtable to Droplet"
+python scripts/codex_sync.py "Start webhook server"
+```
+
+Set `SLACK_WEBHOOK_URL` to enable Slack notifications. `WORKING_COPY_PATH` can point to a Working Copy checkout on an iOS device mounted locally.
+
+The script uses `prism_sync_build.sh` for deployment and exposes placeholder endpoints at `http://localhost:8040` when running the webhook server.

--- a/scripts/codex_sync.py
+++ b/scripts/codex_sync.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Unified CI/CD and connector control for BlackRoad.io."""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import subprocess
+from typing import Callable
+
+import requests
+from fastapi import FastAPI, Request
+import uvicorn
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+log = logging.getLogger(__name__)
+SLACK_WEBHOOK = os.getenv("SLACK_WEBHOOK_URL")
+
+
+def notify_slack(message: str) -> None:
+    """Post a simple message to Slack if configured."""
+    if not SLACK_WEBHOOK:
+        return
+    try:
+        requests.post(SLACK_WEBHOOK, json={"text": message}, timeout=5)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("slack notify failed: %s", exc)
+
+
+def run(cmd: list[str], **kwargs) -> None:
+    """Run a subprocess command and stream output."""
+    log.info("$ %s", " ".join(cmd))
+    subprocess.run(cmd, check=True, **kwargs)
+
+
+def push_latest() -> None:
+    """Commit any changes, rebase, push, then deploy."""
+    status = subprocess.run(
+        ["git", "status", "--porcelain"], capture_output=True, text=True, check=True
+    ).stdout
+    if status.strip():
+        run(["git", "add", "-A"])
+        run(["git", "commit", "-m", "Codex auto-commit"])
+    run(["git", "pull", "--rebase", "origin", "main"])
+    run(["git", "push", "origin", "HEAD"])
+    notify_slack(":rocket: pushed latest to GitHub")
+    trigger_downstream()
+
+
+def refresh_working_copy_and_redeploy() -> None:
+    """Pull latest and redeploy the droplet."""
+    run(["git", "pull", "--rebase", "origin", "main"])
+    deploy_to_droplet()
+    notify_slack(":arrows_counterclockwise: working copy refreshed")
+
+
+def rebase_branch_and_update_site() -> None:
+    """Rebase current branch onto main and redeploy."""
+    run(["git", "fetch", "origin"])
+    run(["git", "rebase", "origin/main"])
+    run(["git", "push", "origin", "HEAD"])
+    deploy_to_droplet()
+    notify_slack(":recycle: branch rebased and site updated")
+
+
+def sync_salesforce_airtable_droplet() -> None:
+    """Stub connector workflow."""
+    log.info("Sync Salesforce -> Airtable -> Droplet (stubbed)")
+    notify_slack(":link: connectors synced (stub)")
+
+
+def trigger_downstream() -> None:
+    refresh_working_copy()
+    deploy_to_droplet()
+
+
+def refresh_working_copy() -> None:
+    path = os.getenv("WORKING_COPY_PATH")
+    if not path:
+        log.info("WORKING_COPY_PATH not set; skipping iOS Working Copy refresh")
+        return
+    run(["git", "-C", path, "pull", "--rebase", "origin", "main"])
+
+
+def deploy_to_droplet() -> None:
+    script = os.path.join(os.path.dirname(__file__), "prism_sync_build.sh")
+    if os.path.exists(script):
+        run(["bash", script])
+    else:
+        log.warning("deploy script missing: %s", script)
+
+
+def launch_connector_server() -> None:
+    """Start a tiny FastAPI app with OAuth/webhook placeholders."""
+    app = FastAPI(title="BlackRoad Connectors")
+
+    @app.get("/health")
+    async def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/oauth/callback")
+    async def oauth_callback(code: str) -> dict[str, str]:
+        log.info("OAuth callback code=%s", code)
+        return {"ok": "callback received"}
+
+    @app.post("/webhooks/salesforce")
+    async def salesforce_webhook(request: Request) -> dict[str, str]:
+        log.info("Salesforce webhook payload: %s", await request.json())
+        return {"received": "salesforce"}
+
+    @app.post("/webhooks/airtable")
+    async def airtable_webhook(request: Request) -> dict[str, str]:
+        log.info("Airtable webhook payload: %s", await request.json())
+        return {"received": "airtable"}
+
+    uvicorn.run(app, host="0.0.0.0", port=int(os.getenv("WEBHOOK_PORT", "8040")))
+
+
+COMMANDS: dict[str, Callable[[], None]] = {
+    "push-latest": push_latest,
+    "refresh": refresh_working_copy_and_redeploy,
+    "rebase-update": rebase_branch_and_update_site,
+    "sync-connectors": sync_salesforce_airtable_droplet,
+    "webhook-server": launch_connector_server,
+}
+
+
+def parse_command(raw: str) -> Callable[[], None]:
+    raw = raw.lower()
+    if "push" in raw and "latest" in raw:
+        return push_latest
+    if "refresh" in raw:
+        return refresh_working_copy_and_redeploy
+    if "rebase" in raw or "update" in raw:
+        return rebase_branch_and_update_site
+    if "salesforce" in raw or "airtable" in raw:
+        return sync_salesforce_airtable_droplet
+    if "webhook" in raw or "server" in raw:
+        return launch_connector_server
+    return lambda: log.error("unknown command: %s", raw)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Codex CI/CD control surface")
+    parser.add_argument("command", help="Free-form command like 'Push latest to BlackRoad.io'")
+    args = parser.parse_args()
+    func = parse_command(args.command)
+    func()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `codex_sync.py` control surface to push code, sync connectors, refresh working copy, and deploy
- document Codex sync pipeline usage and environment variables

## Testing
- `python -m py_compile scripts/codex_sync.py`
- `black scripts/codex_sync.py`
- `ruff check scripts/codex_sync.py`
- `npx prettier --write docs/codex-sync.md`
- `pre-commit run --files scripts/codex_sync.py docs/codex-sync.md` *(failed: command not found and installation blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1af56e008329a4b82899bab4d980