### PR TITLE
feat(agent-summary): fetch services concurrently

### DIFF
--- a/src/services/agentSummary.js
+++ b/src/services/agentSummary.js
@@ -15,8 +15,10 @@ async function fetchJson(url) {
 
 async function getService(id, base) {
   try {
-    const health = await fetchJson(`${base}/health`);
-    const logs = await fetchJson(`${base}/logs?level=error&limit=1`).catch(() => ({ count: 0, logs: [] }));
+    const [health, logs] = await Promise.all([
+      fetchJson(`${base}/health`),
+      fetchJson(`${base}/logs?level=error&limit=1`).catch(() => ({ count: 0, logs: [] }))
+    ]);
     return {
       status: health.status || health.ok || 'FAIL',
       uptime: health.uptime || '-',


### PR DESCRIPTION
## Summary
- fetch agent statuses in parallel for faster dashboard retrieval
- fetch health and error logs concurrently per service

## Testing
- `npm test`
- `npx eslint src/services/agentSummary.js`


------
https://chatgpt.com/codex/tasks/task_e_68b67b173d3c8329b642b0d17155eef0