### PR TITLE
feat: add basic entitlements hook and endpoint

### DIFF
--- a/frontend/src/useEntitlements.js
+++ b/frontend/src/useEntitlements.js
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import { API_BASE } from './api';
+
+function dive(obj, path) {
+  return path.split('.').reduce((acc, key) => (acc ? acc[key] : undefined), obj);
+}
+
+export default function useEntitlements() {
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    axios
+      .get(`${API_BASE}/api/billing/entitlements/me`)
+      .then((res) => setData(res.data))
+      .catch(() => {});
+  }, []);
+
+  return {
+    planName: data?.planName || 'Free',
+    has(cap) {
+      return !!dive(data?.entitlements, cap);
+    },
+    limit(path) {
+      return dive(data?.entitlements, path);
+    },
+  };
+}

--- a/tests/api_health.test.js
+++ b/tests/api_health.test.js
@@ -30,4 +30,17 @@ describe('API security and health', () => {
     const res = await request(app).post('/api/login').send({});
     expect(res.status).toBe(400);
   });
+
+  it('returns default entitlements for logged-in user', async () => {
+    const login = await request(app)
+      .post('/api/login')
+      .send({ username: 'root', password: 'Codex2025' });
+    const cookie = login.headers['set-cookie'];
+    const res = await request(app)
+      .get('/api/billing/entitlements/me')
+      .set('Cookie', cookie);
+    expect(res.status).toBe(200);
+    expect(res.body.planName).toBe('Free');
+    expect(res.body.entitlements.can.math.pro).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- add basic plan-to-entitlements mapping on API and expose `/api/billing/entitlements/me`
- set default plan in session at login
- create `useEntitlements` React hook to query entitlements and provide helper methods
- include test coverage for entitlement endpoint

## Testing
- `npm test` *(fails: sh: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3540fc8108329bb676410358f2496