### PR TITLE
chore: scaffold roadview storage and tables

### DIFF
--- a/server_full.js
+++ b/server_full.js
@@ -77,13 +77,17 @@ app.use(limiter);
 const db = require('./src/db');
 
 // ROADVIEW
-const ROADVIEW_STORAGE = process.env.ROADVIEW_STORAGE
-  ? path.resolve(process.env.ROADVIEW_STORAGE)
-  : path.join(__dirname, 'srv', 'blackroad-api', 'storage', 'roadview');
+const ROADVIEW_STORAGE = path.resolve(
+  process.env.ROADVIEW_STORAGE ||
+    path.join(__dirname, 'srv', 'blackroad-api', 'storage', 'roadview')
+);
 try {
   fs.mkdirSync(path.join(ROADVIEW_STORAGE, 'projects'), { recursive: true });
 } catch (err) {
-  console.error('Failed to ensure RoadView storage directory', err);
+  console.error(
+    `Failed to ensure RoadView storage directory at ${ROADVIEW_STORAGE}`,
+    err
+  );
 }
 app.use(
   '/files/roadview',


### PR DESCRIPTION
## Summary
- log RoadView storage path when initialization fails

## Testing
- `pre-commit run --files server_full.js db/migrations/0003_roadview.sql srv/blackroad-api/storage/roadview/.gitkeep srv/blackroad-api/storage/roadview/projects/.gitkeep` *(fails: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags'))*
- `npm test` *(fails: Invalid package.json: JSONParseError)*
- `node tests/smoke.test.js` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npx eslint server_full.js` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68b685ea4af08329a243c5961355a913