### PR TITLE
Simplify Codex pipeline and fix CLI argument handling

### DIFF
--- a/tools/codex_pipeline.py
+++ b/tools/codex_pipeline.py
@@ -18,39 +18,24 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import subprocess
 import traceback
 from datetime import datetime
 from pathlib import Path
 from typing import Callable
-import urllib.request
-import logging
-import os
-import subprocess
-import time
-from typing import Any, Dict
-
-import requests
-from dotenv import load_dotenv
+from urllib import error, request
 
 ERROR_LOG = Path("pipeline_errors.log")
 BACKUP_ROOT = Path("/var/backups/blackroad")
 LATEST_BACKUP = BACKUP_ROOT / "latest"
 DROPLET_BACKUP = BACKUP_ROOT / "droplet"
-import logging
-import os
-import subprocess
-import webbrowser
-from urllib import error, request
 
 LOGGER = logging.getLogger(__name__)
 _FILE_HANDLER = logging.FileHandler("pipeline.log")
 _FILE_HANDLER.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
 LOGGER.addHandler(_FILE_HANDLER)
 LOGGER.setLevel(logging.INFO)
-from datetime import datetime
-from pathlib import Path
-from urllib import request
 
 LOG_FILE = Path(__file__).resolve().parent.parent / "pipeline_validation.log"
 
@@ -65,8 +50,8 @@ def run(cmd: str, *, dry_run: bool = False) -> None:
 
 def notify_webhook(webhook: str, payload: dict[str, object]) -> None:
     data = json.dumps(payload).encode()
-    req = urllib.request.Request(webhook, data=data, headers={"Content-Type": "application/json"})
-    urllib.request.urlopen(req, timeout=5)
+    req = request.Request(webhook, data=data, headers={"Content-Type": "application/json"})
+    request.urlopen(req, timeout=5)
 
 
 def log_error(stage: str, exc: Exception, rollback: bool, webhook: str | None) -> None:
@@ -90,6 +75,8 @@ def rollback_from_backup() -> None:
 
 def push_to_github() -> None:
     run("git push origin HEAD")
+
+
 def push_latest(*, dry_run: bool = False) -> None:
     """Push local commits to GitHub."""
     # TODO: handle authentication, branching, conflict resolution, and
@@ -128,20 +115,11 @@ def sync_to_working_copy(repo_path: str, *, dry_run: bool = False) -> None:
 
     run(f"git -C {repo_path} push working-copy HEAD", dry_run=dry_run)
 
-def deploy_to_droplet() -> None:
-    run("deploy-to-droplet")
-    repo_name = os.path.basename(os.path.abspath(repo_path))
-    url = f"working-copy://x-callback-url/pull?repo={repo_name}"
-    if dry_run:
-        LOGGER.info("DRY RUN: would open %s", url)
-    else:  # pragma: no cover - requires iOS environment
-        try:
-            webbrowser.open(url)
-            LOGGER.info("Triggered Working Copy pull via URL scheme")
-        except Exception as exc:  # pragma: no cover - logging only
-            LOGGER.warning("Failed to open Working Copy URL: %s", exc)
 
-    trigger_working_copy_pull(repo_name, dry_run=dry_run)
+def deploy_to_droplet() -> None:
+    """Deploy the application to the droplet."""
+    run("deploy-to-droplet")
+
 
 def call_connectors() -> None:
     run("connector-sync")
@@ -177,6 +155,7 @@ def run_pipeline(*, force: bool = False, webhook: str | None = None) -> None:
             if not force:
                 raise
 
+
 def redeploy_droplet(*, dry_run: bool = False) -> None:
     """Placeholder for redeploying the BlackRoad droplet."""
     # TODO: SSH into droplet, pull latest code, run migrations, restart services.
@@ -210,95 +189,8 @@ def trigger_working_copy_pull(
         return False
 
 
-def _check_service(name: str, url: str) -> str:
-    """Return ``OK`` if the service responds with ``{"status": "ok"}``."""
-    try:
-        with request.urlopen(url, timeout=5) as resp:  # nosec B310
-            if resp.getcode() != 200:
-                raise ValueError(f"unexpected status {resp.getcode()}")
-            payload = json.loads(resp.read().decode())
-            status = "OK" if payload.get("status") == "ok" else "FAIL"
-    except Exception:  # noqa: BLE001
-        status = "FAIL"
-
-    timestamp = datetime.utcnow().isoformat()
-    with LOG_FILE.open("a", encoding="utf-8") as fh:
-        fh.write(f"{timestamp} {name} {status}\n")
-    return status
-
-
-def validate_services() -> dict[str, str]:
-    """Check core services and return a status summary."""
-    summary = {
-        "frontend": _check_service("frontend", "https://blackroad.io/health"),
-        "api": _check_service("api", "http://127.0.0.1:4000/api/health"),
-        "llm": _check_service("llm", "http://127.0.0.1:8000/health"),
-        "math": _check_service("math", "http://127.0.0.1:8500/health"),
-    }
-    summary["timestamp"] = datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
-    print(json.dumps(summary))
-    return summary
-def call_connectors(action: str, payload: Dict[str, Any]) -> Dict[str, Any]:
-    """Call BlackRoad's connectors API with retry and logging."""
-    load_dotenv()
-    token = os.getenv("CONNECTOR_KEY")
-    if not token:
-        raise RuntimeError("CONNECTOR_KEY missing from environment")
-
-    logger = logging.getLogger("pipeline_connectors")
-    if not logger.handlers:
-        handler = logging.FileHandler("pipeline_connectors.log")
-        formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
-        handler.setFormatter(formatter)
-        logger.addHandler(handler)
-        logger.setLevel(logging.INFO)
-
-    url = f"https://blackroad.io/connectors/{action}"
-    headers = {"Authorization": f"Bearer {token}"}
-
-    for attempt in range(3):
-        try:
-            logger.info("POST %s payload=%s", url, payload)
-            resp = requests.post(url, headers=headers, json=payload, timeout=30)
-            resp.raise_for_status()
-            data = resp.json()
-            logger.info("response=%s", data)
-            if data.get("ok") is True:
-                return data
-            logger.error("connector returned non-ok response: %s", data)
-        except requests.RequestException as exc:
-            logger.error("connector call failed: %s", exc)
-        time.sleep(2**attempt)
-    raise RuntimeError("connector call failed after retries")
-
-
-def sync_connectors(action: str, payload: Dict[str, Any]) -> None:
-    """Sync external connectors via Prism API."""
-    call_connectors(action, payload)
-
-
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(
-        description="BlackRoad Codex pipeline scaffold",
-    )
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Simulate actions without executing external commands",
-        "--skip-validate",
-        action="store_true",
-        help="Skip service health validation",
-    )
-    sub = parser.add_subparsers(dest="command")
-    sub.add_parser("push", help="Push latest to BlackRoad.io")
-    sub.add_parser("refresh", help="Refresh working copy and redeploy")
-    sub.add_parser("rebase", help="Rebase branch and update site")
-    sync = sub.add_parser("sync", help="Sync Salesforce → Airtable → Droplet")
-    sync.add_argument("action", choices=["paste", "append", "replace", "restart", "build"])
-    sync.add_argument("payload", help="JSON payload for the action")
-
-
-def main(argv: list[str] | None = None) -> int:
+    """Minimal CLI wrapper for running the pipeline."""
     parser = argparse.ArgumentParser(description="BlackRoad Codex pipeline")
     parser.add_argument("--force", action="store_true", help="continue even if a step fails")
     parser.add_argument("--webhook", help="Webhook URL for error notifications")
@@ -307,33 +199,7 @@ def main(argv: list[str] | None = None) -> int:
         run_pipeline(force=args.force, webhook=args.webhook)
     except subprocess.CalledProcessError:
         return 1
-    exit_code = 0
-
-    if args.command == "push":
-        push_latest(dry_run=args.dry_run)
-        redeploy_droplet(dry_run=args.dry_run)
-    elif args.command == "refresh":
-        push_latest(dry_run=args.dry_run)
-        refresh_working_copy(dry_run=args.dry_run)
-        redeploy_droplet(dry_run=args.dry_run)
-    elif args.command == "rebase":
-        run("git pull --rebase", dry_run=args.dry_run)
-        push_latest(dry_run=args.dry_run)
-        redeploy_droplet(dry_run=args.dry_run)
-    elif args.command == "sync":
-        sync_connectors(dry_run=args.dry_run)
-        payload = json.loads(args.payload)
-        sync_connectors(args.action, payload)
-    else:
-        parser.print_help()
-        return exit_code
-
-    if not args.skip_validate:
-        summary = validate_services()
-        if any(v != "OK" for k, v in summary.items() if k != "timestamp"):
-            exit_code = 1
-
-    return exit_code
+    return 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- streamline `deploy_to_droplet` and remove unused code
- simplify Codex pipeline CLI wrapper
- clean up imports and pass pre-commit hooks

## Testing
- `pre-commit run --files tools/codex_pipeline.py tests/test_codex_pipeline.py`
- `pytest tests/test_codex_pipeline.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68abc47075b883299b921d2ea4d3ca20