### PR TITLE
test: add coverage for AutoNovelAgent

### DIFF
--- a/agents/auto_novel_agent.py
+++ b/agents/auto_novel_agent.py
@@ -1,7 +1,7 @@
 """Simple auto novel agent example with game creation abilities."""
 
 from dataclasses import dataclass
-from typing import ClassVar, List
+from typing import ClassVar
 
 
 @dataclass
@@ -31,7 +31,7 @@ class AutoNovelAgent:
             raise ValueError("Weapons are not allowed in generated games.")
         print(f"Creating a {engine_lower.capitalize()} game without weapons...")
 
-    def list_supported_engines(self) -> List[str]:
+    def list_supported_engines(self) -> list[str]:
         """Return a list of supported game engines."""
         return sorted(self.SUPPORTED_ENGINES)
 


### PR DESCRIPTION
## Summary
- add pytest coverage for AutoNovelAgent
- use builtin `list` typing in AutoNovelAgent

## Testing
- `ruff check agents/auto_novel_agent.py tests/test_auto_novel_agent.py`
- `python -m py_compile agents/*.py` *(fails: cleanup_bot.py: SyntaxError)*
- `python agents/auto_novel_agent.py`
- `pytest tests/test_auto_novel_agent.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b680c829688329822270d712914895