### PR TITLE
harden API and add smoke tests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,2 @@
-<!-- FILE: .eslintignore -->
 node_modules
 _trash

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-# <!-- FILE: .gitignore -->
 # Sensitive SSH keys
 sshprivate.sh
 publicssh.sh

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,3 @@
-<!-- FILE: .prettierignore -->
 node_modules/
 dist/
 build/

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,4 +1,3 @@
-<!-- FILE: /srv/blackroad-api/DECISIONS.md -->
 # Decisions
 
 - Implemented a minimal `br-fix` CLI under `srv/blackroad-tools/br-fix` handling scan, apply, and test commands.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,3 @@
-<!-- FILE: jest.config.js -->
 module.exports = {
   testEnvironment: 'node',
   verbose: true,

--- a/scripts/health.js
+++ b/scripts/health.js
@@ -1,4 +1,3 @@
-<!-- FILE: scripts/health.js -->
 const http = require('http');
 const port = process.env.PORT || 4000;
 const req = http.request({ hostname: '127.0.0.1', port, path: '/api/health', method: 'GET' }, (res) => {

--- a/srv/blackroad-api/server_full.js
+++ b/srv/blackroad-api/server_full.js
@@ -1,4 +1,3 @@
-<!-- FILE: srv/blackroad-api/server_full.js -->
 /* BlackRoad API — Express + SQLite + Socket.IO + LLM bridge
    Runs behind Nginx on port 4000 with cookie-session auth.
    Env (optional):

--- a/tests/lucidia_llm_stub_test.py
+++ b/tests/lucidia_llm_stub_test.py
@@ -1,4 +1,3 @@
-# <!-- FILE: tests/lucidia_llm_stub_test.py -->
 from importlib.machinery import SourceFileLoader
 from fastapi.testclient import TestClient
 


### PR DESCRIPTION
## Summary
- remove leftover file-marker comments from config files, health script, server, Jest config, and Python smoke test

## Testing
- `npm test` (fails: jest not installed)
- `pip install -r srv/lucidia-llm/requirements.txt`
- `pytest tests/lucidia_llm_stub_test.py`


------
https://chatgpt.com/codex/tasks/task_e_68b38c88512483299c5147716901097f