### PR TITLE
fix(agents): refine branch cleanup results

### DIFF
--- a/agents/auto_novel_agent.py
+++ b/agents/auto_novel_agent.py
@@ -1,5 +1,7 @@
 """Simple auto novel agent example with game creation abilities."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import ClassVar, List
 


### PR DESCRIPTION
## Summary
- track local and remote deletion status separately in CleanupBot
- enable postponed evaluation of type hints in AutoNovelAgent

## Testing
- `npm test`
- `npm run lint`
- `python3 -m py_compile agents/*.py`
- `python3 agents/auto_novel_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_68b680d020908329891ace2a0844b52d