### PR TITLE
feat: add novelty dashboard

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -26,7 +26,7 @@ import Subscribe from './Subscribe.jsx'
 import io from 'socket.io-client'
 import { Routes, Route, NavLink } from 'react-router-dom'
 import { API_BASE, setToken, login, me, fetchTimeline, fetchTasks, fetchCommits, fetchAgents, fetchWallet, fetchContradictions, getNotes, setNotes, action } from './api'
-import { Activity, Brain, Database, LayoutGrid, Settings, ShieldCheck, SquareDashedMousePointer, HeartPulse } from 'lucide-react'
+import { Activity, Brain, Database, LayoutGrid, Settings, ShieldCheck, SquareDashedMousePointer, HeartPulse, Sparkles } from 'lucide-react'
 import Login from './components/Login.jsx'
 import Dashboard from './pages/Dashboard.jsx'
 import RoadView from './pages/RoadView.jsx'
@@ -138,6 +138,7 @@ export default function App(){
               <NavItem to="/integrations" icon={<Settings size={18} />} text="Integrations" />
               <NavItem to="/roadview" icon={<LayoutGrid size={18} />} text="RoadView" />
               <NavItem to="/autoheal" icon={<HeartPulse size={18} />} text="Auto-Heal" />
+              <NavItem to="/novelty" icon={<Sparkles size={18} />} text="Novelty Dashboard" />
               <NavItem icon={<Rocket size={18} />} text="Orchestrator" to="/orchestrator" />
               <NavItem icon={<Rocket size={18} />} text="Manifesto" href="/manifesto" />
             </nav>

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,13 +1,17 @@
 import React from 'react'
 import { createRoot } from 'react-dom/client'
-import { BrowserRouter } from 'react-router-dom'
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import App from './App.jsx'
+import Novelty from './pages/Novelty.jsx'
 import './index.css'
 
 createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <Routes>
+        <Route path="/novelty" element={<Novelty />} />
+        <Route path="*" element={<App />} />
+      </Routes>
     </BrowserRouter>
   </React.StrictMode>
 )

--- a/frontend/src/pages/Novelty.jsx
+++ b/frontend/src/pages/Novelty.jsx
@@ -1,0 +1,77 @@
+import React, { useEffect, useState } from 'react'
+import { Sparkles } from 'lucide-react'
+
+const agents = [
+  { key: 'love', name: 'Love', color: '#FF4FD8' },
+  { key: 'curiosity', name: 'Curiosity', color: '#0096FF' },
+  { key: 'consent', name: 'Consent', color: '#FDBA2D' },
+  { key: 'creativity', name: 'Creativity', color: '#FF4FD8' },
+  { key: 'art', name: 'Art', color: '#0096FF' },
+  { key: 'poetry', name: 'Poetry', color: '#FDBA2D' },
+  { key: 'music', name: 'Music', color: '#FF4FD8' },
+  { key: 'math', name: 'Math', color: '#0096FF' },
+  { key: 'paradox', name: 'Paradox', color: '#FDBA2D' },
+  { key: 'dream', name: 'Dream', color: '#FF4FD8' },
+  { key: 'oracle', name: 'Oracle', color: '#0096FF' }
+]
+
+export default function Novelty(){
+  const [data, setData] = useState({})
+
+  useEffect(()=>{
+    agents.forEach(a=>{
+      fetch(`/prism/logs/${a.key}.log`).then(r=>r.text()).then(txt=>{
+        const lines = txt.trim().split('\n').slice(-5)
+        setData(d=>({...d, [a.key]: lines}))
+      }).catch(()=>{})
+    })
+    const ws = new WebSocket(`ws://${window.location.host}/ws/novelty`)
+    ws.onmessage = e => {
+      try {
+        const { agent, entry } = JSON.parse(e.data)
+        setData(d=>({ ...d, [agent]: [entry, ...(d[agent]||[])] }))
+      } catch(err) {}
+    }
+    return ()=>ws.close()
+  }, [])
+
+  function ping(agent){
+    fetch(`/api/novelty/${agent}/ping`, { method: 'POST' }).catch(()=>{})
+  }
+  function save(agent){
+    const content = data[agent]?.[0]
+    if(content){
+      fetch(`/api/novelty/${agent}/save`, {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({ content })
+      }).catch(()=>{})
+    }
+  }
+
+  return (
+    <div className="min-h-screen p-4" style={{background:'linear-gradient(135deg,#FF4FD8,#0096FF,#FDBA2D)'}}>
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-2xl font-bold flex items-center gap-2"><Sparkles size={20}/> Novelty Dashboard</h1>
+        <button className="badge" onClick={()=>fetch('/api/novelty/spawn_all',{method:'POST'}).catch(()=>{})}>Spawn All</button>
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {agents.map(a=>(
+          <div key={a.key} className="bg-slate-900/60 rounded-lg p-4 hover:shadow-lg" style={{borderColor:a.color}}>
+            <header className="flex items-center justify-between mb-2">
+              <h2 className="font-semibold" style={{color:a.color}}>{a.name} Agent</h2>
+              <div className="flex gap-2">
+                <button className="badge" onClick={()=>ping(a.key)}>Ping</button>
+                <button className="badge" onClick={()=>save(a.key)}>Save</button>
+              </div>
+            </header>
+            <div className="text-sm space-y-1 h-32 overflow-y-auto">
+              {(data[a.key] || ['No data']).map((line,i)=>(<div key={i}>{line}</div>))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add novelty dashboard page and routing
- link novelty dashboard from sidebar

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aba076fe0c83299502a2ed274cfd3a