### PR TITLE
feat: add Working Copy sync pipeline

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,41 @@
+import os
+import subprocess
+from unittest import mock
+
+from tools import codex_pipeline
+
+
+def test_sync_to_working_copy(monkeypatch):
+    """Ensure sync pushes and triggers Working Copy hooks."""
+    cp = subprocess.CompletedProcess(args=[], returncode=0, stdout="origin\nworking-copy\n")
+
+    def fake_run(cmd, capture_output=False, text=False, check=False):
+        assert cmd == ["git", "-C", ".", "remote"]
+        return cp
+
+    monkeypatch.setattr(codex_pipeline.subprocess, "run", fake_run)
+
+    run_calls = []
+    monkeypatch.setattr(codex_pipeline, "run", lambda cmd, dry_run=False: run_calls.append(cmd))
+
+    browser = mock.Mock()
+    monkeypatch.setattr(codex_pipeline.webbrowser, "open", browser)
+
+    trigger = mock.Mock()
+    monkeypatch.setattr(codex_pipeline, "trigger_working_copy_pull", trigger)
+
+    codex_pipeline.sync_to_working_copy(".", dry_run=False)
+
+    assert "git -C . push working-copy HEAD" in run_calls
+    browser.assert_called_once()
+    trigger.assert_called_once_with(os.path.basename(os.path.abspath(".")), dry_run=False)
+
+
+def test_trigger_working_copy_pull(monkeypatch):
+    """The HTTP request to Working Copy is attempted."""
+    opener = mock.MagicMock()
+    opener.return_value.__enter__.return_value.read.return_value = b"ok"
+    monkeypatch.setattr(codex_pipeline.request, "urlopen", opener)
+
+    assert codex_pipeline.trigger_working_copy_pull("repo", dry_run=False)
+    opener.assert_called_once()

--- a/tools/codex_pipeline.py
+++ b/tools/codex_pipeline.py
@@ -17,44 +17,120 @@ solution rather than a complete deployment utility.
 from __future__ import annotations
 
 import argparse
+import logging
+import os
 import subprocess
-import sys
+import webbrowser
+from urllib import error, request
+
+LOGGER = logging.getLogger(__name__)
+_FILE_HANDLER = logging.FileHandler("pipeline.log")
+_FILE_HANDLER.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
+LOGGER.addHandler(_FILE_HANDLER)
+LOGGER.setLevel(logging.INFO)
 
 
-def run(cmd: str) -> None:
+def run(cmd: str, *, dry_run: bool = False) -> None:
     """Run a shell command and stream output."""
-    print(f"[cmd] {cmd}")
+    LOGGER.info("[cmd] %s", cmd)
+    if dry_run:
+        return
     subprocess.run(cmd, shell=True, check=True)
 
 
-def push_latest() -> None:
+def push_latest(*, dry_run: bool = False) -> None:
     """Push local commits to GitHub."""
     # TODO: handle authentication, branching, conflict resolution, and
     # downstream webhook notifications.
-    run("git push origin HEAD")
+    run("git push origin HEAD", dry_run=dry_run)
 
 
-def refresh_working_copy() -> None:
-    """Placeholder for refreshing iOS Working Copy app."""
-    # TODO: use Working Copy automation or URL schemes to pull latest changes.
-    print("TODO: implement Working Copy refresh")
+def refresh_working_copy(*, repo_path: str = ".", dry_run: bool = False) -> None:
+    """Refresh the Working Copy mirror for this repository."""
+    sync_to_working_copy(repo_path, dry_run=dry_run)
 
 
-def redeploy_droplet() -> None:
+def sync_to_working_copy(repo_path: str, *, dry_run: bool = False) -> None:
+    """Ensure the repo is up to date in the Working Copy app.
+
+    The function checks for a ``working-copy`` remote, pushes to it and
+    triggers a pull inside the iOS application.  On Linux this URL scheme is
+    not executed but left as documentation for iOS automation.
+    """
+
+    LOGGER.info("sync_to_working_copy repo_path=%s", repo_path)
+    try:
+        result = subprocess.run(
+            ["git", "-C", repo_path, "remote"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:  # pragma: no cover - defensive
+        LOGGER.error("git remote failed: %s", exc)
+        return
+
+    if "working-copy" not in result.stdout:
+        LOGGER.info("No Working Copy remote configured; skipping sync")
+        return
+
+    run(f"git -C {repo_path} push working-copy HEAD", dry_run=dry_run)
+
+    repo_name = os.path.basename(os.path.abspath(repo_path))
+    url = f"working-copy://x-callback-url/pull?repo={repo_name}"
+    if dry_run:
+        LOGGER.info("DRY RUN: would open %s", url)
+    else:  # pragma: no cover - requires iOS environment
+        try:
+            webbrowser.open(url)
+            LOGGER.info("Triggered Working Copy pull via URL scheme")
+        except Exception as exc:  # pragma: no cover - logging only
+            LOGGER.warning("Failed to open Working Copy URL: %s", exc)
+
+    trigger_working_copy_pull(repo_name, dry_run=dry_run)
+
+
+def redeploy_droplet(*, dry_run: bool = False) -> None:
     """Placeholder for redeploying the BlackRoad droplet."""
     # TODO: SSH into droplet, pull latest code, run migrations, restart services.
-    print("TODO: implement droplet redeploy")
+    LOGGER.info("TODO: implement droplet redeploy")
 
 
-def sync_connectors() -> None:
+def sync_connectors(*, dry_run: bool = False) -> None:
     """Placeholder for syncing external connectors."""
     # TODO: add OAuth flows, webhook listeners, and Slack notifications.
-    print("TODO: implement connector sync")
+    LOGGER.info("TODO: implement connector sync")
+
+
+def trigger_working_copy_pull(
+    repo_name: str, *, server_url: str = "http://localhost:8081", dry_run: bool = False
+) -> bool:
+    """Trigger a pull via Working Copy's local automation server.
+
+    Returns ``True`` if the request succeeded, ``False`` otherwise.
+    """
+
+    url = f"{server_url}/pull?repo={repo_name}"
+    LOGGER.info("Requesting Working Copy pull: %s", url)
+    if dry_run:
+        return True
+    try:
+        with request.urlopen(url) as resp:  # noqa: S310 - local request
+            LOGGER.info("Working Copy pull response: %s", resp.read())
+        return True
+    except error.URLError as exc:
+        LOGGER.warning("Working Copy pull failed: %s", exc)
+        return False
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="BlackRoad Codex pipeline scaffold",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Simulate actions without executing external commands",
     )
     sub = parser.add_subparsers(dest="command")
     sub.add_parser("push", help="Push latest to BlackRoad.io")
@@ -65,18 +141,18 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     if args.command == "push":
-        push_latest()
-        redeploy_droplet()
+        push_latest(dry_run=args.dry_run)
+        redeploy_droplet(dry_run=args.dry_run)
     elif args.command == "refresh":
-        push_latest()
-        refresh_working_copy()
-        redeploy_droplet()
+        push_latest(dry_run=args.dry_run)
+        refresh_working_copy(dry_run=args.dry_run)
+        redeploy_droplet(dry_run=args.dry_run)
     elif args.command == "rebase":
-        run("git pull --rebase")
-        push_latest()
-        redeploy_droplet()
+        run("git pull --rebase", dry_run=args.dry_run)
+        push_latest(dry_run=args.dry_run)
+        redeploy_droplet(dry_run=args.dry_run)
     elif args.command == "sync":
-        sync_connectors()
+        sync_connectors(dry_run=args.dry_run)
     else:
         parser.print_help()
     return 0
@@ -84,4 +160,3 @@ def main(argv: list[str] | None = None) -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-


### PR DESCRIPTION
## Summary
- implement Working Copy sync with push and iOS pull triggers
- log Codex pipeline actions and support dry-run mode
- add tests mocking Working Copy HTTP and URL calls

## Testing
- `ruff check tools/codex_pipeline.py tests/test_pipeline.py`
- `black --check tools/codex_pipeline.py tests/test_pipeline.py`
- `isort --check-only tools/codex_pipeline.py tests/test_pipeline.py`
- `pytest tests/test_pipeline.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab842d032c8329852acede395c5571