### PR TITLE
feat: add multi-agent chat portal

### DIFF
--- a/sites/multi-agent-chat/.gitignore
+++ b/sites/multi-agent-chat/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.next

--- a/sites/multi-agent-chat/app/api/chat/route.ts
+++ b/sites/multi-agent-chat/app/api/chat/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+interface Message {
+  author: string;
+  content: string;
+}
+
+const personas = ['Lucidia', 'Cecilia', 'Silas', 'Alexa'];
+const conversation: Message[] = [];
+
+function personaReply(name: string, userMessage: string): string {
+  switch (name) {
+    case 'Lucidia':
+      return `Illuminated thought regarding "${userMessage}".`;
+    case 'Cecilia':
+      return `Cecilia reflects: "${userMessage}"? Intriguing.`;
+    case 'Silas':
+      return `Silas computes a view on "${userMessage}".`;
+    case 'Alexa':
+      return `Alexa responds cheerfully about "${userMessage}".`;
+    default:
+      return `${name} has no response.`;
+  }
+}
+
+export async function GET() {
+  return NextResponse.json({ messages: conversation });
+}
+
+export async function POST(req: NextRequest) {
+  const { message } = await req.json();
+  const userMsg: Message = { author: 'User', content: message };
+  conversation.push(userMsg);
+
+  personas.forEach(name => {
+    const reply = personaReply(name, message);
+    conversation.push({ author: name, content: reply });
+  });
+
+  return NextResponse.json({ messages: conversation });
+}

--- a/sites/multi-agent-chat/app/globals.css
+++ b/sites/multi-agent-chat/app/globals.css
@@ -1,0 +1,40 @@
+html, body {
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  font-family: Arial, sans-serif;
+}
+
+main {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 1rem;
+}
+
+.chat-history {
+  flex: 1;
+  overflow-y: auto;
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  margin-bottom: 0.5rem;
+  border-radius: 4px;
+}
+
+.message {
+  margin-bottom: 0.25rem;
+}
+
+.input-area {
+  display: flex;
+}
+
+.input-area input {
+  flex: 1;
+  padding: 0.5rem;
+  margin-right: 0.5rem;
+}
+
+.input-area button {
+  padding: 0.5rem 1rem;
+}

--- a/sites/multi-agent-chat/app/layout.tsx
+++ b/sites/multi-agent-chat/app/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'Multi-Agent Chat Portal',
+  description: 'Chat with multiple AI personas',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/sites/multi-agent-chat/app/page.tsx
+++ b/sites/multi-agent-chat/app/page.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+interface Message {
+  author: string;
+  content: string;
+}
+
+export default function Home() {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState('');
+  const endRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem('chat');
+    if (stored) {
+      setMessages(JSON.parse(stored));
+    } else {
+      fetch('/api/chat')
+        .then(res => res.json())
+        .then(data => setMessages(data.messages));
+    }
+  }, []);
+
+  useEffect(() => {
+    window.localStorage.setItem('chat', JSON.stringify(messages));
+    endRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  const sendMessage = async () => {
+    if (!input.trim()) return;
+    const res = await fetch('/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: input }),
+    });
+    const data = await res.json();
+    setMessages(data.messages);
+    setInput('');
+  };
+
+  const handleKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      sendMessage();
+    }
+  };
+
+  return (
+    <main>
+      <div className="chat-history">
+        {messages.map((msg, idx) => (
+          <div key={idx} className="message">
+            <strong>{msg.author}:</strong> {msg.content}
+          </div>
+        ))}
+        <div ref={endRef} />
+      </div>
+      <div className="input-area">
+        <input
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          onKeyDown={handleKey}
+          placeholder="Type a message..."
+        />
+        <button onClick={sendMessage}>Send</button>
+      </div>
+    </main>
+  );
+}

--- a/sites/multi-agent-chat/next-env.d.ts
+++ b/sites/multi-agent-chat/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/sites/multi-agent-chat/next.config.ts
+++ b/sites/multi-agent-chat/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {};
+
+export default nextConfig;

--- a/sites/multi-agent-chat/package.json
+++ b/sites/multi-agent-chat/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "multi-agent-chat",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "5.3.3",
+    "@types/react": "18.2.34",
+    "@types/node": "20.11.0"
+  }
+}

--- a/sites/multi-agent-chat/tsconfig.json
+++ b/sites/multi-agent-chat/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add Next.js 14 chat portal with four placeholder personas
- simulate persona replies on an API route and render chat UI

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b80b23d1688329bc1baa379bed640f