### PR TITLE
Add novel writing capability to AutoNovelAgent

### DIFF
--- a/agents/auto_novel_agent.py
+++ b/agents/auto_novel_agent.py
@@ -6,7 +6,7 @@ from typing import ClassVar, List
 
 @dataclass
 class AutoNovelAgent:
-    """A toy agent that can deploy itself and create simple games."""
+    """A toy agent that can deploy itself and create simple games or stories."""
 
     name: str = "AutoNovelAgent"
     SUPPORTED_ENGINES: ClassVar[set[str]] = {"unity", "unreal"}
@@ -35,8 +35,21 @@ class AutoNovelAgent:
         """Return a list of supported game engines."""
         return sorted(self.SUPPORTED_ENGINES)
 
+    def write_novel(self, title: str, protagonist: str) -> str:
+        """Generate a minimal novel blurb.
+
+        Args:
+            title: Title of the story to generate.
+            protagonist: Main character of the story.
+
+        Returns:
+            A short string describing the novel.
+        """
+        return f"{title} is a thrilling tale about {protagonist}."
+
 
 if __name__ == "__main__":
     agent = AutoNovelAgent()
     agent.deploy()
     agent.create_game("unity")
+    print(agent.write_novel("Journey", "Alice"))

--- a/agents/test_auto_novel_agent.py
+++ b/agents/test_auto_novel_agent.py
@@ -1,0 +1,18 @@
+import pytest
+from auto_novel_agent import AutoNovelAgent
+
+
+def test_supported_engines_and_novel():
+    agent = AutoNovelAgent()
+    assert agent.list_supported_engines() == ["unity", "unreal"]
+    summary = agent.write_novel("Quest", "Bob")
+    assert summary == "Quest is a thrilling tale about Bob."
+
+
+def test_create_game_validation():
+    agent = AutoNovelAgent()
+    agent.create_game("unity")
+    with pytest.raises(ValueError):
+        agent.create_game("godot")
+    with pytest.raises(ValueError):
+        agent.create_game("unity", include_weapons=True)


### PR DESCRIPTION
## Summary
- expand AutoNovelAgent to write simple novel blurbs
- add tests validating novel writing and game creation rules

## Testing
- `python -m py_compile agents/auto_novel_agent.py agents/test_auto_novel_agent.py`
- `python agents/auto_novel_agent.py`
- `ruff check agents/auto_novel_agent.py agents/test_auto_novel_agent.py`
- `pytest agents/test_auto_novel_agent.py -q`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac0427c48c8329b7163ed20ad76dd1