### PR TITLE
Fix Hello World Playwright test to use static blog asset

### DIFF
--- a/sites/blackroad/tests/blog-hello-world.spec.ts
+++ b/sites/blackroad/tests/blog-hello-world.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from "@playwright/test";
 const base = process.env.E2E_BASE || "http://127.0.0.1:5173";
 
 test("blog post hello world is accessible", async ({ page }) => {
-  await page.goto(base + "/blog/hello-world");
+  await page.goto(base + "/blog/hello-world.html");
   await expect(page.getByRole("heading", { name: /Hello World/i })).toBeVisible();
   await expect(page.getByText(/Welcome to Hello World on BlackRoad.io./i)).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- request the generated hello-world.html blog page in Playwright test

## Testing
- `npm test` *(fails: jest not found; registry 503 during installation attempt)*
- `npm --prefix sites/blackroad run e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba3db4d0008329a8e6ae7a4f5ff84c