### PR TITLE
chore: clear invalid token and log block fetch errors

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -37,7 +37,9 @@ export default function App(){
           connectSocket()
         }
       } catch(e){
-        // User not authenticated; log for debugging but otherwise ignore
+        // Clear invalid token and log for debugging
+        localStorage.removeItem('token')
+        setToken('')
         console.warn('User not authenticated', e)
       }
     })()

--- a/frontend/src/components/RoadChain.jsx
+++ b/frontend/src/components/RoadChain.jsx
@@ -35,6 +35,7 @@ export default function RoadChain(){
     }catch(err){
       setResult(null)
       setError('Block not found')
+      console.warn('Failed to fetch block', err)
     }
   }
 


### PR DESCRIPTION
## Summary
- clear invalid token on auth failure and log details
- warn when block lookup fails to aid debugging

## Testing
- `npm --prefix backend install`
- `npm --prefix backend test`
- `npm --prefix frontend install`
- `npm --prefix frontend test`
- `npm --prefix frontend run build`
- `curl -s http://localhost:4000/api/roadchain/blocks`
- `curl -s http://localhost:4000/api/roadchain/block/0xdef456`


------
https://chatgpt.com/codex/tasks/task_e_68b67dc8eaf0832980e7ac06b3cb4f67