### PR TITLE
feat(agent): allow removing supported engines

### DIFF
--- a/agents/auto_novel_agent.py
+++ b/agents/auto_novel_agent.py
@@ -25,16 +25,6 @@ class AutoNovelAgent:
         """
         return engine.lower() in self.SUPPORTED_ENGINES
 
-    def add_supported_engine(self, engine: str) -> None:
-        """Add a new engine to the supported list.
-
-        Engines are stored in lowercase to keep lookups case-insensitive.
-
-        Args:
-            engine: Name of the engine to add.
-        """
-        self.SUPPORTED_ENGINES.add(engine.lower())
-
     def create_game(self, engine: str, include_weapons: bool = False) -> None:
         """Create a basic game using a supported engine without weapons.
 
@@ -54,11 +44,20 @@ class AutoNovelAgent:
     def add_supported_engine(self, engine: str) -> None:
         """Register a new game engine.
 
+        Engines are stored in lowercase to keep lookups case-insensitive.
+
         Args:
-            engine: Name of the engine to allow. The value is stored in
-                lowercase for case-insensitive matching.
+            engine: Name of the engine to allow.
         """
         self.SUPPORTED_ENGINES.add(engine.lower())
+
+    def remove_supported_engine(self, engine: str) -> None:
+        """Remove a game engine if it is currently supported.
+
+        Args:
+            engine: Name of the engine to remove.
+        """
+        self.SUPPORTED_ENGINES.discard(engine.lower())
 
     def list_supported_engines(self) -> List[str]:
         """Return a list of supported game engines."""

--- a/tests/test_auto_novel_agent.py
+++ b/tests/test_auto_novel_agent.py
@@ -1,5 +1,14 @@
 import pytest
+
 from agents.auto_novel_agent import AutoNovelAgent
+
+
+@pytest.fixture(autouse=True)
+def reset_engines():
+    """Ensure tests do not leak engine changes to each other."""
+    AutoNovelAgent.SUPPORTED_ENGINES = {"unity", "unreal"}
+    yield
+    AutoNovelAgent.SUPPORTED_ENGINES = {"unity", "unreal"}
 
 
 def test_add_supported_engine_enables_creation():
@@ -9,3 +18,10 @@ def test_add_supported_engine_enables_creation():
     agent.add_supported_engine("Godot")
     assert "godot" in agent.list_supported_engines()
     agent.create_game("godot")
+
+
+def test_remove_supported_engine_blocks_creation():
+    agent = AutoNovelAgent()
+    agent.remove_supported_engine("unity")
+    with pytest.raises(ValueError):
+        agent.create_game("unity")


### PR DESCRIPTION
## Summary
- add ability to remove game engines from `AutoNovelAgent`
- ensure engine list resets between tests and cover removal in unit tests

## Testing
- `python -m py_compile agents/*.py`
- `python agents/auto_novel_agent.py`
- `pre-commit run --files agents/auto_novel_agent.py tests/test_auto_novel_agent.py`
- `pytest tests/test_auto_novel_agent.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac9a798fbc8329b4e89210d6726c86