### PR TITLE
Add public hello page and assistant Keycloak user

### DIFF
--- a/ops/keycloak-realm.json
+++ b/ops/keycloak-realm.json
@@ -12,6 +12,11 @@
       "username": "admin",
       "enabled": true,
       "credentials": [{"type": "password", "value": "admin"}]
+    },
+    {
+      "username": "assistant",
+      "enabled": true,
+      "credentials": [{ "type": "password", "value": "assistant" }]
     }
   ]
 }

--- a/sites/blackroad/public/hello.html
+++ b/sites/blackroad/public/hello.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Hello | blackroad.io</title>
+  </head>
+  <body>
+    <h1>Hello, World!</h1>
+    <p><a href="/">Back to home</a></p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- move Hello World page into the public directory so it can be deployed
- register an `assistant` user in the Keycloak realm config

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint`
- `curl -I https://blackroad.io/hello.html`


------
https://chatgpt.com/codex/tasks/task_e_68b3653300048329a18a5ecb636102b6