### PR TITLE
feat: add stub math API

### DIFF
--- a/tests/api_health.test.js
+++ b/tests/api_health.test.js
@@ -1,6 +1,7 @@
 process.env.SESSION_SECRET = 'test-secret';
 process.env.INTERNAL_TOKEN = 'x';
 process.env.ALLOW_ORIGINS = 'https://example.com';
+process.env.MATH_ENGINE_URL = '';
 const request = require('supertest');
 const { app, server } = require('../srv/blackroad-api/server_full.js');
 
@@ -29,5 +30,17 @@ describe('API security and health', () => {
   it('validates login payload', async () => {
     const res = await request(app).post('/api/login').send({});
     expect(res.status).toBe(400);
+  });
+
+  it('provides math health info', async () => {
+    const res = await request(app).get('/api/math/health');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('evaluates a simple expression', async () => {
+    const res = await request(app).post('/api/math/eval').send({ expr: '2+2' });
+    expect(res.status).toBe(200);
+    expect(res.body.result).toBe(4);
   });
 });


### PR DESCRIPTION
## Summary
- add MATH_ENGINE_URL env setting and proxy math endpoints when configured
- update tests to set math engine env

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b351ef70688329a26cc473c269d428