### PR TITLE
Add Verizon LTE connectivity monitor

### DIFF
--- a/etc/default/verizon-check
+++ b/etc/default/verizon-check
@@ -1,0 +1,1 @@
+SLACK_WEBHOOK_URL="https://hooks.slack.com/services/XXX/YYY/ZZZ"

--- a/etc/systemd/system/verizon-check.service
+++ b/etc/systemd/system/verizon-check.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Check Verizon LTE connectivity
+
+[Service]
+Type=oneshot
+EnvironmentFile=/etc/default/verizon-check
+ExecStart=/usr/local/bin/verizon-check.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/etc/systemd/system/verizon-check.timer
+++ b/etc/systemd/system/verizon-check.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run Verizon LTE connectivity check every minute
+
+[Timer]
+OnBootSec=30s
+OnUnitActiveSec=1min
+Unit=verizon-check.service
+
+[Install]
+WantedBy=timers.target

--- a/usr/local/bin/verizon-check.sh
+++ b/usr/local/bin/verizon-check.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LOG_FILE="/var/log/verizon-check.log"
+STATE_FILE="/var/run/verizon-check.state"
+INTERFACE="vzw0"
+PING_HOST="8.8.8.8"
+COUNT=3
+TIMEOUT=3
+ENV_FILE="/etc/default/verizon-check"
+
+if [[ -f "$ENV_FILE" ]]; then
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+fi
+
+timestamp() {
+  date '+%Y-%m-%d %H:%M:%S'
+}
+
+check_conn() {
+  if command -v nmcli >/dev/null 2>&1; then
+    if nmcli -t -f DEVICE,STATE device status | grep -q "^${INTERFACE}:connected"; then
+      return 0
+    fi
+  fi
+  if command -v mmcli >/dev/null 2>&1; then
+    if mmcli -m 0 2>/dev/null | grep -qi 'state.*connected'; then
+      return 0
+    fi
+  fi
+  return 1
+}
+
+ping_test() {
+  ping -I "$INTERFACE" "$PING_HOST" -c "$COUNT" -W "$TIMEOUT" >/dev/null 2>&1
+}
+
+status="up"
+if [[ -f "$STATE_FILE" ]]; then
+  status=$(cat "$STATE_FILE")
+fi
+
+if ! check_conn || ! ping_test; then
+  sleep 2
+  if ! check_conn || ! ping_test; then
+    if [[ "$status" != "down" ]]; then
+      echo "VERIZON_DOWN $(timestamp)" >> "$LOG_FILE"
+      if [[ -n "${SLACK_WEBHOOK_URL:-}" ]]; then
+        curl -X POST -H 'Content-type: application/json' --data '{"text":":red_circle: Verizon LTE connection is down."}' "$SLACK_WEBHOOK_URL" >/dev/null 2>&1 || true
+      fi
+      echo "down" > "$STATE_FILE"
+    fi
+    exit 1
+  fi
+fi
+
+if [[ "$status" == "down" ]]; then
+  echo "VERIZON_RESTORED $(timestamp)" >> "$LOG_FILE"
+  if [[ -n "${SLACK_WEBHOOK_URL:-}" ]]; then
+    curl -X POST -H 'Content-type: application/json' --data '{"text":":white_check_mark: Verizon LTE connection restored."}' "$SLACK_WEBHOOK_URL" >/dev/null 2>&1 || true
+  fi
+fi
+
+echo "up" > "$STATE_FILE"
+exit 0

--- a/verizon-install.sh
+++ b/verizon-install.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+packages=()
+if ! command -v mmcli >/dev/null 2>&1; then
+  packages+=(modemmanager)
+fi
+if ! command -v nmcli >/dev/null 2>&1; then
+  packages+=(network-manager)
+fi
+if [[ ${#packages[@]} -gt 0 ]]; then
+  sudo apt-get update
+  sudo apt-get install -y "${packages[@]}"
+fi
+
+sudo install -m 755 usr/local/bin/verizon-check.sh /usr/local/bin/verizon-check.sh
+sudo install -m 644 etc/systemd/system/verizon-check.service /etc/systemd/system/verizon-check.service
+sudo install -m 644 etc/systemd/system/verizon-check.timer /etc/systemd/system/verizon-check.timer
+sudo install -m 644 etc/default/verizon-check /etc/default/verizon-check
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now verizon-check.timer


### PR DESCRIPTION
## Summary
- monitor Verizon LTE status with Slack alerts
- schedule monitoring via systemd timer running every minute
- add installer script for dependencies and setup

## Testing
- `bash -n usr/local/bin/verizon-check.sh verizon-install.sh`
- `systemd-analyze verify etc/systemd/system/verizon-check.service etc/systemd/system/verizon-check.timer` *(fails: Command /usr/local/bin/verizon-check.sh is not executable: No such file or directory)*
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3831943988329a3de0701d9892dfc