### PR TITLE
Add engine name validation to AutoNovelAgent

### DIFF
--- a/agents/auto_novel_agent.py
+++ b/agents/auto_novel_agent.py
@@ -48,8 +48,14 @@ class AutoNovelAgent:
 
         Args:
             engine: Name of the engine to allow.
+
+        Raises:
+            ValueError: If ``engine`` is empty or only whitespace.
         """
-        self.SUPPORTED_ENGINES.add(engine.lower())
+        engine_clean = engine.strip()
+        if not engine_clean:
+            raise ValueError("Engine name must be a non-empty string.")
+        self.SUPPORTED_ENGINES.add(engine_clean.lower())
 
     def remove_supported_engine(self, engine: str) -> None:
         """Remove a game engine if it is currently supported.

--- a/agents/test_auto_novel_agent.py
+++ b/agents/test_auto_novel_agent.py
@@ -20,6 +20,12 @@ def test_add_supported_engine_and_create_game(capsys):
     assert "Godot" in captured.out
 
 
+def test_add_supported_engine_rejects_empty_string():
+    agent = AutoNovelAgent()
+    with pytest.raises(ValueError):
+        agent.add_supported_engine("   ")
+
+
 def test_create_game_disallows_weapons():
     agent = AutoNovelAgent()
     with pytest.raises(ValueError, match="Weapons are not allowed"):


### PR DESCRIPTION
## Summary
- validate engine names before registering them in AutoNovelAgent
- test rejection of empty engine names

## Testing
- `pre-commit run --files agents/auto_novel_agent.py agents/test_auto_novel_agent.py`
- `python -m py_compile *.py`
- `python auto_novel_agent.py`
- `pytest test_auto_novel_agent.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad065056fc8329a26ae6bdd96a6f94