### PR TITLE
feat: add interactive portal and project flows

### DIFF
--- a/apps/portals/app/backroad/page.tsx
+++ b/apps/portals/app/backroad/page.tsx
@@ -1,0 +1,8 @@
+export default function BackRoadPage() {
+  return (
+    <main className="p-6">
+      <h1 className="text-xl font-bold">BackRoad</h1>
+      <p className="text-sm text-gray-400">Coming soon.</p>
+    </main>
+  );
+}

--- a/apps/portals/app/page.tsx
+++ b/apps/portals/app/page.tsx
@@ -3,9 +3,13 @@ import { Card } from "../components/ui/card";
 import { Logo } from "../components/ui/logo";
 
 const portals = [
+  { name: "Portal", href: "/portal" },
+  { name: "RoadWork", href: "/roadwork" },
+  { name: "RoadView", href: "/roadview" },
+  { name: "RoadGlitch", href: "/roadglitch" },
+  { name: "BackRoad", href: "/backroad" },
   { name: "Login", href: "/login" },
   { name: "Co-Code", href: "/cocode" },
-  { name: "RoadView", href: "/roadview" },
   { name: "RoadCoin", href: "/roadcoin" },
   { name: "RoadChain", href: "/roadchain" },
   { name: "Roadie", href: "/roadie" },

--- a/apps/portals/app/portal/page.tsx
+++ b/apps/portals/app/portal/page.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useChat } from '@ai-sdk/react';
+import { DefaultChatTransport, lastAssistantMessageIsCompleteWithToolCalls } from 'ai';
+import FileManager, { FileData } from '../../components/FileManager';
+import { saveSession, getCurrentSession } from '../../lib/sessionEngine';
+
+const agents = ['Lucidia', 'Silas', 'Cecilia', 'Alexa'];
+
+export default function PortalPage() {
+  const { messages, sendMessage, status, error } = useChat({
+    transport: new DefaultChatTransport({ api: '/api/chat' }),
+    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
+  });
+
+  const [agent, setAgent] = useState('Lucidia');
+  const [input, setInput] = useState('');
+  const [initialMessages, setInitialMessages] = useState<any[]>([]);
+  const [files, setFiles] = useState<FileData[]>([]);
+  const [assets, setAssets] = useState<string[]>([]);
+  const [lastAssistant, setLastAssistant] = useState('');
+
+  useEffect(() => {
+    const session = getCurrentSession();
+    if (session) {
+      setInitialMessages(session.chat || []);
+      setFiles(session.files || []);
+      setAssets(session.assets || []);
+    }
+  }, []);
+
+  const allMessages = [...initialMessages, ...messages];
+
+  useEffect(() => {
+    const last = allMessages.filter(m => m.role === 'assistant').slice(-1)[0];
+    if (last) {
+      const part = last.parts.find((p: any) => p.type === 'text');
+      setLastAssistant(part?.text || '');
+    }
+  }, [allMessages]);
+
+  function handleSave() {
+    const name = prompt('Session name?');
+    if (!name) return;
+    saveSession(name, { chat: allMessages, files, assets });
+  }
+
+  function saveLastToFile() {
+    if (!lastAssistant) return;
+    const name = prompt('File name?', `note-${files.length + 1}.txt`);
+    if (!name) return;
+    setFiles([...files, { name, content: lastAssistant }]);
+  }
+
+  function generateImage() {
+    const url = `https://picsum.photos/seed/${Date.now()}/300/200`;
+    setAssets([...assets, url]);
+  }
+
+  return (
+    <main className="mx-auto grid max-w-6xl gap-6 p-4 md:grid-cols-3">
+      <div className="space-y-4 md:col-span-2">
+        <div className="flex items-center gap-2">
+          <select
+            value={agent}
+            onChange={e => setAgent(e.target.value)}
+            className="rounded border px-2 py-1 text-sm"
+          >
+            {agents.map(a => (
+              <option key={a}>{a}</option>
+            ))}
+          </select>
+          <button onClick={handleSave} className="rounded border px-2 py-1 text-sm">
+            Save Session
+          </button>
+        </div>
+
+        <div className="space-y-3">
+          {allMessages.map((m: any) => (
+            <div key={m.id} className="text-sm leading-relaxed">
+              <b>{m.role}:</b>{' '}
+              {m.parts.map((part: any, i: number) => {
+                switch (part.type) {
+                  case 'text':
+                    return <span key={i}>{part.text}</span>;
+                  default:
+                    return null;
+                }
+              })}
+            </div>
+          ))}
+        </div>
+
+        {status === 'error' && <div className="text-red-600">{String(error)}</div>}
+
+        {lastAssistant && (
+          <div className="flex gap-2 text-xs">
+            <button onClick={saveLastToFile} className="rounded border px-2 py-1">
+              Save to File
+            </button>
+            <button onClick={generateImage} className="rounded border px-2 py-1">
+              Generate Image
+            </button>
+          </div>
+        )}
+
+        <form
+          onSubmit={e => {
+            e.preventDefault();
+            if (input.trim()) {
+              sendMessage({ text: `[${agent}] ${input}` });
+              setInput('');
+            }
+          }}
+          className="flex gap-2"
+        >
+          <input
+            className="flex-1 rounded border px-3 py-2"
+            value={input}
+            onChange={e => setInput(e.target.value)}
+            placeholder={`Ask ${agent}…`}
+          />
+          <button className="rounded border px-3 py-2">Send</button>
+        </form>
+
+        {assets.length > 0 && (
+          <div className="space-y-2">
+            <h2 className="font-bold">Assets</h2>
+            <div className="grid grid-cols-3 gap-2">
+              {assets.map((a, i) => (
+                <img key={i} src={a} alt="asset" className="w-full rounded" />
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+      <div>
+        <FileManager files={files} onChange={setFiles} />
+      </div>
+    </main>
+  );
+}
+

--- a/apps/portals/app/roadglitch/page.tsx
+++ b/apps/portals/app/roadglitch/page.tsx
@@ -1,0 +1,8 @@
+export default function RoadGlitchPage() {
+  return (
+    <main className="p-6">
+      <h1 className="text-xl font-bold">RoadGlitch</h1>
+      <p className="text-sm text-gray-400">Visual experiments coming soon.</p>
+    </main>
+  );
+}

--- a/apps/portals/app/roadwork/page.tsx
+++ b/apps/portals/app/roadwork/page.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { saveSession, setCurrentSession } from '../../lib/sessionEngine';
+
+export default function RoadWorkPage() {
+  const [name, setName] = useState('');
+  const router = useRouter();
+
+  function create() {
+    if (!name.trim()) return;
+    saveSession(name, { chat: [], files: [], assets: [] });
+    setCurrentSession(name);
+    router.push('/portal');
+  }
+
+  return (
+    <main className="mx-auto max-w-md space-y-4 p-6">
+      <h1 className="text-xl font-bold">New Project</h1>
+      <input
+        className="w-full rounded border px-3 py-2"
+        value={name}
+        onChange={e => setName(e.target.value)}
+        placeholder="Project name"
+      />
+      <button onClick={create} className="rounded border px-3 py-2">
+        Create
+      </button>
+    </main>
+  );
+}
+

--- a/apps/portals/components/FileManager.tsx
+++ b/apps/portals/components/FileManager.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useState } from 'react';
+
+export interface FileData {
+  name: string;
+  content: string;
+}
+
+interface Props {
+  files: FileData[];
+  onChange: (files: FileData[]) => void;
+}
+
+export function FileManager({ files, onChange }: Props) {
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
+
+  function createFile() {
+    const name = prompt('File name?');
+    if (!name) return;
+    onChange([...files, { name, content: '' }]);
+  }
+
+  function renameFile(i: number) {
+    const name = prompt('New name?', files[i].name);
+    if (!name) return;
+    const updated = [...files];
+    updated[i].name = name;
+    onChange(updated);
+  }
+
+  function deleteFile(i: number) {
+    if (!confirm('Delete file?')) return;
+    const updated = [...files];
+    updated.splice(i, 1);
+    onChange(updated);
+    if (openIndex === i) setOpenIndex(null);
+  }
+
+  function updateContent(i: number, content: string) {
+    const updated = [...files];
+    updated[i].content = content;
+    onChange(updated);
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <h2 className="font-bold">Files</h2>
+        <button onClick={createFile} className="border rounded px-2 py-1 text-xs">
+          New File
+        </button>
+      </div>
+      <ul className="space-y-1">
+        {files.map((f, i) => (
+          <li key={i} className="border rounded p-2">
+            <div className="flex justify-between">
+              <span
+                className="cursor-pointer"
+                onClick={() => setOpenIndex(openIndex === i ? null : i)}
+              >
+                {f.name}
+              </span>
+              <div className="space-x-1 text-xs">
+                <button onClick={() => renameFile(i)}>Rename</button>
+                <button onClick={() => deleteFile(i)}>Delete</button>
+              </div>
+            </div>
+            {openIndex === i && (
+              <textarea
+                className="mt-2 h-32 w-full rounded border p-2 text-xs"
+                value={f.content}
+                onChange={(e) => updateContent(i, e.target.value)}
+              />
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default FileManager;
+


### PR DESCRIPTION
## Summary
- add `/portal` chat with agent selection, file manager, and asset generation
- implement `/roadwork` creator and session navigation links
- include placeholder `/roadglitch` and `/backroad` routes

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm install` *(fails: unable to resolve dependency tree)*

------
https://chatgpt.com/codex/tasks/task_e_68b81110a8088329a6204d6a7ea583dc