### PR TITLE
fix: resolve portal lint dependency conflicts

### DIFF
--- a/apps/portals/app/api/chat/route.ts
+++ b/apps/portals/app/api/chat/route.ts
@@ -2,7 +2,6 @@
 import { streamText, convertToModelMessages, stepCountIs } from 'ai';
 import { openai } from '@ai-sdk/openai';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
-import { ollama, createOllama } from 'ollama-ai-provider-v2';
 import { z } from 'zod';
 
 export const maxDuration = 30;
@@ -10,12 +9,6 @@ export const maxDuration = 30;
 function pickModel() {
   const provider = process.env.LLM_PROVIDER ?? 'openai';
   const modelId = process.env.LLM_MODEL ?? 'gpt-4o';
-
-  if (provider === 'ollama') {
-    const baseURL = process.env.OLLAMA_BASE_URL || 'http://127.0.0.1:11434/api';
-    const local = createOllama({ baseURL });
-    return local(modelId);
-  }
 
   if (provider === 'openai-compatible') {
     const compat = createOpenAICompatible({

--- a/apps/portals/package.json
+++ b/apps/portals/package.json
@@ -21,13 +21,13 @@
     "@ai-sdk/openai": "latest",
     "@ai-sdk/openai-compatible": "latest",
     "@ai-sdk/react": "latest",
-    "zod": "latest",
-    "ollama-ai-provider-v2": "latest"
+    "zod": "3.25.76"
   },
   "devDependencies": {
     "autoprefixer": "10.4.16",
-    "eslint": "9.9.0",
+    "eslint": "8.57.0",
     "eslint-config-next": "14.2.3",
+    "eslint-config-prettier": "9.1.0",
     "postcss": "8.4.31",
     "prettier": "3.3.3",
     "tailwindcss": "3.4.1",


### PR DESCRIPTION
## Summary
- drop ollama provider and related dependency from portal app
- pin eslint 8.x and zod 3.x; add eslint-config-prettier for portal linting

## Testing
- `npm --prefix apps/portals install`
- `npm --prefix apps/portals run lint`
- `npm run lint`
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b81330b5d4832982d73fa5bb87dd9f