### PR TITLE
fix: remove deployment log from repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ _trash/
 npm-debug.log*
 yarn-debug.log*
 pnpm-debug.log*
+blackroad_deploy.log
 
 # OS
 .DS_Store

--- a/blackroad_deploy.log
+++ b/blackroad_deploy.log
@@ -1,6 +1,0 @@
-Tue Sep  2 18:14:21 UTC 2025: Deployment attempted.
-- /var/www/blackroad missing; git pull skipped.
-- pnpm version: 10.11.0
-- systemd services created but not started (systemd unavailable).
-- nginx configured and started.
-- curl to localhost:3000 and 3001 failed.


### PR DESCRIPTION
# Summary

What does this change?

# Testing
- Local build passes
- `npm run build` (site) / API boots
- E2E (Playwright) green

# Checklist
- Docs/README updated if needed
- No secrets committed
- Labels added (area/site, area/api, etc.)
