### PR TITLE
feat: add roadchain portal

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -26,6 +26,8 @@ export default function App(){
   const streamRef = useRef(true)
 
   const resetState = useCallback(() => {
+    localStorage.removeItem('token')
+    setToken('')
     setUser(null)
     setTab('timeline')
     setTimeline([])
@@ -58,9 +60,7 @@ export default function App(){
           connectSocket()
         }
       } catch(e){
-        // Clear invalid token, reset state, and log the failure
-        localStorage.removeItem('token')
-        setToken('')
+        // Reset state and log the failure
         resetState()
         console.error('User not authenticated:', e)
       }
@@ -92,8 +92,8 @@ export default function App(){
       await bootData()
       connectSocket()
     }catch(e){
-      console.error('Login failed:', e)
       resetState()
+      console.error('Login failed:', e)
       throw e
     }
   }


### PR DESCRIPTION
## Summary
- centralize authentication reset by clearing tokens and reinitializing UI state

## Testing
- `npm --prefix backend install`
- `npm --prefix backend test`
- `npm --prefix frontend install`
- `npm --prefix frontend test`
- `npm --prefix frontend run build`
- `curl -s http://localhost:4000/api/roadchain/blocks`
- `curl -s http://localhost:4000/api/roadchain/block/0xdef456`


------
https://chatgpt.com/codex/tasks/task_e_68b689dc86f48329896ca77570cd117a