### PR TITLE
feat: add auto-heal and deployment framework

### DIFF
--- a/etc/cron.d/blackroad-backup
+++ b/etc/cron.d/blackroad-backup
@@ -1,0 +1,1 @@
+0 2 * * * root /usr/local/bin/blackroad-autoheal.sh backup

--- a/etc/logrotate.d/blackroad-autoheal
+++ b/etc/logrotate.d/blackroad-autoheal
@@ -1,0 +1,7 @@
+/var/log/blackroad-autoheal.log {
+  daily
+  rotate 7
+  compress
+  missingok
+  notifempty
+}

--- a/etc/systemd/system/blackroad-autoheal.service
+++ b/etc/systemd/system/blackroad-autoheal.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=BlackRoad Auto-Heal Watchdog
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/blackroad-autoheal.sh run
+
+[Install]
+WantedBy=multi-user.target

--- a/etc/systemd/system/blackroad-autoheal.timer
+++ b/etc/systemd/system/blackroad-autoheal.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run BlackRoad Auto-Heal every minute
+
+[Timer]
+OnBootSec=60
+OnUnitActiveSec=60
+Unit=blackroad-autoheal.service
+
+[Install]
+WantedBy=timers.target

--- a/nginx/blackroad.conf
+++ b/nginx/blackroad.conf
@@ -1,0 +1,43 @@
+server {
+  listen 80;
+  server_name blackroad.io;
+
+  root /var/www/blackroad;
+  index index.html;
+
+  location /api/ {
+    proxy_pass http://127.0.0.1:4000;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
+  location /ws/ {
+    proxy_pass http://127.0.0.1:4000;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+  }
+
+  location /math/ {
+    proxy_pass http://127.0.0.1:8500;
+  }
+
+  location /llm/ {
+    proxy_pass http://127.0.0.1:8000;
+  }
+
+  location / {
+    try_files $uri /index.html;
+  }
+
+  location ~* \.(js|css|png|jpg|svg)$ {
+    expires 1d;
+    add_header Cache-Control "public";
+  }
+
+  gzip on;
+  gzip_types text/plain text/css application/json application/javascript;
+  # SSL certificates via Let's Encrypt should be managed separately.
+}

--- a/scripts/blackroad-autoheal.sh
+++ b/scripts/blackroad-autoheal.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Self-managing deployment + repair framework for BlackRoad.io
+# Monitors services, auto-repairs, updates, and manages backups.
+set -euo pipefail
+
+LOG_FILE="/var/log/blackroad-autoheal.log"
+STATE_FILE="/var/log/blackroad-autoheal.state"
+BACKUP_ROOT="/var/backups"
+
+API_DIR="/srv/blackroad-api"
+LLM_DIR="/srv/lucidia-llm"
+MATH_DIR="/srv/lucidia-math"
+SPA_DIR="/var/www/blackroad"
+REPO="/srv/blackroad-api"  # main repo
+
+log(){
+  echo "$(date -Is) $1" | tee -a "$LOG_FILE"
+}
+
+curl_check(){
+  curl -fsS "$1" >/dev/null
+}
+
+restart_service(){
+  systemctl restart "$1" && log "Restarted $1"
+}
+
+find_free_port(){
+  local port=$1
+  while ss -ltn | awk '{print $4}' | grep -q ":$port"; do
+    port=$((port+1))
+  done
+  echo "$port"
+}
+
+update_nginx_port(){
+  local label=$1 port=$2
+  sed -i "s/127\.0\.0\.1:[0-9]\+/127.0.0.1:${port}/" /etc/nginx/sites-enabled/blackroad.conf
+  nginx -t && systemctl reload nginx && log "Rebound $label to port $port"
+}
+
+rebuild_frontend(){
+  if [ ! -f "$SPA_DIR/index.html" ]; then
+    log "Frontend build missing; rebuilding"
+    (cd "$REPO" && npm --prefix sites/blackroad run build && cp -r sites/blackroad/dist/* "$SPA_DIR"/)
+  fi
+}
+
+install_api_deps(){ (cd "$API_DIR" && npm install) }
+install_llm_deps(){ (cd "$LLM_DIR" && pip install -r requirements.txt) }
+install_math_deps(){ (cd "$MATH_DIR" && pip install -r requirements.txt) }
+
+perform_backup(){
+  mkdir -p "$BACKUP_ROOT/blackroad" "$BACKUP_ROOT/lucidia-math"
+  local ts=$(date +%Y%m%d)
+  tar -czf "$BACKUP_ROOT/blackroad/blackroad.db-$ts.tar.gz" -C "$API_DIR" blackroad.db
+  tar -czf "$BACKUP_ROOT/lucidia-math/output-$ts.tar.gz" -C "$MATH_DIR" output
+  log "Backup completed for $ts"
+  rotate_keep "$BACKUP_ROOT/blackroad" 7
+  rotate_keep "$BACKUP_ROOT/lucidia-math" 7
+}
+
+rotate_keep(){
+  local dir=$1 keep=$2
+  ls -1t "$dir" | tail -n +$((keep+1)) | xargs -r -I{} rm "$dir/{}"
+}
+
+update_repo(){
+  if git -C "$REPO" pull --rebase; then
+    (cd "$API_DIR" && npm install)
+    (cd "$LLM_DIR" && pip install -r requirements.txt)
+    (cd "$REPO" && npm --prefix sites/blackroad run build)
+    restart_service blackroad-api.service
+    restart_service lucidia-llm.service
+    restart_service lucidia-math.service
+  else
+    log "Git pull encountered merge conflict; deployment skipped"
+  fi
+}
+
+update_failure_state(){
+  local now=$(date +%s)
+  local count=0 last=0
+  if [ -f "$STATE_FILE" ]; then
+    read count last <"$STATE_FILE"
+  fi
+  if (( now - last > 600 )); then count=0; fi
+  count=$((count+1))
+  echo "$count $now" >"$STATE_FILE"
+  if (( count >= 3 )); then
+    log "Escalation: $count failures in 10 minutes"
+  fi
+}
+
+check_all(){
+  local failures=0
+  curl_check https://blackroad.io/health || { log "Frontend check failed"; rebuild_frontend; failures=$((failures+1)); }
+  curl_check http://127.0.0.1:4000/api/health || { log "API check failed"; restart_service blackroad-api.service; install_api_deps; failures=$((failures+1)); }
+  curl_check http://127.0.0.1:8000/health || { log "LLM check failed"; restart_service lucidia-llm.service; install_llm_deps; failures=$((failures+1)); }
+  curl_check http://127.0.0.1:8500/health || { log "Math check failed"; restart_service lucidia-math.service; install_math_deps; failures=$((failures+1)); }
+  if (( failures > 0 )); then update_failure_state; fi
+}
+
+validate(){
+  systemctl is-active blackroad-api.service lucidia-llm.service lucidia-math.service >/dev/null && log "Services active"
+  curl_check http://127.0.0.1:4000/api/health
+  curl_check http://127.0.0.1:8000/health
+  curl_check http://127.0.0.1:8500/health
+  local t=$(curl -o /dev/null -s -w "%{time_total}" https://blackroad.io/)
+  log "Frontend load time ${t}s"
+  curl -s http://127.0.0.1:8000/health > /var/log/blackroad-llm-proof.log || true
+}
+
+case "${1:-run}" in
+  backup)
+    perform_backup
+    ;;
+  update)
+    update_repo
+    ;;
+  run|*)
+    check_all
+    validate
+    ;;
+esac


### PR DESCRIPTION
## Summary
- add blackroad-autoheal script for health checks, auto-repairs, updates and backups
- wire up systemd unit, timer, cron and logrotate configs
- provide nginx config for BlackRoad.io stack routing

## Testing
- `pre-commit run --files scripts/blackroad-autoheal.sh etc/systemd/system/blackroad-autoheal.service etc/systemd/system/blackroad-autoheal.timer nginx/blackroad.conf etc/logrotate.d/blackroad-autoheal etc/cron.d/blackroad-backup` *(fails: CalledProcessError: command: ('/usr/bin/git', 'checkout', 'v3.3.3'))*
- `npm test`
- `npm run lint` *(fails: Parsing error: Unexpected token <)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7d18750883298216b12922d9eaa1