### PR TITLE
chore(ci): cache npm modules in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with: { node-version: 20 }
+        with: { node-version: 22, cache: 'npm' }
       - name: Ensure default test script
         run: |
           if [ ! -f package.json ]; then npm init -y; fi


### PR DESCRIPTION
## Summary
- cache npm dependencies in test workflow for faster CI
- move CI to Node.js 22 for current runtime support

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad0da3c4f48329bb396546ffdce8d3