### PR TITLE
Add Python bot tests

### DIFF
--- a/agents/cleanup_bot.py
+++ b/agents/cleanup_bot.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import subprocess
 from dataclasses import dataclass
 from subprocess import CalledProcessError
-from typing import Dict, List
 
 
 @dataclass
@@ -17,7 +16,7 @@ class CleanupBot:
         dry_run: If ``True``, print commands instead of executing them.
     """
 
-    branches: List[str]
+    branches: list[str]
     dry_run: bool = False
 
     def _run(self, *cmd: str) -> None:
@@ -28,7 +27,11 @@ class CleanupBot:
         subprocess.run(cmd, check=True)
 
     def delete_branch(self, branch: str) -> bool:
-        """Delete a branch locally and remotely."""
+        """Delete a branch locally and remotely.
+
+        Returns:
+            ``True`` if both deletions succeed, ``False`` otherwise.
+        """
         try:
             self._run("git", "branch", "-D", branch)
             self._run("git", "push", "origin", "--delete", branch)
@@ -36,9 +39,13 @@ class CleanupBot:
         except CalledProcessError:
             return False
 
-    def cleanup(self) -> Dict[str, bool]:
-        """Remove the configured branches locally and remotely."""
-        results: Dict[str, bool] = {}
+    def cleanup(self) -> dict[str, bool]:
+        """Remove the configured branches locally and remotely.
+
+        Returns:
+            Mapping of branch names to a boolean indicating success.
+        """
+        results: dict[str, bool] = {}
         for branch in self.branches:
             results[branch] = self.delete_branch(branch)
         return results


### PR DESCRIPTION
## Summary
- repair CleanupBot implementation
- add unit tests for AutoNovelAgent
- add import tests for all bot modules
- modernize CleanupBot type hints and docstrings

## Testing
- `python -m py_compile agents/cleanup_bot.py tests/test_auto_novel_agent.py tests/test_bots_import.py`
- `python agents/auto_novel_agent.py`
- `ruff check agents/cleanup_bot.py tests/test_auto_novel_agent.py tests/test_bots_import.py`
- `pytest tests/test_auto_novel_agent.py tests/test_bots_import.py`
- `npm test`
- `npm run lint` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68b66a17d2448329a5f02a1e551a2ce8