### PR TITLE
feat: allow adding game engines

### DIFF
--- a/agents/auto_novel_agent.py
+++ b/agents/auto_novel_agent.py
@@ -35,6 +35,14 @@ class AutoNovelAgent:
         """Return a list of supported game engines."""
         return sorted(self.SUPPORTED_ENGINES)
 
+    def add_engine(self, engine: str) -> None:
+        """Add a new supported game engine.
+
+        Args:
+            engine: Name of the engine to add.
+        """
+        self.SUPPORTED_ENGINES.add(engine.lower())
+
 
 if __name__ == "__main__":
     agent = AutoNovelAgent()

--- a/tests/test_auto_novel_agent.py
+++ b/tests/test_auto_novel_agent.py
@@ -1,0 +1,16 @@
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "auto_novel_agent",
+    Path(__file__).resolve().parents[1] / "agents" / "auto_novel_agent.py",
+)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+AutoNovelAgent = module.AutoNovelAgent
+
+
+def test_add_engine():
+    agent = AutoNovelAgent()
+    agent.add_engine("godot")
+    assert "godot" in agent.list_supported_engines()


### PR DESCRIPTION
## Summary
- allow AutoNovelAgent to add custom game engines
- cover engine addition with unit test

## Testing
- `python -m py_compile auto_novel_agent.py`
- `python auto_novel_agent.py`
- `npm test`
- `npm run lint`
- `pytest tests/test_auto_novel_agent.py`
- `python -m py_compile *.py` *(fails: cleanup_bot.py syntax error)*
- `python -m pytest` *(fails: 14 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68ac047735c0832986d8e8765f8d2e58