### PR TITLE
Add service validation to Codex pipeline

### DIFF
--- a/tests/test_codex_pipeline_validation.py
+++ b/tests/test_codex_pipeline_validation.py
@@ -1,0 +1,61 @@
+from unittest import mock
+
+import tools.codex_pipeline as pipeline
+
+
+class DummyResponse:
+    def __init__(self, code: int, body: str) -> None:
+        self._code = code
+        self._body = body
+
+    def getcode(self) -> int:  # pragma: no cover - used by urlopen
+        return self._code
+
+    def read(self) -> bytes:  # pragma: no cover - used by urlopen
+        return self._body.encode()
+
+    def __enter__(self) -> "DummyResponse":  # pragma: no cover - context manager
+        return self
+
+    def __exit__(self, *exc: object) -> None:  # pragma: no cover
+        return None
+
+
+def test_validate_services_all_ok(monkeypatch, tmp_path):
+    monkeypatch.setattr(pipeline, "LOG_FILE", tmp_path / "log")
+    responses = [DummyResponse(200, '{"status": "ok"}') for _ in range(4)]
+    monkeypatch.setattr(pipeline.request, "urlopen", mock.Mock(side_effect=responses))
+
+    summary = pipeline.validate_services()
+    assert all(summary[name] == "OK" for name in ["frontend", "api", "llm", "math"])
+    assert "timestamp" in summary
+
+
+def test_validate_services_failure(monkeypatch, tmp_path):
+    monkeypatch.setattr(pipeline, "LOG_FILE", tmp_path / "log")
+    responses = [
+        DummyResponse(200, '{"status": "ok"}'),
+        DummyResponse(500, '{}'),
+        DummyResponse(200, '{"status": "ok"}'),
+        DummyResponse(200, '{"status": "ok"}'),
+    ]
+    monkeypatch.setattr(pipeline.request, "urlopen", mock.Mock(side_effect=responses))
+
+    summary = pipeline.validate_services()
+    assert summary["api"] == "FAIL"
+
+
+def test_skip_validate(monkeypatch):
+    called = False
+
+    def fake_validate() -> dict[str, str]:  # pragma: no cover - patched
+        nonlocal called
+        called = True
+        return {}
+
+    monkeypatch.setattr(pipeline, "validate_services", fake_validate)
+    monkeypatch.setattr(pipeline, "push_latest", lambda: None)
+    monkeypatch.setattr(pipeline, "redeploy_droplet", lambda: None)
+
+    pipeline.main(["--skip-validate", "push"])
+    assert called is False

--- a/tools/codex_pipeline.py
+++ b/tools/codex_pipeline.py
@@ -17,8 +17,13 @@ solution rather than a complete deployment utility.
 from __future__ import annotations
 
 import argparse
+import json
 import subprocess
-import sys
+from datetime import datetime
+from pathlib import Path
+from urllib import request
+
+LOG_FILE = Path(__file__).resolve().parent.parent / "pipeline_validation.log"
 
 
 def run(cmd: str) -> None:
@@ -52,9 +57,44 @@ def sync_connectors() -> None:
     print("TODO: implement connector sync")
 
 
+def _check_service(name: str, url: str) -> str:
+    """Return ``OK`` if the service responds with ``{"status": "ok"}``."""
+    try:
+        with request.urlopen(url, timeout=5) as resp:  # nosec B310
+            if resp.getcode() != 200:
+                raise ValueError(f"unexpected status {resp.getcode()}")
+            payload = json.loads(resp.read().decode())
+            status = "OK" if payload.get("status") == "ok" else "FAIL"
+    except Exception:  # noqa: BLE001
+        status = "FAIL"
+
+    timestamp = datetime.utcnow().isoformat()
+    with LOG_FILE.open("a", encoding="utf-8") as fh:
+        fh.write(f"{timestamp} {name} {status}\n")
+    return status
+
+
+def validate_services() -> dict[str, str]:
+    """Check core services and return a status summary."""
+    summary = {
+        "frontend": _check_service("frontend", "https://blackroad.io/health"),
+        "api": _check_service("api", "http://127.0.0.1:4000/api/health"),
+        "llm": _check_service("llm", "http://127.0.0.1:8000/health"),
+        "math": _check_service("math", "http://127.0.0.1:8500/health"),
+    }
+    summary["timestamp"] = datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+    print(json.dumps(summary))
+    return summary
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="BlackRoad Codex pipeline scaffold",
+    )
+    parser.add_argument(
+        "--skip-validate",
+        action="store_true",
+        help="Skip service health validation",
     )
     sub = parser.add_subparsers(dest="command")
     sub.add_parser("push", help="Push latest to BlackRoad.io")
@@ -63,6 +103,8 @@ def main(argv: list[str] | None = None) -> int:
     sub.add_parser("sync", help="Sync Salesforce → Airtable → Droplet")
 
     args = parser.parse_args(argv)
+
+    exit_code = 0
 
     if args.command == "push":
         push_latest()
@@ -79,7 +121,14 @@ def main(argv: list[str] | None = None) -> int:
         sync_connectors()
     else:
         parser.print_help()
-    return 0
+        return exit_code
+
+    if not args.skip_validate:
+        summary = validate_services()
+        if any(v != "OK" for k, v in summary.items() if k != "timestamp"):
+            exit_code = 1
+
+    return exit_code
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add service health validation and logging to Codex pipeline
- provide --skip-validate flag to bypass checks
- test validation for success, failure, and skip flag

## Testing
- `ruff check tools/codex_pipeline.py tests/test_codex_pipeline_validation.py`
- `pytest tests/test_codex_pipeline_validation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab848e1b288329a28261f43169ad03