### PR TITLE
feat: add Kubernetes deployment for Prism stack

### DIFF
--- a/.github/workflows/prism-k8s.yaml
+++ b/.github/workflows/prism-k8s.yaml
@@ -1,0 +1,79 @@
+name: Prism Kubernetes Deploy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'k8s/**'
+      - '.github/workflows/prism-k8s.yaml'
+      - 'lucidia-llm/**'
+      - 'lucidia_math_lab/**'
+      - 'nginx/**'
+      - 'server_full.js'
+      - 'package.json'
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build API image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository }}/api:latest
+
+      - name: Build LLM image
+        uses: docker/build-push-action@v5
+        with:
+          context: lucidia-llm
+          push: true
+          tags: ghcr.io/${{ github.repository }}/llm:latest
+
+      - name: Build Math image
+        uses: docker/build-push-action@v5
+        with:
+          context: lucidia_math_lab
+          push: true
+          tags: ghcr.io/${{ github.repository }}/math:latest
+
+      - name: Build Nginx image
+        uses: docker/build-push-action@v5
+        with:
+          context: nginx
+          push: true
+          tags: ghcr.io/${{ github.repository }}/nginx:latest
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: v1.29.0
+
+      - name: Configure kubeconfig
+        run: |
+          mkdir -p $HOME/.kube
+          echo "${{ secrets.KUBE_CONFIG }}" > $HOME/.kube/config
+
+      - name: Apply manifests
+        run: kubectl apply -f k8s/
+
+      - name: Rollout restart
+        run: |
+          kubectl rollout restart deployment/api -n prism
+          kubectl rollout restart deployment/llm -n prism
+          kubectl rollout restart deployment/math -n prism
+          kubectl rollout restart deployment/nginx -n prism

--- a/k8s/api-deployment.yaml
+++ b/k8s/api-deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: prism
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: api
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      containers:
+        - name: api
+          image: ghcr.io/blackroad-prism/blackroad-api:latest
+          ports:
+            - containerPort: 4000
+          envFrom:
+            - configMapRef:
+                name: prism-config
+            - secretRef:
+                name: prism-secrets
+          volumeMounts:
+            - name: blackroad-db
+              mountPath: /data
+      volumes:
+        - name: blackroad-db
+          persistentVolumeClaim:
+            claimName: blackroad-db-pvc

--- a/k8s/api-service.yaml
+++ b/k8s/api-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: api
+  namespace: prism
+spec:
+  selector:
+    app: api
+  ports:
+    - port: 4000
+      targetPort: 4000

--- a/k8s/blackroad-db-pv.yaml
+++ b/k8s/blackroad-db-pv.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: blackroad-db-pv
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  hostPath:
+    path: /data/blackroad

--- a/k8s/blackroad-db-pvc.yaml
+++ b/k8s/blackroad-db-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: blackroad-db-pvc
+  namespace: prism
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  volumeName: blackroad-db-pv

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prism-config
+  namespace: prism
+data:
+  DATABASE_PATH: "/data/blackroad.db"
+  MATH_OUTPUT_DIR: "/output"
+  NODE_ENV: "production"

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,40 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: prism-ingress
+  namespace: prism
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  rules:
+    - host: blackroad.io
+      http:
+        paths:
+          - path: /api/
+            pathType: Prefix
+            backend:
+              service:
+                name: api
+                port:
+                  number: 4000
+          - path: /llm/
+            pathType: Prefix
+            backend:
+              service:
+                name: llm
+                port:
+                  number: 8000
+          - path: /math/
+            pathType: Prefix
+            backend:
+              service:
+                name: math
+                port:
+                  number: 9000
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: nginx
+                port:
+                  number: 80

--- a/k8s/llm-deployment.yaml
+++ b/k8s/llm-deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llm
+  namespace: prism
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: llm
+  template:
+    metadata:
+      labels:
+        app: llm
+    spec:
+      containers:
+        - name: llm
+          image: ghcr.io/blackroad-prism/lucidia-llm:latest
+          ports:
+            - containerPort: 8000
+          envFrom:
+            - configMapRef:
+                name: prism-config
+            - secretRef:
+                name: prism-secrets

--- a/k8s/llm-service.yaml
+++ b/k8s/llm-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: llm
+  namespace: prism
+spec:
+  selector:
+    app: llm
+  ports:
+    - port: 8000
+      targetPort: 8000

--- a/k8s/math-deployment.yaml
+++ b/k8s/math-deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: math
+  namespace: prism
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: math
+  template:
+    metadata:
+      labels:
+        app: math
+    spec:
+      containers:
+        - name: math
+          image: ghcr.io/blackroad-prism/lucidia-math:latest
+          ports:
+            - containerPort: 9000
+          envFrom:
+            - configMapRef:
+                name: prism-config
+            - secretRef:
+                name: prism-secrets
+          volumeMounts:
+            - name: math-output
+              mountPath: /output
+      volumes:
+        - name: math-output
+          persistentVolumeClaim:
+            claimName: math-output-pvc

--- a/k8s/math-output-pv.yaml
+++ b/k8s/math-output-pv.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: math-output-pv
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  hostPath:
+    path: /data/math-output

--- a/k8s/math-output-pvc.yaml
+++ b/k8s/math-output-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: math-output-pvc
+  namespace: prism
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi
+  volumeName: math-output-pv

--- a/k8s/math-service.yaml
+++ b/k8s/math-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: math
+  namespace: prism
+spec:
+  selector:
+    app: math
+  ports:
+    - port: 9000
+      targetPort: 9000

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: prism

--- a/k8s/nginx-deployment.yaml
+++ b/k8s/nginx-deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  namespace: prism
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:alpine
+          ports:
+            - containerPort: 80

--- a/k8s/nginx-service.yaml
+++ b/k8s/nginx-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  namespace: prism
+spec:
+  selector:
+    app: nginx
+  ports:
+    - port: 80
+      targetPort: 80
+  type: ClusterIP

--- a/k8s/secrets.yaml
+++ b/k8s/secrets.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: prism-secrets
+  namespace: prism
+type: Opaque
+stringData:
+  CONNECTOR_KEY: "replace-me"
+  JWT_SECRET: "replace-me"


### PR DESCRIPTION
## Summary
- add Kubernetes manifests for API, LLM, math, and nginx services
- set up persistent volumes, configmap, secrets, and ingress routes
- add GitHub Actions workflow to build images and deploy manifests

## Testing
- `npm test`
- `pytest` *(fails: 24 errors during collection)*
- `pre-commit run --files k8s/namespace.yaml k8s/configmap.yaml k8s/secrets.yaml k8s/blackroad-db-pv.yaml k8s/blackroad-db-pvc.yaml k8s/math-output-pv.yaml k8s/math-output-pvc.yaml k8s/api-deployment.yaml k8s/llm-deployment.yaml k8s/math-deployment.yaml k8s/nginx-deployment.yaml k8s/api-service.yaml k8s/llm-service.yaml k8s/math-service.yaml k8s/nginx-service.yaml k8s/ingress.yaml .github/workflows/prism-k8s.yaml` *(fails: pathspec 'v3.3.3' did not match any file(s) known to git)*
- `kubectl apply --dry-run=client -f k8s/` *(fails: connection refused, no cluster)*

------
https://chatgpt.com/codex/tasks/task_e_68ab895366c0832983e0008ac44ec51a