### PR TITLE
chore: keep numpy compatible with Python 3.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ anthropic
 boto3
 fastapi
 matplotlib==3.9.4
-numpy==1.25.2
+numpy==1.26.4
 openai==1.30.1
 pydantic
 pyarrow==16.1.0


### PR DESCRIPTION
## Summary
- revert numpy pin to 1.26.4 to retain Python 3.12 wheel support

## Testing
- `pip install --dry-run -r requirements.txt`
- `pre-commit run --files requirements.txt` *(fails: git fetch 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b38cab1b688329b493dc05e3594583