### PR TITLE
Allow verizon-check connectivity checks to fail without exiting

### DIFF
--- a/usr/local/bin/verizon-check.sh
+++ b/usr/local/bin/verizon-check.sh
@@ -18,16 +18,28 @@ fi
 
 check_device() {
   if command -v nmcli >/dev/null 2>&1; then
+    set +e
     nmcli device status | awk -v dev="$DEVICE" '$1==dev {print $3}' | grep -q "connected"
+    status=$?
+    set -e
+    return $status
   elif command -v mmcli >/dev/null 2>&1; then
+    set +e
     mmcli -m 0 | grep -q "state:.*connected"
+    status=$?
+    set -e
+    return $status
   else
     return 0
   fi
 }
 
 ping_test() {
+  set +e
   ping -I "$DEVICE" "$PING_HOST" -c3 -W3 >/dev/null 2>&1
+  status=$?
+  set -e
+  return $status
 }
 
 prev_state=$(cat "$STATE_FILE" 2>/dev/null || echo "unknown")


### PR DESCRIPTION
## Summary
- prevent nmcli/mmcli and ping failures from exiting verizon-check

## Testing
- `bash -n usr/local/bin/verizon-check.sh`
- `DEVICE=lo PING_HOST=192.0.2.1 usr/local/bin/verizon-check.sh && echo 'script ran'`
- `DEVICE=lo PING_HOST=127.0.0.1 usr/local/bin/verizon-check.sh && echo 'script succeeded'`
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b38be5cd188329acd799a9889683b7