### PR TITLE
feat: add truth pubsub and autopin scripts

### DIFF
--- a/etc/systemd/system/truth-peers.service
+++ b/etc/systemd/system/truth-peers.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Truth Garden swarm peer connect
+After=ipfs.service network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/truth-connect-peers.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/etc/systemd/system/truth-subpin.service
+++ b/etc/systemd/system/truth-subpin.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Truth Garden Auto-Pin (pubsub)
+After=ipfs.service network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart=/usr/bin/node /srv/truth-subpin/truth_subpin.js
+Restart=always
+Environment=TRUTH_TOPIC=truth.garden/v1/announce
+Environment=IPFS_API=http://127.0.0.1:5001
+# Restrict to your DIDs if you want (comma-separated). Leave empty to accept all.
+# Environment=ALLOW_DIDS=did:key:z6Mkw...,did:key:z6Mk...
+
+[Install]
+WantedBy=multi-user.target

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
     "systeminformation": "^5.25.11",
     "uuid": "^9.0.1",
     "better-sqlite3": "^9.4.3",
-    "stripe": "^12.18.0"
+    "stripe": "^12.18.0",
+    "ipfs-http-client": "^60.0.0",
+    "json-canonicalize": "^1.0.4"
   },
   "devDependencies": {
     "nodemon": "^3.0.2",

--- a/srv/blackroad-api/modules/truth_pubsub.js
+++ b/srv/blackroad-api/modules/truth_pubsub.js
@@ -1,0 +1,63 @@
+// Publishes/consumes Truth Garden pubsub and auto-pins locally.
+// Topic: truth.garden/v1/announce
+const { create } = require('ipfs-http-client');
+const canonicalize = require('json-canonicalize');
+const fs = require('fs');
+
+const TOPIC = process.env.TRUTH_TOPIC || 'truth.garden/v1/announce';
+const IPFS_API = process.env.IPFS_API || 'http://127.0.0.1:5001';
+const FEED_APPEND = (line) => {
+  try {
+    fs.mkdirSync('/srv/truth', { recursive: true });
+    fs.appendFileSync('/srv/truth/feed.ndjson', line + '\n');
+  } catch {}
+};
+
+module.exports = async function attachTruthPubSub({ app }) {
+  const ipfs = create({ url: IPFS_API });
+  const ident = app.locals.truthIdentity; // from truth_identity
+  if (!ident) throw new Error('truth_pubsub: identity missing');
+
+  // Subscriber: pin on receipt (simple allow-all; you can add DID allowlist later)
+  await ipfs.pubsub.subscribe(TOPIC, async (msg) => {
+    try {
+      const text = new TextDecoder().decode(msg.data);
+      const o = JSON.parse(text);
+      if (!o?.cid) return;
+      // Pin locally
+      await ipfs.pin.add(o.cid).catch(() => {});
+      FEED_APPEND(
+        JSON.stringify({ ts: Date.now(), cid: o.cid, did: o.did, kind: 'announce', via: 'pubsub' })
+      );
+      // Optional: LED nudge locally via backplane (server)
+      try {
+        await fetch('http://127.0.0.1:4000/api/devices/pi-01/command', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-BlackRoad-Key': process.env.ORIGIN_KEY || '',
+          },
+          body: JSON.stringify({ type: 'led.emotion', emotion: 'busy', ttl_s: 5 }),
+        });
+      } catch {}
+    } catch (_) {}
+  });
+
+  // Expose a helper publisher for truth_api to call
+  app.locals.truthPub = {
+    async announce(cid, type) {
+      const payload = {
+        cid,
+        did: ident.did,
+        type: type || 'Truth',
+        ts: new Date().toISOString(),
+      };
+      const jcs = Buffer.from(canonicalize(payload));
+      const sig = app.locals.truthIdentity.signJcs(jcs);
+      const msg = { ...payload, jcs: true, sig };
+      await ipfs.pubsub.publish(TOPIC, new TextEncoder().encode(JSON.stringify(msg)));
+    },
+  };
+
+  console.log('[truth] pubsub wired on topic %s', TOPIC);
+};

--- a/srv/truth-subpin/truth_subpin.js
+++ b/srv/truth-subpin/truth_subpin.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+// Auto-pin CIDs announced on Truth Garden pubsub.
+// Env: TRUTH_TOPIC (default truth.garden/v1/announce), IPFS_API (default http://127.0.0.1:5001)
+//      ALLOW_DIDS (comma-separated did:key list; if unset -> allow all)
+const { create } = require('ipfs-http-client');
+
+const TOPIC = process.env.TRUTH_TOPIC || 'truth.garden/v1/announce';
+const API = process.env.IPFS_API || 'http://127.0.0.1:5001';
+const ALLOW = (process.env.ALLOW_DIDS || '')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+const ipfs = create({ url: API });
+
+(async () => {
+  console.log('[subpin] connecting', API, 'topic', TOPIC, 'allow', ALLOW.length ? ALLOW : 'ALL');
+  await ipfs.pubsub.subscribe(TOPIC, async (msg) => {
+    try {
+      const text = new TextDecoder().decode(msg.data);
+      const o = JSON.parse(text);
+      if (!o?.cid) return;
+      if (ALLOW.length && (!o.did || !ALLOW.includes(o.did))) return;
+      console.log('[subpin] pin', o.cid, o.did || '?');
+      await ipfs.pin.add(o.cid).catch(() => {});
+    } catch (e) {
+      /* ignore */
+    }
+  });
+})();

--- a/usr/local/sbin/truth-connect-peers.sh
+++ b/usr/local/sbin/truth-connect-peers.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+PEERS_FILE="/etc/truth/peers.txt"
+if [ ! -f "$PEERS_FILE" ]; then echo "No $PEERS_FILE"; exit 0; fi
+while IFS= read -r addr; do
+  [ -z "$addr" ] && continue
+  ipfs swarm connect "$addr" || true
+done < "$PEERS_FILE"


### PR DESCRIPTION
## Summary
- wire Truth Garden pubsub module to auto-pin received CIDs and announce new ones
- add daemon and services for auto-pinning and peer connections on devices
- initialize pubsub asynchronously in API server

## Testing
- `npm run lint` *(fails: A config object is using the "root" key, which is not supported in flat config system)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c08da40a3c832984e55ce974b72f63