### PR TITLE
Track pinned SSH host fingerprints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,8 @@ rag/index/meta.json
 *.enc
 !secrets/README.md
 !secrets/*.env.example
+!secrets/hosts.json
+!secrets/known_hosts
 
 # Codex CI kit
 tests/_codex_autogen/

--- a/secrets/hosts.json
+++ b/secrets/hosts.json
@@ -1,0 +1,8 @@
+{
+  "159.65.43.12": "SHA256:b3uikwBkwnxpMTZjWBFaNgscsWXHRRG3Snj9QYke+ok=",
+  "blackroad.io": "SHA256:b3uikwBkwnxpMTZjWBFaNgscsWXHRRG3Snj9QYke+ok=",
+  "blackroadinc.us": "SHA256:b3uikwBkwnxpMTZjWBFaNgscsWXHRRG3Snj9QYke+ok=",
+  "bitbucket.org": "SHA256:FC73VB6C4OQLSCrjEayhMp9UMxS97caD/Yyi2bhW/J0=",
+  "github.com": "SHA256:p2QAMXNIC1TJYWeIOttrVc98/R1BUFWu3/LiyKgUfQM=",
+  "gitlab.com": "SHA256:HbW3g8zUjNSksFbqTiUWPWg2Bq1x8xdGUrliXFzSnUw="
+}


### PR DESCRIPTION
## Summary
- allow committing pinned SSH host files
- add hosts.json mapping for expected host key fingerprints

## Testing
- `python -m json.tool secrets/hosts.json`
- `python tools/pin_known_hosts.py` *(fails: Network is unreachable)*
- `pre-commit run --files .gitignore secrets/hosts.json` *(fails: CalledProcessError: git fetch origin --tags: 403)*


------
https://chatgpt.com/codex/tasks/task_e_68b37f1cc80883299faf4ac7c72b9959