### PR TITLE
fix(agent): normalize engine names

### DIFF
--- a/agents/auto_novel_agent.py
+++ b/agents/auto_novel_agent.py
@@ -24,7 +24,7 @@ class AutoNovelAgent:
             include_weapons: If True, raise a ``ValueError`` because weapons are not
                 allowed.
         """
-        engine_lower = engine.lower()
+        engine_lower = engine.strip().lower()
         if engine_lower not in self.supported_engines:
             supported = ", ".join(sorted(self.supported_engines))
             raise ValueError(f"Unsupported engine. Choose one of: {supported}.")

--- a/tests/test_auto_novel_agent.py
+++ b/tests/test_auto_novel_agent.py
@@ -43,3 +43,16 @@ def test_add_engine_is_instance_scoped():
     agent_one.add_engine("godot")
     assert "godot" in agent_one.list_supported_engines()
     assert "godot" not in agent_two.list_supported_engines()
+
+
+def test_create_game_normalizes_engine_name(capsys):
+    agent = AutoNovelAgent()
+    agent.create_game(" Unity ")
+    captured = capsys.readouterr()
+    assert "Creating a Unity game without weapons..." in captured.out
+
+
+def test_add_engine_normalizes_name():
+    agent = AutoNovelAgent()
+    agent.add_engine(" Godot ")
+    assert "godot" in agent.list_supported_engines()


### PR DESCRIPTION
## Summary
- strip whitespace from engine names in `create_game`
- add tests ensuring engine names are normalized when creating games or registering engines

## Testing
- `ruff check agents/auto_novel_agent.py tests/test_auto_novel_agent.py`
- `python -m py_compile agents/auto_novel_agent.py tests/test_auto_novel_agent.py`
- `python agents/auto_novel_agent.py`
- `pytest tests/test_auto_novel_agent.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b67ad0be788329a16c759ab3202a1a