### PR TITLE
fix: refine AutoNovelAgent typings and tests

### DIFF
--- a/agents/auto_novel_agent.py
+++ b/agents/auto_novel_agent.py
@@ -1,7 +1,7 @@
 """Simple auto novel agent example with game creation abilities."""
 
 from dataclasses import dataclass
-from typing import ClassVar, List
+from typing import ClassVar
 
 
 @dataclass
@@ -31,7 +31,7 @@ class AutoNovelAgent:
             raise ValueError("Weapons are not allowed in generated games.")
         print(f"Creating a {engine_lower.capitalize()} game without weapons...")
 
-    def list_supported_engines(self) -> List[str]:
+    def list_supported_engines(self) -> list[str]:
         """Return a list of supported game engines."""
         return sorted(self.SUPPORTED_ENGINES)
 

--- a/agents/test_auto_novel_agent.py
+++ b/agents/test_auto_novel_agent.py
@@ -1,15 +1,21 @@
+"""Tests for :mod:`auto_novel_agent`."""
+
 import pytest
 from auto_novel_agent import AutoNovelAgent
 
 
-def test_supported_engines_and_novel():
+def test_supported_engines_and_novel() -> None:
+    """Verify supported engines list and novel generation."""
+
     agent = AutoNovelAgent()
     assert agent.list_supported_engines() == ["unity", "unreal"]
     summary = agent.write_novel("Quest", "Bob")
     assert summary == "Quest is a thrilling tale about Bob."
 
 
-def test_create_game_validation():
+def test_create_game_validation() -> None:
+    """Ensure validation errors are raised appropriately."""
+
     agent = AutoNovelAgent()
     agent.create_game("unity")
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
- switch AutoNovelAgent to builtin `list` typing
- document and type test cases

## Testing
- `python -m py_compile agents/auto_novel_agent.py agents/test_auto_novel_agent.py`
- `python agents/auto_novel_agent.py`
- `ruff check agents/auto_novel_agent.py agents/test_auto_novel_agent.py`
- `pytest agents/test_auto_novel_agent.py -q`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b680dc1de8832986e996c44919c978