### PR TITLE
chore: resolve gitignore merge conflicts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,13 +3,12 @@ sshprivate.sh
 publicssh.sh
 
 # Node
-node_modules/
+# Exclude Node.js dependencies everywhere
 **/node_modules/
 dist/
 .cache/
 .env
-services/*/node_modules/
-services/health-sidecar/node_modules/
+# Ignore environment files for the health sidecar service
 services/health-sidecar/.env
 
 # Logs
@@ -34,7 +33,6 @@ repos/
 runtime/
 __pycache__/
 codex/runtime/
-/benchmarks/
 benchmarks/
 
 # Lucidia artifacts


### PR DESCRIPTION
## Summary
- consolidate Node.js ignores and remove duplicate patterns from `.gitignore`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'libcst')*
- `pre-commit run --files .gitignore` *(fails: CalledProcessError: git fetch 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a62a2c0c83298bfec103ac16f157