### PR TITLE
fix(agent): isolate supported engines per instance

### DIFF
--- a/agents/auto_novel_agent.py
+++ b/agents/auto_novel_agent.py
@@ -1,7 +1,6 @@
 """Simple auto novel agent example with game creation abilities."""
 
-from dataclasses import dataclass
-from typing import ClassVar, List
+from dataclasses import dataclass, field
 
 
 @dataclass
@@ -9,7 +8,9 @@ class AutoNovelAgent:
     """A toy agent that can deploy itself and create simple games."""
 
     name: str = "AutoNovelAgent"
-    SUPPORTED_ENGINES: ClassVar[set[str]] = {"unity", "unreal"}
+    supported_engines: set[str] = field(
+        default_factory=lambda: {"unity", "unreal"}
+    )
 
     def deploy(self) -> None:
         """Deploy the agent by printing a greeting."""
@@ -24,16 +25,16 @@ class AutoNovelAgent:
                 allowed.
         """
         engine_lower = engine.lower()
-        if engine_lower not in self.SUPPORTED_ENGINES:
-            supported = ", ".join(sorted(self.SUPPORTED_ENGINES))
+        if engine_lower not in self.supported_engines:
+            supported = ", ".join(sorted(self.supported_engines))
             raise ValueError(f"Unsupported engine. Choose one of: {supported}.")
         if include_weapons:
             raise ValueError("Weapons are not allowed in generated games.")
         print(f"Creating a {engine_lower.capitalize()} game without weapons...")
 
-    def list_supported_engines(self) -> List[str]:
+    def list_supported_engines(self) -> list[str]:
         """Return a list of supported game engines."""
-        return sorted(self.SUPPORTED_ENGINES)
+        return sorted(self.supported_engines)
 
     def add_engine(self, engine: str) -> None:
         """Add a new game engine to the supported set.
@@ -47,9 +48,9 @@ class AutoNovelAgent:
         engine_lower = engine.strip().lower()
         if not engine_lower:
             raise ValueError("Engine name cannot be empty.")
-        if engine_lower in self.SUPPORTED_ENGINES:
+        if engine_lower in self.supported_engines:
             raise ValueError("Engine already supported.")
-        self.SUPPORTED_ENGINES.add(engine_lower)
+        self.supported_engines.add(engine_lower)
 
 
 if __name__ == "__main__":

--- a/tests/test_auto_novel_agent.py
+++ b/tests/test_auto_novel_agent.py
@@ -35,3 +35,11 @@ def test_add_engine():
         agent.add_engine("godot")
     with pytest.raises(ValueError):
         agent.add_engine("")
+
+
+def test_add_engine_is_instance_scoped():
+    agent_one = AutoNovelAgent()
+    agent_two = AutoNovelAgent()
+    agent_one.add_engine("godot")
+    assert "godot" in agent_one.list_supported_engines()
+    assert "godot" not in agent_two.list_supported_engines()


### PR DESCRIPTION
## Summary
- store supported engines per AutoNovelAgent instance
- test that engine registration doesn't leak across instances

## Testing
- `ruff check agents/auto_novel_agent.py tests/test_auto_novel_agent.py`
- `python -m py_compile agents/auto_novel_agent.py tests/test_auto_novel_agent.py`
- `python agents/auto_novel_agent.py`
- `pytest tests/test_auto_novel_agent.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3a60547a48329a774345ca00a93ae