### PR TITLE
fix: clarify subscribe health route and tests

### DIFF
--- a/src/routes/subscribe.js
+++ b/src/routes/subscribe.js
@@ -9,6 +9,7 @@ const { strictLimiter } = require('../rateLimiter');
 const SUBSCRIPTIONS_ENABLED = process.env.SUBSCRIPTIONS_ENABLED !== 'false';
 
 // GET /api/subscribe/health
+// This endpoint remains available even when subscriptions are disabled.
 router.get('/subscribe/health', (_req, res) => {
   res.json({ status: 'ok' });
 });

--- a/tests/subscribe.health.test.js
+++ b/tests/subscribe.health.test.js
@@ -17,27 +17,40 @@ mockExpress.Router = function () {
   };
 };
 
-const originalLoad = Module._load;
-Module._load = function (request, parent, isMain) {
-  if (request === 'express') return mockExpress;
-  if (request === '../db' || request.includes('db.js')) return {};
-  if (request === '../auth' || request.includes('auth.js')) return { requireAuth: (_req, _res, next) => next() };
-  if (request === '../rateLimiter' || request.includes('rateLimiter.js')) return { strictLimiter: (_req, _res, next) => next() };
-  return originalLoad(request, parent, isMain);
-};
+function loadRouter(subEnabled) {
+  // reset handlers for each load
+  for (const k of Object.keys(handlers)) delete handlers[k];
 
-process.env.SUBSCRIPTIONS_ENABLED = 'false';
-require('../src/routes/subscribe.js');
-Module._load = originalLoad;
-delete process.env.SUBSCRIPTIONS_ENABLED;
+  const originalLoad = Module._load;
+  Module._load = function (request, parent, isMain) {
+    if (request === 'express') return mockExpress;
+    if (request === '../db' || request.includes('db.js')) return {};
+    if (request === '../auth' || request.includes('auth.js')) return { requireAuth: (_req, _res, next) => next() };
+    if (request === '../rateLimiter' || request.includes('rateLimiter.js')) return { strictLimiter: (_req, _res, next) => next() };
+    return originalLoad(request, parent, isMain);
+  };
 
-const res = {
-  body: null,
-  json(obj) {
-    this.body = obj;
-  }
-};
+  if (subEnabled !== undefined) process.env.SUBSCRIPTIONS_ENABLED = subEnabled;
+  delete require.cache[require.resolve('../src/routes/subscribe.js')];
+  require('../src/routes/subscribe.js');
+  Module._load = originalLoad;
+  if (subEnabled !== undefined) delete process.env.SUBSCRIPTIONS_ENABLED;
+}
 
-handlers['/subscribe/health']({}, res);
-assert.deepStrictEqual(res.body, { status: 'ok' });
+function callHealth() {
+  const res = {
+    body: null,
+    json(obj) {
+      this.body = obj;
+    }
+  };
+  handlers['/subscribe/health']({}, res);
+  return res.body;
+}
 
+// health endpoint should respond regardless of subscriptions flag
+loadRouter('true');
+assert.deepStrictEqual(callHealth(), { status: 'ok' });
+
+loadRouter('false');
+assert.deepStrictEqual(callHealth(), { status: 'ok' });


### PR DESCRIPTION
## Summary
- document that `/api/subscribe/health` bypasses subscription gating
- test health endpoint with subscriptions flag enabled and disabled

## Testing
- `npm test`
- `node tests/subscribe.health.test.js`
- `npm run lint` *(fails: eslint: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b670d118c083298c3c2de701951322