### PR TITLE
Add Android development setup guide

### DIFF
--- a/docs/android-development-setup-guide.md
+++ b/docs/android-development-setup-guide.md
@@ -1,0 +1,312 @@
+# Complete Android Development Setup Guide (2025)
+
+Android development device setup has evolved significantly with enhanced wireless debugging capabilities, improved security measures, and streamlined Android Studio integration. **The core developer options activation remains unchanged**, but wireless debugging has become a first-class feature, security restrictions have been strengthened, and manufacturer-specific considerations have expanded. This guide provides current, actionable instructions for setting up any Android device for development and debugging.
+
+## Setting up developer options and USB debugging
+
+The process for enabling developer options remains consistent across **Android 14, Android 15, and upcoming versions**, following the same pattern established since Android 4.2. The location of the build number varies by device manufacturer, but the core process is universal.
+
+### Universal developer options setup
+
+Navigate to your device settings and locate the build number by following this manufacturer-specific guide:
+
+- **Google Pixel**: Settings > About phone > Build number
+- **Samsung Galaxy**: Settings > About phone > Software information > Build number
+- **OnePlus**: Settings > About device > Version > Build number
+- **Xiaomi/MIUI**: Settings > About phone > MIUI version
+- **Huawei/EMUI**: Settings > About phone > Build number
+- **LG**: Settings > System > About phone > Software info > Build number
+- **Other devices**: Generally found under Settings > About phone/device > Build number
+
+**Tap the build number seven times** until you see "You are now a developer!" After activation, developer options appear in different locations based on Android version:
+
+- **Android 16+ (API 36)**: Settings > System > Developer options > Wireless debugging
+- **Android 9+ (API 28)**: Settings > System > Advanced > Developer Options > USB debugging
+- **Android 8.0-8.1 (API 26-27)**: Settings > System > Developer Options > USB debugging
+- **Android 7.1 and lower**: Settings > Developer Options > USB debugging
+
+Enable **USB debugging** and, crucially for wireless functionality, enable **Wireless debugging** on Android 11+ devices. The RSA key authentication dialog will appear when first connecting - **always select "Always allow from this computer"** and ensure your device is unlocked when this prompt appears.
+
+### Android 15 specific features
+
+Android 15 introduces several development-relevant features including **16 KB page size support** on Pixel 8/8a/9 series devices with Android 15 QPR1+, enhanced background activity restrictions, and improved intent security measures. These changes primarily affect app compatibility testing rather than basic debugging setup, but developers should be aware of the enhanced security model that may require additional permissions for certain debugging activities.
+
+## Platform-specific setup requirements
+
+### Windows development environment
+
+Windows requires the most configuration but provides excellent stability once properly set up. **Install Android Studio from the official site** and ensure you have Windows 10 64-bit or newer (Windows 11 recommended) with at least 8GB RAM and preferably 16GB for emulator usage.
+
+**Configure environment variables** through Control Panel > User Accounts > User Accounts > Change my environment variables:
+
+- Create `ANDROID_HOME` variable pointing to `C:\Users\[USERNAME]\AppData\Local\Android\Sdk`
+- Add to PATH: `%ANDROID_HOME%\platform-tools`, `%ANDROID_HOME%\tools`, `%ANDROID_HOME%\tools\bin`
+
+**USB driver installation** is critical on Windows. Install the Google USB Driver through Android Studio's SDK Manager (SDK Tools tab), then manually install manufacturer-specific drivers as needed. For Samsung devices, download the official Samsung Android USB Driver; for OnePlus, use their universal driver from oneplususbdrivers.com.
+
+**Windows 11 users** may need to disable driver signature enforcement temporarily: Settings > Recovery > Advanced startup > Restart now > Troubleshoot > Advanced options > Startup Settings > Restart > Press F7 for "Disable driver signature enforcement."
+
+### macOS streamlined setup
+
+macOS provides the smoothest setup experience with minimal configuration required. **Install Xcode Command Line Tools** first: `xcode-select --install`. Install Homebrew for package management: `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`.
+
+**Java installation** differs between Apple Silicon and Intel Macs. Use Homebrew: `brew install --cask zulu@17` and add to your shell profile:
+
+```bash
+export JAVA_HOME=/Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Home
+export ANDROID_HOME=$HOME/Library/Android/sdk
+export PATH=$PATH:$ANDROID_HOME/tools:$ANDROID_HOME/platform-tools
+```
+
+**Apple Silicon considerations**: Install Rosetta 2 for x86 emulator compatibility: `/usr/sbin/softwareupdate --install-rosetta --agree-to-license`. Prefer ARM64 system images when available for better performance.
+
+### Linux configuration essentials
+
+Linux requires the most manual configuration but offers excellent performance once properly set up. **Install essential packages** based on your distribution:
+
+**Ubuntu/Debian**:
+
+```bash
+sudo apt update && sudo apt install openjdk-17-jdk libc6:i386 libncurses5:i386 libstdc++6:i386 lib32z1 libbz2-1.0:i386 android-sdk-platform-tools-common
+sudo usermod -aG plugdev $LOGNAME
+```
+
+**Fedora/CentOS/RHEL**:
+
+```bash
+sudo dnf install java-17-openjdk-devel zlib.i686 ncurses-libs.i686 bzip2-libs.i686 android-tools
+```
+
+**udev rules setup** is crucial for device recognition. Download comprehensive rules: `git clone https://github.com/M0Rf30/android-udev-rules.git` and install:
+
+```bash
+sudo cp -v 51-android.rules /etc/udev/rules.d/51-android.rules
+sudo chmod a+r /etc/udev/rules.d/51-android.rules
+sudo groupadd adbusers
+sudo usermod -aG adbusers $(whoami)
+sudo udevadm control --reload-rules
+```
+
+**Log out and log back in** for group changes to take effect, then restart udev services and test ADB connectivity.
+
+## Wireless debugging setup and advanced features
+
+Wireless debugging represents the most significant advancement in Android development setup, eliminating USB cable dependency while maintaining full debugging capabilities. **Android 11+ supports native wireless debugging** without initial USB connection, using robust pairing mechanisms and automatic reconnection.
+
+### QR code and pairing code methods
+
+**Android Studio integration** provides the smoothest wireless debugging experience. From the Run configurations menu, select "Pair Devices Using Wi-Fi" and choose either QR code or pairing code method. On your device, navigate to Settings > Developer options > Wireless debugging and select the appropriate pairing method.
+
+**QR code pairing** is fastest: Android Studio displays a QR code, scan it with your device's camera from the pairing screen, and the connection establishes automatically. **Pairing codes** provide an alternative when camera access is unavailable - note the 6-digit code from your device and enter it in Android Studio.
+
+**Command line pairing** offers more control:
+
+```bash
+cd android_sdk/platform-tools
+adb pair ipaddr:port
+# Enter pairing code when prompted
+adb connect ipaddr:wireless_port
+```
+
+### Network requirements and troubleshooting
+
+**Network prerequisites** include both devices on the same Wi-Fi network, with **5GHz networks preferred** for better performance and lower latency. Corporate networks may block peer-to-peer connections - use alternative networks or mobile hotspots for initial setup.
+
+**Persistent connections** survive device reboots and Android Studio restarts. Enable the Quick Settings Developer tile (Developer Options > Quick settings developer tiles > Wireless debugging) for convenient wireless debugging toggle access.
+
+**Performance considerations**: Wireless debugging introduces 10-50ms additional latency compared to USB, with 50-80% of USB throughput depending on network quality. For large file transfers or time-critical debugging, USB connections remain superior, but wireless debugging excels for routine development tasks.
+
+## Manufacturer-specific considerations
+
+### Samsung Galaxy devices and Knox security
+
+**Samsung Knox security** presents the most significant manufacturer-specific challenge. Knox disables USB debugging when a Knox container exists - **uninstall Samsung My Knox** to restore debugging capabilities. Enterprise devices managed by Knox Premium require IT administrator intervention through the Admin Portal: Policies > Endpoint Policies > Samsung Knox Device Settings > Restrictions Settings > "Permit USB debugging" = Yes.
+
+**Samsung-specific debugging issues** include Auto Blocker (S24 series and newer) interfering with USB debugging, OEM unlock being enabled graying out USB debugging options, and connection mode requirements (use "Transferring files" not "Charging only").
+
+**Samsung USB drivers** are required for Windows development and available from developer.samsung.com/android-usb-driver. DeX mode maintains full debugging compatibility without additional configuration.
+
+### Google Pixel advantages
+
+**Pure Android implementation** provides the most consistent debugging experience without manufacturer restrictions. Pixel devices offer full fastboot support, official bootloader unlock processes, and seamless Google USB driver compatibility. **Anti-rollback protection** on Pixel 6 series with Android 13+ prevents downgrading, but doesn't affect standard debugging operations.
+
+### OnePlus and OxygenOS
+
+**OnePlus devices** generally provide excellent debugging compatibility with official bootloader unlock support and Warp/SuperVOOC fast charging compatibility during debugging. Install OnePlus-specific USB drivers on Windows from oneplususbdrivers.com, though universal Google ADB drivers often work as alternatives.
+
+**Connection troubleshooting** for OnePlus devices typically involves switching USB configuration to PTP mode and enabling "Allow debugging in charge only mode" for persistent connections.
+
+### Xiaomi MIUI complexities
+
+**MIUI presents unique challenges** requiring multiple permission toggles. Enable USB debugging, **"Install via USB"** (requires Mi account sign-in or SIM card removal), **"USB debugging (Security settings)"**, and critically, **disable "MIUI Optimization"** in developer options.
+
+**Network dependency workaround**: Some MIUI versions require Chinese server connectivity for "Install via USB" - use VPN with China-Shanghai server endpoint if installation permissions fail to enable.
+
+## Advanced debugging tools and techniques
+
+### Essential ADB commands for modern development
+
+**Device management commands** form the foundation of efficient development workflows:
+
+```bash
+adb devices -l                           # List devices with transport details
+adb -s <device_serial> <command>         # Target specific device
+adb wait-for-device <command>            # Wait for device before executing
+adb connect <ip_address>:5555           # Connect wirelessly
+adb disconnect <ip_address>:5555        # Disconnect specific wireless device
+```
+
+**Package management efficiency** improves with advanced installation options:
+
+```bash
+adb install -r -d app.apk              # Reinstall allowing downgrade
+adb install --fastdeploy app.apk       # Incremental updates (faster)
+adb install-multiple base.apk config.apk # Install app bundles
+adb shell pm grant <package> <permission> # Runtime permission management
+```
+
+**System interaction commands** enable comprehensive testing:
+
+```bash
+adb shell screencap /sdcard/screenshot.png
+adb shell screenrecord --time-limit 10 /sdcard/demo.mp4
+adb shell input text "Hello World"
+adb shell input tap 500 1000
+adb shell am start -a android.intent.action.VIEW -d "http://google.com"
+```
+
+### Performance profiling and optimization
+
+**GPU debugging capabilities** have expanded significantly with **Profile GPU Rendering** visualization (Settings > Developer Options > Profile GPU Rendering > "On screen as bars") and **GPU overdraw debugging** for identifying rendering inefficiencies.
+
+**Command line GPU profiling**:
+
+```bash
+adb shell setprop debug.hwui.profile visual_bars
+adb shell setprop debug.hwui.overdraw show
+```
+
+**Memory analysis tools** include Android Studio's enhanced Memory Profiler with heap dump analysis, memory leak detection, and object allocation tracking. Command line alternatives provide detailed insights:
+
+```bash
+adb shell dumpsys meminfo <package_name>
+adb shell procrank
+adb shell simpleperf record -a -g --duration 30
+```
+
+**Network traffic analysis** through Android Studio's Network Profiler offers real-time monitoring, HTTP/HTTPS request inspection, and latency analysis. Command line network debugging:
+
+```bash
+adb shell dumpsys netstats detail
+adb shell netstat -tuln
+adb shell tcpdump -i any -w /sdcard/capture.pcap  # Rooted devices only
+```
+
+**Battery usage debugging** helps optimize app efficiency:
+
+```bash
+adb shell dumpsys batterystats --reset
+adb shell dumpsys batterystats > battery_stats.txt
+adb shell dumpsys deviceidle step deep    # Test Doze mode
+adb shell am set-inactive <package_name> true  # Test app standby
+```
+
+### Security enhancements and best practices
+
+**Android 12+ introduces ADB authorization timeout** (7-day expiration by default) which can be disabled in Developer Options > "Disable adb authorization timeout" for persistent development environments. **Enhanced certificate validation** and stricter permission models require developers to maintain updated RSA keys and proper authorization workflows.
+
+**RSA key management best practices** include regular key rotation, secure key storage, and team-wide key deployment for consistent authorization. Keys are stored in `~/.android/adbkey` (Linux/macOS) or `%USERPROFILE%\.android\adbkey` (Windows).
+
+**Enterprise security considerations** include MDM restrictions potentially locking developer options, certificate pinning affecting ADB connections, and hardware-backed keystores on modern devices providing enhanced security.
+
+## Comprehensive troubleshooting guide
+
+### Universal connection problems
+
+**"Device unauthorized" errors** require systematic troubleshooting: First, ensure USB debugging is enabled and the device is unlocked when the RSA key dialog appears. Reset ADB authorization by executing `adb kill-server && rm ~/.android/adbkey* && adb start-server`, then reconnect the device and accept the authorization prompt.
+
+**"Device not recognized" issues** depend heavily on platform. On Windows, verify USB driver installation through Device Manager and try different USB ports (prefer USB 2.0 for stability). On Linux, check udev rules and group membership: `groups $USER` should include `plugdev` and `adbusers`. macOS typically works without additional configuration.
+
+**Network debugging problems** often stem from corporate network restrictions blocking peer-to-peer connections. Test with mobile hotspots, verify mDNS functionality (`adb mdns check`), and manually connect using specific IP addresses and ports when automatic discovery fails.
+
+### Platform-specific solutions
+
+**Windows troubleshooting** frequently involves driver conflicts. Install manufacturer-specific drivers (Samsung, OnePlus) or use universal Google USB drivers. Disable Windows Defender real-time protection temporarily during initial setup, and run Android Studio as administrator if connection issues persist.
+
+**Linux permission issues** require proper udev rules and group membership. If devices remain unrecognized after following setup procedures, manually create udev rules using device vendor/product IDs from `lsusb` output:
+
+```bash
+SUBSYSTEM=="usb", ATTR{idVendor}=="18d1", ATTR{idProduct}=="4ee7", MODE="0666", GROUP="adbusers"
+```
+
+**macOS rarely encounters connection problems** but Homebrew permission issues can affect development tools. Fix with:
+
+```bash
+sudo chown -R $(whoami):admin $(brew --prefix)/*
+sudo chmod -R g+rwX $(brew --prefix)
+```
+
+### Advanced troubleshooting techniques
+
+**Multiple device management** requires careful device targeting. Use `adb -s <device_serial> <command>` for specific device operations and set `ANDROID_SERIAL` environment variable for default device selection. Port conflicts typically indicate other development tools or previous ADB instances - kill all ADB processes and restart fresh.
+
+**Wireless debugging persistence issues** often result from network changes or power management. Configure static IP addresses for development devices, disable Wi-Fi power saving modes, and ensure router firewall settings allow connections on ports 5555-5585.
+
+**Performance debugging connectivity problems** in Android Studio typically require enabling advanced profiling in Run/Debug Configurations > Profiling tab. Some devices need "GPU debugging layers" enabled in Developer Options for complete profiler functionality.
+
+## Modern development workflow integration
+
+### Android Studio enhanced connectivity
+
+**Android Studio Narwhal 3 Feature Drop (2025.1.3)** introduces **device mirroring** directly in the IDE with audio redirection, interactive control, and embedded Layout Inspector access. The **Running Devices window** provides comprehensive device management with start apps, screen rotation, and volume control without leaving the development environment.
+
+**Connection Assistant** (Tools > Troubleshoot Device Connections) provides step-by-step setup guidance, USB device scanning, and ADB server restart functionality. The enhanced Device Manager (View > Tool Windows > Device Manager) offers improved virtual device creation with performance recommendations and Firebase-powered remote device integration.
+
+### Cloud-based testing and CI/CD integration
+
+**Firebase Test Lab integration** enables comprehensive testing across multiple device configurations. Configure test matrices using gcloud CLI:
+
+```bash
+gcloud firebase test android run \
+  --app=app-debug.apk \
+  --test=app-debug-androidTest.apk \
+  --device=model=Pixel2,version=28,locale=en,orientation=portrait \
+  --timeout=10m
+```
+
+**GitHub Actions workflow** for automated testing:
+
+```yaml
+- name: Run Firebase Test Lab
+  run: |
+    gcloud firebase test android run \
+      --app app/build/outputs/apk/debug/app-debug.apk \
+      --test app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk \
+      --device model=Pixel2,version=28,locale=en,orientation=portrait
+```
+
+**Gradle managed devices** provide consistent testing environments:
+
+```kotlin
+android {
+    testOptions {
+        managedDevices {
+            devices {
+                pixel2api30(ManagedVirtualDevice) {
+                    device = "Pixel 2"
+                    apiLevel = 30
+                    systemImageSource = "google"
+                }
+            }
+        }
+    }
+}
+```
+
+## Conclusion
+
+Android development device setup in 2025 combines enhanced security measures with improved connectivity options, making wireless debugging a practical reality while maintaining robust security through RSA key authentication and authorization timeouts. The core developer options activation process remains unchanged, providing consistency across Android versions, while manufacturer-specific considerations require targeted approaches, particularly for Samsung Knox security and Xiaomi MIUI restrictions.
+
+Platform-specific setup varies significantly in complexity, with Windows requiring the most configuration through USB drivers and environment variables, macOS providing streamlined setup with minimal requirements, and Linux offering excellent performance after proper udev rules configuration. Modern development workflows increasingly leverage cloud-based testing through Firebase Test Lab and CI/CD pipeline integration, reducing dependency on physical device collections while maintaining comprehensive testing coverage across device configurations and Android versions.
+
+The evolution toward wireless debugging represents the most significant practical improvement for daily development work, eliminating USB cable dependencies while maintaining full debugging capabilities. Combined with Android Studio's enhanced device management features and integrated troubleshooting tools, the modern Android development setup provides developers with more flexibility and efficiency than ever before, while security enhancements ensure that debugging capabilities remain protected through proper authorization mechanisms and certificate management.


### PR DESCRIPTION
## Summary
- add a comprehensive Android development setup guide covering developer options, platform-specific configuration, and wireless debugging

## Testing
- `pre-commit run --files docs/android-development-setup-guide.md`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ce3a28d08329b612ec3b844aec75