### PR TITLE
docs: document AutoNovelAgent errors

### DIFF
--- a/agents/auto_novel_agent.py
+++ b/agents/auto_novel_agent.py
@@ -22,6 +22,9 @@ class AutoNovelAgent:
             engine: Game engine to use.
             include_weapons: If True, raise a ``ValueError`` because weapons are not
                 allowed.
+
+        Raises:
+            ValueError: If the engine is unsupported or weapons are included.
         """
         engine_lower = engine.lower()
         if engine_lower not in self.SUPPORTED_ENGINES:


### PR DESCRIPTION
## Summary
- document AutoNovelAgent's error conditions in create_game docstring

## Testing
- `python -m py_compile *.py` (fails: cleanup_bot.py syntax error)
- `python -m py_compile agents/auto_novel_agent.py`
- `python auto_novel_agent.py`
- `npm run lint` (fails: SyntaxError: Cannot use import statement outside a module)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b666faf3e483298478c5f7001cb7a9