### PR TITLE
feat: add lightshow script and care gate workflow

### DIFF
--- a/.github/workflows/care-gate.yml
+++ b/.github/workflows/care-gate.yml
@@ -1,0 +1,39 @@
+name: care-gate
+on: [pull_request]
+jobs:
+  care:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+      - run: pip install nltk pytest
+      - name: Score care
+        run: |
+          python - <<'PY'
+import os, re, subprocess, json
+root='.'
+todo=fix=long=0
+for dp,_,fs in os.walk(root):
+  if '.git' in dp: continue
+  for f in fs:
+    p=os.path.join(dp,f)
+    try: txt=open(p,'r',errors='ignore').read()
+    except: continue
+    todo+=len(re.findall(r'\bTODO\b',txt))
+    fix +=len(re.findall(r'\bFIXME\b',txt))
+    if sum(1 for _ in open(p,'r',errors='ignore'))>800: long+=1
+# try tests
+try:
+  r=subprocess.run(['pytest','-q'],capture_output=True,text=True,timeout=180)
+  failing = 0 if r.returncode==0 else 1
+except Exception: failing=1
+score = todo*0.5 + fix*1.0 + long*2 + failing*5
+report={"todo":todo,"fixme":fix,"long_files":long,"tests_failing":failing,"score":score}
+print("CARE-REPORT:", json.dumps(report))
+threshold=float(os.environ.get("CARE_THRESHOLD","10"))
+open(os.environ.get("GITHUB_STEP_SUMMARY","/dev/null"),'a').write(f"\n**Care score:** {score} (≤ {threshold} passes)\n")
+exit(0 if score<=threshold else 1)
+PY
+        env:
+          CARE_THRESHOLD: "12"

--- a/usr/local/bin/pr_lightshow.sh
+++ b/usr/local/bin/pr_lightshow.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Usage: GH_PAT=xxxx OWNER=blackboxprogramming REPO=blackroad-prism-console PR=123 pr_lightshow.sh
+set -euo pipefail
+: "${GH_PAT:?}"; : "${OWNER:?}"; : "${REPO:?}"; : "${PR:?}"
+API="https://api.github.com/repos/$OWNER/$REPO/pulls/$PR/files"
+diff=$(curl -fsSL -H "Authorization: token $GH_PAT" "$API" | jq '[.[]|{a:.additions,d:.deletions}]'
+      | jq '[.[]|.a] | add as $A | input | [.[].d] | add as $D | {"A":$A,"D":$D}' --slurpfile input <(curl -fsSL -H "Authorization: token $GH_PAT" "$API"))
+A=$(echo "$diff" | jq -r '.[0].A//0'); D=$(echo "$diff" | jq -r '.[0].D//0')
+KEY="$(sudo cat /srv/secrets/origin.key 2>/dev/null || true)"
+pulse(){ curl -s -H "X-BlackRoad-Key: $KEY" -H 'content-type: application/json' \
+  -d "{\"type\":\"led.emotion\",\"emotion\":\"$1\",\"ttl_s\":$2}" http://127.0.0.1:4000/api/devices/pi-01/command >/dev/null || true; }
+bar(){ pct="$1"; curl -s -H "X-BlackRoad-Key: $KEY" -H 'content-type: application/json' \
+  -d "{\"type\":\"led.progress\",\"pct\":$pct,\"ttl_s\":15}" http://127.0.0.1:4000/api/devices/pi-01/command >/dev/null || true; }
+
+# intro
+pulse busy 6
+# additions sweep
+steps=$(( A>0 ? (A/8+1) : 1 )); for i in $(seq 0 8); do bar $(( i*12 )); sleep 0.25; done
+# deletions warning pulse
+if [ "$D" -gt 0 ]; then pulse error 4; fi
+# close
+pulse thinking 4

--- a/var/www/blackroad/lib/monaco-yjs-editor.js
+++ b/var/www/blackroad/lib/monaco-yjs-editor.js
@@ -1,0 +1,27 @@
+import * as Y from '/lib/yjs.mjs';
+import { WebsocketProvider } from '/lib/y-websocket.js';
+import { MonacoBinding } from '/lib/y-monaco.js';
+
+// --- Dual-room diff: open branch "B" alongside current --- //
+export async function openDiff(roomA, roomB, language='javascript'){
+  const url = (location.protocol==='https:'?'wss://':'ws://') + location.host + '/yjs';
+  // A (current)
+  const docA = new Y.Doc(), yA = docA.getText('monaco');
+  const pA = new WebsocketProvider(url, roomA, docA);
+  // B (alt)
+  const docB = new Y.Doc(), yB = docB.getText('monaco');
+  const pB = new WebsocketProvider(url, roomB, docB);
+
+  const modelA = monaco.editor.createModel(yA.toString(), language);
+  const modelB = monaco.editor.createModel(yB.toString(), language);
+  new MonacoBinding(yA, modelA, new Set(), pA.awareness);
+  new MonacoBinding(yB, modelB, new Set(), pB.awareness);
+
+  const node = document.getElementById('editor');
+  node.innerHTML = ''; // clear existing
+  const diff = monaco.editor.createDiffEditor(node, { theme:'vs-dark', renderSideBySide:true, automaticLayout:true });
+  diff.setModel({ original: modelA, modified: modelB });
+  return { dispose:()=>diff.dispose(), modelA, modelB };
+}
+// usage example (console):
+// openDiff('prj:demo-app:/src/app.js', 'prj:demo-app:/src/app.js#proposal-B','javascript')


### PR DESCRIPTION
## Summary
- chore: add care-gate workflow to score TODO/FIXME density and long files
- feat: script to pulse LEDs based on PR diff stats
- feat: monaco helper to open diff views between two Yjs rooms

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 503 Service Unavailable - GET http://verdaccio.internal:4873/bcrypt)*
- `npm run lint` *(fails: A config object is using the "root" key, which is not supported in flat config system)*

------
https://chatgpt.com/codex/tasks/task_e_68c0860bb0848329be31ef0327959db3