### PR TITLE
feat: add skeleton json connector layer

### DIFF
--- a/src/json/sqlite.js
+++ b/src/json/sqlite.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const db = require('../db');
+
+function list(resource, params) {
+  const limit = Number(params.limit) || 20;
+  const offset = Number(params.offset) || 0;
+  const sort = params.sort;
+  const fields = params.fields;
+  const filters = params.filters || {};
+
+  let sql = `SELECT * FROM ${resource}`;
+  const where = [];
+  const values = [];
+  for (const [field, value] of Object.entries(filters)) {
+    where.push(`${field} = ?`);
+    values.push(value);
+  }
+  if (where.length) sql += ' WHERE ' + where.join(' AND ');
+  if (sort) {
+    const dir = sort.startsWith('-') ? 'DESC' : 'ASC';
+    const col = sort.startsWith('-') ? sort.slice(1) : sort;
+    sql += ` ORDER BY ${col} ${dir}`;
+  }
+  sql += ' LIMIT ? OFFSET ?';
+  values.push(limit, offset);
+
+  const rows = db.prepare(sql).all(...values);
+  const count = db.prepare(`SELECT COUNT(*) as c FROM ${resource}`).get().c;
+
+  let result = rows;
+  if (Array.isArray(fields) && fields.length) {
+    result = rows.map(row => {
+      const obj = {};
+      for (const f of fields) if (Object.prototype.hasOwnProperty.call(row, f)) obj[f] = row[f];
+      return obj;
+    });
+  }
+
+  return { rows: result, count };
+}
+
+function get(resource, id) {
+  return db.prepare(`SELECT * FROM ${resource} WHERE id = ?`).get(id) || null;
+}
+
+module.exports = {
+  name: 'sqlite',
+  list,
+  get,
+};

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -18,6 +18,7 @@ router.use('/metrics', require('./metrics'));
 router.use('/llm', require('./llm'));
 router.use('/roadbook', require('./roadbook'));
 router.use('/deploy', require('./deploy'));
+router.use('/json', require('./json'));
 const subscribe = require('./subscribe');
 router.use('/', subscribe.router);
 

--- a/src/routes/json.js
+++ b/src/routes/json.js
@@ -1,0 +1,64 @@
+// FILE: /srv/blackroad-api/src/routes/json.js
+'use strict';
+
+const express = require('express');
+const router = express.Router();
+const sqlite = require('../json/sqlite');
+
+const adapters = {
+  sqlite,
+};
+
+function envelope(ok, data, meta) {
+  if (ok) return { ok, data, meta };
+  return { ok, error: data };
+}
+
+function parseQuery(q) {
+  const params = {
+    limit: q.limit,
+    offset: q.offset,
+    sort: q.sort,
+    fields: q.fields ? String(q.fields).split(',').filter(Boolean) : undefined,
+    filters: {},
+  };
+  for (const key of Object.keys(q)) {
+    const m = key.match(/^filter\[(.+)\]$/);
+    if (m) params.filters[m[1]] = q[key];
+  }
+  return params;
+}
+
+router.get('/health', (req, res) => {
+  res.json(envelope(true, { status: 'ok' }));
+});
+
+router.get('/:source/:resource', (req, res) => {
+  const { source, resource } = req.params;
+  const adapter = adapters[source];
+  if (!adapter) return res.status(404).json(envelope(false, { code: 'NOT_FOUND', message: 'unknown source' }));
+  try {
+    const params = parseQuery(req.query);
+    const { rows, count } = adapter.list(resource, params);
+    const meta = { count, next: null, prev: null, source, resource };
+    res.json(envelope(true, rows, meta));
+  } catch (e) {
+    res.status(500).json(envelope(false, { code: 'INTERNAL', message: e.message }));
+  }
+});
+
+router.get('/:source/:resource/:id', (req, res) => {
+  const { source, resource, id } = req.params;
+  const adapter = adapters[source];
+  if (!adapter) return res.status(404).json(envelope(false, { code: 'NOT_FOUND', message: 'unknown source' }));
+  try {
+    const row = adapter.get(resource, id);
+    if (!row) return res.status(404).json(envelope(false, { code: 'NOT_FOUND', message: 'not found' }));
+    const meta = { source, resource };
+    res.json(envelope(true, row, meta));
+  } catch (e) {
+    res.status(500).json(envelope(false, { code: 'INTERNAL', message: e.message }));
+  }
+});
+
+module.exports = router;

--- a/srv/blackroad-api/json.connectors.config.json
+++ b/srv/blackroad-api/json.connectors.config.json
@@ -1,0 +1,5 @@
+{
+  "adapters": {
+    "sqlite": { "db": "./db/blackroad.db" }
+  }
+}


### PR DESCRIPTION
## Summary
- add initial sqlite adapter and /api/json router
- wire new router into API and add sample connector config

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Missing script "lint")
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aaa2d433748329ada20096d0b2f5c7