### PR TITLE
Add skeleton analysis scripts and documentation

### DIFF
--- a/analysis/nphase_weierstrass.py
+++ b/analysis/nphase_weierstrass.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+# # N-phase Cancellation & Weierstrass Scaling
+# 
+# Notebook for N-phase cancellation and Weierstrass scaling plots.
+
+# In[ ]:
+
+
+import pandas as pd
+import matplotlib.pyplot as plt
+
+# TODO: implement analysis

--- a/analysis/selectors_autocorr.py
+++ b/analysis/selectors_autocorr.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+# # Selector Tests & Autocorrelation
+# 
+# Selector ablations and ACF contrasts.
+
+# In[ ]:
+
+
+import pandas as pd
+import matplotlib.pyplot as plt
+
+# TODO: implement analysis

--- a/analysis/tap_null_isi.py
+++ b/analysis/tap_null_isi.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+# # Tap-Null ISI
+# 
+# Regenerate Tap-Null vs base plots from raw data.
+
+# In[ ]:
+
+
+import pandas as pd
+import matplotlib.pyplot as plt
+
+# TODO: implement analysis

--- a/analysis/variance_surfaces.py
+++ b/analysis/variance_surfaces.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+# # Variance Surfaces
+# 
+# Trinary/quaternary variance heatmaps with closed-form check.
+
+# In[ ]:
+
+
+import pandas as pd
+import matplotlib.pyplot as plt
+
+# TODO: implement analysis

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,8 @@
+# Agents
+
+The research pipeline relies on lightweight agents to orchestrate analyses and data generation.
+
+* Agents trigger the scripts in `analysis/` to regenerate figures as needed.
+* Each agent has a narrow responsibility and communicates through the filesystem.
+* See `agents/` for implementation details.
+

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,8 @@
+# Architecture
+
+This document outlines the structure of the research pipeline used in this repository.
+
+* **Analysis scripts** live in `analysis/` and can be run as standalone Python modules.
+* Each script reads raw experiment data and produces figures or tables consumed by the wider project.
+* Supporting utilities and shared components are kept minimal so that analyses remain transparent.
+


### PR DESCRIPTION
## Summary
- add placeholder Python scripts for Tap-Null ISI, selector autocorrelation, variance surfaces, and N-phase Weierstrass analyses
- document repository architecture and agent orchestration

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68b543a9ec1c8329a8dfebaff86080d7