### PR TITLE
feat: expose lucidia API route

### DIFF
--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -16,6 +16,7 @@ router.use('/contradictions', require('./contradictions'));
 router.use('/commits', require('./commits'));
 router.use('/metrics', require('./metrics'));
 router.use('/llm', require('./llm'));
+router.use('/lucidia', require('./lucidia'));
 router.use('/roadbook', require('./roadbook'));
 router.use('/deploy', require('./deploy'));
 router.use('/json', require('./json'));

--- a/src/routes/lucidia.js
+++ b/src/routes/lucidia.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const express = require('express');
+const { requireAuth } = require('../auth');
+const llmService = require('../services/llmService');
+
+const router = express.Router();
+
+router.get('/health', (req, res) => {
+  res.json({ ok: true, service: 'lucidia' });
+});
+
+router.post('/chat', requireAuth, async (req, res) => {
+  try {
+    const { messages } = req.body || {};
+    if (!Array.isArray(messages)) {
+      return res.status(400).json({ ok: false, error: 'invalid_messages' });
+    }
+    const result = await llmService.chat(messages);
+    res.json({ ok: true, ...result });
+  } catch (e) {
+    res.status(500).json({ ok: false, error: 'lucidia_failed', detail: String(e) });
+  }
+});
+
+module.exports = router;

--- a/tests/lucidia-route.test.js
+++ b/tests/lucidia-route.test.js
@@ -1,0 +1,15 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const lucidia = require('../src/routes/lucidia');
+
+test('GET /lucidia/health', async () => {
+  const app = express();
+  app.use('/lucidia', lucidia);
+  const server = app.listen(0);
+  const port = server.address().port;
+  const res = await fetch(`http://127.0.0.1:${port}/lucidia/health`);
+  const json = await res.json();
+  assert.deepEqual(json, { ok: true, service: 'lucidia' });
+  server.close();
+});


### PR DESCRIPTION
## Summary
- add `/api/lucidia` Express router with `/health` and `/chat`
- wire new router in main API index and include basic health test

## Testing
- `npx eslint -c .eslintrc.cjs src/routes/lucidia.js src/routes/index.js tests/lucidia-route.test.js` *(fails: A config object is using the "env" key, which is not supported in flat config system)*
- `pre-commit run --files src/routes/lucidia.js src/routes/index.js tests/lucidia-route.test.js` *(fails: pathspec 'v3.3.3' did not match any file(s) known to git)*
- `npm install` *(fails: 503 Service Unavailable)*
- `node --test tests/lucidia-route.test.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68aaa7ee78448329b6f0c6b7d3f5638b