### PR TITLE
feat(lucidia): expand brain step management

### DIFF
--- a/tests/test_lucidia_brain.py
+++ b/tests/test_lucidia_brain.py
@@ -1,8 +1,37 @@
 from lucidia.brain import LucidiaBrain
+import pytest
 
 
 def test_pipeline_executes_in_order():
     brain = LucidiaBrain()
-    brain.register(lambda x: x + 1)
-    brain.register(lambda x: x * 2)
+    brain.register(lambda x: x + 1, name="add1")
+    brain.register(lambda x: x * 2, name="mul2")
     assert brain.think(3) == 8
+
+
+def test_register_names_and_unregister():
+    brain = LucidiaBrain()
+
+    def inc(x: int) -> int:
+        return x + 1
+
+    brain.register(inc)
+    brain.register(lambda x: x * 2, name="double")
+    assert brain.steps == ["inc", "double"]
+    brain.unregister("inc")
+    assert brain.steps == ["double"]
+    assert brain.think(3) == 6
+
+
+def test_reset_clears_steps():
+    brain = LucidiaBrain()
+    brain.register(lambda x: x + 1, name="inc")
+    brain.reset()
+    assert brain.steps == []
+
+
+def test_register_duplicate_name_raises():
+    brain = LucidiaBrain()
+    brain.register(lambda x: x, name="id")
+    with pytest.raises(ValueError):
+        brain.register(lambda x: x, name="id")


### PR DESCRIPTION
## Summary
- allow naming steps in LucidiaBrain and manage them
- add unregister, reset, and introspection helpers
- expand brain tests for step naming and removal

## Testing
- `pytest tests/test_lucidia_brain.py lucidia/test_rpg.py lucidia/test_app.py`

------
https://chatgpt.com/codex/tasks/task_e_68b267a9ec08832995642b20913110dc