### PR TITLE
feat: scaffold BlackroadLM framework

### DIFF
--- a/blackroadlm/__init__.py
+++ b/blackroadlm/__init__.py
@@ -1,0 +1,1 @@
+"""BlackroadLM package initialization."""

--- a/blackroadlm/api.py
+++ b/blackroadlm/api.py
@@ -1,0 +1,44 @@
+"""FastAPI application for BlackroadLM."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+import toml
+
+
+def load_persona(name: str) -> dict:
+    """Load persona configuration from the personas directory."""
+    persona_path = Path(__file__).parent / "personas" / f"{name}.toml"
+    if not persona_path.exists():
+        raise FileNotFoundError(f"Persona '{name}' not found")
+    return toml.loads(persona_path.read_text())
+
+
+class ChatRequest(BaseModel):
+    persona: str
+    messages: list
+    temperature: float | None = None
+
+
+class ChatResponse(BaseModel):
+    persona: str
+    reply: str
+
+
+app = FastAPI(title="BlackroadLM")
+
+
+@app.post("/chat", response_model=ChatResponse)
+async def chat(req: ChatRequest) -> ChatResponse:
+    persona_cfg = load_persona(req.persona)
+    # Placeholder echo response
+    last_message = req.messages[-1] if req.messages else ""
+    reply = f"{persona_cfg['system']['prompt']} | Echo: {last_message}"
+    return ChatResponse(persona=req.persona, reply=reply)
+
+
+def create_app() -> FastAPI:
+    """Factory for application instances."""
+    return app

--- a/blackroadlm/main.py
+++ b/blackroadlm/main.py
@@ -1,0 +1,82 @@
+"""CLI entrypoint for BlackroadLM."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def _serve(args: argparse.Namespace) -> None:
+    """Start the API server."""
+    from .api import create_app
+    import uvicorn
+
+    uvicorn.run(create_app(), host=args.host, port=args.port)
+
+
+def _chat(args: argparse.Namespace) -> None:
+    """Open a terminal chat session for a persona.
+
+    Currently this is a placeholder implementation.
+    """
+    print(f"[chat] Starting chat with persona '{args.persona}' (not implemented)")
+
+
+def _list_items(args: argparse.Namespace) -> None:  # noqa: ARG001
+    """List available models and personas."""
+    models_dir = Path(__file__).parent / "models"
+    personas_dir = Path(__file__).parent / "personas"
+
+    if models_dir.exists():
+        print("Models:")
+        for model in models_dir.iterdir():
+            print(f"- {model.name}")
+    else:
+        print("No models directory found")
+
+    if personas_dir.exists():
+        print("Personas:")
+        for persona in personas_dir.glob("*.toml"):
+            print(f"- {persona.stem}")
+    else:
+        print("No personas directory found")
+
+
+def _pull(args: argparse.Namespace) -> None:
+    """Download a model placeholder."""
+    print(f"[pull] Downloading model '{args.model}' (not implemented)")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="BlackroadLM CLI")
+    sub = parser.add_subparsers(dest="command")
+
+    serve_p = sub.add_parser("serve", help="Start the API server")
+    serve_p.add_argument("--host", default="0.0.0.0")
+    serve_p.add_argument("--port", type=int, default=8000)
+    serve_p.set_defaults(func=_serve)
+
+    chat_p = sub.add_parser("chat", help="Open a chat with a persona")
+    chat_p.add_argument("persona")
+    chat_p.set_defaults(func=_chat)
+
+    list_p = sub.add_parser("list", help="List models and personas")
+    list_p.set_defaults(func=_list_items)
+
+    pull_p = sub.add_parser("pull", help="Download a model")
+    pull_p.add_argument("model")
+    pull_p.set_defaults(func=_pull)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/blackroadlm/personas/Lucidia.toml
+++ b/blackroadlm/personas/Lucidia.toml
@@ -1,0 +1,11 @@
+name = "Lucidia"
+model = "llama3"
+
+[system]
+prompt = "You are Lucidia, the cheerful guide of the Blackroad platform."
+
+[style]
+tone = "warm"
+emoji = true
+verbosity = "balanced"
+creativity = 0.5


### PR DESCRIPTION
## Summary
- add CLI entrypoint for BlackroadLM with serve/chat/list/pull commands
- implement basic FastAPI app that loads personas and echoes messages
- provide initial Lucidia persona configuration

## Testing
- `pytest blackroadlm`


------
https://chatgpt.com/codex/tasks/task_e_68b80eb9f1088329ba4321f37d06274d