### PR TITLE
feat(agents): add novelty & humanistic agents

### DIFF
--- a/agents/auto_novel_agent.py
+++ b/agents/auto_novel_agent.py
@@ -19,13 +19,12 @@ class AutoNovelAgent:
         """Create a basic game using a supported engine.
 
         Args:
-            engine: Game engine to use (case-insensitive).
-            include_weapons: Whether to include weapons. Setting this to ``True``
-                raises a ``ValueError`` because weapons are not allowed.
+            engine: Game engine to use. Comparison is case-insensitive.
+            include_weapons: Whether to include weapons. ``True`` raises a
+                ``ValueError`` because weapons are not allowed.
 
         Raises:
-            ValueError: If the engine is unsupported.
-            ValueError: If weapons are included.
+            ValueError: If the engine is unsupported or weapons are included.
         """
         engine_lower = engine.lower()
         if engine_lower not in self.SUPPORTED_ENGINES:


### PR DESCRIPTION
## Summary
- add suite of novelty agents with manifests, IPC, and log support
- expose `prismsh` commands for spawning, asking, and dreaming
- test novelty agents for basic responses and contradiction logging
- document `AutoNovelAgent.create_game` case-insensitive engines and combined error conditions

## Testing
- `python -m py_compile *.py` *(fails: cleanup_bot.py syntax error)*
- `python -m py_compile auto_novel_agent.py`
- `python auto_novel_agent.py`
- `npm run lint` *(fails: eslint not found)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b83457b2ec83299915058a35a3da4b