### PR TITLE
feat: add LED comment router and workflow

### DIFF
--- a/.github/workflows/pr-led-commands.yml
+++ b/.github/workflows/pr-led-commands.yml
@@ -1,0 +1,46 @@
+name: pr-led-commands
+on:
+  issue_comment:
+    types: [created]
+permissions:
+  contents: read
+  pull-requests: read
+jobs:
+  route:
+    # Only run on PRs (issue_comment also fires on Issues)
+    if: >
+      github.event.issue.pull_request &&
+      (
+        contains(github.event.comment.body, 'athena ') ||
+        startsWith(github.event.comment.body, '/led') ||
+        contains(github.event.comment.body, '/lightshow')
+      )
+    # Require trusted commenters (repo members/collaborators/owners)
+    runs-on: [self-hosted, linux, blackroad]
+    steps:
+      - name: Authorize commenter
+        run: |
+          echo "Assoc: ${{ github.event.comment.author_association }}"
+          case "${{ github.event.comment.author_association }}" in
+            OWNER|MEMBER|COLLABORATOR) exit 0 ;;
+            *) echo "Not authorized."; exit 78 ;;  # neutral
+          esac
+
+      - uses: actions/checkout@v4
+
+      - name: Ensure jq is present
+        run: |
+          command -v jq || (sudo apt-get update && sudo apt-get install -y jq)
+
+      - name: Route comment to LEDs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_COMMENT_BODY: ${{ github.event.comment.body }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          PR: ${{ github.event.issue.number }}
+          # For remote API instead of loopback, uncomment:
+          # LED_BASE: https://blackroad.io
+          # LED_KEY:  ${{ secrets.LED_ORIGIN_KEY }}
+        run: |
+          bash scripts/led/led_router.sh

--- a/scripts/led/led_notify.sh
+++ b/scripts/led/led_notify.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Usage: led_notify.sh emotion [ttl]
+# emotion: ok|busy|error|thinking|celebrate|help
+set -euo pipefail
+EMO="${1:-ok}"; TTL="${2:-10}"
+BASE="${LED_BASE:-http://127.0.0.1:4000}"
+KEY="${LED_KEY:-}"  # set if BASE is not loopback
+
+hdr=(-H 'content-type: application/json')
+[ -n "$KEY" ] && hdr+=(-H "X-BlackRoad-Key: $KEY")
+
+curl -sS "${hdr[@]}" \
+  -d "{\"type\":\"led.emotion\",\"emotion\":\"$EMO\",\"ttl_s\":$TTL}" \
+  "$BASE/api/devices/pi-01/command" >/dev/null || true

--- a/scripts/led/led_router.sh
+++ b/scripts/led/led_router.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Parse a PR comment and route to LED actions.
+# Env:
+#   GITHUB_COMMENT_BODY, OWNER, REPO, PR
+#   LED_BASE (default http://127.0.0.1:4000), LED_KEY (optional)
+set -euo pipefail
+BODY="$(echo "${GITHUB_COMMENT_BODY:-}" | tr '[:upper:]' '[:lower:]')"
+[ -n "$BODY" ] || { echo "no comment body"; exit 0; }
+BASE="${LED_BASE:-http://127.0.0.1:4000}"
+KEY="${LED_KEY:-}"
+
+say(){ printf '[router] %s\n' "$*"; }
+
+run_notify(){ bash scripts/led/led_notify.sh "$@"; }
+post_json(){ 
+  hdr=(-H 'content-type: application/json'); [ -n "$KEY" ] && hdr+=(-H "X-BlackRoad-Key: $KEY")
+  curl -sS "${hdr[@]}" -d "$1" "$BASE/api/devices/pi-01/command" >/dev/null || true
+}
+
+# Map simple "athena <emotion>" and "/led <emotion> [ttl]"
+if [[ "$BODY" =~ (^|[[:space:]])(athena[[:space:]]+ok)($|[[:space:]]) ]];         then run_notify ok 12;        exit 0; fi
+if [[ "$BODY" =~ (^|[[:space:]])(athena[[:space:]]+busy)($|[[:space:]]) ]];       then run_notify busy 15;      exit 0; fi
+if [[ "$BODY" =~ (^|[[:space:]])(athena[[:space:]]+thinking)($|[[:space:]]) ]];   then run_notify thinking 15;  exit 0; fi
+if [[ "$BODY" =~ (^|[[:space:]])(athena[[:space:]]+error)($|[[:space:]]) ]];      then run_notify error 12;     exit 0; fi
+if [[ "$BODY" =~ (^|[[:space:]])(athena[[:space:]]+celebrate)($|[[:space:]]) ]];  then run_notify celebrate 12; exit 0; fi
+if [[ "$BODY" =~ (^|[[:space:]])(athena[[:space:]]+help)($|[[:space:]]) ]];       then run_notify help 20;      exit 0; fi
+
+if [[ "$BODY" =~ /led[[:space:]]+([a-z]+)([[:space:]]+([0-9]+))? ]]; then
+  emo="${BASH_REMATCH[1]}"; ttl="${BASH_REMATCH[3]:-12}"
+  if [[ "$emo" == "progress" ]]; then
+    if [[ "$BODY" =~ /led[[:space:]]+progress[[:space:]]+([0-9]{1,3}) ]]; then
+      pct="${BASH_REMATCH[1]}"; [ "$pct" -gt 100 ] && pct=100
+      post_json "{\"type\":\"led.progress\",\"pct\":$pct,\"ttl_s\":12}"
+      exit 0
+    fi
+  else
+    run_notify "$emo" "$ttl"; exit 0
+  fi
+fi
+
+# Lightshow: "athena play" | "/lightshow" | "/lightshow 123"
+if [[ "$BODY" =~ (athena[[:space:]]+play|/lightshow) ]]; then
+  if [[ "$BODY" =~ /lightshow[[:space:]]+([0-9]+) ]]; then PR="${BASH_REMATCH[1]}"; fi
+  : "${OWNER:?}"; : "${REPO:?}"; : "${PR:?}"
+  bash scripts/led/pr_lightshow.sh
+  exit 0
+fi
+
+say "no recognized command"
+exit 0

--- a/scripts/led/pr_lightshow.sh
+++ b/scripts/led/pr_lightshow.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Play a PR's diff as LEDs; see CI status for celebration.
+set -euo pipefail
+: "${OWNER:?Set OWNER}"; : "${REPO:?Set REPO}"; : "${PR:?Set PR}"
+TOKEN="${GH_PAT:-${GH_TOKEN:-${GITHUB_TOKEN:-}}}"
+[ -n "$TOKEN" ] || { echo "Need GH_TOKEN/GH_PAT"; exit 2; }
+BASE="${LED_BASE:-http://127.0.0.1:4000}"
+KEY="${LED_KEY:-}"
+
+api(){ curl -fsSL -H "Authorization: Bearer $TOKEN" -H "Accept: application/vnd.github+json" "$@"; }
+jhdr=(-H 'content-type: application/json'); [ -n "$KEY" ] && jhdr+=(-H "X-BlackRoad-Key: $KEY")
+
+# Sum additions/deletions (paginate)
+page=1 A=0 D=0
+while :; do
+  resp="$(api "https://api.github.com/repos/$OWNER/$REPO/pulls/$PR/files?per_page=100&page=$page")"
+  cnt="$(echo "$resp" | jq 'length')"; [ "$cnt" -eq 0 ] && break
+  A=$(( A + $(echo "$resp" | jq '[.[]|.additions]|add // 0') ))
+  D=$(( D + $(echo "$resp" | jq '[.[]|.deletions]|add // 0') ))
+  page=$((page+1))
+done
+
+# Head SHA & combined status
+sha="$(api "https://api.github.com/repos/$OWNER/$REPO/pulls/$PR" | jq -r '.head.sha')"
+STATE="$(api "https://api.github.com/repos/$OWNER/$REPO/commits/$sha/status" | jq -r '.state')"
+
+# Helpers
+progress(){ curl -sS "${jhdr[@]}" -d "{\"type\":\"led.progress\",\"pct\":$1,\"ttl_s\":8}" \
+  "$BASE/api/devices/pi-01/command" >/dev/null || true; }
+emo(){ curl -sS "${jhdr[@]}" -d "{\"type\":\"led.emotion\",\"emotion\":\"$1\",\"ttl_s\":$2}" \
+  "$BASE/api/devices/pi-01/command" >/dev/null || true; }
+
+emo busy 6
+for i in $(seq 0 8); do progress $(( i*12 )); sleep 0.22; done
+steps=$(( A>0 ? ( (A>4000 ? 4000 : A) / 8 + 1 ) : 4 ))
+for _ in $(seq 2 $((steps>6?6:steps))); do progress 15; sleep 0.15; progress 60; sleep 0.15; progress 90; sleep 0.15; done
+[ "$D" -gt 0 ] && emo error 4
+[ "$STATE" = "success" ] && curl -sS "${jhdr[@]}" -d '{"type":"led.celebrate","ttl_s":12}' \
+  "$BASE/api/devices/pi-01/command" >/dev/null || emo thinking 6


### PR DESCRIPTION
## Summary
- add LED notifier, lightshow, and router scripts with remote API key support
- wire up `pr-led-commands` workflow to execute LED actions from PR comments

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0876bd07c83299be2ece255bcfeda