### PR TITLE
feat: add browser-only prismweb prototype

### DIFF
--- a/apps/prismweb/index.html
+++ b/apps/prismweb/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PrismWeb Prototype</title>
+  </head>
+  <body class="bg-gray-900 text-gray-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/prismweb/package.json
+++ b/apps/prismweb/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "prismweb",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "idb-keyval": "^6.2.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-draggable": "^4.4.6"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "autoprefixer": "^10.4.19",
+    "postcss": "^8.4.40",
+    "tailwindcss": "^3.4.9",
+    "typescript": "^5.4.0",
+    "vite": "^5.2.0",
+    "@vitejs/plugin-react": "^4.0.0"
+  }
+}

--- a/apps/prismweb/postcss.config.js
+++ b/apps/prismweb/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/apps/prismweb/src/App.tsx
+++ b/apps/prismweb/src/App.tsx
@@ -1,0 +1,31 @@
+import React, { useEffect, useState } from 'react';
+import Terminal from './components/Terminal';
+import AgentWindow from './components/AgentWindow';
+import { PrismKernel } from './kernel';
+
+const kernel = new PrismKernel();
+
+const App: React.FC = () => {
+  const [, setTick] = useState(0);
+
+  useEffect(() => {
+    kernel.init().then(() => setTick(t => t + 1));
+    const id = setInterval(() => setTick(t => t + 1), 500);
+    return () => clearInterval(id);
+  }, []);
+
+  const agents = kernel.listAgents();
+
+  return (
+    <div className="w-full h-full relative">
+      <div className="absolute bottom-0 left-0 w-full h-48">
+        <Terminal kernel={kernel} onChange={() => setTick(t => t + 1)} />
+      </div>
+      {agents.map((a, i) => (
+        <AgentWindow key={a} kernel={kernel} name={a} />
+      ))}
+    </div>
+  );
+};
+
+export default App;

--- a/apps/prismweb/src/components/AgentWindow.tsx
+++ b/apps/prismweb/src/components/AgentWindow.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import Draggable from 'react-draggable';
+import { PrismKernel } from '../kernel';
+
+interface Props {
+  kernel: PrismKernel;
+  name: string;
+}
+
+const AgentWindow: React.FC<Props> = ({ kernel, name }) => {
+  return (
+    <Draggable>
+      <div className="absolute bg-gray-800 text-white p-2 w-64 h-40 overflow-auto">
+        <div className="font-bold mb-1">{name}</div>
+        <pre className="text-xs whitespace-pre-wrap">
+          {kernel.cat(`/prism/logs/${name}`)}
+        </pre>
+      </div>
+    </Draggable>
+  );
+};
+
+export default AgentWindow;

--- a/apps/prismweb/src/components/Terminal.tsx
+++ b/apps/prismweb/src/components/Terminal.tsx
@@ -1,0 +1,85 @@
+import React, { useState, useRef } from 'react';
+import { PrismKernel } from '../kernel';
+
+interface Props {
+  kernel: PrismKernel;
+  onChange: () => void;
+}
+
+const Terminal: React.FC<Props> = ({ kernel, onChange }) => {
+  const [lines, setLines] = useState<string[]>([]);
+  const [input, setInput] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const print = (line: string) => setLines(l => [...l, line]);
+
+  const run = async (cmd: string) => {
+    const parts = cmd.split(' ');
+    const base = parts[0];
+    try {
+      switch (base) {
+        case 'agents':
+          print(kernel.listAgents().join(' '));
+          break;
+        case 'spawn':
+          await kernel.spawn(parts[1]);
+          print(`spawned ${parts[1]}`);
+          onChange();
+          break;
+        case 'send': {
+          const agent = parts[1];
+          const msg = cmd.match(/send\s+\w+\s+"([\s\S]*)"/)?.[1] ?? parts.slice(2).join(' ');
+          kernel.send(agent, msg);
+          print(`sent to ${agent}`);
+          onChange();
+          break;
+        }
+        case 'recv': {
+          const agent = parts[1];
+          const msg = kernel.recv(agent);
+          print(msg ?? '');
+          onChange();
+          break;
+        }
+        case 'ls':
+          print(kernel.ls(parts[1]).join(' '));
+          break;
+        case 'cat':
+          print(kernel.cat(parts[1]) ?? '');
+          break;
+        default:
+          print('unknown command');
+      }
+    } catch (e:any) {
+      print(e.message);
+    }
+  };
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    print(`> ${input}`);
+    run(input);
+    setInput('');
+  };
+
+  return (
+    <div className="bg-black text-green-400 p-2 h-full flex flex-col" onClick={() => inputRef.current?.focus()}>
+      <div className="flex-1 overflow-y-auto font-mono text-sm" id="output">
+        {lines.map((l, i) => (
+          <div key={i}>{l}</div>
+        ))}
+      </div>
+      <form onSubmit={onSubmit} className="mt-1">
+        <input
+          ref={inputRef}
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          className="w-full bg-black text-green-400 outline-none"
+          autoFocus
+        />
+      </form>
+    </div>
+  );
+};
+
+export default Terminal;

--- a/apps/prismweb/src/index.css
+++ b/apps/prismweb/src/index.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html, body, #root {
+  height: 100%;
+}

--- a/apps/prismweb/src/kernel.ts
+++ b/apps/prismweb/src/kernel.ts
@@ -1,0 +1,133 @@
+import { get, set } from 'idb-keyval';
+
+export interface Manifest {
+  name: string;
+  version: string;
+  capabilities: string[];
+}
+
+interface Agent {
+  name: string;
+  manifest: Manifest;
+  instance: WebAssembly.Instance;
+  memory: WebAssembly.Memory;
+  inbox: string[];
+  outbox: string[];
+  log: string;
+}
+
+export class PrismKernel {
+  private fs: Record<string, string> = {};
+  private agents: Map<string, Agent> = new Map();
+
+  async init() {
+    const stored = await get<Record<string, string>>('fs');
+    if (stored) {
+      this.fs = stored;
+      // respawn agents from manifest entries
+      for (const path of Object.keys(this.fs)) {
+        if (path.startsWith('/prism/agents/') && this.fs[path]) {
+          const manifest = JSON.parse(this.fs[path]) as Manifest;
+          await this.spawn(manifest.name);
+        }
+      }
+    } else {
+      // initialize base directories
+      this.fs['/prism/agents/'] = '';
+      this.fs['/prism/logs/'] = '';
+      this.fs['/prism/contradictions/'] = '';
+      await this.persist();
+    }
+  }
+
+  listAgents() {
+    return Array.from(this.agents.keys());
+  }
+
+  async spawn(name: string) {
+    if (this.agents.has(name)) return;
+    const manifest: Manifest = { name, version: '0.1', capabilities: ['ipc'] };
+    // For now only built-in echo agent
+    const wasm = await WebAssembly.instantiate(await this.getEchoWasm());
+    const memory = (wasm.instance.exports.memory as WebAssembly.Memory);
+    const agent: Agent = {
+      name,
+      manifest,
+      instance: wasm.instance,
+      memory,
+      inbox: [],
+      outbox: [],
+      log: ''
+    };
+    this.agents.set(name, agent);
+    this.fs[`/prism/agents/${name}`] = JSON.stringify(manifest);
+    this.fs[`/prism/logs/${name}`] = '';
+    await this.persist();
+  }
+
+  send(name: string, msg: string) {
+    const agent = this.agents.get(name);
+    if (!agent) throw new Error('agent not found');
+    agent.inbox.push(msg);
+    this.process(agent);
+  }
+
+  recv(name: string): string | null {
+    const agent = this.agents.get(name);
+    if (!agent) throw new Error('agent not found');
+    return agent.outbox.shift() ?? null;
+  }
+
+  ls(path: string): string[] {
+    const normalized = path.endsWith('/') ? path : path + '/';
+    const entries = new Set<string>();
+    for (const p of Object.keys(this.fs)) {
+      if (p.startsWith(normalized)) {
+        const rest = p.slice(normalized.length);
+        if (rest === '') continue;
+        const next = rest.split('/')[0];
+        entries.add(next + (rest.includes('/') ? '/' : ''));
+      }
+    }
+    return Array.from(entries).sort();
+  }
+
+  cat(path: string): string | null {
+    return this.fs[path] ?? null;
+  }
+
+  private async process(agent: Agent) {
+    while (agent.inbox.length) {
+      const msg = agent.inbox.shift()!;
+      const encoder = new TextEncoder();
+      const view = new Uint8Array(agent.memory.buffer);
+      const data = encoder.encode(msg);
+      view.set(data, 0);
+      const handle = agent.instance.exports.handle as Function;
+      const ptr = handle(0, data.length) as number;
+      const out = new TextDecoder().decode(view.slice(ptr, ptr + data.length));
+      agent.outbox.push(out);
+      agent.log += out + '\n';
+      this.fs[`/prism/logs/${agent.name}`] = agent.log;
+      await this.persist();
+    }
+  }
+
+  private async persist() {
+    await set('fs', this.fs);
+  }
+
+  private async getEchoWasm(): Promise<ArrayBuffer> {
+    const base64 = ECHO_WASM_BASE64;
+    const binary = atob(base64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes.buffer;
+  }
+}
+
+// Minimal echo wasm compiled from WAT
+const ECHO_WASM_BASE64 =
+  'AGFzbQEAAAABBwFgAn9/AX8DAgEABQMBAAEHEwIGbWVtb3J5AgAGaGFuZGxlAAAKBgEEACAACw==' ;

--- a/apps/prismweb/src/main.tsx
+++ b/apps/prismweb/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/apps/prismweb/tailwind.config.js
+++ b/apps/prismweb/tailwind.config.js
@@ -1,0 +1,4 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ["./index.html", "./src/**/*.{ts,tsx}"]
+};

--- a/apps/prismweb/tsconfig.json
+++ b/apps/prismweb/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/apps/prismweb/vite.config.ts
+++ b/apps/prismweb/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- implement PrismKernel managing WebAssembly agents with IndexedDB-backed /prism filesystem
- add React SPA with terminal shell and draggable agent windows
- include echo WebAssembly agent demonstrating send/recv IPC

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68ab90de43288329acc73dd07ed446ab