### PR TITLE
Parallelize agent summary requests

### DIFF
--- a/src/services/agentSummary.js
+++ b/src/services/agentSummary.js
@@ -4,7 +4,7 @@ const SERVICES = {
   frontend: process.env.FRONTEND_URL || 'http://localhost:3001',
   api: process.env.API_URL || 'http://localhost:3000',
   llm: process.env.LLM_URL || 'http://localhost:4000',
-  math: process.env.MATH_URL || 'http://localhost:5000'
+  math: process.env.MATH_URL || 'http://localhost:5000',
 };
 
 async function fetchJson(url) {
@@ -16,24 +16,27 @@ async function fetchJson(url) {
 async function getService(id, base) {
   try {
     const health = await fetchJson(`${base}/health`);
-    const logs = await fetchJson(`${base}/logs?level=error&limit=1`).catch(() => ({ count: 0, logs: [] }));
+    const logs = await fetchJson(`${base}/logs?level=error&limit=1`).catch(() => ({
+      count: 0,
+      logs: [],
+    }));
     return {
       status: health.status || health.ok || 'FAIL',
       uptime: health.uptime || '-',
       errors: logs.count || (Array.isArray(logs.logs) ? logs.logs.length : 0),
-      contradictions: health.contradictions || 0
+      contradictions: health.contradictions || 0,
     };
   } catch {
     return { status: 'FAIL', uptime: '-', errors: 0, contradictions: 0 };
   }
 }
 
+// Fetch all services concurrently for faster summaries.
 async function getAgentsSummary() {
-  const result = {};
-  for (const [id, base] of Object.entries(SERVICES)) {
-    result[id] = await getService(id, base);
-  }
-  return result;
+  const entries = await Promise.all(
+    Object.entries(SERVICES).map(async ([id, base]) => [id, await getService(id, base)])
+  );
+  return Object.fromEntries(entries);
 }
 
 module.exports = { getAgentsSummary };


### PR DESCRIPTION
## Summary
- fetch agent health and logs in parallel for faster status aggregation

## Testing
- `npm test`
- `pre-commit run --files src/services/agentSummary.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac05e1952c8329a43a0a1f412909b0