### PR TITLE
Add bot experiment catalog

### DIFF
--- a/docs/bot-experiments.md
+++ b/docs/bot-experiments.md
@@ -1,0 +1,54 @@
+# Bot Experiment Catalog
+
+These experiments invite bots to design, code, create, and explore both the Cadillac conversation mode and the Lucidia research modules.
+
+1. Design a REST endpoint scaffold that switches the backend into Cadillac mode.
+2. Generate a Lucidia-compatible schema for storing experimental logs.
+3. Prototype a chatbot flow that toggles between normal and Cadillac conversational styles.
+4. Implement a plugin loader for Lucidia modules in the service worker environment.
+5. Draft a test suite verifying Cadillac mode respects user authentication.
+6. Create a CLI script that initializes a new Lucidia project with defaults.
+7. Build a mock API that streams Cadillac-style responses to a web client.
+8. Write TypeScript interfaces for Lucidia task definitions.
+9. Develop a code formatter rule that enforces Cadillac tone in comments.
+10. Compose a WebSocket broker that routes messages to Lucidia engines.
+11. Craft a Prisma migration adding Cadillac preferences to the user table.
+12. Scaffold a micro-frontend that renders Lucidia analytics widgets.
+13. Establish a GitHub Action running Cadillac-mode lint checks.
+14. Generate synthetic data for stress-testing Lucidia research agents.
+15. Build a Markdown parser that highlights Cadillac trigger phrases.
+16. Produce a schema validator ensuring Lucidia experiment metadata is well-formed.
+17. Design a caching layer optimized for Cadillac dialogue transcripts.
+18. Implement a logging decorator that tags functions with Lucidia experiment IDs.
+19. Compose a unit test harness for Cadillac-specific controller logic.
+20. Prototype a browser extension that exposes Lucidia shortcuts.
+21. Build a docker-compose profile launching Cadillac and Lucidia services together.
+22. Write an ESLint custom rule flagging misuse of the Cadillac phrase library.
+23. Construct a monitoring dashboard tracking Lucidia experiment uptime.
+24. Draft a configuration generator for Cadillac-themed UI skins.
+25. Develop a queue worker that batches Lucidia experiment results.
+26. Script a data migration relocating Cadillac session records.
+27. Compose a Jest test ensuring Lucidia APIs enforce rate limits.
+28. Design an experiment scheduler that alternates between Cadillac and standard modes.
+29. Author a tutorial demonstrating Cadillac-style error handling patterns.
+30. Implement feature flags enabling Lucidia modules incrementally.
+31. Produce a REPL script that lets developers prototype Cadillac dialogs.
+32. Engineer a CI check validating Lucidia experiment naming conventions.
+33. Build a templating helper that injects Cadillac flair into generated files.
+34. Create a protocol buffer definition for Lucidia task exchange.
+35. Add a cron job script archiving Cadillac transcripts nightly.
+36. Compose integration tests covering Lucidia module lifecycle events.
+37. Design a static site that documents all Cadillac commands.
+38. Prototype a VS Code snippet pack for Lucidia experiment scaffolds.
+39. Implement a service mesh policy isolating Cadillac traffic.
+40. Write a tutorial guiding users through first-run Lucidia setup.
+41. Generate a migration script applying Cadillac defaults to legacy data.
+42. Build a REST client library targeting Lucidia endpoints.
+43. Draft a style guide ensuring Cadillac responses remain concise.
+44. Produce a code-mod that refactors callbacks into async/await for Lucidia tools.
+45. Configure a feature-test matrix mixing Cadillac modes with Lucidia modules.
+46. Craft a fake data generator that mimics Lucidia experiment payloads.
+47. Implement a sandboxed execution environment for Cadillac scripts.
+48. Create a metrics exporter exposing Lucidia experiment KPIs.
+49. Author a developer guide on extending Cadillac’s phrasebook.
+50. Build an end-to-end demo combining Cadillac dialogue and Lucidia analytics.


### PR DESCRIPTION
## Summary
- document 50 experiments inviting bots to design, code, and create in Cadillac and Lucidia modes

## Testing
- `pre-commit run --files docs/bot-experiments.md`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad70c2a5cc8329adfd905175ab6f31