### PR TITLE
chore: resolve gitignore merge conflicts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,5 +54,4 @@ lucidia/modules/random_fields/datasets/__pycache__/
 !opt/blackroad/tdb/.env
 
 # Rust build artifacts
-target/
 **/target/


### PR DESCRIPTION
## Summary
- consolidate Rust build artifacts under a single `**/target/` rule in `.gitignore`

## Testing
- `pre-commit run --files .gitignore` *(fails: HTTP 403 during git fetch)*
- `pytest` *(fails: 11 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b69cb801988329adc956e8dd1add5c