### PR TITLE
feat: scaffold BlackRoad CI/CD helper

### DIFF
--- a/scripts/blackroad_sync.py
+++ b/scripts/blackroad_sync.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Unified Codex build script for BlackRoad.io CI/CD pipeline.
+
+This script provides a chat-first interface for orchestrating
+end-to-end synchronization from the Codex environment to the
+live BlackRoad.io deployment. It exposes subcommands that map
+roughly to the spoken phrases operators use, e.g. "push latest to
+BlackRoad.io".
+
+The implementation intentionally focuses on scaffolding and leaves
+connector- and environment-specific details as future work.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import subprocess
+from typing import Iterable
+
+logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
+
+
+def run(cmd: Iterable[str]) -> None:
+    """Run a shell command, raising on failure."""
+    logging.debug("Running command: %s", " ".join(cmd))
+    subprocess.run(cmd, check=True)
+
+
+def push_latest() -> None:
+    """Push committed changes to the default GitHub remote.
+
+    This step assumes the current repository has been configured with the
+    appropriate credentials for push access. Downstream services (connectors,
+    working copy, droplet) are expected to react to the new commit through
+    their respective webhooks.
+    """
+
+    run(["git", "push", "origin", "HEAD"])
+
+
+def refresh_working_copy() -> None:
+    """Trigger the iOS Working Copy app to pull latest changes.
+
+    The actual integration with Working Copy is environment-specific and
+    should be implemented using its URL scheme or SSH hooks. This function
+    acts as a placeholder for that automation.
+    """
+
+    logging.info("Working Copy refresh placeholder executed")
+
+
+def deploy_droplet() -> None:
+    """Pull and deploy latest code on the droplet hosting BlackRoad.io.
+
+    A full implementation would SSH into the droplet, execute git operations,
+    run migrations, and restart services. Here we only outline the sequence.
+    """
+
+    logging.info("Droplet deploy placeholder executed")
+
+
+def sync_connectors() -> None:
+    """Synchronize external connectors such as Salesforce or Slack.
+
+    OAuth setup, webhooks, and background jobs should be wired in here.
+    For now the function only logs the intent.
+    """
+
+    logging.info("Connector sync placeholder executed")
+
+
+def rebase_branch(branch: str) -> None:
+    """Rebase the current branch onto ``branch`` and push the result."""
+    run(["git", "fetch", "origin", branch])
+    run(["git", "rebase", f"origin/{branch}"])
+    push_latest()
+
+
+def refresh_all() -> None:
+    """Run the full end-to-end refresh sequence."""
+    push_latest()
+    sync_connectors()
+    refresh_working_copy()
+    deploy_droplet()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="BlackRoad.io CI/CD helper")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("push", help="Push latest to GitHub and trigger pipeline")
+    sub.add_parser("refresh", help="Refresh working copy and redeploy")
+    rb = sub.add_parser("rebase", help="Rebase branch and update site")
+    rb.add_argument("branch", help="Target branch to rebase onto")
+    sub.add_parser("sync", help="Sync connectors -> droplet")
+    sub.add_parser("full", help="Run the entire sequence")
+
+    args = parser.parse_args()
+
+    if args.cmd == "push":
+        push_latest()
+    elif args.cmd == "refresh":
+        refresh_all()
+    elif args.cmd == "rebase":
+        rebase_branch(args.branch)
+    elif args.cmd == "sync":
+        sync_connectors()
+    elif args.cmd == "full":
+        refresh_all()
+    else:
+        parser.error("Unknown command")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `blackroad_sync.py` script to orchestrate GitHub push, connector sync, working copy refresh, and droplet deploy

## Testing
- `python -m py_compile scripts/blackroad_sync.py`
- `ruff check scripts/blackroad_sync.py`
- `ruff format scripts/blackroad_sync.py`
- `black scripts/blackroad_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa1a7038d08329be4e80087d8d52b3