### PR TITLE
feat: add snapshot and rollback infrastructure

### DIFF
--- a/etc/cron.d/prism-snapshot
+++ b/etc/cron.d/prism-snapshot
@@ -1,0 +1,1 @@
+0 3 * * * root /usr/local/bin/prism-snapshot.sh

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -euo pipefail
+
+DB_PATH=${DB_PATH:-/var/blackroad/blackroad.db}
+API_DIR=${API_DIR:-/srv/blackroad-api}
+LLM_DIR=${LLM_DIR:-/srv/lucidia-llm}
+MATH_DIR=${MATH_DIR:-/srv/lucidia-math}
+
+BACKUP_BASE=${BACKUP_BASE:-/var/backups/prism}
+LOG_FILE=${ROLLBACK_LOG:-/var/log/prism-rollback.log}
+
+if [ -n "${1:-}" ]; then
+  TS="$1"
+else
+  echo "Available snapshots:"
+  ls "$BACKUP_BASE"
+  read -p "Select snapshot: " TS
+fi
+
+if [ "$TS" = "latest" ]; then
+  TS=$(find "$BACKUP_BASE" -mindepth 1 -maxdepth 1 -type d ! -name weekly | sort | tail -n 1)
+fi
+
+SNAP="$BACKUP_BASE/$TS"
+if [ ! -d "$SNAP" ]; then
+  echo "Snapshot not found: $TS" >&2
+  exit 1
+fi
+
+gzip -cd "$SNAP/blackroad.db.gz" > "$DB_PATH" 2>/dev/null || true
+rsync -a "$SNAP/api/" "$API_DIR/" 2>/dev/null || true
+rsync -a "$SNAP/llm/" "$LLM_DIR/" 2>/dev/null || true
+rsync -a "$SNAP/math/" "$MATH_DIR/" 2>/dev/null || true
+
+if command -v systemctl >/dev/null 2>&1; then
+  systemctl restart blackroad-api lucidia-llm lucidia-math || true
+  systemctl reload nginx || systemctl restart nginx || true
+fi
+
+mkdir -p "$(dirname "$LOG_FILE")"
+echo "$(date --iso-8601=seconds) rollback to $TS" >> "$LOG_FILE"

--- a/scripts/snapshot.sh
+++ b/scripts/snapshot.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -euo pipefail
+
+DB_PATH=${DB_PATH:-/var/blackroad/blackroad.db}
+API_DIR=${API_DIR:-/srv/blackroad-api}
+LLM_DIR=${LLM_DIR:-/srv/lucidia-llm}
+MATH_DIR=${MATH_DIR:-/srv/lucidia-math}
+
+BACKUP_BASE=${BACKUP_BASE:-/var/backups/prism}
+LOG_FILE=${SNAPSHOT_LOG:-/var/log/prism-snapshots.log}
+
+TIMESTAMP=$(date +%Y%m%d%H%M%S)
+DEST="$BACKUP_BASE/$TIMESTAMP"
+
+mkdir -p "$DEST/api" "$DEST/llm" "$DEST/math"
+mkdir -p "$(dirname "$LOG_FILE")"
+
+if [ -f "$DB_PATH" ]; then
+  gzip -c "$DB_PATH" > "$DEST/blackroad.db.gz"
+fi
+
+rsync -a "$API_DIR/" "$DEST/api/" 2>/dev/null || true
+rsync -a "$LLM_DIR/" "$DEST/llm/" 2>/dev/null || true
+rsync -a "$MATH_DIR/" "$DEST/math/" 2>/dev/null || true
+
+echo "$(date --iso-8601=seconds) $DEST" >> "$LOG_FILE"
+
+# retain last 7 daily backups
+find "$BACKUP_BASE" -mindepth 1 -maxdepth 1 -type d ! -name weekly | sort | head -n -7 | xargs -r rm -rf
+
+# weekly retention - every Sunday copy to weekly folder and keep last 4
+if [ "$(date +%u)" -eq 7 ]; then
+  WEEKLY="$BACKUP_BASE/weekly"
+  mkdir -p "$WEEKLY"
+  cp -al "$DEST" "$WEEKLY/$TIMESTAMP"
+  find "$WEEKLY" -mindepth 1 -maxdepth 1 -type d | sort | head -n -4 | xargs -r rm -rf
+fi

--- a/tests/test_resilience_snapshot.py
+++ b/tests/test_resilience_snapshot.py
@@ -1,0 +1,110 @@
+import os
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+
+def _run(script: str, env: dict, args: list[str] | None = None) -> None:
+    cmd = ["bash", script]
+    if args:
+        cmd.extend(args)
+    subprocess.run(cmd, check=True, env=env)
+
+
+def test_snapshot_and_rollback(tmp_path):
+    db = tmp_path / "blackroad.db"
+    db.write_text("original")
+
+    api_dir = tmp_path / "api"
+    api_dir.mkdir()
+    (api_dir / "file.txt").write_text("api")
+
+    llm_dir = tmp_path / "llm"
+    llm_dir.mkdir()
+    (llm_dir / "file.txt").write_text("llm")
+
+    math_dir = tmp_path / "math"
+    math_dir.mkdir()
+    (math_dir / "file.txt").write_text("math")
+
+    backup_base = tmp_path / "backups"
+    log_dir = tmp_path / "logs"
+
+    env = {
+        **os.environ,
+        "DB_PATH": str(db),
+        "API_DIR": str(api_dir),
+        "LLM_DIR": str(llm_dir),
+        "MATH_DIR": str(math_dir),
+        "BACKUP_BASE": str(backup_base),
+        "SNAPSHOT_LOG": str(log_dir / "snap.log"),
+        "ROLLBACK_LOG": str(log_dir / "rollback.log"),
+    }
+
+    _run("scripts/snapshot.sh", env)
+    ts = sorted(os.listdir(backup_base))[0]
+
+    db.write_text("corrupt")
+    (api_dir / "file.txt").write_text("broken")
+
+    _run("scripts/rollback.sh", env, [ts])
+
+    assert db.read_text() == "original"
+    assert (api_dir / "file.txt").read_text() == "api"
+
+
+def test_failed_deploy_triggers_rollback(tmp_path, monkeypatch):
+    db = tmp_path / "blackroad.db"
+    db.write_text("good")
+    api_dir = tmp_path / "api"
+    api_dir.mkdir()
+    (api_dir / "file.txt").write_text("api")
+    llm_dir = tmp_path / "llm"
+    llm_dir.mkdir()
+    (llm_dir / "file.txt").write_text("llm")
+    math_dir = tmp_path / "math"
+    math_dir.mkdir()
+    (math_dir / "file.txt").write_text("math")
+
+    backup_base = tmp_path / "backups"
+    log_dir = tmp_path / "logs"
+
+    env = {
+        **os.environ,
+        "DB_PATH": str(db),
+        "API_DIR": str(api_dir),
+        "LLM_DIR": str(llm_dir),
+        "MATH_DIR": str(math_dir),
+        "BACKUP_BASE": str(backup_base),
+        "ROLLBACK_LOG": str(log_dir / "rollback.log"),
+    }
+
+    _run("scripts/snapshot.sh", env)
+    db.write_text("bad")
+
+    import scripts.codex_sync as codex_sync
+
+    def failing_run(cmd, **kwargs):
+        if "prism_sync_build.sh" in cmd[-1]:
+            raise subprocess.CalledProcessError(returncode=1, cmd=cmd)
+        return subprocess.run(cmd, check=True, **kwargs)
+
+    monkeypatch.setattr(codex_sync, "run", failing_run)
+
+    events: list[str] = []
+
+    def fake_post(url, json, timeout):
+        events.append(json["status"])
+        return SimpleNamespace()
+
+    monkeypatch.setattr(codex_sync, "requests", SimpleNamespace(post=fake_post))
+
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        codex_sync.deploy_to_droplet()
+
+    assert db.read_text() == "good"
+    assert events and events[-1] == "deploy-rollback"


### PR DESCRIPTION
## Summary
- add snapshot.sh and rollback.sh to back up database and restore services with retention
- wire codex_sync to create snapshots, auto-rollback on failed deploys, and report to monitoring API
- schedule nightly snapshots via cron and test backup/restore resilience

## Testing
- `npm run lint`
- `npm test`
- `pytest` *(fails: 24 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8ad4d0108329ae72964edf21c006