### PR TITLE
fix: improve desktop window accessibility

### DIFF
--- a/sites/blackroad/src/pages/Desktop.jsx
+++ b/sites/blackroad/src/pages/Desktop.jsx
@@ -47,7 +47,11 @@ function Window({ id, title, layout, setLayout, children }) {
         })
       }
     >
-      <div className="flex flex-col h-full bg-white border shadow-lg">
+      <div
+        className="flex flex-col h-full bg-white border shadow-lg"
+        role="dialog"
+        aria-label={title}
+      >
         <div className="flex items-center justify-between bg-neutral-800 text-white px-2 py-1 cursor-move">
           <span className="text-sm flex items-center gap-1">
             <span className="text-green-400">●</span>
@@ -138,7 +142,7 @@ export default function Desktop() {
               type="button"
               aria-label={isOpen ? `Hide ${a.title}` : `Show ${a.title}`}
               aria-pressed={isOpen}
-              className="px-2 py-1 text-sm hover:bg-white/50 rounded"
+              className={`px-2 py-1 text-sm rounded ${isOpen ? 'bg-white/50' : 'hover:bg-white/50'}`}
               onClick={() => toggle(a.id)}
             >
               {a.title.split(' ')[0]}


### PR DESCRIPTION
## Summary
- identify each desktop window as a dialog for screen readers
- highlight dock buttons when windows are open

## Testing
- `pre-commit run --files sites/blackroad/src/pages/Desktop.jsx`
- `npm test`
- `npm run lint` *(fails: Cannot use import statement outside a module)*
- `npm --prefix sites/blackroad run lint`
- `npm --prefix sites/blackroad test`


------
https://chatgpt.com/codex/tasks/task_e_68c07258f32c8329ada5e7025fa4938e