### PR TITLE
Format billing summary and highlight active plan

### DIFF
--- a/src/components/BillingCard.tsx
+++ b/src/components/BillingCard.tsx
@@ -6,12 +6,23 @@ export interface BillingInfo {
   nextBillingDate: string;
 }
 
+export function formatAmount(amount: number): string {
+  return amount.toFixed(1);
+}
+
 export function BillingCard({ plan, amountDue, nextBillingDate }: BillingInfo) {
+  const formattedAmount = formatAmount(amountDue);
   return (
     <div className="p-4 rounded-lg bg-[var(--bg-elev-1)] border border-[var(--border)] shadow-[var(--shadow-md)]">
       <h3 className="text-lg font-semibold mb-2">Billing</h3>
-      <div className="flex justify-between"><span>Plan</span><span>{plan}</span></div>
-      <div className="flex justify-between"><span>Amount Due</span><span>${amountDue}</span></div>
+      <div className="flex justify-between bg-[var(--accent)]/20 rounded px-1">
+        <span>Plan</span>
+        <span className="font-semibold">{plan}</span>
+      </div>
+      <div className="flex justify-between">
+        <span>Amount Due</span>
+        <span>${formattedAmount}</span>
+      </div>
       <div className="flex justify-between"><span>Next Billing</span><span>{nextBillingDate}</span></div>
     </div>
   );


### PR DESCRIPTION
## Summary
- round billing summary amounts to one decimal
- highlight active plan row to indicate selection

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acdfc9be4c8329a1921d51eaa93bde