### PR TITLE
Add BlackRoad Formalism v0 prototypes

### DIFF
--- a/docs/blackroad-formalism.md
+++ b/docs/blackroad-formalism.md
@@ -1,0 +1,60 @@
+# BlackRoad Formalism v0
+
+This note sketches eight composable constructs for steering large language models with physics‑style dynamics. Each construct includes a mathematical definition and a simple experiment plan.
+
+## 1. Language–Lindblad (LLB)
+Open system evolution for token amplitudes \(\rho = |\psi\rangle\langle\psi|\):
+
+\[
+\frac{d\rho}{dt} = -\frac{i}{\hbar_\psi}[\mathsf{H}_{\text{lang}},\rho] + \sum_k\left( \mathsf{L}_k\rho\mathsf{L}_k^\dagger - \tfrac12\{\mathsf{L}_k^\dagger\mathsf{L}_k,\rho\}\right).
+\]
+
+Experiment: integrate a one step Euler–Maruyama update; show that including a kindness potential \(\lambda_K K\) reduces toxic completions while keeping perplexity.
+
+## 2. BlackRoad Action & Care–Noether Current
+Trajectory action
+
+\[
+\mathcal{S}_{\mathrm{BR}}[\gamma] = \int (\mathcal{L}_{\text{sem}} - \mathcal{H}_{\text{harm}} + \lambda_K K + \lambda_R\mathcal{R}) dt.
+\]
+
+Synonym invariance gives conserved care current \(\partial_\mu J_c^\mu = 0\). Experiment: compute \(J_c\) before and after paraphrase and correlate with human judgments of meaning preservation.
+
+## 3. Quaternion‑Ternary Token Algebra (QT³)
+Statements factor as \(X=vq\) with \(v\in\{-1,0,+1\}\) and unit quaternion \(q\). Composition uses balanced ternary for polarity and quaternion multiplication for orientation. Experiment: compose tokens across a sentence and visualise orientation drift under adversarial reorderings.
+
+## 4. Gödel–Gap Potential
+\(
+\Phi_G(x) = \alpha K(x) - \beta I(x;\text{world})
+\)
+penalises unfalsifiable verbosity. Experiment: lower \(\Phi_G\) should predict higher factual F1 with fewer tokens.
+
+## 5. Trilog & Abacus
+Balanced‑ternary log and projection operator \(\mathcal{A}\) that snaps feature vectors to the nearest balanced‑ternary lattice for discrete attention budgeting. Experiment: compare retrieval slot allocation using \(\mathcal{A}\) against softmax gating.
+
+## 6. Trust–Resilience Dynamics (TRO)
+Coupled ODEs
+
+\[
+\dot T = \alpha K + \gamma J_c - \beta E - \eta S,\qquad
+\dot R = \mu J_c - \nu E - \xi \dot S
+\]
+link care currents to operational trust. Experiment: adapt \(\lambda_K\) online to keep \(T\) above a threshold during outages.
+
+## 7. Schrödinger of Language
+Discrete update for logits \(\ell\):
+
+\[
+\ell_{t+\Delta} \leftarrow \ell_t + \Delta(\nabla^2_{\mathcal{E}}\ell - \nabla V_{\text{prompt}} - \nabla V_{\text{memory}} + \lambda_K\nabla K - \lambda_H \nabla H) + \text{noise}.
+\]
+
+Experiment: ablate each potential and evaluate calibration and harmlessness.
+
+## 8. BlackRoad Claims
+1. Control token amplitudes via the Language–Lindblad equation with kindness and memory potentials, conserving the care‑Noether current.
+2. Represent statements as quaternion‑ternary elements and compose discourse via \(\star\) to regulate orientation and polarity.
+3. Minimise the Gödel–Gap potential to discourage unfalsifiable complexity.
+4. Allocate resources on a balanced‑ternary lattice using the Abacus operator.
+5. Adjust kindness gains using trust–resilience feedback to maintain a care set‑point.
+
+These constructs provide a foundation for a physics‑inspired, care‑aware language model stack.

--- a/experiments/br_math/abacus_gate.py
+++ b/experiments/br_math/abacus_gate.py
@@ -1,0 +1,22 @@
+"""Balanced‑ternary projection operator."""
+from __future__ import annotations
+
+import numpy as np
+
+
+def abacus_projection(x: np.ndarray) -> np.ndarray:
+    """Project a vector to the nearest balanced‑ternary lattice.
+
+    Each element is rounded to -1, 0 or +1.
+    """
+    return np.clip(np.round(x), -1, 1)
+
+
+def trlog(x: float) -> int:
+    """Balanced‑ternary logarithm index for positive scalars."""
+    if x <= 0:
+        raise ValueError("x must be positive")
+    return int(np.round(np.log(x) / np.log(3)))
+
+
+__all__ = ["abacus_projection", "trlog"]

--- a/experiments/br_math/godel_gap.py
+++ b/experiments/br_math/godel_gap.py
@@ -1,0 +1,15 @@
+"""Gödel–Gap potential scorer."""
+from __future__ import annotations
+
+from typing import Iterable
+import numpy as np
+
+
+def godel_gap(complexities: Iterable[float], evidences: Iterable[float], alpha: float = 1.0, beta: float = 1.0) -> float:
+    """Compute \Phi_G = alpha * K - beta * I."""
+    k = np.sum(list(complexities))
+    i = np.sum(list(evidences))
+    return alpha * k - beta * i
+
+
+__all__ = ["godel_gap"]

--- a/experiments/br_math/llb_step.py
+++ b/experiments/br_math/llb_step.py
@@ -1,0 +1,61 @@
+"""Language–Lindblad step prototype.
+
+Implements a single Euler–Maruyama update of logits inspired by the
+Language–Lindblad equation.  The function is intentionally tiny and
+framework agnostic; callers supply gradients for prompt, memory, kindness
+and harm potentials.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+import numpy as np
+
+
+@dataclass
+class Potentials:
+    """Container for gradient callables.
+
+    Each callable accepts the current logits and returns a gradient with
+    the same shape.
+    """
+
+    grad_prompt: Callable[[np.ndarray], np.ndarray]
+    grad_memory: Callable[[np.ndarray], np.ndarray]
+    grad_kindness: Callable[[np.ndarray], np.ndarray]
+    grad_harm: Callable[[np.ndarray], np.ndarray]
+
+
+def llb_step(
+    logits: np.ndarray,
+    potentials: Potentials,
+    dt: float = 1e-2,
+    noise_scale: float = 1e-3,
+    lam_k: float = 1.0,
+    lam_h: float = 1.0,
+) -> np.ndarray:
+    """Perform one stochastic update of the logits.
+
+    Parameters
+    ----------
+    logits: current logit vector.
+    potentials: gradients of prompt, memory, kindness and harm potentials.
+    dt: integration step.
+    noise_scale: standard deviation of gaussian noise.
+    lam_k: kindness strength.
+    lam_h: harm penalty.
+    """
+
+    lap = np.zeros_like(logits)  # placeholder for \nabla^2_E logit smoothing
+    grad = (
+        lap
+        - potentials.grad_prompt(logits)
+        - potentials.grad_memory(logits)
+        + lam_k * potentials.grad_kindness(logits)
+        - lam_h * potentials.grad_harm(logits)
+    )
+    noise = np.random.normal(scale=noise_scale, size=logits.shape)
+    return logits + dt * grad + noise
+
+
+__all__ = ["Potentials", "llb_step"]

--- a/experiments/br_math/noether_care.py
+++ b/experiments/br_math/noether_care.py
@@ -1,0 +1,27 @@
+"""Care–Noether current prototype."""
+from __future__ import annotations
+
+from typing import Iterable
+import numpy as np
+
+
+def care_current(vectors: Iterable[np.ndarray], deltas: Iterable[np.ndarray]) -> np.ndarray:
+    """Compute a simple discrete care current.
+
+    Parameters
+    ----------
+    vectors: iterable of semantic vectors for each token.
+    deltas: iterable of variations produced by a paraphrase.
+
+    Returns
+    -------
+    np.ndarray representing the care current.  Zero indicates preserved
+    meaning under the given transformation.
+    """
+
+    vec = np.stack(list(vectors))
+    deltas = np.stack(list(deltas))
+    return (vec * deltas).sum(axis=0)
+
+
+__all__ = ["care_current"]

--- a/experiments/br_math/qt3.py
+++ b/experiments/br_math/qt3.py
@@ -1,0 +1,51 @@
+"""Quaternion‑Ternary token algebra utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import numpy as np
+
+TERNARY = (-1, 0, 1)
+
+
+def ternary_mul(a: int, b: int) -> int:
+    """Balanced‑ternary multiplication with 0 absorbing."""
+    if a == 0 or b == 0:
+        return 0
+    return 1 if a == b else -1
+
+
+@dataclass
+class QT3:
+    """Quaternion‑Ternary statement."""
+
+    v: int
+    q: np.ndarray  # (4,) quaternion [w,x,y,z]
+
+    def __post_init__(self) -> None:
+        if self.v not in TERNARY:
+            raise ValueError("v must be -1,0,+1")
+        self.q = np.asarray(self.q, dtype=float)
+        self.q = self.q / np.linalg.norm(self.q)
+
+    def star(self, other: "QT3") -> "QT3":
+        """Compose with another statement."""
+        v = ternary_mul(self.v, other.v)
+        q = quat_mul(self.q, other.q)
+        return QT3(v=v, q=q)
+
+
+def quat_mul(a: np.ndarray, b: np.ndarray) -> np.ndarray:
+    """Quaternion multiplication."""
+    w1, x1, y1, z1 = a
+    w2, x2, y2, z2 = b
+    return np.array(
+        [
+            w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2,
+            w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2,
+            w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2,
+            w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2,
+        ]
+    )
+
+
+__all__ = ["QT3", "ternary_mul", "quat_mul"]

--- a/experiments/br_math/tro_control.py
+++ b/experiments/br_math/tro_control.py
@@ -1,0 +1,25 @@
+"""Trust–Resilience ODE controller."""
+from __future__ import annotations
+
+import numpy as np
+
+
+def tro_step(t: float, state: np.ndarray, params: np.ndarray) -> np.ndarray:
+    """One step of the trust–resilience dynamics.
+
+    Parameters
+    ----------
+    t: time (unused but included for ODE solver compatibility)
+    state: array ``[T, R, S, E, Jc, K]`` representing trust, resilience,
+        entropy, error, care current and kindness.
+    params: array ``[alpha, beta, gamma, eta, mu, nu, xi]`` of coefficients.
+    """
+
+    T, R, S, E, Jc, K = state
+    alpha, beta, gamma, eta, mu, nu, xi = params
+    dT = alpha * K + gamma * Jc - beta * E - eta * S
+    dR = mu * Jc - nu * E - xi * np.gradient([S, S])[0]  # crude \dot S estimate
+    return np.array([dT, dR])
+
+
+__all__ = ["tro_step"]


### PR DESCRIPTION
## Summary
- Add whitepaper describing eight constructs for physics-inspired, care-aware language model control
- Provide prototype modules for Language–Lindblad step, quaternion-ternary algebra, care Noether current, Gödel–Gap, Abacus gating and trust–resilience dynamics

## Testing
- `pytest -q` *(fails: No module named 'torch', 'sympy', 'lucidia_reason', 'app', 'anthropic', 'matplotlib', 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_68c08982bf4483299ca4dc406ec478e6