### PR TITLE
fix: ignore whitespace RoadChain searches

### DIFF
--- a/frontend/src/components/RoadChain.jsx
+++ b/frontend/src/components/RoadChain.jsx
@@ -22,7 +22,7 @@ export default function RoadChain(){
   }, [])
 
   useEffect(() => {
-    if (!query) {
+    if (!query.trim()) {
       setResult(null)
       setError('')
     }
@@ -34,9 +34,10 @@ export default function RoadChain(){
 
   async function onSearch(e){
     e.preventDefault()
-    if(!query) return
+    const q = query.trim()
+    if(!q) return
     try{
-      const blk = await fetchBlock(query.trim())
+      const blk = await fetchBlock(q)
       setResult(blk)
       setExpanded(prev => ({ ...prev, [blk.hash]: true }))
       setError('')


### PR DESCRIPTION
## Summary
- treat whitespace-only RoadChain queries as empty to avoid unnecessary lookups and clear stale results

## Testing
- `npm --prefix backend install`
- `npm --prefix backend test`
- `npm --prefix frontend install`
- `npm --prefix frontend test`
- `npm --prefix frontend run build`
- `curl -v http://localhost:4000/api/roadchain/blocks` *(fails: connection refused)*
- `curl -v http://localhost:4000/api/roadchain/block/0xdef456` *(fails: connection refused)*


------
https://chatgpt.com/codex/tasks/task_e_68b833c9115c83299860c592bb4593fc