### PR TITLE
feat: add connectors and auto-heal scripts

### DIFF
--- a/connectors.js
+++ b/connectors.js
@@ -1,0 +1,106 @@
+'use strict';
+
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+const { exec } = require('child_process');
+
+const router = express.Router();
+const LOG_FILE = '/var/log/blackroad-connectors.log';
+const ALLOWED_ROOTS = ['/srv', '/var/www/blackroad'];
+
+function log(action, target) {
+  const line = `${new Date().toISOString()} ${action} ${target}\n`;
+  fs.appendFile(LOG_FILE, line, () => {});
+}
+
+function resolveSafe(p) {
+  const resolved = path.resolve(p);
+  if (
+    !ALLOWED_ROOTS.some((root) =>
+      resolved === root || resolved.startsWith(root + path.sep)
+    )
+  ) {
+    throw new Error('path_not_allowed');
+  }
+  return resolved;
+}
+
+function requireAuth(req, res, next) {
+  const auth = req.get('Authorization') || '';
+  const token = auth.startsWith('Bearer ') ? auth.slice(7) : '';
+  if (token && token === process.env.CONNECTOR_KEY) return next();
+  return res.status(401).json({ error: 'unauthorized' });
+}
+
+router.use(requireAuth);
+
+router.post('/paste', (req, res) => {
+  const { path: filePath, content } = req.body || {};
+  if (!filePath) return res.status(400).json({ error: 'path_required' });
+  try {
+    const target = resolveSafe(filePath);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, content || '');
+    log('paste', target);
+    res.json({ ok: true });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.post('/append', (req, res) => {
+  const { path: filePath, content } = req.body || {};
+  if (!filePath) return res.status(400).json({ error: 'path_required' });
+  try {
+    const target = resolveSafe(filePath);
+    fs.appendFileSync(target, content || '');
+    log('append', target);
+    res.json({ ok: true });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.post('/replace', (req, res) => {
+  const { path: filePath, find, replace } = req.body || {};
+  if (!filePath || find === undefined || replace === undefined)
+    return res.status(400).json({ error: 'invalid_body' });
+  try {
+    const target = resolveSafe(filePath);
+    const data = fs.readFileSync(target, 'utf8');
+    const result = data.replace(find, replace);
+    fs.writeFileSync(target, result);
+    log('replace', target);
+    res.json({ ok: true });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.post('/restart', (req, res) => {
+  const { service } = req.body || {};
+  if (!service) return res.status(400).json({ error: 'service_required' });
+  exec(`systemctl restart ${service}`, (err, stdout, stderr) => {
+    log('restart', service);
+    if (err) return res.status(500).json({ error: err.message, stderr });
+    res.json({ ok: true, stdout });
+  });
+});
+
+router.post('/build', (req, res) => {
+  const { dir } = req.body || {};
+  if (!dir) return res.status(400).json({ error: 'dir_required' });
+  try {
+    const target = resolveSafe(dir);
+    exec(`npm --prefix ${target} run build`, (err, stdout, stderr) => {
+      log('build', target);
+      if (err) return res.status(500).json({ error: err.message, stderr });
+      res.json({ ok: true, stdout });
+    });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+module.exports = router;

--- a/etc/nginx/sites-enabled/blackroad.conf
+++ b/etc/nginx/sites-enabled/blackroad.conf
@@ -1,0 +1,29 @@
+location /api/ {
+    proxy_pass http://127.0.0.1:4000/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+}
+
+location /ws/ {
+    proxy_pass http://127.0.0.1:4000/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+}
+
+location /llm/ {
+    proxy_pass http://127.0.0.1:8000/;
+}
+
+location /math/ {
+    proxy_pass http://127.0.0.1:8500/;
+}
+
+location / {
+    root /var/www/blackroad/;
+    index index.html;
+    try_files $uri /index.html;
+}

--- a/etc/systemd/system/blackroad-autoheal.service
+++ b/etc/systemd/system/blackroad-autoheal.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=BlackRoad Auto-Heal Service
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/blackroad-autoheal.sh
+Restart=always
+StandardOutput=append:/var/log/blackroad-autoheal.log
+StandardError=append:/var/log/blackroad-autoheal.log

--- a/etc/systemd/system/blackroad-autoheal.timer
+++ b/etc/systemd/system/blackroad-autoheal.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run BlackRoad Auto-Heal every 1 min
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=60
+
+[Install]
+WantedBy=timers.target

--- a/server_full.js
+++ b/server_full.js
@@ -11,6 +11,7 @@ const cors = require('cors');
 const morgan = require('morgan');
 const cookieSession = require('cookie-session');
 const rateLimit = require('express-rate-limit');
+const connectors = require('./connectors');
 
 // Allow requiring .ts files as plain JS for lucidia brain modules
 require.extensions['.ts'] = require.extensions['.js'];
@@ -78,6 +79,7 @@ const limiter = rateLimit({
   legacyHeaders: false
 });
 app.use(limiter);
+app.use('/connectors', connectors);
 
 // Initialize DB (auto-migrations on import)
 const db = require('./src/db');

--- a/usr/local/bin/blackroad-autoheal.sh
+++ b/usr/local/bin/blackroad-autoheal.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -e
+
+LOG_FILE=/var/log/blackroad-autoheal.log
+
+echo "$(date --iso-8601=seconds) starting auto-heal check" >> "$LOG_FILE"
+
+check_service() {
+  local name="$1"
+  local url="$2"
+
+  if ! curl -fsS "$url" > /dev/null; then
+    echo "$(date --iso-8601=seconds) $name unhealthy, restarting" >> "$LOG_FILE"
+    if ! systemctl restart "$name" >> "$LOG_FILE" 2>&1; then
+      echo "$(date --iso-8601=seconds) $name restart failed, installing deps" >> "$LOG_FILE"
+      case "$name" in
+        blackroad-api)
+          (cd /srv/blackroad-api && npm install) >> "$LOG_FILE" 2>&1 ;;
+        lucidia-llm)
+          (cd /srv/lucidia-llm && pip install -r requirements.txt) >> "$LOG_FILE" 2>&1 ;;
+        lucidia-math)
+          (cd /srv/lucidia-math && pip install -r requirements.txt) >> "$LOG_FILE" 2>&1 ;;
+      esac
+      systemctl restart "$name" >> "$LOG_FILE" 2>&1
+    fi
+  fi
+}
+
+check_service blackroad-api https://blackroad.io/health
+check_service blackroad-api http://127.0.0.1:4000/api/health
+check_service lucidia-llm http://127.0.0.1:8000/health
+check_service lucidia-math http://127.0.0.1:8500/health

--- a/usr/local/bin/blackroad-backup.sh
+++ b/usr/local/bin/blackroad-backup.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -e
+
+DEST=/var/backups/blackroad
+mkdir -p "$DEST"/daily "$DEST"/weekly "$DEST"/monthly
+TS=$(date +%Y-%m-%d)
+ARCHIVE="$DEST/daily/backup-$TS.tgz"
+
+tar -czf "$ARCHIVE" /srv/blackroad-api/blackroad.db /srv/lucidia-math/output/
+
+# rotate daily: keep 7
+ls -1t "$DEST/daily"/backup-*.tgz 2>/dev/null | tail -n +8 | xargs -r rm --
+
+# weekly on Sunday (1=Mon..7=Sun)
+if [ "$(date +%u)" -eq 7 ]; then
+  cp "$ARCHIVE" "$DEST/weekly/backup-$TS.tgz"
+  ls -1t "$DEST/weekly"/backup-*.tgz 2>/dev/null | tail -n +5 | xargs -r rm --
+fi
+
+# monthly on first day
+if [ "$(date +%d)" -eq 01 ]; then
+  cp "$ARCHIVE" "$DEST/monthly/backup-$TS.tgz"
+  ls -1t "$DEST/monthly"/backup-*.tgz 2>/dev/null | tail -n +7 | xargs -r rm --
+fi


### PR DESCRIPTION
## Summary
- add /connectors Express router for remote file control
- integrate connectors into server_full.js
- add auto-heal script with systemd service and timer
- add nginx proxy config and backup script

## Testing
- `npm run lint` *(fails: Parsing error: Unexpected token <)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab7f0bfec4832987ae8dad17514b62