### PR TITLE
feat: add roadchain portal

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -24,6 +24,21 @@ export default function App(){
   const [socket, setSocket] = useState(null)
   const [stream, setStream] = useState(true)
 
+  function resetState(){
+    setUser(null)
+    setTimeline([])
+    setTasks([])
+    setCommits([])
+    setAgents([])
+    setWallet({ rc: 0 })
+    setContradictions({ issues: 0 })
+    setNotesState('')
+    if(socket){
+      socket.disconnect()
+      setSocket(null)
+    }
+  }
+
   // Bootstrap authentication token from local storage
   useEffect(()=>{
     const token = localStorage.getItem('token')
@@ -37,11 +52,11 @@ export default function App(){
           connectSocket()
         }
       } catch(e){
-        // Clear invalid token and log for debugging
+        // Clear invalid token, reset state, and log the failure
         localStorage.removeItem('token')
         setToken('')
-        setUser(null)
-        console.error('User not authenticated', e)
+        resetState()
+        console.error('User not authenticated:', e)
       }
     })()
   }, [])

--- a/frontend/src/components/RoadChain.jsx
+++ b/frontend/src/components/RoadChain.jsx
@@ -14,8 +14,9 @@ export default function RoadChain(){
         const b = await fetchBlocks()
         setBlocks(b)
       }catch(e){
-        // Ignore errors when fetching initial blocks but log for diagnostics
+        // Surface initial fetch issues so they aren't missed during debugging
         console.error('Failed to fetch initial blocks', e)
+        setError('Failed to fetch initial blocks')
       }
     })()
   }, [])


### PR DESCRIPTION
## Summary
- reset client state on authentication failures for clean recovery
- surface RoadChain initialization errors to users and logs

## Testing
- `npm --prefix backend install`
- `npm --prefix backend test`
- `npm --prefix frontend install`
- `npm --prefix frontend test`
- `npm --prefix frontend run build`
- `curl -s http://localhost:4000/api/roadchain/blocks`
- `curl -s http://localhost:4000/api/roadchain/block/0xdef456`


------
https://chatgpt.com/codex/tasks/task_e_68b685e1bde0832980db0779afb2a265