### PR TITLE
feat: add droplet deployment helper

### DIFF
--- a/codex/build.py
+++ b/codex/build.py
@@ -16,12 +16,27 @@ from __future__ import annotations
 import argparse
 import shlex
 import subprocess
+from datetime import datetime
 from pathlib import Path
+from typing import Iterable
 
 
-def run(cmd: str, cwd: Path | None = None) -> None:
-    """Run a shell command and stream output."""
+def run(cmd: str, cwd: Path | None = None, dry_run: bool = False) -> None:
+    """Run a shell command and stream output.
+
+    Parameters
+    ----------
+    cmd:
+        Command to execute.
+    cwd:
+        Working directory for the command.
+    dry_run:
+        If ``True`` the command is printed but not executed.
+    """
+
     print(f"$ {cmd}")
+    if dry_run:
+        return
     subprocess.run(shlex.split(cmd), check=True, cwd=cwd)
 
 
@@ -29,28 +44,30 @@ def run(cmd: str, cwd: Path | None = None) -> None:
 # GitHub / repo operations
 # ---------------------------------------------------------------------------
 
-def push_latest() -> None:
+
+def push_latest(dry_run: bool = False) -> None:
     """Push local commits and trigger deployment."""
-    run("git push")
-    deploy_to_droplet()
+    run("git push", dry_run=dry_run)
+    deploy_to_droplet(dry_run=dry_run)
 
 
-def refresh_working_copy() -> None:
+def refresh_working_copy(dry_run: bool = False) -> None:
     """Pull the latest changes into the working copy."""
-    run("git pull --ff-only")
+    run("git pull --ff-only", dry_run=dry_run)
 
 
-def rebase_branch(branch: str = "main") -> None:
+def rebase_branch(branch: str = "main", dry_run: bool = False) -> None:
     """Rebase the current branch onto the specified branch."""
-    run(f"git fetch origin {branch}")
-    run(f"git rebase origin/{branch}")
+    run(f"git fetch origin {branch}", dry_run=dry_run)
+    run(f"git rebase origin/{branch}", dry_run=dry_run)
 
 
 # ---------------------------------------------------------------------------
 # Connector and deployment placeholders
 # ---------------------------------------------------------------------------
 
-def sync_connectors() -> None:
+
+def sync_connectors(dry_run: bool = False) -> None:
     """Synchronise external connectors (Salesforce, Airtable, etc.).
 
     This is a placeholder for OAuth setup and webhook processing.  Extend
@@ -60,27 +77,56 @@ def sync_connectors() -> None:
     print("[connectors] TODO: implement OAuth and webhook logic")
 
 
-def deploy_to_droplet() -> None:
-    """Deploy the latest code to the droplet.
+def _log(message: str, logfile: Path) -> None:
+    timestamp = datetime.utcnow().isoformat()
+    logfile.parent.mkdir(parents=True, exist_ok=True)
+    with logfile.open("a", encoding="utf-8") as fh:
+        fh.write(f"{timestamp} {message}\n")
 
-    Actual deployment commands (git pull, migrations, service restarts)
-    should be added here.  The function currently acts as a stub so the
-    broader orchestration flow can be wired up without side effects.
-    """
 
-    print("[droplet] TODO: implement remote deployment commands")
+def deploy_to_droplet(dry_run: bool = False) -> None:
+    """Deploy the latest code to the droplet."""
+
+    deploy_log = Path("deploy.log")
+    error_log = Path("deploy_errors.log")
+
+    paths: Iterable[tuple[str, str]] = [
+        ("var/www/blackroad/", "/var/www/blackroad/"),
+        ("srv/blackroad-api/", "/srv/blackroad-api/"),
+        ("srv/lucidia-llm/", "/srv/lucidia-llm/"),
+        ("srv/lucidia-math/", "/srv/lucidia-math/"),
+    ]
+
+    try:
+        _log("Starting deployment", deploy_log)
+        for local, remote in paths:
+            cmd = f"rsync -az {local} blackroad.io:{remote}"
+            _log(f"Sync {local} -> {remote}", deploy_log)
+            run(cmd, dry_run=dry_run)
+
+        _log("Restarting services", deploy_log)
+        run(
+            "ssh blackroad.io sudo systemctl restart blackroad-api lucidia-llm lucidia-math",
+            dry_run=dry_run,
+        )
+        run("ssh blackroad.io sudo systemctl reload nginx", dry_run=dry_run)
+        _log("Deployment complete", deploy_log)
+    except (subprocess.CalledProcessError, OSError) as exc:
+        _log(f"Deployment failed: {exc}", error_log)
+        raise
 
 
 # ---------------------------------------------------------------------------
 # Chat-first control surface
 # ---------------------------------------------------------------------------
 
-def handle_command(cmd: str) -> None:
+
+def handle_command(cmd: str, dry_run: bool = False) -> None:
     actions = {
-        "push": push_latest,
-        "refresh": refresh_working_copy,
-        "rebase": rebase_branch,
-        "sync": sync_connectors,
+        "push": lambda: push_latest(dry_run=dry_run),
+        "refresh": lambda: refresh_working_copy(dry_run=dry_run),
+        "rebase": lambda: rebase_branch(dry_run=dry_run),
+        "sync": lambda: sync_connectors(dry_run=dry_run),
     }
     action = actions.get(cmd)
     if action:
@@ -92,14 +138,23 @@ def handle_command(cmd: str) -> None:
 def main() -> None:
     parser = argparse.ArgumentParser(description="Codex build pipeline")
     parser.add_argument("command", help="push|refresh|rebase|sync")
-    parser.add_argument("branch", nargs="?", default="main",
-                        help="branch name for rebase (default: main)")
+    parser.add_argument(
+        "branch",
+        nargs="?",
+        default="main",
+        help="branch name for rebase (default: main)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print commands without executing",
+    )
     args = parser.parse_args()
 
     if args.command == "rebase":
-        rebase_branch(args.branch)
+        rebase_branch(args.branch, dry_run=args.dry_run)
     else:
-        handle_command(args.command)
+        handle_command(args.command, dry_run=args.dry_run)
 
 
 if __name__ == "__main__":

--- a/tests/test_deploy_to_droplet.py
+++ b/tests/test_deploy_to_droplet.py
@@ -1,0 +1,44 @@
+import importlib.util
+from pathlib import Path
+from unittest.mock import call, patch
+
+spec = importlib.util.spec_from_file_location("build", Path("codex/build.py"))
+build = importlib.util.module_from_spec(spec)
+assert spec.loader is not None  # for mypy
+spec.loader.exec_module(build)
+
+
+def test_deploy_runs_commands():
+    expected = [
+        call(
+            "rsync -az var/www/blackroad/ blackroad.io:/var/www/blackroad/",
+            dry_run=False,
+        ),
+        call(
+            "rsync -az srv/blackroad-api/ blackroad.io:/srv/blackroad-api/",
+            dry_run=False,
+        ),
+        call(
+            "rsync -az srv/lucidia-llm/ blackroad.io:/srv/lucidia-llm/",
+            dry_run=False,
+        ),
+        call(
+            "rsync -az srv/lucidia-math/ blackroad.io:/srv/lucidia-math/",
+            dry_run=False,
+        ),
+        call(
+            "ssh blackroad.io sudo systemctl restart blackroad-api lucidia-llm lucidia-math",
+            dry_run=False,
+        ),
+        call("ssh blackroad.io sudo systemctl reload nginx", dry_run=False),
+    ]
+    with patch.object(build, "run") as mock_run:
+        build.deploy_to_droplet()
+        assert mock_run.call_args_list == expected
+
+
+def test_deploy_dry_run():
+    with patch.object(build, "run") as mock_run:
+        build.deploy_to_droplet(dry_run=True)
+        for args in mock_run.call_args_list:
+            assert args.kwargs.get("dry_run") is True


### PR DESCRIPTION
## Summary
- add deployment pipeline that rsyncs to blackroad.io and restarts services
- support dry-run deployments and log stages to disk
- cover deployment helper with unit tests

## Testing
- `ruff check codex/build.py tests/test_deploy_to_droplet.py`
- `black --check codex/build.py tests/test_deploy_to_droplet.py`
- `isort --check-only codex/build.py tests/test_deploy_to_droplet.py`
- `pytest tests/test_deploy_to_droplet.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab840871b88329a22eeae78b9ce207