### PR TITLE
Simplify Codex pipeline helpers

### DIFF
--- a/tests/test_codex_pipeline.py
+++ b/tests/test_codex_pipeline.py
@@ -1,4 +1,10 @@
-"""Unit tests for the minimal Codex deployment pipeline."""
+"""Unit tests for the minimal Codex deployment pipeline.
+
+The suite simulates failures in each pipeline stage and asserts that
+rollback or skip behavior occurs as expected.  This keeps coverage focused
+on error handling in ``tools.codex_pipeline`` without relying on external
+services.
+"""
 
 import subprocess
 


### PR DESCRIPTION
## Summary
- drop unused pipeline helper functions
- expand Codex pipeline test module docstring

## Testing
- ⚠️ `pre-commit run --files tools/codex_pipeline.py tests/test_codex_pipeline.py` (fetch failed: HTTP 403)
- ✅ `pytest tests/test_codex_pipeline.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b67f686fa08329839c8cac1a818c89