### PR TITLE
feat: add sandboxed job runner with docker support

### DIFF
--- a/srv/blackroad-api/modules/jobs.js
+++ b/srv/blackroad-api/modules/jobs.js
@@ -1,0 +1,566 @@
+// Jobs • sandboxed (Docker-first), precise progress, hard cancel, weighted pipelines, SSE logs.
+//
+// Env knobs:
+//   JOB_RUNNER=docker|host          (default: docker, auto-fallback to host if docker is missing)
+//   DOCKER_DEFAULT_IMAGE=node:20-slim
+//   DB_PATH=/srv/blackroad-api/blackroad.db
+//   PROJECTS_DIR=/srv/projects
+//   DEPLOY_ROOT=/var/www/blackroad/apps
+//   ORIGIN_KEY_PATH=/srv/secrets/origin.key
+//
+// Endpoints (unchanged from v2):
+//   POST /api/jobs/start  {project, kind:'test'|'build'|'deploy'|'custom'|'pipeline', script?, cmd?, args?, env?}
+//   GET  /api/jobs/:id
+//   GET  /api/jobs/:id/events   (SSE: log|progress|state|stage)
+//   GET  /api/jobs?project=<id>
+//   POST /api/jobs/:id/cancel
+//
+// Pipeline file (per project): /srv/projects/<id>/.blackroad/pipeline.yaml
+// Step fields (all optional):
+//   name, cmd, weight, image, binds[], env{}, user
+//
+// Progress markers inside step stdout/stderr:
+//   [[PROGRESS 37]]  or [[PROGRESS 37%]]  or [[PROGRESS 0.37]]
+//   {"progress":0.37}   (JSON line)
+//   [[STAGE name=compile start]] / [[STAGE name=compile done]] / [[STAGE name=compile error]]
+//
+const { spawn } = require('child_process');
+const { v4: uuidv4 } = require('uuid');
+const fs = require('fs');
+const path = require('path');
+const Database = require('better-sqlite3');
+const YAML = require('yaml');
+
+const DB_PATH = process.env.DB_PATH || '/srv/blackroad-api/blackroad.db';
+const PROJECTS_DIR = process.env.PROJECTS_DIR || '/srv/projects';
+const DEPLOY_ROOT = process.env.DEPLOY_ROOT || '/var/www/blackroad/apps';
+const ORIGIN_KEY_PATH =
+  process.env.ORIGIN_KEY_PATH || '/srv/secrets/origin.key';
+const RUNNER = (process.env.JOB_RUNNER || 'docker').toLowerCase();
+const DEFAULT_IMG = process.env.DOCKER_DEFAULT_IMAGE || 'node:20-slim';
+
+function db() {
+  return new Database(DB_PATH);
+}
+function run(db, sql, p = []) {
+  return Promise.resolve(db.prepare(sql).run(p));
+}
+function all(db, sql, p = []) {
+  return Promise.resolve(db.prepare(sql).all(p));
+}
+function get(db, sql, p = []) {
+  return Promise.resolve(db.prepare(sql).get(p));
+}
+function now() {
+  return Math.floor(Date.now() / 1000);
+}
+function orKey() {
+  try {
+    return fs.readFileSync(ORIGIN_KEY_PATH, 'utf8').trim();
+  } catch {
+    return '';
+  }
+}
+async function led(payload) {
+  try {
+    await fetch('http://127.0.0.1:4000/api/devices/pi-01/command', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-BlackRoad-Key': orKey(),
+      },
+      body: JSON.stringify(payload),
+    });
+  } catch {}
+}
+const clamp01 = (x) => Math.max(0, Math.min(1, Number(x) || 0));
+
+// progress/stage parsers
+function parseProgressLine(line) {
+  const m = line.match(/\[\[\s*PROGRESS\s+([0-9.]+)%?\s*\]\]/i);
+  if (m) {
+    const v = parseFloat(m[1]);
+    return v > 1 ? v / 100 : v;
+  }
+  try {
+    if (line[0] === '{' && line.includes('progress')) {
+      const j = JSON.parse(line);
+      if (typeof j.progress === 'number') {
+        const v = j.progress;
+        return v > 1 ? v / 100 : v;
+      }
+    }
+  } catch {}
+  return null;
+}
+function parseStageLine(line) {
+  const m = line.match(/\[\[\s*STAGE\s+(.+?)\s*\]\]/i);
+  if (!m) return null;
+  const toks = Object.fromEntries(
+    m[1]
+      .split(/\s+/)
+      .filter(Boolean)
+      .map((kv) => {
+        const p = kv.split('=');
+        return [p[0], p[1] === undefined ? true : p[1]];
+      })
+  );
+  return toks; // {name, weight?, start|done|error?}
+}
+
+// in-flight processes for cancel
+const PROCS = new Map(); // job_id -> { child, pgid, dockerName? }
+
+function spawnHostTracked(job_id, cmd, args, opts) {
+  const child = spawn(cmd, args, { ...opts, detached: true });
+  PROCS.set(job_id, { child, pgid: child.pid });
+  return child;
+}
+
+function dockerAvailableSync() {
+  try {
+    require('child_process').execSync('docker info >/dev/null 2>&1');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function spawnDockerTracked(
+  job_id,
+  { image, workdir, cmdString, env = {}, binds = [] }
+) {
+  // build docker args
+  const name = `br_job_${job_id.replace(/[^a-zA-Z0-9_.-]/g, '').slice(-24)}`;
+  const args = ['run', '--rm', '--name', name, '-w', '/workspace'];
+  // binds: always mount project dir RW into /workspace
+  for (const b of binds || []) {
+    args.push('-v', b);
+  }
+  if (
+    !binds.some((b) => b.includes(': /workspace') || b.endsWith(':/workspace'))
+  ) {
+    args.push('-v', `${workdir}:/workspace:rw`);
+  }
+  // env
+  for (const [k, v] of Object.entries(env || {})) {
+    args.push('-e', `${k}=${v}`);
+  }
+  args.push(image || DEFAULT_IMG);
+  args.push('/bin/bash', '-lc', cmdString);
+  const child = spawn('docker', args, { env: process.env, detached: true });
+  PROCS.set(job_id, { child, pgid: child.pid, dockerName: name });
+  return child;
+}
+
+// core streaming/LED updates
+async function wireChild(job_id, child, onClose) {
+  let lastPct = 0;
+  const handleChunk = async (buf, source) => {
+    const s = buf.toString();
+    await appendEvent(job_id, 'log', s);
+    for (const line of s.split(/\r?\n/)) {
+      const p = parseProgressLine(line);
+      if (p != null && Math.abs(p - lastPct) >= 0.01) {
+        lastPct = clamp01(p);
+        await updateJob(job_id, { progress: lastPct });
+        await led({
+          type: 'led.progress',
+          pct: Math.round(lastPct * 100),
+          ttl_s: 90,
+        });
+      }
+      const stage = parseStageLine(line);
+      if (stage && stage.name) {
+        await appendEvent(job_id, 'stage', {
+          name: stage.name,
+          status: stage.error ? 'error' : stage.done ? 'done' : 'start',
+        });
+      }
+    }
+  };
+  child.stdout?.on('data', (buf) => handleChunk(buf, 'stdout'));
+  child.stderr?.on('data', (buf) => handleChunk(buf, 'stderr'));
+  child.on('close', async (code) => {
+    PROCS.delete(job_id);
+    await onClose(code, lastPct);
+  });
+}
+
+// db + sse helpers
+const d = db();
+async function appendEvent(job_id, type, data) {
+  const row = await get(
+    d,
+    `SELECT max(seq)+1 AS n FROM job_events WHERE job_id=?`,
+    [job_id]
+  );
+  const seq = row && row.n ? row.n : 1;
+  await run(
+    d,
+    `INSERT INTO job_events (job_id,seq,ts,type,data) VALUES (?,?,?,?,?)`,
+    [
+      job_id,
+      seq,
+      now(),
+      type,
+      typeof data === 'string' ? data : JSON.stringify(data),
+    ]
+  );
+  const set = clients.get(job_id);
+  if (!set) return;
+  const line = `event: ${type}\ndata: ${typeof data === 'string' ? data : JSON.stringify(data)}\n\n`;
+  for (const res of set) {
+    try {
+      res.write(line);
+    } catch {}
+  }
+}
+async function updateJob(job_id, patch) {
+  const j = await get(d, `SELECT * FROM jobs WHERE job_id=?`, [job_id]);
+  if (!j) return;
+  const status = patch.status ?? j.status;
+  const progress =
+    patch.progress != null ? clamp01(patch.progress) : j.progress;
+  const exit_code = patch.exit_code != null ? patch.exit_code : j.exit_code;
+  const finished =
+    patch.finished_at != null ? patch.finished_at : j.finished_at;
+  const pid = patch.pid != null ? patch.pid : j.pid;
+  await run(
+    d,
+    `UPDATE jobs SET status=?, progress=?, exit_code=?, finished_at=?, pid=? WHERE job_id=?`,
+    [status, progress, exit_code, finished, pid, job_id]
+  );
+  if (patch.progress != null)
+    await appendEvent(job_id, 'progress', { progress });
+  if (patch.status) await appendEvent(job_id, 'state', { status });
+}
+
+// single command (kind=test/build/deploy/custom)
+async function runSingle(job_id, project, cmd, args, env) {
+  const cwd = path.join(PROJECTS_DIR, project);
+  const cmdString =
+    Array.isArray(args) && args.length ? [cmd, ...args].join(' ') : cmd;
+  let child;
+  if (RUNNER === 'docker' && dockerAvailableSync()) {
+    child = spawnDockerTracked(job_id, {
+      image: DEFAULT_IMG,
+      workdir: cwd,
+      cmdString,
+      env,
+      binds: [],
+    });
+  } else {
+    child = spawnHostTracked(job_id, cmd, args, {
+      cwd,
+      env: { ...process.env, ...env },
+      shell: false,
+    });
+  }
+  await run(d, `UPDATE jobs SET pid=? WHERE job_id=?`, [child.pid, job_id]);
+  await wireChild(job_id, child, async (code, lastPct) => {
+    const ok = code === 0;
+    await updateJob(job_id, {
+      status: ok ? 'ok' : 'error',
+      progress: ok ? 1 : lastPct,
+      exit_code: code,
+      finished_at: now(),
+    });
+    await appendEvent(job_id, 'log', `\n[exit ${code}]\n`);
+    if (ok) await led({ type: 'led.celebrate', ttl_s: 20 });
+    else await led({ type: 'led.emotion', emotion: 'error', ttl_s: 20 });
+  });
+}
+
+// pipeline
+async function runPipeline(job_id, project, env) {
+  const root = path.join(PROJECTS_DIR, project);
+  const pfile = path.join(root, '.blackroad', 'pipeline.yaml');
+  let pipe = { steps: [], on_error: 'stop', env: {} };
+  if (fs.existsSync(pfile))
+    pipe = YAML.parse(fs.readFileSync(pfile, 'utf8')) || pipe;
+  else {
+    pipe = {
+      steps: [
+        {
+          name: 'build',
+          cmd: 'npm run build || true',
+          weight: 60,
+          image: DEFAULT_IMG,
+        },
+        {
+          name: 'deploy',
+          cmd: `mkdir -p ${DEPLOY_ROOT}/${project} && rsync -a --delete public/ ${DEPLOY_ROOT}/${project}/`,
+          weight: 40,
+          image: DEFAULT_IMG,
+        },
+      ],
+      on_error: 'stop',
+    };
+  }
+
+  const steps = pipe.steps || [];
+  let totalW = steps.reduce((s, x) => s + (Number(x.weight) || 0), 0);
+  if (totalW <= 0) {
+    const w = 100 / Math.max(1, steps.length);
+    steps.forEach((s) => (s.weight = w));
+    totalW = 100;
+  }
+
+  let base = 0;
+  for (let i = 0; i < steps.length; i++) {
+    const st = steps[i];
+    await appendEvent(job_id, 'stage', {
+      name: st.name || `step-${i + 1}`,
+      index: i + 1,
+      total: steps.length,
+      status: 'start',
+    });
+    await updateJob(job_id, { progress: clamp01(base / 100) });
+    await led({ type: 'led.progress', pct: Math.round(base), ttl_s: 180 });
+
+    const image = st.image || DEFAULT_IMG;
+    const binds = Array.isArray(st.binds) ? st.binds.slice() : [];
+    const stepEnv = { ...pipe.env, ...env, ...(st.env || {}) };
+    const user = st.user; // e.g., "1000:1000"
+
+    let child;
+    const cmdString = st.cmd || 'true';
+
+    if (RUNNER === 'docker' && dockerAvailableSync()) {
+      // default bind: project => /workspace (RW)
+      if (!binds.some((b) => b.includes(':/workspace'))) {
+        binds.push(`${root}:/workspace:rw`);
+      }
+      // propagate user if set for file ownership hygiene
+      const args = [
+        'run',
+        '--rm',
+        '--name',
+        `br_job_${job_id}_${i}`,
+        '-w',
+        '/workspace',
+      ];
+      for (const b of binds) args.push('-v', b);
+      for (const [k, v] of Object.entries(stepEnv))
+        args.push('-e', `${k}=${v}`);
+      if (user) args.push('--user', user);
+      args.push(image, '/bin/bash', '-lc', cmdString);
+      child = spawn('docker', args, { env: process.env, detached: true });
+      PROCS.set(job_id, {
+        child,
+        pgid: child.pid,
+        dockerName: `br_job_${job_id}_${i}`,
+      });
+    } else {
+      child = spawnHostTracked(job_id, '/bin/bash', ['-lc', cmdString], {
+        cwd: root,
+        env: { ...process.env, ...stepEnv },
+        shell: false,
+      });
+    }
+
+    await wireChild(job_id, child, async (code, lastPct) => {
+      const w = Number(st.weight) || 0;
+      if (code !== 0) {
+        await appendEvent(job_id, 'stage', {
+          name: st.name || `step-${i + 1}`,
+          index: i + 1,
+          total: steps.length,
+          status: 'error',
+          exit: code,
+        });
+        if ((pipe.on_error || 'stop') === 'stop') {
+          PROCS.delete(job_id);
+          await updateJob(job_id, {
+            status: 'error',
+            progress: clamp01((base + w * lastPct) / 100),
+            exit_code: code,
+            finished_at: now(),
+          });
+        }
+      } else {
+        base += w;
+        await appendEvent(job_id, 'stage', {
+          name: st.name || `step-${i + 1}`,
+          index: i + 1,
+          total: steps.length,
+          status: 'ok',
+        });
+        await updateJob(job_id, { progress: clamp01(base / 100) });
+      }
+    });
+
+    // if pipeline already marked error, stop loop
+    const cur = await get(d, `SELECT status FROM jobs WHERE job_id=?`, [
+      job_id,
+    ]);
+    if (cur && cur.status === 'error') return;
+  }
+  await updateJob(job_id, { status: 'ok', progress: 1, finished_at: now() });
+  await led({ type: 'led.celebrate', ttl_s: 20 });
+}
+
+// entrypoint: start job
+async function startJob(body) {
+  const project = (body.project || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-');
+  const kind = body.kind || 'custom';
+  const id = 'job-' + uuidv4();
+  const cwd = path.join(PROJECTS_DIR, project);
+  const env = body.env || {};
+  if (!fs.existsSync(cwd)) throw new Error('project not found');
+
+  // resolve command for single kinds
+  let cmd = body.cmd,
+    args = body.args || [];
+  if (!cmd && kind !== 'custom' && kind !== 'pipeline') {
+    if (kind === 'deploy') {
+      if (fs.existsSync(path.join(cwd, 'scripts/deploy.sh'))) {
+        cmd = '/bin/bash';
+        args = ['-lc', 'chmod +x scripts/deploy.sh && scripts/deploy.sh'];
+      } else {
+        cmd = '/bin/bash';
+        args = [
+          '-lc',
+          `mkdir -p ${DEPLOY_ROOT}/${project} && rsync -a --delete public/ ${DEPLOY_ROOT}/${project}/`,
+        ];
+      }
+    } else if (kind === 'test') {
+      cmd = '/bin/bash';
+      args = ['-lc', 'npm test || echo "no tests"'];
+    } else if (kind === 'build') {
+      cmd = '/bin/bash';
+      args = ['-lc', 'npm run build || echo "no build"'];
+    }
+  }
+  if (kind === 'custom' && !cmd && body.script) {
+    cmd = '/bin/bash';
+    args = ['-lc', body.script];
+  }
+
+  await run(
+    d,
+    `INSERT INTO jobs (job_id,project_id,kind,cmd,args_json,env_json,status,progress,started_at,pid)
+                VALUES (?,?,?,?,?,?,?, ?,?, NULL)`,
+    [
+      id,
+      project,
+      kind,
+      cmd || '',
+      JSON.stringify(args),
+      JSON.stringify(env),
+      'running',
+      0,
+      now(),
+    ]
+  );
+  await appendEvent(id, 'state', { status: 'running', project, kind });
+  await led({ type: 'led.progress', pct: 5, ttl_s: 180 });
+
+  if (kind === 'pipeline') {
+    runPipeline(id, project, env).catch(async (e) => {
+      await appendEvent(id, 'log', `\n[error] ${String(e)}\n`);
+      await updateJob(id, { status: 'error', finished_at: now() });
+      await led({ type: 'led.emotion', emotion: 'error', ttl_s: 20 });
+    });
+  } else {
+    await runSingle(id, project, cmd, args, env);
+  }
+  return id;
+}
+
+// HTTP plumbing (unchanged surface)
+const clients = new Map(); // job_id -> Set(res)
+module.exports = function attachJobs({ app }) {
+  app.post('/api/jobs/start', async (req, res) => {
+    let raw = '';
+    req.on('data', (d) => (raw += d));
+    await new Promise((r) => req.on('end', r));
+    let body = {};
+    try {
+      body = JSON.parse(raw || '{}');
+    } catch {
+      return res.status(400).json({ error: 'bad json' });
+    }
+    try {
+      const id = await startJob(body);
+      res.json({ ok: true, job_id: id });
+    } catch (e) {
+      res.status(500).json({ error: String(e) });
+    }
+  });
+
+  app.get('/api/jobs/:id', async (req, res) => {
+    const id = String(req.params.id);
+    const j = await get(d, `SELECT * FROM jobs WHERE job_id=?`, [id]);
+    if (!j) return res.status(404).json({ error: 'not found' });
+    res.json(j);
+  });
+
+  app.get('/api/jobs', async (req, res) => {
+    const pr = String(req.query.project || '');
+    const rows = await all(
+      d,
+      `SELECT job_id,project_id,kind,status,progress,started_at,finished_at FROM jobs
+                               ${pr ? 'WHERE project_id=?' : ''} ORDER BY started_at DESC LIMIT 50`,
+      pr ? [pr] : []
+    );
+    res.json(rows);
+  });
+
+  app.post('/api/jobs/:id/cancel', async (req, res) => {
+    const id = String(req.params.id);
+    await updateJob(id, { status: 'canceled', finished_at: now() });
+    await appendEvent(id, 'log', '\n[cancel requested]\n');
+    const proc = PROCS.get(id);
+    if (proc) {
+      try {
+        if (proc.dockerName) {
+          spawn('docker', ['rm', '-f', proc.dockerName], { detached: false });
+        } else if (proc.pgid) {
+          process.kill(-proc.pgid, 'SIGTERM');
+          setTimeout(() => {
+            try {
+              process.kill(-proc.pgid, 'SIGKILL');
+            } catch {}
+          }, 5000);
+        }
+      } catch {}
+    }
+    res.json({ ok: true });
+  });
+
+  app.get('/api/jobs/:id/events', async (req, res) => {
+    const id = String(req.params.id);
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+      'X-Accel-Buffering': 'no',
+    });
+    const rows = await all(
+      d,
+      `SELECT type,data FROM job_events WHERE job_id=? ORDER BY seq ASC`,
+      [id]
+    );
+    for (const r of rows) {
+      res.write(`event: ${r.type}\n`);
+      res.write(`data: ${r.data}\n\n`);
+    }
+    if (!clients.has(id)) clients.set(id, new Set());
+    clients.get(id).add(res);
+    req.on('close', () => {
+      const set = clients.get(id);
+      if (set) {
+        set.delete(res);
+        if (!set.size) clients.delete(id);
+      }
+    });
+  });
+
+  console.log(
+    `[jobs] sandboxed runner online • runner=${RUNNER}${RUNNER === 'docker' && !dockerAvailableSync() ? ' (fallback to host)' : ''}`
+  );
+};

--- a/srv/blackroad-api/server_full.js
+++ b/srv/blackroad-api/server_full.js
@@ -1,4 +1,3 @@
-<!-- FILE: srv/blackroad-api/server_full.js -->
 /* BlackRoad API — Express + SQLite + Socket.IO + LLM bridge
    Runs behind Nginx on port 4000 with cookie-session auth.
    Env (optional):
@@ -26,11 +25,8 @@ const Database = require('better-sqlite3');
 const { Server: SocketIOServer } = require('socket.io');
 const { exec } = require('child_process');
 const { randomUUID } = require('crypto');
-const EventEmitter = require('events');
 const Stripe = require('stripe');
 const verify = require('./lib/verify');
-const git = require('./lib/git');
-const deploy = require('./lib/deploy');
 const notify = require('./lib/notify');
 const logger = require('./lib/log');
 
@@ -39,17 +35,18 @@ const PORT = parseInt(process.env.PORT || '4000', 10);
 const SESSION_SECRET = process.env.SESSION_SECRET || 'dev-secret-change-me';
 const DB_PATH = process.env.DB_PATH || '/srv/blackroad-api/blackroad.db';
 const LLM_URL = process.env.LLM_URL || 'http://127.0.0.1:8000/chat';
-const ALLOW_SHELL = String(process.env.ALLOW_SHELL || 'false').toLowerCase() === 'true';
+const ALLOW_SHELL =
+  String(process.env.ALLOW_SHELL || 'false').toLowerCase() === 'true';
 const WEB_ROOT = process.env.WEB_ROOT || '/var/www/blackroad';
-const BILLING_DISABLE = String(process.env.BILLING_DISABLE || 'false').toLowerCase() === 'true';
+const BILLING_DISABLE =
+  String(process.env.BILLING_DISABLE || 'false').toLowerCase() === 'true';
 const INTERNAL_TOKEN = process.env.INTERNAL_TOKEN || 'change-me';
-const GITHUB_WEBHOOK_SECRET = process.env.GITHUB_WEBHOOK_SECRET || '';
-const BRANCH_MAIN = process.env.BRANCH_MAIN || 'main';
-const BRANCH_STAGING = process.env.BRANCH_STAGING || 'staging';
 const STRIPE_SECRET = process.env.STRIPE_SECRET || '';
 const STRIPE_WEBHOOK_SECRET = process.env.STRIPE_WEBHOOK_SECRET || '';
 const stripeClient = STRIPE_SECRET ? new Stripe(STRIPE_SECRET) : null;
-const ALLOW_ORIGINS = process.env.ALLOW_ORIGINS ? process.env.ALLOW_ORIGINS.split(',').map((s) => s.trim()) : [];
+const ALLOW_ORIGINS = process.env.ALLOW_ORIGINS
+  ? process.env.ALLOW_ORIGINS.split(',').map((s) => s.trim())
+  : [];
 
 ['SESSION_SECRET', 'INTERNAL_TOKEN'].forEach((name) => {
   if (!process.env[name]) {
@@ -167,36 +164,7 @@ require('./modules/projects')({ app });
 require('./modules/pr_proxy')({ app });
 require('./modules/patentnet')({ app });
 require('./modules/love_math')({ app });
-
-const emitter = new EventEmitter();
-const jobs = new Map();
-let jobSeq = 0;
-
-function addJob(type, payload, runner) {
-  const id = String(++jobSeq);
-  const job = { id, type, payload, status: 'queued', created: Date.now(), logs: [] };
-  jobs.set(id, job);
-  process.nextTick(async () => {
-    job.status = 'running';
-    try {
-      await runner(id, payload);
-      job.status = 'success';
-    } catch (e) {
-      job.status = 'failed';
-      job.error = String(e);
-    } finally {
-      emitter.emit(id, null);
-    }
-  });
-  return job;
-}
-
-function logLine(id, line) {
-  const job = jobs.get(id);
-  if (job) job.logs.push(line);
-  emitter.emit(id, line);
-}
-
+require('./modules/jobs')({ app });
 // --- Middleware
 app.disable('x-powered-by');
 app.use(helmet());
@@ -207,7 +175,7 @@ app.use(
       return cb(new Error('Not allowed'), false);
     },
     credentials: true,
-  }),
+  })
 );
 app.use(rateLimit({ windowMs: 60_000, max: 100 }));
 app.use((req, res, next) => {
@@ -233,7 +201,7 @@ app.use(
     sameSite: 'lax',
     secure: process.env.NODE_ENV === 'production',
     maxAge: 1000 * 60 * 60 * 8, // 8h
-  }),
+  })
 );
 
 // --- Homepage
@@ -244,7 +212,6 @@ app.head('/health', (_req, res) => res.status(200).end());
 app.get('/health', (_req, res) => {
   res.json({ ok: true, version: '1.0.0', uptime: process.uptime() });
 });
-
 
 // --- Health
 app.head('/api/health', (_, res) => res.status(200).end());
@@ -258,7 +225,7 @@ app.get('/api/health', async (_req, res) => {
     ok: true,
     version: '1.0.0',
     uptime: process.uptime(),
-    services: { api: true, llm }
+    services: { api: true, llm },
   });
 });
 
@@ -280,12 +247,15 @@ app.post(
     }
     const { username, password } = req.body || {};
     // dev defaults: root / Codex2025 (can be replaced with real auth)
-    if ((username === 'root' && password === 'Codex2025') || process.env.BYPASS_LOGIN === 'true') {
+    if (
+      (username === 'root' && password === 'Codex2025') ||
+      process.env.BYPASS_LOGIN === 'true'
+    ) {
       req.session.user = { username, role: 'dev', plan: 'free' };
       return res.json({ ok: true, user: req.session.user });
     }
     return res.status(401).json({ error: 'invalid_credentials' });
-  },
+  }
 );
 app.post('/api/logout', (req, res) => {
   req.session = null;
@@ -338,7 +308,6 @@ app.post('/api/billing/webhook', (req, res) => {
     logger.error('stripe_webhook_verify_failed', e);
     return res.status(400).json({ error: 'invalid_signature' });
   }
-  emitter.emit('stripe:event', event);
   res.json({ received: true });
 });
 
@@ -349,18 +318,21 @@ db.pragma('synchronous = NORMAL');
 
 const TABLES = ['projects', 'agents', 'datasets', 'models', 'integrations'];
 for (const t of TABLES) {
-  db.prepare(`
+  db.prepare(
+    `
     CREATE TABLE IF NOT EXISTS ${t} (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       name TEXT NOT NULL,
       updated_at TEXT NOT NULL DEFAULT (datetime('now')),
       meta JSON
     )
-  `).run();
+  `
+  ).run();
 }
 
 // Subscription tables
-db.prepare(`
+db.prepare(
+  `
   CREATE TABLE IF NOT EXISTS subscribers (
     id TEXT PRIMARY KEY,
     email TEXT UNIQUE,
@@ -369,8 +341,10 @@ db.prepare(`
     created_at TEXT,
     source TEXT
   )
-`).run();
-db.prepare(`
+`
+).run();
+db.prepare(
+  `
   CREATE TABLE IF NOT EXISTS subscriptions (
     id TEXT PRIMARY KEY,
     subscriber_id TEXT,
@@ -382,8 +356,10 @@ db.prepare(`
     created_at TEXT,
     updated_at TEXT
   )
-`).run();
-db.prepare(`
+`
+).run();
+db.prepare(
+  `
   CREATE TABLE IF NOT EXISTS payments (
     id TEXT PRIMARY KEY,
     subscription_id TEXT,
@@ -394,8 +370,10 @@ db.prepare(`
     raw JSON,
     created_at TEXT
   )
-`).run();
-db.prepare(`
+`
+).run();
+db.prepare(
+  `
   CREATE TABLE IF NOT EXISTS logs_connectors (
     id TEXT PRIMARY KEY,
     subscriber_id TEXT,
@@ -405,10 +383,12 @@ db.prepare(`
     detail TEXT,
     created_at TEXT
   )
-`).run();
+`
+).run();
 
 // Billing tables (minimal subset)
-db.prepare(`
+db.prepare(
+  `
   CREATE TABLE IF NOT EXISTS plans (
     id TEXT PRIMARY KEY,
     name TEXT NOT NULL,
@@ -417,30 +397,59 @@ db.prepare(`
     features TEXT NOT NULL,
     is_active INTEGER NOT NULL DEFAULT 1
   )
-`).run();
+`
+).run();
 
 // Seed default plans if table empty
 const planCount = db.prepare('SELECT COUNT(*) as c FROM plans').get().c;
 if (planCount === 0) {
   const defaultPlans = [
-    { id: 'free', name: 'Free', monthly: 0, yearly: 0, features: ['Basic access'] },
-    { id: 'builder', name: 'Builder', monthly: 1500, yearly: 15000, features: ['Builder tools', 'Email support'] },
-    { id: 'pro', name: 'Pro', monthly: 4000, yearly: 40000, features: ['All builder features', 'Priority support'] },
-    { id: 'enterprise', name: 'Enterprise', monthly: 0, yearly: 0, features: ['Custom pricing', 'Dedicated support'] },
+    {
+      id: 'free',
+      name: 'Free',
+      monthly: 0,
+      yearly: 0,
+      features: ['Basic access'],
+    },
+    {
+      id: 'builder',
+      name: 'Builder',
+      monthly: 1500,
+      yearly: 15000,
+      features: ['Builder tools', 'Email support'],
+    },
+    {
+      id: 'pro',
+      name: 'Pro',
+      monthly: 4000,
+      yearly: 40000,
+      features: ['All builder features', 'Priority support'],
+    },
+    {
+      id: 'enterprise',
+      name: 'Enterprise',
+      monthly: 0,
+      yearly: 0,
+      features: ['Custom pricing', 'Dedicated support'],
+    },
   ];
-  const stmt = db.prepare('INSERT INTO plans (id, name, monthly_price_cents, yearly_price_cents, features, is_active) VALUES (?, ?, ?, ?, ?, 1)');
+  const stmt = db.prepare(
+    'INSERT INTO plans (id, name, monthly_price_cents, yearly_price_cents, features, is_active) VALUES (?, ?, ?, ?, ?, 1)'
+  );
   for (const p of defaultPlans) {
     stmt.run(p.id, p.name, p.monthly, p.yearly, JSON.stringify(p.features));
   }
 }
 
 // Quantum AI table seed
-db.prepare(`
+db.prepare(
+  `
   CREATE TABLE IF NOT EXISTS quantum_ai (
     topic TEXT PRIMARY KEY,
     summary TEXT NOT NULL
   )
-`).run();
+`
+).run();
 const qSeed = [
   {
     topic: 'reasoning',
@@ -459,37 +468,48 @@ const qSeed = [
   },
 ];
 for (const row of qSeed) {
-  db.prepare('INSERT OR IGNORE INTO quantum_ai (topic, summary) VALUES (?, ?)').run(
-    row.topic,
-    row.summary,
-  );
+  db.prepare(
+    'INSERT OR IGNORE INTO quantum_ai (topic, summary) VALUES (?, ?)'
+  ).run(row.topic, row.summary);
 }
 
 // Helpers
 function listRows(t) {
-  return db.prepare(`SELECT id, name, updated_at, meta FROM ${t} ORDER BY datetime(updated_at) DESC`).all();
+  return db
+    .prepare(
+      `SELECT id, name, updated_at, meta FROM ${t} ORDER BY datetime(updated_at) DESC`
+    )
+    .all();
 }
 function createRow(t, name, meta = null) {
-  const stmt = db.prepare(`INSERT INTO ${t} (name, updated_at, meta) VALUES (?, datetime('now'), ?)`);
+  const stmt = db.prepare(
+    `INSERT INTO ${t} (name, updated_at, meta) VALUES (?, datetime('now'), ?)`
+  );
   const info = stmt.run(name, meta ? JSON.stringify(meta) : null);
   return info.lastInsertRowid;
 }
 function updateRow(t, id, name, meta = null) {
-  const stmt = db.prepare(`UPDATE ${t} SET name = COALESCE(?, name), meta = COALESCE(?, meta), updated_at = datetime('now') WHERE id = ?`);
+  const stmt = db.prepare(
+    `UPDATE ${t} SET name = COALESCE(?, name), meta = COALESCE(?, meta), updated_at = datetime('now') WHERE id = ?`
+  );
   stmt.run(name ?? null, meta ? JSON.stringify(meta) : null, id);
 }
 function deleteRow(t, id) {
   db.prepare(`DELETE FROM ${t} WHERE id = ?`).run(id);
 }
-function validKind(kind) { return TABLES.includes(kind); }
-
+function validKind(kind) {
+  return TABLES.includes(kind);
+}
 
 // --- CRUD routes (guard with auth once you’re ready)
 app.get('/api/:kind', requireAuth, (req, res) => {
   const { kind } = req.params;
   if (!validKind(kind)) return res.status(404).json({ error: 'unknown_kind' });
-  try { res.json(listRows(kind)); }
-  catch (e) { res.status(500).json({ error: 'db_list_failed', detail: String(e) }); }
+  try {
+    res.json(listRows(kind));
+  } catch (e) {
+    res.status(500).json({ error: 'db_list_failed', detail: String(e) });
+  }
 });
 app.post('/api/:kind', requireAuth, (req, res) => {
   const { kind } = req.params;
@@ -499,7 +519,9 @@ app.post('/api/:kind', requireAuth, (req, res) => {
   try {
     const id = createRow(kind, name, meta);
     res.json({ ok: true, id });
-  } catch (e) { res.status(500).json({ error: 'db_create_failed', detail: String(e) }); }
+  } catch (e) {
+    res.status(500).json({ error: 'db_create_failed', detail: String(e) });
+  }
 });
 app.post('/api/:kind/:id', requireAuth, (req, res) => {
   const { kind, id } = req.params;
@@ -508,13 +530,19 @@ app.post('/api/:kind/:id', requireAuth, (req, res) => {
   try {
     updateRow(kind, Number(id), name, meta);
     res.json({ ok: true });
-  } catch (e) { res.status(500).json({ error: 'db_update_failed', detail: String(e) }); }
+  } catch (e) {
+    res.status(500).json({ error: 'db_update_failed', detail: String(e) });
+  }
 });
 app.delete('/api/:kind/:id', requireAuth, (req, res) => {
   const { kind, id } = req.params;
   if (!validKind(kind)) return res.status(404).json({ error: 'unknown_kind' });
-  try { deleteRow(kind, Number(id)); res.json({ ok: true }); }
-  catch (e) { res.status(500).json({ error: 'db_delete_failed', detail: String(e) }); }
+  try {
+    deleteRow(kind, Number(id));
+    res.json({ ok: true });
+  } catch (e) {
+    res.status(500).json({ error: 'db_delete_failed', detail: String(e) });
+  }
 });
 
 // --- Subscribe & connectors
@@ -522,10 +550,18 @@ const VALID_PLANS = ['free', 'builder', 'guardian'];
 const VALID_CYCLES = ['monthly', 'annual'];
 
 app.get('/api/connectors/status', (req, res) => {
-  const stripe = !!(process.env.STRIPE_PUBLIC_KEY && process.env.STRIPE_SECRET && process.env.STRIPE_WEBHOOK_SECRET);
+  const stripe = !!(
+    process.env.STRIPE_PUBLIC_KEY &&
+    process.env.STRIPE_SECRET &&
+    process.env.STRIPE_WEBHOOK_SECRET
+  );
   const mail = !!process.env.MAIL_PROVIDER;
-  const sheets = !!(process.env.GSHEETS_SA_JSON || process.env.SHEETS_CONNECTOR_TOKEN);
-  const calendar = !!(process.env.GOOGLE_CALENDAR_CREDENTIALS || process.env.ICS_URL);
+  const sheets = !!(
+    process.env.GSHEETS_SA_JSON || process.env.SHEETS_CONNECTOR_TOKEN
+  );
+  const calendar = !!(
+    process.env.GOOGLE_CALENDAR_CREDENTIALS || process.env.ICS_URL
+  );
   const discord = !!process.env.DISCORD_INVITE;
   const webhooks = stripe; // placeholder
   res.json({ stripe, mail, sheets, calendar, discord, webhooks });
@@ -533,7 +569,13 @@ app.get('/api/connectors/status', (req, res) => {
 
 // Basic health endpoint exposing provider mode
 app.get('/api/subscribe/health', (_req, res) => {
-  const mode = process.env.SUBSCRIBE_MODE || (process.env.STRIPE_SECRET ? 'stripe' : process.env.GUMROAD_TOKEN ? 'gumroad' : 'local');
+  const mode =
+    process.env.SUBSCRIBE_MODE ||
+    (process.env.STRIPE_SECRET
+      ? 'stripe'
+      : process.env.GUMROAD_TOKEN
+        ? 'gumroad'
+        : 'local');
   let providerReady = false;
   if (mode === 'stripe') providerReady = !!process.env.STRIPE_SECRET;
   else if (mode === 'gumroad') providerReady = !!process.env.GUMROAD_TOKEN;
@@ -561,28 +603,42 @@ app.post('/api/subscribe/invoice-intent', (req, res) => {
   let sub = db.prepare('SELECT id FROM subscribers WHERE email = ?').get(email);
   let subscriberId = sub ? sub.id : randomUUID();
   if (!sub) {
-    db.prepare('INSERT INTO subscribers (id, email, name, company, created_at, source) VALUES (?, ?, ?, ?, datetime("now"), ?)')
-      .run(subscriberId, email, name || null, company || null, 'invoice');
+    db.prepare(
+      'INSERT INTO subscribers (id, email, name, company, created_at, source) VALUES (?, ?, ?, ?, datetime("now"), ?)'
+    ).run(subscriberId, email, name || null, company || null, 'invoice');
   }
   const subscriptionId = randomUUID();
-  db.prepare('INSERT INTO subscriptions (id, subscriber_id, plan, cycle, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, datetime("now"), datetime("now"))')
-    .run(subscriptionId, subscriberId, plan, cycle, 'pending_invoice');
+  db.prepare(
+    'INSERT INTO subscriptions (id, subscriber_id, plan, cycle, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, datetime("now"), datetime("now"))'
+  ).run(subscriptionId, subscriberId, plan, cycle, 'pending_invoice');
   res.json({ ok: true, next: '/subscribe/thanks' });
 });
 
 app.get('/api/subscribe/status', (req, res) => {
   const { email } = req.query || {};
   if (!email) return res.status(400).json({ error: 'email_required' });
-  const row = db.prepare('SELECT s.plan, s.cycle, s.status FROM subscribers sub JOIN subscriptions s ON sub.id = s.subscriber_id WHERE sub.email = ? ORDER BY datetime(s.created_at) DESC LIMIT 1').get(email);
+  const row = db
+    .prepare(
+      'SELECT s.plan, s.cycle, s.status FROM subscribers sub JOIN subscriptions s ON sub.id = s.subscriber_id WHERE sub.email = ? ORDER BY datetime(s.created_at) DESC LIMIT 1'
+    )
+    .get(email);
   res.json(row || { status: 'none' });
 });
 
 // --- Billing: plans
 app.get('/api/subscribe/plans', requireAuth, (_req, res) => {
   try {
-    const rows = db.prepare('SELECT id, name, monthly_price_cents, yearly_price_cents, features, is_active FROM plans WHERE is_active = 1').all();
+    const rows = db
+      .prepare(
+        'SELECT id, name, monthly_price_cents, yearly_price_cents, features, is_active FROM plans WHERE is_active = 1'
+      )
+      .all();
     for (const r of rows) {
-      try { r.features = JSON.parse(r.features); } catch { r.features = []; }
+      try {
+        r.features = JSON.parse(r.features);
+      } catch {
+        r.features = [];
+      }
     }
     res.json(rows);
   } catch (e) {
@@ -596,7 +652,7 @@ app.post('/api/llm/chat', requireAuth, async (req, res) => {
   try {
     const upstream = await fetch(LLM_URL, {
       method: 'POST',
-      headers: {'Content-Type': 'application/json'},
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(req.body || {}),
     });
 
@@ -620,8 +676,14 @@ app.post('/api/llm/chat', requireAuth, async (req, res) => {
     const txt = await upstream.text().catch(() => '');
     // try to unwrap {text: "..."}
     let out = txt;
-    try { const j = JSON.parse(txt); if (j && typeof j.text === 'string') out = j.text; } catch {}
-    res.status(upstream.ok ? 200 : upstream.status).type('text/plain').send(out || '(no content)');
+    try {
+      const j = JSON.parse(txt);
+      if (j && typeof j.text === 'string') out = j.text;
+    } catch {}
+    res
+      .status(upstream.ok ? 200 : upstream.status)
+      .type('text/plain')
+      .send(out || '(no content)');
   } catch (e) {
     res.status(502).type('text/plain').send('(llm upstream error)');
   }
@@ -630,117 +692,48 @@ app.post('/api/llm/chat', requireAuth, async (req, res) => {
 // --- Optional shell exec (disabled by default)
 app.post('/api/exec', requireAuth, (req, res) => {
   if (!ALLOW_SHELL) return res.status(403).json({ error: 'exec_disabled' });
-  const cmd = (req.body && req.body.cmd || '').trim();
+  const cmd = ((req.body && req.body.cmd) || '').trim();
   if (!cmd) return res.status(400).json({ error: 'cmd_required' });
   exec(cmd, { timeout: 20000 }, (err, stdout, stderr) => {
-    if (err) return res.status(500).json({ error: 'exec_failed', detail: String(err), stderr });
+    if (err)
+      return res
+        .status(500)
+        .json({ error: 'exec_failed', detail: String(err), stderr });
     res.json({ out: stdout, stderr });
   });
 });
 
-// --- Deployment and CI endpoints
-app.post('/api/webhooks/github', async (req, res) => {
-  const sig = req.get('X-Hub-Signature-256');
-  const raw = JSON.stringify(req.body || {});
-  if (!verify.verifySignature(GITHUB_WEBHOOK_SECRET, raw, sig)) {
-    return res.status(401).end('invalid_signature');
-  }
-  const event = req.get('X-GitHub-Event');
-  if (event === 'ping') return res.json({ ok: true });
-  if (event === 'push') {
-    const branch = req.body.ref?.replace('refs/heads/', '');
-    if (!verify.branchAllowed(branch, [BRANCH_MAIN, BRANCH_STAGING])) return res.status(202).end();
-    const sha = req.body.after;
-    const job = addJob('deploy', { branch, sha }, async (id, payload) => {
-      logLine(id, 'git fetch');
-      await git.fetch();
-      await git.checkout(payload.branch);
-      await git.resetHard(payload.sha);
-      await git.clean();
-      logLine(id, 'deploy');
-      await deploy.stageAndSwitch(payload);
-      await notify.slack(`Deploy ${payload.branch} ${payload.sha} succeeded`);
-    });
-    return res.json({ ok: true, jobId: job.id });
-  }
-  if (event === 'pull_request') {
-    const job = addJob('ci', {}, async (id) => logLine(id, 'ci not implemented'));
-    return res.json({ ok: true, jobId: job.id });
-  }
-  res.json({ ok: true });
-});
-
-app.post('/api/deploy/plan', (req, res) => {
-  if (!verify.verifyToken(req.get('X-Internal-Token'), INTERNAL_TOKEN)) return res.status(401).end();
-  res.json({ ok: true, steps: ['build', 'switch'] });
-});
-
-app.post('/api/deploy/execute', (req, res) => {
-  if (!verify.verifyToken(req.get('X-Internal-Token'), INTERNAL_TOKEN)) return res.status(401).end();
-  const { branch = BRANCH_MAIN, sha } = req.body || {};
-  const job = addJob('deploy_manual', { branch, sha }, async (id, payload) => {
-    await git.fetch();
-    await git.checkout(payload.branch);
-    if (payload.sha) await git.resetHard(payload.sha);
-    await git.clean();
-    await deploy.stageAndSwitch(payload);
-  });
-  res.json({ ok: true, jobId: job.id });
-});
-
-app.post('/api/git/sync', (req, res) => {
-  if (!verify.verifyToken(req.get('X-Internal-Token'), INTERNAL_TOKEN)) return res.status(401).end();
-  const { branch = BRANCH_MAIN } = req.body || {};
-  addJob('git_sync', { branch }, async (id, payload) => {
-    await git.fetch();
-    await git.checkout(payload.branch);
-    await git.resetHard(`origin/${payload.branch}`);
-    await git.clean();
-  });
-  res.json({ ok: true });
-});
-
-app.get('/api/jobs', (req, res) => {
-  res.json(Array.from(jobs.values()).reverse());
-});
-
-app.get('/api/jobs/:id/log', (req, res) => {
-  const { id } = req.params;
-  res.setHeader('Content-Type', 'text/event-stream');
-  res.setHeader('Cache-Control', 'no-cache');
-  const send = (line) => {
-    if (line === null) return res.write('event: end\n\n');
-    res.write(`data: ${line}\n\n`);
-  };
-  const listener = (l) => send(l);
-  emitter.on(id, listener);
-  const job = jobs.get(id);
-  if (job) job.logs.forEach(send);
-  req.on('close', () => emitter.removeListener(id, listener));
-});
-
-app.post('/api/rollback/:releaseId', (req, res) => {
-  if (!verify.verifyToken(req.get('X-Internal-Token'), INTERNAL_TOKEN)) return res.status(401).end();
-  const releaseId = req.params.releaseId;
-  const job = addJob('rollback', { releaseId }, async (id, payload) => {
-    await deploy.stageAndSwitch({ branch: 'rollback', sha: payload.releaseId });
-  });
-  res.json({ ok: true, jobId: job.id });
-});
-
 app.get('/api/connectors/status', async (_req, res) => {
-  const status = { slack: false, airtable: false, linear: false, salesforce: false };
-  try { if (process.env.SLACK_WEBHOOK_URL) { await notify.slack('status check'); status.slack = true; } } catch {}
-  try { if (process.env.AIRTABLE_API_KEY) status.airtable = true; } catch {}
-  try { if (process.env.LINEAR_API_KEY) status.linear = true; } catch {}
-  try { if (process.env.SF_USERNAME) status.salesforce = true; } catch {}
+  const status = {
+    slack: false,
+    airtable: false,
+    linear: false,
+    salesforce: false,
+  };
+  try {
+    if (process.env.SLACK_WEBHOOK_URL) {
+      await notify.slack('status check');
+      status.slack = true;
+    }
+  } catch {}
+  try {
+    if (process.env.AIRTABLE_API_KEY) status.airtable = true;
+  } catch {}
+  try {
+    if (process.env.LINEAR_API_KEY) status.linear = true;
+  } catch {}
+  try {
+    if (process.env.SF_USERNAME) status.salesforce = true;
+  } catch {}
   res.json(status);
 });
 
 // --- Quantum AI summaries
 app.get('/api/quantum/:topic', (req, res) => {
   const { topic } = req.params;
-  const row = db.prepare('SELECT summary FROM quantum_ai WHERE topic = ?').get(topic);
+  const row = db
+    .prepare('SELECT summary FROM quantum_ai WHERE topic = ?')
+    .get(topic);
   if (!row) return res.status(404).json({ error: 'not_found' });
   res.json({ topic, summary: row.summary });
 });
@@ -748,7 +741,11 @@ app.get('/api/quantum/:topic', (req, res) => {
 // --- Actions (stubs)
 app.post('/api/actions/mint', requireAuth, (req, res) => {
   // TODO: integrate wallet; for now echo a stub tx id
-  res.json({ ok: true, minted: Number(req.body?.amount || 1), tx: 'rc_' + Math.random().toString(36).slice(2, 10) });
+  res.json({
+    ok: true,
+    minted: Number(req.body?.amount || 1),
+    tx: 'rc_' + Math.random().toString(36).slice(2, 10),
+  });
 });
 
 require('./modules/yjs_callback')({ app });
@@ -758,11 +755,12 @@ io.on('connection', (socket) => {
   socket.emit('hello', { ok: true, t: Date.now() });
 });
 setInterval(() => {
-  const total = os.totalmem(), free = os.freemem();
+  const total = os.totalmem(),
+    free = os.freemem();
   const payload = {
     t: Date.now(),
     load: os.loadavg()[0],
-    mem: { total, free, used: total - free, pct: (1 - free / total) },
+    mem: { total, free, used: total - free, pct: 1 - free / total },
     cpuCount: os.cpus()?.length || 1,
     host: os.hostname(),
   };
@@ -771,7 +769,9 @@ setInterval(() => {
 
 // --- Start
 server.listen(PORT, () => {
-  console.log(`[blackroad-api] listening on ${PORT} (db: ${DB_PATH}, llm: ${LLM_URL}, shell: ${ALLOW_SHELL})`);
+  console.log(
+    `[blackroad-api] listening on ${PORT} (db: ${DB_PATH}, llm: ${LLM_URL}, shell: ${ALLOW_SHELL})`
+  );
 });
 
 // --- Safety


### PR DESCRIPTION
## Summary
- add sandboxed jobs module with Docker-first execution and precise progress reporting
- integrate new jobs module into API server and drop legacy job endpoints

## Testing
- `apt-get update`
- `apt-get install -y docker.io`
- `npm i --prefix /srv/blackroad-api uuid yaml --no-save`
- `npm run lint` *(fails: A config object is using the "root" key)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c099887b748329ac1b446dc61074c7