### PR TITLE
feat(agents): manage supported engines

### DIFF
--- a/agents/auto_novel_agent.py
+++ b/agents/auto_novel_agent.py
@@ -9,7 +9,7 @@ class AutoNovelAgent:
     """A toy agent that can deploy itself and create simple games."""
 
     name: str = "AutoNovelAgent"
-    SUPPORTED_ENGINES: ClassVar[set[str]] = {"unity", "unreal"}
+    SUPPORTED_ENGINES: ClassVar[set[str]] = {"unity", "unreal", "godot"}
 
     def deploy(self) -> None:
         """Deploy the agent by printing a greeting."""
@@ -34,6 +34,14 @@ class AutoNovelAgent:
     def list_supported_engines(self) -> List[str]:
         """Return a list of supported game engines."""
         return sorted(self.SUPPORTED_ENGINES)
+
+    def add_engine(self, engine: str) -> None:
+        """Add a new engine to the supported set.
+
+        Args:
+            engine: Name of the engine to add.
+        """
+        self.SUPPORTED_ENGINES.add(engine.lower())
 
 
 if __name__ == "__main__":

--- a/tests/test_auto_novel_agent.py
+++ b/tests/test_auto_novel_agent.py
@@ -1,0 +1,33 @@
+import pytest
+
+from agents.auto_novel_agent import AutoNovelAgent
+
+
+@pytest.fixture(autouse=True)
+def reset_engines():
+    original = AutoNovelAgent.SUPPORTED_ENGINES.copy()
+    yield
+    AutoNovelAgent.SUPPORTED_ENGINES = original
+
+
+def test_default_supported_engines():
+    agent = AutoNovelAgent()
+    assert agent.list_supported_engines() == ["godot", "unity", "unreal"]
+
+
+def test_add_engine_and_list():
+    agent = AutoNovelAgent()
+    agent.add_engine("cryengine")
+    assert "cryengine" in agent.list_supported_engines()
+
+
+def test_invalid_engine_raises():
+    agent = AutoNovelAgent()
+    with pytest.raises(ValueError):
+        agent.create_game("cryengine")
+
+
+def test_weapons_not_allowed():
+    agent = AutoNovelAgent()
+    with pytest.raises(ValueError):
+        agent.create_game("unity", include_weapons=True)


### PR DESCRIPTION
## Summary
- expand AutoNovelAgent to support Godot and adding engines dynamically
- cover AutoNovelAgent with tests for engine management and safety checks

## Testing
- `pre-commit run --files agents/auto_novel_agent.py tests/test_auto_novel_agent.py`
- `python agents/auto_novel_agent.py`
- `python -m py_compile agents/auto_novel_agent.py`
- `python -m py_compile agents/*.py` *(fails: agents/cleanup_bot.py has syntax error)*
- `pytest tests/test_auto_novel_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_68abc48e4f708329b28f19684d57ee7d