### PR TITLE
chore: clarify ssh-keygen comment

### DIFF
--- a/codex/tools/codex_repo_wizard.py
+++ b/codex/tools/codex_repo_wizard.py
@@ -99,7 +99,8 @@ def fp_of_line(line):
     p = subprocess.run(["ssh-keygen","-lf","-"], input=line+"\n", capture_output=True, text=True)
     if p.returncode != 0: return None
     parts = p.stdout.strip().split()
-    return parts[1] if len(parts) >= 2 else None  # "bits SHA256:... type comment"
+    # ssh-keygen -lf output: "<bits> SHA256:<fingerprint> <comment> [type]"
+    return parts[1] if len(parts) >= 2 else None
 
 def pin_known_hosts(host_map):
     ensure_dir(KNOWN_HOSTS_PATH.parent)


### PR DESCRIPTION
## Summary
- clarify `ssh-keygen` output comment in codex repo wizard

## Testing
- `python -m py_compile codex/tools/codex_repo_wizard.py`
- `pytest codex/tools -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4c0647f5c8329bcb1d9ec7f8d298d