### PR TITLE
Add multi-theme story generation to AutoNovelAgent

### DIFF
--- a/agents/auto_novel_agent.py
+++ b/agents/auto_novel_agent.py
@@ -85,6 +85,31 @@ class AutoNovelAgent:
             "discovering wonders along the way."
         )
 
+    def generate_story_series(
+        self, themes: List[str], protagonist: str = "An adventurer"
+    ) -> List[str]:
+        """Generate a series of short stories for multiple themes.
+
+        Args:
+            themes: A list of themes. Each must be a non-empty string.
+            protagonist: Name or description of the main character used for all
+                stories.
+
+        Returns:
+            A list containing a short story for each provided theme.
+
+        Raises:
+            ValueError: If ``themes`` is empty or any theme is blank.
+        """
+        if not themes:
+            raise ValueError("Themes list must not be empty.")
+        stories: List[str] = []
+        for theme in themes:
+            if not theme or not theme.strip():
+                raise ValueError("Each theme must be a non-empty string.")
+            stories.append(self.generate_story(theme, protagonist))
+        return stories
+
 
 if __name__ == "__main__":
     agent = AutoNovelAgent()

--- a/agents/test_auto_novel_agent.py
+++ b/agents/test_auto_novel_agent.py
@@ -36,3 +36,12 @@ def test_generate_story_requires_theme():
     agent = AutoNovelAgent()
     with pytest.raises(ValueError):
         agent.generate_story("")
+
+
+def test_generate_story_series_produces_multiple_stories():
+    agent = AutoNovelAgent()
+    stories = agent.generate_story_series(["mystery", "space"], protagonist="Explorer")
+    assert len(stories) == 2
+    assert "Explorer" in stories[0]
+    assert "mystery" in stories[0]
+    assert "space" in stories[1]


### PR DESCRIPTION
## Summary
- allow AutoNovelAgent to create a series of short stories via new `generate_story_series` method
- test multi-theme story generation

## Testing
- `python -m py_compile agents/*.py`
- `python agents/auto_novel_agent.py`
- `pre-commit run --files agents/auto_novel_agent.py agents/test_auto_novel_agent.py`
- `pytest agents/test_auto_novel_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad4609b49083299f378891ed202976