### PR TITLE
feat: track agent location for unified UI

### DIFF
--- a/backend/data.js
+++ b/backend/data.js
@@ -78,9 +78,9 @@ const store = {
   sessions: [],
   wallet: { rc: 1.2 },
   agents: [
-    { id: 'phi', name: 'Phi', status: 'idle', cpu: 0, memory: 0 },
-    { id: 'gpt', name: 'GPT', status: 'idle', cpu: 0, memory: 0 },
-    { id: 'mistral', name: 'Mistral', status: 'idle', cpu: 0, memory: 0 }
+    { id: 'phi', name: 'Phi', status: 'idle', cpu: 0, memory: 0, location: 'local' },
+    { id: 'gpt', name: 'GPT', status: 'idle', cpu: 0, memory: 0, location: 'cloud' },
+    { id: 'mistral', name: 'Mistral', status: 'idle', cpu: 0, memory: 0, location: 'cloud' }
   ],
   contradictions: { issues: 2 },
   sessionNotes: "",

--- a/db/migrations/0006_agents_location.sql
+++ b/db/migrations/0006_agents_location.sql
@@ -1,0 +1,2 @@
+-- FILE: /srv/blackroad-api/db/migrations/0006_agents_location.sql
+ALTER TABLE agents ADD COLUMN location TEXT NOT NULL DEFAULT 'local';

--- a/frontend/src/Orchestrator.jsx
+++ b/frontend/src/Orchestrator.jsx
@@ -41,6 +41,7 @@ export default function Orchestrator({ socket }){
         <thead className="text-left">
           <tr className="border-b border-slate-700">
             <th className="py-2">Name</th>
+            <th>Location</th>
             <th>Status</th>
             <th>CPU</th>
             <th>Memory</th>
@@ -51,6 +52,7 @@ export default function Orchestrator({ socket }){
           {agents.map(a => (
             <tr key={a.id} className="border-b border-slate-800 last:border-none">
               <td className="py-2">{a.name}</td>
+              <td>{a.location}</td>
               <td>{a.status}</td>
               <td>{a.cpu}%</td>
               <td>{a.memory}%</td>

--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -51,6 +51,7 @@ export default function Dashboard(){
             <div key={a.id} className="card p-4">
               <div className="font-medium">{a.name}</div>
               <div className="text-xs text-slate-400">{a.status}</div>
+              <div className="text-xs text-slate-500">Location: {a.location}</div>
             </div>
           ))}
         </div>

--- a/src/routes/agents.js
+++ b/src/routes/agents.js
@@ -13,13 +13,13 @@ router.get('/', requireAuth, (req, res) => {
 });
 
 router.post('/', requireAdmin, (req, res) => {
-  const { slug, name, status, memory_path, notes } = req.body || {};
+  const { slug, name, status, memory_path, notes, location } = req.body || {};
   if (!slug || !name) return res.status(400).json({ ok: false, error: 'missing_fields' });
   const id = cryptoRandomId();
   db.prepare(`
-    INSERT INTO agents (id, slug, name, status, memory_path, notes)
-    VALUES (?, ?, ?, COALESCE(?, 'idle'), ?, ?)
-  `).run(id, slug, name, status || null, memory_path || null, notes || null);
+    INSERT INTO agents (id, slug, name, status, memory_path, notes, location)
+    VALUES (?, ?, ?, COALESCE(?, 'idle'), ?, ?, COALESCE(?, 'local'))
+  `).run(id, slug, name, status || null, memory_path || null, notes || null, location || null);
   res.json({ ok: true, agent: db.prepare('SELECT * FROM agents WHERE id = ?').get(id) });
 });
 

--- a/src/tests/backend.test.js
+++ b/src/tests/backend.test.js
@@ -122,6 +122,7 @@ describe('Logs and Contradictions', () => {
       .send({ slug: 'agent', name: 'Agent' });
     expect(createAgent.status).toBe(200);
     agentId = createAgent.body.agent.id;
+    expect(createAgent.body.agent.location).toBe('local');
 
     const logRes = await request(app)
       .post(`/api/agents/${agentId}/logs`)


### PR DESCRIPTION
## Summary
- add `location` column to agents table
- expose agent location in API and sample data
- show location in dashboard and orchestrator views
- test default location assignment

## Testing
- `npm test`
- `npx jest src/tests/backend.test.js` *(fails: 503 Service Unavailable - GET http://verdaccio.internal:4873/jest)*
- `node src/tests/backend.test.js` *(fails: Cannot find module 'supertest')*
- `npm run lint` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68ab90b4af808329b0b32baed9656933