### PR TITLE
feat: create 30 student bots

### DIFF
--- a/agents/student_bots.py
+++ b/agents/student_bots.py
@@ -1,4 +1,5 @@
 """Definitions for student bots guided by leader agents."""
+
 from dataclasses import dataclass
 from itertools import cycle
 from typing import List
@@ -13,7 +14,7 @@ class StudentBot:
 
 
 def create_student_bots() -> List[StudentBot]:
-    """Create 25 student bots guided by phi, gpt, mistral, codex, and lucidia.
+    """Create 30 student bots guided by phi, gpt, mistral, codex, and lucidia.
 
     The leaders act as mentors rather than managers. Bots cycle through the
     leaders, demonstrating collaborative learning while traversing repositories
@@ -21,7 +22,7 @@ def create_student_bots() -> List[StudentBot]:
     """
     leaders = ["phi", "gpt", "mistral", "codex", "lucidia"]
     bot_cycle = cycle(leaders)
-    return [StudentBot(name=f"student_bot_{i+1}", leader=next(bot_cycle)) for i in range(25)]
+    return [StudentBot(name=f"student_bot_{i+1}", leader=next(bot_cycle)) for i in range(30)]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- expand student bot roster to 30 learners rotating among phi, gpt, mistral, codex, and lucidia mentors

## Testing
- `python -m py_compile student_bots.py`
- `python auto_novel_agent.py`
- `pre-commit run --files agents/student_bots.py`
- `pytest` *(fails: 29 errors during collection)*
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad7276b35883299a8f3b173960746a