### PR TITLE
Fix whisper dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,5 @@ streamlit==1.35.0
 openai==1.30.1
 matplotlib==3.8.4
 numpy==1.26.4
-whisper
+openai-whisper
 torch
-


### PR DESCRIPTION
## Summary
- replace placeholder `whisper` requirement with the proper `openai-whisper` package

## Testing
- `pytest`
- `pre-commit run --files requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_68ad14a7f6e083299701f2666c30796b