### PR TITLE
chore: log roadview storage errors

### DIFF
--- a/server_full.js
+++ b/server_full.js
@@ -82,7 +82,9 @@ const ROADVIEW_STORAGE = process.env.ROADVIEW_STORAGE
   : path.join(__dirname, 'srv', 'blackroad-api', 'storage', 'roadview');
 try {
   fs.mkdirSync(path.join(ROADVIEW_STORAGE, 'projects'), { recursive: true });
-} catch {}
+} catch (err) {
+  console.error('Failed to ensure RoadView storage directory', err);
+}
 app.use(
   '/files/roadview',
   express.static(ROADVIEW_STORAGE, { index: false, fallthrough: false })


### PR DESCRIPTION
## Summary
- log failure when creating the RoadView storage directory

## Testing
- ⚠️ `pre-commit run --files server_full.js db/migrations/0003_roadview.sql srv/blackroad-api/storage/roadview/.gitkeep srv/blackroad-api/storage/roadview/projects/.gitkeep` *(CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags'))*
- ❌ `npm test` *(Invalid package.json: JSONParseError)*
- ❌ `node tests/smoke.test.js` *(SyntaxError: Cannot use import statement outside a module)*
- ❌ `npx eslint server_full.js` *(ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68b669cda26c8329b754c6b891e16ad0