### PR TITLE
chore: log ignored roadchain and auth errors

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -36,7 +36,10 @@ export default function App(){
           await bootData()
           connectSocket()
         }
-      } catch(e){ /* User not authenticated; ignore error */ }
+      } catch(e){
+        // User not authenticated; log for debugging but otherwise ignore
+        console.warn('User not authenticated', e)
+      }
     })()
   }, [])
 

--- a/frontend/src/components/RoadChain.jsx
+++ b/frontend/src/components/RoadChain.jsx
@@ -13,7 +13,10 @@ export default function RoadChain(){
       try{
         const b = await fetchBlocks()
         setBlocks(b)
-      }catch(e){ /* Ignore errors when fetching initial blocks */ }
+      }catch(e){
+        // Ignore errors when fetching initial blocks but log for diagnostics
+        console.warn('Failed to fetch initial blocks', e)
+      }
     })()
   }, [])
 


### PR DESCRIPTION
## Summary
- log unauthenticated bootstrap failures for easier debugging
- warn when RoadChain explorer fails to fetch initial blocks

## Testing
- `npm --prefix backend test`
- `npm --prefix frontend test`
- `npm --prefix frontend run build`
- `curl -v http://localhost:4000/api/roadchain/blocks` *(fails: Couldn't connect to server)*
- `curl -v http://localhost:4000/api/roadchain/block/0xdef456` *(fails: Couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_68b669c1d2fc8329abd3a2adf7089470