### PR TITLE
feat(agent): allow runtime engine registration

### DIFF
--- a/agents/auto_novel_agent.py
+++ b/agents/auto_novel_agent.py
@@ -35,8 +35,19 @@ class AutoNovelAgent:
         """Return a list of supported game engines."""
         return sorted(self.SUPPORTED_ENGINES)
 
+    def add_supported_engine(self, engine: str) -> None:
+        """Register a new supported game engine.
+
+        Args:
+            engine: Name of the engine to add. Stored in lowercase to
+                preserve consistency.
+        """
+        self.SUPPORTED_ENGINES.add(engine.lower())
+
 
 if __name__ == "__main__":
     agent = AutoNovelAgent()
     agent.deploy()
+    agent.add_supported_engine("godot")
     agent.create_game("unity")
+    agent.create_game("godot")


### PR DESCRIPTION
## Summary
- add `add_supported_engine` to AutoNovelAgent for dynamic engine support
- demo registering Godot engine in script

## Testing
- `python -m py_compile auto_novel_agent.py`
- `python auto_novel_agent.py`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abcb7f1a908329b00133e568274096