### PR TITLE
Fix local setup script

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.3.3
+    rev: v3.1.0
     hooks:
       - id: prettier
         additional_dependencies: ["prettier@^3"]
@@ -47,4 +47,3 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
-        additional_dependencies: ['prettier@3.3.3']

--- a/scripts/setup_local.sh
+++ b/scripts/setup_local.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Create virtual environment
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$ROOT"
+
+# Create virtual environment if it doesn't exist
 if [ ! -d ".venv" ]; then
   python3 -m venv .venv
 fi
@@ -11,32 +14,12 @@ source .venv/bin/activate
 python -m pip install --upgrade pip
 pip install -r requirements-local.txt
 
-cat <<'MSG'
-MuJoCo dependencies are skipped. To enable MuJoCo later, install mujoco and gymnasium[mujoco].
-MSG
+echo "Skipping MuJoCo installation. To enable later: pip install mujoco gymnasium[mujoco]"
 
 python - <<'PY'
 import importlib
 mods = ["numpy", "scipy", "gymnasium", "torch", "tensorboard", "tqdm", "click", "cloudpickle"]
 for m in mods:
     importlib.import_module(m)
-print("\N{white heavy check mark} READY")
-set -e
-
-ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-cd "$ROOT"
-
-if [ ! -d .venv ]; then
-    python3 -m venv .venv
-fi
-
-source .venv/bin/activate
-python -m pip install --upgrade pip
-pip install -r requirements-local.txt
-
-echo "Skipping MuJoCo installation. To enable later: pip install mujoco gymnasium[mujoco]"
-
-python - <<'PY'
-import numpy, scipy, gymnasium, torch, tensorboard, tqdm, click, cloudpickle
-print('✅ READY')
+print("✅ READY")
 PY


### PR DESCRIPTION
## Summary
- correct `scripts/setup_local.sh` to create and validate the virtual environment without duplicate sections
- fix pre-commit config to pin Prettier to an existing tag so hooks run

## Testing
- `shellcheck scripts/setup_local.sh`
- `pre-commit run --files scripts/setup_local.sh`
- `pytest tests/test_tokenize_url.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab6f531afc83299c08723face5c335