### PR TITLE
Restrict Atlas page to admins

### DIFF
--- a/sites/blackroad/src/App.jsx
+++ b/sites/blackroad/src/App.jsx
@@ -10,7 +10,6 @@ import Subscribe from "./pages/Subscribe.jsx";
 import Lucidia from "./pages/Lucidia.jsx";
 import InfinityMath from "./pages/InfinityMath.jsx";
 import Agents from "./pages/Agents.jsx";
-import { useEffect, useState } from "react";
 import Desktop from "./pages/Desktop.jsx";
 
 function useApiHealth(){

--- a/sites/blackroad/src/pages/Atlas.jsx
+++ b/sites/blackroad/src/pages/Atlas.jsx
@@ -1,9 +1,13 @@
 import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
 
 export default function Atlas() {
+  const nav = useNavigate()
+
   useEffect(() => {
-    // TODO: enforce RBAC so only admins can access this route
-  }, [])
+    const role = localStorage.getItem('role')
+    if (role !== 'admin') nav('/')
+  }, [nav])
 
   return (
     <div className="card">


### PR DESCRIPTION
## Summary
- limit Atlas page access to admin role via simple client-side check
- remove duplicate React import in App to satisfy site lint

## Testing
- `npm run lint`
- `npm test`
- `npm --prefix sites/blackroad run lint`
- `npm --prefix sites/blackroad test`


------
https://chatgpt.com/codex/tasks/task_e_68abc6c77b9c8329b1c0f974fc4c432a