### PR TITLE
feat: add simple RPG game module

### DIFF
--- a/lucidia/__init__.py
+++ b/lucidia/__init__.py
@@ -1,2 +1,5 @@
 """Lucidia engines and utilities."""
-"""Lucidia namespace package."""
+
+from .rpg import Character, Game
+
+__all__ = ["Character", "Game"]

--- a/lucidia/rpg.py
+++ b/lucidia/rpg.py
@@ -1,0 +1,90 @@
+"""Tiny text-based RPG engine for Lucidia.
+
+This module provides minimal classes to model a small turn-based battle game.
+It can be imported as a library or executed directly for a quick demo.
+"""
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class Character:
+    """Basic combatant with hit points and attack range."""
+
+    name: str
+    hp: int
+    attack_min: int
+    attack_max: int
+
+    def is_alive(self) -> bool:
+        """Return ``True`` if the character still has hit points."""
+        return self.hp > 0
+
+    def attack(self, other: "Character", rng: random.Random) -> int:
+        """Attack ``other`` and return the damage dealt."""
+        damage = rng.randint(self.attack_min, self.attack_max)
+        other.hp = max(0, other.hp - damage)
+        return damage
+
+
+class Game:
+    """Manage a simple player-versus-enemy battle."""
+
+    def __init__(
+        self, player: Character, enemy: Character, rng: Optional[random.Random] = None
+    ) -> None:
+        self.player = player
+        self.enemy = enemy
+        self.rng = rng or random.Random()
+
+    def player_turn(self) -> int:
+        """Execute the player's attack."""
+        return self.player.attack(self.enemy, self.rng)
+
+    def enemy_turn(self) -> int:
+        """Execute the enemy's attack."""
+        return self.enemy.attack(self.player, self.rng)
+
+    def run(self) -> str:
+        """Run the battle until one character is defeated.
+
+        Returns
+        -------
+        str
+            The name of the winning character.
+        """
+        while self.player.is_alive() and self.enemy.is_alive():
+            self.player_turn()
+            if not self.enemy.is_alive():
+                break
+            self.enemy_turn()
+        return self.player.name if self.player.is_alive() else self.enemy.name
+
+
+def main() -> None:
+    """Play a quick demo game in the console."""
+    rng = random.Random()
+    player = Character("Hero", hp=20, attack_min=2, attack_max=5)
+    enemy = Character("Goblin", hp=15, attack_min=1, attack_max=4)
+    game = Game(player, enemy, rng)
+    print("Welcome to Lucidia RPG! Type 'attack' to strike your foe.")
+    while player.is_alive() and enemy.is_alive():
+        cmd = input("> ").strip().lower()
+        if cmd != "attack":
+            print("Unknown command. Try 'attack'.")
+            continue
+        dmg = game.player_turn()
+        print(f"You hit {enemy.name} for {dmg} damage (hp={enemy.hp}).")
+        if not enemy.is_alive():
+            break
+        dmg = game.enemy_turn()
+        print(f"{enemy.name} hits you for {dmg} damage (hp={player.hp}).")
+    winner = game.player.name if player.is_alive() else enemy.name
+    print(f"{winner} wins!")
+
+
+if __name__ == "__main__":
+    main()

--- a/lucidia/test_rpg.py
+++ b/lucidia/test_rpg.py
@@ -1,0 +1,15 @@
+"""Tests for the tiny Lucidia RPG game."""
+import random
+
+from lucidia.rpg import Character, Game
+
+
+def test_player_wins_against_weak_enemy() -> None:
+    rng = random.Random(0)
+    player = Character("Hero", hp=10, attack_min=3, attack_max=3)
+    enemy = Character("Goblin", hp=5, attack_min=1, attack_max=1)
+    game = Game(player, enemy, rng)
+    winner = game.run()
+    assert winner == "Hero"
+    assert player.is_alive()
+    assert not enemy.is_alive()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 pre-commit
 pytest
+libcst
 black==24.4.2
 ruff==0.6.9
 isort==5.13.2


### PR DESCRIPTION
## Summary
- introduce a tiny turn-based RPG engine with `Character` and `Game` classes and a console demo
- expose the new RPG utilities at the package level
- cover the RPG battle logic with a unit test
- ensure dev requirements include `libcst` for test collection

## Testing
- `ruff check lucidia/rpg.py lucidia/test_rpg.py lucidia/__init__.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch', 'numpy', 'networkx', 'lucidia_reason', 'anthropic', etc)*
- `pytest lucidia/test_rpg.py`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad11460a888329a22bd2af3fb9db67