### PR TITLE
feat(agents): add short story generation

### DIFF
--- a/agents/auto_novel_agent.py
+++ b/agents/auto_novel_agent.py
@@ -35,25 +35,58 @@ class AutoNovelAgent:
         """Return a list of supported game engines."""
         return sorted(self.SUPPORTED_ENGINES)
 
-    def write_short_story(self, theme: str) -> str:
-        """Generate a short, two-sentence story for the given theme.
+    def write_short_story(
+        self, theme: str, *, setting: str | None = None, protagonist: str | None = None
+    ) -> str:
+        """Generate a short, three-sentence story for the given theme.
 
         Args:
             theme: The central theme of the story.
+            setting: Optional setting to ground the story. If provided, it must be a
+                non-empty string.
+            protagonist: Optional protagonist for the story. If provided, it must be a
+                non-empty string.
 
         Returns:
-            A short story featuring the theme.
+            A short story featuring the theme, optionally grounded in a setting and
+            starring a protagonist.
         """
         clean_theme = theme.strip()
         if not clean_theme:
             raise ValueError("Theme must be provided.")
-        return (
-            f"A tale of {clean_theme} begins with hope. In the end, {clean_theme} prevails."
+
+        clean_setting = setting.strip() if setting is not None else None
+        if clean_setting is not None and not clean_setting:
+            raise ValueError("Setting, when provided, must be non-empty.")
+
+        clean_protagonist = protagonist.strip() if protagonist is not None else None
+        if clean_protagonist is not None and not clean_protagonist:
+            raise ValueError("Protagonist, when provided, must be non-empty.")
+
+        hero = clean_protagonist or "a wanderer"
+        hero_title = clean_protagonist or "A wanderer"
+
+        if clean_setting:
+            opening = f"In {clean_setting}, {hero} discovers a spark of {clean_theme}."
+        else:
+            opening = f"{hero_title} discovers a spark of {clean_theme}."
+
+        conflict = (
+            f"Challenges rise, but {hero} refuses to let {clean_theme} fade.".replace(
+                "  ", " "
+            )
         )
+        resolution = f"In the end, {clean_theme} transforms the world around them."
+
+        return " ".join([opening, conflict, resolution])
 
 
 if __name__ == "__main__":
     agent = AutoNovelAgent()
     agent.deploy()
     agent.create_game("unity")
-    print(agent.write_short_story("friendship"))
+    print(
+        agent.write_short_story(
+            "friendship", setting="a bustling spaceport", protagonist="Rin"
+        )
+    )


### PR DESCRIPTION
## Summary
- expand AutoNovelAgent with `write_short_story` for simple theme-based stories
- demo story generation in module main

## Testing
- `python -m py_compile agents/*.py` *(fails: cleanup_bot.py syntax error)*
- `python -m py_compile agents/auto_novel_agent.py`
- `python agents/auto_novel_agent.py`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abcb5c22588329830687252eaef5cd