### PR TITLE
feat(agent-summary): fetch services concurrently

### DIFF
--- a/src/services/agentSummary.js
+++ b/src/services/agentSummary.js
@@ -29,11 +29,11 @@ async function getService(id, base) {
 }
 
 async function getAgentsSummary() {
-  const result = {};
-  for (const [id, base] of Object.entries(SERVICES)) {
-    result[id] = await getService(id, base);
-  }
-  return result;
+  const entries = Object.entries(SERVICES);
+  const results = await Promise.all(
+    entries.map(([id, base]) => getService(id, base).then(data => [id, data]))
+  );
+  return Object.fromEntries(results);
 }
 
 module.exports = { getAgentsSummary };


### PR DESCRIPTION
## Summary
- fetch agent statuses in parallel for faster dashboard retrieval

## Testing
- `npm test`
- `npx eslint src/services/agentSummary.js`


------
https://chatgpt.com/codex/tasks/task_e_68abc71eb2cc8329992a50617bfa8661