### PR TITLE
Fix ESM test execution and add ESLint config

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,0 +1,6 @@
+module.exports = [
+  {
+    files: ['**/*.{js,mjs,cjs}'],
+    languageOptions: { ecmaVersion: 2022, sourceType: 'module' },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prepare": "husky",
     "lint": "eslint . --ext .js,.jsx,.mjs,.cjs || true",
     "format": "prettier -w .",
-    "test": "node tests/smoke.test.js",
+    "test": "node tests/smoke.test.mjs",
     "dev:site": "npm --prefix sites/blackroad run dev",
     "build": "npm --prefix sites/blackroad run build",
     "fix-anything": "node .github/tools/codex-apply.js .github/prompts/codex-fix-anything.md || true"

--- a/tests/git-route.test.mjs
+++ b/tests/git-route.test.mjs
@@ -1,7 +1,8 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { applyPatches } from '../var/www/blackroad/server/routes/git.js';
+import git from '../var/www/blackroad/server/routes/git.js';
+const { applyPatches } = git;
 
 const tempFile = 'tmp-applyPatches.txt';
 const abs = path.join(process.cwd(), tempFile);

--- a/tests/smoke.test.mjs
+++ b/tests/smoke.test.mjs
@@ -1,3 +1,3 @@
 import assert from 'node:assert';
-import './git-route.test.js';
+import './git-route.test.mjs';
 assert.ok(true);

--- a/var/www/blackroad/server/routes/git.js
+++ b/var/www/blackroad/server/routes/git.js
@@ -1,6 +1,6 @@
-import { spawn } from 'node:child_process';
-import fs from 'node:fs/promises';
-import path from 'node:path';
+const { spawn } = require('node:child_process');
+const fs = require('node:fs/promises');
+const path = require('node:path');
 
 const repoRoot = process.cwd();
 
@@ -40,7 +40,7 @@ async function applyPatch(patch) {
   return 'ok';
 }
 
-export async function applyPatches(req, res) {
+async function applyPatches(req, res) {
   const { patches } = req.body || {};
   if (!Array.isArray(patches)) {
     return res.status(400).json({ error: 'patches[] required' });
@@ -55,4 +55,8 @@ export async function applyPatches(req, res) {
   }
   res.json({ applied });
 }
+
+module.exports = {
+  applyPatches,
+};
 


### PR DESCRIPTION
## Summary
- Rename smoke and git-route tests to `.mjs` and adjust imports for Node's ESM handling
- Convert git route module to CommonJS to align with server and tests
- Add minimal `eslint.config.cjs` so lint script can run

## Testing
- `npm test`
- `npm run lint` *(fails: 75 problems (74 errors, 1 warning))*

------
https://chatgpt.com/codex/tasks/task_e_68ab76b9b8e88329b3e03f8f2063d54c