### PR TITLE
Fix local setup script: remove duplicate pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,15 +5,6 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
-  - repo: https://github.com/psf/black
-    rev: 24.4.2
-    hooks: [{ id: black }]
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
-    hooks:
-      - id: trailing-whitespace
-      - id: end-of-file-fixer
-      - id: check-yaml
       - id: check-json
       - id: check-merge-conflict
       - id: forbid-new-submodules
@@ -41,9 +32,3 @@ repos:
       - id: eslint
         args: ["--fix"]
         files: "\\.(js|jsx|ts|tsx)$"
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
-    hooks:
-      - id: trailing-whitespace
-      - id: end-of-file-fixer
-      - id: check-yaml


### PR DESCRIPTION
## Summary
- deduplicate entries in `.pre-commit-config.yaml` so each hook repo is defined once

## Testing
- `shellcheck scripts/setup_local.sh`
- `pre-commit run --files scripts/setup_local.sh` *(fails: RPC 403 when fetching repo)*
- `pytest tests/test_tokenize_url.py`


------
https://chatgpt.com/codex/tasks/task_e_68b66a0c5dac832982843c97aebce9ca