### PR TITLE
chore: dedupe test scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prepare": "husky",
     "lint": "eslint . --ext .js,.jsx,.mjs,.cjs || true",
     "format": "prettier -w .",
-    "test": "cross-env NODE_ENV=test jest --runInBand",
+    "test:jest": "cross-env NODE_ENV=test jest --runInBand",
     "test-db": "node tests/test_db.js",
     "test-auth": "node tests/test_auth.js",
     "test-projects-tasks": "node tests/test_projects_tasks.js",
@@ -23,8 +23,7 @@
     "test-agents-pack": "node tests/test_agents_mega.js",
     "frontend:dev": "npm --prefix sites/blackroad run dev",
     "frontend:build": "npm --prefix sites/blackroad run build",
-    "fix-anything": "node .github/tools/codex-apply.js .github/prompts/codex-fix-anything.md || true",
-    "test-auth": "node tests/test_auth.js"
+    "fix-anything": "node .github/tools/codex-apply.js .github/prompts/codex-fix-anything.md || true"
   },
   "engines": {
     "node": ">=18.17"


### PR DESCRIPTION
## Summary
- rename overwritten `test` script to `test:jest`
- drop duplicate `test-auth` entry

## Testing
- `npm test`
- `npm run lint`
- `npm run test:jest` *(fails: cross-env: not found)*
- `pytest tests/test_tokenize_url.py`


------
https://chatgpt.com/codex/tasks/task_e_68abc331ec8c83299f80c311677d2d32