### PR TITLE
feat: add agents dashboard and summary endpoint

### DIFF
--- a/sites/blackroad/src/App.jsx
+++ b/sites/blackroad/src/App.jsx
@@ -7,6 +7,7 @@ import RoadView from "./pages/RoadView.jsx";
 import BackRoad from "./pages/BackRoad.jsx";
 import Subscribe from "./pages/Subscribe.jsx";
 import Lucidia from "./pages/Lucidia.jsx";
+import Agents from "./pages/Agents.jsx";
 import { useEffect, useState } from "react";
 
 function useApiHealth(){
@@ -48,6 +49,7 @@ export default function App(){
           <NavLink className="nav-link" to="/terminal">Terminal</NavLink>
           <NavLink className="nav-link" to="/roadview">RoadView</NavLink>
           <NavLink className="nav-link" to="/backroad">BackRoad</NavLink>
+          <NavLink className="nav-link" to="/agents">Agents</NavLink>
           <NavLink className="nav-link" to="/subscribe">Subscribe</NavLink>
           <NavLink className="nav-link" to="/lucidia">Lucidia</NavLink>
         </nav>
@@ -69,6 +71,7 @@ export default function App(){
             <Route path="/terminal" element={<Terminal/>} />
             <Route path="/roadview" element={<RoadView/>} />
             <Route path="/backroad" element={<BackRoad/>} />
+            <Route path="/agents" element={<Agents/>} />
             <Route path="/subscribe" element={<Subscribe/>} />
             <Route path="/lucidia" element={<Lucidia/>} />
             <Route path="*" element={<div>Not found</div>} />

--- a/sites/blackroad/src/pages/Agents.jsx
+++ b/sites/blackroad/src/pages/Agents.jsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from 'react';
+
+const AGENTS = [
+  { id: 'frontend', name: 'Frontend (SPA)' },
+  { id: 'api', name: 'API (blackroad-api)' },
+  { id: 'llm', name: 'Lucidia LLM' },
+  { id: 'math', name: 'Infinity Math' }
+];
+
+function indicator(status){
+  if(status === 'OK') return '🟢';
+  if(status === 'Degraded') return '🟡';
+  if(!status) return '⚪️';
+  return '🔴';
+}
+
+export default function Agents(){
+  const [summary,setSummary]=useState({});
+  const [logs,setLogs]=useState([]);
+  const [active,setActive]=useState('');
+
+  async function load(){
+    try{ const r = await fetch('/api/agents/summary'); const j = await r.json(); setSummary(j); }catch{}
+  }
+
+  useEffect(()=>{
+    load();
+    const t=setInterval(load,15000);
+    const ws = new WebSocket(`${location.origin.replace('http','ws')}/ws/agents`);
+    ws.onmessage = e=>{ try{ const d=JSON.parse(e.data); setSummary(s=>({...s,...d})); }catch{} };
+    return ()=>{ clearInterval(t); ws.close(); };
+  },[]);
+
+  async function viewLogs(id){
+    try {
+      const r = await fetch(`/api/agents/${id}/logs?limit=50`);
+      const j = await r.json();
+      setLogs(j.logs || []);
+      setActive(id);
+    } catch {}
+  }
+  const closeLogs=()=>{ setActive(''); setLogs([]); };
+  const restart=id=>{ fetch(`/autoheal/restart/${id}`,{method:'POST'}).catch(()=>{}); };
+  const snapshot=()=>{ fetch('/snapshots',{method:'POST'}).catch(()=>{}); };
+  const rollback=id=>{ fetch(`/rollback/latest/${id}`,{method:'POST'}).catch(()=>{}); };
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      {AGENTS.map(a=>{
+        const info=summary[a.id]||{};
+        return (
+          <div key={a.id} className="card p-4 space-y-2">
+            <div className="flex items-center justify-between">
+              <div className="font-semibold">{a.name}</div>
+              <span>{indicator(info.status)}</span>
+            </div>
+            <div className="text-sm text-neutral-400">Status: {info.status||'Unknown'}</div>
+            <div className="text-sm text-neutral-400">Uptime: {info.uptime||'-'}</div>
+            <div className="text-sm text-neutral-400">Errors: {info.errors ?? 0}</div>
+            {info.contradictions!==undefined && <div className="text-sm text-neutral-400">Contradictions: {info.contradictions}</div>}
+            <div className="mt-2 flex flex-wrap gap-2">
+              <button className="btn" onClick={()=>restart(a.id)}>Restart</button>
+              <button className="btn" onClick={()=>viewLogs(a.id)}>Logs</button>
+              {a.id==='api' && <button className="btn" onClick={snapshot}>Snapshot DB</button>}
+              {(a.id==='api'||a.id==='math') && <button className="btn" onClick={()=>rollback(a.id)}>Rollback</button>}
+            </div>
+          </div>
+        );
+      })}
+
+      {active && (
+        <div className="fixed inset-0 bg-black/60 flex items-center justify-center" onClick={closeLogs}>
+          <div className="bg-neutral-900 p-4 rounded max-w-lg w-full max-h-[80vh] overflow-auto" onClick={e=>e.stopPropagation()}>
+            <div className="flex items-center justify-between mb-2">
+              <div className="font-semibold">{active} logs</div>
+              <button className="btn" onClick={closeLogs}>Close</button>
+            </div>
+            <pre className="text-xs whitespace-pre-wrap">
+{logs.map(l=>`${l.created_at}: ${l.message}`).join('\n')}
+            </pre>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/routes/agents.js
+++ b/src/routes/agents.js
@@ -4,12 +4,19 @@
 const express = require('express');
 const db = require('../db');
 const { requireAuth, requireAdmin } = require('../auth');
+const { getAgentsSummary } = require('../services/agentSummary');
 
 const router = express.Router();
 
 router.get('/', requireAuth, (req, res) => {
   const rows = db.prepare('SELECT * FROM agents ORDER BY name').all();
   res.json({ ok: true, agents: rows });
+});
+
+// Aggregate health information for core services
+router.get('/summary', requireAuth, async (_req, res) => {
+  const summary = await getAgentsSummary();
+  res.json(summary);
 });
 
 router.post('/', requireAdmin, (req, res) => {
@@ -52,7 +59,10 @@ router.post('/:id/logs', requireAuth, (req, res) => {
 });
 
 router.get('/:id/logs', requireAuth, (req, res) => {
-  const rows = db.prepare('SELECT * FROM agent_logs WHERE agent_id = ? ORDER BY created_at DESC LIMIT 200').all(req.params.id);
+  const limit = Math.min(parseInt(req.query.limit, 10) || 50, 200);
+  const rows = db
+    .prepare('SELECT * FROM agent_logs WHERE agent_id = ? ORDER BY created_at DESC LIMIT ?')
+    .all(req.params.id, limit);
   res.json({ ok: true, logs: rows });
 });
 

--- a/src/services/agentSummary.js
+++ b/src/services/agentSummary.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const SERVICES = {
+  frontend: process.env.FRONTEND_URL || 'http://localhost:3001',
+  api: process.env.API_URL || 'http://localhost:3000',
+  llm: process.env.LLM_URL || 'http://localhost:4000',
+  math: process.env.MATH_URL || 'http://localhost:5000'
+};
+
+async function fetchJson(url) {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error('fetch_failed');
+  return res.json();
+}
+
+async function getService(id, base) {
+  try {
+    const health = await fetchJson(`${base}/health`);
+    const logs = await fetchJson(`${base}/logs?level=error&limit=1`).catch(() => ({ count: 0, logs: [] }));
+    return {
+      status: health.status || health.ok || 'FAIL',
+      uptime: health.uptime || '-',
+      errors: logs.count || (Array.isArray(logs.logs) ? logs.logs.length : 0),
+      contradictions: health.contradictions || 0
+    };
+  } catch {
+    return { status: 'FAIL', uptime: '-', errors: 0, contradictions: 0 };
+  }
+}
+
+async function getAgentsSummary() {
+  const result = {};
+  for (const [id, base] of Object.entries(SERVICES)) {
+    result[id] = await getService(id, base);
+  }
+  return result;
+}
+
+module.exports = { getAgentsSummary };

--- a/tests/agents-summary.test.mjs
+++ b/tests/agents-summary.test.mjs
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import { getAgentsSummary } from '../src/services/agentSummary.js';
+
+const responses = {
+  'http://localhost:3001/health': { status: 'OK', uptime: '1d' },
+  'http://localhost:3001/logs?level=error&limit=1': { count: 0 },
+  'http://localhost:3000/health': { status: 'OK', uptime: '2h' },
+  'http://localhost:3000/logs?level=error&limit=1': { count: 0 },
+  'http://localhost:4000/health': { status: 'OK', uptime: '4h' },
+  'http://localhost:4000/logs?level=error&limit=1': { count: 2 },
+  'http://localhost:5000/health': { status: 'FAIL', uptime: '-' },
+  'http://localhost:5000/logs?level=error&limit=1': { count: 5 }
+};
+
+global.fetch = async (url) => ({ ok: true, json: async () => responses[url] });
+
+const summary = await getAgentsSummary();
+assert.deepStrictEqual(summary, {
+  frontend: { status: 'OK', uptime: '1d', errors: 0, contradictions: 0 },
+  api: { status: 'OK', uptime: '2h', errors: 0, contradictions: 0 },
+  llm: { status: 'OK', uptime: '4h', errors: 2, contradictions: 0 },
+  math: { status: 'FAIL', uptime: '-', errors: 5, contradictions: 0 }
+});

--- a/tests/smoke.test.mjs
+++ b/tests/smoke.test.mjs
@@ -1,3 +1,4 @@
 import assert from 'node:assert';
 import './git-route.test.mjs';
+import './agents-summary.test.mjs';
 assert.ok(true);


### PR DESCRIPTION
## Summary
- expose `/api/agents/summary` aggregating status, uptime, and error counts for core services
- allow limiting agent log retrieval and add dashboard page with controls for each service
- cover agent summary aggregation with unit test

## Testing
- `npm test`
- `npm run lint` *(fails: eslint: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8ba3b0f48329b5d21fc8c7b14070