### PR TITLE
feat: quantum consciousness portal and API

### DIFF
--- a/sites/blackroad/src/App.jsx
+++ b/sites/blackroad/src/App.jsx
@@ -11,6 +11,7 @@ import Lucidia from "./pages/Lucidia.jsx";
 import InfinityMath from "./pages/InfinityMath.jsx";
 import Agents from "./pages/Agents.jsx";
 import Desktop from "./pages/Desktop.jsx";
+import QuantumConsciousness from "./pages/QuantumConsciousness.jsx";
 
 function useApiHealth(){
   const [state,setState]=useState({ok:null, info:""});
@@ -43,6 +44,7 @@ export default function App(){
   return (
     <Routes>
       <Route path="/" element={<Desktop/>} />
+      <Route path="/quantum-consciousness" element={<QuantumConsciousness/>} />
       <Route path="/*" element={<LegacyApp/>} />
     </Routes>
   );

--- a/sites/blackroad/src/pages/QuantumConsciousness.jsx
+++ b/sites/blackroad/src/pages/QuantumConsciousness.jsx
@@ -1,0 +1,87 @@
+import { useEffect, useState } from "react";
+
+function Card({ title, metaphor, color, delay }) {
+  const [show, setShow] = useState(false);
+  useEffect(() => {
+    const t = setTimeout(() => setShow(true), delay);
+    return () => clearTimeout(t);
+  }, [delay]);
+  return (
+    <div
+      className={`p-4 rounded-lg border-2 transition-all duration-700 ${
+        show ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
+      }`}
+      style={{ borderColor: color }}
+    >
+      <h3 className="text-xl font-semibold mb-2">{title}</h3>
+      <p className="text-sm opacity-80">{metaphor}</p>
+    </div>
+  );
+}
+
+export default function QuantumConsciousness() {
+  const [log, setLog] = useState("");
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      const topics = ["reasoning", "memory", "symbolic"];
+      const lines = [];
+      for (const t of topics) {
+        try {
+          const r = await fetch(`/api/quantum/${t}`);
+          const j = await r.json();
+          lines.push(`${t.toUpperCase()}: ${j.summary}`);
+        } catch {
+          lines.push(`${t.toUpperCase()}: error`);
+        }
+      }
+      if (alive) setLog(lines.join("\n"));
+    })();
+    return () => {
+      alive = false;
+    };
+  }, []);
+  const ts = new Date().toISOString();
+  return (
+    <div className="min-h-screen flex flex-col items-center p-8 space-y-8">
+      <header className="text-center">
+        <h1
+          className="text-4xl font-bold mb-4"
+          style={{
+            background: "linear-gradient(90deg,#FF4FD8,#0096FF,#FDBA2D)",
+            WebkitBackgroundClip: "text",
+            WebkitTextFillColor: "transparent",
+          }}
+        >
+          Quantum x Consciousness
+        </h1>
+      </header>
+      <section className="grid md:grid-cols-3 gap-4 w-full max-w-5xl">
+        <Card
+          title="Reasoning"
+          metaphor="Superposition lets minds hold multiple thoughts at once for quantum parallelism."
+          color="#FF4FD8"
+          delay={0}
+        />
+        <Card
+          title="Memory"
+          metaphor="Entangled quantum RAM could bind experiences across vast memory webs."
+          color="#0096FF"
+          delay={150}
+        />
+        <Card
+          title="Symbolic Processing"
+          metaphor="Interference patterns refine symbolic chains, amplifying the meaningful paths."
+          color="#FDBA2D"
+          delay={300}
+        />
+      </section>
+      <section className="w-full max-w-5xl">
+        <div className="bg-black text-green-400 font-mono p-4 rounded-md h-48 overflow-auto">
+          <pre>{log || "Loading research notes..."}</pre>
+        </div>
+      </section>
+      <footer className="text-xs opacity-60">Deployed via Codex • {ts}</footer>
+    </div>
+  );
+}

--- a/srv/blackroad-api/server_full.js
+++ b/srv/blackroad-api/server_full.js
@@ -422,6 +422,37 @@ if (planCount === 0) {
   }
 }
 
+// Quantum AI table seed
+db.prepare(`
+  CREATE TABLE IF NOT EXISTS quantum_ai (
+    topic TEXT PRIMARY KEY,
+    summary TEXT NOT NULL
+  )
+`).run();
+const qSeed = [
+  {
+    topic: 'reasoning',
+    summary:
+      'Quantum parallelism lets models explore many reasoning paths simultaneously for accelerated insight.',
+  },
+  {
+    topic: 'memory',
+    summary:
+      'Quantum RAM with entangled states hints at dense, instantly linked memory architectures.',
+  },
+  {
+    topic: 'symbolic',
+    summary:
+      'Interference in quantum-symbolic AI could amplify useful symbol chains while damping noise.',
+  },
+];
+for (const row of qSeed) {
+  db.prepare('INSERT OR IGNORE INTO quantum_ai (topic, summary) VALUES (?, ?)').run(
+    row.topic,
+    row.summary,
+  );
+}
+
 // Helpers
 function listRows(t) {
   return db.prepare(`SELECT id, name, updated_at, meta FROM ${t} ORDER BY datetime(updated_at) DESC`).all();
@@ -692,6 +723,14 @@ app.get('/api/connectors/status', async (_req, res) => {
   try { if (process.env.LINEAR_API_KEY) status.linear = true; } catch {}
   try { if (process.env.SF_USERNAME) status.salesforce = true; } catch {}
   res.json(status);
+});
+
+// --- Quantum AI summaries
+app.get('/api/quantum/:topic', (req, res) => {
+  const { topic } = req.params;
+  const row = db.prepare('SELECT summary FROM quantum_ai WHERE topic = ?').get(topic);
+  if (!row) return res.status(404).json({ error: 'not_found' });
+  res.json({ topic, summary: row.summary });
 });
 
 // --- Actions (stubs)


### PR DESCRIPTION
## Summary
- add `/quantum-consciousness` portal with animated cards and research console
- seed `quantum_ai` table and expose `/api/quantum/:topic` summaries

## Testing
- `npm run lint` *(fails: A config object is using the "root" key, which is not supported in flat config system.)*
- `npm test` *(fails: jest: not found)*
- `npm --prefix sites/blackroad run lint`
- `npm --prefix sites/blackroad test`
- `node srv/blackroad-api/server_full.js` *(fails: Cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_68be090ca5108329a91a035fa59bc0e0