### PR TITLE
feat: add desktop-style agent windows

### DIFF
--- a/sites/blackroad/src/pages/Desktop.jsx
+++ b/sites/blackroad/src/pages/Desktop.jsx
@@ -54,8 +54,16 @@ function Window({ id, title, layout, setLayout, children }) {
             {title}
           </span>
           <div className="space-x-1">
-            <button onClick={() => update({ open: false })}>_</button>
             <button
+              type="button"
+              aria-label="minimize"
+              onClick={() => update({ open: false })}
+            >
+              _
+            </button>
+            <button
+              type="button"
+              aria-label="maximize"
               onClick={() =>
                 update({
                   x: 0,
@@ -67,7 +75,13 @@ function Window({ id, title, layout, setLayout, children }) {
             >
               □
             </button>
-            <button onClick={() => update({ open: false })}>×</button>
+            <button
+              type="button"
+              aria-label="close"
+              onClick={() => update({ open: false })}
+            >
+              ×
+            </button>
           </div>
         </div>
         <div className="flex-1 overflow-auto">{children}</div>


### PR DESCRIPTION
## Summary
- add Desktop page that renders agent windows in a draggable workspace
- persist window layout in IndexedDB and toggle visibility via dock icons
- include react-rnd and idb-keyval dependencies and mount Desktop at app root
- add accessible labels to window control buttons

## Testing
- `pre-commit run --files sites/blackroad/src/pages/Desktop.jsx` *(fails: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags'))*
- `npm test`
- `npm run lint` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npm --prefix sites/blackroad run lint`
- `npm --prefix sites/blackroad test`


------
https://chatgpt.com/codex/tasks/task_e_68b8342e85a48329a2185b1c9281b78b