### PR TITLE
Cleanup Python scripts and adjust ESLint config

### DIFF
--- a/agents/cleanup_bot.py
+++ b/agents/cleanup_bot.py
@@ -14,9 +14,9 @@ class CleanupBot:
 
     Attributes
     ----------
-    branches:
-        A list of branch names to remove.
-    dry_run:
+    branches : list[str]
+        Branch names to remove.
+    dry_run : bool, default=False
         When True, commands are printed instead of executed.
     """
 

--- a/main.py
+++ b/main.py
@@ -1,6 +1,5 @@
 """Streamlit app for BlackRoad Prism Generator with GPT and voice input."""
 
-import ast
 import os
 import tempfile
 
@@ -21,18 +20,6 @@ if not _api_key:
 def load_whisper_model():
     """Load the Whisper model once and reuse across reruns."""
     return whisper.load_model("base")
-
-
-def parse_numeric_prefix(text: str) -> float:
-    """Return the leading numeric value in text or 1.0 if not found."""
-    try:
-        value = ast.literal_eval(text.split(",", maxsplit=1)[0].strip())
-        if isinstance(value, (int, float)):
-            return float(value)
-    except Exception:
-        pass
-    return 1.0
-
 
 def _transcribe_audio(uploaded_file) -> str:
     """Transcribe an uploaded audio file using Whisper and clean up temp file."""


### PR DESCRIPTION
## Summary
- drop unused numeric prefix helper in Streamlit entry and rely solely on audio transcription
- document `CleanupBot` fields with types and default value

## Testing
- `npm run lint` *(fails: 83 errors, 787 warnings)*
- `npm test`
- `python -m py_compile *.py`
- `cd agents && python -m py_compile *.py && python auto_novel_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba3ddf16788329a356bb80dd12173f