### PR TITLE
chore: align react versions in blackroad site

### DIFF
--- a/sites/blackroad/package-lock.json
+++ b/sites/blackroad/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.3.1",
       "dependencies": {
         "react": "^18.3.1",
-        "react-dom": "^19.1.1",
+        "react-dom": "^18.3.1",
         "react-rnd": "10.5.2",
         "react-router-dom": "7.8.2",
         "recharts": "^2.11.0"
@@ -19,7 +19,7 @@
         "@playwright/test": "^1.47.0",
         "@size-limit/file": "^11.1.5",
         "@types/react": "^18.3.4",
-        "@types/react-dom": "^19.1.9",
+        "@types/react-dom": "^18.3.7",
         "@typescript-eslint/eslint-plugin": "^8.4.0",
         "@typescript-eslint/parser": "^8.4.0",
         "@vitejs/plugin-react": "5.0.2",
@@ -1377,13 +1377,13 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.1.9",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.9.tgz",
-      "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^19.0.0"
+        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3866,15 +3866,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.1.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
-      "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
       "dependencies": {
-        "scheduler": "^0.26.0"
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
       },
       "peerDependencies": {
-        "react": "^19.1.1"
+        "react": "^18.3.1"
       }
     },
     "node_modules/react-draggable": {
@@ -4162,10 +4163,13 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
-      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
-      "license": "MIT"
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
     },
     "node_modules/section-matter": {
       "version": "1.0.0",
@@ -4656,6 +4660,21 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/update-browserslist-db": {

--- a/sites/blackroad/package.json
+++ b/sites/blackroad/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "react": "^18.3.1",
-    "react-dom": "^19.1.1",
+    "react-dom": "^18.3.1",
     "react-rnd": "10.5.2",
     "react-router-dom": "7.8.2",
     "recharts": "^2.11.0"
@@ -26,7 +26,7 @@
     "@playwright/test": "^1.47.0",
     "@size-limit/file": "^11.1.5",
     "@types/react": "^18.3.4",
-    "@types/react-dom": "^19.1.9",
+    "@types/react-dom": "^18.3.7",
     "@typescript-eslint/eslint-plugin": "^8.4.0",
     "@typescript-eslint/parser": "^8.4.0",
     "@vitejs/plugin-react": "5.0.2",


### PR DESCRIPTION
## Summary
- align `react`, `react-dom`, and `@types/react-dom` to React 18 for the BlackRoad site
- reinstall packages and rebuild the site

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7314dbf2c8329bbecf1739270bd29