### PR TITLE
feat(agent): allow adding custom engines

### DIFF
--- a/agents/auto_novel_agent.py
+++ b/agents/auto_novel_agent.py
@@ -16,6 +16,20 @@ class AutoNovelAgent:
         """Deploy the agent by printing a greeting."""
         print(f"{self.name} deployed and ready to generate novels!")
 
+    def _normalize_engine(self, engine: str) -> str:
+        """Normalize an engine name to a lowercase, trimmed string.
+
+        Args:
+            engine: Engine name to normalize.
+
+        Raises:
+            ValueError: If the engine name is empty after normalization.
+        """
+        engine_lower = engine.strip().lower()
+        if not engine_lower:
+            raise ValueError("Engine name cannot be empty.")
+        return engine_lower
+
     def create_game(self, engine: str, include_weapons: bool = False) -> None:
         """Create a basic game using a supported engine without weapons.
 
@@ -24,7 +38,7 @@ class AutoNovelAgent:
             include_weapons: If True, raise a ``ValueError`` because weapons are not
                 allowed.
         """
-        engine_lower = engine.strip().lower()
+        engine_lower = self._normalize_engine(engine)
         if engine_lower not in self.supported_engines:
             supported = ", ".join(sorted(self.supported_engines))
             raise ValueError(f"Unsupported engine. Choose one of: {supported}.")
@@ -45,9 +59,7 @@ class AutoNovelAgent:
         Raises:
             ValueError: If the engine name is empty or already supported.
         """
-        engine_lower = engine.strip().lower()
-        if not engine_lower:
-            raise ValueError("Engine name cannot be empty.")
+        engine_lower = self._normalize_engine(engine)
         if engine_lower in self.supported_engines:
             raise ValueError("Engine already supported.")
         self.supported_engines.add(engine_lower)

--- a/tests/test_auto_novel_agent.py
+++ b/tests/test_auto_novel_agent.py
@@ -16,6 +16,12 @@ def test_create_game_unsupported_engine():
         agent.create_game("godot")
 
 
+def test_create_game_empty_engine():
+    agent = AutoNovelAgent()
+    with pytest.raises(ValueError):
+        agent.create_game("   ")
+
+
 def test_create_game_disallows_weapons():
     agent = AutoNovelAgent()
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
- allow AutoNovelAgent to register new game engines safely
- test engine creation and registration behaviors

## Testing
- `ruff check agents/auto_novel_agent.py tests/test_auto_novel_agent.py`
- `python -m py_compile agents/auto_novel_agent.py`
- `python agents/auto_novel_agent.py`
- `pytest tests/test_auto_novel_agent.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68abc3d6bc50832981f0e5d27fd2bacc