### PR TITLE
fix: redirect RoadWork wizard to existing route

### DIFF
--- a/sites/blackroad/src/pages/RoadWork.jsx
+++ b/sites/blackroad/src/pages/RoadWork.jsx
@@ -33,7 +33,7 @@ export default function RoadWork() {
   useEffect(() => {
     if (generating) {
       const t = setTimeout(() => {
-        navigate('/portal');
+        navigate('/roadview');
       }, 1200);
       return () => clearTimeout(t);
     }


### PR DESCRIPTION
## Summary
- avoid redirecting to nonexistent /portal after generation

## Testing
- `npm test` *(fails: jest: not found)*
- `npm --prefix sites/blackroad test`
- `npm --prefix sites/blackroad run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b8159464c48329abc76781a9451061