### PR TITLE
Fix ssh-keygen comment examples

### DIFF
--- a/codex/tools/codex_repo_wizard.py
+++ b/codex/tools/codex_repo_wizard.py
@@ -99,7 +99,7 @@ def fp_of_line(line):
     p = subprocess.run(["ssh-keygen","-lf","-"], input=line+"\n", capture_output=True, text=True)
     if p.returncode != 0: return None
     parts = p.stdout.strip().split()
-    return parts[1] if len(parts) >= 2 else None  # output: "bits SHA256:... (TYPE) host"
+    return parts[1] if len(parts) >= 2 else None  # output: "bits SHA256:... host (TYPE)"
 
 def pin_known_hosts(host_map):
     ensure_dir(KNOWN_HOSTS_PATH.parent)

--- a/tools/pin_known_hosts.py
+++ b/tools/pin_known_hosts.py
@@ -21,7 +21,7 @@ def fp_of_line(line):
     p = subprocess.run(["ssh-keygen","-lf","-"], input=line+"\n",
                        capture_output=True, text=True)
     if p.returncode != 0: return None
-    # Example output: "2048 SHA256:abcdef... (ED25519) host"
+    # Example output: "256 SHA256:abcdef... host (ED25519)"
     parts = p.stdout.strip().split()
     return parts[1] if len(parts) >= 2 else None
 


### PR DESCRIPTION
## Summary
- correct ssh-keygen output comments in host pinning scripts

## Testing
- `pre-commit run --files codex/tools/codex_repo_wizard.py tools/pin_known_hosts.py` *(fails: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags') return code: 128 stdout: (none) stderr: error: RPC failed; HTTP 403 curl 22 The requested URL returned error: 403; fatal: expected flush after ref listing)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c0744ed88329aaab4bbd1d641b20