### PR TITLE
chore: de-duplicate npm test scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,19 +12,18 @@
     "prepare": "husky",
     "lint": "eslint . --ext .js,.jsx,.mjs,.cjs || true",
     "format": "prettier -w .",
-    "test": "cross-env NODE_ENV=test jest --runInBand",
+    "test": "node tests/smoke.test.mjs",
+    "test:jest": "NODE_ENV=test jest --runInBand",
     "test-db": "node tests/test_db.js",
     "test-auth": "node tests/test_auth.js",
     "test-projects-tasks": "node tests/test_projects_tasks.js",
     "test-logs-contradictions": "node tests/test_logs_contradictions.js",
     "dev:site": "npm --prefix sites/blackroad run dev",
     "build": "npm --prefix sites/blackroad run build",
-    "test": "node tests/smoke.test.mjs",
     "test-agents-pack": "node tests/test_agents_mega.js",
     "frontend:dev": "npm --prefix sites/blackroad run dev",
     "frontend:build": "npm --prefix sites/blackroad run build",
-    "fix-anything": "node .github/tools/codex-apply.js .github/prompts/codex-fix-anything.md || true",
-    "test-auth": "node tests/test_auth.js"
+    "fix-anything": "node .github/tools/codex-apply.js .github/prompts/codex-fix-anything.md || true"
   },
   "engines": {
     "node": ">=18.17"


### PR DESCRIPTION
## Summary
- rename duplicate npm scripts and provide dedicated `test:jest` command

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad064a1f5c832994a8a91bd17720e9