### PR TITLE
Add canonical metadata and redirects for portals site

### DIFF
--- a/apps/portals/app/layout.tsx
+++ b/apps/portals/app/layout.tsx
@@ -1,12 +1,40 @@
 import "./globals.css";
 import type { ReactNode } from "react";
-import BlackRoadCopilot from "@/components/BlackRoadCopilot";
 import type { Metadata } from "next";
 import BlackRoadCopilot from "../components/BlackRoadCopilot";
 
 export const metadata: Metadata = {
-  title: "BlackRoad Portals",
+  metadataBase: new URL("https://blackroad.io"),
+  title: {
+    default: "BlackRoad Portals",
+    template: "%s | BlackRoad Portals",
+  },
   description: "BlackRoad.io portal hub",
+  alternates: {
+    canonical: "/",
+  },
+  openGraph: {
+    title: "BlackRoad Portals",
+    description: "BlackRoad.io portal hub",
+    url: "https://blackroad.io",
+    siteName: "BlackRoad",
+    images: [
+      {
+        url: "https://blackroad.io/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "BlackRoad",
+      },
+    ],
+    locale: "en_US",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "BlackRoad Portals",
+    description: "BlackRoad.io portal hub",
+    images: ["https://blackroad.io/og-image.png"],
+  },
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {

--- a/apps/portals/middleware.ts
+++ b/apps/portals/middleware.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function middleware(request: NextRequest) {
+  const url = request.nextUrl.clone();
+  const proto = request.headers.get("x-forwarded-proto");
+
+  if (proto === "http") {
+    url.protocol = "https";
+    return NextResponse.redirect(url);
+  }
+
+  if (url.hostname === "www.blackroad.io") {
+    url.hostname = "blackroad.io";
+    return NextResponse.redirect(url);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: "/:path*",
+};

--- a/apps/portals/next.config.mjs
+++ b/apps/portals/next.config.mjs
@@ -1,6 +1,27 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  async redirects() {
+    return [
+      {
+        source: "/:path*",
+        has: [
+          { type: "host", value: "www.blackroad.io" },
+        ],
+        destination: "https://blackroad.io/:path*",
+        permanent: true,
+      },
+      {
+        source: "/:path*",
+        has: [
+          { type: "host", value: "blackroad.io" },
+          { type: "header", key: "x-forwarded-proto", value: "http" },
+        ],
+        destination: "https://blackroad.io/:path*",
+        permanent: true,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- define canonical, Open Graph, and Twitter metadata for consistent SEO previews
- redirect www and http traffic to https://blackroad.io
- enforce HTTPS and apex domain at the edge via middleware

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Could not resolve dependency: eslint-config-next@14.2.3)*
- `npm run build` *(fails: Could not resolve dependency: eslint-config-next@14.2.3)*

------
https://chatgpt.com/codex/tasks/task_e_68b80e14311083299db9e2d8613c4df5