### PR TITLE
feat: add Lucidia multi-agent chat portal

### DIFF
--- a/modules/lucidia/README.md
+++ b/modules/lucidia/README.md
@@ -1,0 +1,15 @@
+# Lucidia
+
+A lightweight multi-agent chat portal that routes natural-language requests to
+available agents. Initial support is provided through an adapter for the existing
+`AutoNovelAgent` found under `agents/`.
+
+## Usage
+
+```python
+from modules.lucidia import LucidiaPortal, AutoNovelAdapter
+
+portal = LucidiaPortal([AutoNovelAdapter()])
+responses = portal.chat("tell me a story about exploration")
+print(responses["AutoNovelAgent"])  # -> short story
+```

--- a/modules/lucidia/__init__.py
+++ b/modules/lucidia/__init__.py
@@ -1,0 +1,6 @@
+"""Lucidia module: multi-agent chat portal."""
+
+from .portal import LucidiaPortal
+from .adapters import AutoNovelAdapter
+
+__all__ = ["LucidiaPortal", "AutoNovelAdapter"]

--- a/modules/lucidia/adapters.py
+++ b/modules/lucidia/adapters.py
@@ -1,0 +1,42 @@
+"""Adapters for integrating existing agents with the portal."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import Optional
+
+# Ensure we can import from the standalone ``agents`` directory.
+AGENTS_PATH = Path(__file__).resolve().parents[2] / "agents"
+if str(AGENTS_PATH) not in sys.path:
+    sys.path.append(str(AGENTS_PATH))
+
+from auto_novel_agent import AutoNovelAgent  # type: ignore
+
+
+class AutoNovelAdapter:
+    """Wrap :class:`AutoNovelAgent` to provide chat-style responses."""
+
+    name = "AutoNovelAgent"
+
+    def __init__(self, agent: Optional[AutoNovelAgent] = None) -> None:
+        self.agent = agent or AutoNovelAgent()
+
+    def respond(self, message: str) -> str:
+        msg = message.lower()
+        story_match = re.search(r"story about (.+)", msg)
+        if story_match:
+            theme = story_match.group(1).strip()
+            return self.agent.generate_story(theme)
+
+        game_match = re.search(r"create (?:a )?game.*in\s+([\w-]+)", msg)
+        if game_match:
+            engine = game_match.group(1)
+            try:
+                self.agent.create_game(engine)
+                return f"Creating a {engine.capitalize()} game without weapons..."
+            except Exception as exc:  # noqa: BLE001 - provide user feedback
+                return str(exc)
+
+        return "AutoNovelAgent is unsure how to respond."

--- a/modules/lucidia/portal.py
+++ b/modules/lucidia/portal.py
@@ -1,0 +1,34 @@
+"""Core chat portal orchestrating multiple agents."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Protocol
+
+
+class Agent(Protocol):
+    """Simple protocol that all chat agents must follow."""
+
+    def respond(self, message: str) -> str:  # pragma: no cover - protocol definition
+        """Return a response for the given message."""
+
+
+class LucidiaPortal:
+    """Coordinate a conversation across multiple agents."""
+
+    def __init__(self, agents: List[Agent] | None = None) -> None:
+        self.agents: List[Agent] = agents or []
+
+    def register(self, agent: Agent) -> None:
+        """Register a new agent with the portal."""
+        self.agents.append(agent)
+
+    def chat(self, message: str) -> Dict[str, str]:
+        """Send ``message`` to all agents and collect their responses."""
+        responses: Dict[str, str] = {}
+        for agent in self.agents:
+            name = getattr(agent, "name", agent.__class__.__name__)
+            try:
+                responses[name] = agent.respond(message)
+            except Exception as exc:  # noqa: BLE001 - generic for user feedback
+                responses[name] = f"Error: {exc}"
+        return responses

--- a/modules/lucidia/test_portal.py
+++ b/modules/lucidia/test_portal.py
@@ -1,0 +1,15 @@
+"""Tests for the Lucidia multi-agent chat portal."""
+
+from modules.lucidia import AutoNovelAdapter, LucidiaPortal
+
+
+def test_story_response() -> None:
+    portal = LucidiaPortal([AutoNovelAdapter()])
+    responses = portal.chat("tell me a story about space exploration")
+    assert "space exploration" in responses["AutoNovelAgent"].lower()
+
+
+def test_create_game_response() -> None:
+    portal = LucidiaPortal([AutoNovelAdapter()])
+    responses = portal.chat("please create a game in Unity")
+    assert "creating a unity game without weapons" in responses["AutoNovelAgent"].lower()


### PR DESCRIPTION
## Summary
- add Lucidia module for multi-agent chat
- expose adapter for AutoNovelAgent
- document usage and provide tests

## Testing
- `python -m py_compile modules/lucidia/*.py`
- `pytest modules/lucidia/test_portal.py`

------
https://chatgpt.com/codex/tasks/task_e_68b80e2dd57883298392e1a04a7cc717