### PR TITLE
harden OpenAI codex integration

### DIFF
--- a/tests/test_llm_security.py
+++ b/tests/test_llm_security.py
@@ -1,0 +1,40 @@
+import os
+from unittest.mock import patch
+
+import pytest
+
+from tools.llm import _openai_chat
+
+
+class DummyResponse:
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return {"choices": [{"message": {"content": "ok"}}]}
+
+
+@patch("requests.post", return_value=DummyResponse())
+def test_valid_base(mock_post):
+    os.environ["OPENAI_API_KEY"] = "test-key"
+    if "OPENAI_BASE" in os.environ:
+        del os.environ["OPENAI_BASE"]
+    assert _openai_chat("hi") == "ok"
+
+
+@patch("requests.post", return_value=DummyResponse())
+def test_invalid_scheme(mock_post):
+    os.environ["OPENAI_API_KEY"] = "test-key"
+    os.environ["OPENAI_BASE"] = "http://api.openai.com/v1"
+    with pytest.raises(ValueError):
+        _openai_chat("hi")
+    del os.environ["OPENAI_BASE"]
+
+
+@patch("requests.post", return_value=DummyResponse())
+def test_invalid_host(mock_post):
+    os.environ["OPENAI_API_KEY"] = "test-key"
+    os.environ["OPENAI_BASE"] = "https://evil.example.com/v1"
+    with pytest.raises(ValueError):
+        _openai_chat("hi")
+    del os.environ["OPENAI_BASE"]


### PR DESCRIPTION
## Summary
- validate OpenAI base URL uses https and official host
- add unit tests for OpenAI base URL validation

## Testing
- `npm run lint`
- `npm test`
- `pytest tests/test_llm_security.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad06818c848329bcf92d77c83b272c