### PR TITLE
feat: add mini inference endpoint

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -115,6 +115,8 @@ export async function runCodex(prompt){
 export async function fetchCodexHistory(){
   const { data } = await axios.get(`${API_BASE}/api/codex/history`)
   return data.runs
+}
+
 export async function fetchRoadbookChapters(){
   const { data } = await axios.get(`${API_BASE}/api/roadbook/chapters`)
   return data.chapters
@@ -128,9 +130,13 @@ export async function fetchRoadbookChapter(id){
 export async function searchRoadbook(term){
   const { data } = await axios.get(`${API_BASE}/api/roadbook/search`, { params: { q: term } })
   return data.results
+}
+
 export async function fetchRoadviewStreams(){
   const { data } = await axios.get(`${API_BASE}/api/roadview/list`)
   return data.streams
+}
+
 export async function fetchManifesto(){
   const { data } = await axios.get(`${API_BASE}/api/manifesto`)
   return data.content
@@ -144,6 +150,11 @@ export async function fetchAutohealEvents(){
 export async function postAutohealEscalation(note){
   const { data } = await axios.post(`${API_BASE}/api/autoheal/escalations`, { note })
   return data.event
+}
+
+export async function infer(x, y){
+  const { data } = await axios.post(`${API_BASE}/api/mini/infer`, { x, y })
+  return data
 }
 
 export { API_BASE }

--- a/services/api/server.mjs
+++ b/services/api/server.mjs
@@ -30,6 +30,13 @@ app.post("/api/echo", (req, res) => {
   res.json({ ok: true, received: req.body ?? null });
 });
 
+// Minimal inference endpoint
+app.post("/api/mini/infer", (req, res) => {
+  const { x, y } = req.body || {};
+  const output = Number(x) * Number(y);
+  res.json({ output });
+});
+
 const server = app.listen(PORT, "0.0.0.0", () => {
   console.log(`BlackRoad API bridge listening on :${PORT}`);
 });


### PR DESCRIPTION
## Summary
- add simple POST `/api/mini/infer` endpoint to toy express server
- expose `infer` helper on frontend API module to call the endpoint
- tidy up frontend API utilities with missing braces

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: config root key unsupported)*

------
https://chatgpt.com/codex/tasks/task_e_68b830e270bc8329aeea7bacbf6615d3