### PR TITLE
fix: handle quotes in remote_bash deploy helper

### DIFF
--- a/usr/local/bin/blackroad-deploy.sh
+++ b/usr/local/bin/blackroad-deploy.sh
@@ -47,7 +47,8 @@ rsh() { ssh $SSH_OPTS "$DROPLET_SSH" "$@"; }
 remote_bash() {
   # Run a bash -lc command on droplet (ensures login semantics for PATH)
   local cmd="$1"
-  rsh "bash -lc '$cmd'"
+  # Avoid wrapping in single quotes to prevent quoting conflicts with caller-provided strings
+  rsh bash -lc "$cmd"
 }
 
 require_cmd() {


### PR DESCRIPTION
## Summary
- avoid wrapping remote command in single quotes to prevent quoting conflicts in deploy helper

## Testing
- `npm test` (fails: jest not found)
- `npm ci` (warn: Unknown env config "http-proxy"; terminated)


------
https://chatgpt.com/codex/tasks/task_e_68b661a9cfe88329be5ad38b6032ec5b