### PR TITLE
Add trust curvature and truth diff endpoints

### DIFF
--- a/srv/blackroad-api/modules/trust_curvature.js
+++ b/srv/blackroad-api/modules/trust_curvature.js
@@ -1,0 +1,31 @@
+const graph = {
+  a: { b: 1, c: 1 },
+  b: { a: 1, c: 1 },
+  c: { a: 1, b: 1 },
+};
+
+function computeCurvature(g) {
+  const edges = [];
+  const nodes = Object.keys(g);
+  nodes.forEach((u) => {
+    Object.keys(g[u]).forEach((v) => {
+      if (u < v) {
+        const Nu = Object.keys(g[u]);
+        const Nv = Object.keys(g[v]);
+        const inter = Nu.filter((x) => Nv.includes(x)).length;
+        const maxDeg = Math.max(Nu.length, Nv.length) || 1;
+        const W1 = 1 - inter / maxDeg;
+        const kappa = 1 - W1;
+        edges.push({ u, v, kappa: Number(kappa.toFixed(3)) });
+      }
+    });
+  });
+  return edges;
+}
+
+module.exports = function attachCurvature({ app }) {
+  app.get('/api/trust/curvature', (_req, res) => {
+    const results = computeCurvature(graph);
+    res.json(results);
+  });
+};

--- a/srv/blackroad-api/modules/truth_diff.js
+++ b/srv/blackroad-api/modules/truth_diff.js
@@ -1,0 +1,46 @@
+function diffJson(a, b, base = '') {
+  const ops = [];
+  if (
+    typeof a !== 'object' ||
+    typeof b !== 'object' ||
+    a === null ||
+    b === null
+  ) {
+    if (JSON.stringify(a) !== JSON.stringify(b)) {
+      ops.push({ op: 'replace', path: base || '/', from: a, to: b });
+    }
+    return ops;
+  }
+  const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+  keys.forEach((k) => {
+    const path = `${base}/${k}`;
+    if (!(k in a)) {
+      ops.push({ op: 'replace', path, from: undefined, to: b[k] });
+    } else if (!(k in b)) {
+      ops.push({ op: 'replace', path, from: a[k], to: undefined });
+    } else {
+      ops.push(...diffJson(a[k], b[k], path));
+    }
+  });
+  return ops;
+}
+
+const truths = {
+  a: { meta: { title: 'A' }, proof: 'p1' },
+  b: { meta: { title: 'B' }, proof: 'p1' },
+};
+
+module.exports = function attachTruthDiff({ app }) {
+  app.get('/api/truth/diff', (req, res) => {
+    let { cid } = req.query;
+    if (!cid) return res.status(400).json({ error: 'missing cid' });
+    if (!Array.isArray(cid)) cid = [cid];
+    const [cidA, cidB] = cid;
+    const j1 = truths[cidA];
+    const j2 = truths[cidB];
+    if (!j1 || !j2) return res.status(404).json({ error: 'not_found' });
+    const ops = diffJson(j1, j2);
+    const ctd = ops.length;
+    res.json({ ctd, ops });
+  });
+};

--- a/srv/blackroad-api/server_full.js
+++ b/srv/blackroad-api/server_full.js
@@ -752,6 +752,8 @@ app.post('/api/actions/mint', requireAuth, (req, res) => {
 });
 
 require('./modules/yjs_callback')({ app });
+require('./modules/trust_curvature')({ app });
+require('./modules/truth_diff')({ app });
 
 // --- Socket.IO presence (metrics)
 io.on('connection', (socket) => {

--- a/tests/api_health.test.js
+++ b/tests/api_health.test.js
@@ -43,4 +43,20 @@ describe('API security and health', () => {
     expect(res.body.planName).toBe('Free');
     expect(res.body.entitlements.can.math.pro).toBe(false);
   });
+
+  it('computes curvature', async () => {
+    const res = await request(app).get('/api/trust/curvature');
+    expect(res.status).toBe(200);
+    const edge = res.body.find((e) => e.u === 'a' && e.v === 'b');
+    expect(edge.kappa).toBeGreaterThan(0);
+  });
+
+  it('computes CTD between two truths', async () => {
+    const res = await request(app)
+      .get('/api/truth/diff')
+      .query({ cid: ['a', 'b'] });
+    expect(res.status).toBe(200);
+    expect(res.body.ctd).toBe(1);
+    expect(res.body.ops[0].path).toBe('/meta/title');
+  });
 });


### PR DESCRIPTION
## Summary
- add /api/trust/curvature to expose simple Ricci-like edge curvature values
- add /api/truth/diff to compute a basic Canonical Truth Distance between two CIDs
- cover new endpoints with tests

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: A config object is using the "root" key, which is not supported in flat config system)*

------
https://chatgpt.com/codex/tasks/task_e_68c09c1d33cc832995c769dedebb5add