### PR TITLE
fix: sync stream ref and search state

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -39,6 +39,7 @@ export default function App(){
     setSystem({ cpu: 0, mem: 0, gpu: 0 })
     setNotesState('')
     setStream(true)
+    streamRef.current = true
     setSocket(prev => {
       if(prev) prev.disconnect()
       return null

--- a/frontend/src/components/RoadChain.jsx
+++ b/frontend/src/components/RoadChain.jsx
@@ -21,6 +21,13 @@ export default function RoadChain(){
     })()
   }, [])
 
+  useEffect(() => {
+    if (!query) {
+      setResult(null)
+      setError('')
+    }
+  }, [query])
+
   function toggle(hash){
     setExpanded(prev => ({ ...prev, [hash]: !prev[hash] }))
   }


### PR DESCRIPTION
## Summary
- resetState now refreshes the stream ref so auth failures restore streaming defaults
- clear RoadChain search result and error when the query input is emptied

## Testing
- `npm --prefix backend install`
- `npm --prefix backend test`
- `npm --prefix frontend install`
- `npm --prefix frontend test`
- `npm --prefix frontend run build`
- `curl -v http://localhost:4000/api/roadchain/blocks` *(fails: connection refused)*
- `curl -v http://localhost:4000/api/roadchain/block/0xdef456` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b68bcdf4dc8329a0ab484a2bba49c5