### PR TITLE
Add scaffold for BlackRoad.io sync pipeline

### DIFF
--- a/codex/tools/blackroad_sync.py
+++ b/codex/tools/blackroad_sync.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Scaffold for BlackRoad.io end-to-end sync and deployment.
+
+This script provides a chat-first control surface for triggering the
+full pipeline from Codex to the live BlackRoad.io site. The current
+implementation is a skeleton; connector integration and droplet deploy
+steps are placeholders to be filled in later.
+"""
+
+import argparse
+import subprocess
+import logging
+from typing import List
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+
+def run(cmd: List[str]) -> None:
+    """Run a shell command and log it."""
+    logging.info("Running: %s", " ".join(cmd))
+    subprocess.run(cmd, check=False)
+
+
+def push_latest() -> None:
+    """Commit and push local changes to GitHub."""
+    run(["git", "add", "-A"])
+    run(["git", "commit", "-m", "chore: automatic commit from codex"])
+    run(["git", "push"])
+
+
+def sync_connectors() -> None:
+    """Placeholder for connector sync (Salesforce, Airtable, Slack, etc.)."""
+    logging.info("TODO: implement connector synchronization")
+
+
+def refresh_working_copy() -> None:
+    """Placeholder for iOS Working Copy refresh."""
+    logging.info("TODO: implement Working Copy automation")
+
+
+def deploy_to_droplet() -> None:
+    """Placeholder for droplet deployment."""
+    logging.info("TODO: implement droplet deployment")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="BlackRoad.io sync scaffold")
+    sub = parser.add_subparsers(dest="cmd")
+
+    sub.add_parser("push", help="Commit and push local changes")
+    sub.add_parser("sync", help="Sync connectors and Working Copy")
+    sub.add_parser("deploy", help="Deploy latest code to droplet")
+    sub.add_parser("all", help="Run push, sync, and deploy steps")
+
+    args = parser.parse_args()
+
+    if args.cmd == "push":
+        push_latest()
+    elif args.cmd == "sync":
+        sync_connectors()
+        refresh_working_copy()
+    elif args.cmd == "deploy":
+        deploy_to_droplet()
+    elif args.cmd == "all":
+        push_latest()
+        sync_connectors()
+        refresh_working_copy()
+        deploy_to_droplet()
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/blackroad_sync.md
+++ b/docs/blackroad_sync.md
@@ -1,0 +1,17 @@
+# BlackRoad.io Sync Scaffold
+
+This repository includes a helper script, `codex/tools/blackroad_sync.py`,
+that sketches an end-to-end pipeline for pushing code through Codex,
+GitHub, and eventually to the live BlackRoad.io deployment.
+
+The script currently provides a minimal chat-first control surface:
+
+```bash
+python codex/tools/blackroad_sync.py push   # commit and push local changes
+python codex/tools/blackroad_sync.py sync   # placeholder for connector sync
+python codex/tools/blackroad_sync.py deploy # placeholder for droplet deploy
+python codex/tools/blackroad_sync.py all    # run all steps sequentially
+```
+
+Connector integration, Working Copy automation, and droplet deployment
+are not yet implemented and are marked as TODOs inside the script.


### PR DESCRIPTION
## Summary
- add `blackroad_sync.py` scaffold with push/sync/deploy commands
- document usage of the new sync script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'libcst', torchquantum, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68aa19acd4c0832982219221e9e248ba