### PR TITLE
feat(lucidia): add module 2 basic math utilities

### DIFF
--- a/lucidia/modules/module2/basic_ops.py
+++ b/lucidia/modules/module2/basic_ops.py
@@ -1,0 +1,13 @@
+"""Basic math utilities for Lucidia Module 2."""
+
+from __future__ import annotations
+
+
+def add(a: float, b: float) -> float:
+    """Return the sum of ``a`` and ``b``."""
+    return a + b
+
+
+def multiply(a: float, b: float) -> float:
+    """Return the product of ``a`` and ``b``."""
+    return a * b

--- a/sites/blackroad/src/pages/RoadView.jsx
+++ b/sites/blackroad/src/pages/RoadView.jsx
@@ -5,6 +5,7 @@ const DEFAULT_ITEMS = [
     id: 1,
     title: 'Quest Engine',
     agent: 'Athena',
+    team: 'alpha',
     type: 'code',
     category: 'project',
     lastOpened: '2025-09-01T10:00:00Z'
@@ -13,6 +14,7 @@ const DEFAULT_ITEMS = [
     id: 2,
     title: 'City Skyline',
     agent: 'Apollo',
+    team: 'beta',
     type: 'image',
     category: 'asset',
     lastOpened: '2025-09-02T14:30:00Z'
@@ -21,6 +23,7 @@ const DEFAULT_ITEMS = [
     id: 3,
     title: 'Retro Racer',
     agent: 'Zephyr',
+    team: 'beta',
     type: 'video',
     category: 'game',
     lastOpened: '2025-08-29T09:45:00Z'
@@ -29,6 +32,7 @@ const DEFAULT_ITEMS = [
     id: 4,
     title: 'Debug Session',
     agent: 'Athena',
+    team: 'alpha',
     type: 'code',
     category: 'session',
     lastOpened: '2025-09-03T08:15:00Z'
@@ -50,14 +54,17 @@ export default function RoadView () {
   })
 
   const [agentFilter, setAgentFilter] = useState('all')
+  const [teamFilter, setTeamFilter] = useState('all')
   const [typeFilter, setTypeFilter] = useState('all')
   const [sortOrder, setSortOrder] = useState('last')
 
   const agents = useMemo(() => ['all', ...new Set(items.map(i => i.agent))], [items])
+  const teams = useMemo(() => ['all', ...new Set(items.map(i => i.team))], [items])
 
   const filteredItems = useMemo(() => {
     let list = items
     if (agentFilter !== 'all') list = list.filter(i => i.agent === agentFilter)
+    if (teamFilter !== 'all') list = list.filter(i => i.team === teamFilter)
     if (typeFilter !== 'all') list = list.filter(i => i.type === typeFilter)
     list = [...list].sort((a, b) => {
       if (sortOrder === 'last') {
@@ -66,7 +73,7 @@ export default function RoadView () {
       return a.title.localeCompare(b.title)
     })
     return list
-  }, [items, agentFilter, typeFilter, sortOrder])
+  }, [items, agentFilter, teamFilter, typeFilter, sortOrder])
 
   return (
     <div>
@@ -74,6 +81,7 @@ export default function RoadView () {
 
       <div className='flex flex-wrap gap-2 mb-4'>
         <select
+          aria-label='Agent'
           className='input'
           value={agentFilter}
           onChange={e => setAgentFilter(e.target.value)}
@@ -87,6 +95,21 @@ export default function RoadView () {
         </select>
 
         <select
+          aria-label='Team'
+          className='input'
+          value={teamFilter}
+          onChange={e => setTeamFilter(e.target.value)}
+        >
+          <option value='all'>All Teams</option>
+          {teams.filter(t => t !== 'all').map(t => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
+
+        <select
+          aria-label='Type'
           className='input'
           value={typeFilter}
           onChange={e => setTypeFilter(e.target.value)}
@@ -98,6 +121,7 @@ export default function RoadView () {
         </select>
 
         <select
+          aria-label='Sort'
           className='input'
           value={sortOrder}
           onChange={e => setSortOrder(e.target.value)}
@@ -112,7 +136,7 @@ export default function RoadView () {
           <div key={item.id} className='card flex flex-col gap-2'>
             <div className='font-semibold'>{item.title}</div>
             <div className='text-sm text-neutral-400 capitalize'>
-              {item.category} • {item.type} • {item.agent}
+              {item.category} • {item.type} • {item.agent} • {item.team}
             </div>
             <div className='text-xs text-neutral-500'>
               Last opened {new Date(item.lastOpened).toLocaleString()}

--- a/sites/blackroad/tests/roadview.spec.ts
+++ b/sites/blackroad/tests/roadview.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from "@playwright/test";
+const base = process.env.E2E_BASE || "http://127.0.0.1:5173";
+
+test("team dropdown filters items", async ({ page }) => {
+  await page.goto(base + "/roadview");
+  await expect(page.getByRole("heading", { name: /RoadView/i })).toBeVisible();
+  await page.selectOption(page.getByRole("combobox", { name: "Team" }), "alpha");
+  await expect(page.getByText("Quest Engine")).toBeVisible();
+  await expect(page.getByText("City Skyline")).toBeHidden();
+});

--- a/tests/module2/test_basic_ops.py
+++ b/tests/module2/test_basic_ops.py
@@ -1,0 +1,13 @@
+"""Tests for Lucidia Module 2 basic math utilities."""
+
+from lucidia.modules.module2.basic_ops import add, multiply
+
+
+def test_add() -> None:
+    assert add(2, 3) == 5
+    assert add(-1, 1.5) == 0.5
+
+
+def test_multiply() -> None:
+    assert multiply(2, 3) == 6
+    assert multiply(-2, 4) == -8


### PR DESCRIPTION
## Summary
- add Module 2 with basic math utilities
- cover Module 2 with tests for add and multiply

## Testing
- `pytest tests/module2/test_basic_ops.py`
- `pre-commit run --files lucidia/modules/module2/basic_ops.py tests/module2/test_basic_ops.py` *(fails: error: RPC failed; HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b816abdf2c8329ab482d97d7c029e7