### PR TITLE
Add device quorum tracking for attested pins

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,10 @@
     "uuid": "^9.0.1",
     "better-sqlite3": "^9.4.3",
     "stripe": "^12.18.0",
-    "ethers": "^6.10.0"
+    "ethers": "^6.10.0",
+    "bs58": "^5.0.0",
+    "json-canonicalize": "^1.0.4",
+    "ipfs-http-client": "^60.0.0"
   },
   "devDependencies": {
     "nodemon": "^3.0.2",

--- a/srv/blackroad-api/db_migrations/011_quorum.sql
+++ b/srv/blackroad-api/db_migrations/011_quorum.sql
@@ -1,0 +1,11 @@
+PRAGMA journal_mode=WAL;
+
+CREATE TABLE IF NOT EXISTS truth_quorum (
+  cid   TEXT NOT NULL,
+  did   TEXT NOT NULL,  -- attesting device DID
+  node  TEXT,           -- hostname or label
+  ts    INTEGER NOT NULL,
+  PRIMARY KEY (cid, did)
+);
+
+CREATE INDEX IF NOT EXISTS idx_quorum_cid ON truth_quorum (cid);

--- a/srv/blackroad-api/modules/truth_quorum.js
+++ b/srv/blackroad-api/modules/truth_quorum.js
@@ -1,0 +1,148 @@
+// Quorum subscriber + API: verifies PinAttestation messages and records quorum.
+// Env: TRUTH_TOPIC (default "truth.garden/v1/announce"), TRUTH_MAX_AGE_SEC (default 7d)
+//      QUORUM_TARGET (default 2) -> when reached, optional LED celebrate.
+const { create } = require('ipfs-http-client');
+const canonicalize = require('json-canonicalize');
+const bs58 = require('bs58');
+const sqlite3 = require('sqlite3').verbose();
+const fs = require('fs');
+
+const IPFS_API = process.env.IPFS_API || 'http://127.0.0.1:5001';
+const TOPIC = process.env.TRUTH_TOPIC || 'truth.garden/v1/announce';
+const MAX_AGE = Number(process.env.TRUTH_MAX_AGE_SEC || 7 * 24 * 3600);
+const QUORUM_TARGET = Number(process.env.QUORUM_TARGET || 2);
+const DB_PATH = process.env.DB_PATH || '/srv/blackroad-api/blackroad.db';
+
+function db() {
+  return new sqlite3.Database(DB_PATH);
+}
+function run(db, sql, p = []) {
+  return new Promise((r, j) =>
+    db.run(sql, p, function (e) {
+      e ? j(e) : r(this);
+    }),
+  );
+}
+function all(db, sql, p = []) {
+  return new Promise((r, j) =>
+    db.all(sql, p, (e, x) => (e ? j(e) : r(x))),
+  );
+}
+
+function didkeyToSPKI(did) {
+  const z = did.startsWith('did:key:') ? did.slice(8) : did;
+  if (!z.startsWith('z')) throw new Error('did not base58btc');
+  const bytes = Buffer.from(bs58.decode(z.slice(1)));
+  if (bytes.length !== 34 || bytes[0] !== 0xed || bytes[1] !== 0x01)
+    throw new Error('not ed25519 did:key');
+  const raw = bytes.slice(2);
+  // SPKI DER for Ed25519
+  const derPrefix = Buffer.from([
+    0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00,
+  ]);
+  return Buffer.concat([derPrefix, raw]);
+}
+
+function verifyAttestation(o) {
+  // expected: {cid, did, type:"PinAttestation", ts, node?, sig}
+  const { cid, did, type, ts, node, sig } = o || {};
+  if (!cid || !did || !type || !ts || !sig) throw new Error('missing fields');
+  if (type !== 'PinAttestation') throw new Error('wrong type');
+  const age = Math.abs(Date.now() - Date.parse(ts)) / 1000;
+  if (!Number.isFinite(age) || age > MAX_AGE) throw new Error('too old');
+
+  const payload = node ? { cid, did, type, ts, node } : { cid, did, type, ts };
+  const jcs = Buffer.from(canonicalize(payload));
+  const crypto = require('crypto');
+  const pub = crypto.createPublicKey({
+    key: didkeyToSPKI(did),
+    format: 'der',
+    type: 'spki',
+  });
+  const ok = crypto.verify(null, jcs, pub, Buffer.from(sig, 'base64url'));
+  if (!ok) throw new Error('bad signature');
+}
+
+async function celebrateIf(db, cid) {
+  const rows = await all(
+    db,
+    `SELECT COUNT(*) as c FROM truth_quorum WHERE cid=?`,
+    [cid],
+  );
+  const c = rows?.[0]?.c || 0;
+  if (c >= QUORUM_TARGET) {
+    try {
+      await fetch('http://127.0.0.1:4000/api/devices/pi-01/command', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-BlackRoad-Key': process.env.ORIGIN_KEY || '',
+        },
+        body: JSON.stringify({ type: 'led.celebrate', ttl_s: 20 }),
+      });
+    } catch {}
+  }
+}
+
+module.exports = async function attachTruthQuorum({ app }) {
+  const ipfs = create({ url: IPFS_API });
+  const d = db();
+
+  // Subscriber
+  await ipfs.pubsub.subscribe(TOPIC, async (msg) => {
+    try {
+      const text = new TextDecoder().decode(msg.data);
+      const o = JSON.parse(text);
+      if (o?.type !== 'PinAttestation') return;
+      verifyAttestation(o);
+
+      // insert (ignore if exists)
+      const ts = Math.floor(Date.parse(o.ts) / 1000) || Math.floor(Date.now() / 1000);
+      await run(
+        d,
+        `INSERT OR IGNORE INTO truth_quorum (cid,did,node,ts) VALUES (?,?,?,?)`,
+        [o.cid, o.did, o.node || null, ts],
+      );
+
+      await celebrateIf(d, o.cid);
+    } catch (e) {
+      // ignore invalid or old
+    }
+  });
+
+  // API: quorum for a CID
+  app.get('/api/truth/quorum', async (req, res) => {
+    try {
+      const cid = String(req.query.cid || '');
+      if (!cid) return res.status(400).json({ error: 'cid required' });
+      const rows = await all(
+        d,
+        `SELECT did,node,ts FROM truth_quorum WHERE cid=? ORDER BY ts DESC`,
+        [cid],
+      );
+      res.json({ cid, count: rows.length, attestors: rows });
+    } catch (e) {
+      res.status(500).json({ error: String(e) });
+    }
+  });
+
+  // API: recent attestations
+  app.get('/api/truth/quorum/recent', async (_req, res) => {
+    try {
+      const rows = await all(
+        d,
+        `SELECT cid,did,node,ts FROM truth_quorum ORDER BY ts DESC LIMIT 200`,
+        [],
+      );
+      res.json(rows);
+    } catch (e) {
+      res.status(500).json({ error: String(e) });
+    }
+  });
+
+  console.log(
+    '[truth] quorum verifier online (topic %s, target %d)',
+    TOPIC,
+    QUORUM_TARGET,
+  );
+};

--- a/srv/blackroad-api/server_full.js
+++ b/srv/blackroad-api/server_full.js
@@ -167,6 +167,15 @@ require('./modules/projects')({ app });
 require('./modules/pr_proxy')({ app });
 require('./modules/patentnet')({ app });
 
+// Truth quorum subscriber
+;(async () => {
+  try {
+    await require('./modules/truth_quorum')({ app });
+  } catch (e) {
+    console.error(e);
+  }
+})();
+
 const emitter = new EventEmitter();
 const jobs = new Map();
 let jobSeq = 0;

--- a/srv/truth-subpin/device_identity.js
+++ b/srv/truth-subpin/device_identity.js
@@ -1,0 +1,31 @@
+// Ensure device Ed25519 keypair and compute did:key.
+// Files: /srv/truth-subpin/ed25519.sk.pem (PKCS8), ed25519.pk.pem (SPKI)
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const bs58 = require('bs58');
+const DIR = '/srv/truth-subpin';
+const SK = path.join(DIR, 'ed25519.sk.pem');
+const PK = path.join(DIR, 'ed25519.pk.pem');
+
+function ensureIdentity() {
+  fs.mkdirSync(DIR, { recursive: true });
+  if (!fs.existsSync(SK)) {
+    const { privateKey, publicKey } = crypto.generateKeyPairSync('ed25519');
+    fs.writeFileSync(SK, privateKey.export({ type: 'pkcs8', format: 'pem' }));
+    fs.writeFileSync(PK, publicKey.export({ type: 'spki', format: 'pem' }));
+  }
+  const pub = crypto.createPublicKey(fs.readFileSync(PK));
+  const der = pub.export({ format: 'der', type: 'spki' });
+  const raw = der.slice(-32);
+  const prefixed = Buffer.concat([Buffer.from([0xed, 0x01]), raw]);
+  const mb = 'z' + bs58.encode(prefixed);
+  return { did: 'did:key:' + mb };
+}
+
+function signJcs(bytes) {
+  const sk = crypto.createPrivateKey(fs.readFileSync(SK));
+  return Buffer.from(crypto.sign(null, bytes, sk)).toString('base64url');
+}
+
+module.exports = { ensureIdentity, signJcs };

--- a/srv/truth-subpin/truth_subpin_verify.js
+++ b/srv/truth-subpin/truth_subpin_verify.js
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+// Verified subpin + device attestation publisher.
+const { create } = require('ipfs-http-client');
+const canonicalize = require('json-canonicalize');
+const bs58 = require('bs58');
+const crypto = require('crypto');
+const os = require('os');
+const { ensureIdentity, signJcs } = require('./device_identity');
+
+const TOPIC = process.env.TRUTH_TOPIC || 'truth.garden/v1/announce';
+const API = process.env.IPFS_API || 'http://127.0.0.1:5001';
+const MAX_AGE_SEC = Number(process.env.TRUTH_MAX_AGE_SEC || 7 * 24 * 3600);
+const ALLOW = (process.env.ALLOW_DIDS || '')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+function didkeyToSPKI(did) {
+  const z = did.startsWith('did:key:') ? did.slice(8) : did;
+  if (!z.startsWith('z')) throw new Error('did not base58btc');
+  const bytes = Buffer.from(bs58.decode(z.slice(1)));
+  if (bytes.length !== 34 || bytes[0] !== 0xed || bytes[1] !== 0x01)
+    throw new Error('not ed25519 did:key');
+  const raw = bytes.slice(2);
+  const derPrefix = Buffer.from([
+    0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00,
+  ]);
+  return Buffer.concat([derPrefix, raw]);
+}
+function verify(o) {
+  const { cid, did, type, ts, sig } = o || {};
+  if (!cid || !did || !sig || !type || !ts) throw new Error('missing fields');
+  const age = Math.abs(Date.now() - Date.parse(ts)) / 1000;
+  if (!Number.isFinite(age) || age > MAX_AGE_SEC) throw new Error('too old');
+  if (ALLOW.length && !ALLOW.includes(did)) throw new Error('did not allowed');
+  const jcs = Buffer.from(canonicalize({ cid, did, type, ts }));
+  const pub = crypto.createPublicKey({
+    key: didkeyToSPKI(did),
+    format: 'der',
+    type: 'spki',
+  });
+  if (!crypto.verify(null, jcs, pub, Buffer.from(sig, 'base64url')))
+    throw new Error('bad sig');
+  return true;
+}
+
+const ipfs = create({ url: API });
+const ident = ensureIdentity();
+
+async function publishAttestation(cid) {
+  const payload = {
+    cid,
+    did: ident.did,
+    type: 'PinAttestation',
+    node: os.hostname(),
+    ts: new Date().toISOString(),
+  };
+  const jcs = Buffer.from(canonicalize(payload));
+  const sig = signJcs(jcs);
+  const msg = { ...payload, jcs: true, sig };
+  await ipfs.pubsub.publish(TOPIC, new TextEncoder().encode(JSON.stringify(msg)));
+}
+
+(async () => {
+  console.log(
+    '[subpin-verify] api=%s topic=%s DID=%s allow=%s',
+    API,
+    TOPIC,
+    ident.did,
+    ALLOW.length ? ALLOW.join(',') : 'ALL',
+  );
+  await ipfs.pubsub.subscribe(TOPIC, async (msg) => {
+    try {
+      const text = new TextDecoder().decode(msg.data);
+      const o = JSON.parse(text);
+      if (o.type !== 'Truth' && o.type !== 'Note' && o.type !== 'Announcement')
+        return; // only pin content announces
+      verify(o);
+      await ipfs.pin.add(o.cid).catch(() => {});
+      await publishAttestation(o.cid);
+      console.log('[subpin-verify] pinned & attested', o.cid);
+    } catch (e) {
+      // ignore invalid/old
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- track device quorum in SQLite and expose `/api/truth/quorum`
- subscribe to PinAttestation messages and trigger celebration when quorum reached
- add device identity helpers to sign and publish attestations

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: A config object is using the "root" key, which is not supported in flat config system.)*

------
https://chatgpt.com/codex/tasks/task_e_68c0932699b483298edbcf6c1a9a41a5