### PR TITLE
feat(agent): allow removing supported engines

### DIFF
--- a/agents/auto_novel_agent.py
+++ b/agents/auto_novel_agent.py
@@ -35,6 +35,14 @@ class AutoNovelAgent:
         """
         self.SUPPORTED_ENGINES.add(engine.lower())
 
+    def remove_supported_engine(self, engine: str) -> None:
+        """Remove an engine from the supported list if present.
+
+        Args:
+            engine: Name of the engine to remove.
+        """
+        self.SUPPORTED_ENGINES.discard(engine.lower())
+
     def create_game(self, engine: str, include_weapons: bool = False) -> None:
         """Create a basic game using a supported engine without weapons.
 
@@ -50,15 +58,6 @@ class AutoNovelAgent:
         if include_weapons:
             raise ValueError("Weapons are not allowed in generated games.")
         print(f"Creating a {engine_lower.capitalize()} game without weapons...")
-
-    def add_supported_engine(self, engine: str) -> None:
-        """Register a new game engine.
-
-        Args:
-            engine: Name of the engine to allow. The value is stored in
-                lowercase for case-insensitive matching.
-        """
-        self.SUPPORTED_ENGINES.add(engine.lower())
 
     def list_supported_engines(self) -> List[str]:
         """Return a list of supported game engines."""

--- a/agents/test_auto_novel_agent.py
+++ b/agents/test_auto_novel_agent.py
@@ -20,6 +20,13 @@ def test_add_supported_engine_and_create_game(capsys):
     assert "Godot" in captured.out
 
 
+def test_remove_supported_engine():
+    agent = AutoNovelAgent()
+    agent.add_supported_engine("godot")
+    agent.remove_supported_engine("godot")
+    assert not agent.supports_engine("godot")
+
+
 def test_create_game_disallows_weapons():
     agent = AutoNovelAgent()
     with pytest.raises(ValueError, match="Weapons are not allowed"):


### PR DESCRIPTION
## Summary
- add method to remove supported game engines from AutoNovelAgent
- test removing engines from support list

## Testing
- `python -m py_compile *.py`
- `python auto_novel_agent.py`
- `ruff check agents/auto_novel_agent.py agents/test_auto_novel_agent.py`
- `pytest agents/test_auto_novel_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac9b673ec883298b2bf2d92332c677