### PR TITLE
feat: add codex pipeline cli

### DIFF
--- a/tests/test_codex_pipeline_connectors.py
+++ b/tests/test_codex_pipeline_connectors.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 import pytest
 
@@ -6,10 +6,10 @@ from tools.codex_pipeline import call_connectors
 
 
 class DummyResponse:
-    def __init__(self, data: Dict[str, Any]):
+    def __init__(self, data: dict[str, Any]):
         self._data = data
 
-    def json(self) -> Dict[str, Any]:
+    def json(self) -> dict[str, Any]:
         return self._data
 
     def raise_for_status(self) -> None:  # pragma: no cover - simple stub
@@ -18,10 +18,10 @@ class DummyResponse:
 
 @pytest.mark.parametrize("action", ["paste", "append", "replace", "restart", "build"])
 def test_call_connectors(monkeypatch: pytest.MonkeyPatch, action: str) -> None:
-    called: Dict[str, Any] = {}
+    called: dict[str, Any] = {}
 
     def fake_post(
-        url: str, *, headers: Dict[str, str], json: Dict[str, Any], timeout: int
+        url: str, *, headers: dict[str, str], json: dict[str, Any], timeout: int
     ) -> DummyResponse:
         called["url"] = url
         called["headers"] = headers

--- a/tests/test_codex_pipeline_validation.py
+++ b/tests/test_codex_pipeline_validation.py
@@ -54,8 +54,8 @@ def test_skip_validate(monkeypatch):
         return {}
 
     monkeypatch.setattr(pipeline, "validate_services", fake_validate)
-    monkeypatch.setattr(pipeline, "push_latest", lambda: None)
-    monkeypatch.setattr(pipeline, "redeploy_droplet", lambda: None)
+    monkeypatch.setattr(pipeline, "push_latest", lambda dry_run=False: None)
+    monkeypatch.setattr(pipeline, "redeploy_droplet", lambda dry_run=False: None)
 
     pipeline.main(["--skip-validate", "push"])
     assert called is False

--- a/tools/codex_pipeline.py
+++ b/tools/codex_pipeline.py
@@ -8,7 +8,7 @@ import subprocess
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Callable, Dict
+from typing import Any, Callable
 from urllib import request
 
 import requests
@@ -140,7 +140,7 @@ def run_pipeline(*, force: bool = False, webhook: str | None = None) -> None:
                 raise
 
 
-def call_connectors(action: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+def call_connectors(action: str, payload: dict[str, Any]) -> dict[str, Any]:
     """Call BlackRoad's connectors API with retry and logging."""
     load_dotenv()
     token = os.getenv("CONNECTOR_KEY")
@@ -206,16 +206,17 @@ def main(argv: list[str] | None = None) -> int:
     exit_code = 0
 
     if args.command == "push":
-        push_latest(dry_run=True) if args.dry_run else push_latest()
-        redeploy_droplet(dry_run=True) if args.dry_run else redeploy_droplet()
+        push_latest(dry_run=args.dry_run)
+        redeploy_droplet(dry_run=args.dry_run)
     elif args.command == "refresh":
-        push_latest(dry_run=True) if args.dry_run else push_latest()
-        refresh_working_copy(dry_run=True) if args.dry_run else refresh_working_copy()
-        redeploy_droplet(dry_run=True) if args.dry_run else redeploy_droplet()
+        push_latest(dry_run=args.dry_run)
+        refresh_working_copy(dry_run=args.dry_run)
+        redeploy_droplet(dry_run=args.dry_run)
     elif args.command == "rebase":
-        run("git pull --rebase") if not args.dry_run else None
-        push_latest(dry_run=True) if args.dry_run else push_latest()
-        redeploy_droplet(dry_run=True) if args.dry_run else redeploy_droplet()
+        if not args.dry_run:
+            run("git pull --rebase")
+        push_latest(dry_run=args.dry_run)
+        redeploy_droplet(dry_run=args.dry_run)
     elif args.command == "sync":
         payload = json.loads(args.payload)
         call_connectors(args.action, payload)


### PR DESCRIPTION
## Summary
- streamline dry-run handling in codex pipeline CLI
- replace `typing.Dict` with built-in generics and adjust tests

## Testing
- `pre-commit run --files tools/codex_pipeline.py tests/test_codex_pipeline.py tests/test_codex_pipeline_connectors.py tests/test_codex_pipeline_validation.py` *(fails: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags'))*
- `pytest tests/test_codex_pipeline.py tests/test_codex_pipeline_connectors.py tests/test_codex_pipeline_validation.py`


------
https://chatgpt.com/codex/tasks/task_e_68b66ce8ec74832990e5f73aa4f3e33d