### PR TITLE
refactor: clarify ssh-keygen comment example

### DIFF
--- a/codex/tools/codex_repo_wizard.py
+++ b/codex/tools/codex_repo_wizard.py
@@ -99,7 +99,7 @@ def fp_of_line(line):
     p = subprocess.run(["ssh-keygen","-lf","-"], input=line+"\n", capture_output=True, text=True)
     if p.returncode != 0: return None
     parts = p.stdout.strip().split()
-    return parts[1] if len(parts) >= 2 else None  # output: "bits SHA256:... host (TYPE)"
+    return parts[1] if len(parts) >= 2 else None  # Example: "256 SHA256:abcdef... host (ED25519)"
 
 def pin_known_hosts(host_map):
     ensure_dir(KNOWN_HOSTS_PATH.parent)


### PR DESCRIPTION
## Summary
- clarify example output for `ssh-keygen -lf` in `fp_of_line`

## Testing
- `pre-commit run --files codex/tools/codex_repo_wizard.py` *(fails: CalledProcessError: git fetch origin: HTTP 403)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'torchquantum')*

------
https://chatgpt.com/codex/tasks/task_e_68b80459be7883299195e690d5daa66e