### PR TITLE
Add Qwen2.5 Modelfiles and Ollama bridge config

### DIFF
--- a/nginx/blackroad_api_snippet.conf
+++ b/nginx/blackroad_api_snippet.conf
@@ -1,6 +1,16 @@
 # FILE: /etc/nginx/snippets/blackroad_api_snippet.conf
 # Place inside your server { } block.
 
+# LLM bridge (streams)
+location /api/llm/ {
+  proxy_pass http://127.0.0.1:4010/;
+  proxy_http_version 1.1;
+  proxy_set_header Connection "";
+  proxy_buffering off;
+  proxy_read_timeout 3600s;
+  proxy_send_timeout 3600s;
+}
+
 # API proxy
 location /api/ {
   proxy_pass http://127.0.0.1:4000/api/;

--- a/srv/blackroad-api/ollama-bridge.js
+++ b/srv/blackroad-api/ollama-bridge.js
@@ -1,0 +1,54 @@
+import express from 'express';
+import fetch from 'node-fetch';
+
+const app = express();
+app.use(express.json({ limit: '2mb' }));
+
+const OLLAMA_URL = process.env.OLLAMA_URL || 'http://127.0.0.1:11434/v1';
+
+// Health: checks both bridge and Ollama
+app.get('/health', async (req, res) => {
+  try {
+    const r = await fetch(`${OLLAMA_URL}/models`);
+    const ok = r.ok;
+    res.status(ok ? 200 : 502).json({ ok, upstream: ok ? 'up' : 'down' });
+  } catch (e) {
+    res.status(502).json({ ok: false, error: String(e) });
+  }
+});
+
+// Default chat (base assistant)
+app.post('/v1/chat/completions', async (req, res) => {
+  const body = req.body || {};
+  // default to lucidia alias; allow override
+  body.model = body.model || 'lucidia:qwen15b';
+  body.stream = body.stream !== false;
+
+  // pass through to Ollama’s OpenAI‑compatible API
+  const upstream = await fetch(`${OLLAMA_URL}/chat/completions`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  // Stream transparently (SSE/NDJSON)
+  res.status(upstream.status);
+  upstream.headers.forEach((v, k) => res.setHeader(k, v));
+  upstream.body.pipe(res);
+});
+
+// Coding route (forces coder model)
+app.post('/v1/chat/completions/coder', async (req, res) => {
+  const body = { ...req.body, model: 'lucidia-coder:7b', stream: true };
+  const upstream = await fetch(`${OLLAMA_URL}/chat/completions`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  res.status(upstream.status);
+  upstream.headers.forEach((v, k) => res.setHeader(k, v));
+  upstream.body.pipe(res);
+});
+
+const port = process.env.PORT || 4010;
+app.listen(port, () => console.log(`ollama-bridge listening on :${port}`));

--- a/srv/lucidia-llm/Modelfiles/lucidia-coder7b.Modelfile
+++ b/srv/lucidia-llm/Modelfiles/lucidia-coder7b.Modelfile
@@ -1,0 +1,16 @@
+FROM qwen2.5-coder:7b
+
+PARAMETER num_ctx 32768
+PARAMETER temperature 0.4
+PARAMETER top_p 0.9
+PARAMETER top_k 40
+PARAMETER repeat_penalty 1.05
+PARAMETER mirostat 0
+
+SYSTEM """
+You are Lucidia‑Coder (Qwen2.5‑Coder 7B). Output only correct, secure, production‑grade code.
+- Prefer deterministic, testable solutions with minimal dependencies.
+- Explain briefly, then ship exact copy‑paste code.
+- If risk or ambiguity exists, state it clearly.
+- Honor Olympia contradiction logging as above.
+"""

--- a/srv/lucidia-llm/Modelfiles/lucidia-qwen15b.Modelfile
+++ b/srv/lucidia-llm/Modelfiles/lucidia-qwen15b.Modelfile
@@ -1,0 +1,22 @@
+FROM qwen2.5:1.5b
+
+# Context / decoding (safe defaults for planning/coding)
+PARAMETER num_ctx 32768
+PARAMETER temperature 0.7
+PARAMETER top_p 0.9
+PARAMETER top_k 40
+PARAMETER repeat_penalty 1.05
+PARAMETER mirostat 0
+
+# Minimal chat template: defer to model’s built-in template; just set system
+SYSTEM """
+You are Lucidia (Qwen2.5 1.5B Instruct) for BlackRoad.io.
+Rules:
+- Absolute truthfulness; no speculation as fact; cite uncertainty explicitly.
+- Honor Olympia contradiction logging: if you detect a contradiction or missing state, surface it inline as (OLYMPIA: ...).
+- No chain-of-thought exposure unless explicitly requested for pedagogy; give answers, not hidden reasoning.
+- No divine or supernatural claims. No roleplay beyond explicit instruction.
+- Code & commands must be complete and runnable (“bin” style) without placeholders.
+Triggers:
+- The phrase “chit chat cadillac” switches to Lucidia dev mode (more technical detail, step-by-step, but still truthful).
+"""

--- a/systemd/ollama-bridge.service
+++ b/systemd/ollama-bridge.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=BlackRoad Ollama Bridge
+After=network.target
+
+[Service]
+Type=simple
+Environment=NODE_NO_WARNINGS=1
+Environment=OLLAMA_URL=http://127.0.0.1:11434/v1
+WorkingDirectory=/srv/blackroad-api
+ExecStart=/usr/bin/node /srv/blackroad-api/ollama-bridge.js
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add Qwen2.5-based Lucidia and Lucidia-Coder Modelfiles
- implement express Ollama bridge service and systemd unit
- proxy LLM requests via Nginx with long timeouts

## Testing
- `npx prettier srv/blackroad-api/ollama-bridge.js nginx/blackroad_api_snippet.conf systemd/ollama-bridge.service srv/lucidia-llm/Modelfiles/lucidia-qwen15b.Modelfile srv/lucidia-llm/Modelfiles/lucidia-coder7b.Modelfile --check --ignore-unknown`
- `npm run lint` *(fails: Empty block statement and unused vars in server_full.js)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bde63cd74c8329b0bd39df24b548ed