### PR TITLE
feat: add Codex sync scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,27 @@ npm test
 
 Additional operational docs live in the [`docs/`](docs) folder.
 
+## Codex Sync Script
+
+The repository includes a minimal scaffold to experiment with the end-to-end
+flow described in the BlackRoad deployment docs. The helper accepts natural
+language commands and turns them into git/deploy operations.
+
+```bash
+python scripts/blackroad_sync.py "Push latest to BlackRoad.io"
+```
+
+Other examples:
+
+- `python scripts/blackroad_sync.py "Refresh working copy and redeploy"`
+- `python scripts/blackroad_sync.py "Rebase branch and update site"`
+- `python scripts/blackroad_sync.py "Sync Salesforce → Airtable → Droplet"`
+
+The script currently prints placeholder actions; extend the functions to hook
+into real connectors and infrastructure.
+
 ## Bot Commands (ChatOps)
+
 - `/deploy blackroad <channel> [provider]` — deploy canary/beta/prod
 - `/rollback blackroad <channel> [steps] [provider]` — revert to earlier build
 - `/blog new "Title"` — scaffold blog post PR
@@ -43,6 +63,7 @@ Additional operational docs live in the [`docs/`](docs) folder.
 - `/fix <freeform prompt>` — dispatch AI Fix with your prompt
 
 ## Agents Overview
+
 - **Auto-Heal**: reacts to failing workflows and dispatches **AI Fix**.
 - **AI Fix**: runs Codex/LLM prompts, formats, builds, opens PRs.
 - **AI Sweeper**: nightly formatter/linter; opens PR if needed.

--- a/scripts/blackroad_sync.py
+++ b/scripts/blackroad_sync.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Chat-first sync and deploy scaffold for BlackRoad.io.
+
+This script provides a minimal command surface that translates natural
+language requests into git and deployment operations. It is intended as a
+starting point for the full Codex pipeline described in project docs.
+Actual connector integrations and remote deployments must be wired in by
+operators.
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+
+
+# --------------------------- helpers ---------------------------
+
+def run(cmd: str) -> None:
+    """Run shell command and stream output."""
+    print(f"-> {cmd}")
+    try:
+        subprocess.run(cmd, shell=True, check=True)
+    except subprocess.CalledProcessError as exc:  # noqa: BLE001
+        print(f"command failed: {exc}")
+        sys.exit(exc.returncode)
+
+
+# --------------------------- actions ---------------------------
+
+def push_latest() -> None:
+    """Commit local changes, rebase and push to origin."""
+    run("git add -A")
+    # commit may fail if nothing to commit; swallow error
+    subprocess.run(
+        'git commit -m "Sync from Codex" || echo "nothing to commit"',
+        shell=True,
+        check=False,
+    )
+    run("git pull --rebase")
+    run("git push")
+    print("triggered connectors and deployment hooks (placeholder)")
+
+
+def refresh_working_copy() -> None:
+    """Pull latest changes and redeploy site."""
+    run("git pull")
+    print("refreshed working copy and redeployed site (placeholder)")
+
+
+def rebase_branch() -> None:
+    """Rebase current branch on origin/main and push."""
+    run("git fetch origin")
+    run("git rebase origin/main")
+    run("git push --force-with-lease")
+    print("rebased branch and updated site (placeholder)")
+
+
+def sync_salesforce_airtable_droplet() -> None:
+    """Demonstrate connector sync flow."""
+    print("syncing Salesforce → Airtable → Droplet (placeholder)")
+
+
+COMMANDS = {
+    "push latest": push_latest,
+    "refresh working copy": refresh_working_copy,
+    "rebase branch": rebase_branch,
+    "sync salesforce": sync_salesforce_airtable_droplet,
+}
+
+
+# --------------------------- main interface ---------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="BlackRoad Codex sync utility",
+        epilog="example: python scripts/blackroad_sync.py \"Push latest to BlackRoad.io\"",
+    )
+    parser.add_argument("command", nargs="+", help="natural language command")
+    args = parser.parse_args()
+    text = " ".join(args.command).lower()
+    for key, func in COMMANDS.items():
+        if key in text:
+            func()
+            break
+    else:
+        print(f"unknown command: {text}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add chat-first `blackroad_sync` script scaffolding git/deploy actions
- document sync helper and usage in README

## Testing
- `npx prettier -w README.md`
- `npm run lint`
- `npm test`
- `python -m py_compile scripts/blackroad_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa198dd2e483299d931de6750fccaa