### PR TITLE
Validate theme input in AutoNovelAgent

### DIFF
--- a/agents/auto_novel_agent.py
+++ b/agents/auto_novel_agent.py
@@ -67,13 +67,23 @@ class AutoNovelAgent:
         """Generate a short themed story.
 
         Args:
-            theme: Central theme of the story.
+            theme: Central theme of the story. Must be a non-empty string.
             protagonist: Name or description of the main character.
 
         Returns:
             A short story string.
+
+        Raises:
+            ValueError: If ``theme`` is empty or whitespace.
         """
-        return f"{protagonist} set out on a {theme} journey, " "discovering wonders along the way."
+        if not theme or not theme.strip():
+            raise ValueError("Theme must be a non-empty string.")
+        theme_clean = theme.strip()
+        protagonist_clean = protagonist.strip()
+        return (
+            f"{protagonist_clean} set out on a {theme_clean} journey, "
+            "discovering wonders along the way."
+        )
 
 
 if __name__ == "__main__":

--- a/agents/test_auto_novel_agent.py
+++ b/agents/test_auto_novel_agent.py
@@ -30,3 +30,9 @@ def test_create_game_rejects_unsupported_engine():
     agent = AutoNovelAgent()
     with pytest.raises(ValueError):
         agent.create_game("cryengine")
+
+
+def test_generate_story_requires_theme():
+    agent = AutoNovelAgent()
+    with pytest.raises(ValueError):
+        agent.generate_story("")


### PR DESCRIPTION
## Summary
- ensure AutoNovelAgent.generate_story rejects empty themes and trims inputs
- cover empty-theme case with new unit test

## Testing
- `npm test`
- `npm run lint`
- `python -m py_compile *.py`
- `python auto_novel_agent.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad0599a75883299db4ce4553fe63c5