### PR TITLE
feat: add code completion tool for lucidia ollama

### DIFF
--- a/lmcp/servers/lucidia_ollama/lucidia_ollama/server.py
+++ b/lmcp/servers/lucidia_ollama/lucidia_ollama/server.py
@@ -3,11 +3,11 @@
 This server exposes simple tools to interact with a locally running
 `ollama` instance. Only models present in the allow-list are accepted.
 """
+
 from __future__ import annotations
 
 import os
 from typing import Any, Dict, List
-
 
 try:
     import requests
@@ -64,6 +64,25 @@ if server:
         _check_model(model)
         data = _post("api/embed", {"model": model, "input": text})
         return data.get("embedding", [])
+
+
+def complete_code(model: str, prompt: str, language: str = "python") -> str:
+    """Return a code completion for ``prompt`` in ``language`` using ``model``."""
+    _check_model(model)
+    full_prompt = f"# language: {language}\n{prompt}"
+    data = _post(
+        "api/generate",
+        {
+            "model": model,
+            "prompt": full_prompt,
+            "options": {"num_predict": 256, "temperature": 0.0},
+        },
+    )
+    return data.get("response", "")
+
+
+if server:
+    complete_code = server.tool()(complete_code)
 
 
 def main() -> None:

--- a/lmcp/tests/test_lucidia_ollama.py
+++ b/lmcp/tests/test_lucidia_ollama.py
@@ -13,3 +13,21 @@ def test_model_allowlist(monkeypatch):
     importlib.reload(ollama_server)
     with pytest.raises(ValueError):
         ollama_server._check_model("c")
+
+
+def test_complete_code(monkeypatch):
+    monkeypatch.setenv("LUCIDIA_OLLAMA_MODELS", "x")
+    importlib.reload(ollama_server)
+
+    called = {}
+
+    def fake_post(endpoint, payload):
+        called["endpoint"] = endpoint
+        called["payload"] = payload
+        return {"response": "code"}
+
+    monkeypatch.setattr(ollama_server, "_post", fake_post)
+    result = ollama_server.complete_code("x", "def add(a, b):")
+    assert called["endpoint"] == "api/generate"
+    assert "def add(a, b):" in called["payload"]["prompt"]
+    assert result == "code"


### PR DESCRIPTION
## Summary
- add `complete_code` tool to the Lucidia Ollama server for code-specific completions
- test new code completion helper

## Testing
- `ruff check lmcp/servers/lucidia_ollama/lucidia_ollama/server.py lmcp/tests/test_lucidia_ollama.py`
- `black lmcp/servers/lucidia_ollama/lucidia_ollama/server.py lmcp/tests/test_lucidia_ollama.py`
- `pytest lmcp/tests/test_lucidia_ollama.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad40813978832991c242feb467ccff