### PR TITLE
feat(projects-tasks): add CRUD API for projects and tasks with auth enforcement

### DIFF
--- a/src/routes/projects.js
+++ b/src/routes/projects.js
@@ -12,16 +12,20 @@ router.post('/', requireAuth, (req, res) => {
   if (!name || !name.trim()) {
     return res.status(400).json({ ok: false, error: 'missing_name' });
   }
+  const trimmed = name.trim();
+  if (trimmed.length > 255) {
+    return res.status(400).json({ ok: false, error: 'invalid_name' });
+  }
   const exists = db
     .prepare('SELECT id FROM projects WHERE user_id = ? AND name = ?')
-    .get(req.user.id, name.trim());
+    .get(req.user.id, trimmed);
   if (exists) {
     return res.status(409).json({ ok: false, error: 'duplicate_project' });
   }
   const id = cryptoRandomId();
   db.prepare(
     'INSERT INTO projects (id, user_id, name, metadata) VALUES (?, ?, ?, ?)',
-  ).run(id, req.user.id, name.trim(), metadata ? JSON.stringify(metadata) : null);
+  ).run(id, req.user.id, trimmed, metadata ? JSON.stringify(metadata) : null);
   const project = db.prepare('SELECT * FROM projects WHERE id = ?').get(id);
   res.json({ ok: true, project });
 });
@@ -47,19 +51,24 @@ router.put('/:id', requireAuth, (req, res) => {
   const id = req.params.id;
   const project = db.prepare('SELECT * FROM projects WHERE id = ?').get(id);
   if (!project) return res.status(404).json({ ok: false, error: 'not_found' });
-  if (project.user_id !== req.user.id) {
+  if (project.user_id !== req.user.id && req.user.role !== 'admin') {
     return res.status(403).json({ ok: false, error: 'forbidden' });
   }
+  let trimmed;
   if (name && name.trim()) {
+    trimmed = name.trim();
+    if (trimmed.length > 255) {
+      return res.status(400).json({ ok: false, error: 'invalid_name' });
+    }
     const dup = db
       .prepare('SELECT id FROM projects WHERE user_id = ? AND name = ? AND id != ?')
-      .get(req.user.id, name.trim(), id);
+      .get(project.user_id, trimmed, id);
     if (dup) return res.status(409).json({ ok: false, error: 'duplicate_project' });
   }
   db.prepare(
     'UPDATE projects SET name = COALESCE(?, name), metadata = COALESCE(?, metadata) WHERE id = ?',
   ).run(
-    name && name.trim() ? name.trim() : null,
+    trimmed || null,
     metadata ? JSON.stringify(metadata) : null,
     id,
   );

--- a/src/routes/tasks.js
+++ b/src/routes/tasks.js
@@ -6,23 +6,20 @@ const { requireAuth } = require('../auth');
 
 const router = express.Router();
 
+// all task routes require authentication
 router.use(requireAuth);
 
-// List tasks for current user
-router.get('/', (req, res) => {
-  const tasks = db
-    .prepare('SELECT * FROM tasks WHERE user_id = ? ORDER BY created_at DESC')
-    .all(req.user.id);
-  res.json({ ok: true, tasks });
-});
-
-// Create task under project
-router.post('/', (req, res) => {
-  const { project_id, title, status } = req.body || {};
-  if (!project_id || !title || !title.trim()) {
-    return res.status(400).json({ ok: false, error: 'missing_fields' });
+// Create task within a project
+router.post('/projects/:projectId/tasks', (req, res) => {
+  const { title, status } = req.body || {};
+  if (!title || !title.trim()) {
+    return res.status(400).json({ ok: false, error: 'missing_title' });
   }
-  const project = db.prepare('SELECT * FROM projects WHERE id = ?').get(project_id);
+  const trimmed = title.trim();
+  if (trimmed.length > 255) {
+    return res.status(400).json({ ok: false, error: 'invalid_title' });
+  }
+  const project = db.prepare('SELECT * FROM projects WHERE id = ?').get(req.params.projectId);
   if (!project) return res.status(404).json({ ok: false, error: 'not_found' });
   if (project.user_id !== req.user.id && req.user.role !== 'admin') {
     return res.status(403).json({ ok: false, error: 'forbidden' });
@@ -30,28 +27,58 @@ router.post('/', (req, res) => {
   const id = cryptoRandomId();
   db.prepare(
     'INSERT INTO tasks (id, project_id, user_id, title, status) VALUES (?, ?, ?, ?, COALESCE(?, "pending"))',
-  ).run(id, project_id, req.user.id, title.trim(), status || null);
+  ).run(id, project.id, project.user_id, trimmed, status || null);
   const task = db.prepare('SELECT * FROM tasks WHERE id = ?').get(id);
   res.json({ ok: true, task });
 });
 
-// Update task
-router.put('/:id', (req, res) => {
+// List tasks for a project
+router.get('/projects/:projectId/tasks', (req, res) => {
+  const project = db.prepare('SELECT * FROM projects WHERE id = ?').get(req.params.projectId);
+  if (!project) return res.status(404).json({ ok: false, error: 'not_found' });
+  if (project.user_id !== req.user.id && req.user.role !== 'admin') {
+    return res.status(403).json({ ok: false, error: 'forbidden' });
+  }
+  const tasks = db
+    .prepare('SELECT * FROM tasks WHERE project_id = ? ORDER BY created_at DESC')
+    .all(project.id);
+  res.json({ ok: true, tasks });
+});
+
+// Fetch single task
+router.get('/tasks/:id', (req, res) => {
+  const task = db.prepare('SELECT * FROM tasks WHERE id = ?').get(req.params.id);
+  if (!task) return res.status(404).json({ ok: false, error: 'not_found' });
+  if (task.user_id !== req.user.id && req.user.role !== 'admin') {
+    return res.status(403).json({ ok: false, error: 'forbidden' });
+  }
+  res.json({ ok: true, task });
+});
+
+// Update a task
+router.put('/tasks/:id', (req, res) => {
   const { title, status } = req.body || {};
   const task = db.prepare('SELECT * FROM tasks WHERE id = ?').get(req.params.id);
   if (!task) return res.status(404).json({ ok: false, error: 'not_found' });
   if (task.user_id !== req.user.id && req.user.role !== 'admin') {
     return res.status(403).json({ ok: false, error: 'forbidden' });
   }
+  let trimmed;
+  if (title && title.trim()) {
+    trimmed = title.trim();
+    if (trimmed.length > 255) {
+      return res.status(400).json({ ok: false, error: 'invalid_title' });
+    }
+  }
   db.prepare(
     'UPDATE tasks SET title = COALESCE(?, title), status = COALESCE(?, status) WHERE id = ?',
-  ).run(title ? title.trim() : null, status || null, req.params.id);
+  ).run(trimmed || null, status || null, req.params.id);
   const updated = db.prepare('SELECT * FROM tasks WHERE id = ?').get(req.params.id);
   res.json({ ok: true, task: updated });
 });
 
-// Delete task
-router.delete('/:id', (req, res) => {
+// Delete a task
+router.delete('/tasks/:id', (req, res) => {
   const task = db.prepare('SELECT * FROM tasks WHERE id = ?').get(req.params.id);
   if (!task) return res.status(404).json({ ok: false, error: 'not_found' });
   if (task.user_id !== req.user.id && req.user.role !== 'admin') {


### PR DESCRIPTION
## Summary
- implement auth-protected CRUD endpoints for projects and tasks
- enforce ownership/admin checks and validation
- support nested task routes under projects

## Testing
- `npm run lint` *(fails: ESLint config import outside module)*
- `npm run test-projects-tasks` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68aba233c3c48329b52fa29347a30fd2