### PR TITLE
feat: add project rooms API and UI

### DIFF
--- a/srv/blackroad-api/modules/projects.js
+++ b/srv/blackroad-api/modules/projects.js
@@ -1,0 +1,212 @@
+// Projects API: safe FS workspace with Git + LED-aware deploy.
+// Env: PROJECTS_DIR (default /srv/projects), ORIGIN_KEY_PATH, DEPLOY_ROOT (/var/www/blackroad/apps)
+// Auth: X-BlackRoad-Key (loopback allowed, like other modules)
+const fs = require('fs');
+const path = require('path');
+const { spawn } = require('child_process');
+
+module.exports = function attachProjects({ app }) {
+  if (!app) throw new Error('projects: need app');
+
+  const BASE = process.env.PROJECTS_DIR || '/srv/projects';
+  const DEPLOY_ROOT = process.env.DEPLOY_ROOT || '/var/www/blackroad/apps';
+  const originKeyPath = process.env.ORIGIN_KEY_PATH || '/srv/secrets/origin.key';
+  let ORIGIN_KEY = ''; try { ORIGIN_KEY = fs.readFileSync(originKeyPath, 'utf8').trim(); } catch {}
+
+  fs.mkdirSync(BASE, { recursive: true });
+  fs.mkdirSync(DEPLOY_ROOT, { recursive: true });
+
+  function guard(req, res, next) {
+    const ip = req.socket.remoteAddress || '';
+    if (ip.startsWith('127.') || ip === '::1') return next();
+    const k = req.get('X-BlackRoad-Key') || '';
+    if (ORIGIN_KEY && k === ORIGIN_KEY) return next();
+    return res.status(401).json({ error: 'unauthorized' });
+  }
+  const ok = (res, obj) => res.json(obj);
+  const bad = (res, code, msg) => res.status(code).json({ error: msg });
+
+  const slugify = s => (s || '').toLowerCase().replace(/[^a-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 64);
+  const j = (...p) => path.join(...p);
+  const within = (root, p) => {
+    const abs = path.resolve(root, p);
+    if (!abs.startsWith(path.resolve(root))) throw new Error('path_outside_project');
+    return abs;
+  };
+
+  function ensureProject(name) {
+    const id = slugify(name);
+    if (!id) throw new Error('bad_name');
+    const root = j(BASE, id);
+    if (!fs.existsSync(root)) fs.mkdirSync(root, { recursive: true });
+    // init meta
+    const metaPath = j(root, '.project.json');
+    if (!fs.existsSync(metaPath)) fs.writeFileSync(metaPath, JSON.stringify({ id, name, created_at: Date.now() }, null, 2));
+    // init git if absent
+    if (!fs.existsSync(j(root, '.git'))) {
+      spawn('git', ['init'], { cwd: root }).on('close', () => {
+        fs.writeFileSync(j(root, '.gitignore'), 'node_modules\n*.log\n.DS_Store\n');
+      });
+    }
+    return { id, root };
+  }
+
+  function scanTree(root, rel = '') {
+    const dir = within(root, rel);
+    const out = [];
+    for (const name of fs.readdirSync(dir)) {
+      if (name === '.git') continue;
+      const p = j(dir, name);
+      const stat = fs.statSync(p);
+      const entry = { name, path: path.posix.join(rel || '/', name), type: stat.isDirectory() ? 'dir' : 'file', size: stat.size };
+      if (stat.isDirectory()) entry.children = scanTree(root, path.posix.join(rel, name));
+      out.push(entry);
+    }
+    return out.sort((a, b) => (a.type === b.type ? a.name.localeCompare(b.name) : a.type === 'dir' ? -1 : 1));
+  }
+
+  async function sendLED(payload) {
+    try {
+      await fetch('http://127.0.0.1:4000/api/devices/pi-01/command', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-BlackRoad-Key': ORIGIN_KEY },
+        body: JSON.stringify(payload)
+      });
+    } catch {}
+  }
+
+  // --- Routes ---
+  app.post('/api/projects', guard, (req, res) => {
+    let buf=''; req.on('data',d=>buf+=d); req.on('end', ()=>{
+      let body={}; try{ body=JSON.parse(buf||'{}'); }catch{}
+      try {
+        const { id } = ensureProject(body.name || 'project');
+        ok(res, { ok:true, id });
+      } catch (e) { bad(res, 400, String(e.message||e)); }
+    });
+  });
+
+  app.get('/api/projects', guard, (req, res) => {
+    const list = [];
+    for (const name of fs.readdirSync(BASE)) {
+      const root = j(BASE, name);
+      try {
+        const st = fs.statSync(root); if (!st.isDirectory()) continue;
+        const meta = JSON.parse(fs.readFileSync(j(root, '.project.json'), 'utf8'));
+        list.push({ id: meta.id || name, name: meta.name || name, updated: st.mtimeMs });
+      } catch {}
+    }
+    ok(res, list.sort((a,b)=>b.updated-a.updated));
+  });
+
+  app.get('/api/projects/:id/tree', guard, (req,res)=>{
+    const id = slugify(req.params.id);
+    const root = j(BASE, id);
+    if (!fs.existsSync(root)) return bad(res, 404, 'not_found');
+    ok(res, scanTree(root, ''));
+  });
+
+  app.post('/api/projects/:id/mkdir', guard, (req, res)=>{
+    const id = slugify(req.params.id); const root = j(BASE,id);
+    if (!fs.existsSync(root)) return bad(res,404,'not_found');
+    let buf=''; req.on('data',d=>buf+=d); req.on('end', ()=>{
+      let body={}; try{ body=JSON.parse(buf||'{}'); }catch{}
+      try {
+        const dir = within(root, body.path || '');
+        fs.mkdirSync(dir, { recursive: true });
+        ok(res, { ok:true });
+      } catch(e){ bad(res,400,String(e.message||e)); }
+    });
+  });
+
+  app.get('/api/projects/:id/file', guard, (req,res)=>{
+    const id = slugify(req.params.id); const root = j(BASE,id);
+    if (!fs.existsSync(root)) return bad(res,404,'not_found');
+    try {
+      const fp = within(root, req.query.path || '');
+      const data = fs.readFileSync(fp, 'utf8');
+      res.type('text/plain').send(data);
+    } catch(e){ bad(res,400,String(e.message||e)); }
+  });
+
+  app.put('/api/projects/:id/file', guard, (req,res)=>{
+    const id = slugify(req.params.id); const root = j(BASE,id);
+    if (!fs.existsSync(root)) return bad(res,404,'not_found');
+    const target = req.query.path || '';
+    let buf=''; req.on('data',d=>buf+=d); req.on('end', ()=>{
+      try {
+        const fp = within(root, target);
+        fs.mkdirSync(path.dirname(fp), { recursive: true });
+        fs.writeFileSync(fp, buf ?? '', 'utf8');
+        ok(res,{ ok:true, path: target });
+      } catch(e){ bad(res,400,String(e.message||e)); }
+    });
+  });
+
+  app.delete('/api/projects/:id/file', guard, (req,res)=>{
+    const id = slugify(req.params.id); const root = j(BASE,id);
+    if (!fs.existsSync(root)) return bad(res,404,'not_found');
+    try {
+      const fp = within(root, req.query.path || '');
+      fs.rmSync(fp, { recursive: true, force: true });
+      ok(res,{ ok:true });
+    } catch(e){ bad(res,400,String(e.message||e)); }
+  });
+
+  app.post('/api/projects/:id/commit', guard, (req,res)=>{
+    const id=slugify(req.params.id); const root=j(BASE,id);
+    if (!fs.existsSync(root)) return bad(res,404,'not_found');
+    let buf=''; req.on('data',d=>buf+=d); req.on('end', ()=>{
+      let body={}; try{ body=JSON.parse(buf||'{}'); }catch{}
+      const msg = String(body.message || 'Update');
+      sendLED({type:'led.emotion', emotion:'busy', ttl_s:30});
+      const run = (cmd, args) => new Promise(r=> spawn(cmd,args,{cwd:root}).on('close', code=>r(code)));
+      (async ()=>{
+        await run('git',['add','-A']);
+        const code = await run('git',['commit','-m', msg]);
+        if (body.push === true) await run('git',['push']); // requires remote configured
+        await sendLED({type: code===0?'led.celebrate':'led.emotion', emotion: code===0?undefined:'error', ttl_s:20});
+        ok(res,{ ok:true, code });
+      })().catch(e=> bad(res,500,String(e)));
+    });
+  });
+
+  app.post('/api/projects/:id/deploy', guard, (req,res)=>{
+    const id=slugify(req.params.id); const root=j(BASE,id);
+    if (!fs.existsSync(root)) return bad(res,404,'not_found');
+    let buf=''; req.on('data',d=>buf+=d); req.on('end', ()=>{
+      let body={}; try{ body=JSON.parse(buf||'{}'); }catch{}
+      const dest = j(DEPLOY_ROOT, id);
+      (async ()=>{
+        await sendLED({type:'led.progress', pct:10, ttl_s:180});
+        // If scripts/deploy.sh exists, run it; else static copy from /public
+        const script = j(root, 'scripts/deploy.sh');
+        if (fs.existsSync(script)) {
+          const p = spawn('/bin/bash', ['-lc', 'chmod +x scripts/deploy.sh && scripts/deploy.sh'], { cwd: root });
+          p.on('close', async code=>{
+            await sendLED({type: code===0?'led.celebrate':'led.emotion', emotion: code===0?undefined:'error', ttl_s:20});
+          });
+        } else {
+          // default static deploy: copy /public -> /var/www/blackroad/apps/<id>/
+          fs.mkdirSync(dest, { recursive: true });
+          copyDir(j(root,'public'), dest);
+          await sendLED({type:'led.progress', pct:90, ttl_s:60});
+          await sendLED({type:'led.celebrate', ttl_s:20});
+        }
+        ok(res,{ ok:true, deployed_to: dest });
+      })().catch(e=> bad(res,500,String(e)));
+    });
+  });
+
+  function copyDir(src, dst) {
+    if (!fs.existsSync(src)) return;
+    for (const name of fs.readdirSync(src)) {
+      const s = j(src,name), d = j(dst,name);
+      const st = fs.statSync(s);
+      if (st.isDirectory()) { fs.mkdirSync(d,{recursive:true}); copyDir(s,d); }
+      else fs.copyFileSync(s,d);
+    }
+  }
+
+  console.log('[projects] mounted at /api/projects  BASE=', BASE);
+};

--- a/srv/blackroad-api/server_full.js
+++ b/srv/blackroad-api/server_full.js
@@ -161,6 +161,7 @@ const io = new SocketIOServer(server, {
 
 // Partner relay for mTLS-authenticated teammates
 require('./modules/partner_relay_mtls')({ app });
+require('./modules/projects')({ app });
 
 const emitter = new EventEmitter();
 const jobs = new Map();

--- a/var/www/blackroad/lib/project-rooms.js
+++ b/var/www/blackroad/lib/project-rooms.js
@@ -1,0 +1,144 @@
+import monaco from '/lib/monaco-bind.js';
+import * as Y from '/lib/yjs.mjs';
+import { WebsocketProvider } from '/lib/y-websocket.js';
+import { MonacoBinding } from '/lib/y-monaco.js';
+
+const $ = id => document.getElementById(id);
+let KEY = localStorage.getItem('br_origin_key') || '';
+let currentProject = null;
+let tabs = []; // { path, doc, ytext, provider, editorModel }
+
+function api(path, opts={}){
+  opts.headers = Object.assign({'X-BlackRoad-Key': KEY}, opts.headers||{});
+  return fetch(path, opts);
+}
+
+async function listProjects(){
+  const r = await api('/api/projects'); const arr = await r.json();
+  $('proj').innerHTML = arr.map(p=>`<option value="${p.id}">${p.id}</option>`).join('');
+}
+async function loadProj(){
+  currentProject = $('proj').value;
+  const r = await api(`/api/projects/${encodeURIComponent(currentProject)}/tree`); const tree = await r.json();
+  renderTree(tree);
+}
+async function createProj(){
+  const name=$('newname').value.trim(); if(!name) return;
+  await api('/api/projects',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({name})});
+  listProjects().then(loadProj);
+}
+
+function renderTree(nodes){
+  const t = $('tree'); t.innerHTML='';
+  function item(n, depth=0){
+    const li=document.createElement('div');
+    li.style.paddingLeft=(depth*12)+'px';
+    li.innerHTML = n.type==='dir' ? `📁 ${n.name}` : `📄 ${n.name}`;
+    li.onclick=()=> { if(n.type==='file') openFile(n.path); };
+    t.appendChild(li);
+    (n.children||[]).forEach(c=>item(c, depth+1));
+  }
+  nodes.forEach(n=>item(n,0));
+}
+
+function slugRoom(proj, file){ // room id: prj:<id>:<path>
+  return `prj:${proj}:${file}`;
+}
+
+function addTab(path, model){
+  const tabsEl=$('tabs');
+  const el=document.createElement('div'); el.className='tab'; el.textContent=path.split('/').pop();
+  el.onclick=()=> switchTab(path);
+  tabsEl.appendChild(el);
+  tabs.forEach(t=>t.tabEl?.classList.remove('active'));
+  const tab = tabs.find(t=>t.path===path); tab.tabEl = el; el.classList.add('active');
+}
+
+function switchTab(path){
+  const tab = tabs.find(t=>t.path===path);
+  if(!tab) return;
+  tabs.forEach(t=>t.tabEl?.classList.remove('active')); tab.tabEl?.classList.add('active');
+  monaco.editor.setModel(tab.editorModel);
+}
+
+async function openFile(path){
+  if(!currentProject) return;
+  // Already open?
+  const exist = tabs.find(t=>t.path===path);
+  if (exist) { switchTab(path); return; }
+
+  const doc = new Y.Doc();
+  const ytext = doc.getText('monaco');
+  const url = (location.protocol==='https:'?'wss://':'ws://') + location.host + '/yjs';
+  const room = slugRoom(currentProject, path);
+  const provider = new WebsocketProvider(url, room, doc);
+  provider.awareness.setLocalStateField('user', { name:'you', color:'#0096FF' });
+
+  // If first load, seed with file contents
+  const seed = await (await api(`/api/projects/${encodeURIComponent(currentProject)}/file?path=${encodeURIComponent(path)}`)).text().catch(()=> '');
+  if (seed && ytext.length === 0) ytext.insert(0, seed);
+
+  // Create a Monaco model for this file
+  const model = monaco.editor.createModel('', detectLanguage(path));
+  const binding = new MonacoBinding(ytext, model, new Set([editor]), provider.awareness);
+
+  // Track tab
+  const tab = { path, doc, ytext, provider, editorModel: model, binding };
+  tabs.push(tab);
+  addTab(path, model);
+  monaco.editor.setModel(model);
+}
+
+function detectLanguage(p){
+  if (p.endsWith('.ts')) return 'typescript';
+  if (p.endsWith('.js')) return 'javascript';
+  if (p.endsWith('.json')) return 'json';
+  if (p.endsWith('.py')) return 'python';
+  if (p.endsWith('.md')) return 'markdown';
+  if (p.endsWith('.html')) return 'html';
+  if (p.endsWith('.css')) return 'css';
+  return 'plaintext';
+}
+
+async function saveFile(){
+  const active = monaco.editor.getModels()[0];
+  // find tab with this model
+  const tab = tabs.find(t=>t.editorModel===active);
+  if(!tab) return;
+  const text = tab.ytext.toString();
+  const r = await api(`/api/projects/${encodeURIComponent(currentProject)}/file?path=${encodeURIComponent(tab.path)}`, {
+    method:'PUT', body: text
+  });
+  $('hint').textContent = r.ok ? 'Saved.' : 'Save error.';
+}
+
+async function commit(){
+  const msg = $('msg').value || 'Update';
+  const r = await api(`/api/projects/${encodeURIComponent(currentProject)}/commit`, {
+    method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({message: msg})
+  });
+  $('hint').textContent = 'Committed.';
+}
+
+async function deploy(){
+  const r = await api(`/api/projects/${encodeURIComponent(currentProject)}/deploy`, {method:'POST'});
+  $('hint').textContent = 'Deploy requested.';
+}
+
+async function mkfile(){
+  const p = $('newpath').value.trim(); if(!p) return;
+  await api(`/api/projects/${encodeURIComponent(currentProject)}/file?path=${encodeURIComponent(p)}`, {method:'PUT', body:''});
+  loadProj(); openFile(p);
+}
+async function mkdir(){
+  const p = $('newpath').value.trim(); if(!p) return;
+  await api(`/api/projects/${encodeURIComponent(currentProject)}/mkdir`, {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({path:p})});
+  loadProj();
+}
+function setKey(){ KEY = prompt('Origin key:', KEY || '') || ''; localStorage.setItem('br_origin_key', KEY); }
+
+let editor;
+(function boot(){
+  editor = monaco.editor.create($('editor'), { value:'', language:'javascript', theme:'vs-dark', minimap:{enabled:false}, automaticLayout:true });
+  listProjects();
+})();

--- a/var/www/blackroad/project.html
+++ b/var/www/blackroad/project.html
@@ -1,0 +1,57 @@
+<!doctype html><meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>BlackRoad • Project Rooms</title>
+<link rel="preconnect" href="/yjs/"><link rel="preconnect" href="/socket.io/">
+<style>
+  body{margin:0;background:#0b0b10;color:#e9e9f1;font:14px system-ui}
+  header{display:flex;gap:8px;align-items:center;padding:10px 12px;background:#0f0f1a;border-bottom:1px solid #1e1e2f}
+  .pill{border:1px solid #24244a;border-radius:999px;padding:4px 10px;font-size:12px;background:#141428}
+  .row{display:flex;gap:8px;align-items:center}
+  main{display:grid;grid-template-columns:300px 1fr;gap:12px;padding:12px}
+  .card{background:#131320;border:1px solid #24244a;border-radius:12px;padding:10px}
+  input,button,select{border-radius:10px;border:1px solid #24244a;background:#10102a;color:#e9e9f1;padding:8px}
+  button{cursor:pointer}
+  #tree{max-height:72vh;overflow:auto}
+  #editor{height:72vh;border:1px solid #24244a;border-radius:12px;overflow:hidden}
+  ul{list-style:none;margin:0;padding:0} li{padding:4px 0;cursor:pointer}
+  small{color:#9aa0aa}
+  .tab{display:inline-block;padding:6px 10px;border:1px solid #24244a;border-bottom:none;border-top-left-radius:10px;border-top-right-radius:10px;margin-right:6px;background:#0f0f1a}
+  .tab.active{background:#171730}
+</style>
+<header>
+  <div class="pill">Project Rooms</div>
+  <a class="pill" href="/editor-monaco.html" style="text-decoration:none;color:#0096FF">Single Doc</a>
+  <a class="pill" href="/collab.html" style="text-decoration:none;color:#0096FF">Presence</a>
+</header>
+<main>
+  <div class="card">
+    <h3>Projects</h3>
+    <div class="row">
+      <select id="proj"></select>
+      <button onclick="loadProj()">Open</button>
+    </div>
+    <div class="row" style="margin-top:6px">
+      <input id="newname" placeholder="new project name"><button onclick="createProj()">Create</button>
+    </div>
+    <h3 style="margin-top:10px">Tree</h3>
+    <div id="tree"></div>
+    <div class="row" style="margin-top:8px">
+      <input id="newpath" placeholder="path/in/project.txt" style="flex:1">
+      <button onclick="mkfile()">+file</button><button onclick="mkdir()">+dir</button>
+    </div>
+    <h3 style="margin-top:10px">Actions</h3>
+    <div class="row" style="gap:6px;flex-wrap:wrap">
+      <input id="msg" placeholder="commit message" style="flex:1">
+      <button onclick="saveFile()">Save</button>
+      <button onclick="commit()">Commit</button>
+      <button onclick="deploy()">Deploy</button>
+      <button onclick="setKey()">Key</button>
+    </div>
+    <small id="hint"></small>
+  </div>
+  <div class="card">
+    <div id="tabs"></div>
+    <div id="editor"></div>
+  </div>
+</main>
+<script type="module" src="/lib/project-rooms.js"></script>


### PR DESCRIPTION
## Summary
- add Projects API module providing CRUD file operations, git commit/push, and LED-aware deploys
- expose new Project Rooms UI using Monaco + Yjs for collaborative editing
- wire module into API server

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config root key unsupported)*

------
https://chatgpt.com/codex/tasks/task_e_68bf95e532e88329a8c2c5061822cd0a