### PR TITLE
chore: archive unused root files

### DIFF
--- a/srv/lucidia-llm/test_app.py
+++ b/srv/lucidia-llm/test_app.py
@@ -1,4 +1,9 @@
 # <!-- FILE: srv/lucidia-llm/test_app.py -->
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
 from fastapi.testclient import TestClient
 from app import app
 


### PR DESCRIPTION
## Summary
- resolve FastAPI smoke test import by inserting the service directory into `sys.path`

## Testing
- `npm run format:check`
- `npm run lint`
- ⚠️ `npm test` (missing `jest`; `npm install` failed with 503)
- `python3 -m pytest srv/lucidia-llm/test_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b670535038832995ed5754c2183c42