### PR TITLE
fix: correct FastAPI app import in test

### DIFF
--- a/srv/lucidia-llm/test_app.py
+++ b/srv/lucidia-llm/test_app.py
@@ -1,5 +1,11 @@
 # <!-- FILE: srv/lucidia-llm/test_app.py -->
 from fastapi.testclient import TestClient
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(ROOT))
+
 from app import app
 
 


### PR DESCRIPTION
## Summary
- ensure smoke test imports FastAPI app from `srv/lucidia-llm/app.py`

## Testing
- `npm run format:check`
- `npm run lint`
- `npm test` *(fails: jest not found; `npm install` returns 503 Service Unavailable from internal registry)*
- `python3 -m pytest srv/lucidia-llm/test_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b66ed843608329aca3a8afff4fa630