### PR TITLE
Add scaffold for BlackRoad.io pipeline

### DIFF
--- a/codex/blackroad_pipeline.py
+++ b/codex/blackroad_pipeline.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Scaffold for the BlackRoad.io deployment pipeline.
+
+This module defines a small interface that outlines the end-to-end flow for
+keeping BlackRoad.io in sync with local code.  The functions are lightweight
+placeholders meant to be extended with real CI/CD logic.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Sequence
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _run(cmd: Sequence[str]) -> None:
+    """Run a command in the repository root and echo it."""
+    print("+", " ".join(cmd))
+    subprocess.run(cmd, cwd=ROOT, check=True)
+
+
+class BlackRoadPipeline:
+    """Utility helpers for common BlackRoad.io operations."""
+
+    def push_latest(self) -> None:
+        """Push committed changes to GitHub and trigger downstream syncs."""
+        _run(["git", "push"])
+
+    def refresh_working_copy(self) -> None:
+        """Pull updates and redeploy the droplet."""
+        _run(["git", "pull", "--rebase"])
+        # Placeholder for remote deployment automation.
+        print("Refreshing droplet and restarting services...")
+
+    def rebase_branch(self, branch: str) -> None:
+        """Rebase the current branch on ``branch`` and update the site."""
+        _run(["git", "fetch"])
+        _run(["git", "rebase", branch])
+        self.push_latest()
+        self.refresh_working_copy()
+
+    def sync_connectors(self) -> None:
+        """Sync Salesforce, Airtable, Slack and other connectors."""
+        # Placeholder for connector synchronization.
+        print("Syncing external connectors...")

--- a/scripts/blackroad_pipeline.py
+++ b/scripts/blackroad_pipeline.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Chat-first control surface for the BlackRoad.io pipeline."""
+from __future__ import annotations
+
+import argparse
+
+from codex.blackroad_pipeline import BlackRoadPipeline
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Operate the BlackRoad.io pipeline")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("push", help="Push latest changes to GitHub")
+    sub.add_parser("refresh", help="Refresh working copy and redeploy")
+    rebase = sub.add_parser("rebase", help="Rebase branch and update site")
+    rebase.add_argument("branch", help="Branch to rebase onto")
+    sub.add_parser("sync", help="Sync external connectors")
+    args = parser.parse_args()
+
+    pipeline = BlackRoadPipeline()
+    if args.cmd == "push":
+        pipeline.push_latest()
+    elif args.cmd == "refresh":
+        pipeline.refresh_working_copy()
+    elif args.cmd == "rebase":
+        pipeline.rebase_branch(args.branch)
+    elif args.cmd == "sync":
+        pipeline.sync_connectors()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- scaffold Python interface for Codex-driven BlackRoad.io pipeline
- add CLI wrapper for push, refresh, rebase and connector sync commands

## Testing
- `python -m py_compile codex/blackroad_pipeline.py scripts/blackroad_pipeline.py`
- `pre-commit run --files codex/blackroad_pipeline.py scripts/blackroad_pipeline.py` *(fails: command not found)*
- `PYTHONPATH=. python scripts/blackroad_pipeline.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68aa1ac48e3883298307282aa9cebeb2