### PR TITLE
feat: add blackroad deployment scaffold script

### DIFF
--- a/codex/tools/blackroad_pipeline.py
+++ b/codex/tools/blackroad_pipeline.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Unified deployment scaffolding for BlackRoad.io.
+
+This script provides a placeholder control surface for Codex
+operators. It models the sequential steps required to propagate
+repository changes through GitHub, connector services, working copy
+refreshes, and droplet deployments. Real integrations should replace
+these stubs with concrete logic for the target environment.
+
+Usage examples:
+    python codex/tools/blackroad_pipeline.py push
+    python codex/tools/blackroad_pipeline.py refresh
+    python codex/tools/blackroad_pipeline.py rebase
+    python codex/tools/blackroad_pipeline.py sync
+    python codex/tools/blackroad_pipeline.py all
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from typing import Callable, Dict
+
+
+def run(cmd: str) -> int:
+    """Run a shell command and return the exit code.
+
+    This helper prints the command so operators can follow the flow.
+    """
+    print(f"[blackroad] $ {cmd}")
+    return subprocess.call(cmd, shell=True)
+
+
+def push_latest() -> None:
+    """Push local commits to the default remote."""
+    run("git push")
+
+
+def refresh_working_copy() -> None:
+    """Fast-forward the local checkout."""
+    run("git pull --ff-only")
+
+
+def rebase_branch() -> None:
+    """Rebase current branch onto origin/main."""
+    run("git fetch origin")
+    run("git rebase origin/main")
+
+
+def sync_connectors() -> None:
+    """Placeholder for syncing external systems.
+
+    OAuth flows, webhook listeners and background jobs should be
+    implemented here. This stub merely logs the requested action.
+    """
+    print("sync_connectors: not yet implemented")
+
+
+def deploy_droplet() -> None:
+    """Placeholder for pulling latest code onto the droplet and
+    restarting services.
+
+    Real deployments may use SSH or other orchestration tools to
+    update code, run database migrations and expose health checks.
+    """
+    print("deploy_droplet: not yet implemented")
+
+
+COMMANDS: Dict[str, Callable[[], None]] = {
+    "push": lambda: (push_latest(), deploy_droplet()),
+    "refresh": refresh_working_copy,
+    "rebase": lambda: (rebase_branch(), deploy_droplet()),
+    "sync": lambda: (sync_connectors(), deploy_droplet()),
+    "all": lambda: (push_latest(), sync_connectors(), refresh_working_copy(), deploy_droplet()),
+}
+
+
+def main(argv: list[str]) -> int:
+    cmd = argv[1] if len(argv) > 1 else "all"
+    action = COMMANDS.get(cmd)
+    if action is None:
+        print("Usage: blackroad_pipeline.py [push|refresh|rebase|sync|all]")
+        return 2
+    action()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## Summary
- add `blackroad_pipeline.py` skeleton for unified Codex deployment flow

## Testing
- `pre-commit run --files codex/tools/blackroad_pipeline.py` *(fails: pre-commit not installed)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1a84e04083299fb1226f8edff926