### PR TITLE
Clarify ssh-keygen output comments

### DIFF
--- a/codex/tools/codex_repo_wizard.py
+++ b/codex/tools/codex_repo_wizard.py
@@ -99,7 +99,7 @@ def fp_of_line(line):
     p = subprocess.run(["ssh-keygen","-lf","-"], input=line+"\n", capture_output=True, text=True)
     if p.returncode != 0: return None
     parts = p.stdout.strip().split()
-    return parts[1] if len(parts) >= 2 else None  # "bits SHA256:... type comment"
+    return parts[1] if len(parts) >= 2 else None  # output: "bits SHA256:... (TYPE) host"
 
 def pin_known_hosts(host_map):
     ensure_dir(KNOWN_HOSTS_PATH.parent)

--- a/tools/pin_known_hosts.py
+++ b/tools/pin_known_hosts.py
@@ -21,7 +21,7 @@ def fp_of_line(line):
     p = subprocess.run(["ssh-keygen","-lf","-"], input=line+"\n",
                        capture_output=True, text=True)
     if p.returncode != 0: return None
-    # Example: "2048 SHA256:abcdef... type comment"
+    # Example output: "2048 SHA256:abcdef... (ED25519) host"
     parts = p.stdout.strip().split()
     return parts[1] if len(parts) >= 2 else None
 


### PR DESCRIPTION
## Summary
- clarify example output in pinned host comment
- align repo wizard comment with ssh-keygen output format

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b3a770ee5883299417458accdd880d