### PR TITLE
feat: add mtls partner relay

### DIFF
--- a/etc/logrotate.d/partner-relay
+++ b/etc/logrotate.d/partner-relay
@@ -1,0 +1,9 @@
+/var/log/blackroad/partner-relay.log {
+  daily
+  rotate 14
+  missingok
+  compress
+  delaycompress
+  notifempty
+  copytruncate
+}

--- a/etc/nginx/snippets/blackroad-partner-mtls.conf
+++ b/etc/nginx/snippets/blackroad-partner-mtls.conf
@@ -1,0 +1,22 @@
+# Client CA store
+ssl_client_certificate /etc/nginx/client_ca/ca.crt;
+ssl_verify_depth 2;
+
+# Per-location mTLS + rate limit zone (define zone in http{} too)
+location ^~ /api/relay/partner/ {
+  # require a valid client certificate for this path
+  ssl_verify_client on;
+  # quick reject if not verified
+  if ($ssl_client_verify != SUCCESS) { return 403; }
+
+  # rate limit to protect backend (60 req/min, burst 10)
+  limit_req zone=partner_zone burst=10 nodelay;
+
+  # forward verification metadata to app (for auditing)
+  proxy_set_header X-Client-Verify $ssl_client_verify;
+  proxy_set_header X-Client-DN     $ssl_client_s_dn;
+  proxy_set_header X-Client-CN     $ssl_client_s_dn_cn;
+
+  proxy_set_header Host $host;
+  proxy_pass http://127.0.0.1:4000;
+}

--- a/nginx/blackroad.conf
+++ b/nginx/blackroad.conf
@@ -24,6 +24,8 @@ server {
   root /var/www/blackroad;
   index index.html;
 
+  include /etc/nginx/snippets/blackroad-partner-mtls.conf;
+
   # SPA fallback
   location / {
     try_files $uri /index.html;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -27,6 +27,7 @@ http {
   # Rate limiting zones
   limit_req_zone $binary_remote_addr zone=api:10m rate=10r/s;
   limit_req_zone $binary_remote_addr zone=general:10m rate=5r/s;
+  limit_req_zone $binary_remote_addr zone=partner_zone:10m rate=60r/m;
 
   # Gzip
   gzip on;

--- a/srv/blackroad-api/modules/partner_relay_mtls.js
+++ b/srv/blackroad-api/modules/partner_relay_mtls.js
@@ -1,0 +1,76 @@
+// mTLS Relay for partners (e.g., Claude-as-teammate)
+// Requires: Nginx mTLS in front; Nginx passes X-Client-Verify/X-Client-CN headers
+// Injects origin.key server-side; allowlist device+type; JSON audit log.
+const fs = require('fs');
+const path = require('path');
+
+module.exports = function attachPartnerRelay({ app }) {
+  if (!app) throw new Error('partner_relay_mtls: need app');
+
+  const ORIGIN_KEY_PATH = process.env.ORIGIN_KEY_PATH || '/srv/secrets/origin.key';
+  const ALLOW_SUBJECTS = (process.env.PARTNER_SUBJECTS || 'Claude-Partner').split(',').map(s=>s.trim()).filter(Boolean);
+  const ALLOW_DEVICES  = (process.env.PARTNER_DEVICES  || 'pi-01,jetson-01,display-mini,display-main').split(',').map(s=>s.trim()).filter(Boolean);
+  const LOG_DIR = '/var/log/blackroad';
+  const LOG_FILE = path.join(LOG_DIR, 'partner-relay.log');
+
+  let ORIGIN_KEY = '';
+  try { ORIGIN_KEY = fs.readFileSync(ORIGIN_KEY_PATH, 'utf8').trim(); } catch { console.warn('[partner] WARN: origin.key not found'); }
+  try { if (!fs.existsSync(LOG_DIR)) fs.mkdirSync(LOG_DIR, {recursive:true}); } catch {}
+
+  const TYPES = new Set(['led.emotion','display.show','display.clear','fan.set']);
+
+  function audit(obj){
+    try { fs.appendFileSync(LOG_FILE, JSON.stringify(obj)+'\n'); } catch {}
+  }
+  function json(req, cb){
+    let buf=''; req.on('data',d=>buf+=d); req.on('end',()=>{ try{cb(JSON.parse(buf||'{}'));}catch{cb({});} });
+  }
+  function denied(res, code, msg){ res.status(code).json({error:msg}); }
+
+  app.post('/api/relay/partner/command', (req, res) => {
+    const verified = req.get('X-Client-Verify') === 'SUCCESS';
+    const cn = (req.get('X-Client-CN') || '').trim();
+    const ip = req.socket.remoteAddress || '';
+    if (!verified) return denied(res, 403, 'mtls_required');
+    if (!ALLOW_SUBJECTS.includes(cn)) return denied(res, 403, 'subject_not_allowed');
+
+    json(req, async (body) => {
+      const t0 = Date.now();
+      const device = (body && body.device || '').trim();
+      const payload = body && body.payload || {};
+      const typ = payload && payload.type;
+      // schema guard
+      if (!device)            return denied(res, 400, 'missing device');
+      if (!ALLOW_DEVICES.includes(device)) return denied(res, 403, 'device_not_allowed');
+      if (!typ || !TYPES.has(typ)) return denied(res, 400, 'type_not_allowed');
+      if (typ === 'led.emotion' && !payload.emotion) return denied(res, 400, 'emotion_required');
+      if (typ === 'display.show' && !(payload.target && payload.mode && payload.src)) return denied(res, 400, 'target/mode/src required');
+      if (typ === 'fan.set' && (payload.pwm == null || payload.pwm < 0 || payload.pwm > 255)) return denied(res, 400, 'pwm 0-255 required');
+      payload.ttl_s ??= 120;
+
+      // forward to devices endpoint with server-side origin key
+      try{
+        const r = await fetch(`http://127.0.0.1:4000/api/devices/${encodeURIComponent(device)}/command`, {
+          method: 'POST',
+          headers: {'Content-Type':'application/json','X-BlackRoad-Key': ORIGIN_KEY},
+          body: JSON.stringify(payload)
+        });
+        const text = await r.text();
+        audit({ts:new Date().toISOString(), ip, cn, device, type:typ, code:r.status, dur_ms: Date.now()-t0});
+        res.status(r.status).type('application/json').send(text);
+      }catch(e){
+        audit({ts:new Date().toISOString(), ip, cn, device, type:typ, code:502, err:String(e)});
+        denied(res, 502, 'upstream_failed');
+      }
+    });
+  });
+
+  app.get('/api/relay/partner/devices', (req, res) => {
+    const verified = req.get('X-Client-Verify') === 'SUCCESS';
+    const cn = (req.get('X-Client-CN') || '').trim();
+    if (!verified || !ALLOW_SUBJECTS.includes(cn)) return denied(res, 403, 'forbidden');
+    res.json({ devices: ALLOW_DEVICES, types: Array.from(TYPES) });
+  });
+
+  console.log('[partner] mTLS relay attached; allow subjects=%s; devices=%s', ALLOW_SUBJECTS.join(','), ALLOW_DEVICES.join(','));
+};

--- a/srv/blackroad-api/server_full.js
+++ b/srv/blackroad-api/server_full.js
@@ -159,6 +159,9 @@ const io = new SocketIOServer(server, {
   cors: { origin: false }, // same-origin via Nginx
 });
 
+// Partner relay for mTLS-authenticated teammates
+require('./modules/partner_relay_mtls')({ app });
+
 const emitter = new EventEmitter();
 const jobs = new Map();
 let jobSeq = 0;

--- a/usr/local/sbin/partner_ca_issue.sh
+++ b/usr/local/sbin/partner_ca_issue.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+CA_DIR=/etc/nginx/client_ca
+NAME="${1:-Claude-Partner}"
+DAYS="${2:-365}"
+
+sudo mkdir -p "$CA_DIR"
+cd "$CA_DIR"
+
+# 1) CA (if absent)
+if [ ! -f ca.key ]; then
+  openssl genrsa -out ca.key 4096
+  openssl req -x509 -new -nodes -key ca.key -sha256 -days 3650 \
+    -subj "/CN=BlackRoad Partner CA" -out ca.crt
+  echo "[+] Created CA at $CA_DIR"
+fi
+
+# 2) Client key + CSR
+openssl genrsa -out "$NAME.key" 4096
+openssl req -new -key "$NAME.key" -subj "/CN=$NAME" -out "$NAME.csr"
+
+# 3) Sign client cert
+openssl x509 -req -in "$NAME.csr" -CA ca.crt -CAkey ca.key -CAcreateserial \
+  -out "$NAME.crt" -days "$DAYS" -sha256 \
+  -extfile <(printf "subjectAltName=DNS:%s\nextendedKeyUsage=clientAuth\n" "$NAME")
+
+# 4) Export P12 bundle for easy sharing (protect with a pass)
+PASS=$(openssl rand -hex 12)
+echo "$PASS" > "$NAME.p12.pass"
+openssl pkcs12 -export -inkey "$NAME.key" -in "$NAME.crt" -certfile ca.crt \
+  -out "$NAME.p12" -passout pass:"$PASS"
+
+echo "[+] Issued client cert:"
+echo "    Subject CN: $NAME"
+echo "    Files: $CA_DIR/$NAME.crt $CA_DIR/$NAME.key"
+echo "    P12:   $CA_DIR/$NAME.p12  (password in $CA_DIR/$NAME.p12.pass)"
+echo "[!] Copy $CA_DIR/ca.crt into Nginx ssl_client_certificate (already set)."


### PR DESCRIPTION
## Summary
- add mTLS relay module to forward partner commands with allowlists and audit logging
- require client certificate for partner relay through nginx snippet and rate limit zone
- provide CA issuance script and logrotate config for partner relay logs

## Testing
- `npm test` *(fails: jest not found)*
- `npm install --no-audit --no-fund --verbose` *(fails: fetch 503 from verdaccio.internal)*
- `npm run lint` *(fails: config object using unsupported root key)*

------
https://chatgpt.com/codex/tasks/task_e_68bf90bbfe648329af0aff7b56cdb219