### PR TITLE
feat(logs-contradictions): add persistent APIs for logs and contradictions

### DIFF
--- a/backend/data.js
+++ b/backend/data.js
@@ -170,6 +170,23 @@ function getLogs() {
   return getDb().prepare('SELECT * FROM logs ORDER BY timestamp DESC').all();
 }
 
+// ---- Contradictions ----
+function addContradiction(module, description) {
+  getDb()
+    .prepare('INSERT INTO contradictions (module, description) VALUES (?, ?)')
+    .run(module, description);
+}
+
+function getContradictions() {
+  return getDb()
+    .prepare('SELECT * FROM contradictions ORDER BY timestamp DESC')
+    .all();
+}
+
+function deleteContradiction(id) {
+  return getDb().prepare('DELETE FROM contradictions WHERE id = ?').run(id);
+}
+
 module.exports = {
   getDb,
   closeDb,
@@ -186,5 +203,8 @@ module.exports = {
   deleteTask,
   addLog,
   getLogs,
+  addContradiction,
+  getContradictions,
+  deleteContradiction,
 };
 

--- a/src/routes/contradictions.js
+++ b/src/routes/contradictions.js
@@ -3,7 +3,7 @@
 
 const express = require('express');
 const db = require('../db');
-const { requireAuth } = require('../auth');
+const { requireAuth, requireAdmin } = require('../auth');
 
 const router = express.Router();
 
@@ -26,6 +26,15 @@ router.post('/', requireAuth, (req, res) => {
     description
   );
   res.json({ ok: true, id });
+});
+
+router.delete('/:id', requireAdmin, (req, res) => {
+  const { id } = req.params;
+  const info = db.prepare('DELETE FROM contradictions WHERE id = ?').run(id);
+  if (info.changes === 0) {
+    return res.status(404).json({ ok: false, error: 'not_found' });
+  }
+  res.json({ ok: true });
 });
 
 function cryptoRandomId() {

--- a/tests/test_logs_contradictions.js
+++ b/tests/test_logs_contradictions.js
@@ -2,40 +2,33 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const path = require('path');
 const fs = require('fs');
-const express = require('../backend/node_modules/express');
+const express = require('express');
 
 const dbPath = path.join(__dirname, 'tmp', 'monitor.db');
 fs.mkdirSync(path.dirname(dbPath), { recursive: true });
 process.env.DB_PATH = dbPath;
 
 const db = require('../src/db');
-db.prepare('INSERT INTO users (id, email, password_hash, role) VALUES (?,?,?,?)').run(
-  'u1',
-  'svc@example.com',
-  'x',
-  'service'
-);
+db.prepare('INSERT INTO users (id, email, password_hash, role) VALUES (?,?,?,?)').run('u1', 'svc@example.com', 'x', 'service');
+db.prepare('INSERT INTO users (id, email, password_hash, role) VALUES (?,?,?,?)').run('a1', 'admin@example.com', 'x', 'admin');
 
 const logsRouter = require('../src/routes/logs');
 const contradictionsRouter = require('../src/routes/contradictions');
 
-function auth(req, _res, next) {
-  req.session = { userId: 'u1' };
-  next();
+function makeApp(userId, router, mount) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.session = { userId };
+    next();
+  });
+  app.use(mount, router);
+  return app;
 }
 
-const appLogs = express();
-appLogs.use(express.json());
-appLogs.use(auth);
-appLogs.use('/logs', logsRouter);
-
-const appContr = express();
-appContr.use(express.json());
-appContr.use(auth);
-appContr.use('/contradictions', contradictionsRouter);
-
 test('insert and retrieve logs', async () => {
-  const server = appLogs.listen(0);
+  const app = makeApp('u1', logsRouter, '/logs');
+  const server = app.listen(0);
   const base = `http://127.0.0.1:${server.address().port}/logs`;
   let res = await fetch(base, {
     method: 'POST',
@@ -52,7 +45,8 @@ test('insert and retrieve logs', async () => {
 });
 
 test('insert and retrieve contradictions', async () => {
-  const server = appContr.listen(0);
+  const app = makeApp('u1', contradictionsRouter, '/contradictions');
+  const server = app.listen(0);
   const base = `http://127.0.0.1:${server.address().port}/contradictions`;
   let res = await fetch(base, {
     method: 'POST',
@@ -65,5 +59,38 @@ test('insert and retrieve contradictions', async () => {
   assert.ok(data.contradictions.length >= 1);
   assert.equal(data.contradictions[0].module, 'math');
   assert.ok(data.contradictions[0].timestamp);
+  server.close();
+});
+
+test('unauthorized users blocked from delete', async () => {
+  const app = makeApp('u1', contradictionsRouter, '/contradictions');
+  const server = app.listen(0);
+  const base = `http://127.0.0.1:${server.address().port}/contradictions`;
+  let res = await fetch(base, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ module: 'test', description: 'temp' })
+  });
+  const body = await res.json();
+  res = await fetch(`${base}/${body.id}`, { method: 'DELETE' });
+  assert.equal(res.status, 403);
+  server.close();
+});
+
+test('admin delete succeeded', async () => {
+  const app = makeApp('a1', contradictionsRouter, '/contradictions');
+  const server = app.listen(0);
+  const base = `http://127.0.0.1:${server.address().port}/contradictions`;
+  let res = await fetch(base, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ module: 'auth', description: 'cleanup' })
+  });
+  const body = await res.json();
+  res = await fetch(`${base}/${body.id}`, { method: 'DELETE' });
+  assert.equal(res.status, 200);
+  res = await fetch(base);
+  const data = await res.json();
+  assert.ok(!data.contradictions.find(c => c.id === body.id));
   server.close();
 });


### PR DESCRIPTION
### Summary
This PR introduces persistent APIs for logs and contradictions, building on the SQLite backend.

### Changes
- Added `src/routes/logs.js` with POST/GET endpoints
- Added `src/routes/contradictions.js` with POST/GET/DELETE endpoints
- Integrated with SQLite (logs + contradictions tables)
- Added DB helpers in backend/data.js
- Secured endpoints with JWT auth
- Admin-only delete for contradictions
- Added tests in tests/test_logs_contradictions.js

### Testing
- Ran `npm run test-logs-contradictions`
- Ran `npm run lint`

### Next Steps
- Hook Codex pipeline into POST /logs and POST /contradictions
- Surface contradictions and logs in Prism UI dashboards

------
https://chatgpt.com/codex/tasks/task_e_68ab9cf994688329a141bea23d498ba8