### PR TITLE
Add orchestrator bot for agent workflows

### DIFF
--- a/AGENT_WORKBOARD.md
+++ b/AGENT_WORKBOARD.md
@@ -1,0 +1,15 @@
+# Agent Workboard
+
+## To Do
+- [ ] Build site (`BuildBlackRoadSiteAgent`)
+- [ ] Deploy site (`WebsiteBot`)
+- [ ] Clean up merged branches (`CleanupBot`)
+
+## In Progress
+
+## Blocked
+
+## Done
+
+## Last Status Report
+- Workboard initialized.

--- a/agents/orchestrator_bot.py
+++ b/agents/orchestrator_bot.py
@@ -1,0 +1,68 @@
+"""Orchestrator bot for coordinating agents and updating workboard."""
+
+from __future__ import annotations
+
+import subprocess
+from datetime import datetime
+from pathlib import Path
+from typing import Sequence
+
+WORKBOARD = Path(__file__).resolve().parent.parent / "AGENT_WORKBOARD.md"
+
+
+def update_workboard(section: str, task: str, status: str = "") -> None:
+    """Move a task between workboard sections and append status."""
+    lines = WORKBOARD.read_text().splitlines(keepends=True)
+    sections = {"To Do": [], "In Progress": [], "Blocked": [], "Done": []}
+    current = None
+    for line in lines:
+        if line.startswith("## "):
+            current = line[3:].strip()
+        elif current in sections and line.strip().startswith("- ["):
+            sections[current].append(line)
+    for key in sections:
+        sections[key] = [l for l in sections[key] if task not in l]
+    if section in sections:
+        status_str = f" ({status})" if status else ""
+        task_line = (
+            f"- [ ] {task}{status_str}\n" if section != "Done" else f"- [x] {task}{status_str}\n"
+        )
+        sections[section].append(task_line)
+    out = ["# Agent Workboard\n\n"]
+    for sec in ["To Do", "In Progress", "Blocked", "Done"]:
+        out.append(f"## {sec}\n")
+        out.extend(sections[sec])
+        out.append("\n")
+    out.append("## Last Status Report\n")
+    out.append(f"- {datetime.utcnow()} {task} moved to {section} {status}\n")
+    WORKBOARD.write_text("".join(out))
+
+
+def run_agent(cmd: Sequence[str], taskname: str) -> None:
+    """Run a command and update workboard based on its result."""
+    update_workboard("In Progress", taskname)
+    try:
+        subprocess.run(cmd, check=True)
+        update_workboard("Done", taskname, "Success")
+    except subprocess.CalledProcessError as exc:
+        update_workboard("Blocked", taskname, f"Failed: {exc}")
+
+
+def main() -> None:
+    """Orchestrate build, deploy, and cleanup agents."""
+    run_agent(
+        ["python", "agents/build_blackroad_site_agent.py"],
+        "Build site (`BuildBlackRoadSiteAgent`)",
+    )
+    run_agent(
+        ["python", "agents/website_bot.py"],
+        "Deploy site (`WebsiteBot`)",
+    )
+    run_agent(
+        ["python", "agents/cleanup_bot.py", "--base", "main"],
+        "Clean up merged branches (`CleanupBot`)",
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- introduce `orchestrator_bot` to coordinate agent runs and update a shared workboard
- track build, deploy, and cleanup tasks in new `AGENT_WORKBOARD.md`

## Testing
- `python -m py_compile *.py`
- `python auto_novel_agent.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68bf71c9b0ec8329875312ff6dc65bae