### PR TITLE
feat: add chrome build and display sleep support

### DIFF
--- a/srv/display-agent/display_agent.py
+++ b/srv/display-agent/display_agent.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+import glob
+import json
+import os
+import subprocess
+import time
+import urllib.request
+
+ROLE = os.getenv("ROLE", "mini")  # mini|main
+API = os.getenv("BACKPLANE_URL", "http://127.0.0.1:4000")
+KEY = os.getenv("BR_KEY", "")
+ID = os.getenv("DEVICE_ID", f"display-{ROLE}")
+SLEEP_MIN = int(os.getenv("SLEEP_AFTER_MIN", "0"))  # 0 = disable auto-sleep
+
+last_activity = time.time()
+screen_state = "on"
+saved_brightness = None
+
+
+def api_get(path):
+    req = urllib.request.Request(API + path, headers={"X-BlackRoad-Key": KEY})
+    with urllib.request.urlopen(req, timeout=15) as r:
+        return json.loads(r.read().decode())
+
+
+def sys(cmd):
+    try:
+        return subprocess.run(
+            cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+        ).stdout
+    except subprocess.CalledProcessError:
+        return ""
+
+
+def backlight_paths():
+    dirs = sorted(glob.glob("/sys/class/backlight/*"))
+    if dirs:
+        return dirs[0]
+    return None
+
+
+def bl_set(value):
+    """value: 0..100 (percent)"""
+    global saved_brightness
+    bl = backlight_paths()
+    if not bl:
+        return False
+    try:
+        maxb = int(open(os.path.join(bl, "max_brightness")).read().strip())
+        if saved_brightness is None:
+            saved_brightness = int(open(os.path.join(bl, "brightness")).read().strip())
+        new = max(0, min(maxb, int(round(value / 100.0 * maxb))))
+        open(os.path.join(bl, "brightness"), "w").write(str(new))
+        return True
+    except Exception:
+        # try bl_power (0=on, 4=off commonly)
+        try:
+            open(os.path.join(bl, "bl_power"), "w").write("4" if value == 0 else "0")
+            return True
+        except Exception:
+            return False
+
+
+def hdmi_power(on: bool):
+    # Prefer vcgencmd; fallback to xset if DISPLAY set
+    if subprocess.run(["which", "vcgencmd"], stdout=subprocess.DEVNULL).returncode == 0:
+        sys(["vcgencmd", "display_power", "1" if on else "0"])
+        return True
+    if os.environ.get("DISPLAY"):
+        if on:
+            sys(["xset", "dpms", "force", "on"])
+        else:
+            sys(["xset", "dpms", "force", "off"])
+        return True
+    return False
+
+
+def screen_sleep():
+    global screen_state
+    if screen_state == "off":
+        return
+    # Try backlight first (silent if not present), then HDMI
+    bl_set(0)
+    hdmi_power(False)
+    screen_state = "off"
+
+
+def screen_wake():
+    global screen_state, saved_brightness
+    if screen_state == "on":
+        return
+    hdmi_power(True)
+    # restore brightness (or 70%)
+    if saved_brightness is not None and backlight_paths():
+        try:
+            open(os.path.join(backlight_paths(), "brightness"), "w").write(str(saved_brightness))
+        except Exception:
+            bl_set(70)
+    else:
+        bl_set(70)
+    screen_state = "on"
+
+
+def show(cmd):
+    global last_activity
+    mode = cmd.get("mode", "image")
+    src = cmd.get("src")
+    target = cmd.get("target", "mini")
+    _fit = cmd.get("fit", "contain")
+    if ROLE not in (target, "both"):
+        return
+    last_activity = time.time()
+    screen_wake()
+    if mode == "image":
+        subprocess.Popen(["feh", "-F", "-Z", "--auto-zoom", src])
+    elif mode == "video":
+        subprocess.Popen(["mpv", "--fs", src])
+    elif mode == "url":
+        subprocess.Popen(["chromium-browser", "--kiosk", src])
+
+
+def loop():
+    global last_activity
+    while True:
+        try:
+            cmds = api_get(f"/api/devices/{ID}/commands")
+            for c in cmds:
+                p = c.get("payload") or c
+                t = p.get("type", "")
+                if t == "display.show":
+                    show(p)
+                elif t == "display.clear":
+                    subprocess.call(["pkill", "-9", "feh", "mpv", "chromium-browser"])
+                elif t == "display.sleep":
+                    screen_sleep()
+                elif t == "display.wake":
+                    last_activity = time.time()
+                    screen_wake()
+                elif t == "display.brightness":
+                    v = int(p.get("value", 70))
+                    bl_set(max(0, min(100, v)))
+                    last_activity = time.time()
+        except Exception:
+            time.sleep(2)
+
+        # Idle auto-sleep
+        if (
+            SLEEP_MIN > 0
+            and screen_state == "on"
+            and (time.time() - last_activity) > (SLEEP_MIN * 60)
+        ):
+            screen_sleep()
+        time.sleep(2)
+
+
+if __name__ == "__main__":
+    loop()

--- a/srv/projects/blackroad-firefox-chat/extension/manifest.chrome.json
+++ b/srv/projects/blackroad-firefox-chat/extension/manifest.chrome.json
@@ -1,0 +1,22 @@
+{
+  "manifest_version": 3,
+  "name": "BlackRoad Chat",
+  "version": "1.0.0",
+  "description": "Local LLM chat (BlackRoad) — no cloud.",
+  "action": {
+    "default_title": "BlackRoad Chat",
+    "default_popup": "popup.html"
+  },
+  "background": { "service_worker": "sw.js", "type": "module" },
+  "permissions": ["storage", "activeTab", "contextMenus", "scripting"],
+  "host_permissions": ["https://blackroad.io/*"],
+  "icons": {
+    "16": "icons/16.png",
+    "32": "icons/32.png",
+    "48": "icons/48.png",
+    "128": "icons/128.png"
+  },
+  "content_security_policy": {
+    "extension_pages": "default-src 'self'; connect-src 'self' https://blackroad.io; img-src 'self' data:; style-src 'self' 'unsafe-inline'"
+  }
+}

--- a/srv/projects/blackroad-firefox-chat/extension/sw.js
+++ b/srv/projects/blackroad-firefox-chat/extension/sw.js
@@ -1,0 +1,34 @@
+// MV3 service worker (Chrome)
+chrome.runtime.onInstalled.addListener(() => {
+  try {
+    chrome.contextMenus.create({
+      id: 'ask-blackroad',
+      title: 'Ask BlackRoad about selection…',
+      contexts: ['selection'],
+    });
+  } catch (e) {}
+});
+
+chrome.contextMenus.onClicked.addListener(async (info, tab) => {
+  if (info.menuItemId === 'ask-blackroad' && info.selectionText) {
+    await chrome.storage.local.set({ pendingQuestion: info.selectionText });
+    // Chrome can't open the popup programmatically; open the page instead.
+    chrome.tabs.create({ url: chrome.runtime.getURL('popup.html') });
+  }
+});
+
+// (Optional) defensive block
+chrome.declarativeNetRequest.updateDynamicRules({
+  addRules: [
+    {
+      id: 1,
+      priority: 1,
+      action: { type: 'block' },
+      condition: {
+        urlFilter: '||openai.com',
+        resourceTypes: ['main_frame', 'xmlhttprequest'],
+      },
+    },
+  ],
+  removeRuleIds: [1],
+});

--- a/srv/projects/blackroad-firefox-chat/scripts/build-all.sh
+++ b/srv/projects/blackroad-firefox-chat/scripts/build-all.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEST="/var/www/blackroad/apps/blackroad-firefox-chat"
+mkdir -p "$DEST"
+# 1) Ensure icons (requires ImageMagick)
+bash "$ROOT/scripts/icons.sh" || echo "[warn] icons.sh failed; using whatever icons exist."
+# 2) Firefox XPI
+( cd "$ROOT/extension" && zip -r "$DEST/blackroad-chat.xpi" . -x '*.DS_Store' >/dev/null )
+# 3) Chrome ZIP (swap manifest)
+TMP="$(mktemp -d)"
+rsync -a "$ROOT/extension/" "$TMP/"
+cp "$TMP/manifest.chrome.json" "$TMP/manifest.json" 2>/dev/null || true
+zip -r "$DEST/blackroad-chat.zip" -j \
+  "$TMP/manifest.json" \
+  "$TMP"/{popup.html,popup.css,popup.js,background.js,sw.js} \
+  "$TMP"/icons/* >/dev/null
+rm -rf "$TMP"
+echo "Built:"
+echo "  $DEST/blackroad-chat.xpi  (Firefox)"
+echo "  $DEST/blackroad-chat.zip  (Chrome)"

--- a/srv/projects/blackroad-firefox-chat/scripts/icons.sh
+++ b/srv/projects/blackroad-firefox-chat/scripts/icons.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Requires: ImageMagick (convert)
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT="$ROOT/extension/icons"
+mkdir -p "$OUT"
+# Make clean brand squares w/ subtle corner text “BR”
+make_icon() {
+  local size="$1" color="$2" text="$3"
+  convert -size ${size}x${size} xc:"$color" \
+    -gravity southeast -pointsize $((size/6)) -fill white -annotate +6+4 "$text" \
+    -gravity center \( -size ${size}x${size} xc:none \
+      -fill "rgba(255,255,255,0.08)" -draw "roundrectangle 8,8,$((size-8)),$((size-8)),18,18" \) -compose over -composite \
+    "$OUT/${size}.png"
+}
+# Use brand accent-2 by default
+make_icon 16  "#0096FF" "BR"
+make_icon 32  "#0096FF" "BR"
+make_icon 48  "#0096FF" "BR"
+make_icon 128 "#0096FF" "BR"
+echo "Icons written to $OUT/"


### PR DESCRIPTION
## Summary
- add Chrome manifest and service worker for BlackRoad Chat extension
- include icon generator and build script for Firefox/Chrome bundles
- implement display agent with sleep, wake, and brightness controls

## Testing
- `SKIP=eslint pre-commit run --files srv/projects/blackroad-firefox-chat/extension/manifest.chrome.json srv/projects/blackroad-firefox-chat/extension/sw.js srv/projects/blackroad-firefox-chat/scripts/icons.sh srv/projects/blackroad-firefox-chat/scripts/build-all.sh srv/display-agent/display_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0d0e03c288329a1aeb425f4b2352e