### PR TITLE
fix: apply review feedback for roadview scaffolding

### DIFF
--- a/db/migrations/0003_roadview.sql
+++ b/db/migrations/0003_roadview.sql
@@ -66,18 +66,6 @@ CREATE INDEX IF NOT EXISTS roadview_jobs_type_idx ON roadview_jobs(type);
 CREATE INDEX IF NOT EXISTS roadview_jobs_status_idx ON roadview_jobs(status);
 CREATE INDEX IF NOT EXISTS roadview_jobs_created_idx ON roadview_jobs(created_at);
 
-CREATE TABLE IF NOT EXISTS rc_charges (
-  id TEXT PRIMARY KEY,
-  user_id TEXT,
-  project_id TEXT,
-  job_id TEXT,
-  amount INTEGER,
-  reason TEXT,
-  created_at INTEGER
-);
-CREATE INDEX IF NOT EXISTS rc_charges_user_idx ON rc_charges(user_id);
-CREATE INDEX IF NOT EXISTS rc_charges_project_idx ON rc_charges(project_id);
-
 CREATE VIEW IF NOT EXISTS roadview_project_summary_v AS
 SELECT
   p.id,

--- a/server_full.js
+++ b/server_full.js
@@ -77,7 +77,9 @@ app.use(limiter);
 const db = require('./src/db');
 
 // ROADVIEW
-const ROADVIEW_STORAGE = path.join(__dirname, 'srv', 'blackroad-api', 'storage', 'roadview');
+const ROADVIEW_STORAGE = process.env.ROADVIEW_STORAGE
+  ? path.resolve(process.env.ROADVIEW_STORAGE)
+  : path.join(__dirname, 'srv', 'blackroad-api', 'storage', 'roadview');
 try {
   fs.mkdirSync(path.join(ROADVIEW_STORAGE, 'projects'), { recursive: true });
 } catch {}


### PR DESCRIPTION
## Summary
- allow ROADVIEW_STORAGE override via environment variable
- drop unused rc_charges table from migration

## Testing
- `pre-commit run --files server_full.js db/migrations/0003_roadview.sql` *(fails: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags'))*
- `npm test` *(fails: Invalid package.json)*
- `node tests/smoke.test.js` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npx eslint server_full.js` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68b666b2bfd4832993800fb23d49e431