### PR TITLE
feat: add optional llama model to lucidia llm

### DIFF
--- a/lucidia-llm/app.py
+++ b/lucidia-llm/app.py
@@ -1,23 +1,65 @@
-# FILE: /srv/lucidia-llm/app.py
+"""Minimal LLM service with optional open source model support.
+
+The service defaults to a lightweight echo stub so that unit tests can run
+without large model downloads.  If the ``LUCIDIA_USE_MODEL`` environment
+variable is set to ``"1"`` and the ``transformers`` library is available, the
+service will load ``meta-llama/Meta-Llama-3-8B-Instruct`` (or another model
+specified via ``LUCIDIA_MODEL``) and use it to generate responses.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import List
+
 from fastapi import FastAPI
 from pydantic import BaseModel
-from typing import List, Optional
 
-app = FastAPI(title="Lucidia LLM Stub")
+try:  # Optional heavy dependency
+    from transformers import pipeline
+except Exception:  # pragma: no cover - transformers may be absent
+    pipeline = None  # type: ignore
+
+app = FastAPI(title="Lucidia LLM")
+
 
 class Msg(BaseModel):
     role: str
     content: str
 
+
 class ChatReq(BaseModel):
     messages: List[Msg]
 
+
+MODEL_NAME = os.getenv("LUCIDIA_MODEL", "meta-llama/Meta-Llama-3-8B-Instruct")
+USE_MODEL = os.getenv("LUCIDIA_USE_MODEL") == "1"
+_pipe = None
+
+
+def _get_pipe():
+    """Lazily initialise the text generation pipeline."""
+
+    global _pipe
+    if not USE_MODEL or pipeline is None:
+        return None
+    if _pipe is None:
+        _pipe = pipeline("text-generation", model=MODEL_NAME)
+    return _pipe
+
+
 @app.get("/health")
 def health():
-    return {"ok": True, "service": "lucidia-llm-stub"}
+    return {"ok": True, "service": "lucidia-llm"}
+
 
 @app.post("/chat")
 def chat(req: ChatReq):
     last = req.messages[-1].content if req.messages else "(empty)"
-    # Simple echo stub
-    return {"choices": [{"role": "assistant", "content": f"Lucidia stub: {last}"}]}
+    pipe = _get_pipe()
+    if pipe is None:
+        content = f"Lucidia stub: {last}"
+    else:
+        result = pipe(last, max_new_tokens=60)
+        content = result[0]["generated_text"]
+    return {"choices": [{"role": "assistant", "content": content}]}

--- a/lucidia-llm/requirements.txt
+++ b/lucidia-llm/requirements.txt
@@ -2,3 +2,4 @@
 fastapi==0.115.0
 uvicorn==0.30.6
 pydantic==2.8.2
+transformers==4.43.0

--- a/tests/test_lucidia_llm.py
+++ b/tests/test_lucidia_llm.py
@@ -1,0 +1,18 @@
+from importlib import util
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+spec = util.spec_from_file_location("lucidia_llm_app", Path("lucidia-llm/app.py"))
+module = util.module_from_spec(spec)
+assert spec.loader is not None  # for mypy
+spec.loader.exec_module(module)  # type: ignore[attr-defined]
+
+client = TestClient(module.app)
+
+
+def test_chat_stub():
+    resp = client.post("/chat", json={"messages": [{"role": "user", "content": "hi"}]})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["choices"][0]["content"].startswith("Lucidia stub:")


### PR DESCRIPTION
## Summary
- add optional Meta-Llama-3-8B model integration for lucidia-llm service
- update lucidia-llm requirements with transformers dependency
- test lucidia-llm chat stub endpoint

## Testing
- `python -m pre_commit run --files lucidia-llm/app.py lucidia-llm/requirements.txt tests/test_lucidia_llm.py`
- `python -m pytest lucidia/test_app.py tests/test_lucidia_llm.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad40c772608329bc7bda2a36d78ace