### PR TITLE
feat(portals): redirect after login

### DIFF
--- a/apps/portals/app/login/page.tsx
+++ b/apps/portals/app/login/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { Button } from "../../components/ui/button";
 import { Card } from "../../components/ui/card";
 import { Input } from "../../components/ui/input";
@@ -8,11 +9,17 @@ import { Logo } from "../../components/ui/logo";
 
 export default function LoginPage() {
   const [loading, setLoading] = useState(false);
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const next = searchParams.get("next") ?? "/";
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setLoading(true);
-    setTimeout(() => setLoading(false), 1000);
+    setTimeout(() => {
+      setLoading(false);
+      router.push(next);
+    }, 1000);
   }
 
   return (


### PR DESCRIPTION
## Summary
- add router-based redirect after login using `next` query param

## Testing
- `npm test` *(fails: jest not found)*
- `npm --prefix apps/portals test` *(fails: missing script)*
- `npm --prefix apps/portals run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b80aa9088083299ff744ec1e51fe32