### PR TITLE
feat: add stubbed subscribe connectors flow

### DIFF
--- a/frontend/src/subscribeApi.js
+++ b/frontend/src/subscribeApi.js
@@ -25,3 +25,23 @@ export async function fetchFeatureGates(){
   const { data } = await axios.get(`${API_BASE}/api/subscribe/feature-gates`);
   return data;
 }
+
+export async function startConnector(service){
+  const { data } = await axios.get(`${API_BASE}/api/connect/google/start?service=${service}`);
+  return data;
+}
+
+export async function revokeConnector(service){
+  const { data } = await axios.post(`${API_BASE}/api/connect/google/revoke`, { service });
+  return data;
+}
+
+export async function fetchOnboardingSlots(){
+  const { data } = await axios.get(`${API_BASE}/api/subscribe/onboarding/slots`);
+  return data;
+}
+
+export async function bookOnboarding(slot){
+  const { data } = await axios.post(`${API_BASE}/api/subscribe/onboarding/book`, { slot });
+  return data;
+}

--- a/src/routes/connect.js
+++ b/src/routes/connect.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const express = require('express');
+const router = express.Router();
+const { requireAuth } = require('../auth');
+const store = require('../services/connectorStore');
+
+const SERVICES = ['gmail','calendar','contacts'];
+
+router.get('/google/start', requireAuth, (req,res)=>{
+  const { service } = req.query;
+  if(!SERVICES.includes(service)) return res.status(400).json({ ok:false, error:'invalid_service' });
+  // In real implementation, build Google OAuth URL. Here, return redirect placeholder.
+  const url = (process.env.GOOGLE_REDIRECT_URI || '/subscribe') + `?connected=${service}`;
+  res.json({ url });
+});
+
+router.get('/google/callback', requireAuth, (req,res)=>{
+  const { service } = req.query;
+  if(!SERVICES.includes(service)) return res.status(400).send('invalid_service');
+  store.connect(req.session.userId, service);
+  res.redirect(`/subscribe?connected=${service}`);
+});
+
+router.post('/google/revoke', requireAuth, (req,res)=>{
+  const { service } = req.body || {};
+  if(!SERVICES.includes(service)) return res.status(400).json({ ok:false, error:'invalid_service' });
+  store.revoke(req.session.userId, service);
+  res.json({ ok:true });
+});
+
+module.exports = router;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -19,6 +19,7 @@ router.use('/llm', require('./llm'));
 router.use('/roadbook', require('./roadbook'));
 router.use('/deploy', require('./deploy'));
 router.use('/json', require('./json'));
+router.use('/connect', require('./connect'));
 const subscribe = require('./subscribe');
 router.use('/', subscribe.router);
 

--- a/src/services/connectorStore.js
+++ b/src/services/connectorStore.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const store = {};
+
+function connect(userId, service){
+  if(!userId || !service) return;
+  if(!store[userId]) store[userId] = {};
+  store[userId][service] = { connectedAt: Date.now() };
+}
+
+function revoke(userId, service){
+  if(store[userId]) delete store[userId][service];
+}
+
+function getStatus(userId){
+  const s = store[userId] || {};
+  return {
+    gmail: !!s.gmail,
+    calendar: !!s.calendar,
+    contacts: !!s.contacts
+  };
+}
+
+module.exports = { connect, revoke, getStatus };


### PR DESCRIPTION
## Summary
- add in-memory connector store and express routes for Google service stubs
- extend subscription API with dev success and onboarding placeholder endpoints
- enhance Subscribe React page with connector, onboarding, and finish sections

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --test tests/subscribe.validators.mjs`
- `npx eslint frontend/src/Subscribe.jsx frontend/src/subscribeApi.js src/routes/subscribe.js src/routes/connect.js src/services/connectorStore.js` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68ab366ca258832987684792a6b3662b