### PR TITLE
feat: add subscribe health endpoint

### DIFF
--- a/srv/blackroad-api/server_full.js
+++ b/srv/blackroad-api/server_full.js
@@ -325,6 +325,16 @@ app.get('/api/connectors/status', (req, res) => {
   res.json({ stripe, mail, sheets, calendar, discord, webhooks });
 });
 
+// Basic health endpoint exposing provider mode
+app.get('/api/subscribe/health', (_req, res) => {
+  const mode = process.env.SUBSCRIBE_MODE || (process.env.STRIPE_SECRET ? 'stripe' : process.env.GUMROAD_TOKEN ? 'gumroad' : 'local');
+  let providerReady = false;
+  if (mode === 'stripe') providerReady = !!process.env.STRIPE_SECRET;
+  else if (mode === 'gumroad') providerReady = !!process.env.GUMROAD_TOKEN;
+  else providerReady = true;
+  res.json({ ok: true, mode, providerReady });
+});
+
 app.post('/api/subscribe/checkout', (req, res) => {
   const { plan, cycle } = req.body || {};
   if (!VALID_PLANS.includes(plan) || !VALID_CYCLES.includes(cycle)) {


### PR DESCRIPTION
## Summary
- add `/api/subscribe/health` endpoint to reveal subscription provider mode and readiness

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*
- `pre-commit run --files srv/blackroad-api/server_full.js` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5b6a0dc48329a309be64ddf5a766