### PR TITLE
Validate theme for auto novel agent

### DIFF
--- a/agents/auto_novel_agent.py
+++ b/agents/auto_novel_agent.py
@@ -72,7 +72,12 @@ class AutoNovelAgent:
 
         Returns:
             A short story string.
+
+        Raises:
+            ValueError: If ``theme`` is empty or only whitespace.
         """
+        if not theme.strip():
+            raise ValueError("Theme must be a non-empty string.")
         return f"{protagonist} set out on a {theme} journey, " "discovering wonders along the way."
 
 

--- a/agents/test_auto_novel_agent.py
+++ b/agents/test_auto_novel_agent.py
@@ -30,3 +30,9 @@ def test_create_game_rejects_unsupported_engine():
     agent = AutoNovelAgent()
     with pytest.raises(ValueError):
         agent.create_game("cryengine")
+
+
+def test_generate_story_requires_theme():
+    agent = AutoNovelAgent()
+    with pytest.raises(ValueError, match="Theme must be a non-empty string"):
+        agent.generate_story(" ")


### PR DESCRIPTION
## Summary
- ensure AutoNovelAgent.generate_story raises a ValueError when theme is empty
- test that empty themes are rejected

## Testing
- `python -m py_compile agents/*.py`
- `python agents/auto_novel_agent.py`
- `pytest agents/test_auto_novel_agent.py`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad05d2ea5c8329b411b5ef6a4bb19f