### PR TITLE
Fix local ES model utilities

### DIFF
--- a/local/models.py
+++ b/local/models.py
@@ -1,20 +1,9 @@
-# mypy: ignore-errors
-"""Model definitions for local ES training."""
-
 from __future__ import annotations
+
+"""Lightweight models and utilities for local ES experiments."""
 
 import torch
 from torch import nn, Tensor
-
-
-class MLPPolicy(nn.Module):
-    """Simple MLP policy network."""
-"""Models for local ES experiments."""
-from __future__ import annotations
-
-
-import torch
-from torch import nn
 
 
 class MLPPolicy(nn.Module):
@@ -36,43 +25,50 @@ class MLPPolicy(nn.Module):
 
 def params_to_vector(model: nn.Module) -> Tensor:
     """Flatten model parameters to a 1D tensor."""
+
     return torch.nn.utils.parameters_to_vector(model.parameters())
 
 
 def vector_to_params(vec: Tensor, model: nn.Module) -> None:
     """Load a 1D tensor into a model's parameters."""
+
     torch.nn.utils.vector_to_parameters(vec, model.parameters())
 
 
 def num_params(model: nn.Module) -> int:
     """Return number of parameters in the model."""
+
     return sum(p.numel() for p in model.parameters())
 
 
 def perturb_params(params: Tensor, noise: Tensor, sigma: float) -> Tensor:
-    """Apply noise to parameter vector."""
+    """Apply noise to a parameter vector."""
+
     return params + sigma * noise
-    def forward(self, obs: torch.Tensor) -> torch.Tensor:
-        return self.net(obs)
-
-    def act(self, obs: torch.Tensor) -> int:
-        with torch.no_grad():
-            logits = self.forward(obs)
-            return int(torch.argmax(logits).item())
 
 
-def flatten_params(model: nn.Module) -> torch.Tensor:
-    """Flatten model parameters into a single 1-D tensor."""
+def flatten_params(model: nn.Module) -> Tensor:
+    """Flatten model parameters into a single 1‑D tensor."""
+
     return torch.cat([p.detach().view(-1) for p in model.parameters()])
 
 
-def unflatten_params(model: nn.Module, flat: torch.Tensor) -> None:
+def unflatten_params(model: nn.Module, flat: Tensor) -> None:
     """Load parameters from a flat tensor back into the model."""
+
     pointer = 0
     for p in model.parameters():
         numel = p.numel()
-        p.data.copy_(flat[pointer:pointer + numel].view_as(p))
+        p.data.copy_(flat[pointer : pointer + numel].view_as(p))
         pointer += numel
 
 
-__all__ = ["MLPPolicy", "flatten_params", "unflatten_params"]
+__all__ = [
+    "MLPPolicy",
+    "params_to_vector",
+    "vector_to_params",
+    "num_params",
+    "perturb_params",
+    "flatten_params",
+    "unflatten_params",
+]


### PR DESCRIPTION
## Summary
- clean up `local.models` and provide vectorization helpers

## Testing
- `pre-commit run --all-files` *(fails: CalledProcessError: command: ('/usr/bin/git', 'checkout', 'v3.3.3') )*
- `pytest local/test_vectorization.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'libcst')*


------
https://chatgpt.com/codex/tasks/task_e_68aa4f1b05e0832991717464af1ecb07