### PR TITLE
feat: add codefix bot service

### DIFF
--- a/CODEFIX.md
+++ b/CODEFIX.md
@@ -1,0 +1,31 @@
+# CodeFix Bot
+
+Autonomous service that watches GitHub for issues labelled `bug`, `fix`, `lint` or comments containing `@codefix fix this`. When triggered it attempts to reproduce the failure, propose a patch via an LLM and open a Pull Request.
+
+## Setup
+
+1. Copy `srv/codefix-bot/.env.example` to `.env` and fill in tokens.
+2. Ensure `/var/log/codefix-bot` is writable.
+3. Start the service:
+   ```bash
+   node srv/codefix-bot/server.js
+   ```
+4. Expose port `4100` as `/api/codefix` through your proxy.
+
+## GitHub Integration
+
+Provide a Personal Access Token with repo scope in `GITHUB_TOKEN`. Configure a webhook on the target repositories pointing to `/api/webhooks/github` using `GITHUB_WEBHOOK_SECRET`.
+
+## Manual Trigger
+
+`POST /api/fix/:repo/:issueId` with header `Authorization: Bearer $INTERNAL_TOKEN` will queue a job. Append `?dry=true` for dry-run mode.
+
+## Logs
+
+Job logs are written to `/var/log/codefix-bot/` and listed via `GET /api/jobs`.
+
+## Safety
+
+* Branch names use `codefix/*`.
+* Max diff applied is limited by the LLM prompt.
+* Requires PR review before merge.

--- a/srv/codefix-bot/.env.example
+++ b/srv/codefix-bot/.env.example
@@ -1,0 +1,4 @@
+GITHUB_TOKEN=ghp_xxxxx
+GITHUB_WEBHOOK_SECRET=change-me
+LLM_URL=http://127.0.0.1:8000/generate
+INTERNAL_TOKEN=change-me

--- a/srv/codefix-bot/server.js
+++ b/srv/codefix-bot/server.js
@@ -1,0 +1,116 @@
+const express = require('express');
+const crypto = require('crypto');
+const { spawn } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+const PORT = process.env.PORT || 4100;
+const LOG_DIR = '/var/log/codefix-bot';
+const GITHUB_WEBHOOK_SECRET = process.env.GITHUB_WEBHOOK_SECRET || '';
+const INTERNAL_TOKEN = process.env.INTERNAL_TOKEN || '';
+
+// Ensure log directory exists
+fs.mkdirSync(LOG_DIR, { recursive: true });
+
+const app = express();
+app.use(express.json());
+
+// Simple in-memory job queue
+const jobs = [];
+let running = false;
+
+function verifySignature(req) {
+  const signature = req.header('X-Hub-Signature-256');
+  if (!signature) return false;
+  const body = JSON.stringify(req.body);
+  const hmac = crypto.createHmac('sha256', GITHUB_WEBHOOK_SECRET);
+  const digest = 'sha256=' + hmac.update(body).digest('hex');
+  return crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(digest));
+}
+
+function runNextJob() {
+  if (running) return;
+  const job = jobs.shift();
+  if (!job) return;
+  running = true;
+
+  const logFile = path.join(LOG_DIR, `${job.id}.log`);
+  const out = fs.createWriteStream(logFile);
+
+  const args = [job.repo, job.issueId];
+  if (job.dryRun) args.push('--dry-run');
+
+  const proc = spawn('/usr/local/bin/codefix-run.sh', args);
+  proc.stdout.pipe(out);
+  proc.stderr.pipe(out);
+  proc.on('close', code => {
+    job.status = code === 0 ? 'success' : 'failed';
+    job.log = logFile;
+    running = false;
+    runNextJob();
+  });
+}
+
+app.post('/api/webhooks/github', (req, res) => {
+  if (!verifySignature(req)) {
+    return res.status(401).send('Invalid signature');
+  }
+  const event = req.header('X-GitHub-Event');
+  const payload = req.body;
+  let trigger = false;
+  if (event === 'issues') {
+    const labels = payload.issue.labels.map(l => l.name);
+    trigger = labels.some(l => ['bug', 'fix', 'lint'].includes(l));
+  } else if (event === 'issue_comment') {
+    trigger = payload.comment.body.includes('@codefix fix this');
+  }
+  if (trigger) {
+    const job = {
+      id: Date.now().toString(),
+      repo: payload.repository.full_name,
+      issueId: payload.issue ? payload.issue.number : payload.issue_number,
+      status: 'queued',
+      dryRun: false
+    };
+    jobs.push(job);
+    runNextJob();
+  }
+  res.json({ ok: true });
+});
+
+app.post('/api/fix/:repo/:issueId', (req, res) => {
+  if (req.header('Authorization') !== `Bearer ${INTERNAL_TOKEN}`) {
+    return res.status(403).send('Forbidden');
+  }
+  const job = {
+    id: Date.now().toString(),
+    repo: req.params.repo,
+    issueId: req.params.issueId,
+    status: 'queued',
+    dryRun: !!req.query.dry
+  };
+  jobs.push(job);
+  runNextJob();
+  res.json({ job });
+});
+
+app.get('/api/jobs', (req, res) => {
+  res.json(jobs);
+});
+
+app.get('/admin', (req, res) => {
+  res.send(`<!DOCTYPE html>
+<html><head><title>CodeFix Jobs</title></head>
+<body><h1>Jobs</h1><pre id="jobs"></pre>
+<script>
+fetch('/api/jobs').then(r=>r.json()).then(j=>{
+  document.getElementById('jobs').textContent = JSON.stringify(j, null, 2);
+});
+</script></body></html>`);
+});
+
+app.listen(PORT, () => {
+  console.log(`codefix-bot listening on ${PORT}`);
+});
+
+module.exports = app;

--- a/usr/local/bin/codefix-run.sh
+++ b/usr/local/bin/codefix-run.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -euo pipefail
+
+REPO="$1"
+ISSUE="$2"
+DRY_RUN="${3:-}"
+WORKDIR=$(mktemp -d)
+LOGPREFIX="[codefix]"
+
+echo "$LOGPREFIX cloning $REPO to $WORKDIR"
+cd "$WORKDIR"
+
+git clone "https://github.com/$REPO.git" repo
+cd repo
+
+BRANCH="codefix/$ISSUE-$(date +%s)"
+
+git checkout -b "$BRANCH"
+
+if npm run lint >/tmp/lint.log 2>&1 && npm test >/tmp/test.log 2>&1; then
+  echo "$LOGPREFIX no issues detected"
+  exit 0
+fi
+
+ERRORS=$(cat /tmp/lint.log /tmp/test.log 2>/dev/null)
+
+echo "$LOGPREFIX requesting patch from LLM"
+PATCH=$(curl -s -X POST -H 'Content-Type: application/json' -d "{\"errors\": \"$ERRORS\"}" "${LLM_URL:-http://127.0.0.1:8000/generate}")
+
+echo "$PATCH" | git apply --reject --whitespace=fix
+
+git commit -am "chore: codefix for issue #$ISSUE"
+
+if [ "$DRY_RUN" = "--dry-run" ]; then
+  echo "$LOGPREFIX dry run - skipping push and PR"
+  exit 0
+fi
+
+git push origin "$BRANCH"
+
+curl -s -X POST -H "Authorization: token $GITHUB_TOKEN" \
+  -d "{\"title\": \"Codefix for issue #$ISSUE\", \"head\": \"$BRANCH\", \"base\": \"main\"}" \
+  "https://api.github.com/repos/$REPO/pulls"
+
+echo "$LOGPREFIX job complete"


### PR DESCRIPTION
## Summary
- scaffold codefix bot express service with webhook and job queue
- add run script and env example
- document setup in CODEFIX.md

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5f0fb0e48329a2c92ff1e9f02941