### PR TITLE
Add minimal AICodeCloud scaffold

### DIFF
--- a/srv/aicodecloud/app.py
+++ b/srv/aicodecloud/app.py
@@ -1,0 +1,53 @@
+from flask import Flask, jsonify
+import time
+import os
+
+app = Flask(__name__)
+_start_time = time.time()
+
+
+def _system_state():
+    uptime = time.time() - _start_time
+    try:
+        load1m = os.getloadavg()[0]
+    except OSError:
+        load1m = 0.0
+    if load1m < 0.5:
+        load_state = "calm"
+    elif load1m < 1.5:
+        load_state = "engaged"
+    else:
+        load_state = "stressed"
+    try:
+        import psutil
+        mem_percent = psutil.virtual_memory().percent
+    except Exception:
+        mem_percent = 0.0
+    if mem_percent < 50:
+        mem_state = "clear"
+    elif mem_percent < 80:
+        mem_state = "tight"
+    else:
+        mem_state = "overwhelmed"
+    return {
+        "uptime": uptime,
+        "load1m": load1m,
+        "mem_percent": mem_percent,
+        "emotion": f"I feel {load_state} and {mem_state}.",
+    }
+
+
+@app.get("/api/health")
+def health() -> tuple[dict, int]:
+    """Basic health check."""
+    return {"status": "ok"}, 200
+
+
+@app.get("/api/state")
+def state() -> tuple[dict, int]:
+    """Return basic system state information."""
+    return _system_state(), 200
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)

--- a/srv/aicodecloud/catalog.json
+++ b/srv/aicodecloud/catalog.json
@@ -1,0 +1,5 @@
+{
+  "python": ["numpy", "pandas", "tensorflow"],
+  "java": ["spring", "hibernate"],
+  "javascript": ["react", "tailwind"]
+}

--- a/srv/aicodecloud/static/index.html
+++ b/srv/aicodecloud/static/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>AICodeCloud</title>
+  <style>
+    body { font-family: sans-serif; padding: 2rem; }
+  </style>
+</head>
+<body>
+  <h1>AICodeCloud</h1>
+  <p id="health">Checking health...</p>
+  <script>
+    fetch('/api/health').then(r => r.json()).then(j => {
+      document.getElementById('health').innerText = 'Health: ' + j.status;
+    }).catch(() => {
+      document.getElementById('health').innerText = 'Health check failed';
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- bootstrap AICodeCloud directory structure
- implement basic Flask app with `/api/health` and `/api/state`
- add simple static page and catalog

## Testing
- `pytest` *(fails: ModuleNotFoundError for multiple optional deps)*
- `python -m py_compile srv/aicodecloud/app.py`
- `python srv/aicodecloud/app.py &` and `curl -s http://127.0.0.1:5000/api/health`
- `curl -s http://127.0.0.1:5000/api/state`


------
https://chatgpt.com/codex/tasks/task_e_68c0985f4cf88329b1ec592a9f39e051