### PR TITLE
feat: handle existing credentials in tokenize_url

### DIFF
--- a/tests/test_tokenize_url.py
+++ b/tests/test_tokenize_url.py
@@ -24,3 +24,8 @@ def test_tokenize_url_empty_token_returns_original():
 def test_tokenize_url_non_https_unchanged():
     ssh_url = "git@github.com:org/repo.git"
     assert tokenize_url(ssh_url, "TOKEN") == ssh_url
+
+
+def test_tokenize_url_existing_credentials_unchanged():
+    url = "https://user@github.com/org/repo.git"
+    assert tokenize_url(url, "TOKEN") == url


### PR DESCRIPTION
## Summary
- ensure tokenize_url respects existing credentials and only embeds tokens when safe
- cover credentialed URLs in tests

## Testing
- `pre-commit run --files tools/codex_multi_repo_loader.py tests/test_tokenize_url.py`
- `pytest tests/test_tokenize_url.py -q`
- `npm test`
- `pytest` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'cargo')*

------
https://chatgpt.com/codex/tasks/task_e_68abc56f7ee88329a69451a2c3f5648e