### PR TITLE
feat(agent): allow removing supported engines

### DIFF
--- a/agents/auto_novel_agent.py
+++ b/agents/auto_novel_agent.py
@@ -25,16 +25,6 @@ class AutoNovelAgent:
         """
         return engine.lower() in self.SUPPORTED_ENGINES
 
-    def add_supported_engine(self, engine: str) -> None:
-        """Add a new engine to the supported list.
-
-        Engines are stored in lowercase to keep lookups case-insensitive.
-
-        Args:
-            engine: Name of the engine to add.
-        """
-        self.SUPPORTED_ENGINES.add(engine.lower())
-
     def create_game(self, engine: str, include_weapons: bool = False) -> None:
         """Create a basic game using a supported engine without weapons.
 
@@ -59,6 +49,21 @@ class AutoNovelAgent:
                 lowercase for case-insensitive matching.
         """
         self.SUPPORTED_ENGINES.add(engine.lower())
+
+    def remove_supported_engine(self, engine: str) -> None:
+        """Remove a game engine from the supported list.
+
+        Args:
+            engine: Name of the engine to remove. The lookup is
+                case-insensitive.
+
+        Raises:
+            ValueError: If the engine is not currently supported.
+        """
+        try:
+            self.SUPPORTED_ENGINES.remove(engine.lower())
+        except KeyError as exc:
+            raise ValueError(f"Unsupported engine: {engine}.") from exc
 
     def list_supported_engines(self) -> List[str]:
         """Return a list of supported game engines."""

--- a/agents/test_auto_novel_agent.py
+++ b/agents/test_auto_novel_agent.py
@@ -30,3 +30,16 @@ def test_create_game_rejects_unsupported_engine():
     agent = AutoNovelAgent()
     with pytest.raises(ValueError):
         agent.create_game("cryengine")
+
+
+def test_remove_supported_engine():
+    agent = AutoNovelAgent()
+    agent.add_supported_engine("godot")
+    agent.remove_supported_engine("godot")
+    assert not agent.supports_engine("godot")
+
+
+def test_remove_unsupported_engine_raises():
+    agent = AutoNovelAgent()
+    with pytest.raises(ValueError):
+        agent.remove_supported_engine("godot")

--- a/tests/test_auto_novel_agent.py
+++ b/tests/test_auto_novel_agent.py
@@ -9,3 +9,11 @@ def test_add_supported_engine_enables_creation():
     agent.add_supported_engine("Godot")
     assert "godot" in agent.list_supported_engines()
     agent.create_game("godot")
+
+
+def test_remove_supported_engine_disables_creation():
+    agent = AutoNovelAgent()
+    agent.add_supported_engine("godot")
+    agent.remove_supported_engine("godot")
+    with pytest.raises(ValueError):
+        agent.create_game("godot")


### PR DESCRIPTION
## Summary
- support removing game engines and error when an unknown engine is requested
- test engine removal behavior

## Testing
- `python -m py_compile *.py`
- `python auto_novel_agent.py`
- `pytest agents/test_auto_novel_agent.py -q`
- `pytest tests/test_auto_novel_agent.py -q`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac9d1834988329a32e7ece165e97ea