### PR TITLE
test: ensure backend not found returns json

### DIFF
--- a/tests/backend-validation.test.js
+++ b/tests/backend-validation.test.js
@@ -53,7 +53,8 @@ test('returns json for not found routes', async () => {
   try {
     const res = await fetch(`http://127.0.0.1:${port}/nope`);
     assert.equal(res.status, 404);
-    assert.equal(res.headers.get('content-type'), 'application/json');
+    const contentType = res.headers.get('content-type') || '';
+    assert.ok(contentType.includes('application/json'));
     const body = await res.json();
     assert.equal(body.error, 'not found');
   } finally {


### PR DESCRIPTION
## Summary
- harden backend validation tests and confirm unknown routes return JSON `not found`
- verify 404 responses specify `application/json`
- loosen content-type assertion to allow additional charset information

## Testing
- `node tests/backend-validation.test.js`
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b367a21ec4832984c67c661b3674ca