### PR TITLE
chore: use flat eslint config

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "nodemon server_full.js",
     "seed": "node scripts/seed_admin.js",
     "prepare": "husky",
-    "lint": "eslint . --ext .js,.jsx,.mjs,.cjs || true",
+    "lint": "eslint . --ext .js,.jsx,.mjs,.cjs",
     "format": "prettier -w .",
     "test": "cross-env NODE_ENV=test jest --runInBand",
     "test-db": "node tests/test_db.js",

--- a/sites/blackroad/eslint.config.cjs
+++ b/sites/blackroad/eslint.config.cjs
@@ -1,4 +1,4 @@
-export default [
+module.exports = [
   {
     ignores: [
       "node_modules/",

--- a/sites/blackroad/package.json
+++ b/sites/blackroad/package.json
@@ -8,7 +8,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "lint": "eslint . --ext .js,.jsx,.ts,.tsx || true",
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "format": "prettier -w .",
     "test": "echo \"(add Playwright later)\"",
     "e2e": "playwright test || true"

--- a/sites/blackroad/src/App.jsx
+++ b/sites/blackroad/src/App.jsx
@@ -1,5 +1,4 @@
 import { NavLink, Routes, Route } from "react-router-dom";
-import { useEffect, useState } from "react";
 import Chat from "./pages/Chat.jsx";
 import Canvas from "./pages/Canvas.jsx";
 import Editor from "./pages/Editor.jsx";


### PR DESCRIPTION
## Summary
- convert site eslint config to CommonJS flat config
- drop "|| true" from lint scripts
- remove duplicate React hook import in App.jsx

## Testing
- `npm test`
- `npm run lint` (fails: 388 problems, 116 errors, 272 warnings)
- `npm --prefix sites/blackroad run lint`
- `npm --prefix sites/blackroad test`


------
https://chatgpt.com/codex/tasks/task_e_68b3a61b2908832996c03c9367bbce76