### PR TITLE
Skip codemod test when libcst is missing

### DIFF
--- a/codemods/test_rename_foo_to_bar.py
+++ b/codemods/test_rename_foo_to_bar.py
@@ -1,8 +1,10 @@
-from libcst import parse_module
+import pytest
+
+libcst = pytest.importorskip("libcst")
 from codemods.rename_foo_to_bar import codemod
 
 
 def test_simple():
     src = "def foo():\n    return foo"
-    out = codemod(parse_module(src)).code
+    out = codemod(libcst.parse_module(src)).code
     assert out == "def bar():\n    return bar"


### PR DESCRIPTION
## Summary
- gracefully skip codemod rename test if libcst isn't available

## Testing
- `pytest codemods/test_rename_foo_to_bar.py -vv`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae0e5598888329a29130631694d73a