### PR TITLE
test: ensure backend not found returns json

### DIFF
--- a/tests/backend-validation.test.js
+++ b/tests/backend-validation.test.js
@@ -45,3 +45,16 @@ test('rejects malformed json and missing fields', async () => {
 
   server.close();
 });
+
+test('returns json for not found routes', async () => {
+  const server = app.listen(0);
+  const port = getPort(server);
+
+  const res = await fetch(`http://127.0.0.1:${port}/nope`);
+  assert.equal(res.status, 404);
+  assert.equal(res.headers.get('content-type'), 'application/json');
+  const body = await res.json();
+  assert.equal(body.error, 'not found');
+
+  server.close();
+});


### PR DESCRIPTION
## Summary
- add regression test to verify backend 404 responses return JSON with error field

## Testing
- `node tests/backend-validation.test.js`
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b25b8e31508329aaf4a855db2b254a