### PR TITLE
feat: add roadwork builder

### DIFF
--- a/sites/blackroad/src/App.jsx
+++ b/sites/blackroad/src/App.jsx
@@ -11,6 +11,7 @@ import Lucidia from "./pages/Lucidia.jsx";
 import InfinityMath from "./pages/InfinityMath.jsx";
 import Agents from "./pages/Agents.jsx";
 import Desktop from "./pages/Desktop.jsx";
+import RoadWork from "./pages/RoadWork.jsx";
 
 function useApiHealth(){
   const [state,setState]=useState({ok:null, info:""});
@@ -60,6 +61,7 @@ function LegacyApp(){
           <NavLink className="nav-link" to="/terminal">Terminal</NavLink>
           <NavLink className="nav-link" to="/roadview">RoadView</NavLink>
           <NavLink className="nav-link" to="/backroad">BackRoad</NavLink>
+          <NavLink className="nav-link" to="/roadwork">RoadWork</NavLink>
           <NavLink className="nav-link" to="/agents">Agents</NavLink>
           <NavLink className="nav-link" to="/subscribe">Subscribe</NavLink>
           <NavLink className="nav-link" to="/lucidia">Lucidia</NavLink>
@@ -94,6 +96,7 @@ function LegacyApp(){
             <Route path="/terminal" element={<Terminal/>} />
             <Route path="/roadview" element={<RoadView/>} />
             <Route path="/backroad" element={<BackRoad/>} />
+            <Route path="/roadwork" element={<RoadWork/>} />
             <Route path="/agents" element={<Agents/>} />
             <Route path="/subscribe" element={<Subscribe/>} />
             <Route path="/lucidia" element={<Lucidia/>} />
@@ -104,6 +107,7 @@ function LegacyApp(){
             <Route path="terminal" element={<Terminal/>} />
             <Route path="roadview" element={<RoadView/>} />
             <Route path="backroad" element={<BackRoad/>} />
+            <Route path="roadwork" element={<RoadWork/>} />
             <Route path="subscribe" element={<Subscribe/>} />
             <Route path="lucidia" element={<Lucidia/>} />
             <Route path="math" element={<InfinityMath/>} />

--- a/sites/blackroad/src/pages/RoadWork.jsx
+++ b/sites/blackroad/src/pages/RoadWork.jsx
@@ -1,0 +1,106 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const TYPES = ['code', 'image', 'game', 'story', 'tool'];
+const AGENTS = ['Lucidia', 'Silas', 'Aria', 'Nova'];
+
+function StepModal({ show, children }) {
+  return (
+    <div
+      className={`fixed inset-0 flex items-center justify-center bg-black/50 transition-opacity duration-300 ${
+        show ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
+      }`}
+    >
+      <div
+        className={`bg-neutral-900 p-6 rounded-xl shadow-xl transform transition-transform duration-300 ${
+          show ? 'scale-100' : 'scale-95'
+        }`}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export default function RoadWork() {
+  const [step, setStep] = useState(0);
+  const [name, setName] = useState('');
+  const [type, setType] = useState('');
+  const [agent, setAgent] = useState('');
+  const [generating, setGenerating] = useState(false);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (generating) {
+      const t = setTimeout(() => {
+        navigate('/portal');
+      }, 1200);
+      return () => clearTimeout(t);
+    }
+  }, [generating, navigate]);
+
+  return (
+    <div className="relative">
+      <StepModal show={step === 0}>
+        <h2 className="text-xl font-semibold mb-2">Name your project</h2>
+        <input
+          className="input w-full mb-4"
+          placeholder="Project name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <button className="btn" disabled={!name.trim()} onClick={() => setStep(1)}>
+          Next
+        </button>
+      </StepModal>
+
+      <StepModal show={step === 1}>
+        <h2 className="text-xl font-semibold mb-2">Choose type</h2>
+        <div className="flex flex-wrap gap-2 mb-4">
+          {TYPES.map((t) => (
+            <button
+              key={t}
+              className={`btn ${type === t ? '' : 'opacity-60'}`}
+              onClick={() => setType(t)}
+            >
+              {t.charAt(0).toUpperCase() + t.slice(1)}
+            </button>
+          ))}
+        </div>
+        <button className="btn" disabled={!type} onClick={() => setStep(2)}>
+          Next
+        </button>
+      </StepModal>
+
+      <StepModal show={step === 2}>
+        <h2 className="text-xl font-semibold mb-2">Select lead agent</h2>
+        <div className="flex flex-wrap gap-2 mb-4">
+          {AGENTS.map((a) => (
+            <button
+              key={a}
+              className={`btn ${agent === a ? '' : 'opacity-60'}`}
+              onClick={() => setAgent(a)}
+            >
+              {a}
+            </button>
+          ))}
+        </div>
+        <button className="btn" disabled={!agent} onClick={() => setStep(3)}>
+          Next
+        </button>
+      </StepModal>
+
+      <StepModal show={step === 3}>
+        <h2 className="text-xl font-semibold mb-4">Generate starter files</h2>
+        {generating ? (
+          <div className="animate-pulse text-center">Preparing {name}...</div>
+        ) : (
+          <button className="btn" onClick={() => setGenerating(true)}>
+            Generate
+          </button>
+        )}
+      </StepModal>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add RoadWork project builder UI with step-by-step panels
- link route `/roadwork` in legacy app navigation

## Testing
- `npm test` *(fails: jest: not found)*
- `npm --prefix sites/blackroad test`
- `npm --prefix sites/blackroad run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b80de37fa08329b5e0e575beab4445