### PR TITLE
feat(agents): add short story generation

### DIFF
--- a/agents/auto_novel_agent.py
+++ b/agents/auto_novel_agent.py
@@ -35,8 +35,25 @@ class AutoNovelAgent:
         """Return a list of supported game engines."""
         return sorted(self.SUPPORTED_ENGINES)
 
+    def write_short_story(self, theme: str) -> str:
+        """Generate a short, two-sentence story for the given theme.
+
+        Args:
+            theme: The central theme of the story.
+
+        Returns:
+            A short story featuring the theme.
+        """
+        clean_theme = theme.strip()
+        if not clean_theme:
+            raise ValueError("Theme must be provided.")
+        return (
+            f"A tale of {clean_theme} begins with hope. In the end, {clean_theme} prevails."
+        )
+
 
 if __name__ == "__main__":
     agent = AutoNovelAgent()
     agent.deploy()
     agent.create_game("unity")
+    print(agent.write_short_story("friendship"))


### PR DESCRIPTION
## Summary
- expand AutoNovelAgent with `write_short_story` for simple theme-based stories
- demo story generation in module main

## Testing
- `python -m py_compile agents/*.py` *(fails: cleanup_bot.py syntax error)*
- `python -m py_compile agents/auto_novel_agent.py`
- `python agents/auto_novel_agent.py`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abcb5c22588329830687252eaef5cd