### PR TITLE
feat: add interactive portal and project flows

### DIFF
--- a/apps/portals/app/portal/page.tsx
+++ b/apps/portals/app/portal/page.tsx
@@ -1,25 +1,29 @@
-'use client';
+"use client";
 
-import { useEffect, useState } from 'react';
-import { useChat } from '@ai-sdk/react';
-import { DefaultChatTransport, lastAssistantMessageIsCompleteWithToolCalls } from 'ai';
-import FileManager, { FileData } from '../../components/FileManager';
-import { saveSession, getCurrentSession } from '../../lib/sessionEngine';
+import { useEffect, useState } from "react";
+import { useChat } from "@ai-sdk/react";
+import {
+  DefaultChatTransport,
+  lastAssistantMessageIsCompleteWithToolCalls,
+  type Message,
+} from "ai";
+import FileManager, { FileData } from "../../components/FileManager";
+import { saveSession, getCurrentSession } from "../../lib/sessionEngine";
 
-const agents = ['Lucidia', 'Silas', 'Cecilia', 'Alexa'];
+const agents = ["Lucidia", "Silas", "Cecilia", "Alexa"];
 
 export default function PortalPage() {
   const { messages, sendMessage, status, error } = useChat({
-    transport: new DefaultChatTransport({ api: '/api/chat' }),
+    transport: new DefaultChatTransport({ api: "/api/chat" }),
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
   });
 
-  const [agent, setAgent] = useState('Lucidia');
-  const [input, setInput] = useState('');
-  const [initialMessages, setInitialMessages] = useState<any[]>([]);
+  const [agent, setAgent] = useState("Lucidia");
+  const [input, setInput] = useState("");
+  const [initialMessages, setInitialMessages] = useState<Message[]>([]);
   const [files, setFiles] = useState<FileData[]>([]);
   const [assets, setAssets] = useState<string[]>([]);
-  const [lastAssistant, setLastAssistant] = useState('');
+  const [lastAssistant, setLastAssistant] = useState("");
 
   useEffect(() => {
     const session = getCurrentSession();
@@ -30,25 +34,27 @@ export default function PortalPage() {
     }
   }, []);
 
-  const allMessages = [...initialMessages, ...messages];
+  const allMessages: Message[] = [...initialMessages, ...messages];
 
   useEffect(() => {
-    const last = allMessages.filter(m => m.role === 'assistant').slice(-1)[0];
+    const last = allMessages.filter((m) => m.role === "assistant").slice(-1)[0];
     if (last) {
-      const part = last.parts.find((p: any) => p.type === 'text');
-      setLastAssistant(part?.text || '');
+      const part = last.parts.find((p) => p.type === "text") as
+        | { type: "text"; text: string }
+        | undefined;
+      setLastAssistant(part?.text || "");
     }
   }, [allMessages]);
 
   function handleSave() {
-    const name = prompt('Session name?');
+    const name = prompt("Session name?");
     if (!name) return;
     saveSession(name, { chat: allMessages, files, assets });
   }
 
   function saveLastToFile() {
     if (!lastAssistant) return;
-    const name = prompt('File name?', `note-${files.length + 1}.txt`);
+    const name = prompt("File name?", `note-${files.length + 1}.txt`);
     if (!name) return;
     setFiles([...files, { name, content: lastAssistant }]);
   }
@@ -64,26 +70,31 @@ export default function PortalPage() {
         <div className="flex items-center gap-2">
           <select
             value={agent}
-            onChange={e => setAgent(e.target.value)}
+            onChange={(e) => setAgent(e.target.value)}
             className="rounded border px-2 py-1 text-sm"
           >
-            {agents.map(a => (
+            {agents.map((a) => (
               <option key={a}>{a}</option>
             ))}
           </select>
-          <button onClick={handleSave} className="rounded border px-2 py-1 text-sm">
+          <button
+            onClick={handleSave}
+            className="rounded border px-2 py-1 text-sm"
+          >
             Save Session
           </button>
         </div>
 
         <div className="space-y-3">
-          {allMessages.map((m: any) => (
+          {allMessages.map((m) => (
             <div key={m.id} className="text-sm leading-relaxed">
-              <b>{m.role}:</b>{' '}
-              {m.parts.map((part: any, i: number) => {
+              <b>{m.role}:</b>{" "}
+              {m.parts.map((part, i) => {
                 switch (part.type) {
-                  case 'text':
-                    return <span key={i}>{part.text}</span>;
+                  case "text":
+                    return (
+                      <span key={i}>{(part as { text: string }).text}</span>
+                    );
                   default:
                     return null;
                 }
@@ -92,25 +103,33 @@ export default function PortalPage() {
           ))}
         </div>
 
-        {status === 'error' && <div className="text-red-600">{String(error)}</div>}
+        {status === "error" && (
+          <div className="text-red-600">{String(error)}</div>
+        )}
 
         {lastAssistant && (
           <div className="flex gap-2 text-xs">
-            <button onClick={saveLastToFile} className="rounded border px-2 py-1">
+            <button
+              onClick={saveLastToFile}
+              className="rounded border px-2 py-1"
+            >
               Save to File
             </button>
-            <button onClick={generateImage} className="rounded border px-2 py-1">
+            <button
+              onClick={generateImage}
+              className="rounded border px-2 py-1"
+            >
               Generate Image
             </button>
           </div>
         )}
 
         <form
-          onSubmit={e => {
+          onSubmit={(e) => {
             e.preventDefault();
             if (input.trim()) {
               sendMessage({ text: `[${agent}] ${input}` });
-              setInput('');
+              setInput("");
             }
           }}
           className="flex gap-2"
@@ -118,7 +137,7 @@ export default function PortalPage() {
           <input
             className="flex-1 rounded border px-3 py-2"
             value={input}
-            onChange={e => setInput(e.target.value)}
+            onChange={(e) => setInput(e.target.value)}
             placeholder={`Ask ${agent}…`}
           />
           <button className="rounded border px-3 py-2">Send</button>
@@ -141,4 +160,3 @@ export default function PortalPage() {
     </main>
   );
 }
-


### PR DESCRIPTION
## Summary
- type portal chat handling with `Message` to drop `any`

## Testing
- `npm test` *(fails: jest: not found)*
- `npm --prefix apps/portals run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8150f94e08329b7b3e964fcbac2b7