### PR TITLE
feat: add session and ability logic

### DIFF
--- a/apps/portals/app/hooks/useSessionManager.ts
+++ b/apps/portals/app/hooks/useSessionManager.ts
@@ -1,0 +1,73 @@
+'use client';
+
+import { useState } from 'react';
+
+export interface File {
+  name: string;
+  content: string;
+  type: 'code' | 'image' | 'text' | 'json';
+}
+
+export interface Session {
+  id: string;
+  title: string;
+  agent: string;
+  messages: Message[];
+  files: File[];
+  createdAt: number;
+}
+
+export interface Message {
+  role: 'user' | 'agent';
+  content: string;
+  ability?: string;
+  timestamp: number;
+}
+
+export const useSessionManager = () => {
+  const [sessions, setSessions] = useState<Session[]>([]);
+  const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
+
+  const createSession = (agent = 'lucidia') => {
+    const newSession: Session = {
+      id: crypto.randomUUID(),
+      title: `Untitled Session`,
+      agent,
+      messages: [],
+      files: [],
+      createdAt: Date.now(),
+    };
+    setSessions(prev => [newSession, ...prev]);
+    setActiveSessionId(newSession.id);
+    return newSession;
+  };
+
+  const addMessage = (sessionId: string, message: Message) => {
+    setSessions(prev =>
+      prev.map(s =>
+        s.id === sessionId ? { ...s, messages: [...s.messages, message] } : s
+      )
+    );
+  };
+
+  const addFile = (sessionId: string, file: File) => {
+    setSessions(prev =>
+      prev.map(s =>
+        s.id === sessionId ? { ...s, files: [...s.files, file] } : s
+      )
+    );
+  };
+
+  const getActiveSession = () =>
+    sessions.find(s => s.id === activeSessionId) ?? null;
+
+  return {
+    sessions,
+    createSession,
+    addMessage,
+    addFile,
+    getActiveSession,
+    setActiveSessionId,
+  };
+};
+

--- a/apps/portals/lib/interpreter.ts
+++ b/apps/portals/lib/interpreter.ts
@@ -1,0 +1,21 @@
+export interface ParsedAbility {
+  ability: string;
+  content: string;
+}
+
+export function parseAgentOutput(raw: string): ParsedAbility {
+  const match = raw.match(/<ability:(.*?)>(.*?)<\/ability>/s);
+
+  if (match) {
+    return {
+      ability: match[1].trim(),
+      content: match[2].trim(),
+    };
+  }
+
+  return {
+    ability: 'generic.chat',
+    content: raw.trim(),
+  };
+}
+

--- a/apps/portals/lib/runAbility.ts
+++ b/apps/portals/lib/runAbility.ts
@@ -1,0 +1,43 @@
+import { File } from '../app/hooks/useSessionManager';
+
+interface AbilityPayload {
+  ability: string;
+  content: string;
+}
+
+export const runAbility = async (
+  payload: AbilityPayload
+): Promise<{ file?: File; output?: string }> => {
+  const { ability, content } = payload;
+
+  switch (ability) {
+    case 'codestream.generateFile':
+      return {
+        file: {
+          name: 'main.py',
+          type: 'code',
+          content: content,
+        },
+      };
+
+    case 'visioncraft.generateImage':
+      return {
+        file: {
+          name: 'generated-image.png',
+          type: 'image',
+          content: '[base64 image or URL]',
+        },
+      };
+
+    case 'thoughtmirror.reflect':
+      return {
+        output: `“${content}” — a thought worth keeping. Saved to memory.`,
+      };
+
+    default:
+      return {
+        output: `Lucidia whispered something unclear: ${content}`,
+      };
+  }
+};
+


### PR DESCRIPTION
## Summary
- add `useSessionManager` hook for session, message, file state
- introduce ability interpreter and runner
- wire portal chat UI to parse abilities and handle agent output

## Testing
- `npm test` *(fails: jest: not found)*
- `npm --prefix apps/portals run lint` *(fails: next: not found)*
- `npm --prefix apps/portals install` *(fails: ERESOLVE unable to resolve dependency tree)*

------
https://chatgpt.com/codex/tasks/task_e_68b8130d7bd483299707df90f8682e07