### PR TITLE
feat: add desktop-style agent windows

### DIFF
--- a/sites/blackroad/package-lock.json
+++ b/sites/blackroad/package-lock.json
@@ -8,8 +8,10 @@
       "name": "blackroad-site",
       "version": "0.3.1",
       "dependencies": {
+        "idb-keyval": "6.2.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-rnd": "10.5.2",
         "react-router-dom": "6.30.1",
         "recharts": "^2.11.0"
       },
@@ -2894,6 +2896,12 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
+    "node_modules/idb-keyval": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
+      "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
+      "license": "Apache-2.0"
+    },
     "node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -3819,6 +3827,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/re-resizable": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.11.2.tgz",
+      "integrity": "sha512-2xI2P3OHs5qw7K0Ud1aLILK6MQxW50TcO+DetD9eIV58j84TqYeHoZcL9H4GXFXXIh7afhH8mv5iUCXII7OW7A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -3844,6 +3862,29 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-draggable": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.6.tgz",
+      "integrity": "sha512-LtY5Xw1zTPqHkVmtM3X8MUOxNDOUhv/khTgBgrUvwaS064bwVvxT+q5El0uUFNx5IEPKXuRejr7UqLwBIg5pdw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^1.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
+    "node_modules/react-draggable/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -3858,6 +3899,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-rnd": {
+      "version": "10.5.2",
+      "resolved": "https://registry.npmjs.org/react-rnd/-/react-rnd-10.5.2.tgz",
+      "integrity": "sha512-0Tm4x7k7pfHf2snewJA8x7Nwgt3LV+58MVEWOVsFjk51eYruFEa6Wy7BNdxt4/lH0wIRsu7Gm3KjSXY2w7YaNw==",
+      "license": "MIT",
+      "dependencies": {
+        "re-resizable": "6.11.2",
+        "react-draggable": "4.4.6",
+        "tslib": "2.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
       }
     },
     "node_modules/react-router": {
@@ -4580,6 +4636,12 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/sites/blackroad/package.json
+++ b/sites/blackroad/package.json
@@ -14,8 +14,10 @@
     "e2e": "playwright test || true"
   },
   "dependencies": {
+    "idb-keyval": "6.2.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-rnd": "10.5.2",
     "react-router-dom": "6.30.1",
     "recharts": "^2.11.0"
   },

--- a/sites/blackroad/src/main.jsx
+++ b/sites/blackroad/src/main.jsx
@@ -1,13 +1,13 @@
-import React from "react";
-import { createRoot } from "react-dom/client";
-import { BrowserRouter } from "react-router-dom";
-import App from "./App.jsx";
-import "./styles.css";
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import Desktop from './pages/Desktop.jsx';
+import './styles.css';
 
-createRoot(document.getElementById("root")).render(
+createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <Desktop />
     </BrowserRouter>
   </React.StrictMode>
 );

--- a/sites/blackroad/src/pages/Desktop.jsx
+++ b/sites/blackroad/src/pages/Desktop.jsx
@@ -1,0 +1,139 @@
+import { useState, useEffect } from 'react';
+import { Rnd } from 'react-rnd';
+import { get, set } from 'idb-keyval';
+
+const DEFAULT_LAYOUT = {
+  echo: { open: true, x: 40, y: 40, width: 320, height: 240 },
+  llm: { open: true, x: 380, y: 40, width: 320, height: 400 },
+  math: { open: false, x: 100, y: 100, width: 320, height: 240 },
+  guardian: { open: false, x: 120, y: 120, width: 320, height: 240 },
+  api: { open: false, x: 140, y: 140, width: 320, height: 240 },
+  files: { open: false, x: 160, y: 160, width: 320, height: 240 },
+};
+
+function usePersistedLayout() {
+  const [layout, setLayout] = useState(DEFAULT_LAYOUT);
+  useEffect(() => {
+    let alive = true;
+    get('prism-desktop-layout').then((saved) => {
+      if (saved && alive) setLayout({ ...DEFAULT_LAYOUT, ...saved });
+    });
+    return () => {
+      alive = false;
+    };
+  }, []);
+  useEffect(() => {
+    set('prism-desktop-layout', layout).catch(() => {});
+  }, [layout]);
+  return [layout, setLayout];
+}
+
+function Window({ id, title, layout, setLayout, children }) {
+  const cfg = layout[id];
+  if (!cfg?.open) return null;
+  const update = (patch) => setLayout((l) => ({ ...l, [id]: { ...l[id], ...patch } }));
+  return (
+    <Rnd
+      bounds="parent"
+      size={{ width: cfg.width, height: cfg.height }}
+      position={{ x: cfg.x, y: cfg.y }}
+      onDragStop={(e, d) => update({ x: d.x, y: d.y })}
+      onResizeStop={(e, dir, ref, delta, pos) =>
+        update({
+          width: ref.offsetWidth,
+          height: ref.offsetHeight,
+          x: pos.x,
+          y: pos.y,
+        })
+      }
+    >
+      <div className="flex flex-col h-full bg-white border shadow-lg">
+        <div className="flex items-center justify-between bg-neutral-800 text-white px-2 py-1 cursor-move">
+          <span className="text-sm flex items-center gap-1">
+            <span className="text-green-400">●</span>
+            {title}
+          </span>
+          <div className="space-x-1">
+            <button onClick={() => update({ open: false })}>_</button>
+            <button
+              onClick={() =>
+                update({
+                  x: 0,
+                  y: 0,
+                  width: window.innerWidth,
+                  height: window.innerHeight,
+                })
+              }
+            >
+              □
+            </button>
+            <button onClick={() => update({ open: false })}>×</button>
+          </div>
+        </div>
+        <div className="flex-1 overflow-auto">{children}</div>
+      </div>
+    </Rnd>
+  );
+}
+
+export default function Desktop() {
+  const [layout, setLayout] = usePersistedLayout();
+  const agents = [
+    {
+      id: 'echo',
+      title: 'Echo Agent',
+      content: <div className="p-2 text-sm">Echo console coming soon.</div>,
+    },
+    {
+      id: 'llm',
+      title: 'LLM Agent',
+      content: <div className="p-2 text-sm">LLM chat coming soon.</div>,
+    },
+    {
+      id: 'math',
+      title: 'Math Agent',
+      content: <div className="p-2 text-sm">Graph canvas coming soon.</div>,
+    },
+    {
+      id: 'guardian',
+      title: 'Guardian Agent',
+      content: <div className="p-2 text-sm">Contradiction inspector coming soon.</div>,
+    },
+    {
+      id: 'api',
+      title: 'API Agent',
+      content: <div className="p-2 text-sm">Log tail coming soon.</div>,
+    },
+    {
+      id: 'files',
+      title: 'File Explorer',
+      content: <div className="p-2 text-sm">File explorer coming soon.</div>,
+    },
+  ];
+  const toggle = (id) => setLayout((l) => ({ ...l, [id]: { ...l[id], open: !l[id]?.open } }));
+  return (
+    <div
+      className="w-screen h-screen relative"
+      style={{
+        background: 'linear-gradient(135deg,#FF4FD8,#0096FF,#FDBA2D)',
+      }}
+    >
+      {agents.map((a) => (
+        <Window key={a.id} id={a.id} title={a.title} layout={layout} setLayout={setLayout}>
+          {a.content}
+        </Window>
+      ))}
+      <div className="absolute bottom-2 left-1/2 -translate-x-1/2 bg-white/70 rounded px-2 py-1 flex gap-2">
+        {agents.map((a) => (
+          <button
+            key={a.id}
+            className="px-2 py-1 text-sm hover:bg-white/50 rounded"
+            onClick={() => toggle(a.id)}
+          >
+            {a.title.split(' ')[0]}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Desktop page that renders agent windows in a draggable workspace
- persist window layout in IndexedDB and toggle visibility via dock icons
- include react-rnd and idb-keyval dependencies and mount Desktop at app root

## Testing
- `pre-commit run --files sites/blackroad/package.json sites/blackroad/package-lock.json sites/blackroad/src/main.jsx sites/blackroad/src/pages/Desktop.jsx`
- `npm test`
- `npm run lint` *(fails: eslint not found)*
- `npm --prefix sites/blackroad run lint`
- `npm --prefix sites/blackroad test`


------
https://chatgpt.com/codex/tasks/task_e_68ab937694c483298d012056a80ea387