### PR TITLE
test: clear metrics interval for API smoke tests

### DIFF
--- a/srv/blackroad-api/server_full.js
+++ b/srv/blackroad-api/server_full.js
@@ -664,7 +664,7 @@ app.post('/api/actions/mint', requireAuth, (req, res) => {
 io.on('connection', (socket) => {
   socket.emit('hello', { ok: true, t: Date.now() });
 });
-setInterval(() => {
+const metricsInterval = setInterval(() => {
   const total = os.totalmem(), free = os.freemem();
   const payload = {
     t: Date.now(),
@@ -685,4 +685,4 @@ server.listen(PORT, () => {
 process.on('unhandledRejection', (e) => console.error('UNHANDLED', e));
 process.on('uncaughtException', (e) => console.error('UNCAUGHT', e));
 
-module.exports = { app, server };
+module.exports = { app, server, io, metricsInterval };

--- a/tests/api_health.test.js
+++ b/tests/api_health.test.js
@@ -3,10 +3,17 @@ process.env.INTERNAL_TOKEN = 'x';
 process.env.ALLOW_ORIGINS = 'https://example.com';
 process.env.DB_PATH = ':memory:';
 const request = require('supertest');
-const { app, server } = require('../srv/blackroad-api/server_full.js');
+const {
+  app,
+  server,
+  io,
+  metricsInterval,
+} = require('../srv/blackroad-api/server_full.js');
 
 describe('API smoke tests', () => {
   afterAll((done) => {
+    clearInterval(metricsInterval);
+    io.close();
     server.close(done);
   });
 


### PR DESCRIPTION
## Summary
- expose `io` and metrics interval handle from API server for cleanup
- clear metrics interval and close Socket.IO in API smoke test

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b38cfc74208329a24981da7f01ed64