### PR TITLE
feat(mci): add basic math compute service

### DIFF
--- a/docs/mci/README.md
+++ b/docs/mci/README.md
@@ -1,0 +1,20 @@
+# MCI API
+
+This module provides a minimal Math×Code Integrator (MCI) service.
+
+## Endpoints
+
+- `POST /api/mci/compute` – evaluate a mathematical expression using a Python sandbox.
+- `GET /api/mci/health` – report enabled capabilities and cache stats.
+
+## Example
+
+```bash
+curl -X POST http://localhost:4000/api/mci/compute \
+  -H 'Content-Type: application/json' \
+  -d '{"expr":"1+1","mode":"numeric"}'
+```
+
+## Rollback
+
+Remove the router mount in `server_full.js` and delete the `srv/blackroad-api/mci` directory.

--- a/server_full.js
+++ b/server_full.js
@@ -78,6 +78,10 @@ const db = require('./src/db');
 const apiRouter = require('./src/routes');
 app.use('/api', apiRouter);
 
+// MCI routes
+const mciRouter = require('./srv/blackroad-api/mci/routes/mci.routes');
+app.use('/api/mci', mciRouter);
+
 // Root
 app.get('/', (req, res) => {
   res.status(200).json({ ok: true, service: 'blackroad-api', env: NODE_ENV || 'dev' });

--- a/srv/blackroad-api/mci/routes/mci.autodiff.js
+++ b/srv/blackroad-api/mci/routes/mci.autodiff.js
@@ -1,0 +1,3 @@
+module.exports = async (req, res) => {
+  res.status(501).json({ error: 'UNSUPPORTED' });
+};

--- a/srv/blackroad-api/mci/routes/mci.controller.js
+++ b/srv/blackroad-api/mci/routes/mci.controller.js
@@ -1,0 +1,59 @@
+const path = require('path');
+const { spawn } = require('child_process');
+const cache = require('../services/mci.cache');
+const logger = require('../services/mci.logger');
+const solver = require('./mci.solver');
+const autodiff = require('./mci.autodiff');
+const explain = require('./mci.explain');
+const health = require('./mci.health');
+
+function runPython(payload, timeout) {
+  return new Promise((resolve, reject) => {
+    const script = path.join(__dirname, '../sandbox/runner.py');
+    const proc = spawn('python3', [script]);
+    let out = '';
+    let err = '';
+    proc.stdout.on('data', d => (out += d));
+    proc.stderr.on('data', d => (err += d));
+    proc.on('close', code => {
+      if (code !== 0) return reject(new Error(err || 'runner error'));
+      try {
+        resolve(JSON.parse(out));
+      } catch (e) {
+        reject(e);
+      }
+    });
+    proc.stdin.write(JSON.stringify(payload));
+    proc.stdin.end();
+    setTimeout(() => {
+      proc.kill('SIGKILL');
+      reject(new Error('timeout'));
+    }, timeout);
+  });
+}
+
+async function compute(req, res) {
+  const payload = req.mci;
+  const cacheKey = JSON.stringify({ expr: payload.expr, vars: payload.vars, mode: payload.mode, precision: payload.precision });
+  const cached = cache.get(cacheKey);
+  if (cached) {
+    logger.log({ rid: req.id, route: 'compute', cache_hit: true });
+    return res.json({ ...cached, cache_hit: true });
+  }
+  try {
+    const result = await runPython(payload, payload.timeout_ms);
+    cache.set(cacheKey, result);
+    logger.log({ rid: req.id, route: 'compute', cache_hit: false });
+    res.json(result);
+  } catch (e) {
+    res.status(400).json({ error: 'BAD_INPUT', message: e.message });
+  }
+}
+
+module.exports = {
+  compute,
+  solve: solver,
+  autodiff,
+  explain,
+  health
+};

--- a/srv/blackroad-api/mci/routes/mci.explain.js
+++ b/srv/blackroad-api/mci/routes/mci.explain.js
@@ -1,0 +1,3 @@
+module.exports = async (req, res) => {
+  res.status(501).json({ error: 'UNSUPPORTED' });
+};

--- a/srv/blackroad-api/mci/routes/mci.health.js
+++ b/srv/blackroad-api/mci/routes/mci.health.js
@@ -1,0 +1,13 @@
+const { spawnSync } = require('child_process');
+const cache = require('../services/mci.cache');
+
+module.exports = (req, res) => {
+  let versions = {};
+  try {
+    const py = spawnSync('python3', ['-c', 'import json, sympy, mpmath; print(json.dumps({"sympy": sympy.__version__, "mpmath": mpmath.__version__}))']);
+    versions = JSON.parse(py.stdout.toString() || '{}');
+  } catch (e) {
+    versions = { error: 'python_missing' };
+  }
+  res.json({ ok: true, versions, cache: cache.stats(), capabilities: { compute: true, solve: false, autodiff: false, explain: false } });
+};

--- a/srv/blackroad-api/mci/routes/mci.routes.js
+++ b/srv/blackroad-api/mci/routes/mci.routes.js
@@ -1,0 +1,21 @@
+const express = require('express');
+const { randomUUID } = require('crypto');
+const validators = require('./mci.validators');
+const controller = require('./mci.controller');
+const limiter = require('../services/mci.limiter');
+
+const router = express.Router();
+router.use(express.json({ limit: '32kb' }));
+router.use(limiter);
+router.use((req, res, next) => {
+  req.id = randomUUID();
+  next();
+});
+
+router.post('/compute', validators.compute, controller.compute);
+router.post('/solve', validators.solve, controller.solve);
+router.post('/autodiff', validators.autodiff, controller.autodiff);
+router.post('/explain', validators.explain, controller.explain);
+router.get('/health', controller.health);
+
+module.exports = router;

--- a/srv/blackroad-api/mci/routes/mci.solver.js
+++ b/srv/blackroad-api/mci/routes/mci.solver.js
@@ -1,0 +1,3 @@
+module.exports = async (req, res) => {
+  res.status(501).json({ error: 'UNSUPPORTED' });
+};

--- a/srv/blackroad-api/mci/routes/mci.validators.js
+++ b/srv/blackroad-api/mci/routes/mci.validators.js
@@ -1,0 +1,32 @@
+function clamp(val, min, max, def) {
+  const n = Number(val);
+  if (Number.isNaN(n)) return def;
+  return Math.max(min, Math.min(max, n));
+}
+
+function compute(req, res, next) {
+  const body = req.body || {};
+  if (typeof body.expr !== 'string') {
+    return res.status(400).json({ error: 'BAD_INPUT' });
+  }
+  const mode = body.mode || 'both';
+  if (!['symbolic', 'numeric', 'both'].includes(mode)) {
+    return res.status(400).json({ error: 'BAD_INPUT' });
+  }
+  const precision = clamp(body.precision, 32, 4096, 64);
+  const timeout_ms = clamp(body.timeout_ms, 0, 10000, 2000);
+  req.mci = { expr: body.expr, mode, vars: body.vars || {}, assumptions: body.assumptions || {}, precision, timeout_ms };
+  next();
+}
+
+function passthrough(req, res, next) {
+  req.mci = req.body || {};
+  next();
+}
+
+module.exports = {
+  compute,
+  solve: passthrough,
+  autodiff: passthrough,
+  explain: passthrough
+};

--- a/srv/blackroad-api/mci/sandbox/env_whitelist.txt
+++ b/srv/blackroad-api/mci/sandbox/env_whitelist.txt
@@ -1,0 +1,3 @@
+sympy
+mpmath
+numpy

--- a/srv/blackroad-api/mci/sandbox/requirements.txt
+++ b/srv/blackroad-api/mci/sandbox/requirements.txt
@@ -1,0 +1,3 @@
+sympy
+mpmath
+numpy

--- a/srv/blackroad-api/mci/sandbox/runner.py
+++ b/srv/blackroad-api/mci/sandbox/runner.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+import json, sys
+import sympy as sp
+
+def main():
+    try:
+        data = json.load(sys.stdin)
+        expr = data.get("expr", "")
+        mode = data.get("mode", "both")
+        vars_dict = data.get("vars", {}) or {}
+        precision = int(data.get("precision", 64))
+        precision = max(32, min(precision, 4096))
+        sym = sp.sympify(expr)
+        tree = str(sym)
+        result = {"id": "mci_req", "mode": mode, "warnings": [], "cache_hit": False}
+        if mode in ("symbolic", "both"):
+            result["symbolic"] = {"latex": sp.latex(sym), "tree": tree}
+        if mode in ("numeric", "both"):
+            subs = {sp.symbols(k): v for k, v in vars_dict.items()}
+            numeric_val = float(sym.evalf(precision, subs=subs))
+            result["numeric"] = {"value": numeric_val, "units": None, "precision": precision}
+        result["duration_ms"] = 0
+        json.dump(result, sys.stdout)
+    except Exception as e:
+        json.dump({"error": str(e)}, sys.stdout)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/srv/blackroad-api/mci/services/mci.cache.js
+++ b/srv/blackroad-api/mci/services/mci.cache.js
@@ -1,0 +1,13 @@
+const cache = new Map();
+const MAX = 100;
+module.exports = {
+  get: (k) => cache.get(k),
+  set: (k, v) => {
+    if (cache.size >= MAX) {
+      const first = cache.keys().next().value;
+      cache.delete(first);
+    }
+    cache.set(k, v);
+  },
+  stats: () => ({ size: cache.size })
+};

--- a/srv/blackroad-api/mci/services/mci.limiter.js
+++ b/srv/blackroad-api/mci/services/mci.limiter.js
@@ -1,0 +1,16 @@
+const hits = new Map();
+module.exports = (req, res, next) => {
+  const now = Date.now();
+  const ip = req.ip || 'global';
+  const entry = hits.get(ip) || { count: 0, ts: now };
+  if (now - entry.ts > 60 * 1000) {
+    entry.count = 0;
+    entry.ts = now;
+  }
+  entry.count++;
+  hits.set(ip, entry);
+  if (entry.count > 60) {
+    return res.status(429).json({ error: 'RATE_LIMIT' });
+  }
+  next();
+};

--- a/srv/blackroad-api/mci/services/mci.logger.js
+++ b/srv/blackroad-api/mci/services/mci.logger.js
@@ -1,0 +1,9 @@
+module.exports = {
+  log: (info) => {
+    try {
+      console.log(JSON.stringify(info));
+    } catch (err) {
+      console.log('mci_logger_error', err);
+    }
+  }
+};

--- a/srv/blackroad-api/mci/tests/mci.e2e.spec.js
+++ b/srv/blackroad-api/mci/tests/mci.e2e.spec.js
@@ -1,0 +1,30 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const express = require('express');
+const router = require('../routes/mci.routes');
+
+function setup() {
+  const app = express();
+  app.use('/api/mci', router);
+  return new Promise(resolve => {
+    const server = app.listen(0, () => {
+      const port = server.address().port;
+      resolve({ server, base: `http://127.0.0.1:${port}/api/mci` });
+    });
+  });
+}
+
+test('compute caching and health', async () => {
+  const { server, base } = await setup();
+  const body = { expr: '1+2', mode: 'numeric' };
+  let res = await fetch(base + '/compute', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+  let json = await res.json();
+  assert.equal(json.cache_hit, false);
+  res = await fetch(base + '/compute', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+  json = await res.json();
+  assert.equal(json.cache_hit, true);
+  const healthRes = await fetch(base + '/health');
+  const health = await healthRes.json();
+  assert.ok(health.versions);
+  server.close();
+});

--- a/srv/blackroad-api/mci/tests/mci.fuzz.spec.js
+++ b/srv/blackroad-api/mci/tests/mci.fuzz.spec.js
@@ -1,0 +1,22 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const express = require('express');
+const router = require('../routes/mci.routes');
+
+function setup() {
+  const app = express();
+  app.use('/api/mci', router);
+  return new Promise(resolve => {
+    const server = app.listen(0, () => {
+      const port = server.address().port;
+      resolve({ server, base: `http://127.0.0.1:${port}/api/mci` });
+    });
+  });
+}
+
+test('rejects __import__ attempts', async () => {
+  const { server, base } = await setup();
+  const res = await fetch(base + '/compute', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ expr: "__import__('os')", mode: 'numeric' }) });
+  assert.equal(res.status, 400);
+  server.close();
+});

--- a/srv/blackroad-api/mci/tests/mci.unit.spec.js
+++ b/srv/blackroad-api/mci/tests/mci.unit.spec.js
@@ -1,0 +1,31 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const express = require('express');
+const router = require('../routes/mci.routes');
+
+function setup() {
+  const app = express();
+  app.use('/api/mci', router);
+  return new Promise(resolve => {
+    const server = app.listen(0, () => {
+      const port = server.address().port;
+      resolve({ server, base: `http://127.0.0.1:${port}/api/mci` });
+    });
+  });
+}
+
+test('compute adds numbers', async () => {
+  const { server, base } = await setup();
+  const res = await fetch(base + '/compute', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ expr: '1+1', mode: 'numeric' }) });
+  const json = await res.json();
+  assert.equal(json.numeric.value, 2);
+  server.close();
+});
+
+test('precision clamp to 32 bits minimum', async () => {
+  const { server, base } = await setup();
+  const res = await fetch(base + '/compute', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ expr: '1', mode: 'numeric', precision: 1 }) });
+  const json = await res.json();
+  assert.equal(json.numeric.precision, 32);
+  server.close();
+});

--- a/srv/blackroad-api/migrations/00_mci_init.sql
+++ b/srv/blackroad-api/migrations/00_mci_init.sql
@@ -1,0 +1,6 @@
+-- Initializes MCI cache table
+CREATE TABLE IF NOT EXISTS mci_cache (
+  key TEXT PRIMARY KEY,
+  value TEXT,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/var/www/blackroad/mci/MciWorkbench.js
+++ b/var/www/blackroad/mci/MciWorkbench.js
@@ -1,0 +1,25 @@
+import React, { useState } from 'react';
+
+export default function MciWorkbench() {
+  const [expr, setExpr] = useState('');
+  const [result, setResult] = useState(null);
+
+  async function run() {
+    const res = await fetch('/api/mci/compute', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ expr, mode: 'both' })
+    });
+    const json = await res.json();
+    setResult(json);
+  }
+
+  return (
+    <div className="mci-workbench">
+      <h2>Math×Code Workbench</h2>
+      <textarea value={expr} onChange={e => setExpr(e.target.value)} />
+      <button onClick={run}>Run</button>
+      {result && <pre>{JSON.stringify(result, null, 2)}</pre>}
+    </div>
+  );
+}

--- a/var/www/blackroad/mci/mci.css
+++ b/var/www/blackroad/mci/mci.css
@@ -1,0 +1,13 @@
+.mci-workbench {
+  padding: 1rem;
+}
+.mci-workbench textarea {
+  width: 100%;
+  height: 6rem;
+}
+.mci-workbench button {
+  background: var(--accent);
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border: none;
+}


### PR DESCRIPTION
## Summary
- add preliminary Math×Code Integrator (MCI) service with `/api/mci` routes
- implement compute endpoint backed by a Python sympy sandbox and basic health report
- include minimal frontend workbench, docs, and tests

## Testing
- `node --test srv/blackroad-api/mci/tests/*.js`
- `python3 -m pre_commit run --files server_full.js docs/mci/README.md srv/blackroad-api/mci/sandbox/runner.py srv/blackroad-api/mci/sandbox/env_whitelist.txt srv/blackroad-api/mci/sandbox/requirements.txt srv/blackroad-api/mci/routes/mci.routes.js srv/blackroad-api/mci/routes/mci.validators.js srv/blackroad-api/mci/routes/mci.controller.js srv/blackroad-api/mci/routes/mci.solver.js srv/blackroad-api/mci/routes/mci.autodiff.js srv/blackroad-api/mci/routes/mci.explain.js srv/blackroad-api/mci/routes/mci.health.js srv/blackroad-api/mci/services/mci.cache.js srv/blackroad-api/mci/services/mci.limiter.js srv/blackroad-api/mci/services/mci.logger.js srv/blackroad-api/mci/tests/mci.unit.spec.js srv/blackroad-api/mci/tests/mci.e2e.spec.js srv/blackroad-api/mci/tests/mci.fuzz.spec.js srv/blackroad-api/migrations/00_mci_init.sql var/www/blackroad/mci/MciWorkbench.js var/www/blackroad/mci/mci.css` *(fails: pathspec 'v3.3.3' did not match any file)*

------
https://chatgpt.com/codex/tasks/task_e_68ab373f2ae0832987497f22a67bee47