### PR TITLE
feat: add br-fix tool and json health etag

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,0 +1,6 @@
+<!-- FILE: /srv/blackroad-api/DECISIONS.md -->
+# Decisions
+
+- Implemented a minimal `br-fix` CLI under `srv/blackroad-tools/br-fix` handling scan, apply, and test commands.
+- Backup during `br-fix apply` only captures `src/routes/json.js` to keep repository footprint small.
+- Added ETag generation to `/api/json/health` response for cache friendliness.

--- a/src/routes/json.js
+++ b/src/routes/json.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const express = require('express');
+const crypto = require('crypto');
 const router = express.Router();
 const sqlite = require('../json/sqlite');
 
@@ -30,7 +31,10 @@ function parseQuery(q) {
 }
 
 router.get('/health', (req, res) => {
-  res.json(envelope(true, { status: 'ok' }));
+  const payload = envelope(true, { status: 'ok' });
+  const etag = crypto.createHash('sha1').update(JSON.stringify(payload)).digest('hex');
+  res.set('ETag', `"${etag}"`);
+  res.json(payload);
 });
 
 router.get('/:source/:resource', (req, res) => {

--- a/srv/blackroad-tools/br-fix/bin/br-fix.js
+++ b/srv/blackroad-tools/br-fix/bin/br-fix.js
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+// FILE: /srv/blackroad-tools/br-fix/bin/br-fix.js
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+function run(cmd) {
+  try {
+    execSync(cmd, { stdio: 'inherit' });
+    return { cmd, ok: true };
+  } catch (e) {
+    return { cmd, ok: false, error: e.message };
+  }
+}
+
+function writeJSON(file, obj) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(obj, null, 2));
+}
+
+const args = process.argv.slice(2);
+const cmd = args[0];
+const repoIdx = args.indexOf('--repo');
+const repo = repoIdx >= 0 ? args[repoIdx + 1] : process.cwd();
+
+switch (cmd) {
+  case 'scan': {
+    const outIdx = args.indexOf('--out');
+    const out = outIdx >= 0 ? args[outIdx + 1] : path.join(__dirname, '../reports/scan.json');
+    const results = [];
+    results.push(run(`npx eslint ${path.join(repo, 'src/routes/json.js')}`));
+    const pyFiles = execSync(`git -C ${repo} ls-files '*.py'`, { encoding: 'utf8' }).trim().split('\n').filter(Boolean);
+    if (pyFiles.length) {
+      results.push(run(`python -m py_compile ${pyFiles.map(f => path.join(repo, f)).join(' ')}`));
+    }
+    writeJSON(out, { summary: results });
+    break;
+  }
+  case 'apply': {
+    const backupIdx = args.indexOf('--backup');
+    if (backupIdx >= 0) {
+      const dest = args[backupIdx + 1];
+      const ts = new Date().toISOString().replace(/[-:]/g, '').replace(/\..*/, '');
+      const dir = path.join(dest, ts);
+      fs.mkdirSync(dir, { recursive: true });
+      fs.copyFileSync(path.join(repo, 'src/routes/json.js'), path.join(dir, 'json.js'));
+      fs.writeFileSync(path.join(dir, 'restore.sh'), "#!/usr/bin/env bash\ncp json.js " + path.join(repo, 'src/routes/json.js') + "\n");
+    }
+    console.log('No patches applied');
+    break;
+  }
+  case 'test': {
+    run(`npm test --prefix ${repo}`);
+    break;
+  }
+  case 'report': {
+    console.log('Reports stored in', path.join(__dirname, '../reports'));
+    break;
+  }
+  default:
+    console.log('Usage: br-fix <scan|apply|test|report> [--repo path]');
+}

--- a/srv/blackroad-tools/br-fix/package.json
+++ b/srv/blackroad-tools/br-fix/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "br-fix",
+  "version": "0.1.0",
+  "bin": {
+    "br-fix": "bin/br-fix.js"
+  },
+  "scripts": {
+    "postinstall": "mkdir -p node_modules/.bin && ln -sf ../bin/br-fix.js node_modules/.bin/br-fix"
+  }
+}


### PR DESCRIPTION
## Summary
- add small `br-fix` CLI for scanning, backups, and testing
- expose ETag header on `/api/json/health` responses
- record implementation choices in `DECISIONS.md`

## Testing
- `npx --yes eslint src/routes/json.js` *(fails: ESLint couldn't find configuration)*
- `npm test` *(fails: Missing script "test")*
- `pre-commit run --files src/routes/json.js srv/blackroad-tools/br-fix/bin/br-fix.js srv/blackroad-tools/br-fix/package.json DECISIONS.md` *(fails: CalledProcessError: pathspec 'v3.3.3')*
- `node srv/blackroad-tools/br-fix/bin/br-fix.js scan --repo . --out /tmp/scan.json` *(reports ESLint and Python errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa4b41d3c83298bab7fee63790dca