### PR TITLE
feat: add desktop shell with windowed agents

### DIFF
--- a/sites/blackroad/package-lock.json
+++ b/sites/blackroad/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-rnd": "10.5.2",
         "react-router-dom": "6.30.1",
         "recharts": "^2.11.0"
       },
@@ -3819,6 +3820,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/re-resizable": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.11.2.tgz",
+      "integrity": "sha512-2xI2P3OHs5qw7K0Ud1aLILK6MQxW50TcO+DetD9eIV58j84TqYeHoZcL9H4GXFXXIh7afhH8mv5iUCXII7OW7A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -3844,6 +3855,29 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-draggable": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.6.tgz",
+      "integrity": "sha512-LtY5Xw1zTPqHkVmtM3X8MUOxNDOUhv/khTgBgrUvwaS064bwVvxT+q5El0uUFNx5IEPKXuRejr7UqLwBIg5pdw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^1.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
+    "node_modules/react-draggable/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -3858,6 +3892,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-rnd": {
+      "version": "10.5.2",
+      "resolved": "https://registry.npmjs.org/react-rnd/-/react-rnd-10.5.2.tgz",
+      "integrity": "sha512-0Tm4x7k7pfHf2snewJA8x7Nwgt3LV+58MVEWOVsFjk51eYruFEa6Wy7BNdxt4/lH0wIRsu7Gm3KjSXY2w7YaNw==",
+      "license": "MIT",
+      "dependencies": {
+        "re-resizable": "6.11.2",
+        "react-draggable": "4.4.6",
+        "tslib": "2.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
       }
     },
     "node_modules/react-router": {
@@ -4580,6 +4629,12 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/sites/blackroad/package.json
+++ b/sites/blackroad/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-rnd": "10.5.2",
     "react-router-dom": "6.30.1",
     "recharts": "^2.11.0"
   },

--- a/sites/blackroad/src/App.jsx
+++ b/sites/blackroad/src/App.jsx
@@ -1,4 +1,5 @@
 import { NavLink, Routes, Route } from "react-router-dom";
+import { useEffect, useState } from "react";
 import Chat from "./pages/Chat.jsx";
 import Canvas from "./pages/Canvas.jsx";
 import Editor from "./pages/Editor.jsx";
@@ -8,7 +9,7 @@ import BackRoad from "./pages/BackRoad.jsx";
 import Subscribe from "./pages/Subscribe.jsx";
 import Lucidia from "./pages/Lucidia.jsx";
 import InfinityMath from "./pages/InfinityMath.jsx";
-import { useEffect, useState } from "react";
+import Desktop from "./pages/Desktop.jsx";
 
 function useApiHealth(){
   const [state,setState]=useState({ok:null, info:""});
@@ -38,6 +39,15 @@ function StatusPill(){
 }
 
 export default function App(){
+  return (
+    <Routes>
+      <Route path="/" element={<Desktop/>} />
+      <Route path="/*" element={<LegacyApp/>} />
+    </Routes>
+  );
+}
+
+function LegacyApp(){
   return (
     <div className="min-h-screen grid md:grid-cols-[240px_1fr] gap-4 p-4">
       <aside className="sidebar p-3">
@@ -75,16 +85,15 @@ export default function App(){
 
         <section className="card">
           <Routes>
-            <Route path="/" element={<Chat/>} />
-            <Route path="/chat" element={<Chat/>} />
-            <Route path="/canvas" element={<Canvas/>} />
-            <Route path="/editor" element={<Editor/>} />
-            <Route path="/terminal" element={<Terminal/>} />
-            <Route path="/roadview" element={<RoadView/>} />
-            <Route path="/backroad" element={<BackRoad/>} />
-            <Route path="/subscribe" element={<Subscribe/>} />
-            <Route path="/lucidia" element={<Lucidia/>} />
-            <Route path="/math" element={<InfinityMath/>} />
+            <Route path="chat" element={<Chat/>} />
+            <Route path="canvas" element={<Canvas/>} />
+            <Route path="editor" element={<Editor/>} />
+            <Route path="terminal" element={<Terminal/>} />
+            <Route path="roadview" element={<RoadView/>} />
+            <Route path="backroad" element={<BackRoad/>} />
+            <Route path="subscribe" element={<Subscribe/>} />
+            <Route path="lucidia" element={<Lucidia/>} />
+            <Route path="math" element={<InfinityMath/>} />
             <Route path="*" element={<div>Not found</div>} />
           </Routes>
         </section>

--- a/sites/blackroad/src/desktop/Window.jsx
+++ b/sites/blackroad/src/desktop/Window.jsx
@@ -1,0 +1,37 @@
+import { Rnd } from "react-rnd";
+
+export default function Window({ win, onClose, onToggleMin, onToggleMax, onUpdate, children }) {
+  if (win.minimized) return null;
+  const size = win.maximized ? { width: "100%", height: "100%" } : { width: win.w, height: win.h };
+  const position = win.maximized ? { x: 0, y: 0 } : { x: win.x, y: win.y };
+
+  return (
+    <Rnd
+      size={size}
+      position={position}
+      onDragStop={(e, d) => onUpdate({ x: d.x, y: d.y })}
+      onResizeStop={(e, dir, ref, delta, pos) =>
+        onUpdate({ w: ref.offsetWidth, h: ref.offsetHeight, x: pos.x, y: pos.y })
+      }
+      enableResizing={!win.maximized}
+      dragHandleClassName="title-bar"
+      bounds="parent"
+    >
+      <div className="flex flex-col h-full bg-white shadow-lg">
+        <div className="title-bar flex items-center justify-between bg-gray-800 text-white px-2 py-1 cursor-move select-none">
+          <div className="flex items-center gap-2">
+            <span className="text-green-400">●</span>
+            <span>{win.title}</span>
+          </div>
+          <div className="space-x-1">
+            <button onClick={onToggleMin} className="px-1">▁</button>
+            <button onClick={onToggleMax} className="px-1">▢</button>
+            <button onClick={onClose} className="px-1">✕</button>
+          </div>
+        </div>
+        <div className="flex-1 overflow-auto">{children}</div>
+      </div>
+    </Rnd>
+  );
+}
+

--- a/sites/blackroad/src/pages/Desktop.jsx
+++ b/sites/blackroad/src/pages/Desktop.jsx
@@ -1,0 +1,131 @@
+import { useEffect, useState } from "react";
+import Window from "../desktop/Window.jsx";
+
+const APPS = {
+  api: { title: "API Agent", icon: "API" },
+  llm: { title: "LLM Agent", icon: "LLM" },
+  math: { title: "Math Agent", icon: "MATH" },
+  echo: { title: "Echo Agent", icon: "ECHO" },
+  guardian: { title: "Guardian Agent", icon: "GUARD" },
+  explorer: { title: "Prism Explorer", icon: "FS" },
+};
+
+function defaultWin(key) {
+  return {
+    id: crypto.randomUUID(),
+    app: key,
+    title: APPS[key].title,
+    x: 80,
+    y: 80,
+    w: 400,
+    h: 300,
+    minimized: false,
+    maximized: false,
+  };
+}
+
+function loadLayout() {
+  return new Promise((resolve) => {
+    const req = indexedDB.open("prism-desktop", 1);
+    req.onupgradeneeded = () => {
+      req.result.createObjectStore("layout");
+    };
+    req.onsuccess = () => {
+      const db = req.result;
+      const tx = db.transaction("layout", "readonly");
+      const store = tx.objectStore("layout");
+      const getReq = store.get("windows");
+      getReq.onsuccess = () => resolve(getReq.result || []);
+      getReq.onerror = () => resolve([]);
+    };
+    req.onerror = () => resolve([]);
+  });
+}
+
+function saveLayout(windows) {
+  const req = indexedDB.open("prism-desktop", 1);
+  req.onupgradeneeded = () => {
+    req.result.createObjectStore("layout");
+  };
+  req.onsuccess = () => {
+    const db = req.result;
+    const tx = db.transaction("layout", "readwrite");
+    tx.objectStore("layout").put(windows, "windows");
+  };
+}
+
+export default function Desktop() {
+  const [wins, setWins] = useState([]);
+
+  useEffect(() => {
+    loadLayout().then((data) => setWins(data));
+  }, []);
+
+  useEffect(() => {
+    saveLayout(wins);
+  }, [wins]);
+
+  const open = (key) => {
+    setWins((ws) => {
+      const existing = ws.find((w) => w.app === key);
+      if (existing) return ws.map((w) => (w.app === key ? { ...w, minimized: false } : w));
+      return [...ws, defaultWin(key)];
+    });
+  };
+
+  const update = (id, patch) => setWins((ws) => ws.map((w) => (w.id === id ? { ...w, ...patch } : w)));
+
+  return (
+    <div
+      className="w-screen h-screen relative overflow-hidden"
+      style={{
+        background: "linear-gradient(135deg,#FF4FD8,#0096FF,#FDBA2D)",
+      }}
+    >
+      {wins.map((win) => (
+        <Window
+          key={win.id}
+          win={win}
+          onClose={() => setWins((ws) => ws.filter((w) => w.id !== win.id))}
+          onToggleMin={() => update(win.id, { minimized: !win.minimized })}
+          onToggleMax={() => update(win.id, { maximized: !win.maximized })}
+          onUpdate={(data) => update(win.id, data)}
+        >
+          {renderApp(win.app)}
+        </Window>
+      ))}
+
+      <div className="taskbar absolute bottom-0 left-0 right-0 bg-black/60 text-white flex gap-2 p-2">
+        {Object.entries(APPS).map(([key, app]) => (
+          <button
+            key={key}
+            onClick={() => open(key)}
+            className="px-2 py-1 bg-white/20 rounded hover:bg-white/30"
+          >
+            {app.icon}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function renderApp(key) {
+  switch (key) {
+    case "api":
+      return <pre className="p-2">/prism/logs/api tail</pre>;
+    case "llm":
+      return <div className="p-2">LLM chat placeholder</div>;
+    case "math":
+      return <div className="p-2">Graph canvas placeholder</div>;
+    case "echo":
+      return <div className="p-2">Echo agent window</div>;
+    case "guardian":
+      return <div className="p-2">Contradictions list</div>;
+    case "explorer":
+      return <div className="p-2">/prism file explorer</div>;
+    default:
+      return null;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `react-rnd` and desktop/window components
- route root path to new desktop shell with persistent window layout

## Testing
- `npm test`
- `npm run lint` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npm --prefix sites/blackroad run lint`
- `npm --prefix sites/blackroad test`


------
https://chatgpt.com/codex/tasks/task_e_68ab916c9d9c8329af254f6629239b46