### PR TITLE
feat(agents): set json headers for bot requests

### DIFF
--- a/agents/comment_bot.py
+++ b/agents/comment_bot.py
@@ -41,7 +41,11 @@ class CommentBot:
         url = (
             f"https://api.github.com/repos/{self.repo}/issues/{issue_number}/comments"
         )
-        headers = {"Authorization": f"token {self.token}"}
+        headers = {
+            "Authorization": f"token {self.token}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+        }
         payload = {"body": body}
         response = requests.post(url, json=payload, headers=headers, timeout=10)
         response.raise_for_status()

--- a/agents/droplet_repair_agent.py
+++ b/agents/droplet_repair_agent.py
@@ -39,7 +39,10 @@ class DropletRepairAgent:
     )
 
     def _headers(self) -> Dict[str, str]:
-        return {"Authorization": f"Bearer {self.do_api_token}"}
+        return {
+            "Authorization": f"Bearer {self.do_api_token}",
+            "Accept": "application/json",
+        }
 
     def discover_droplet(self) -> Dict[str, Any]:
         """Locate droplet information by matching the final IP octet."""

--- a/agents/issue_bot.py
+++ b/agents/issue_bot.py
@@ -22,7 +22,14 @@ class IssueBot:
     def create_issue(self, title: str, body: str = "") -> dict:
         """Create a new issue on GitHub."""
         url = f"https://api.github.com/repos/{self.repo}/issues"
-        headers = {"Authorization": f"token {self.token}"} if self.token else {}
+        headers = {
+            "Authorization": f"token {self.token}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+        } if self.token else {
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+        }
         payload = {"title": title, "body": body}
         response = requests.post(url, json=payload, headers=headers, timeout=10)
         response.raise_for_status()
@@ -35,7 +42,10 @@ class IssueBot:
             state: Filter by issue state ("open", "closed", or "all").
         """
         url = f"https://api.github.com/repos/{self.repo}/issues"
-        headers = {"Authorization": f"token {self.token}"} if self.token else {}
+        headers = {
+            "Authorization": f"token {self.token}",
+            "Accept": "application/vnd.github+json",
+        } if self.token else {"Accept": "application/vnd.github+json"}
         params = {"state": state}
         response = requests.get(url, headers=headers, params=params, timeout=10)
         response.raise_for_status()
@@ -44,7 +54,14 @@ class IssueBot:
     def close_issue(self, issue_number: int) -> dict:
         """Close an existing GitHub issue."""
         url = f"https://api.github.com/repos/{self.repo}/issues/{issue_number}"
-        headers = {"Authorization": f"token {self.token}"} if self.token else {}
+        headers = {
+            "Authorization": f"token {self.token}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+        } if self.token else {
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+        }
         payload = {"state": "closed"}
         response = requests.patch(url, json=payload, headers=headers, timeout=10)
         response.raise_for_status()

--- a/agents/label_bot.py
+++ b/agents/label_bot.py
@@ -22,7 +22,14 @@ class LabelBot:
     def add_labels(self, issue_number: int, labels: list[str]) -> dict:
         """Add labels to a GitHub issue or pull request."""
         url = f"https://api.github.com/repos/{self.repo}/issues/{issue_number}/labels"
-        headers = {"Authorization": f"token {self.token}"} if self.token else {}
+        headers = {
+            "Authorization": f"token {self.token}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+        } if self.token else {
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+        }
         payload = {"labels": labels}
         response = requests.post(url, json=payload, headers=headers, timeout=10)
         response.raise_for_status()
@@ -33,7 +40,10 @@ class LabelBot:
         url = (
             f"https://api.github.com/repos/{self.repo}/issues/{issue_number}/labels/{label}"
         )
-        headers = {"Authorization": f"token {self.token}"} if self.token else {}
+        headers = {
+            "Authorization": f"token {self.token}",
+            "Accept": "application/vnd.github+json",
+        } if self.token else {"Accept": "application/vnd.github+json"}
         response = requests.delete(url, headers=headers, timeout=10)
         response.raise_for_status()
 

--- a/agents/merge_bot.py
+++ b/agents/merge_bot.py
@@ -22,7 +22,14 @@ class MergeBot:
     def merge_pull_request(self, pr_number: int, commit_message: str | None = None) -> dict:
         """Merge a pull request using the GitHub API."""
         url = f"https://api.github.com/repos/{self.repo}/pulls/{pr_number}/merge"
-        headers = {"Authorization": f"token {self.token}"} if self.token else {}
+        headers = {
+            "Authorization": f"token {self.token}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+        } if self.token else {
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+        }
         payload: dict[str, str] = {}
         if commit_message:
             payload["commit_message"] = commit_message

--- a/agents/milestone_bot.py
+++ b/agents/milestone_bot.py
@@ -22,7 +22,14 @@ class MilestoneBot:
     def create_milestone(self, title: str, description: str = "") -> dict:
         """Create a new milestone."""
         url = f"https://api.github.com/repos/{self.repo}/milestones"
-        headers = {"Authorization": f"token {self.token}"} if self.token else {}
+        headers = {
+            "Authorization": f"token {self.token}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+        } if self.token else {
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+        }
         payload = {"title": title, "description": description}
         response = requests.post(url, json=payload, headers=headers, timeout=10)
         response.raise_for_status()
@@ -31,7 +38,14 @@ class MilestoneBot:
     def close_milestone(self, milestone_number: int) -> dict:
         """Close an existing milestone."""
         url = f"https://api.github.com/repos/{self.repo}/milestones/{milestone_number}"
-        headers = {"Authorization": f"token {self.token}"} if self.token else {}
+        headers = {
+            "Authorization": f"token {self.token}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+        } if self.token else {
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+        }
         payload = {"state": "closed"}
         response = requests.patch(url, json=payload, headers=headers, timeout=10)
         response.raise_for_status()

--- a/agents/notification_bot.py
+++ b/agents/notification_bot.py
@@ -22,7 +22,13 @@ class NotificationBot:
         """Post ``message`` to the configured webhook."""
         if not self.webhook_url:
             raise ValueError("webhook_url not configured")
-        response = requests.post(self.webhook_url, json={"text": message}, timeout=10)
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+        response = requests.post(
+            self.webhook_url, json={"text": message}, headers=headers, timeout=10
+        )
         response.raise_for_status()
 
 

--- a/agents/pull_request_bot.py
+++ b/agents/pull_request_bot.py
@@ -22,7 +22,14 @@ class PullRequestBot:
     def update_pull_request(self, pr_number: int, title: str | None = None, body: str | None = None) -> dict:
         """Update the title or body of an existing pull request."""
         url = f"https://api.github.com/repos/{self.repo}/pulls/{pr_number}"
-        headers = {"Authorization": f"token {self.token}"} if self.token else {}
+        headers = {
+            "Authorization": f"token {self.token}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+        } if self.token else {
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+        }
         payload: dict[str, str] = {}
         if title is not None:
             payload["title"] = title
@@ -35,7 +42,14 @@ class PullRequestBot:
     def create_pull_request(self, title: str, head: str, base: str, body: str = "") -> dict:
         """Create a new pull request on GitHub."""
         url = f"https://api.github.com/repos/{self.repo}/pulls"
-        headers = {"Authorization": f"token {self.token}"} if self.token else {}
+        headers = {
+            "Authorization": f"token {self.token}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+        } if self.token else {
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+        }
         payload = {"title": title, "head": head, "base": base, "body": body}
         response = requests.post(url, json=payload, headers=headers, timeout=10)
         response.raise_for_status()

--- a/agents/release_bot.py
+++ b/agents/release_bot.py
@@ -22,7 +22,14 @@ class ReleaseBot:
     def create_release(self, tag: str, name: str, body: str = "") -> dict:
         """Create a release for the given tag."""
         url = f"https://api.github.com/repos/{self.repo}/releases"
-        headers = {"Authorization": f"token {self.token}"} if self.token else {}
+        headers = {
+            "Authorization": f"token {self.token}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+        } if self.token else {
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+        }
         payload = {"tag_name": tag, "name": name, "body": body}
         response = requests.post(url, json=payload, headers=headers, timeout=10)
         response.raise_for_status()

--- a/agents/review_bot.py
+++ b/agents/review_bot.py
@@ -24,7 +24,14 @@ class ReviewBot:
         url = (
             f"https://api.github.com/repos/{self.repo}/pulls/{pr_number}/requested_reviewers"
         )
-        headers = {"Authorization": f"token {self.token}"} if self.token else {}
+        headers = {
+            "Authorization": f"token {self.token}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+        } if self.token else {
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+        }
         payload = {"reviewers": reviewers}
         response = requests.post(url, json=payload, headers=headers, timeout=10)
         response.raise_for_status()

--- a/agents/solar_network_agent.py
+++ b/agents/solar_network_agent.py
@@ -45,7 +45,10 @@ class SolarNetworkClient:
             requests.HTTPError: If the HTTP request fails.
         """
         query = {"api_key": self.api_key} | params
-        response = requests.get(self.base_url, params=query, timeout=10)
+        headers = {"Accept": "application/json"}
+        response = requests.get(
+            self.base_url, params=query, headers=headers, timeout=10
+        )
         response.raise_for_status()
         return response.json()
 

--- a/agents/status_bot.py
+++ b/agents/status_bot.py
@@ -22,7 +22,10 @@ class StatusBot:
     def latest_status(self, workflow: str) -> str:
         """Return the status of the most recent workflow run."""
         url = f"https://api.github.com/repos/{self.repo}/actions/workflows/{workflow}/runs"
-        headers = {"Authorization": f"token {self.token}"} if self.token else {}
+        headers = {
+            "Authorization": f"token {self.token}",
+            "Accept": "application/vnd.github+json",
+        } if self.token else {"Accept": "application/vnd.github+json"}
         response = requests.get(url, headers=headers, timeout=10)
         response.raise_for_status()
         data = response.json()


### PR DESCRIPTION
## Summary
- ensure webhook NotificationBot sends explicit JSON headers
- set default JSON headers on GitHub automation bots for consistent content type
- add Accept headers to status and solar API bots

## Testing
- `python -m py_compile *.py`
- `python auto_novel_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6744805508329897f99d329d3354f