### PR TITLE
feat(logger): log EOF shutdown

### DIFF
--- a/agents/logger/agent.py
+++ b/agents/logger/agent.py
@@ -54,7 +54,8 @@ class LoggerAgent:
                     continue
                 self.log(line)
         except EOFError:
-            pass
+            # Gracefully handle EOF to signal shutdown of the agent
+            self.log("EOF received; exiting")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- log a shutdown message when LoggerAgent reaches EOF to end its loop gracefully

## Testing
- `pytest`
- `npm test`
- `npm run lint`
- `python -m py_compile *.py` *(fails: cleanup_bot.py SyntaxError)*
- `python -m py_compile logger/agent.py auto_novel_agent.py`
- `python auto_novel_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_68abcb67e34c8329ae4d6e9123e2f555