### PR TITLE
feat: add ability to register game engines

### DIFF
--- a/agents/auto_novel_agent.py
+++ b/agents/auto_novel_agent.py
@@ -31,6 +31,15 @@ class AutoNovelAgent:
             raise ValueError("Weapons are not allowed in generated games.")
         print(f"Creating a {engine_lower.capitalize()} game without weapons...")
 
+    def add_supported_engine(self, engine: str) -> None:
+        """Register a new game engine.
+
+        Args:
+            engine: Name of the engine to allow. The value is stored in
+                lowercase for case-insensitive matching.
+        """
+        self.SUPPORTED_ENGINES.add(engine.lower())
+
     def list_supported_engines(self) -> List[str]:
         """Return a list of supported game engines."""
         return sorted(self.SUPPORTED_ENGINES)

--- a/tests/test_auto_novel_agent.py
+++ b/tests/test_auto_novel_agent.py
@@ -1,0 +1,11 @@
+import pytest
+from agents.auto_novel_agent import AutoNovelAgent
+
+
+def test_add_supported_engine_enables_creation():
+    agent = AutoNovelAgent()
+    with pytest.raises(ValueError):
+        agent.create_game("godot")
+    agent.add_supported_engine("Godot")
+    assert "godot" in agent.list_supported_engines()
+    agent.create_game("godot")


### PR DESCRIPTION
## Summary
- allow AutoNovelAgent to register additional game engines
- add unit test for dynamic engine registration

## Testing
- `python -m py_compile agents/auto_novel_agent.py tests/test_auto_novel_agent.py`
- `python agents/auto_novel_agent.py`
- `flake8 agents/auto_novel_agent.py tests/test_auto_novel_agent.py` *(fails: command not found)*
- `pytest tests/test_auto_novel_agent.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ac04852f50832999e2eaead2709bd9