### PR TITLE
feat: add asset creator placeholder component

### DIFF
--- a/sites/blackroad/public/portal/asset-creator.js
+++ b/sites/blackroad/public/portal/asset-creator.js
@@ -1,0 +1,38 @@
+(function () {
+  function initAssetCreator(el) {
+    if (!el) return;
+    const style = document.createElement('style');
+    style.textContent = `
+      .ac-form { display:flex; gap:8px; margin:20px 0; }
+      .ac-form input { flex:1; padding:8px; border-radius:4px; border:1px solid #23232c; background:#0f0f15; color:#e8e8f0; }
+      .ac-form button { padding:8px 12px; border:none; border-radius:4px; background:#34d399; color:#0b0b10; cursor:pointer; }
+      .ac-gallery { display:grid; grid-template-columns:repeat(auto-fill,minmax(160px,1fr)); gap:12px; }
+      .ac-item { background:#23232c; border-radius:8px; height:120px; display:flex; align-items:center; justify-content:center; color:#a3a3ad; font-size:12px; text-align:center; padding:8px; }
+    `;
+    document.head.appendChild(style);
+
+    const form = document.createElement('form');
+    form.className = 'ac-form';
+    form.innerHTML = `
+      <input type="text" placeholder="Describe an asset" aria-label="asset prompt" />
+      <button type="submit">Create</button>
+    `;
+    const gallery = document.createElement('div');
+    gallery.className = 'ac-gallery';
+    el.appendChild(form);
+    el.appendChild(gallery);
+
+    form.addEventListener('submit', function (e) {
+      e.preventDefault();
+      const input = form.querySelector('input');
+      const prompt = input.value.trim();
+      if (!prompt) return;
+      const item = document.createElement('div');
+      item.className = 'ac-item';
+      item.textContent = prompt;
+      gallery.appendChild(item);
+      input.value = '';
+    });
+  }
+  window.initAssetCreator = initAssetCreator;
+})();

--- a/sites/blackroad/public/portal/index.html
+++ b/sites/blackroad/public/portal/index.html
@@ -31,7 +31,11 @@
       <h1>Portals</h1>
       <p class="muted">Jump into any portal. (Main app at <a href="/">/</a>.)</p>
       <div class="grid" id="grid"></div>
+      <h2 style="margin:40px 0 12px">Asset Creator</h2>
+      <p class="muted" style="margin:0 0 12px">Type a command to simulate assets.</p>
+      <div id="assetCreator"></div>
     </div>
+    <script src="asset-creator.js"></script>
     <script>
       const portals = [
         { name: "Roadbook",  desc: "Trip journals, maps, and itineraries.", href: "/portal/roadbook" },
@@ -51,6 +55,7 @@
           <a href="${p.href}" aria-label="Open ${p.name}">Open →</a>
         </article>
       `).join('');
+      initAssetCreator(document.getElementById('assetCreator'));
     </script>
   </body>
 </html>

--- a/sites/blackroad/public/portal/roadview/index.html
+++ b/sites/blackroad/public/portal/roadview/index.html
@@ -48,14 +48,19 @@
       <h1>Roadview</h1>
       <p>Live journey streams on an interactive globe. Back to <a href="/">home</a>.</p>
       <div id="globe"></div>
+      <h2 style="margin:40px 0 12px">Asset Creator</h2>
+      <p>Type a command to simulate assets.</p>
+      <div id="assetCreator"></div>
     </div>
     <script src="https://unpkg.com/three@0.155.0/build/three.min.js"></script>
     <script src="https://unpkg.com/globe.gl@3.9.0/dist/globe.gl.min.js"></script>
+    <script src="../asset-creator.js"></script>
     <script>
       const world = Globe()(document.getElementById('globe'))
         .globeImageUrl('//unpkg.com/three-globe/example/img/earth-dark.jpg')
         .backgroundColor('#0b0b10');
       world.pointOfView({ lat: 0, lng: 0, altitude: 2.5 });
+      initAssetCreator(document.getElementById('assetCreator'));
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add reusable Asset Creator script for generating placeholder assets
- expose Asset Creator on /portal and /portal/roadview pages

## Testing
- `npm test` *(fails: jest: not found)*
- `npx jest tests/api_health.test.js` *(fails: npm 503 Service Unavailable fetching jest)*
- `npm --prefix sites/blackroad test`


------
https://chatgpt.com/codex/tasks/task_e_68b80dfd6d888329a5747f7957c0f6c6