### PR TITLE
feat: add engine utilities to AutoNovelAgent

### DIFF
--- a/agents/auto_novel_agent.py
+++ b/agents/auto_novel_agent.py
@@ -15,6 +15,26 @@ class AutoNovelAgent:
         """Deploy the agent by printing a greeting."""
         print(f"{self.name} deployed and ready to generate novels!")
 
+    def supports_engine(self, engine: str) -> bool:
+        """Return ``True`` if the engine is supported.
+
+        The check is case-insensitive.
+
+        Args:
+            engine: Name of the engine to verify.
+        """
+        return engine.lower() in self.SUPPORTED_ENGINES
+
+    def add_supported_engine(self, engine: str) -> None:
+        """Add a new engine to the supported list.
+
+        Engines are stored in lowercase to keep lookups case-insensitive.
+
+        Args:
+            engine: Name of the engine to add.
+        """
+        self.SUPPORTED_ENGINES.add(engine.lower())
+
     def create_game(self, engine: str, include_weapons: bool = False) -> None:
         """Create a basic game using a supported engine without weapons.
 
@@ -24,7 +44,7 @@ class AutoNovelAgent:
                 allowed.
         """
         engine_lower = engine.lower()
-        if engine_lower not in self.SUPPORTED_ENGINES:
+        if not self.supports_engine(engine_lower):
             supported = ", ".join(sorted(self.SUPPORTED_ENGINES))
             raise ValueError(f"Unsupported engine. Choose one of: {supported}.")
         if include_weapons:

--- a/agents/test_auto_novel_agent.py
+++ b/agents/test_auto_novel_agent.py
@@ -1,0 +1,32 @@
+"""Tests for the AutoNovelAgent class."""
+
+import pytest
+from auto_novel_agent import AutoNovelAgent
+
+
+def test_supports_engine_case_insensitive():
+    agent = AutoNovelAgent()
+    assert agent.supports_engine("UNITY")
+    assert agent.supports_engine("unreal")
+    assert not agent.supports_engine("godot")
+
+
+def test_add_supported_engine_and_create_game(capsys):
+    agent = AutoNovelAgent()
+    agent.add_supported_engine("godot")
+    assert agent.supports_engine("Godot")
+    agent.create_game("godot")
+    captured = capsys.readouterr()
+    assert "Godot" in captured.out
+
+
+def test_create_game_disallows_weapons():
+    agent = AutoNovelAgent()
+    with pytest.raises(ValueError, match="Weapons are not allowed"):
+        agent.create_game("unity", include_weapons=True)
+
+
+def test_create_game_rejects_unsupported_engine():
+    agent = AutoNovelAgent()
+    with pytest.raises(ValueError):
+        agent.create_game("cryengine")


### PR DESCRIPTION
## Summary
- add engine support helpers to `AutoNovelAgent`
- cover agent features with pytest unit tests

## Testing
- `python -m py_compile auto_novel_agent.py test_auto_novel_agent.py`
- `python auto_novel_agent.py`
- `ruff check auto_novel_agent.py test_auto_novel_agent.py`
- `pytest test_auto_novel_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac03aa1b9c8329b5243b62f163c475