### PR TITLE
feat: add case-insensitive safety checks

### DIFF
--- a/services/discord-bot/src/safety.py
+++ b/services/discord-bot/src/safety.py
@@ -1,14 +1,19 @@
 import re
-from typing import Tuple, List
+from typing import List, Tuple
+
 
 class Safety:
+    """Minimal moderation helper for blocklist checks and PII redaction."""
+
     def __init__(self, blocklist: List[str], pii_patterns: List[str], action: str):
-        self.blocklist = [re.compile(p) for p in blocklist]
-        self.pii = [re.compile(p) for p in pii_patterns]
+        # Compile patterns case-insensitively to catch mixed-case input
+        self.blocklist = [re.compile(p, re.IGNORECASE) for p in blocklist]
+        self.pii = [re.compile(p, re.IGNORECASE) for p in pii_patterns]
         self.action = action
 
     def scan(self, text: str) -> Tuple[bool, str, List[str]]:
-        """Returns (blocked, cleaned_text, hits)"""
+        """Scan ``text`` and return ``(blocked, cleaned_text, hits)``."""
+
         hits = []
         for rx in self.blocklist:
             if rx.search(text):

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+
+# Allow importing the safety module despite hyphenated directory name
+sys.path.append(str(Path(__file__).resolve().parents[1] / "services" / "discord-bot" / "src"))
+
+from safety import Safety  # type: ignore  # pylint: disable=import-error
+
+
+def test_blocklist_hard_blocks_case_insensitively():
+    s = Safety(blocklist=[r"bad"], pii_patterns=[], action="hard")
+    blocked, cleaned, hits = s.scan("This BAD content")
+    assert blocked
+    assert hits == ["bad"]
+    assert cleaned == "This BAD content"
+
+
+def test_blocklist_soft_flags_without_blocking():
+    s = Safety(blocklist=[r"bad"], pii_patterns=[], action="soft")
+    blocked, _, hits = s.scan("bad news")
+    assert not blocked
+    assert hits == ["bad"]
+
+
+def test_pii_redaction_case_insensitive():
+    s = Safety(blocklist=[], pii_patterns=[r"secret"], action="soft")
+    _, cleaned, hits = s.scan("My SECRET code")
+    assert "[REDACTED-PII]" in cleaned
+    assert "SECRET" not in cleaned
+    assert hits == []


### PR DESCRIPTION
## Summary
- ensure safety filters are case-insensitive and document behavior
- add tests for blocklist handling and PII redaction

## Testing
- `pre-commit run --files services/discord-bot/src/safety.py tests/test_safety.py`
- `pytest tests/test_safety.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac9cfd93dc8329a72747a284ccd84d