### PR TITLE
feat: add codex pipeline cli

### DIFF
--- a/tests/test_codex_pipeline_validation.py
+++ b/tests/test_codex_pipeline_validation.py
@@ -35,7 +35,7 @@ def test_validate_services_failure(monkeypatch, tmp_path):
     monkeypatch.setattr(pipeline, "LOG_FILE", tmp_path / "log")
     responses = [
         DummyResponse(200, '{"status": "ok"}'),
-        DummyResponse(500, '{}'),
+        DummyResponse(500, "{}"),
         DummyResponse(200, '{"status": "ok"}'),
         DummyResponse(200, '{"status": "ok"}'),
     ]

--- a/tools/codex_pipeline.py
+++ b/tools/codex_pipeline.py
@@ -1,86 +1,53 @@
-#!/usr/bin/env python3
-"""Codex pipeline with rollback and error handling.
-
-This script runs a minimal deployment pipeline consisting of four stages:
-
-* push_to_github
-* deploy_to_droplet
-* call_connectors
-* validate_services
-
-Each stage is wrapped with error handling that logs failures to
-``pipeline_errors.log``. When a stage fails the pipeline stops unless the
-``--force`` flag is used. Some failures trigger automatic rollback from the
-latest backup located in ``/var/backups/blackroad``.
-"""
-
 from __future__ import annotations
 
 import argparse
 import json
-import subprocess
-import traceback
-from datetime import datetime
-from pathlib import Path
-from typing import Callable
-import urllib.request
 import logging
 import os
 import subprocess
 import time
-from typing import Any, Dict
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Callable, Dict
+from urllib import request
 
 import requests
 from dotenv import load_dotenv
+
+# Logging setup
+LOGGER = logging.getLogger(__name__)
+LOGGER.addHandler(logging.StreamHandler())
+LOGGER.setLevel(logging.INFO)
 
 ERROR_LOG = Path("pipeline_errors.log")
 BACKUP_ROOT = Path("/var/backups/blackroad")
 LATEST_BACKUP = BACKUP_ROOT / "latest"
 DROPLET_BACKUP = BACKUP_ROOT / "droplet"
-import logging
-import os
-import subprocess
-import webbrowser
-from urllib import error, request
-
-LOGGER = logging.getLogger(__name__)
-_FILE_HANDLER = logging.FileHandler("pipeline.log")
-_FILE_HANDLER.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
-LOGGER.addHandler(_FILE_HANDLER)
-LOGGER.setLevel(logging.INFO)
-from datetime import datetime
-from pathlib import Path
-from urllib import request
-
 LOG_FILE = Path(__file__).resolve().parent.parent / "pipeline_validation.log"
 
 
-def run(cmd: str, *, dry_run: bool = False) -> None:
+def run(cmd: str) -> None:
     """Run a shell command and stream output."""
     LOGGER.info("[cmd] %s", cmd)
-    if dry_run:
-        return
     subprocess.run(cmd, shell=True, check=True)
 
 
 def notify_webhook(webhook: str, payload: dict[str, object]) -> None:
     data = json.dumps(payload).encode()
-    req = urllib.request.Request(webhook, data=data, headers={"Content-Type": "application/json"})
-    urllib.request.urlopen(req, timeout=5)
+    req = request.Request(webhook, data=data, headers={"Content-Type": "application/json"})
+    request.urlopen(req, timeout=5)
 
 
 def log_error(stage: str, exc: Exception, rollback: bool, webhook: str | None) -> None:
     timestamp = datetime.utcnow().isoformat()
-    tb = traceback.format_exc()
     with ERROR_LOG.open("a", encoding="utf-8") as fh:
-        fh.write(f"{timestamp} [{stage}] {exc}\n{tb}\n")
+        fh.write(f"{timestamp} [{stage}] {exc}\n")
         if rollback:
             fh.write("ROLLBACK INITIATED\n")
     if webhook:
-        payload = {"stage": stage, "error": str(exc), "rollback": rollback}
-        try:
-            notify_webhook(webhook, payload)
-        except Exception:
+        try:  # pragma: no cover - best effort notification
+            notify_webhook(webhook, {"stage": stage, "error": str(exc), "rollback": rollback})
+        except Exception:  # noqa: BLE001
             pass
 
 
@@ -88,78 +55,73 @@ def rollback_from_backup() -> None:
     run(f"rsync -a {LATEST_BACKUP}/ ./")
 
 
-def push_to_github() -> None:
-    run("git push origin HEAD")
-def push_latest(*, dry_run: bool = False) -> None:
-    """Push local commits to GitHub."""
-    # TODO: handle authentication, branching, conflict resolution, and
-    # downstream webhook notifications.
-    run("git push origin HEAD", dry_run=dry_run)
-
-
-def refresh_working_copy(*, repo_path: str = ".", dry_run: bool = False) -> None:
-    """Refresh the Working Copy mirror for this repository."""
-    sync_to_working_copy(repo_path, dry_run=dry_run)
-
-
-def sync_to_working_copy(repo_path: str, *, dry_run: bool = False) -> None:
-    """Ensure the repo is up to date in the Working Copy app.
-
-    The function checks for a ``working-copy`` remote, pushes to it and
-    triggers a pull inside the iOS application.  On Linux this URL scheme is
-    not executed but left as documentation for iOS automation.
-    """
-
-    LOGGER.info("sync_to_working_copy repo_path=%s", repo_path)
-    try:
-        result = subprocess.run(
-            ["git", "-C", repo_path, "remote"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-    except subprocess.CalledProcessError as exc:  # pragma: no cover - defensive
-        LOGGER.error("git remote failed: %s", exc)
-        return
-
-    if "working-copy" not in result.stdout:
-        LOGGER.info("No Working Copy remote configured; skipping sync")
-        return
-
-    run(f"git -C {repo_path} push working-copy HEAD", dry_run=dry_run)
-
-def deploy_to_droplet() -> None:
-    run("deploy-to-droplet")
-    repo_name = os.path.basename(os.path.abspath(repo_path))
-    url = f"working-copy://x-callback-url/pull?repo={repo_name}"
+def push_to_github(*, dry_run: bool = False) -> None:
     if dry_run:
-        LOGGER.info("DRY RUN: would open %s", url)
-    else:  # pragma: no cover - requires iOS environment
-        try:
-            webbrowser.open(url)
-            LOGGER.info("Triggered Working Copy pull via URL scheme")
-        except Exception as exc:  # pragma: no cover - logging only
-            LOGGER.warning("Failed to open Working Copy URL: %s", exc)
+        return
+    run("git push origin HEAD")
 
-    trigger_working_copy_pull(repo_name, dry_run=dry_run)
 
-def call_connectors() -> None:
+def push_latest(*, dry_run: bool = False) -> None:
+    push_to_github(dry_run=dry_run)
+
+
+def deploy_to_droplet(*, dry_run: bool = False) -> None:
+    if dry_run:
+        return
+    run("deploy-to-droplet")
+
+
+def sync_connectors(*, dry_run: bool = False) -> None:
+    if dry_run:
+        return
     run("connector-sync")
 
 
-def validate_services() -> None:
+def validate_services() -> dict[str, str]:
+    """Check core services and return a status summary."""
+
+    def _check(name: str, url: str) -> str:
+        try:
+            with request.urlopen(url, timeout=5) as resp:  # noqa: S310 - integration check
+                if resp.getcode() != 200:
+                    raise ValueError("bad status")
+                payload = json.loads(resp.read().decode())
+                status = "OK" if payload.get("status") == "ok" else "FAIL"
+        except Exception:  # noqa: BLE001
+            status = "FAIL"
+        ts = datetime.utcnow().isoformat()
+        with LOG_FILE.open("a", encoding="utf-8") as fh:
+            fh.write(f"{ts} {name} {status}\n")
+        return status
+
+    summary = {
+        "frontend": _check("frontend", "https://blackroad.io/health"),
+        "api": _check("api", "http://127.0.0.1:4000/api/health"),
+        "llm": _check("llm", "http://127.0.0.1:8000/health"),
+        "math": _check("math", "http://127.0.0.1:8500/health"),
+    }
+    summary["timestamp"] = datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+    print(json.dumps(summary))
+    return summary
+
+
+def validate_services_stage() -> None:
     run("validate-services")
+
+
+validate_services_stage.__name__ = "validate_services"
 
 
 STAGES: list[Callable[[], None]] = [
     push_to_github,
     deploy_to_droplet,
-    call_connectors,
-    validate_services,
+    sync_connectors,
+    validate_services_stage,
 ]
 
 
 def run_pipeline(*, force: bool = False, webhook: str | None = None) -> None:
+    """Execute pipeline stages with rollback on failure."""
     for stage in STAGES:
         try:
             stage()
@@ -170,74 +132,14 @@ def run_pipeline(*, force: bool = False, webhook: str | None = None) -> None:
             elif stage is deploy_to_droplet:
                 rollback = True
                 run(f"rsync -a {DROPLET_BACKUP}/ /srv/blackroad/")
-            elif stage is validate_services:
+            elif stage.__name__ == "validate_services":
                 rollback = True
                 rollback_from_backup()
             log_error(stage.__name__, exc, rollback, webhook)
             if not force:
                 raise
 
-def redeploy_droplet(*, dry_run: bool = False) -> None:
-    """Placeholder for redeploying the BlackRoad droplet."""
-    # TODO: SSH into droplet, pull latest code, run migrations, restart services.
-    LOGGER.info("TODO: implement droplet redeploy")
 
-
-def sync_connectors(*, dry_run: bool = False) -> None:
-    """Placeholder for syncing external connectors."""
-    # TODO: add OAuth flows, webhook listeners, and Slack notifications.
-    LOGGER.info("TODO: implement connector sync")
-
-
-def trigger_working_copy_pull(
-    repo_name: str, *, server_url: str = "http://localhost:8081", dry_run: bool = False
-) -> bool:
-    """Trigger a pull via Working Copy's local automation server.
-
-    Returns ``True`` if the request succeeded, ``False`` otherwise.
-    """
-
-    url = f"{server_url}/pull?repo={repo_name}"
-    LOGGER.info("Requesting Working Copy pull: %s", url)
-    if dry_run:
-        return True
-    try:
-        with request.urlopen(url) as resp:  # noqa: S310 - local request
-            LOGGER.info("Working Copy pull response: %s", resp.read())
-        return True
-    except error.URLError as exc:
-        LOGGER.warning("Working Copy pull failed: %s", exc)
-        return False
-
-
-def _check_service(name: str, url: str) -> str:
-    """Return ``OK`` if the service responds with ``{"status": "ok"}``."""
-    try:
-        with request.urlopen(url, timeout=5) as resp:  # nosec B310
-            if resp.getcode() != 200:
-                raise ValueError(f"unexpected status {resp.getcode()}")
-            payload = json.loads(resp.read().decode())
-            status = "OK" if payload.get("status") == "ok" else "FAIL"
-    except Exception:  # noqa: BLE001
-        status = "FAIL"
-
-    timestamp = datetime.utcnow().isoformat()
-    with LOG_FILE.open("a", encoding="utf-8") as fh:
-        fh.write(f"{timestamp} {name} {status}\n")
-    return status
-
-
-def validate_services() -> dict[str, str]:
-    """Check core services and return a status summary."""
-    summary = {
-        "frontend": _check_service("frontend", "https://blackroad.io/health"),
-        "api": _check_service("api", "http://127.0.0.1:4000/api/health"),
-        "llm": _check_service("llm", "http://127.0.0.1:8000/health"),
-        "math": _check_service("math", "http://127.0.0.1:8500/health"),
-    }
-    summary["timestamp"] = datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
-    print(json.dumps(summary))
-    return summary
 def call_connectors(action: str, payload: Dict[str, Any]) -> Dict[str, Any]:
     """Call BlackRoad's connectors API with retry and logging."""
     load_dotenv()
@@ -272,22 +174,25 @@ def call_connectors(action: str, payload: Dict[str, Any]) -> Dict[str, Any]:
     raise RuntimeError("connector call failed after retries")
 
 
-def sync_connectors(action: str, payload: Dict[str, Any]) -> None:
-    """Sync external connectors via Prism API."""
-    call_connectors(action, payload)
+def refresh_working_copy(*, dry_run: bool = False) -> None:
+    if dry_run:
+        return
+    run("refresh-working-copy")
+
+
+def redeploy_droplet(*, dry_run: bool = False) -> None:
+    deploy_to_droplet(dry_run=dry_run)
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(
-        description="BlackRoad Codex pipeline scaffold",
-    )
+    parser = argparse.ArgumentParser(description="BlackRoad Codex pipeline")
     parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Simulate actions without executing external commands",
-        "--skip-validate",
-        action="store_true",
-        help="Skip service health validation",
+    )
+    parser.add_argument(
+        "--skip-validate", action="store_true", help="Skip service health validation"
     )
     sub = parser.add_subparsers(dest="command")
     sub.add_parser("push", help="Push latest to BlackRoad.io")
@@ -297,33 +202,23 @@ def main(argv: list[str] | None = None) -> int:
     sync.add_argument("action", choices=["paste", "append", "replace", "restart", "build"])
     sync.add_argument("payload", help="JSON payload for the action")
 
-
-def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="BlackRoad Codex pipeline")
-    parser.add_argument("--force", action="store_true", help="continue even if a step fails")
-    parser.add_argument("--webhook", help="Webhook URL for error notifications")
     args = parser.parse_args(argv)
-    try:
-        run_pipeline(force=args.force, webhook=args.webhook)
-    except subprocess.CalledProcessError:
-        return 1
     exit_code = 0
 
     if args.command == "push":
-        push_latest(dry_run=args.dry_run)
-        redeploy_droplet(dry_run=args.dry_run)
+        push_latest(dry_run=True) if args.dry_run else push_latest()
+        redeploy_droplet(dry_run=True) if args.dry_run else redeploy_droplet()
     elif args.command == "refresh":
-        push_latest(dry_run=args.dry_run)
-        refresh_working_copy(dry_run=args.dry_run)
-        redeploy_droplet(dry_run=args.dry_run)
+        push_latest(dry_run=True) if args.dry_run else push_latest()
+        refresh_working_copy(dry_run=True) if args.dry_run else refresh_working_copy()
+        redeploy_droplet(dry_run=True) if args.dry_run else redeploy_droplet()
     elif args.command == "rebase":
-        run("git pull --rebase", dry_run=args.dry_run)
-        push_latest(dry_run=args.dry_run)
-        redeploy_droplet(dry_run=args.dry_run)
+        run("git pull --rebase") if not args.dry_run else None
+        push_latest(dry_run=True) if args.dry_run else push_latest()
+        redeploy_droplet(dry_run=True) if args.dry_run else redeploy_droplet()
     elif args.command == "sync":
-        sync_connectors(dry_run=args.dry_run)
         payload = json.loads(args.payload)
-        sync_connectors(args.action, payload)
+        call_connectors(args.action, payload)
     else:
         parser.print_help()
         return exit_code
@@ -336,5 +231,5 @@ def main(argv: list[str] | None = None) -> int:
     return exit_code
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     raise SystemExit(main())


### PR DESCRIPTION
## Summary
- overhaul codex pipeline with staged CLI, rollback handling and connector syncing
- exercise validation flow with adjusted test fixture

## Testing
- `pytest tests/test_codex_pipeline.py tests/test_codex_pipeline_connectors.py tests/test_codex_pipeline_validation.py`
- `pre-commit run --files tools/codex_pipeline.py tests/test_codex_pipeline.py tests/test_codex_pipeline_connectors.py tests/test_codex_pipeline_validation.py`


------
https://chatgpt.com/codex/tasks/task_e_68abc45f32408329911d5e6a2ffb7459