### PR TITLE
Add engine removal to AutoNovelAgent

### DIFF
--- a/agents/auto_novel_agent.py
+++ b/agents/auto_novel_agent.py
@@ -51,12 +51,16 @@ class AutoNovelAgent:
         self.SUPPORTED_ENGINES.add(engine.lower())
 
     def remove_supported_engine(self, engine: str) -> None:
-        """Remove an engine from the supported list if present.
+        """Remove a supported engine, raising ``ValueError`` when unknown."""
 
-        Args:
-            engine: Name of the engine to remove. The lookup is case-insensitive.
-        """
-        self.SUPPORTED_ENGINES.discard(engine.lower())
+        engine_lower = engine.lower()
+        if engine_lower not in self.SUPPORTED_ENGINES:
+            supported = ", ".join(sorted(self.SUPPORTED_ENGINES))
+            raise ValueError(
+                "Cannot remove unsupported engine "
+                f"'{engine_lower}'. Supported engines: {supported}."
+            )
+        self.SUPPORTED_ENGINES.remove(engine_lower)
 
     def list_supported_engines(self) -> List[str]:
         """Return a list of supported game engines."""

--- a/agents/test_auto_novel_agent.py
+++ b/agents/test_auto_novel_agent.py
@@ -4,6 +4,13 @@ import pytest
 from auto_novel_agent import AutoNovelAgent
 
 
+@pytest.fixture(autouse=True)
+def reset_supported_engines():
+    """Ensure each test starts with the default supported engines."""
+
+    AutoNovelAgent.SUPPORTED_ENGINES = {"unity", "unreal"}
+
+
 def test_supports_engine_case_insensitive():
     agent = AutoNovelAgent()
     assert agent.supports_engine("UNITY")
@@ -38,3 +45,9 @@ def test_remove_supported_engine():
     assert agent.supports_engine("godot")
     agent.remove_supported_engine("Godot")
     assert not agent.supports_engine("godot")
+
+
+def test_remove_supported_engine_errors_when_unknown():
+    agent = AutoNovelAgent()
+    with pytest.raises(ValueError, match="Supported engines: unity, unreal"):
+        agent.remove_supported_engine("cryengine")

--- a/tests/test_auto_novel_agent.py
+++ b/tests/test_auto_novel_agent.py
@@ -2,6 +2,13 @@ import pytest
 from agents.auto_novel_agent import AutoNovelAgent
 
 
+@pytest.fixture(autouse=True)
+def reset_supported_engines():
+    """Reset class-level supported engines before each test."""
+
+    AutoNovelAgent.SUPPORTED_ENGINES = {"unity", "unreal"}
+
+
 def test_add_supported_engine_enables_creation():
     agent = AutoNovelAgent()
     with pytest.raises(ValueError):
@@ -17,3 +24,9 @@ def test_remove_supported_engine_disallows_creation():
     agent.remove_supported_engine("godot")
     with pytest.raises(ValueError):
         agent.create_game("godot")
+
+
+def test_remove_supported_engine_unknown_engine_error():
+    agent = AutoNovelAgent()
+    with pytest.raises(ValueError, match="Supported engines: unity, unreal"):
+        agent.remove_supported_engine("cryengine")


### PR DESCRIPTION
## Summary
- add `remove_supported_engine` method to AutoNovelAgent
- test engine removal to ensure unsupported engines can't be used

## Testing
- `python -m py_compile *.py`
- `python auto_novel_agent.py`
- `python -m pytest agents/test_auto_novel_agent.py`
- `python -m pytest tests/test_auto_novel_agent.py`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac99afa338832981be8e788f449fa1