### PR TITLE
feat: add memory and brain chat modules

### DIFF
--- a/srv/blackroad-api/modules/brain_chat.js
+++ b/srv/blackroad-api/modules/brain_chat.js
@@ -1,0 +1,29 @@
+module.exports = function attachBrainChat({ app }) {
+  async function search(q){ const r = await fetch('http://127.0.0.1:4000/api/memory/search',{method:'POST',headers:{'Content-Type':'application/json'}, body:JSON.stringify({q,top_k:5})}); return await r.json(); }
+  async function llm(body){ const r = await fetch('http://127.0.0.1:4010/api/llm/chat',{method:'POST',headers:{'Content-Type':'application/json'}, body: JSON.stringify(body)}); return await r.json(); }
+
+  app.post('/api/brain/chat', async (req,res)=>{
+    let raw=''; req.on('data',d=>raw+=d); await new Promise(r=>req.on('end',r));
+    const body = raw?JSON.parse(raw):{};
+    const msgs = body.messages || [];
+    const lastUser = [...msgs].reverse().find(m=>m.role==='user')?.content || '';
+    const hits = await search(lastUser).catch(()=>({results:[]}));
+    const context = hits.results?.map((r,i)=>`[${i+1}] ${r.text}\n(source: ${r.meta?.source||r.id})`).join('\n\n') || '';
+    const system = [
+      "You are BlackRoad’s local assistant. Use the CONTEXT when helpful; keep answers truthful and concise.",
+      "Always ask 1 short follow-up question.",
+      context?("CONTEXT:\n"+context):""
+    ].filter(Boolean).join('\n\n');
+
+    const out = await llm({
+      model: body.model || 'qwen2:1.5b',
+      stream: false,
+      messages: [
+        {role:'system', content: system},
+        ...msgs
+      ]
+    });
+    res.json(out);
+  });
+  console.log('[brain-chat] /api/brain/chat ready');
+};

--- a/srv/blackroad-api/modules/memory.js
+++ b/srv/blackroad-api/modules/memory.js
@@ -1,0 +1,68 @@
+// Local memory index/search using SQLite + FTS5 + Ollama embeddings
+// DB: /srv/blackroad-api/memory.db  Tables: docs(id TEXT PK, text, meta JSON, ts INT)
+//      fts(content uses content=docs, content_rowid=rowid)
+const fs = require('fs'); const path = require('path'); const Database = require('better-sqlite3');
+
+module.exports = function attachMemory({ app }) {
+  const DBP = process.env.MEMORY_DB || '/srv/blackroad-api/memory.db';
+  fs.mkdirSync(path.dirname(DBP), { recursive: true });
+  const db = new Database(DBP);
+  db.exec(`CREATE TABLE IF NOT EXISTS docs (id TEXT PRIMARY KEY, text TEXT, meta TEXT, ts INTEGER);
+CREATE VIRTUAL TABLE IF NOT EXISTS fts USING fts5(text, content='docs', content_rowid='rowid');
+CREATE TRIGGER IF NOT EXISTS docs_ai AFTER INSERT ON docs BEGIN INSERT INTO fts(rowid,text) VALUES (new.rowid, new.text); END;
+CREATE TRIGGER IF NOT EXISTS docs_ad AFTER DELETE ON docs BEGIN INSERT INTO fts(fts, rowid, text) VALUES('delete', old.rowid, old.text); END;
+CREATE TRIGGER IF NOT EXISTS docs_au AFTER UPDATE ON docs BEGIN INSERT INTO fts(fts, rowid, text) VALUES('delete', old.rowid, old.text); INSERT INTO fts(rowid,text) VALUES (new.rowid, new.text); END;
+CREATE TABLE IF NOT EXISTS vecs (id TEXT PRIMARY KEY, v TEXT);`);
+
+  async function embed(text){
+    // Call local Ollama embeddings endpoint (pull nomic-embed-text first)
+    const r = await fetch('http://127.0.0.1:11434/api/embeddings', {
+      method:'POST', headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({ model: process.env.EMBED_MODEL || 'nomic-embed-text', prompt: text })
+    });
+    const j = await r.json();
+    return j.embedding || j.data?.[0]?.embedding || [];
+  }
+
+  function run(sql, p=[]) { return Promise.resolve(db.prepare(sql).run(p)); }
+  function all(sql, p=[]) { return Promise.resolve(db.prepare(sql).all(p)); }
+  function get(sql, p=[]) { return Promise.resolve(db.prepare(sql).get(p)); }
+
+  function cosine(a,b){ let dot=0,na=0,nb=0; for(let i=0;i<Math.min(a.length,b.length);i++){dot+=a[i]*b[i];na+=a[i]*a[i];nb+=b[i]*b[i];} return dot/(Math.sqrt(na)*Math.sqrt(nb)+1e-9); }
+
+  app.post('/api/memory/index', async (req,res)=>{
+    let raw=''; req.on('data',d=>raw+=d); await new Promise(r=>req.on('end',r));
+    const body = raw?JSON.parse(raw):{};
+    const id = body.id || `doc:${Date.now()}:${Math.random().toString(36).slice(2,8)}`;
+    const text = String(body.text||'').slice(0, 200000);
+    const meta = JSON.stringify({source:body.source||null,tags:body.tags||[]});
+    if (!text) return res.status(400).json({error:'missing text'});
+    await run(`INSERT OR REPLACE INTO docs(id,text,meta,ts) VALUES(?,?,?,?)`, [id,text,meta,Date.now()]);
+    // embed a few chunks ~1k chars
+    const chunks=[]; for(let i=0;i<text.length;i+=1000) chunks.push(text.slice(i,i+1000));
+    const embs=[]; for(const c of chunks){ embs.push(await embed(c)); }
+    await run(`INSERT OR REPLACE INTO vecs(id,v) VALUES(?,?)`, [id, JSON.stringify(embs.flat().slice(0,1536))]);
+    res.json({ok:true,id});
+  });
+
+  app.post('/api/memory/search', async (req,res)=>{
+    let raw=''; req.on('data',d=>raw+=d); await new Promise(r=>req.on('end',r));
+    const body = raw?JSON.parse(raw):{};
+    const q = String(body.q||'').trim(); const k = Math.max(1, Math.min(20, body.top_k||5));
+    if (!q) return res.status(400).json({error:'empty query'});
+    // coarse FTS
+    const rows = await all(`SELECT id, text, meta FROM docs WHERE rowid IN (SELECT rowid FROM fts WHERE fts MATCH ? LIMIT 50)`, [q.split(/\s+/).join(' ')]);
+    // embeddings rerank
+    const qv = await (async()=>await embed(q))();
+    const scored = [];
+    for (const r of rows){
+      const vrow = await get(`SELECT v FROM vecs WHERE id=?`, [r.id]);
+      const v = vrow ? JSON.parse(vrow.v) : [];
+      scored.push({ id:r.id, score: cosine(qv, v), text:r.text.slice(0,2000), meta: JSON.parse(r.meta||'{}') });
+    }
+    scored.sort((a,b)=>b.score-a.score);
+    res.json({ results: scored.slice(0,k) });
+  });
+
+  console.log('[memory] online:', DBP);
+};

--- a/srv/blackroad-api/server_full.js
+++ b/srv/blackroad-api/server_full.js
@@ -167,6 +167,8 @@ require('./modules/pr_proxy')({ app });
 require('./modules/patentnet')({ app });
 require('./modules/love_math')({ app });
 require('./modules/jobs')({ app });
+require('./modules/memory')({ app });
+require('./modules/brain_chat')({ app });
 // --- Middleware
 app.disable('x-powered-by');
 app.use(helmet());

--- a/var/www/blackroad/.well-known/blackroad-agent.json
+++ b/var/www/blackroad/.well-known/blackroad-agent.json
@@ -1,0 +1,22 @@
+{
+  "name": "BlackRoad Skills",
+  "version": "1.0",
+  "base_url": "https://blackroad.io",
+  "endpoints": {
+    "normalize": {"method":"POST","path":"/api/normalize","body":{"text?":"string","path?":"string","kind?":"auto|json|yaml|toml|xml|csv|text"}},
+    "projects_list": {"method":"GET","path":"/api/projects"},
+    "projects_tree": {"method":"GET","path":"/api/projects/{id}/tree"},
+    "projects_get":  {"method":"GET","path":"/api/projects/{id}/file?path={p}"},
+    "projects_put":  {"method":"PUT","path":"/api/projects/{id}/file?path={p}"},
+    "projects_commit":{"method":"POST","path":"/api/projects/{id}/commit"},
+    "projects_deploy":{"method":"POST","path":"/api/projects/{id}/deploy"},
+    "llm_chat":      {"method":"POST","path":"/api/brain/chat"},
+    "memory_index":  {"method":"POST","path":"/api/memory/index"},
+    "memory_search": {"method":"POST","path":"/api/memory/search"},
+    "devices_cmd":   {"method":"POST","path":"/api/devices/{id}/command","auth":"X-BlackRoad-Key"}
+  },
+  "notes": [
+    "Use /api/normalize before indexing files or pasted text.",
+    "For devices_cmd, do not call directly unless I provide the key; otherwise print a curl."
+  ]
+}


### PR DESCRIPTION
## Summary
- add SQLite-backed memory index/search service with local embeddings
- expose brain chat router that retrieves context before querying local LLM
- publish capability manifest for skill autodiscovery

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint root config unsupported)*


------
https://chatgpt.com/codex/tasks/task_e_68c0bd2debe08329acda2b8bde5eaa92