### PR TITLE
feat: improve unsupported engine error

### DIFF
--- a/agents/auto_novel_agent.py
+++ b/agents/auto_novel_agent.py
@@ -29,14 +29,23 @@ class AutoNovelAgent:
         """Create a basic game using a supported engine without weapons.
 
         Args:
-            engine: Game engine to use.
+            engine: Game engine to use. Must be a non-empty string.
             include_weapons: If True, raise a ``ValueError`` because weapons are not
                 allowed.
         """
-        engine_lower = engine.lower()
-        if not self.supports_engine(engine_lower):
+        if not engine or not engine.strip():
+            raise ValueError("Engine name must be a non-empty string.")
+
+        engine_clean = engine.strip()
+        if not self.supports_engine(engine_clean):
             supported = ", ".join(sorted(self.SUPPORTED_ENGINES))
-            raise ValueError(f"Unsupported engine '{engine_lower}'. Choose one of: {supported}.")
+            raise ValueError(
+                "Unsupported engine "
+                f"'{engine_clean}'. Supported engines: {supported}. "
+                "Use ``add_supported_engine`` to register new engines."
+            )
+
+        engine_lower = engine_clean.lower()
         if include_weapons:
             raise ValueError("Weapons are not allowed in generated games.")
         print(f"Creating a {engine_lower.capitalize()} game without weapons...")

--- a/agents/test_auto_novel_agent.py
+++ b/agents/test_auto_novel_agent.py
@@ -28,8 +28,19 @@ def test_create_game_disallows_weapons():
 
 def test_create_game_rejects_unsupported_engine():
     agent = AutoNovelAgent()
-    with pytest.raises(ValueError, match="Unsupported engine 'cryengine'"):
+    with pytest.raises(ValueError) as excinfo:
         agent.create_game("cryengine")
+
+    message = str(excinfo.value)
+    assert "Unsupported engine 'cryengine'" in message
+    assert "Supported engines:" in message
+    assert "add_supported_engine" in message
+
+
+def test_create_game_requires_engine_name():
+    agent = AutoNovelAgent()
+    with pytest.raises(ValueError, match="Engine name must be a non-empty string."):
+        agent.create_game("   ")
 
 
 def test_generate_story_requires_theme():


### PR DESCRIPTION
## Summary
- improve error message when unsupported engine is provided
- test error message for unsupported engines

## Testing
- `python -m py_compile agents/auto_novel_agent.py agents/test_auto_novel_agent.py`
- `python agents/auto_novel_agent.py`
- `pytest agents/test_auto_novel_agent.py`
- `pre-commit run --files agents/auto_novel_agent.py agents/test_auto_novel_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad07a847588329951cdf0efce017fa