### PR TITLE
Add trust graph and lens-based feed ranking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,10 @@
     "": {
       "name": "blackroad-prism-console",
       "version": "0.0.0",
+      "dependencies": {
+        "sqlite3": "^5.1.7",
+        "yaml": "^2.5.0"
+      },
       "devDependencies": {
         "nodemon": "^3.0.2",
         "jest": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
     "uuid": "^9.0.1",
     "better-sqlite3": "^9.4.3",
     "stripe": "^12.18.0",
-    "ethers": "^6.10.0"
+    "ethers": "^6.10.0",
+    "sqlite3": "^5.1.7",
+    "yaml": "^2.5.0"
   },
   "devDependencies": {
     "nodemon": "^3.0.2",

--- a/srv/blackroad-api/db_migrations/010_trust.sql
+++ b/srv/blackroad-api/db_migrations/010_trust.sql
@@ -1,0 +1,25 @@
+PRAGMA journal_mode=WAL;
+
+CREATE TABLE IF NOT EXISTS trust_identities (
+  did TEXT PRIMARY KEY,
+  label TEXT,
+  created_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS trust_edges (
+  src TEXT NOT NULL,
+  dst TEXT NOT NULL,
+  weight REAL NOT NULL,        -- [-1..1], >0 trust, <0 distrust
+  evidence_cid TEXT,
+  created_at INTEGER NOT NULL,
+  UNIQUE (src, dst)
+);
+
+CREATE TABLE IF NOT EXISTS trust_lenses (
+  lens_id TEXT PRIMARY KEY,
+  label   TEXT,
+  lambda  REAL NOT NULL DEFAULT 0.6,     -- blend: score = λ*Love + (1-λ)*Trust
+  seeds_json   TEXT,                     -- seed DIDs with priors, e.g. {"did:key:…":1}
+  love_override_json TEXT,               -- override weights for Love (optional)
+  created_at INTEGER NOT NULL
+);

--- a/srv/blackroad-api/modules/trust_graph.js
+++ b/srv/blackroad-api/modules/trust_graph.js
@@ -1,0 +1,218 @@
+// Trust graph + lenses + ranked feed (Love ⨂ Trust).
+// Uses signed TrustRank: t = (1-α)·s + α·(P+^T t - β P-^T t), clip to [0,1].
+// Caches Truth objects from IPFS locally for fast ranking.
+
+const fs = require('fs');
+const path = require('path');
+const sqlite3 = require('sqlite3').verbose();
+
+const IPFS_API = process.env.IPFS_API || 'http://127.0.0.1:5001';
+const IPFS_GATE = process.env.IPFS_GATE || 'http://127.0.0.1:8080'; // for GET /ipfs/:cid
+const DB_PATH = process.env.DB_PATH || '/srv/blackroad-api/blackroad.db';
+const TRUTH_DIR = process.env.TRUTH_DIR || '/srv/truth';
+const CACHE_DIR = path.join(TRUTH_DIR, 'cache');
+
+function dbOpen() { return new sqlite3.Database(DB_PATH); }
+function all(db, sql, p=[]) { return new Promise((r,j)=>db.all(sql,p,(e,x)=>e?j(e):r(x))); }
+function run(db, sql, p=[]) { return new Promise((r,j)=>db.run(sql,p,function(e){e?j(e):r(this)})); }
+
+async function getEdges(db){
+  const rows = await all(db, `SELECT src,dst,weight FROM trust_edges`);
+  const ids = new Set();
+  rows.forEach(r=>{ids.add(r.src); ids.add(r.dst);});
+  const idArr = Array.from(ids);
+  const index = Object.fromEntries(idArr.map((d,i)=>[d,i]));
+  // build outgoing lists for + and -
+  const outPlus = Array(idArr.length).fill(0).map(()=>[]);
+  const outMinus= Array(idArr.length).fill(0).map(()=>[]);
+  for (const {src,dst,weight} of rows){
+    const i = index[src], j = index[dst];
+    if (weight > 0) outPlus[i].push({j,w:weight});
+    else if (weight < 0) outMinus[i].push({j,w:Math.abs(weight)});
+  }
+  return { idArr, index, outPlus, outMinus };
+}
+
+function normalizeOut(lists){
+  // convert outgoing weighted edges to row-stochastic probs
+  return lists.map(arr=>{
+    const sum = arr.reduce((s,e)=>s+e.w,0);
+    if (sum <= 0) return [];
+    return arr.map(e=>({j:e.j, p:e.w/sum}));
+  });
+}
+
+function trustRank({ idArr, outPlus, outMinus, seeds={}, alpha=0.85, beta=0.5, iters=50 }){
+  const n = idArr.length;
+  if (n===0) return {};
+  const Pp = normalizeOut(outPlus);
+  const Pm = normalizeOut(outMinus);
+  const s = new Float64Array(n).fill(0);
+  let ssum = 0;
+  for (const [did, val] of Object.entries(seeds)){
+    const k = idArr.indexOf(did); if (k>=0){ s[k] = Math.max(0, Math.min(1, +val||0)); ssum += s[k]; }
+  }
+  if (ssum===0){ s[0]=1; ssum=1; } // fallback seed
+  for (let i=0;i<n;i++) s[i]/=ssum;
+
+  let t = new Float64Array(n).fill(1/n);
+  let nxt = new Float64Array(n);
+  for (let k=0;k<iters;k++){
+    nxt.fill(0);
+    // add positive walk
+    for (let i=0;i<n;i++){
+      const ti = t[i];
+      const row = Pp[i];
+      for (let e=0;e<row.length;e++){
+        const {j,p} = row[e];
+        nxt[j] += alpha * ti * p;
+      }
+    }
+    // subtract negative influence
+    for (let i=0;i<n;i++){
+      const ti = t[i];
+      const row = Pm[i];
+      for (let e=0;e<row.length;e++){
+        const {j,p} = row[e];
+        nxt[j] -= alpha*beta * ti * p;
+      }
+    }
+    // restart + clip
+    for (let i=0;i<n;i++){
+      nxt[i] += (1-alpha) * s[i];
+      if (nxt[i] < 0) nxt[i]=0;
+    }
+    // normalize to [0,1] by max
+    let mx=0; for (let i=0;i<n;i++) if (nxt[i]>mx) mx=nxt[i];
+    if (mx>0){ for (let i=0;i<n;i++) nxt[i]/=mx; }
+    // swap
+    t.set(nxt);
+  }
+  const out = {};
+  for (let i=0;i<n;i++) out[idArr[i]] = Math.max(0, Math.min(1, t[i]));
+  return out;
+}
+
+async function fetchTruth(cid){
+  fs.mkdirSync(CACHE_DIR, {recursive:true});
+  const fp = path.join(CACHE_DIR, cid+'.json');
+  if (fs.existsSync(fp)){
+    try { return JSON.parse(fs.readFileSync(fp,'utf8')); } catch {}
+  }
+  // fetch from local IPFS gateway
+  const r = await fetch(`${IPFS_GATE}/ipfs/${cid}`, { method:'GET' });
+  if (!r.ok) throw new Error('ipfs fetch '+r.status);
+  const txt = await r.text();
+  fs.writeFileSync(fp, txt);
+  return JSON.parse(txt);
+}
+
+function ageSeconds(tsIso){
+  const t = +new Date(tsIso || Date.now());
+  return Math.max(0, (Date.now()-t)/1000);
+}
+
+module.exports = function attachTrustGraph({ app }){
+  const db = dbOpen();
+
+  // identities
+  app.post('/api/trust/identities', async (req,res)=>{
+    let raw=''; req.on('data',d=>raw+=d); await new Promise(r=>req.on('end',r));
+    let o={}; try{o=JSON.parse(raw||'{}');}catch{return res.status(400).json({error:'bad json'})}
+    if (!o.did) return res.status(400).json({error:'did required'});
+    try{
+      await run(db, `INSERT OR IGNORE INTO trust_identities (did,label,created_at) VALUES (?,?,?)`, [o.did, o.label||null, Math.floor(Date.now()/1000)]);
+      res.json({ok:true});
+    }catch(e){ res.status(500).json({error:String(e)}); }
+  });
+
+  // add/replace edge
+  app.post('/api/trust/edge', async (req,res)=>{
+    let raw=''; req.on('data',d=>raw+=d); await new Promise(r=>req.on('end',r));
+    let o={}; try{o=JSON.parse(raw||'{}');}catch{return res.status(400).json({error:'bad json'})}
+    const {src,dst,weight,evidence} = o;
+    if (!(src&&dst) || typeof weight!=='number') return res.status(400).json({error:'src,dst,weight required'});
+    if (weight<-1 || weight>1) return res.status(400).json({error:'weight in [-1,1]'});
+    try{
+      await run(db, `INSERT INTO trust_edges (src,dst,weight,evidence_cid,created_at) VALUES (?,?,?,?,?)
+                     ON CONFLICT(src,dst) DO UPDATE SET weight=excluded.weight, evidence_cid=excluded.evidence_cid, created_at=excluded.created_at`,
+                [src,dst,weight,evidence||null, Math.floor(Date.now()/1000)]);
+      res.json({ok:true});
+    }catch(e){ res.status(500).json({error:String(e)}); }
+  });
+
+  // lenses
+  app.post('/api/lenses', async (req,res)=>{
+    let raw=''; req.on('data',d=>raw+=d); await new Promise(r=>req.on('end',r));
+    let o={}; try{o=JSON.parse(raw||'{}');}catch{return res.status(400).json({error:'bad json'})}
+    const id = (o.lens_id || o.id || 'lens-'+Math.random().toString(36).slice(2,8));
+    const seeds = JSON.stringify(o.seeds||{});
+    const loveOver = JSON.stringify(o.love_override||null);
+    const lambda = Math.max(0, Math.min(1, +o.lambda ?? 0.6));
+    try{
+      await run(db, `INSERT OR REPLACE INTO trust_lenses (lens_id,label,lambda,seeds_json,love_override_json,created_at)
+                     VALUES (?,?,?,?,?,?)`,
+                [id, o.label||id, lambda, seeds, loveOver, Math.floor(Date.now()/1000)]);
+      res.json({ok:true, lens_id:id});
+    }catch(e){ res.status(500).json({error:String(e)}); }
+  });
+  app.get('/api/lenses', async (_req,res)=>{
+    const rows = await all(db, `SELECT lens_id,label,lambda,seeds_json,love_override_json FROM trust_lenses ORDER BY created_at DESC`);
+    res.json(rows.map(r=>({ lens_id:r.lens_id, label:r.label, lambda:r.lambda,
+      seeds: (()=>{
+        try{return JSON.parse(r.seeds_json||'{}');}catch{return {};}
+      })(),
+      love_override:(()=>{ try{return JSON.parse(r.love_override_json||'null');}catch{return null;}})()
+    })));
+  });
+
+  // compute trust scores
+  app.post('/api/trust/compute', async (req,res)=>{
+    let raw=''; req.on('data',d=>raw+=d); await new Promise(r=>req.on('end',r));
+    let o={}; try{o=JSON.parse(raw||'{}');}catch{}
+    const { idArr,index,outPlus,outMinus } = await getEdges(db);
+    const seeds = o.seeds || {};
+    const t = trustRank({ idArr, outPlus, outMinus, seeds, alpha:o.alpha??0.85, beta:o.beta??0.5, iters:o.iters??50 });
+    res.json(t);
+  });
+
+  // ranked feed with lens
+  app.get('/api/truth/feed:lens', async (req,res)=>{
+    try{
+      const lid = req.query.lid || null;
+      const lens = lid ? (await all(db, `SELECT * FROM trust_lenses WHERE lens_id=?`, [lid]))[0] : null;
+      const seeds = lens ? JSON.parse(lens.seeds_json||'{}') : {};
+      const lambda = lens ? +lens.lambda : 0.6;
+
+      const { idArr,outPlus,outMinus } = await getEdges(db);
+      const trustVec = trustRank({ idArr, outPlus, outMinus, seeds, alpha:0.85, beta:0.5, iters:50 });
+
+      // load local feed
+      const feedPath = path.join(TRUTH_DIR, 'feed.ndjson');
+      const lines = fs.existsSync(feedPath) ? fs.readFileSync(feedPath,'utf8').trim().split('\n').filter(Boolean) : [];
+      const rows = lines.slice(-500).map(x=>JSON.parse(x)).reverse();
+
+      const out = [];
+      for (const r of rows){
+        try{
+          const obj = await fetchTruth(r.cid);                // {title, meta.publisher, love, ...}
+          const pub = obj?.meta?.publisher || obj?.meta?.did || 'unknown';
+          const love = Math.max(0, Math.min(1, +obj?.love || 0.5));
+          const attestCids = Array.isArray(obj?.evidence) ? obj.evidence : [];
+          // NOTE: if you store attestors separately, pull their DIDs; here we just use publisher trust
+          const T = Math.max(0, Math.min(1, trustVec[pub] ?? 0.5));
+          const age = ageSeconds(obj?.meta?.created);
+          const rec = Math.exp(-age/172800);  // ~2 days
+          const attestBoost = 1 + 0.3*Math.log(1 + attestCids.length);
+          const score = (lambda*love + (1-lambda)*T) * rec * attestBoost;
+
+          out.push({ cid:r.cid, title:obj?.title||obj?.type||'(untitled)', publisher: pub, love, trust:T, score, created: obj?.meta?.created });
+        }catch{}
+      }
+      out.sort((a,b)=>b.score-a.score);
+      res.json(out.slice(0,200));
+    }catch(e){ res.status(500).json({error:String(e)}) }
+  });
+
+  console.log('[trust] graph + lenses online');
+};

--- a/srv/blackroad-api/server_full.js
+++ b/srv/blackroad-api/server_full.js
@@ -166,6 +166,7 @@ require('./modules/partner_relay_mtls')({ app });
 require('./modules/projects')({ app });
 require('./modules/pr_proxy')({ app });
 require('./modules/patentnet')({ app });
+require('./modules/trust_graph')({ app });
 
 const emitter = new EventEmitter();
 const jobs = new Map();

--- a/var/www/blackroad/lenses.html
+++ b/var/www/blackroad/lenses.html
@@ -1,0 +1,56 @@
+<!doctype html><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Trust Lenses</title>
+<style>
+  body{margin:0;background:#0b0b10;color:#e9e9f1;font:14px system-ui}
+  header{display:flex;gap:8px;align-items:center;padding:10px;background:#0f0f1a;border-bottom:1px solid #1e1e2f}
+  .pill{border:1px solid #24244a;border-radius:999px;padding:4px 10px;background:#141428}
+  main{max-width:1100px;margin:12px auto;padding:0 12px;display:grid;grid-template-columns:320px 1fr;gap:12px}
+  .card{background:#131320;border:1px solid #24244a;border-radius:12px;padding:10px}
+  input,textarea,button{border-radius:10px;border:1px solid #24244a;background:#10102a;color:#e9e9f1;padding:8px}
+  button{cursor:pointer}
+  ul{list-style:none;margin:0;padding:0} li{padding:8px;border-bottom:1px dashed #24244a}
+  a{color:#0096FF;text-decoration:none}
+</style>
+<header>
+  <div class="pill">Trust Lenses</div>
+  <a class="pill" href="/truth.html">Truth Garden</a>
+</header>
+<main>
+  <div class="card">
+    <h3>Create Lens</h3>
+    <input id="lid" placeholder="lens id" value="ours"><br><br>
+    <label>λ (Love weight 0..1): <input id="lam" type="number" step="0.05" value="0.6"></label><br><br>
+    <textarea id="seeds" rows="5" placeholder='{"did:key:...":1, "did:key:...":0.5}'></textarea><br><br>
+    <button onclick="save()">Save</button>
+    <pre id="out" style="white-space:pre-wrap;margin-top:6px"></pre>
+  </div>
+  <div class="card">
+    <h3>Lenses</h3>
+    <ul id="list"></ul>
+    <h3>Feed (ranked)</h3>
+    <select id="sel"></select>
+    <button onclick="load()">Load</button>
+    <ul id="feed"></ul>
+  </div>
+</main>
+<script>
+async function save(){
+  const o={ lens_id: document.getElementById('lid').value,
+            lambda: +document.getElementById('lam').value,
+            seeds: JSON.parse(document.getElementById('seeds').value||'{}') };
+  const r = await fetch('/api/lenses', {method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify(o)});
+  document.getElementById('out').textContent = await r.text();
+  list();
+}
+async function list(){
+  const r=await fetch('/api/lenses'); const arr=await r.json();
+  document.getElementById('list').innerHTML = arr.map(x=>`<li><b>${x.lens_id}</b> λ=${x.lambda} seeds=${Object.keys(x.seeds).length}</li>`).join('');
+  document.getElementById('sel').innerHTML = arr.map(x=>`<option>${x.lens_id}</option>`).join('');
+}
+async function load(){
+  const lid=document.getElementById('sel').value;
+  const r=await fetch('/api/truth/feed:lens?lid='+encodeURIComponent(lid)); const arr=await r.json();
+  document.getElementById('feed').innerHTML = arr.map(x=>`<li><b>${x.title}</b><br><small>${x.cid}</small><br>score=${x.score.toFixed(3)} love=${(x.love*100|0)}% trust=${(x.trust*100|0)}%</li>`).join('');
+}
+list();
+</script>


### PR DESCRIPTION
## Summary
- add trust graph schema and APIs with signed TrustRank
- expose lens-based ranked feed and minimal UI
- wire trust graph module into server

## Testing
- `sqlite3 srv/blackroad-api/blackroad.db < srv/blackroad-api/db_migrations/010_trust.sql`
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: A config object is using the "root" key, which is not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68c090b9c49c83299ea5421275db7339