### PR TITLE
chore: add robust droplet deploy script

### DIFF
--- a/usr/local/bin/blackroad-deploy.sh
+++ b/usr/local/bin/blackroad-deploy.sh
@@ -26,7 +26,7 @@ DRY_RUN="${DRY_RUN:-false}"                                    # set true to pre
 SSH_OPTS="${SSH_OPTS:- -o BatchMode=yes -o StrictHostKeyChecking=accept-new }"
 
 if [[ "$WORKING_COPY_SSH" == "local" ]]; then
-  WORKING_COPY_PATH="${WORKING_COPY_PATH/#\~/$HOME}"
+  WORKING_COPY_PATH="${WORKING_COPY_PATH/#~/$HOME}"
 fi
 ### ──────────────────────────────
 ### Helpers


### PR DESCRIPTION
## Summary
- ensure local deploy uses expanded working-copy path when `WORKING_COPY_SSH` is `local`

## Testing
- ⚠️ `pre-commit run --files usr/local/bin/blackroad-deploy.sh` (error: RPC failed; HTTP 403)
- ✅ `shellcheck usr/local/bin/blackroad-deploy.sh`
- ⚠️ `npm test` (jest: not found)


------
https://chatgpt.com/codex/tasks/task_e_68b660de75c88329a180708490690d8b