### PR TITLE
feat(backend): add task listing endpoint

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -65,6 +65,13 @@ const app = http.createServer(async (req, res) => {
     }
   }
 
+  if (req.method === 'GET' && req.url === '/api/tasks') {
+    if (req.headers.authorization !== `Bearer ${VALID_USER.token}`) {
+      return send(res, 401, { error: 'unauthorized' });
+    }
+    return send(res, 200, { tasks });
+  }
+
   // invalid JSON catch-all
   if (req.method === 'POST') {
     try {


### PR DESCRIPTION
## Summary
- allow clients to fetch current tasks via `GET /api/tasks`

## Testing
- `npm test` *(fails: jest: not found)*
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b69f99311883298fb1c5af54b163df