### PR TITLE
fix: expand local working copy path

### DIFF
--- a/usr/local/bin/blackroad-deploy.sh
+++ b/usr/local/bin/blackroad-deploy.sh
@@ -16,7 +16,7 @@ set -Eeuo pipefail
 ### ──────────────────────────────
 ### Tunables (override via env)
 ### ──────────────────────────────
-WORKING_COPY_PATH="${WORKING_COPY_PATH:-~/blackroad-api}"     # path to repo on the working-copy host (or local path if WORKING_COPY_SSH=local)
+WORKING_COPY_PATH="${WORKING_COPY_PATH:-$HOME/blackroad-api}" # path to repo on the working-copy host (or local path if WORKING_COPY_SSH=local)
 SERVICE_NAME="${SERVICE_NAME:-blackroad-api}"                 # systemd or PM2 process name on droplet
 HEALTH_URL="${HEALTH_URL:-http://127.0.0.1:4000/api/health}"  # droplet-local health endpoint
 KEEP_RELEASES="${KEEP_RELEASES:-7}"                           # how many releases to keep
@@ -25,6 +25,9 @@ NPM_CI="${NPM_CI:-true}"                                      # run npm ci if pa
 DRY_RUN="${DRY_RUN:-false}"                                    # set true to preview rsync (no remote switch/restart)
 SSH_OPTS="${SSH_OPTS:- -o BatchMode=yes -o StrictHostKeyChecking=accept-new }"
 
+if [[ "$WORKING_COPY_SSH" == "local" ]]; then
+  WORKING_COPY_PATH="${WORKING_COPY_PATH/#\~/$HOME}"
+fi
 ### ──────────────────────────────
 ### Helpers
 ### ──────────────────────────────


### PR DESCRIPTION
## Summary
- expand default WORKING_COPY_PATH to use $HOME and resolve ~ when deploying locally

## Testing
- `pre-commit run --files usr/local/bin/blackroad-deploy.sh` *(fails: CalledProcessError: git fetch returned 128)*
- `shellcheck usr/local/bin/blackroad-deploy.sh`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b36882615c8329a96593ee74a93c7e