### PR TITLE
chore: remove unused urllib error import

### DIFF
--- a/tools/codex_pipeline.py
+++ b/tools/codex_pipeline.py
@@ -24,7 +24,7 @@ import traceback
 from datetime import datetime
 from pathlib import Path
 from typing import Callable
-from urllib import error, request
+from urllib import request
 
 ERROR_LOG = Path("pipeline_errors.log")
 BACKUP_ROOT = Path("/var/backups/blackroad")


### PR DESCRIPTION
## Summary
- remove unused urllib error import

## Testing
- ⚠️ `pre-commit run --files tools/codex_pipeline.py tests/test_codex_pipeline.py` (HTTP 403 while fetching hook repository)
- ✅ `pytest tests/test_codex_pipeline.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6804a1e588329b1e235b3075aa883