### PR TITLE
docs: clarify comment bot and restore codex prompt

### DIFF
--- a/.github/prompts/codex-fix-comments.md
+++ b/.github/prompts/codex-fix-comments.md
@@ -1,0 +1,6 @@
+# CODEx: Fix Comments
+
+- Ensure code comments are clear, concise, and grammatically correct.
+- Use proper punctuation and capitalization.
+- Remove outdated or redundant comments without altering code behavior.
+- Verify examples and references remain accurate after edits.

--- a/agents/comment_bot.py
+++ b/agents/comment_bot.py
@@ -20,7 +20,15 @@ class CommentBot:
             self.token = os.getenv("GITHUB_TOKEN")
 
     def comment(self, issue_number: int, body: str) -> dict:
-        """Post a comment on the specified issue or pull request."""
+        """Post a comment on a GitHub issue or pull request.
+
+        Args:
+            issue_number: The target issue or pull request number.
+            body: Markdown content of the comment.
+
+        Returns:
+            The JSON response from the GitHub API.
+        """
         url = f"https://api.github.com/repos/{self.repo}/issues/{issue_number}/comments"
         headers = {"Authorization": f"token {self.token}"} if self.token else {}
         payload = {"body": body}


### PR DESCRIPTION
## Summary
- document CommentBot.comment arguments and return value
- restore `codex-fix-comments` prompt for comment cleanups

## Testing
- `pre-commit run --files agents/comment_bot.py .github/prompts/codex-fix-comments.md` *(fails: CalledProcessError: git fetch 403)*
- `python -m py_compile *.py`
- `python auto_novel_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_68b804bc2118832987ff7d56f04512f2