### PR TITLE
chore: remove esm eslint config

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,3 +1,4 @@
+// ESLint flat config exported via CommonJS to avoid ESM loader issues
 module.exports = [
   {
     files: ['**/*.{js,mjs,cjs}'],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,0 @@
-import js from "@eslint/js";
-import prettier from "eslint-config-prettier";
-export default [ js.configs.recommended, prettier, {
-  ignores: ["node_modules/","dist/","build/",".github/","public/vendor/"],
-  rules: { "no-unused-vars":["warn",{ "argsIgnorePattern":"^_", "varsIgnorePattern":"^_" }], "no-undef":"warn" }
-} ];


### PR DESCRIPTION
## Summary
- remove leftover ESM-based `eslint.config.js`
- document CommonJS flat ESLint setup to avoid ESM loader errors

## Testing
- `npm run lint` *(fails: Parsing error: Unexpected token <)*
- `npm test`
- `node tests/autoheal.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68b67040c50c83299b8d42deea10a91d