### PR TITLE
chore: scaffold roadview storage and tables

### DIFF
--- a/server_full.js
+++ b/server_full.js
@@ -81,11 +81,12 @@ const ROADVIEW_STORAGE = path.resolve(
   process.env.ROADVIEW_STORAGE ||
     path.join(__dirname, 'srv', 'blackroad-api', 'storage', 'roadview')
 );
+const ROADVIEW_PROJECTS_DIR = path.join(ROADVIEW_STORAGE, 'projects');
 try {
-  fs.mkdirSync(path.join(ROADVIEW_STORAGE, 'projects'), { recursive: true });
+  fs.mkdirSync(ROADVIEW_PROJECTS_DIR, { recursive: true });
 } catch (err) {
   console.error(
-    `Failed to ensure RoadView storage directory at ${ROADVIEW_STORAGE}`,
+    `Failed to ensure RoadView projects directory at ${ROADVIEW_PROJECTS_DIR}`,
     err
   );
 }


### PR DESCRIPTION
## Summary
- scaffold RoadView storage directory and expose static route
- add SQL migrations for RoadView project, asset, scene, job tables and summary view
- log RoadView projects path on init failure for easier troubleshooting

## Testing
- ⚠️ `pre-commit run --files server_full.js db/migrations/0003_roadview.sql srv/blackroad-api/storage/roadview/.gitkeep srv/blackroad-api/storage/roadview/projects/.gitkeep` *(CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags'))*
- ❌ `npm test` *(Invalid package.json: JSONParseError)*
- ❌ `node tests/smoke.test.js` *(SyntaxError: Cannot use import statement outside a module)*
- ❌ `npx eslint server_full.js` *(ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68b687421d4083298e6775e073886edd