### PR TITLE
feat: add desktop-style agent windows

### DIFF
--- a/sites/blackroad/src/App.jsx
+++ b/sites/blackroad/src/App.jsx
@@ -9,6 +9,7 @@ import Subscribe from "./pages/Subscribe.jsx";
 import Lucidia from "./pages/Lucidia.jsx";
 import InfinityMath from "./pages/InfinityMath.jsx";
 import Agents from "./pages/Agents.jsx";
+import Desktop from "./pages/Desktop.jsx";
 import { useEffect, useState } from "react";
 
 function useApiHealth(){
@@ -50,6 +51,7 @@ export default function App(){
           <NavLink className="nav-link" to="/terminal">Terminal</NavLink>
           <NavLink className="nav-link" to="/roadview">RoadView</NavLink>
           <NavLink className="nav-link" to="/backroad">BackRoad</NavLink>
+          <NavLink className="nav-link" to="/desktop">Desktop</NavLink>
           <NavLink className="nav-link" to="/agents">Agents</NavLink>
           <NavLink className="nav-link" to="/subscribe">Subscribe</NavLink>
           <NavLink className="nav-link" to="/lucidia">Lucidia</NavLink>
@@ -84,6 +86,7 @@ export default function App(){
             <Route path="/terminal" element={<Terminal/>} />
             <Route path="/roadview" element={<RoadView/>} />
             <Route path="/backroad" element={<BackRoad/>} />
+            <Route path="/desktop" element={<Desktop/>} />
             <Route path="/agents" element={<Agents/>} />
             <Route path="/subscribe" element={<Subscribe/>} />
             <Route path="/lucidia" element={<Lucidia/>} />

--- a/sites/blackroad/src/main.jsx
+++ b/sites/blackroad/src/main.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
-import Desktop from './pages/Desktop.jsx';
+import App from './App.jsx';
 import './styles.css';
 
 createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <BrowserRouter>
-      <Desktop />
+      <App />
     </BrowserRouter>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- integrate Desktop page into existing App router with a sidebar link
- render App at the root instead of mounting Desktop directly

## Testing
- `pre-commit run --files sites/blackroad/src/main.jsx sites/blackroad/src/App.jsx sites/blackroad/src/pages/Desktop.jsx` *(fails: CalledProcessError: git fetch origin --tags returned 128)*
- `npm test`
- `npm run lint` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npm --prefix sites/blackroad run lint`
- `npm --prefix sites/blackroad test`


------
https://chatgpt.com/codex/tasks/task_e_68b8340c6c148329befd0b2bcb7dd3fa