### PR TITLE
Add minimal Lucidia backend agents and API server

### DIFF
--- a/srv/blackroad-backend/agents/__init__.py
+++ b/srv/blackroad-backend/agents/__init__.py
@@ -1,0 +1,1 @@
+"""Utility agents for the Lucidia API backend."""

--- a/srv/blackroad-backend/agents/guardian.py
+++ b/srv/blackroad-backend/agents/guardian.py
@@ -1,0 +1,17 @@
+"""Guardian agent that performs a basic integrity check."""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+class Guardian:
+    """Verifies that the memory directory exists and is readable."""
+
+    def __init__(self, memory_dir: str | Path) -> None:
+        self.memory_path = Path(memory_dir)
+
+    def verify_integrity(self) -> str:
+        """Return a simple integrity status message."""
+        if self.memory_path.is_dir():
+            return "memory directory present"
+        return "memory directory missing"

--- a/srv/blackroad-backend/agents/roadie.py
+++ b/srv/blackroad-backend/agents/roadie.py
@@ -1,0 +1,29 @@
+"""Simple file-based search agent."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Dict
+
+
+class Roadie:
+    """Searches text files in a memory directory for a query string."""
+
+    def __init__(self, memory_dir: str | Path) -> None:
+        self.memory_path = Path(memory_dir)
+
+    def search(self, query: str) -> List[Dict[str, str]]:
+        """Return list of files containing the query with small snippets."""
+        results: List[Dict[str, str]] = []
+        if not self.memory_path.is_dir():
+            return results
+
+        for path in self.memory_path.rglob("*"):
+            if path.is_file():
+                try:
+                    text = path.read_text(encoding="utf-8", errors="ignore")
+                except OSError:
+                    continue
+                if query.lower() in text.lower():
+                    snippet = text[:200]
+                    results.append({"file": str(path), "snippet": snippet})
+        return results

--- a/srv/blackroad-backend/api/__init__.py
+++ b/srv/blackroad-backend/api/__init__.py
@@ -1,0 +1,1 @@
+# intentionally empty

--- a/srv/blackroad-backend/api/server.py
+++ b/srv/blackroad-backend/api/server.py
@@ -1,0 +1,31 @@
+"""
+Lucidia API Server – WebSocket + REST
+Exposes Roadie and Guardian functions via simple endpoints.
+"""
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from agents.roadie import Roadie
+from agents.guardian import Guardian
+
+app = FastAPI(title="Lucidia API")
+
+# Instantiate agents pointing at the memory directory
+roadie = Roadie(memory_dir="/srv/blackroad-backend/memory")
+guardian = Guardian(memory_dir="/srv/blackroad-backend/memory")
+
+
+@app.get("/")
+def home():
+    return {"status": "Lucidia API online"}
+
+
+@app.get("/search/{query}")
+def search(query: str):
+    results = roadie.search(query)
+    return JSONResponse(content={"results": results})
+
+
+@app.get("/audit")
+def audit():
+    result = guardian.verify_integrity()
+    return JSONResponse(content={"result": result})


### PR DESCRIPTION
## Summary
- add basic Roadie and Guardian agents to back-end
- wire up FastAPI server exposing search and audit endpoints

## Testing
- `pre-commit run --files srv/blackroad-backend/api/__init__.py srv/blackroad-backend/api/server.py srv/blackroad-backend/agents/__init__.py srv/blackroad-backend/agents/roadie.py srv/blackroad-backend/agents/guardian.py` *(fails: pathspec 'v3.3.3' did not match)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'libcst', torch, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68aa652ff1848329bc6345d712243b7f