### PR TITLE
chore: add robust droplet deploy script

### DIFF
--- a/usr/local/bin/blackroad-deploy.sh
+++ b/usr/local/bin/blackroad-deploy.sh
@@ -17,6 +17,9 @@ set -Eeuo pipefail
 ### Tunables (override via env)
 ### ──────────────────────────────
 WORKING_COPY_PATH="${WORKING_COPY_PATH:-~/blackroad-api}"     # path to repo on the working-copy host (or local path if WORKING_COPY_SSH=local)
+if [[ "$WORKING_COPY_SSH" == "local" ]]; then
+  WORKING_COPY_PATH="${WORKING_COPY_PATH/#\~/$HOME}"
+fi
 SERVICE_NAME="${SERVICE_NAME:-blackroad-api}"                 # systemd or PM2 process name on droplet
 HEALTH_URL="${HEALTH_URL:-http://127.0.0.1:4000/api/health}"  # droplet-local health endpoint
 KEEP_RELEASES="${KEEP_RELEASES:-7}"                           # how many releases to keep


### PR DESCRIPTION
## Summary
- expand blackroad-deploy.sh into an env-driven, atomic rsync deploy script with health checks, rollback, and Slack alerts
- expand local WORKING_COPY_PATH to ensure tilde expansion in local deployments

## Testing
- `pre-commit run --files usr/local/bin/blackroad-deploy.sh` *(fails: HTTP 403 fetching pre-commit hooks)*
- `shellcheck usr/local/bin/blackroad-deploy.sh`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3670f38448329a07c0360fd5d7814