### PR TITLE
feat(api): add health endpoints and typed responses

### DIFF
--- a/api/amplicon/main.py
+++ b/api/amplicon/main.py
@@ -1,21 +1,34 @@
 from fastapi import FastAPI, File, UploadFile
-from fastapi.responses import JSONResponse
+from pydantic import BaseModel
 
 app = FastAPI(title="Amplicon API")
 
 
-@app.post("/api/jobs/amplicon")
-async def submit_job(runsheet: UploadFile = File(...)):
+class JobResponse(BaseModel):
+    """Response model for amplicon jobs."""
+
+    job_id: str
+    status: str | None = None
+
+
+@app.post("/api/jobs/amplicon", response_model=JobResponse)
+async def submit_job(runsheet: UploadFile = File(...)) -> JobResponse:
     """Placeholder endpoint accepting a runsheet CSV.
     In production this would enqueue an offline Nextflow run and return a job id."""
     # The file is ignored; implement job queuing here.
-    return {"job_id": "demo"}
+    return JobResponse(job_id="demo")
 
 
-@app.get("/api/jobs/{job_id}")
-async def get_job(job_id: str):
+@app.get("/api/jobs/{job_id}", response_model=JobResponse)
+async def get_job(job_id: str) -> JobResponse:
     """Return stub status for a job."""
-    return JSONResponse({"job_id": job_id, "status": "pending"})
+    return JobResponse(job_id=job_id, status="pending")
+
+
+@app.get("/health")
+async def health() -> dict[str, bool]:
+    """Simple health check."""
+    return {"ok": True}
 
 
 @app.get("/")

--- a/api/lucidia/main.py
+++ b/api/lucidia/main.py
@@ -1,19 +1,15 @@
-import os
-import asyncio
 import io
-import json
+import os
 import struct
-from fastapi import FastAPI, Request
-from fastapi.responses import (
-    StreamingResponse,
-    JSONResponse,
-    PlainTextResponse,
-)
+
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
 from pydantic import BaseModel
 from runtime.ollama_client import chat as ollama_chat
 
 LUCIDIA_MODEL = os.getenv("LUCIDIA_MODEL", "lucidia")
 app = FastAPI()
+
 
 class ChatBody(BaseModel):
     messages: list
@@ -27,9 +23,18 @@ class VideoBody(BaseModel):
     prompt: str
     frame_delay: int | None = 20
 
-@app.get("/health")
-async def health():
-    return {"ok": True, "model": LUCIDIA_MODEL}
+
+class HealthResponse(BaseModel):
+    """Response model for service health."""
+
+    ok: bool
+    model: str
+
+
+@app.get("/health", response_model=HealthResponse)
+async def health() -> HealthResponse:
+    """Basic service health."""
+    return HealthResponse(ok=True, model=LUCIDIA_MODEL)
 
 @app.post("/chat")
 async def chat(body: ChatBody):


### PR DESCRIPTION
## Summary
- define Pydantic JobResponse model and add health endpoint to Amplicon API
- expose typed HealthResponse in Lucidia API

## Testing
- `ruff check api/amplicon/main.py api/lucidia/main.py`
- `npm test`
- `pytest tests/lucidia_meta_annotator`


------
https://chatgpt.com/codex/tasks/task_e_68ad0dacf60883298e2b1c86bff789f5