### PR TITLE
feat: add local session engine

### DIFF
--- a/apps/portals/app/roadview/page.tsx
+++ b/apps/portals/app/roadview/page.tsx
@@ -1,42 +1,39 @@
-import { Card } from "../../components/ui/card";
+'use client';
 
-interface Video {
-  title: string;
-  description: string;
-  url: string;
-}
-
-const videos: Video[] = [
-  {
-    title: "Welcome to RoadView",
-    description: "Introductory clip about the RoadView portal.",
-    url: "https://www.w3schools.com/html/mov_bbb.mp4",
-  },
-  {
-    title: "Road Infrastructure Update",
-    description: "A short look at the latest RoadChain upgrade.",
-    url: "https://www.w3schools.com/html/movie.mp4",
-  },
-];
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { listSessions, setCurrentSession, SessionData } from '../../lib/sessionEngine';
 
 export default function RoadViewPage() {
+  const [sessions, setSessions] = useState<SessionData[]>([]);
+  const router = useRouter();
+
+  useEffect(() => {
+    setSessions(listSessions());
+  }, []);
+
+  function load(name: string) {
+    setCurrentSession(name);
+    router.push('/chat');
+  }
+
   return (
     <main className="mx-auto max-w-5xl space-y-4 p-4">
-      <h1 className="text-2xl font-bold">RoadView</h1>
-      <div className="grid gap-4 md:grid-cols-2">
-        {videos.map((video) => (
-          <Card key={video.title} className="p-4">
-            <div
-              className="mb-2 w-full overflow-hidden rounded bg-black"
-              style={{ aspectRatio: "16 / 9" }}
-            >
-              <video className="h-full w-full" controls src={video.url} />
+      <h1 className="text-2xl font-bold">Saved Sessions</h1>
+      {sessions.length === 0 && (
+        <p className="text-sm text-gray-400">No sessions saved yet.</p>
+      )}
+      <ul className="space-y-2">
+        {sessions.map(s => (
+          <li key={s.name} className="flex items-center justify-between border p-3 rounded">
+            <div>
+              <div className="font-semibold">{s.name}</div>
+              <div className="text-xs text-gray-400">{new Date(s.timestamp).toLocaleString()}</div>
             </div>
-            <h2 className="text-lg font-semibold">{video.title}</h2>
-            <p className="text-sm text-gray-400">{video.description}</p>
-          </Card>
+            <button onClick={() => load(s.name)} className="border rounded px-3 py-1">Load</button>
+          </li>
         ))}
-      </div>
+      </ul>
     </main>
   );
 }

--- a/apps/portals/lib/sessionEngine.ts
+++ b/apps/portals/lib/sessionEngine.ts
@@ -1,0 +1,45 @@
+export interface SessionData {
+  name: string;
+  chat: any[];
+  files: any[];
+  assets: any[];
+  timestamp: number;
+}
+
+const STORAGE_KEY = 'portalSessions';
+const CURRENT_KEY = 'currentPortalSession';
+
+export function saveSession(name: string, data: { chat: any[]; files: any[]; assets: any[] }) {
+  if (typeof window === 'undefined') return;
+  const sessions: SessionData[] = JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+  const idx = sessions.findIndex(s => s.name === name);
+  const session: SessionData = { name, timestamp: Date.now(), ...data };
+  if (idx >= 0) {
+    sessions[idx] = session;
+  } else {
+    sessions.push(session);
+  }
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(sessions));
+}
+
+export function listSessions(): SessionData[] {
+  if (typeof window === 'undefined') return [];
+  return JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+}
+
+export function loadSession(name: string): SessionData | null {
+  const sessions = listSessions();
+  return sessions.find(s => s.name === name) || null;
+}
+
+export function setCurrentSession(name: string) {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(CURRENT_KEY, name);
+}
+
+export function getCurrentSession(): SessionData | null {
+  if (typeof window === 'undefined') return null;
+  const name = localStorage.getItem(CURRENT_KEY);
+  if (!name) return null;
+  return loadSession(name);
+}


### PR DESCRIPTION
## Summary
- add browser-based session engine storing chat, files, and assets
- allow saving current chat as a named session
- list and load saved sessions from /roadview

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b80e0a02d48329bcbdee2409a357f7