### PR TITLE
feat: add rollback and error handling

### DIFF
--- a/tests/test_codex_pipeline.py
+++ b/tests/test_codex_pipeline.py
@@ -1,0 +1,57 @@
+import subprocess
+
+import pytest
+
+import tools.codex_pipeline as cp
+
+
+class Runner:
+    def __init__(self, fail_on: str):
+        self.fail_on = fail_on
+        self.commands: list[str] = []
+
+    def __call__(self, cmd: str) -> None:
+        self.commands.append(cmd)
+        if self.fail_on in cmd:
+            raise subprocess.CalledProcessError(1, cmd)
+
+
+def test_git_failure(monkeypatch):
+    runner = Runner("git push")
+    monkeypatch.setattr(cp, "run", runner)
+    monkeypatch.setattr(cp, "log_error", lambda *a, **k: None)
+    with pytest.raises(subprocess.CalledProcessError):
+        cp.run_pipeline()
+    assert any("git reset --hard" in c for c in runner.commands)
+
+
+def test_connector_failure(monkeypatch):
+    runner = Runner("connector-sync")
+    monkeypatch.setattr(cp, "run", runner)
+    monkeypatch.setattr(cp, "log_error", lambda *a, **k: None)
+    with pytest.raises(subprocess.CalledProcessError):
+        cp.run_pipeline()
+    assert "validate-services" not in "".join(runner.commands)
+    assert not any("/var/backups/blackroad" in c for c in runner.commands)
+
+
+def test_droplet_copy_failure(monkeypatch):
+    runner = Runner("deploy-to-droplet")
+    monkeypatch.setattr(cp, "run", runner)
+    monkeypatch.setattr(cp, "log_error", lambda *a, **k: None)
+    with pytest.raises(subprocess.CalledProcessError):
+        cp.run_pipeline()
+    assert any("/var/backups/blackroad/droplet" in c for c in runner.commands)
+
+
+def test_validation_failure_triggers_rollback(monkeypatch):
+    runner = Runner("validate-services")
+    monkeypatch.setattr(cp, "run", runner)
+    logs: list[tuple[str, bool]] = []
+    monkeypatch.setattr(
+        cp, "log_error", lambda stage, exc, rollback, webhook=None: logs.append((stage, rollback))
+    )
+    with pytest.raises(subprocess.CalledProcessError):
+        cp.run_pipeline()
+    assert any("/var/backups/blackroad/latest" in c for c in runner.commands)
+    assert ("validate_services", True) in logs


### PR DESCRIPTION
## Summary
- enhance codex pipeline with structured error handling, rollback, and optional webhook notifications
- add tests covering git, droplet, connector, and validation failures

## Testing
- `pre-commit run --files tools/codex_pipeline.py tests/test_codex_pipeline.py` *(fails: pathspec 'v3.3.3' did not match any file(s) known to git)*
- `black tools/codex_pipeline.py tests/test_codex_pipeline.py`
- `ruff check tools/codex_pipeline.py tests/test_codex_pipeline.py`
- `pytest tests/test_codex_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab84ab72b08329877c4be58eb1a47f