### PR TITLE
Add Hello World blog Playwright test

### DIFF
--- a/sites/blackroad/tests/blog-hello-world.spec.ts
+++ b/sites/blackroad/tests/blog-hello-world.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from "@playwright/test";
+const base = process.env.E2E_BASE || "http://127.0.0.1:5173";
+
+test("blog post hello world is accessible", async ({ page }) => {
+  await page.goto(base + "/blog/hello-world");
+  await expect(page.getByRole("heading", { name: /Hello World/i })).toBeVisible();
+  await expect(page.getByText(/Welcome to Hello World on BlackRoad.io./i)).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- add Playwright e2e test covering the Hello World blog page

## Testing
- `npm test`
- `npm run e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c4f7ce948329a0be8ff0e4d9f20f