### PR TITLE
feat: allow @codex fix comments command

### DIFF
--- a/.github/tools/codex-apply.js
+++ b/.github/tools/codex-apply.js
@@ -6,7 +6,10 @@ const MAX = 200 * 1024;
 let body = (process.env.CODEx_BODY || '').replace(/\r/g, '');
 if (body.startsWith('@codex')) {
   if (/^@codex\s+fix comments/i.test(body)) {
-    body = '/codex apply .github/prompts/codex-fix-comments.md';
+    body = body.replace(
+      /^@codex\s+fix comments/i,
+      '/codex apply .github/prompts/codex-fix-comments.md'
+    );
   } else {
     body = body.replace(/^@codex/, '/codex');
   }


### PR DESCRIPTION
## Summary
- allow `@codex` prefix in Codex Bridge workflow
- translate `@codex fix comments` into applying new prompt
- preserve diff content when handling `@codex fix comments`

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b686eac8488329858ca0aa73aae84b