### PR TITLE
feat(agent): add engine registration

### DIFF
--- a/agents/auto_novel_agent.py
+++ b/agents/auto_novel_agent.py
@@ -1,7 +1,7 @@
 """Simple auto novel agent example with game creation abilities."""
 
 from dataclasses import dataclass
-from typing import ClassVar, List
+from typing import ClassVar
 
 
 @dataclass
@@ -31,7 +31,23 @@ class AutoNovelAgent:
             raise ValueError("Weapons are not allowed in generated games.")
         print(f"Creating a {engine_lower.capitalize()} game without weapons...")
 
-    def list_supported_engines(self) -> List[str]:
+    def add_engine(self, engine: str) -> None:
+        """Register a new supported game engine.
+
+        Args:
+            engine: Engine name to register.
+
+        Raises:
+            ValueError: If the engine name is invalid or already supported.
+        """
+        normalized = engine.strip().lower()
+        if not normalized.isalpha():
+            raise ValueError("Engine name must contain only letters.")
+        if normalized in self.SUPPORTED_ENGINES:
+            raise ValueError("Engine already supported.")
+        self.SUPPORTED_ENGINES.add(normalized)
+
+    def list_supported_engines(self) -> list[str]:
         """Return a list of supported game engines."""
         return sorted(self.SUPPORTED_ENGINES)
 

--- a/tests/test_auto_novel_agent.py
+++ b/tests/test_auto_novel_agent.py
@@ -1,0 +1,28 @@
+"""Tests for :mod:`agents.auto_novel_agent`."""
+
+import pytest
+
+from agents.auto_novel_agent import AutoNovelAgent
+
+
+def test_add_engine_and_create_game(capsys):
+    agent = AutoNovelAgent()
+    agent.add_engine("Godot")
+    assert "godot" in agent.SUPPORTED_ENGINES
+    agent.create_game("godot")
+    captured = capsys.readouterr()
+    assert "Creating a Godot game without weapons" in captured.out
+
+
+def test_add_engine_invalid():
+    agent = AutoNovelAgent()
+    with pytest.raises(ValueError):
+        agent.add_engine("unity")
+    with pytest.raises(ValueError):
+        agent.add_engine("engine-1")
+
+
+def test_create_game_unknown_engine():
+    agent = AutoNovelAgent()
+    with pytest.raises(ValueError):
+        agent.create_game("unknown")


### PR DESCRIPTION
## Summary
- allow AutoNovelAgent to register custom game engines
- test engine registration and error cases

## Testing
- `python -m py_compile agents/auto_novel_agent.py tests/test_auto_novel_agent.py`
- `python agents/auto_novel_agent.py`
- `pre-commit run --files agents/auto_novel_agent.py tests/test_auto_novel_agent.py`
- `pytest tests/test_auto_novel_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_68abcf308a54832984952312f616b3a6