### PR TITLE
Clarify Codex pipeline logging

### DIFF
--- a/tests/test_codex_pipeline.py
+++ b/tests/test_codex_pipeline.py
@@ -1,3 +1,5 @@
+"""Unit tests for the minimal Codex deployment pipeline."""
+
 import subprocess
 
 import pytest

--- a/tools/codex_pipeline.py
+++ b/tools/codex_pipeline.py
@@ -8,7 +8,7 @@ This script runs a minimal deployment pipeline consisting of four stages:
 * call_connectors
 * validate_services
 
-Each stage is wrapped with error handling that logs failures to
+Each stage logs console output to ``pipeline.log`` and records failures in
 ``pipeline_errors.log``. When a stage fails the pipeline stops unless the
 ``--force`` flag is used. Some failures trigger automatic rollback from the
 latest backup located in ``/var/backups/blackroad``.


### PR DESCRIPTION
## Summary
- document log destinations in `codex_pipeline`
- add module docstring for pipeline tests

## Testing
- ⚠️ `pre-commit run --files tools/codex_pipeline.py tests/test_codex_pipeline.py` (fetch failed: HTTP 403)
- ✅ `pytest tests/test_codex_pipeline.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b67da58b988329a26526bb407e48aa