### PR TITLE
feat: extend lucidia coding capabilities

### DIFF
--- a/lucidia/app.py
+++ b/lucidia/app.py
@@ -6,6 +6,22 @@ from contextlib import redirect_stdout
 
 from flask import Flask, jsonify, render_template, request
 
+# Expose a restricted set of safe built-in functions to executed code.
+SAFE_BUILTINS: dict[str, object] = {
+    "abs": abs,
+    "enumerate": enumerate,
+    "len": len,
+    "list": list,
+    "max": max,
+    "min": min,
+    "print": print,
+    "range": range,
+    "sum": sum,
+}
+
+# Preserve variables and functions defined across runs.
+GLOBAL_VARS: dict[str, object] = {}
+
 app = Flask(__name__)
 
 
@@ -20,11 +36,10 @@ def run_code():
     """Execute user-supplied Python code and return the output."""
     data = request.get_json(silent=True) or {}
     code = data.get("code", "")
-    local_vars: dict[str, object] = {}
     stdout = io.StringIO()
     try:
         with redirect_stdout(stdout):
-            exec(code, {"__builtins__": {"print": print}}, local_vars)
+            exec(code, {"__builtins__": SAFE_BUILTINS}, GLOBAL_VARS)
         output = stdout.getvalue()
     except Exception as exc:  # noqa: BLE001 - broad for user feedback
         output = f"Error: {exc}"

--- a/lucidia/templates/index.html
+++ b/lucidia/templates/index.html
@@ -6,6 +6,7 @@
   </head>
   <body>
     <h1>Lucidia Co Coding Portal</h1>
+    <p>Supports basic Python built-ins like <code>range</code> and <code>len</code>; state persists across runs.</p>
     <form id="code-form">
       <textarea id="code" rows="10" cols="80" placeholder="print('Hello')"></textarea><br />
       <button type="submit">Run</button>

--- a/lucidia/test_app.py
+++ b/lucidia/test_app.py
@@ -1,4 +1,12 @@
-from lucidia.app import app
+import pytest
+
+from lucidia.app import GLOBAL_VARS, app
+
+
+@pytest.fixture(autouse=True)
+def clear_state():
+    """Ensure each test has an isolated execution environment."""
+    GLOBAL_VARS.clear()
 
 
 def test_index():
@@ -13,3 +21,11 @@ def test_run_code():
     resp = client.post("/run", json={"code": "print('hi')"})
     assert resp.status_code == 200
     assert "hi" in resp.get_json()["output"]
+
+
+def test_state_and_builtins():
+    client = app.test_client()
+    client.post("/run", json={"code": "nums = list(range(3))"})
+    resp = client.post("/run", json={"code": "print(len(nums))"})
+    assert resp.status_code == 200
+    assert resp.get_json()["output"].strip() == "3"


### PR DESCRIPTION
## Summary
- allow safe Python built-ins and persistent variables in Lucidia coding portal
- document new capabilities on portal index page
- test that built-ins and state persistence work

## Testing
- `ruff check lucidia/app.py lucidia/test_app.py`
- `pytest lucidia/test_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad0ddea1808329b545ef8b413474d3