### PR TITLE
Add agent runtime and IPC prototype

### DIFF
--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -18,6 +18,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "anstream"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -35,7 +85,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -70,6 +120,52 @@ name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "clap"
+version = "4.5.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "cpufeatures"
@@ -249,6 +345,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,6 +486,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,7 +562,7 @@ checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -465,6 +573,18 @@ checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "percent-encoding"
@@ -500,6 +620,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prismos"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "once_cell",
 ]
 
 [[package]]
@@ -606,7 +734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -614,6 +742,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -682,7 +816,7 @@ dependencies = [
  "slab",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -764,6 +898,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,12 +916,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
 name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -790,14 +945,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -807,10 +979,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -819,10 +1003,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -831,10 +1027,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -843,10 +1051,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "writeable"

--- a/packages/Cargo.toml
+++ b/packages/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [ "ladls",
     "lucidia-geodesy",
-    "lucidia-geodesy-ffi"
+    "lucidia-geodesy-ffi",
+    "prismos"
 ]

--- a/packages/prismos/Cargo.toml
+++ b/packages/prismos/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "prismos"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+once_cell = "1.19"
+clap = { version = "4", features = ["derive"] }
+

--- a/packages/prismos/src/bin/prismsh.rs
+++ b/packages/prismos/src/bin/prismsh.rs
@@ -1,0 +1,45 @@
+use clap::{Parser, Subcommand};
+use prismos::*;
+
+#[derive(Parser)]
+#[command(author, version, about)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    Agents,
+    Restart { agent: String },
+    Send { agent: String, msg: String },
+    Recv { agent: String },
+}
+
+fn main() {
+    boot();
+    let cli = Cli::parse();
+    match cli.command {
+        Commands::Agents => {
+            for (name, state) in list_agents() {
+                println!("{}: {:?}", name, state);
+            }
+        }
+        Commands::Restart { agent } => {
+            let mut a = Agent {
+                name: Box::leak(agent.into_boxed_str()),
+                state: AgentState::Stopped,
+                entrypoint: || {},
+            };
+            restart_agent(&mut a);
+        }
+        Commands::Send { agent, msg } => {
+            send_message(&agent, &msg);
+        }
+        Commands::Recv { agent } => {
+            if let Some(msg) = recv_message(&agent) {
+                println!("{}", msg);
+            }
+        }
+    }
+}

--- a/packages/prismos/src/lib.rs
+++ b/packages/prismos/src/lib.rs
@@ -1,0 +1,232 @@
+use once_cell::sync::OnceCell;
+use std::collections::{HashMap, VecDeque};
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::{mpsc, Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+#[derive(Clone)]
+pub struct Agent {
+    pub name: &'static str,
+    pub state: AgentState,
+    pub entrypoint: fn(),
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum AgentState {
+    Running,
+    Stopped,
+    Crashed,
+}
+
+struct AgentRuntime {
+    agent: Agent,
+    handle: Option<JoinHandle<()>>,
+    inbox: Arc<Mutex<VecDeque<String>>>,
+    outbox: Arc<Mutex<VecDeque<String>>>,
+    stop_tx: mpsc::Sender<()>,
+    stop_rx: Arc<Mutex<mpsc::Receiver<()>>>,
+}
+
+static AGENT_TABLE: OnceCell<Mutex<HashMap<&'static str, AgentRuntime>>> = OnceCell::new();
+
+fn table() -> &'static Mutex<HashMap<&'static str, AgentRuntime>> {
+    AGENT_TABLE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn ipc_dir() -> PathBuf {
+    Path::new("prism/ipc").to_path_buf()
+}
+
+fn log_dir() -> PathBuf {
+    Path::new("prism/logs").to_path_buf()
+}
+
+pub fn spawn_agent(agent: &Agent) {
+    fs::create_dir_all(ipc_dir()).ok();
+    fs::create_dir_all(log_dir()).ok();
+    let mut tbl = table().lock().unwrap();
+    if tbl.contains_key(agent.name) {
+        return;
+    }
+    let (stop_tx, stop_rx) = mpsc::channel();
+    let stop_rx_arc = Arc::new(Mutex::new(stop_rx));
+    let inbox = Arc::new(Mutex::new(VecDeque::new()));
+    let outbox = Arc::new(Mutex::new(VecDeque::new()));
+    let agent_clone = agent.clone();
+    let inbox_clone = inbox.clone();
+    let outbox_clone = outbox.clone();
+    let name = agent.name;
+    let handle = thread::spawn(move || {
+        let res = std::panic::catch_unwind(|| {
+            (agent_clone.entrypoint)();
+        });
+        if res.is_err() {
+            let mut tbl = table().lock().unwrap();
+            if let Some(rt) = tbl.get_mut(name) {
+                rt.agent.state = AgentState::Crashed;
+            }
+            let path = log_dir().join(format!("{}.log", name));
+            if let Ok(mut f) = OpenOptions::new().create(true).append(true).open(path) {
+                let _ = writeln!(f, "agent {} crashed", name);
+            }
+        }
+    });
+    tbl.insert(
+        agent.name,
+        AgentRuntime {
+            agent: Agent {
+                state: AgentState::Running,
+                ..agent.clone()
+            },
+            handle: Some(handle),
+            inbox: inbox_clone,
+            outbox: outbox_clone,
+            stop_tx,
+            stop_rx: stop_rx_arc,
+        },
+    );
+}
+
+pub fn stop_agent(agent: &mut Agent) {
+    let mut tbl = table().lock().unwrap();
+    if let Some(rt) = tbl.get_mut(agent.name) {
+        let _ = rt.stop_tx.send(());
+        if let Some(handle) = rt.handle.take() {
+            let _ = handle.join();
+        }
+        rt.agent.state = AgentState::Stopped;
+        agent.state = AgentState::Stopped;
+    }
+}
+
+pub fn restart_agent(agent: &mut Agent) {
+    stop_agent(agent);
+    spawn_agent(agent);
+}
+
+pub fn send_message(agent: &str, msg: &str) {
+    let tbl = table().lock().unwrap();
+    if let Some(rt) = tbl.get(agent) {
+        let mut inbox = rt.inbox.lock().unwrap();
+        inbox.push_back(msg.to_string());
+    }
+}
+
+pub fn recv_message(agent: &str) -> Option<String> {
+    let tbl = table().lock().unwrap();
+    if let Some(rt) = tbl.get(agent) {
+        let mut outbox = rt.outbox.lock().unwrap();
+        outbox.pop_front()
+    } else {
+        None
+    }
+}
+
+fn agent_recv(agent: &str) -> Option<String> {
+    let tbl = table().lock().unwrap();
+    tbl.get(agent)
+        .and_then(|rt| rt.inbox.lock().unwrap().pop_front())
+}
+
+fn agent_send(agent: &str, msg: &str) {
+    let tbl = table().lock().unwrap();
+    if let Some(rt) = tbl.get(agent) {
+        let mut outbox = rt.outbox.lock().unwrap();
+        outbox.push_back(msg.to_string());
+        let path = ipc_dir().join(agent);
+        if let Ok(mut f) = OpenOptions::new().create(true).append(true).open(path) {
+            let _ = writeln!(f, "{}", msg);
+        }
+    }
+}
+
+fn should_stop(agent: &str) -> bool {
+    let tbl = table().lock().unwrap();
+    if let Some(rt) = tbl.get(agent) {
+        let rx = rt.stop_rx.lock().unwrap();
+        rx.try_recv().is_ok()
+    } else {
+        true
+    }
+}
+
+pub fn list_agents() -> Vec<(String, AgentState)> {
+    let tbl = table().lock().unwrap();
+    tbl.values()
+        .map(|rt| (rt.agent.name.to_string(), rt.agent.state))
+        .collect()
+}
+
+fn system_agent() {
+    loop {
+        if should_stop("system") {
+            break;
+        }
+        agent_send("system", "heartbeat");
+        thread::sleep(Duration::from_secs(1));
+    }
+}
+
+fn echo_agent() {
+    loop {
+        if should_stop("echo") {
+            break;
+        }
+        if let Some(msg) = agent_recv("echo") {
+            if msg == "panic" {
+                panic!("echo agent crash");
+            }
+            agent_send("echo", &msg);
+        } else {
+            thread::sleep(Duration::from_millis(100));
+        }
+    }
+}
+
+pub fn boot() {
+    let system = Agent {
+        name: "system",
+        state: AgentState::Stopped,
+        entrypoint: system_agent,
+    };
+    spawn_agent(&system);
+    let echo = Agent {
+        name: "echo",
+        state: AgentState::Stopped,
+        entrypoint: echo_agent,
+    };
+    spawn_agent(&echo);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn echo_roundtrip() {
+        boot();
+        send_message("echo", "hello");
+        for _ in 0..20 {
+            if let Some(msg) = recv_message("echo") {
+                assert_eq!(msg, "hello");
+                return;
+            }
+            thread::sleep(Duration::from_millis(100));
+        }
+        panic!("no message");
+    }
+
+    #[test]
+    fn echo_crash() {
+        boot();
+        send_message("echo", "panic");
+        thread::sleep(Duration::from_millis(200));
+        let agents = list_agents();
+        let state = agents.into_iter().find(|(n, _)| n == "echo").unwrap().1;
+        assert_eq!(state, AgentState::Crashed);
+        let log_path = log_dir().join("echo.log");
+        assert!(log_path.exists());
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `prismos` crate with agent abstraction, lifecycle control, and in-memory IPC
- add built-in `system` and `echo` agents plus `prismsh` CLI for interaction
- test echo roundtrip and crash handling

## Testing
- `cargo fmt --package prismos -- --check`
- `cargo clippy --package prismos -- -D warnings`
- `cargo test --package prismos`


------
https://chatgpt.com/codex/tasks/task_e_68ab8c77fdb88329b2eede14fcf63c1f