### PR TITLE
Add network connectivity watchdog

### DIFF
--- a/net-install.sh
+++ b/net-install.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${SLACK_WEBHOOK_URL:?SLACK_WEBHOOK_URL must be set}"
+
+install -m 755 usr/local/bin/network-watch.sh /usr/local/bin/network-watch.sh
+install -m 644 systemd/network-watch.service /etc/systemd/system/network-watch.service
+install -m 644 systemd/network-watch.timer /etc/systemd/system/network-watch.timer
+
+install -d /etc/default
+printf 'SLACK_WEBHOOK_URL="%s"\n' "$SLACK_WEBHOOK_URL" > /etc/default/network-watch
+
+systemctl daemon-reload
+systemctl enable --now network-watch.timer
+systemctl list-timers | grep network-watch || true
+
+echo "network-watch timer enabled"

--- a/systemd/network-watch.service
+++ b/systemd/network-watch.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Network connectivity watchdog
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=/etc/default/network-watch
+ExecStart=/bin/bash -c '/usr/local/bin/network-watch.sh 2>&1 | tee -a /var/log/netwatch.log'
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/network-watch.timer
+++ b/systemd/network-watch.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run network connectivity watchdog every minute
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=1min
+Unit=network-watch.service
+
+[Install]
+WantedBy=timers.target

--- a/usr/local/bin/network-watch.sh
+++ b/usr/local/bin/network-watch.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Return early if network is up
+if ping -c 3 -W 3 8.8.8.8 >/dev/null 2>&1; then
+  exit 0
+fi
+
+# Alert Slack about the outage
+curl -sS -X POST "$SLACK_WEBHOOK_URL" -H 'Content-type: application/json' \
+  --data '{"text":":rotating_light: Network outage detected — attempting auto-heal."}' || true
+
+for attempt in 1 2; do
+  systemctl restart systemd-networkd || true
+  ip addr flush dev eth0 && dhclient -v eth0
+  sleep 5
+  if ping -c 3 -W 3 8.8.8.8 >/dev/null 2>&1; then
+    ts=$(date -Is)
+    echo "NETWORK_RESTORED $ts"
+    curl -sS -X POST "$SLACK_WEBHOOK_URL" -H 'Content-type: application/json' \
+      --data "{\"text\":\":white_check_mark: Network restored at $ts.\"}" || true
+    exit 0
+  fi
+done
+
+ts=$(date -Is)
+echo "REBOOT $ts"
+curl -sS -X POST "$SLACK_WEBHOOK_URL" -H 'Content-type: application/json' \
+  --data '{"text":":rotating_light: Network still unreachable after auto-heal attempts. Rebooting."}' || true
+shutdown -r now


### PR DESCRIPTION
## Summary
- add network-watch script to detect and repair network outages
- provide systemd service and timer for periodic checks
- include installation helper script

## Testing
- `pre-commit run --files net-install.sh systemd/network-watch.service systemd/network-watch.timer usr/local/bin/network-watch.sh` *(fails: RPC failed; HTTP 403 curl 22)*

------
https://chatgpt.com/codex/tasks/task_e_68b38280b87c8329ab7ca54640152bef