### PR TITLE
feat: persist backend data in sqlite

### DIFF
--- a/backend/data.js
+++ b/backend/data.js
@@ -1,60 +1,127 @@
-// Ephemeral in-memory store. Replace with DB in prod.
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
 const { v4: uuidv4 } = require('uuid');
+const Database = require('better-sqlite3');
+const migrate = require('./migrate');
 
-const store = {
-  users: [
-    { id: 'u-root', username: 'root', displayName: 'Root', role: 'owner', plan: 'free', lastLogin: new Date().toISOString() }
-  ],
-  wallet: { rc: 1.2 },
-  agents: [
-    { id: 'phi', name: 'Phi', status: 'idle', cpu: 0, memory: 0 },
-    { id: 'gpt', name: 'GPT', status: 'idle', cpu: 0, memory: 0 },
-    { id: 'mistral', name: 'Mistral', status: 'idle', cpu: 0, memory: 0 }
-  ],
-  contradictions: { issues: 2 },
-  sessionNotes: "",
-  guardian: {
-    status: { secure: true, mfa: true, encryption: true, lastScan: '2025-08-20' },
-    alerts: [
-      { id: uuidv4(), type: 'Unauthorized login', severity: 'high', time: new Date().toISOString(), status: 'active' }
-    ]
-  },
-  posts: [
-    {
-      id: uuidv4(),
-      author: 'Root',
-      time: new Date().toISOString(),
-      content: 'Welcome to BackRoad!'
-        + '\n\nShare updates with your fellow travelers.',
-      likes: 0,
-    },
-  ],
-  tasks: [
-    { id: uuidv4(), title: "Calculus HW 3", course: "Math 201", status: "todo", due: "2025-08-25", reward: 12, progress: 0.2 },
-    { id: uuidv4(), title: "Lab: Sorting", course: "CS 101", status: "inprogress", due: "2025-08-23", reward: 20, progress: 0.55 },
-    { id: uuidv4(), title: "Essay Draft", course: "ENG 210", status: "review", due: "2025-08-24", reward: 15, progress: 0.8 },
-    { id: uuidv4(), title: "Fix auth bug", course: "CS 101", status: "done", due: "2025-08-21", reward: 5, progress: 1.0 }
-  ],
-  commits: [
-    { id: 'c1', hash: 'd1f6e52', author: 'Mistral agent', message: 'Revert last commit', time: new Date(Date.now()-3600e3).toISOString() },
-    { id: 'c2', hash: 'a9c1b02', author: 'User', message: 'Add print("Hello, world!")', time: new Date(Date.now()-1800e3).toISOString() }
-  ],
-  projects: [
-    { id: uuidv4(), name: 'Demo Project', status: 'active' }
-  ],
-  timeline: [
-    { id: uuidv4(), type: 'agent', agent: 'Phi', text: "created a branch `main`", time: new Date().toISOString() },
-    { id: uuidv4(), type: 'agent', agent: 'GPT', text: "ran a code generation (env: prod, branch: main)", time: new Date().toISOString() },
-  ],
-  lucidiaHistory: []
-  claudeHistory: []
-  codexRuns: []
-};
+const DB_FILE = '/srv/blackroad-api/blackroad.db';
 
-function addTimeline(evt){
-  const item = { id: uuidv4(), time: new Date().toISOString(), ...evt };
-  store.timeline.unshift(item);
-  return item;
+// Ensure database and schema are ready
+migrate();
+
+// Simple connection pool (single connection reused)
+const pool = [];
+function getDb() {
+  if (pool.length === 0) {
+    fs.mkdirSync(path.dirname(DB_FILE), { recursive: true });
+    const db = new Database(DB_FILE);
+    db.pragma('journal_mode = WAL');
+    db.pragma('foreign_keys = ON');
+    pool.push(db);
+  }
+  return pool[0];
 }
 
-module.exports = { store, addTimeline };
+function closeDb() {
+  if (pool[0]) {
+    pool[0].close();
+    pool.length = 0;
+  }
+}
+
+// ---- Users ----
+function addUser(email, passwordHash) {
+  const id = uuidv4();
+  getDb()
+    .prepare('INSERT INTO users (id, email, password_hash) VALUES (?, ?, ?)')
+    .run(id, email, passwordHash);
+  return id;
+}
+
+function getUsers() {
+  return getDb().prepare('SELECT id, email, password_hash, created_at FROM users').all();
+}
+
+// ---- Projects ----
+function addProject(userId, name) {
+  const id = uuidv4();
+  getDb()
+    .prepare('INSERT INTO projects (id, user_id, name) VALUES (?, ?, ?)')
+    .run(id, userId, name);
+  return getProject(id);
+}
+
+function getProject(id) {
+  return getDb().prepare('SELECT * FROM projects WHERE id = ?').get(id);
+}
+
+function getProjects(userId) {
+  return getDb().prepare('SELECT * FROM projects WHERE user_id = ?').all(userId);
+}
+
+// ---- Tasks ----
+function addTask(projectId, title, status = 'todo') {
+  const id = uuidv4();
+  getDb()
+    .prepare('INSERT INTO tasks (id, project_id, title, status) VALUES (?, ?, ?, ?)')
+    .run(id, projectId, title, status);
+  return getTask(id);
+}
+
+function getTask(id) {
+  return getDb().prepare('SELECT * FROM tasks WHERE id = ?').get(id);
+}
+
+function getTasks(projectId) {
+  return getDb()
+    .prepare('SELECT * FROM tasks WHERE project_id = ? ORDER BY created_at DESC')
+    .all(projectId);
+}
+
+function getAllTasks() {
+  return getDb().prepare('SELECT * FROM tasks ORDER BY created_at DESC').all();
+}
+
+function updateTask(id, fields) {
+  const { title, status } = fields || {};
+  getDb()
+    .prepare(
+      `UPDATE tasks SET title = COALESCE(?, title), status = COALESCE(?, status), updated_at = datetime('now') WHERE id = ?`
+    )
+    .run(title || null, status || null, id);
+  return getTask(id);
+}
+
+function deleteTask(id) {
+  getDb().prepare('DELETE FROM tasks WHERE id = ?').run(id);
+}
+
+// ---- Logs ----
+function addLog(service, message) {
+  getDb().prepare('INSERT INTO logs (service, message) VALUES (?, ?)').run(service, message);
+}
+
+function getLogs() {
+  return getDb().prepare('SELECT * FROM logs ORDER BY timestamp DESC').all();
+}
+
+module.exports = {
+  getDb,
+  closeDb,
+  addUser,
+  getUsers,
+  addProject,
+  getProject,
+  getProjects,
+  addTask,
+  getTask,
+  getTasks,
+  getAllTasks,
+  updateTask,
+  deleteTask,
+  addLog,
+  getLogs,
+};
+

--- a/backend/migrate.js
+++ b/backend/migrate.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const Database = require('better-sqlite3');
+
+const DB_FILE = '/srv/blackroad-api/blackroad.db';
+
+function migrate() {
+  fs.mkdirSync(path.dirname(DB_FILE), { recursive: true });
+  const db = new Database(DB_FILE);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS users (
+      id TEXT PRIMARY KEY,
+      email TEXT UNIQUE NOT NULL,
+      password_hash TEXT NOT NULL,
+      created_at TEXT DEFAULT (datetime('now'))
+    );
+    CREATE TABLE IF NOT EXISTS projects (
+      id TEXT PRIMARY KEY,
+      user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      name TEXT NOT NULL,
+      created_at TEXT DEFAULT (datetime('now'))
+    );
+    CREATE TABLE IF NOT EXISTS tasks (
+      id TEXT PRIMARY KEY,
+      project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+      title TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'todo',
+      created_at TEXT DEFAULT (datetime('now')),
+      updated_at TEXT DEFAULT (datetime('now'))
+    );
+    CREATE TABLE IF NOT EXISTS logs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      service TEXT NOT NULL,
+      message TEXT NOT NULL,
+      timestamp TEXT DEFAULT (datetime('now'))
+    );
+  `);
+  db.close();
+}
+
+if (require.main === module) {
+  migrate();
+  console.log('Database migrated');
+}
+
+module.exports = migrate;

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,7 +14,8 @@
     "express": "^4.19.2",
     "jsonwebtoken": "^9.0.2",
     "socket.io": "^4.7.5",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "better-sqlite3": "^9.4.3"
   },
   "devDependencies": {
     "nodemon": "^3.0.2"

--- a/tests/test_db.js
+++ b/tests/test_db.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const DB_FILE = '/srv/blackroad-api/blackroad.db';
+
+// Start fresh
+try {
+  fs.rmSync(DB_FILE, { force: true });
+} catch {}
+
+const migrate = require('../backend/migrate');
+migrate();
+
+let data = require('../backend/data');
+
+// Insert user
+const userId = data.addUser('tester@example.com', 'hash');
+let users = data.getUsers();
+assert.strictEqual(users.length, 1);
+
+// Insert project
+const project = data.addProject(userId, 'Demo Project');
+let projects = data.getProjects(userId);
+assert.strictEqual(projects.length, 1);
+
+// Insert task
+const task = data.addTask(project.id, 'First task', 'todo');
+let tasks = data.getTasks(project.id);
+assert.strictEqual(tasks.length, 1);
+assert.strictEqual(tasks[0].status, 'todo');
+
+// Update task
+data.updateTask(task.id, { status: 'done' });
+tasks = data.getTasks(project.id);
+assert.strictEqual(tasks[0].status, 'done');
+
+// Delete task
+data.deleteTask(task.id);
+tasks = data.getTasks(project.id);
+assert.strictEqual(tasks.length, 0);
+
+// Verify persistence across reload
+data.closeDb();
+delete require.cache[require.resolve('../backend/data')];
+data = require('../backend/data');
+users = data.getUsers();
+assert.strictEqual(users.length, 1);
+projects = data.getProjects(userId);
+assert.strictEqual(projects.length, 1);
+
+console.log('test_db passed');


### PR DESCRIPTION
## Summary
- replace in-memory backend store with SQLite database and helper functions
- add migration script to create users, projects, tasks, and logs tables
- wire tasks route and tests to use persistent storage

## Testing
- `npm run lint` *(fails: Parsing error in JSX files)*
- `npm test`
- `node tests/test_db.js` *(fails: Cannot find module 'better-sqlite3')*

------
https://chatgpt.com/codex/tasks/task_e_68ab84d1975c8329b584a333ed8bd90c