### PR TITLE
feat(api): enforce JSON envelope and snapshot logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2025-09-09
+
+- enforce JSON envelope and snapshot logging for API routes
+
 ## 2025-08-16
 
 - Cleanup: hardened API, added tests and CI tooling.

--- a/PR1_RECON.md
+++ b/PR1_RECON.md
@@ -1,0 +1,10 @@
+# PR1 Recon
+
+| File | Impact |
+| --- | --- |
+| CHANGELOG.md | other |
+| PR1_RUNBOOK.md | other |
+| srv/blackroad-api/controllers/guardianController.js | api |
+| srv/blackroad-api/controllers/llmController.js | api |
+| srv/blackroad-api/routes/index.js | api |
+| srv/blackroad-api/lib/snapshot.js | api |

--- a/PR1_RUNBOOK.md
+++ b/PR1_RUNBOOK.md
@@ -1,0 +1,14 @@
+# PR1 Apply Plan
+
+## Restart Order
+1. `systemctl restart yjs`
+2. `systemctl restart blackroad-api`
+3. `systemctl restart nginx`
+4. `systemctl restart ollama-bridge`
+
+## Verification
+- `curl -s http://localhost:4000/healthz`
+- `curl -s http://localhost:4000/api/projects`
+- `curl -s http://localhost:4000/api/devices`
+- `curl -s http://localhost:4000/api/llm/health`
+- `curl -s http://localhost:12345/yjs/test`

--- a/srv/blackroad-api/controllers/guardianController.js
+++ b/srv/blackroad-api/controllers/guardianController.js
@@ -1,3 +1,7 @@
-exports.handle = (req, res) => {
-  res.json({ ok: true, message: 'guardian endpoint' });
+const logSnapshot = require('../lib/snapshot');
+
+exports.handle = async (_req, res) => {
+  const payload = { ok: true, data: { message: 'guardian endpoint' } };
+  await logSnapshot(payload);
+  res.json(payload);
 };

--- a/srv/blackroad-api/controllers/llmController.js
+++ b/srv/blackroad-api/controllers/llmController.js
@@ -1,4 +1,5 @@
 const LLM_URL = process.env.LLM_URL || 'http://127.0.0.1:8000';
+const logSnapshot = require('../lib/snapshot');
 
 exports.chat = async (req, res, next) => {
   try {
@@ -8,7 +9,9 @@ exports.chat = async (req, res, next) => {
       body: JSON.stringify(req.body || {})
     });
     const text = await upstream.text();
-    res.status(upstream.ok ? 200 : upstream.status).type('text/plain').send(text);
+    const payload = { ok: upstream.ok, data: text };
+    await logSnapshot(payload);
+    res.status(upstream.ok ? 200 : upstream.status).json(payload);
   } catch (err) {
     next(err);
   }

--- a/srv/blackroad-api/lib/snapshot.js
+++ b/srv/blackroad-api/lib/snapshot.js
@@ -1,0 +1,17 @@
+const logger = require('./log');
+
+const NORMALIZE_URL = 'http://127.0.0.1:4505/normalize';
+
+module.exports = async function logSnapshot(payload) {
+  try {
+    const res = await fetch(NORMALIZE_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    const normalized = await res.json();
+    logger.info({ snapshot: normalized });
+  } catch (err) {
+    logger.error({ snapshotError: String(err) });
+  }
+};

--- a/srv/blackroad-api/routes/index.js
+++ b/srv/blackroad-api/routes/index.js
@@ -1,8 +1,11 @@
 const express = require('express');
+const logSnapshot = require('../lib/snapshot');
 const router = express.Router();
 
-router.get('/health', (req, res) => {
-  res.json({ ok: true });
+router.get('/health', async (_req, res) => {
+  const payload = { ok: true, data: { status: 'ok' } };
+  await logSnapshot(payload);
+  res.json(payload);
 });
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- ensure API routes return `application/json` with a `{ ok, data }` envelope
- log normalized JSON snapshots via `br_jsond`
- document restart plan and recon of touched files

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: Cannot read config file: .eslintrc.cjs)*

------
https://chatgpt.com/codex/tasks/task_e_68c075f94ee48329a6495931ed778342