### PR TITLE
feat: secure backend with jwt auth

### DIFF
--- a/backend/auth.js
+++ b/backend/auth.js
@@ -1,0 +1,87 @@
+'use strict';
+
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+const { v4: uuidv4 } = require('uuid');
+const { store } = require('./data');
+
+const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret-change-me';
+
+function sanitizeUser(u) {
+  const { id, username, role, created_at, projectId } = u;
+  return { id, username, role, created_at, projectId };
+}
+
+function signToken(user, expires = '1h') {
+  return jwt.sign({ id: user.id, role: user.role, projectId: user.projectId }, JWT_SECRET, { expiresIn: expires });
+}
+
+function signup(req, res) {
+  const { username, password, role } = req.body || {};
+  if (!username || !password) return res.status(400).json({ error: 'missing_fields' });
+  if (store.users.find(u => u.username === username)) {
+    return res.status(409).json({ error: 'user_exists' });
+  }
+  const user = {
+    id: uuidv4(),
+    username,
+    passwordHash: bcrypt.hashSync(password, 10),
+    role: role === 'admin' ? 'admin' : 'user',
+    created_at: new Date().toISOString(),
+    projectId: store.projects[0]?.id || null
+  };
+  store.users.push(user);
+  const token = signToken(user);
+  res.json({ token, user: sanitizeUser(user) });
+}
+
+function login(req, res) {
+  const { username, password } = req.body || {};
+  const user = store.users.find(u => u.username === username);
+  if (!user || !bcrypt.compareSync(password, user.passwordHash)) {
+    return res.status(401).json({ error: 'invalid_credentials' });
+  }
+  const token = signToken(user);
+  const refreshToken = uuidv4();
+  store.sessions.push({ token: refreshToken, userId: user.id });
+  res.json({ token, refreshToken, user: sanitizeUser(user) });
+}
+
+function logout(req, res) {
+  const { refreshToken } = req.body || {};
+  const idx = store.sessions.findIndex(s => s.token === refreshToken);
+  if (idx >= 0) store.sessions.splice(idx, 1);
+  res.json({ ok: true });
+}
+
+function authMiddleware(req, res, next) {
+  const hdr = req.headers.authorization || '';
+  const token = hdr.startsWith('Bearer ') ? hdr.slice(7) : null;
+  if (!token) return res.status(401).json({ error: 'missing_token' });
+  try {
+    const payload = jwt.verify(token, JWT_SECRET);
+    req.user = payload;
+    next();
+  } catch {
+    res.status(401).json({ error: 'invalid_token' });
+  }
+}
+
+function requireRole(role) {
+  return (req, res, next) => {
+    if (!req.user || req.user.role !== role) {
+      return res.status(403).json({ error: 'forbidden' });
+    }
+    next();
+  };
+}
+
+module.exports = {
+  signup,
+  login,
+  logout,
+  authMiddleware,
+  requireRole,
+  JWT_SECRET,
+  signToken
+};

--- a/backend/data.js
+++ b/backend/data.js
@@ -1,10 +1,21 @@
 // Ephemeral in-memory store. Replace with DB in prod.
 const { v4: uuidv4 } = require('uuid');
+const bcrypt = require('bcryptjs');
+
+const demoProjectId = uuidv4();
 
 const store = {
   users: [
-    { id: 'u-root', username: 'root', displayName: 'Root', role: 'owner', plan: 'free', lastLogin: new Date().toISOString() }
+    {
+      id: 'u-admin',
+      username: 'admin',
+      passwordHash: bcrypt.hashSync('adminpass', 10),
+      role: 'admin',
+      created_at: new Date().toISOString(),
+      projectId: demoProjectId
+    }
   ],
+  sessions: [],
   wallet: { rc: 1.2 },
   agents: [
     { id: 'phi', name: 'Phi', status: 'idle', cpu: 0, memory: 0 },
@@ -22,32 +33,31 @@ const store = {
   posts: [
     {
       id: uuidv4(),
-      author: 'Root',
+      author: 'Admin',
       time: new Date().toISOString(),
-      content: 'Welcome to BackRoad!'
-        + '\n\nShare updates with your fellow travelers.',
+      content: 'Welcome to BackRoad!\n\nShare updates with your fellow travelers.',
       likes: 0,
     },
   ],
   tasks: [
-    { id: uuidv4(), title: "Calculus HW 3", course: "Math 201", status: "todo", due: "2025-08-25", reward: 12, progress: 0.2 },
-    { id: uuidv4(), title: "Lab: Sorting", course: "CS 101", status: "inprogress", due: "2025-08-23", reward: 20, progress: 0.55 },
-    { id: uuidv4(), title: "Essay Draft", course: "ENG 210", status: "review", due: "2025-08-24", reward: 15, progress: 0.8 },
-    { id: uuidv4(), title: "Fix auth bug", course: "CS 101", status: "done", due: "2025-08-21", reward: 5, progress: 1.0 }
+    { id: uuidv4(), projectId: demoProjectId, title: "Calculus HW 3", course: "Math 201", status: "todo", due: "2025-08-25", reward: 12, progress: 0.2 },
+    { id: uuidv4(), projectId: demoProjectId, title: "Lab: Sorting", course: "CS 101", status: "inprogress", due: "2025-08-23", reward: 20, progress: 0.55 },
+    { id: uuidv4(), projectId: demoProjectId, title: "Essay Draft", course: "ENG 210", status: "review", due: "2025-08-24", reward: 15, progress: 0.8 },
+    { id: uuidv4(), projectId: demoProjectId, title: "Fix auth bug", course: "CS 101", status: "done", due: "2025-08-21", reward: 5, progress: 1.0 }
   ],
   commits: [
     { id: 'c1', hash: 'd1f6e52', author: 'Mistral agent', message: 'Revert last commit', time: new Date(Date.now()-3600e3).toISOString() },
     { id: 'c2', hash: 'a9c1b02', author: 'User', message: 'Add print("Hello, world!")', time: new Date(Date.now()-1800e3).toISOString() }
   ],
   projects: [
-    { id: uuidv4(), name: 'Demo Project', status: 'active' }
+    { id: demoProjectId, name: 'Demo Project', status: 'active' }
   ],
   timeline: [
     { id: uuidv4(), type: 'agent', agent: 'Phi', text: "created a branch `main`", time: new Date().toISOString() },
     { id: uuidv4(), type: 'agent', agent: 'GPT', text: "ran a code generation (env: prod, branch: main)", time: new Date().toISOString() },
   ],
-  lucidiaHistory: []
-  claudeHistory: []
+  lucidiaHistory: [],
+  claudeHistory: [],
   codexRuns: []
 };
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -12,8 +12,9 @@ const express = require('express');
 const cors = require('cors');
 const http = require('http');
 const { Server } = require('socket.io');
-const { signToken, authMiddleware, nowISO } = require('./utils');
+const { authMiddleware, requireRole, signup, login, logout, JWT_SECRET } = require('./auth');
 const { store, addTimeline } = require('./data');
+const { nowISO } = require('./utils');
 const { exec } = require('child_process');
 const { v4: uuidv4 } = require('uuid');
 
@@ -43,21 +44,15 @@ app.use(cors({ origin: process.env.CORS_ORIGIN?.split(',') || '*'}));
 const server = http.createServer(app);
 const io = new Server(server, { cors: { origin: process.env.CORS_ORIGIN?.split(',') || '*' } });
 
-const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret-change-me';
 const ALLOW_SHELL = (process.env.ALLOW_SHELL || 'false').toLowerCase() === 'true';
 
 // ---- Auth ----
-app.post('/api/auth/login', (req, res) => {
-  const { username, password } = req.body || {};
-  if (username === 'root' && password === 'Codex2025') {
-    const token = signToken({ uid: 'u-root', username: 'root', role: 'owner' }, JWT_SECRET, '12h');
-    return res.json({ token, user: { id: 'u-root', username: 'root', displayName: 'Root', role: 'owner' }});
-  }
-  res.status(401).json({ error: 'invalid credentials' });
-});
-
-app.get('/api/auth/me', authMiddleware(JWT_SECRET), (req, res) => {
-  res.json({ user: store.users[0] });
+app.post('/api/auth/signup', signup);
+app.post('/api/auth/login', login);
+app.post('/api/auth/logout', authMiddleware, logout);
+app.get('/api/auth/me', authMiddleware, (req, res) => {
+  const user = store.users.find(u => u.id === req.user.id);
+  res.json({ user });
 });
 
 // ---- Public Info ----
@@ -73,44 +68,60 @@ app.get('/api/droplet', (req, res) => {
 });
 
 // ---- Data Endpoints ----
-app.get('/api/timeline', authMiddleware(JWT_SECRET), (req, res)=>{
+app.get('/api/timeline', authMiddleware, (req, res)=>{
   res.json({ timeline: store.timeline.slice(0, 50) });
 });
 
-app.get('/api/commits', authMiddleware(JWT_SECRET), (req, res)=>{
+app.get('/api/commits', authMiddleware, (req, res)=>{
   res.json({ commits: store.commits });
 });
 
-app.get('/api/tasks', authMiddleware(JWT_SECRET), (req, res)=>{
-  res.json({ tasks: store.tasks });
+app.get('/api/tasks', authMiddleware, (req, res)=>{
+  const tasks = store.tasks.filter(t => t.projectId === req.user.projectId);
+  res.json({ tasks });
 });
 
-app.post('/api/tasks', authMiddleware(JWT_SECRET), (req, res)=>{
+app.post('/api/tasks', authMiddleware, (req, res)=>{
   const t = req.body;
-  t.id = t.id || require('uuid').v4();
+  t.id = t.id || uuidv4();
+  if (t.projectId !== req.user.projectId) return res.status(403).json({ error: 'wrong_project' });
   store.tasks.push(t);
-  addTimeline({ type: 'task', text: `New task created: ${t.title}`, by: req.user.username });
+  addTimeline({ type: 'task', text: `New task created: ${t.title}`, by: req.user.id });
   io.emit('timeline:new', { at: nowISO(), item: store.timeline[0] });
   res.status(201).json({ ok: true, task: t });
 });
 
-app.patch('/api/tasks/:id', authMiddleware(JWT_SECRET), (req, res)=>{
+app.patch('/api/tasks/:id', authMiddleware, (req, res)=>{
   const idx = store.tasks.findIndex(t=>t.id === req.params.id);
   if (idx < 0) return res.status(404).json({ error: 'not found' });
   store.tasks[idx] = { ...store.tasks[idx], ...req.body };
   res.json({ ok: true, task: store.tasks[idx] });
 });
 
-app.get('/api/agents', authMiddleware(JWT_SECRET), (req, res)=>{
+app.delete('/api/users/:id', authMiddleware, requireRole('admin'), (req, res) => {
+  const idx = store.users.findIndex(u => u.id === req.params.id);
+  if (idx < 0) return res.status(404).json({ error: 'not found' });
+  store.users.splice(idx, 1);
+  res.json({ ok: true });
+});
+
+app.delete('/api/projects/:id', authMiddleware, requireRole('admin'), (req, res) => {
+  const idx = store.projects.findIndex(p => p.id === req.params.id);
+  if (idx < 0) return res.status(404).json({ error: 'not found' });
+  store.projects.splice(idx, 1);
+  res.json({ ok: true });
+});
+
+app.get('/api/agents', authMiddleware, (req, res)=>{
   res.json({ agents: store.agents });
 });
 
 // Orchestrator APIs
-app.get('/api/orchestrator/agents', authMiddleware(JWT_SECRET), (req, res)=>{
+app.get('/api/orchestrator/agents', authMiddleware, (req, res)=>{
   res.json({ agents: store.agents });
 });
 
-app.post('/api/orchestrator/control/:id', authMiddleware(JWT_SECRET), (req, res)=>{
+app.post('/api/orchestrator/control/:id', authMiddleware, (req, res)=>{
   const { action } = req.body || {};
   const id = req.params.id;
   const agent = store.agents.find(a => a.id === id);
@@ -121,19 +132,19 @@ app.post('/api/orchestrator/control/:id', authMiddleware(JWT_SECRET), (req, res)
   res.json({ ok: true, agent });
 });
 
-app.get('/api/wallet', authMiddleware(JWT_SECRET), (req, res)=>{
+app.get('/api/wallet', authMiddleware, (req, res)=>{
   res.json({ wallet: store.wallet });
 });
 
-app.get('/api/contradictions', authMiddleware(JWT_SECRET), (req, res)=>{
+app.get('/api/contradictions', authMiddleware, (req, res)=>{
   res.json({ contradictions: store.contradictions });
 });
 
-app.get('/api/notes', authMiddleware(JWT_SECRET), (req, res)=>{
+app.get('/api/notes', authMiddleware, (req, res)=>{
   res.json({ notes: store.sessionNotes });
 });
 
-app.post('/api/notes', authMiddleware(JWT_SECRET), (req, res)=>{
+app.post('/api/notes', authMiddleware, (req, res)=>{
   store.sessionNotes = String(req.body?.notes || '');
   io.emit('notes:update', store.sessionNotes);
   res.json({ ok: true });
@@ -167,30 +178,30 @@ app.post('/api/lucidia/chat', (req, res) => {
     }
   }, 200);
 // Guardian endpoints
-app.get('/api/guardian/status', authMiddleware(JWT_SECRET), (req, res)=>{
+app.get('/api/guardian/status', authMiddleware, (req, res)=>{
   res.json(store.guardian.status);
 });
 
-app.get('/api/guardian/alerts', authMiddleware(JWT_SECRET), (req, res)=>{
+app.get('/api/guardian/alerts', authMiddleware, (req, res)=>{
   res.json({ alerts: store.guardian.alerts });
 });
 
-app.post('/api/guardian/alerts/:id/resolve', authMiddleware(JWT_SECRET), (req, res)=>{
+app.post('/api/guardian/alerts/:id/resolve', authMiddleware, (req, res)=>{
   const alert = store.guardian.alerts.find(a=>a.id === req.params.id);
   if (!alert) return res.status(404).json({ error: 'not found' });
   alert.status = req.body?.status || 'resolved';
   res.json({ ok: true, alert });
 // Dashboard
-app.get('/api/dashboard/system', authMiddleware(JWT_SECRET), (req, res)=>{
+app.get('/api/dashboard/system', authMiddleware, (req, res)=>{
   res.json({ cpu, gpu, memory: mem, network: net });
 });
 
-app.get('/api/dashboard/feed', authMiddleware(JWT_SECRET), (req, res)=>{
+app.get('/api/dashboard/feed', authMiddleware, (req, res)=>{
   res.json({ events: store.timeline.slice(0, 20) });
 });
 
 // Personal profile
-app.get('/api/you/profile', authMiddleware(JWT_SECRET), (req, res)=>{
+app.get('/api/you/profile', authMiddleware, (req, res)=>{
   const user = store.users[0];
   res.json({
     username: user.username,
@@ -200,7 +211,7 @@ app.get('/api/you/profile', authMiddleware(JWT_SECRET), (req, res)=>{
     projects: store.projects || []
   });
 // Claude chat
-app.post('/api/claude/chat', authMiddleware(JWT_SECRET), (req, res)=>{
+app.post('/api/claude/chat', authMiddleware, (req, res)=>{
   const prompt = String(req.body?.prompt || '');
   const response = `Claude heard: ${prompt}`;
   let sent = 0;
@@ -218,10 +229,10 @@ app.post('/api/claude/chat', authMiddleware(JWT_SECRET), (req, res)=>{
   res.json({ ok: true });
 });
 
-app.get('/api/claude/history', authMiddleware(JWT_SECRET), (req, res)=>{
+app.get('/api/claude/history', authMiddleware, (req, res)=>{
   res.json({ history: store.claudeHistory });
 // Codex
-app.post('/api/codex/run', authMiddleware(JWT_SECRET), (req, res)=>{
+app.post('/api/codex/run', authMiddleware, (req, res)=>{
   const prompt = String(req.body?.prompt || '');
   const plan = [
     { step: 1, agent: 'Phi', action: 'Analyze prompt' },
@@ -234,28 +245,28 @@ app.post('/api/codex/run', authMiddleware(JWT_SECRET), (req, res)=>{
   res.json(run);
 });
 
-app.get('/api/codex/history', authMiddleware(JWT_SECRET), (req, res)=>{
+app.get('/api/codex/history', authMiddleware, (req, res)=>{
   res.json({ runs: store.codexRuns });
 // Roadbook endpoints
-app.get('/api/roadbook/chapters', authMiddleware(JWT_SECRET), (req, res) => {
+app.get('/api/roadbook/chapters', authMiddleware, (req, res) => {
   const chapters = roadbookChapters.map(({ id, title }) => ({ id, title }));
   res.json({ chapters });
 });
 
-app.get('/api/roadbook/chapter/:id', authMiddleware(JWT_SECRET), (req, res) => {
+app.get('/api/roadbook/chapter/:id', authMiddleware, (req, res) => {
   const chapter = roadbookChapters.find(c => c.id === req.params.id);
   if (!chapter) return res.status(404).json({ error: 'not found' });
   res.json({ chapter });
 });
 
-app.get('/api/roadbook/search', authMiddleware(JWT_SECRET), (req, res) => {
+app.get('/api/roadbook/search', authMiddleware, (req, res) => {
   const q = String(req.query.q || '').toLowerCase();
   const results = roadbookChapters
     .filter(c => c.title.toLowerCase().includes(q) || c.content.toLowerCase().includes(q))
     .map(c => ({ id: c.id, title: c.title, snippet: c.content.slice(0, 80) }));
   res.json({ results });
 // RoadView sample streams
-app.get('/api/roadview/list', authMiddleware(JWT_SECRET), (req, res)=>{
+app.get('/api/roadview/list', authMiddleware, (req, res)=>{
   res.json({ streams: [
     { id: 'cam-1', name: 'Main Street', status: 'offline' },
     { id: 'cam-2', name: 'Downtown', status: 'offline' }
@@ -289,19 +300,19 @@ app.post('/api/backroad/like/:id', (req, res)=>{
 });
 
 // Actions
-app.post('/api/actions/run', authMiddleware(JWT_SECRET), (req,res)=>{
+app.post('/api/actions/run', authMiddleware, (req,res)=>{
   const item = addTimeline({ type: 'action', text: 'Run triggered', by: req.user.username });
   io.emit('timeline:new', { at: nowISO(), item });
   res.json({ ok: true });
 });
 
-app.post('/api/actions/revert', authMiddleware(JWT_SECRET), (req,res)=>{
+app.post('/api/actions/revert', authMiddleware, (req,res)=>{
   const item = addTimeline({ type: 'action', text: 'Revert last change', by: req.user.username });
   io.emit('timeline:new', { at: nowISO(), item });
   res.json({ ok: true });
 });
 
-app.post('/api/actions/mint', authMiddleware(JWT_SECRET), (req,res)=>{
+app.post('/api/actions/mint', authMiddleware, (req,res)=>{
   store.wallet.rc += 0.05;
   const item = addTimeline({ type: 'wallet', text: 'Minted 0.05 RC', by: req.user.username });
   io.emit('timeline:new', { at: nowISO(), item });
@@ -310,7 +321,7 @@ app.post('/api/actions/mint', authMiddleware(JWT_SECRET), (req,res)=>{
 });
 
 // Optional shell exec (guarded)
-app.post('/api/exec', authMiddleware(JWT_SECRET), (req, res)=>{
+app.post('/api/exec', authMiddleware, (req, res)=>{
   if (!ALLOW_SHELL) return res.status(403).json({ error: 'shell disabled' });
   const cmd = String(req.body?.cmd || '').slice(0, 256);
   exec(cmd, { timeout: 5000 }, (err, stdout, stderr)=>{
@@ -354,3 +365,5 @@ const HOST = '0.0.0.0';
 server.listen(PORT, HOST, () => {
   console.log(`Backend listening on http://${HOST}:${PORT}`);
 });
+
+module.exports = { app, server };

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prepare": "husky",
     "lint": "eslint . --ext .js,.jsx,.mjs,.cjs || true",
     "format": "prettier -w .",
-    "test": "node tests/smoke.test.mjs",
+    "test": "node tests/test_auth.js && node tests/smoke.test.mjs",
     "dev:site": "npm --prefix sites/blackroad run dev",
     "build": "npm --prefix sites/blackroad run build",
     "fix-anything": "node .github/tools/codex-apply.js .github/prompts/codex-fix-anything.md || true"

--- a/src/routes/tasks.js
+++ b/src/routes/tasks.js
@@ -3,31 +3,31 @@
 
 const express = require('express');
 const db = require('../db');
-const { requireAuth } = require('../auth');
+const { authMiddleware } = require('../../backend/auth');
 
 const router = express.Router();
 
-router.get('/', requireAuth, (req, res) => {
+router.get('/', authMiddleware, (req, res) => {
   const rows = db.prepare(`
     SELECT * FROM tasks
     WHERE assignee_id = ? OR assignee_id IS NULL
     ORDER BY created_at DESC
-  `).all(req.session.userId);
+  `).all(req.user.id);
   res.json({ ok: true, tasks: rows });
 });
 
-router.post('/', requireAuth, (req, res) => {
+router.post('/', authMiddleware, (req, res) => {
   const { title, description, status, priority, due_date } = req.body || {};
   if (!title) return res.status(400).json({ ok: false, error: 'missing_title' });
   const id = cryptoRandomId();
   db.prepare(`
     INSERT INTO tasks (id, title, description, status, priority, assignee_id, due_date)
     VALUES (?, ?, ?, COALESCE(?, 'todo'), COALESCE(?, 3), ?, ?)
-  `).run(id, title, description || null, status || null, priority || null, req.session.userId, due_date || null);
+  `).run(id, title, description || null, status || null, priority || null, req.user.id, due_date || null);
   res.json({ ok: true, task: db.prepare('SELECT * FROM tasks WHERE id = ?').get(id) });
 });
 
-router.put('/:id', requireAuth, (req, res) => {
+router.put('/:id', authMiddleware, (req, res) => {
   const id = req.params.id;
   const { title, description, status, priority, due_date } = req.body || {};
   const t = db.prepare('SELECT * FROM tasks WHERE id = ?').get(id);
@@ -45,7 +45,7 @@ router.put('/:id', requireAuth, (req, res) => {
   res.json({ ok: true });
 });
 
-router.delete('/:id', requireAuth, (req, res) => {
+router.delete('/:id', authMiddleware, (req, res) => {
   db.prepare('DELETE FROM tasks WHERE id = ?').run(req.params.id);
   res.json({ ok: true });
 });

--- a/tests/test_auth.js
+++ b/tests/test_auth.js
@@ -1,0 +1,69 @@
+const assert = require('node:assert/strict');
+const fetch = global.fetch;
+const { JWT_SECRET } = require('../backend/auth');
+const { server } = require('../backend/server');
+
+const base = 'http://localhost:4000/api';
+
+async function run() {
+  await new Promise(r => setTimeout(r, 300));
+
+  // signup
+  let res = await fetch(base + '/auth/signup', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ username: 'alice', password: 'password' })
+  });
+  let body = await res.json();
+  assert.equal(res.status, 200);
+  assert.ok(body.token);
+  const userId = body.user.id;
+
+  // login
+  res = await fetch(base + '/auth/login', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ username: 'alice', password: 'password' })
+  });
+  body = await res.json();
+  const token = body.token;
+  assert.ok(token);
+
+  // access protected route
+  res = await fetch(base + '/tasks', { headers: { Authorization: `Bearer ${token}` } });
+  assert.equal(res.status, 200);
+
+  // invalid token
+  res = await fetch(base + '/tasks', { headers: { Authorization: 'Bearer badtoken' } });
+  assert.equal(res.status, 401);
+
+  // expired token
+  const jwt = require('jsonwebtoken');
+  const expired = jwt.sign({ id: 'x', role: 'user' }, JWT_SECRET, { expiresIn: -1 });
+  res = await fetch(base + '/tasks', { headers: { Authorization: `Bearer ${expired}` } });
+  assert.equal(res.status, 401);
+
+  // admin-only delete
+  // normal user should fail
+  res = await fetch(base + `/users/${userId}`, { method: 'DELETE', headers: { Authorization: `Bearer ${token}` } });
+  assert.equal(res.status, 403);
+
+  // admin login
+  res = await fetch(base + '/auth/login', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ username: 'admin', password: 'adminpass' })
+  });
+  body = await res.json();
+  const adminToken = body.token;
+  assert.ok(adminToken);
+
+  res = await fetch(base + `/users/${userId}`, { method: 'DELETE', headers: { Authorization: `Bearer ${adminToken}` } });
+  assert.equal(res.status, 200);
+  server.close();
+}
+
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add JWT-based auth middleware for signup, login, and logout
- protect task routes with auth and project checks
- restrict destructive user/project actions to admins only
- add initial auth tests

## Testing
- `npm test` *(fails: Cannot find module 'bcryptjs')*
- `npm run lint` *(fails: Parsing error: Unexpected token < in various files)*

------
https://chatgpt.com/codex/tasks/task_e_68ab850aeb608329be2715e265bb4049