### PR TITLE
fix: resolve cleanup bot syntax errors

### DIFF
--- a/agents/cleanup_bot.py
+++ b/agents/cleanup_bot.py
@@ -1,11 +1,15 @@
-"""Bot for cleaning up merged Git branches."""
+"""Bot for cleaning up merged Git branches.
+
+Provides :class:`CleanupBot` to delete local and remote branches after they
+have been merged. Supports a dry-run mode to preview actions without
+executing them.
+"""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 import subprocess
 from subprocess import CalledProcessError
-from typing import List
 from typing import Dict, List
 
 
@@ -16,97 +20,48 @@ class CleanupBot:
     Parameters
     ----------
     branches:
-        A list of branch names to remove.
+        Branch names to remove.
     dry_run:
-        When ``True`` no commands are executed and planned actions are
-        printed instead. This is helpful for verifying branch names before
-        actual deletion.
-    Args:
-        branches: Branch names to delete.
-        dry_run: If True, print commands instead of executing them.
+        If ``True`` commands are printed instead of executed.
     """
 
     branches: List[str]
     dry_run: bool = False
 
-    def _run_git(self, *args: str) -> subprocess.CompletedProcess:
-        """Execute a git command with ``check=True`` and captured output."""
-        return subprocess.run(["git", *args], check=True, capture_output=True, text=True)
-
-    def delete_branch(self, branch: str) -> bool:
-        """Delete a branch locally and remotely.
-
-        Args:
-            branch: The branch name to remove.
     def _run(self, *cmd: str) -> None:
-        """Run a command unless in dry-run mode."""
+        """Run ``cmd`` unless in dry-run mode."""
         if self.dry_run:
             print("DRY-RUN:", " ".join(cmd))
             return
         subprocess.run(cmd, check=True)
 
-        Returns:
-            ``True`` if the branch was deleted both locally and remotely, ``False``
-            otherwise.
+    def delete_branch(self, branch: str) -> bool:
+        """Delete a branch locally and remotely.
+
+        Returns
+        -------
+        bool
+            ``True`` if deletion succeeded both locally and remotely,
+            ``False`` otherwise.
         """
         try:
-            self._run_git("branch", "-D", branch)
-            self._run_git("push", "origin", "--delete", branch)
-            return True
-        except subprocess.CalledProcessError:
+            self._run("git", "branch", "-D", branch)
+        except CalledProcessError:
+            print(f"Local branch '{branch}' does not exist.")
             return False
+        try:
+            self._run("git", "push", "origin", "--delete", branch)
+        except CalledProcessError:
+            print(f"Remote branch '{branch}' does not exist.")
+            return False
+        return True
 
     def cleanup(self) -> Dict[str, bool]:
-        """Remove the configured branches locally and remotely.
-
-        Returns:
-            Mapping of branch names to deletion success.
-        """
+        """Remove configured branches locally and remotely."""
         results: Dict[str, bool] = {}
         for branch in self.branches:
-            if self.dry_run:
-                print(f"Would delete branch '{branch}' locally and remotely")
-                continue
-            try:
-                subprocess.run(["git", "branch", "-D", branch], check=True)
-            except CalledProcessError:
-                print(f"Failed to delete local branch '{branch}'")
-            try:
-                subprocess.run(
-                    ["git", "push", "origin", "--delete", branch],
-                    check=True,
-                )
-            except CalledProcessError:
-                print(f"Failed to delete remote branch '{branch}'")
             results[branch] = self.delete_branch(branch)
         return results
-    def cleanup(self) -> None:
-        """Remove the configured branches locally and remotely.
-
-        Branches missing either locally or remotely are skipped with a message.
-        """
-        for branch in self.branches:
-            try:
-                subprocess.run(["git", "branch", "-D", branch], check=True)
-            except subprocess.CalledProcessError:
-                print(f"Local branch '{branch}' does not exist.")
-            try:
-                subprocess.run(
-                    ["git", "push", "origin", "--delete", branch], check=True
-                )
-            except subprocess.CalledProcessError:
-                print(f"Remote branch '{branch}' does not exist.")
-        Skips branches that are missing locally or remotely.
-        """
-        for branch in self.branches:
-            try:
-                self._run("git", "branch", "-D", branch)
-            except CalledProcessError:
-                print(f"Local branch {branch} not found; skipping")
-            try:
-                self._run("git", "push", "origin", "--delete", branch)
-            except CalledProcessError:
-                print(f"Remote branch {branch} not found; skipping")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- simplify cleanup bot and fix syntax errors causing py_compile to fail

## Testing
- `python -m py_compile *.py`
- `python agents/auto_novel_agent.py`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b680baaf548329bc5ce57c21a951ff