### PR TITLE
test: ensure backend not found returns json

### DIFF
--- a/tests/backend-validation.test.js
+++ b/tests/backend-validation.test.js
@@ -11,37 +11,53 @@ function getPort(server) {
 test('rejects malformed json and missing fields', async () => {
   const server = app.listen(0);
   const port = getPort(server);
+  try {
+    // login to get token
+    const loginRes = await fetch(`http://127.0.0.1:${port}/api/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 'root', password: 'Codex2025' })
+    });
+    const loginJson = await loginRes.json();
+    const token = loginJson.token;
 
-  // login to get token
-  const loginRes = await fetch(`http://127.0.0.1:${port}/api/auth/login`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ username: 'root', password: 'Codex2025' })
-  });
-  const loginJson = await loginRes.json();
-  const token = loginJson.token;
+    // malformed json
+    const badRes = await fetch(`http://127.0.0.1:${port}/api/tasks`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`
+      },
+      body: '{"title": "bad"' // missing closing brace
+    });
+    assert.equal(badRes.status, 400);
 
-  // malformed json
-  const badRes = await fetch(`http://127.0.0.1:${port}/api/tasks`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${token}`
-    },
-    body: '{"title": "bad"' // missing closing brace
-  });
-  assert.equal(badRes.status, 400);
-
-  // missing title field
-  const missRes = await fetch(`http://127.0.0.1:${port}/api/tasks`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${token}`
-    },
-    body: JSON.stringify({})
-  });
-  assert.equal(missRes.status, 400);
-
-  server.close();
+    // missing title field
+    const missRes = await fetch(`http://127.0.0.1:${port}/api/tasks`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`
+      },
+      body: JSON.stringify({})
+    });
+    assert.equal(missRes.status, 400);
+  } finally {
+    server.close();
+  }
 });
+
+test('returns json for not found routes', async () => {
+  const server = app.listen(0);
+  const port = getPort(server);
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/nope`);
+    assert.equal(res.status, 404);
+    assert.equal(res.headers.get('content-type'), 'application/json');
+    const body = await res.json();
+    assert.equal(body.error, 'not found');
+  } finally {
+    server.close();
+  }
+});
+


### PR DESCRIPTION
## Summary
- harden backend validation tests and confirm unknown routes return JSON `not found`
- verify 404 responses specify `application/json`

## Testing
- `node tests/backend-validation.test.js`
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b25b8e31508329aaf4a855db2b254a