### PR TITLE
feat: enable package install and git cleanup

### DIFF
--- a/lucidia/app.py
+++ b/lucidia/app.py
@@ -1,9 +1,13 @@
 """Simple coding portal for executing Python snippets."""
 
 import io
+import math
 import os
+import subprocess
 from contextlib import redirect_stdout
+from pathlib import Path
 
+import sympy as sp
 from flask import Flask, jsonify, render_template, request
 
 app = Flask(__name__)
@@ -20,15 +24,81 @@ def run_code():
     """Execute user-supplied Python code and return the output."""
     data = request.get_json(silent=True) or {}
     code = data.get("code", "")
-    local_vars: dict[str, object] = {}
+    local_vars: dict[str, object] = {"math": math}
+    safe_builtins = {"print": print, "abs": abs, "round": round, "pow": pow}
     stdout = io.StringIO()
     try:
         with redirect_stdout(stdout):
-            exec(code, {"__builtins__": {"print": print}}, local_vars)
+            exec(code, {"__builtins__": safe_builtins}, local_vars)
         output = stdout.getvalue()
     except Exception as exc:  # noqa: BLE001 - broad for user feedback
         output = f"Error: {exc}"
     return jsonify({"output": output})
+
+
+@app.post("/math")
+def evaluate_math():
+    """Evaluate a mathematical expression and optionally report its derivative."""
+    data = request.get_json(silent=True) or {}
+    expr = data.get("expression")
+    if not expr:
+        return jsonify({"error": "missing expression"}), 400
+    curious = data.get("curious")
+    try:
+        sym_expr = sp.sympify(expr)
+    except sp.SympifyError as exc:
+        return jsonify({"error": str(exc)}), 400
+    response: dict[str, str] = {"result": str(sym_expr)}
+    if curious:
+        symbols = list(sym_expr.free_symbols)
+        if symbols:
+            response["derivative"] = str(sp.diff(sym_expr, symbols[0]))
+    return jsonify(response)
+
+
+@app.post("/install")
+def install_package():
+    """Install a Python package via ``pip`` within the environment."""
+    data = request.get_json(silent=True) or {}
+    package = data.get("package")
+    if not package:
+        return jsonify({"error": "missing package"}), 400
+    proc = subprocess.run(
+        ["pip", "install", package],
+        capture_output=True,
+        text=True,
+    )
+    return (
+        jsonify({"code": proc.returncode, "stdout": proc.stdout, "stderr": proc.stderr}),
+        200 if proc.returncode == 0 else 500,
+    )
+
+
+@app.post("/git/clean")
+def git_clean():
+    """Reset and remove untracked files from a git repository."""
+    data = request.get_json(silent=True) or {}
+    repo_path = Path(data.get("path", "."))
+    if not repo_path.is_dir():
+        return jsonify({"error": "invalid path"}), 400
+    reset = subprocess.run(
+        ["git", "reset", "--hard"],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+    )
+    clean = subprocess.run(
+        ["git", "clean", "-ffdx"],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+    )
+    output = reset.stdout + reset.stderr + clean.stdout + clean.stderr
+    code = reset.returncode or clean.returncode
+    return (
+        jsonify({"code": code, "output": output}),
+        200 if code == 0 else 500,
+    )
 
 
 if __name__ == "__main__":

--- a/lucidia/requirements.txt
+++ b/lucidia/requirements.txt
@@ -1,1 +1,2 @@
-Flask==2.3.2 --hash=sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+Flask==2.3.2 --hash=sha256:77fd4e1249d8c9923de34907236b747ced06e5467ecac1a7bb7115ae0e9670b0
+sympy==1.12 --hash=sha256:c3588cd4295d0c0f603d0f2ae780587e64e2efeedb3521e46b9bb1d08d184fa5

--- a/lucidia/test_app.py
+++ b/lucidia/test_app.py
@@ -1,3 +1,5 @@
+import subprocess
+
 from lucidia.app import app
 
 
@@ -13,3 +15,41 @@ def test_run_code():
     resp = client.post("/run", json={"code": "print('hi')"})
     assert resp.status_code == 200
     assert "hi" in resp.get_json()["output"]
+
+
+def test_run_code_math():
+    client = app.test_client()
+    resp = client.post("/run", json={"code": "print(math.sqrt(16))"})
+    assert resp.status_code == 200
+    assert "4.0" in resp.get_json()["output"]
+
+
+def test_install_package():
+    client = app.test_client()
+    resp = client.post("/install", json={"package": "itsdangerous==2.2.0"})
+    data = resp.get_json()
+    assert resp.status_code == 200
+    assert data["code"] == 0
+
+
+def test_git_clean(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    (repo / "tracked.txt").write_text("tracked")
+    subprocess.run(["git", "add", "tracked.txt"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo, check=True, capture_output=True)
+    (repo / "untracked.txt").write_text("temp")
+    client = app.test_client()
+    resp = client.post("/git/clean", json={"path": str(repo)})
+    assert resp.status_code == 200
+    assert not (repo / "untracked.txt").exists()
+
+
+def test_math_endpoint():
+    client = app.test_client()
+    resp = client.post("/math", json={"expression": "x**2", "curious": True})
+    data = resp.get_json()
+    assert resp.status_code == 200
+    assert data["result"] == "x**2"
+    assert data["derivative"] == "2*x"


### PR DESCRIPTION
## Summary
- fix lucidia requirements hash so dependencies install cleanly
- add endpoints to install packages and clean Git repositories from the Lucidia portal
- cover new endpoints with tests
- expose safe math helpers and a SymPy-powered `/math` endpoint

## Testing
- `ruff check lucidia/app.py lucidia/test_app.py`
- `black --check lucidia/app.py lucidia/test_app.py`
- `pytest lucidia/test_app.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad43d18a4483299f0a318c831b1d3a