### PR TITLE
feat: create 30 student bots

### DIFF
--- a/agents/student_bots.py
+++ b/agents/student_bots.py
@@ -1,8 +1,10 @@
 """Definitions for student bots guided by leader agents."""
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from itertools import cycle
-from typing import List
+
+LEADERS: tuple[str, ...] = ("phi", "gpt", "mistral", "codex", "lucidia")
 
 
 @dataclass
@@ -13,16 +15,25 @@ class StudentBot:
     leader: str
 
 
-def create_student_bots() -> List[StudentBot]:
-    """Create 30 student bots guided by phi, gpt, mistral, codex, and lucidia.
+def create_student_bots(count: int = 30, leaders: Iterable[str] = LEADERS) -> list[StudentBot]:
+    """Create student bots guided by phi, gpt, mistral, codex, and lucidia.
 
     The leaders act as mentors rather than managers. Bots cycle through the
     leaders, demonstrating collaborative learning while traversing repositories
     to keep them in harmony.
+
+    Args:
+        count: Number of student bots to create. Defaults to 30.
+        leaders: Sequence of leader names to cycle through.
+
+    Returns:
+        A list of configured student bots.
     """
-    leaders = ["phi", "gpt", "mistral", "codex", "lucidia"]
     bot_cycle = cycle(leaders)
-    return [StudentBot(name=f"student_bot_{i+1}", leader=next(bot_cycle)) for i in range(30)]
+    return [
+        StudentBot(name=f"student_bot_{i+1}", leader=next(bot_cycle))
+        for i in range(count)
+    ]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- parameterize student bot generation and expose leader cycle
- adopt built-in generics and centralize default leaders

## Testing
- `python -m py_compile agents/student_bots.py`
- `python agents/auto_novel_agent.py`
- `pre-commit run --files agents/student_bots.py` *(fails: RPC 403 during fetch)*
- `pytest` *(fails: 32 errors during collection)*
- `npm test` *(fails: jest not found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b367f6aee8832988d69d1ccc24c724