### PR TITLE
Add Verizon LTE connectivity check with systemd timer

### DIFF
--- a/etc/default/verizon-check
+++ b/etc/default/verizon-check
@@ -1,0 +1,1 @@
+SLACK_WEBHOOK_URL="https://hooks.slack.com/services/XXX/YYY/ZZZ"

--- a/etc/systemd/system/verizon-check.service
+++ b/etc/systemd/system/verizon-check.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Verizon LTE connectivity check
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/verizon-check.sh
+EnvironmentFile=/etc/default/verizon-check
+
+[Install]
+WantedBy=multi-user.target

--- a/etc/systemd/system/verizon-check.timer
+++ b/etc/systemd/system/verizon-check.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run Verizon LTE connectivity check every minute
+
+[Timer]
+OnBootSec=30s
+OnUnitActiveSec=1min
+Unit=verizon-check.service
+
+[Install]
+WantedBy=timers.target

--- a/usr/local/bin/verizon-check.sh
+++ b/usr/local/bin/verizon-check.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEVICE=${DEVICE:-vzw0}
+PING_HOST=${PING_HOST:-8.8.8.8}
+LOG_FILE=/var/log/verizon-check.log
+STATE_DIR=/var/run/verizon-check
+STATE_FILE="$STATE_DIR/state"
+FAIL_FILE="$STATE_DIR/failcount"
+
+mkdir -p "$STATE_DIR" /var/log
+
+# Source environment variables if present
+if [ -f /etc/default/verizon-check ]; then
+  # shellcheck disable=SC1091
+  source /etc/default/verizon-check
+fi
+
+check_device() {
+  if command -v nmcli >/dev/null 2>&1; then
+    nmcli device status | awk -v dev="$DEVICE" '$1==dev {print $3}' | grep -q "connected"
+  elif command -v mmcli >/dev/null 2>&1; then
+    mmcli -m 0 | grep -q "state:.*connected"
+  else
+    return 0
+  fi
+}
+
+ping_test() {
+  ping -I "$DEVICE" "$PING_HOST" -c3 -W3 >/dev/null 2>&1
+}
+
+prev_state=$(cat "$STATE_FILE" 2>/dev/null || echo "unknown")
+fail_count=$(cat "$FAIL_FILE" 2>/dev/null || echo 0)
+
+if ! check_device || ! ping_test; then
+  fail_count=$((fail_count + 1))
+  echo "$fail_count" > "$FAIL_FILE"
+  if [ "$fail_count" -ge 2 ] && [ "$prev_state" != "down" ]; then
+    echo "VERIZON_DOWN $(date -Is)" >> "$LOG_FILE"
+    if [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
+      curl -s -X POST "$SLACK_WEBHOOK_URL" -H 'Content-type: application/json' \
+        --data '{"text":":red_circle: Verizon LTE connection is down."}' >/dev/null
+    fi
+    echo "down" > "$STATE_FILE"
+  fi
+else
+  if [ "$prev_state" = "down" ]; then
+    echo "VERIZON_RESTORED $(date -Is)" >> "$LOG_FILE"
+    if [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
+      curl -s -X POST "$SLACK_WEBHOOK_URL" -H 'Content-type: application/json' \
+        --data '{"text":":white_check_mark: Verizon LTE connection restored."}' >/dev/null
+    fi
+  fi
+  echo "up" > "$STATE_FILE"
+  echo 0 > "$FAIL_FILE"
+fi

--- a/verizon-install.sh
+++ b/verizon-install.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -e
+
+if ! command -v nmcli >/dev/null 2>&1; then
+  apt-get update && apt-get install -y network-manager
+fi
+if ! command -v mmcli >/dev/null 2>&1; then
+  apt-get update && apt-get install -y modemmanager
+fi
+
+install -Dm755 usr/local/bin/verizon-check.sh /usr/local/bin/verizon-check.sh
+install -Dm644 etc/systemd/system/verizon-check.service /etc/systemd/system/verizon-check.service
+install -Dm644 etc/systemd/system/verizon-check.timer /etc/systemd/system/verizon-check.timer
+install -Dm644 etc/default/verizon-check /etc/default/verizon-check
+
+systemctl daemon-reload
+systemctl enable --now verizon-check.timer


### PR DESCRIPTION
## Summary
- add `verizon-check.sh` to monitor LTE connection, log status, and notify Slack
- provide systemd service and timer to run check every minute
- include environment file and installer script

## Testing
- `systemd-analyze verify etc/systemd/system/verizon-check.service etc/systemd/system/verizon-check.timer`
- `systemd-analyze calendar "*:0/1"`
- `/usr/local/bin/verizon-check.sh` (twice to trigger down, then simulated restore)
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b38306f33c832988cb4c2055093c47