### PR TITLE
Add Lucidia Infinity math system

### DIFF
--- a/lucidia_infinity/__init__.py
+++ b/lucidia_infinity/__init__.py
@@ -1,0 +1,18 @@
+"""Lucidia Infinity Math System package.
+
+This package hosts experimental modules combining classical computation
+with paradox-aware Ψ′ logic. Each submodule exposes a small `demo`
+function that exercises its core ideas so the package can be explored
+programmatically or through the CLI in :mod:`lucidia_infinity.ui`.
+"""
+
+__all__ = [
+    "logic",
+    "primes",
+    "proofs",
+    "waves",
+    "finance",
+    "numbers",
+    "fractals",
+    "ui",
+]

--- a/lucidia_infinity/finance.py
+++ b/lucidia_infinity/finance.py
@@ -1,0 +1,57 @@
+"""Quantum finance sandbox.
+
+A toy model representing a market price as a probability amplitude across
+states.  Evolution is modelled as a simple unitary rotation and observation
+collapses the state to a classical price.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict
+
+import numpy as np
+
+
+@dataclass
+class QuantumMarket:
+    """Evolve a price distribution like a quantum state."""
+
+    amplitudes: np.ndarray
+
+    def step(self) -> None:
+        """Apply a unitary rotation to evolve the amplitudes."""
+
+        theta = np.pi / 8
+        rot = np.array([[np.cos(theta), -np.sin(theta)], [np.sin(theta), np.cos(theta)]])
+        self.amplitudes = rot @ self.amplitudes
+
+    def observe(self) -> int:
+        """Collapse the distribution to a classical outcome index."""
+
+        probs = np.abs(self.amplitudes) ** 2
+        choice = int(np.random.choice(len(probs), p=probs))
+        collapsed = np.zeros_like(self.amplitudes)
+        collapsed[choice] = 1.0
+        self.amplitudes = collapsed
+        return choice
+
+
+def demo(steps: int = 5, output_dir: Path | str = Path("output/finance")) -> Dict[str, str]:
+    """Simulate ``steps`` of market evolution and log results."""
+
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    market = QuantumMarket(np.array([1.0, 0.0]))
+    history = []
+    for _ in range(steps):
+        market.step()
+        history.append(market.amplitudes.tolist())
+    price = market.observe()
+    log = {"history": history, "collapsed": price}
+    with (out / "quantum_finance.json").open("w", encoding="utf8") as fh:
+        json.dump(log, fh, indent=2)
+    return {"log": str(out / "quantum_finance.json")}

--- a/lucidia_infinity/fractals.py
+++ b/lucidia_infinity/fractals.py
@@ -1,0 +1,46 @@
+"""Ψ′ fractal explorations.
+
+A light‑weight Mandelbrot style fractal is implemented.  The function
+:func:`generate_fractal` writes the resulting image into
+``output/fractals`` and returns the file path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def generate_fractal(
+    width: int = 400, height: int = 400, max_iter: int = 50, output_dir: Path | str = Path("output/fractals")
+) -> str:
+    """Generate a simple Mandelbrot fractal and save it."""
+
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    x = np.linspace(-2.0, 1.0, width)
+    y = np.linspace(-1.5, 1.5, height)
+    C = x + y[:, None] * 1j
+    Z = np.zeros_like(C)
+    div_time = np.zeros(C.shape, dtype=int)
+    for i in range(max_iter):
+        Z = Z**2 + C
+        diverge = np.abs(Z) > 2
+        div_now = diverge & (div_time == 0)
+        div_time[div_now] = i
+        Z[diverge] = 2
+    fig, ax = plt.subplots()
+    ax.imshow(div_time, cmap="magma")
+    ax.set_axis_off()
+    path = out / "psi_fractal.png"
+    fig.savefig(path, bbox_inches="tight", pad_inches=0)
+    plt.close(fig)
+    return str(path)
+
+
+def demo() -> str:
+    """Generate an example fractal image."""
+
+    return generate_fractal()

--- a/lucidia_infinity/logic.py
+++ b/lucidia_infinity/logic.py
@@ -1,0 +1,150 @@
+"""Trinary logic with classical and Ψ′ operators.
+
+The module defines a small trinary logic system with values ``{-1, 0, 1}``.
+Classical operators (:func:`t_and`, :func:`t_or`, :func:`t_not`,
+:func:`t_xor`) as well as whimsical Ψ′ operators
+(:func:`psi_merge`, :func:`psi_fold`, :func:`psi_collapse`) are provided.
+
+The :func:`generate_truth_tables` helper exports truth tables for all
+operators into JSON and NetworkX graph formats.  The data is written to an
+``output/logic`` directory relative to the repository root.
+"""
+
+from __future__ import annotations
+
+import itertools
+import json
+from pathlib import Path
+from typing import Callable, Dict, Iterable, Tuple
+
+import networkx as nx
+import numpy as np
+
+TRI_VALUES = (-1, 0, 1)
+
+
+def t_and(a: int, b: int) -> int:
+    """Trinary logical AND defined as the minimum of the operands."""
+
+    return int(min(a, b))
+
+
+def t_or(a: int, b: int) -> int:
+    """Trinary logical OR defined as the maximum of the operands."""
+
+    return int(max(a, b))
+
+
+def t_not(a: int) -> int:
+    """Trinary logical NOT implemented as negation."""
+
+    return int(-a)
+
+
+def t_xor(a: int, b: int) -> int:
+    """Trinary XOR implemented as the product of ``a`` and ``-b``."""
+
+    return int(a * -b)
+
+
+def psi_merge(a: int, b: int) -> int:
+    """Ψ′ paradox merge operator.
+
+    Returns ``0`` when the operands agree and ``1`` otherwise.  The value ``-1``
+    is treated as a contradiction state and therefore always yields ``1`` when
+    paired with any other value.
+    """
+
+    if a == b and a != -1:
+        return 0
+    return 1
+
+
+def psi_fold(a: int, b: int) -> int:
+    """Ψ′ infinite fold operator represented as multiplication."""
+
+    return int(a * b)
+
+
+def psi_collapse(a: int) -> int:
+    """Ψ′ collapse operator that maps any value to ``0``."""
+
+    return 0
+
+
+BINARY_OPERATORS: Dict[str, Callable[[int, int], int]] = {
+    "AND": t_and,
+    "OR": t_or,
+    "XOR": t_xor,
+    "⊕": psi_merge,
+    "⊗": psi_fold,
+}
+
+UNARY_OPERATORS: Dict[str, Callable[[int], int]] = {
+    "NOT": t_not,
+    "↯": psi_collapse,
+}
+
+
+def _truth_table(
+    op: Callable[..., int],
+    values: Iterable[int],
+    unary: bool = False,
+) -> Dict[Tuple[int, int] | Tuple[int], int]:
+    """Return the truth table for ``op`` over ``values``."""
+
+    table: Dict[Tuple[int, int] | Tuple[int], int] = {}
+    if unary:
+        for a in values:
+            table[(a,)] = op(a)
+    else:
+        for a, b in itertools.product(values, repeat=2):
+            table[(a, b)] = op(a, b)
+    return table
+
+
+def generate_truth_tables(output_dir: Path | str = Path("output/logic")) -> Dict[str, dict]:
+    """Generate truth tables for all operators and write them to ``output_dir``.
+
+    The function creates three artefacts:
+
+    * ``truth_tables.json`` – JSON serialisation of all tables.
+    * ``matrices.npy`` – NumPy array with each table represented as a matrix.
+    * ``logic.gexf`` – A NetworkX graph describing value transitions.
+    """
+
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    tables: Dict[str, dict] = {}
+    matrices: Dict[str, np.ndarray] = {}
+    graph = nx.DiGraph()
+
+    for name, op in BINARY_OPERATORS.items():
+        table = _truth_table(op, TRI_VALUES)
+        tables[name] = {f"{a},{b}": res for (a, b), res in table.items()}
+        matrices[name] = np.array(
+            [[op(a, b) for b in TRI_VALUES] for a in TRI_VALUES], dtype=int
+        )
+        for (a, b), res in table.items():
+            graph.add_edge(f"{a},{b}", str(res))
+
+    for name, op in UNARY_OPERATORS.items():
+        table = _truth_table(op, TRI_VALUES, unary=True)
+        tables[name] = {f"{a}": res for (a,), res in table.items()}
+        matrices[name] = np.array([[op(a) for a in TRI_VALUES]], dtype=int)
+        for (a,), res in table.items():
+            graph.add_edge(f"{a}", str(res))
+
+    with (out / "truth_tables.json").open("w", encoding="utf8") as fh:
+        json.dump(tables, fh, indent=2)
+    np.save(out / "matrices.npy", matrices)
+    nx.write_gexf(graph, out / "logic.gexf")
+
+    return tables
+
+
+def demo() -> Dict[str, dict]:
+    """Run :func:`generate_truth_tables` and return the produced tables."""
+
+    return generate_truth_tables()

--- a/lucidia_infinity/main.py
+++ b/lucidia_infinity/main.py
@@ -1,0 +1,15 @@
+"""Entry point for Lucidia Infinity Math System."""
+
+from __future__ import annotations
+
+from .ui import repl
+
+
+def main() -> None:
+    """Launch the command line REPL."""
+
+    repl()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()

--- a/lucidia_infinity/numbers.py
+++ b/lucidia_infinity/numbers.py
@@ -1,0 +1,61 @@
+"""Invented number systems with operator overloading.
+
+Three playful systems are provided just to illustrate the concept:
+``FractalNumber`` storing a value and a fractal dimension, ``DimensionalNumber``
+carrying a magnitude and unit, and ``WaveNumber`` composed of amplitude and
+phase.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class FractalNumber:
+    value: float
+    dimension: float
+
+    def __add__(self, other: "FractalNumber") -> "FractalNumber":
+        return FractalNumber(self.value + other.value, max(self.dimension, other.dimension))
+
+    def __mul__(self, other: "FractalNumber") -> "FractalNumber":
+        return FractalNumber(self.value * other.value, self.dimension + other.dimension)
+
+
+@dataclass
+class DimensionalNumber:
+    magnitude: float
+    unit: str
+
+    def __add__(self, other: "DimensionalNumber") -> "DimensionalNumber":
+        if self.unit != other.unit:
+            raise ValueError("unit mismatch")
+        return DimensionalNumber(self.magnitude + other.magnitude, self.unit)
+
+    def __mul__(self, other: "DimensionalNumber") -> "DimensionalNumber":
+        return DimensionalNumber(self.magnitude * other.magnitude, f"{self.unit}*{other.unit}")
+
+
+@dataclass
+class WaveNumber:
+    amplitude: float
+    phase: float
+
+    def __add__(self, other: "WaveNumber") -> "WaveNumber":
+        return WaveNumber(self.amplitude + other.amplitude, self.phase)
+
+    def __mul__(self, other: "WaveNumber") -> "WaveNumber":
+        return WaveNumber(self.amplitude * other.amplitude, self.phase + other.phase)
+
+
+__all__ = ["FractalNumber", "DimensionalNumber", "WaveNumber", "demo"]
+
+
+def demo() -> tuple[FractalNumber, DimensionalNumber, WaveNumber]:
+    """Return sample calculations in each invented system."""
+
+    f = FractalNumber(1, 1.5) + FractalNumber(2, 2.0)
+    d = DimensionalNumber(3, "m") * DimensionalNumber(2, "s")
+    w = WaveNumber(1, 0) * WaveNumber(0.5, 1.0)
+    return f, d, w

--- a/lucidia_infinity/primes.py
+++ b/lucidia_infinity/primes.py
@@ -1,0 +1,96 @@
+"""Prime and pattern exploration utilities.
+
+Only small illustrative implementations are provided: generation of an Ulam
+spiral, construction of modular residue grids and a Fourier transform of prime
+number gaps.  The produced images are written to ``output/primes`` with a
+timestamp so that runs are reproducible.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import List
+
+import matplotlib.pyplot as plt
+import numpy as np
+import sympy as sp
+
+__all__ = ["ulam_spiral", "residue_grid", "prime_gap_fft", "demo"]
+
+
+def _timestamp() -> str:
+    return datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+
+
+def ulam_spiral(size: int = 101) -> np.ndarray:
+    """Return an ``size``\ x\ ``size`` array forming an Ulam prime spiral."""
+
+    if size % 2 == 0:
+        raise ValueError("size must be odd so there is a center cell")
+
+    spiral = np.zeros((size, size), dtype=int)
+    x = y = size // 2
+    dx, dy = 0, -1
+    for n in range(1, size * size + 1):
+        if -size // 2 < x <= size // 2 and -size // 2 < y <= size // 2:
+            if sp.isprime(n):
+                spiral[y + size // 2, x + size // 2] = 1
+        if x == y or (x < 0 and x == -y) or (x > 0 and x == 1 - y):
+            dx, dy = -dy, dx
+        x, y = x + dx, y + dy
+    return spiral
+
+
+def residue_grid(mod: int = 10) -> np.ndarray:
+    """Return a grid of modular residues for values ``0..mod^2``."""
+
+    numbers = np.arange(mod ** 2).reshape(mod, mod)
+    return numbers % mod
+
+
+def prime_gap_fft(limit: int = 200) -> np.ndarray:
+    """Return the magnitude of the FFT of prime number gaps up to ``limit``."""
+
+    primes: List[int] = list(sp.primerange(2, limit))
+    gaps = np.diff(primes)
+    fft_vals = np.fft.fft(gaps)
+    return np.abs(fft_vals)
+
+
+def _save_image(path: Path, data: np.ndarray, title: str) -> None:
+    fig, ax = plt.subplots()
+    ax.imshow(data, cmap="viridis", interpolation="nearest")
+    ax.set_title(title)
+    fig.savefig(path)
+    plt.close(fig)
+
+
+def demo(output_dir: Path | str = Path("output/primes")) -> dict:
+    """Generate example artefacts for prime exploration and return metadata."""
+
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    ts = _timestamp()
+
+    spiral = ulam_spiral(51)
+    spiral_path = out / f"ulam_spiral_{ts}.png"
+    _save_image(spiral_path, spiral, "Ulam Spiral")
+
+    grid = residue_grid(10)
+    grid_path = out / f"residue_grid_{ts}.png"
+    _save_image(grid_path, grid, "Residue Grid")
+
+    fft_vals = prime_gap_fft(200)
+    fft_path = out / f"prime_gap_fft_{ts}.png"
+    fig, ax = plt.subplots()
+    ax.plot(fft_vals)
+    ax.set_title("FFT of Prime Gaps")
+    fig.savefig(fft_path)
+    plt.close(fig)
+
+    return {
+        "ulam_spiral": str(spiral_path),
+        "residue_grid": str(grid_path),
+        "prime_gap_fft": str(fft_path),
+    }

--- a/lucidia_infinity/proofs.py
+++ b/lucidia_infinity/proofs.py
@@ -1,0 +1,45 @@
+"""Recursive proof and contradiction engine.
+
+This module only sketches the idea of a system that can detect
+self-referential definitions.  It accepts simple recursive definitions
+expressed as strings and heuristically flags ones that contain direct
+self-reference, logging them to ``contradiction_log.json``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+LOG_FILE = Path("contradiction_log.json")
+
+
+def is_contradictory(expr: str) -> bool:
+    """Return ``True`` if ``expr`` appears self-referential.
+
+    The heuristic simply checks for nested occurrences of ``f(f(`` which is
+    characteristic of some Gödel-like undecidable constructions.
+    """
+
+    needle = "f(f("
+    return needle in expr.replace(" ", "")
+
+
+def log_contradiction(expr: str) -> None:
+    """Append ``expr`` to :data:`LOG_FILE`."""
+
+    data = []
+    if LOG_FILE.exists():
+        data = json.loads(LOG_FILE.read_text())
+    data.append(expr)
+    LOG_FILE.write_text(json.dumps(data, indent=2))
+
+
+def demo() -> bool:
+    """Demonstrate contradiction detection with a toy example."""
+
+    example = "f(x) = f(f(x-1)) + 1"
+    flag = is_contradictory(example)
+    if flag:
+        log_contradiction(example)
+    return flag

--- a/lucidia_infinity/ui.py
+++ b/lucidia_infinity/ui.py
@@ -1,0 +1,76 @@
+"""User interfaces for the Lucidia Infinity Math System."""
+
+from __future__ import annotations
+
+import json
+from typing import Callable, Dict
+
+from flask import Flask, jsonify
+from flask_socketio import SocketIO
+
+from . import finance, fractals, logic, numbers, primes, proofs, waves
+
+MENU: Dict[str, Callable[[], object]] = {
+    "Logic": logic.demo,
+    "Primes": primes.demo,
+    "Proofs": proofs.demo,
+    "Waves": waves.demo,
+    "Finance": finance.demo,
+    "Numbers": numbers.demo,
+    "Fractals": fractals.demo,
+}
+
+
+def repl() -> None:
+    """Simple command line REPL exposing demo functions."""
+
+    options = list(MENU.keys())
+    while True:
+        for i, name in enumerate(options, start=1):
+            print(f"{i}. {name}")
+        print("0. Exit")
+        try:
+            choice = int(input("Select module: "))
+        except ValueError:
+            print("Invalid input\n")
+            continue
+        if choice == 0:
+            break
+        if 1 <= choice <= len(options):
+            name = options[choice - 1]
+            result = MENU[name]()
+            print(json.dumps({"result": result}, indent=2))
+        else:
+            print("Invalid selection\n")
+
+
+def create_app() -> Flask:
+    """Create a minimal Flask + Socket.IO application."""
+
+    app = Flask(__name__)
+    socketio = SocketIO(app, async_mode="threading")
+
+    @app.get("/api/demo/<module>")
+    def api_demo(module: str):  # pragma: no cover - thin wrapper
+        func = MENU.get(module.capitalize())
+        if not func:
+            return jsonify({"error": "unknown module"}), 404
+        return jsonify(func())
+
+    # expose socket for completeness
+    @socketio.on("demo")  # pragma: no cover - requires running server
+    def handle_demo(message):
+        module = message.get("module", "").capitalize()
+        func = MENU.get(module)
+        if func:
+            socketio.emit("result", func())
+        else:
+            socketio.emit("result", {"error": "unknown module"})
+
+    return app
+
+
+def demo() -> None:
+    """Launch the REPL for interactive exploration."""
+
+    repl()

--- a/lucidia_infinity/waves.py
+++ b/lucidia_infinity/waves.py
@@ -1,0 +1,67 @@
+"""Sine Wave Codex Algebra.
+
+Sine waves are treated as algebraic objects supporting addition (superposition),
+multiplication (modulation) and inversion (phase shift by π).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+@dataclass
+class SineWave:
+    """Simple representation of a sine wave."""
+
+    frequency: float
+    amplitude: float = 1.0
+    phase: float = 0.0
+
+    def sample(self, t: np.ndarray) -> np.ndarray:
+        return self.amplitude * np.sin(2 * np.pi * self.frequency * t + self.phase)
+
+    def __add__(self, other: "SineWave") -> "SineWave":
+        return SineWave(
+            frequency=self.frequency,
+            amplitude=self.amplitude + other.amplitude,
+            phase=self.phase,
+        )
+
+    def __mul__(self, other: "SineWave") -> "SineWave":
+        return SineWave(
+            frequency=self.frequency + other.frequency,
+            amplitude=self.amplitude * other.amplitude,
+            phase=self.phase + other.phase,
+        )
+
+    def inverse(self) -> "SineWave":
+        return SineWave(self.frequency, self.amplitude, self.phase + np.pi)
+
+
+def visualize_interference(
+    a: SineWave, b: SineWave, path: Path | str = Path("output/waves/interference.png")
+) -> str:
+    """Visualise superposition of ``a`` and ``b`` and save to ``path``."""
+
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    t = np.linspace(0, 1, 1000)
+    combined = (a + b).sample(t)
+    fig, ax = plt.subplots()
+    ax.plot(t, combined)
+    ax.set_title("Wave Interference")
+    fig.savefig(path)
+    plt.close(fig)
+    return str(path)
+
+
+def demo() -> str:
+    """Create an interference plot for two example waves."""
+
+    a = SineWave(5, 1.0, 0)
+    b = SineWave(7, 0.5, np.pi / 4)
+    return visualize_interference(a, b)

--- a/tests/test_lucidia_infinity.py
+++ b/tests/test_lucidia_infinity.py
@@ -1,0 +1,47 @@
+import json
+from pathlib import Path
+
+import numpy as np
+
+from lucidia_infinity import finance, fractals, logic, numbers, primes, proofs, waves
+
+
+def test_logic_demo(tmp_path):
+    out = logic.generate_truth_tables(tmp_path)
+    assert "AND" in out
+
+
+def test_primes_demo(tmp_path):
+    meta = primes.demo(tmp_path)
+    for path in meta.values():
+        assert Path(path).exists()
+
+
+def test_proofs_demo(tmp_path, monkeypatch):
+    log = tmp_path / "log.json"
+    monkeypatch.setattr(proofs, "LOG_FILE", log)
+    assert proofs.demo() is True
+    data = json.loads(log.read_text())
+    assert data
+
+
+def test_waves_demo(tmp_path):
+    path = waves.visualize_interference(waves.SineWave(1), waves.SineWave(2), tmp_path / "img.png")
+    assert Path(path).exists()
+
+
+def test_finance_demo(tmp_path):
+    meta = finance.demo(steps=2, output_dir=tmp_path)
+    assert Path(meta["log"]).exists()
+
+
+def test_numbers_demo():
+    f, d, w = numbers.demo()
+    assert f.dimension >= 2.0
+    assert d.unit == "m*s"
+    assert np.isclose(w.phase, 1.0)
+
+
+def test_fractals_demo(tmp_path):
+    path = fractals.generate_fractal(output_dir=tmp_path)
+    assert Path(path).exists()


### PR DESCRIPTION
## Summary
- introduce `lucidia_infinity` package with trinary logic, prime exploration, recursive proof heuristics, wave algebra, quantum finance, custom number systems, and fractal generation
- provide CLI/Flask interface for demoing modules
- add tests covering demos and file generation

## Testing
- `ruff check lucidia_infinity tests/test_lucidia_infinity.py`
- `pytest tests/test_lucidia_infinity.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab7b8b5b64832993520a0eda1cbd43