### PR TITLE
feat: add ops runbooks and diagnostics

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,10 +1,7 @@
 title = "BlackRoad Secrets Policy"
 
-[[rules]]
-id = "generic-api-key"
-description = "Generic API key"
-regex = '''(?i)(api[_-]?key|secret|token)\s*[:=]\s*['"][0-9a-zA-Z_\-]{16,}['"]'''
-entropy = 3.5
+[extend]
+useDefault = true
 
 [allowlist]
 description = "Allow non-secret test fixtures"


### PR DESCRIPTION
## Summary
- extend `.gitleaks.toml` to include gitleaks' default rule set while keeping project allowlist

## Testing
- ⚠️ `pre-commit run --files .gitleaks.toml requirements.txt` (CalledProcessError 128: HTTP 403 fetching hooks)
- ❌ `gitleaks detect --verbose` (leaks found: 9)


------
https://chatgpt.com/codex/tasks/task_e_68b6609014d08329858416a3d5e3c457