### PR TITLE
fix: address review comments for AutoNovelAgent

### DIFF
--- a/agents/auto_novel_agent.py
+++ b/agents/auto_novel_agent.py
@@ -1,7 +1,7 @@
 """Simple auto novel agent example with game creation abilities."""
 
-from dataclasses import dataclass
-from typing import ClassVar, List
+from dataclasses import dataclass, field
+from typing import List, Set
 
 
 @dataclass
@@ -9,7 +9,9 @@ class AutoNovelAgent:
     """A toy agent that can deploy itself and create simple games."""
 
     name: str = "AutoNovelAgent"
-    SUPPORTED_ENGINES: ClassVar[set[str]] = {"unity", "unreal"}
+    supported_engines: Set[str] = field(
+        default_factory=lambda: {"unity", "unreal"}
+    )
 
     def deploy(self) -> None:
         """Deploy the agent by printing a greeting."""
@@ -24,8 +26,8 @@ class AutoNovelAgent:
                 allowed.
         """
         engine_lower = engine.lower()
-        if engine_lower not in self.SUPPORTED_ENGINES:
-            supported = ", ".join(sorted(self.SUPPORTED_ENGINES))
+        if engine_lower not in self.supported_engines:
+            supported = ", ".join(sorted(self.supported_engines))
             raise ValueError(f"Unsupported engine. Choose one of: {supported}.")
         if include_weapons:
             raise ValueError("Weapons are not allowed in generated games.")
@@ -33,15 +35,16 @@ class AutoNovelAgent:
 
     def list_supported_engines(self) -> List[str]:
         """Return a list of supported game engines."""
-        return sorted(self.SUPPORTED_ENGINES)
+        return sorted(self.supported_engines)
 
     def add_engine(self, engine: str) -> None:
         """Add a new supported game engine.
 
         Args:
-            engine: Name of the engine to add.
+            engine: Name of the engine to add. Comparison is case-insensitive.
+
         """
-        self.SUPPORTED_ENGINES.add(engine.lower())
+        self.supported_engines.add(engine.lower())
 
 
 if __name__ == "__main__":

--- a/tests/test_auto_novel_agent.py
+++ b/tests/test_auto_novel_agent.py
@@ -1,13 +1,4 @@
-import importlib.util
-from pathlib import Path
-
-spec = importlib.util.spec_from_file_location(
-    "auto_novel_agent",
-    Path(__file__).resolve().parents[1] / "agents" / "auto_novel_agent.py",
-)
-module = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(module)
-AutoNovelAgent = module.AutoNovelAgent
+from agents.auto_novel_agent import AutoNovelAgent
 
 
 def test_add_engine():


### PR DESCRIPTION
## Summary
- manage supported engines per AutoNovelAgent instance
- simplify unit test import for AutoNovelAgent

## Testing
- `python -m py_compile auto_novel_agent.py`
- `python -m py_compile *.py` *(fails: cleanup_bot.py syntax error)*
- `python auto_novel_agent.py`
- `pytest tests/test_auto_novel_agent.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b680eb729083298ee6349f1100b321