### PR TITLE
feat: scaffold lucidia portal

### DIFF
--- a/sites/blackroad/src/App.jsx
+++ b/sites/blackroad/src/App.jsx
@@ -6,6 +6,7 @@ import Terminal from "./pages/Terminal.jsx";
 import RoadView from "./pages/RoadView.jsx";
 import BackRoad from "./pages/BackRoad.jsx";
 import Subscribe from "./pages/Subscribe.jsx";
+import Lucidia from "./pages/Lucidia.jsx";
 import { useEffect, useState } from "react";
 
 function useApiHealth(){
@@ -48,6 +49,7 @@ export default function App(){
           <NavLink className="nav-link" to="/roadview">RoadView</NavLink>
           <NavLink className="nav-link" to="/backroad">BackRoad</NavLink>
           <NavLink className="nav-link" to="/subscribe">Subscribe</NavLink>
+          <NavLink className="nav-link" to="/lucidia">Lucidia</NavLink>
         </nav>
         <div className="mt-6 text-xs text-neutral-400"><StatusPill/></div>
       </aside>
@@ -68,6 +70,7 @@ export default function App(){
             <Route path="/roadview" element={<RoadView/>} />
             <Route path="/backroad" element={<BackRoad/>} />
             <Route path="/subscribe" element={<Subscribe/>} />
+            <Route path="/lucidia" element={<Lucidia/>} />
             <Route path="*" element={<div>Not found</div>} />
           </Routes>
         </section>

--- a/sites/blackroad/src/pages/Lucidia.jsx
+++ b/sites/blackroad/src/pages/Lucidia.jsx
@@ -1,0 +1,9 @@
+export default function Lucidia(){
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl mb-4">Lucidia</h1>
+      <p>Lucidia portal placeholder.</p>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- scaffold backend for Lucidia with mock LLM provider, database tables, and basic project & conversation routes
- expose Lucidia placeholder page in React SPA

## Testing
- `pre-commit run --files server_full.js sites/blackroad/src/App.jsx sites/blackroad/src/pages/Lucidia.jsx` *(fails: pathspec 'v3.3.3' did not match any file)*
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npm --prefix sites/blackroad test`


------
https://chatgpt.com/codex/tasks/task_e_68ab77ffe554832988bbeb40c279435c