### PR TITLE
feat(atlas): restrict access to admins

### DIFF
--- a/sites/blackroad/src/App.jsx
+++ b/sites/blackroad/src/App.jsx
@@ -12,6 +12,7 @@ import InfinityMath from "./pages/InfinityMath.jsx";
 import Agents from "./pages/Agents.jsx";
 import { useEffect, useState } from "react";
 import Desktop from "./pages/Desktop.jsx";
+import Atlas from "./pages/Atlas.jsx";
 
 function useApiHealth(){
   const [state,setState]=useState({ok:null, info:""});
@@ -64,6 +65,7 @@ function LegacyApp(){
           <NavLink className="nav-link" to="/agents">Agents</NavLink>
           <NavLink className="nav-link" to="/subscribe">Subscribe</NavLink>
           <NavLink className="nav-link" to="/lucidia">Lucidia</NavLink>
+          <NavLink className="nav-link" to="/atlas">Atlas</NavLink>
           <NavLink className="nav-link" to="/math">
             <span
               style={{
@@ -98,6 +100,7 @@ function LegacyApp(){
             <Route path="/agents" element={<Agents/>} />
             <Route path="/subscribe" element={<Subscribe/>} />
             <Route path="/lucidia" element={<Lucidia/>} />
+            <Route path="/atlas" element={<Atlas/>} />
             <Route path="/math" element={<InfinityMath/>} />
             <Route path="chat" element={<Chat/>} />
             <Route path="canvas" element={<Canvas/>} />
@@ -107,6 +110,7 @@ function LegacyApp(){
             <Route path="backroad" element={<BackRoad/>} />
             <Route path="subscribe" element={<Subscribe/>} />
             <Route path="lucidia" element={<Lucidia/>} />
+            <Route path="atlas" element={<Atlas/>} />
             <Route path="math" element={<InfinityMath/>} />
             <Route path="*" element={<div>Not found</div>} />
           </Routes>

--- a/sites/blackroad/src/pages/Atlas.jsx
+++ b/sites/blackroad/src/pages/Atlas.jsx
@@ -1,9 +1,23 @@
 import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
 
 export default function Atlas() {
+  const navigate = useNavigate()
+
   useEffect(() => {
-    // TODO: enforce RBAC so only admins can access this route
-  }, [])
+    ;(async () => {
+      try {
+        const res = await fetch('/api/session', { cache: 'no-store' })
+        const data = await res.json()
+        const role = data?.user?.role
+        if (!role || !['admin', 'dev'].includes(role)) {
+          navigate('/', { replace: true })
+        }
+      } catch {
+        navigate('/', { replace: true })
+      }
+    })()
+  }, [navigate])
 
   return (
     <div className="card">


### PR DESCRIPTION
## Summary
- guard Atlas page so only admin-like roles may view
- expose Atlas route and navigation link

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abc72c09f08329909d51a8eeea0bfe