### PR TITLE
fix: avoid condor dependency for dummy algebraic solves

### DIFF
--- a/lucidia/engines/condor_engine.py
+++ b/lucidia/engines/condor_engine.py
@@ -109,9 +109,14 @@ def solve_algebraic(model_cls: Type[Any], **params: Any) -> Any:
     """Instantiate ``model_cls`` and call its ``solve`` method.
 
     The returned object is converted to basic Python types so that it is
-    easy to serialise to JSON.  The function does not require the real
-    Condor dependency which keeps unit tests lightweight.
+    easy to serialise to JSON.  When the real Condor library is absent,
+    models that originate from the ``condor`` package cannot be
+    instantiated and a :class:`RuntimeError` is raised.  User supplied
+    models remain supported even without Condor installed.
     """
+
+    if condor is None and model_cls.__module__.split(".")[0] == "condor":
+        raise RuntimeError("Condor is not installed")
 
     model = model_cls(**params)
     result = model.solve() if hasattr(model, "solve") else model

--- a/tests/test_condor_engine.py
+++ b/tests/test_condor_engine.py
@@ -24,6 +24,18 @@ def test_solve_algebraic_with_dummy():
     assert result == {"x": 1}
 
 
+def test_solve_algebraic_requires_condor_for_real_models(monkeypatch):
+    class FakeCondorModel:
+        def solve(self):
+            return {"x": 1}
+
+    FakeCondorModel.__module__ = "condor.fake"
+
+    monkeypatch.setattr(condor_engine, "condor", None)
+    with pytest.raises(RuntimeError, match="Condor is not installed"):
+        condor_engine.solve_algebraic(FakeCondorModel)
+
+
 def test_validate_model_source_allows_basic_imports():
     src = """
 import math


### PR DESCRIPTION
## Summary
- raise RuntimeError only when condor models are used without Condor installed
- test that solve_algebraic still works for dummy models and errors for real ones

## Testing
- `pytest tests/test_condor_engine.py::test_solve_algebraic_with_dummy tests/test_condor_engine.py::test_solve_algebraic_requires_condor_for_real_models -q`


------
https://chatgpt.com/codex/tasks/task_e_68b38c4881cc8329b98953e2c4bde9c7