### PR TITLE
Fix prime explorer test import path

### DIFF
--- a/tests/test_prime_explorer.py
+++ b/tests/test_prime_explorer.py
@@ -1,3 +1,11 @@
+"""Tests for prime explorer utilities."""
+
+import os
+import sys
+
+# Ensure repository root is on PYTHONPATH when running the test directly.
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
 from lucidia_math_lab.prime_explorer import (
     fourier_prime_gaps,
     residue_grid,


### PR DESCRIPTION
## Summary
- ensure prime explorer tests add repo root to PYTHONPATH

## Testing
- `python tests/test_prime_explorer.py && echo 'test complete'`
- `npm test`
- `npm run lint`
- `pre-commit run --files tests/test_prime_explorer.py`
- `npm run test:jest` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ade42bc6fc8329840b450e41defda5