### PR TITLE
feat: add basic entitlements hook and endpoint

### DIFF
--- a/srv/blackroad-api/server_full.js
+++ b/srv/blackroad-api/server_full.js
@@ -117,11 +117,25 @@ const PLAN_ENTITLEMENTS = {
       limits: { api: { qps: 5 } },
     },
   },
+  builder: {
+    planName: 'Builder',
+    entitlements: {
+      can: { math: { pro: true } },
+      limits: { api: { qps: 10 } },
+    },
+  },
   pro: {
     planName: 'Pro',
     entitlements: {
       can: { math: { pro: true } },
       limits: { api: { qps: 10 } },
+    },
+  },
+  guardian: {
+    planName: 'Guardian',
+    entitlements: {
+      can: { math: { pro: true } },
+      limits: { api: { qps: 20 } },
     },
   },
   enterprise: {


### PR DESCRIPTION
## Summary
- add basic plan-to-entitlements mapping on API and expose `/api/billing/entitlements/me`
- set default plan in session at login
- create `useEntitlements` React hook to query entitlements and provide helper methods
- include test coverage for entitlement endpoint
- align entitlements mapping with existing plan slugs

## Testing
- `npm test` *(fails: sh: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b36734040c83298f960b883024bc53