### PR TITLE
fix: clear session cookie on logout

### DIFF
--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -4,6 +4,7 @@
 const express = require('express');
 const { hashPassword, verifyPassword, requireAuth } = require('../auth');
 const db = require('../db');
+const { NODE_ENV } = require('../config');
 
 const router = express.Router();
 
@@ -44,6 +45,11 @@ router.post('/login', (req, res) => {
 
 router.post('/logout', requireAuth, (req, res) => {
   req.session = null;
+  res.clearCookie('brsid', {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: NODE_ENV === 'production'
+  });
   res.json({ ok: true });
 });
 


### PR DESCRIPTION
## Summary
- ensure /api/auth/logout clears the brsid cookie so sessions are fully terminated

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Missing script "lint")

------
https://chatgpt.com/codex/tasks/task_e_68aa5ea905e88329b0ebdc7a3f6fcb73