### PR TITLE
fix: escape remote command in deploy helper

### DIFF
--- a/usr/local/bin/blackroad-deploy.sh
+++ b/usr/local/bin/blackroad-deploy.sh
@@ -48,7 +48,7 @@ remote_bash() {
   # Run a bash -lc command on droplet (ensures login semantics for PATH)
   local cmd
   # Escape single quotes so payload can be safely wrapped for the remote shell
-  cmd=$(printf '%s' "$1" | sed "s/'/'\\''/g")
+  cmd=$(printf '%s' "$1" | sed "s/'/'\"'\"'/g")
   rsh "bash -lc '$cmd'"
 }
 


### PR DESCRIPTION
## Summary
- escape single quotes in remote_bash so commands with quoted paths run correctly

## Testing
- `npm test` *(fails: jest not found)*
- `npm ci` *(no output; interrupted)*
- `pre-commit run --files usr/local/bin/blackroad-deploy.sh` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_68b6735c8c388329a8121735ecf1ff27