### PR TITLE
fix(agent-summary): preserve zero error counts

### DIFF
--- a/src/services/agentSummary.js
+++ b/src/services/agentSummary.js
@@ -20,9 +20,9 @@ async function getService(id, base) {
       fetchJson(`${base}/logs?level=error&limit=1`).catch(() => ({ count: 0, logs: [] }))
     ]);
     return {
-      status: health.status || health.ok || 'FAIL',
+      status: health.status ?? (health.ok ? 'OK' : 'FAIL'),
       uptime: health.uptime || '-',
-      errors: logs.count || (Array.isArray(logs.logs) ? logs.logs.length : 0),
+      errors: logs.count ?? (Array.isArray(logs.logs) ? logs.logs.length : 0),
       contradictions: health.contradictions || 0
     };
   } catch {


### PR DESCRIPTION
## Summary
- ensure `getService` preserves zero error counts and status values

## Testing
- `npm test`
- `NPM_CONFIG_PROGRESS=false npx -y eslint src/services/agentSummary.js`


------
https://chatgpt.com/codex/tasks/task_e_68b6805c79448329b2e2bb564b7a4743