### PR TITLE
chore: add robust droplet deploy script

### DIFF
--- a/usr/local/bin/blackroad-deploy.sh
+++ b/usr/local/bin/blackroad-deploy.sh
@@ -46,9 +46,10 @@ rsh() { ssh $SSH_OPTS "$DROPLET_SSH" "$@"; }
 
 remote_bash() {
   # Run a bash -lc command on droplet (ensures login semantics for PATH)
-  local cmd="$1"
-  # Avoid wrapping in single quotes to prevent quoting conflicts with caller-provided strings
-  rsh bash -lc "$cmd"
+  local cmd
+  # Escape single quotes so payload can be safely wrapped for the remote shell
+  cmd=$(printf '%s' "$1" | sed "s/'/'\\''/g")
+  rsh "bash -lc '$cmd'"
 }
 
 require_cmd() {


### PR DESCRIPTION
## Summary
- escape single quotes in `remote_bash` helper to safely wrap commands for remote execution

## Testing
- `npm test` *(fails: jest not found)*
- `npm ci` *(warn: Unknown env config "http-proxy"; command interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b670fb42c88329817bb0d205998f58