### PR TITLE
feat: add Hilbert–Pólya GUE spacing check script

### DIFF
--- a/experiments/hilbert_polya_gue.py
+++ b/experiments/hilbert_polya_gue.py
@@ -1,0 +1,77 @@
+"""Hilbert–Pólya / GUE spacing test.
+
+This script compares normalized spacing distributions of the
+first `nzeros` nontrivial zeros of the Riemann zeta function and
+random Gaussian Unitary Ensemble (GUE) eigenvalues against the
+Wigner surmise.  It reports the Kolmogorov–Smirnov distance for
+both samples relative to the Wigner CDF.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+from typing import Callable
+
+import mpmath as mp
+import numpy as np
+
+
+def wigner_cdf(s: np.ndarray) -> np.ndarray:
+    """CDF of the Wigner surmise for the GUE."""
+    return np.vectorize(
+        lambda x: math.erf(2 * x / math.sqrt(math.pi))
+        - (4 * x / math.pi) * math.exp(-4 * x**2 / math.pi)
+    )(s)
+
+
+def ks_distance(sample: np.ndarray, cdf: Callable[[np.ndarray], np.ndarray]) -> float:
+    """Return the Kolmogorov–Smirnov distance between a sample and a CDF."""
+    x = np.sort(sample)
+    n = x.size
+    ecdf = np.arange(1, n + 1) / n
+    return float(np.max(np.abs(ecdf - cdf(x))))
+
+
+def riemann_zeros(n: int) -> np.ndarray:
+    """Return the imaginary parts of the first n Riemann zeta zeros."""
+    mp.mp.dps = 30
+    return np.array([float(mp.zetazero(k).imag) for k in range(1, n + 1)])
+
+
+def normalized_spacings(vals: np.ndarray) -> np.ndarray:
+    """Return consecutive spacings normalised to unit mean."""
+    diffs = np.diff(vals)
+    return diffs / np.mean(diffs)
+
+
+def gue_spacings(n: int, k: int) -> np.ndarray:
+    """Sample spacings from k random n×n GUE matrices."""
+    spacings: list[float] = []
+    for _ in range(k):
+        a = np.random.normal(size=(n, n)) + 1j * np.random.normal(size=(n, n))
+        h = (a + a.conj().T) / 2  # Hermitian
+        eigvals = np.linalg.eigvalsh(h)
+        spacings.extend(normalized_spacings(eigvals))
+    return np.array(spacings)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--nzeros", type=int, default=200, help="number of zeta zeros")
+    parser.add_argument("--gue_n", type=int, default=200, help="dimension of GUE matrix")
+    parser.add_argument("--gue_k", type=int, default=20, help="number of GUE samples")
+    args = parser.parse_args()
+
+    zero_spacings = normalized_spacings(riemann_zeros(args.nzeros))
+    gue_sample = gue_spacings(args.gue_n, args.gue_k)
+
+    ks_zero = ks_distance(zero_spacings, wigner_cdf)
+    ks_gue = ks_distance(gue_sample, wigner_cdf)
+
+    print(f"KS distance (zeros vs Wigner): {ks_zero:.4f}")
+    print(f"KS distance (GUE vs Wigner): {ks_gue:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ anthropic
 boto3
 fastapi
 matplotlib==3.9.4
+mpmath
 numpy==1.26.4
 openai==1.30.1
 pydantic


### PR DESCRIPTION
## Summary
- add mpmath dependency
- add Hilbert–Pólya GUE spacing comparison script

## Testing
- `pre-commit run --files experiments/hilbert_polya_gue.py requirements.txt`
- `pytest` *(fails: local/test_vectorization.py, modules/lucidia/test_portal.py, opt/blackroad/lucidia/tests/test_clfm_minimal.py, packages/lucidia_reason/tests/test_plan.py, packages/lucidia_reason/tests/test_trinary.py, services/lucidia_api/tests/test_health.py, srv/blackroad/examples/claude_smoke_test.py, srv/lucidia-llm/test_app.py, tests/random_fields/test_clfm_basic.py, tests/test_lucidia_infinity.py, tests/test_prime_explorer.py, tests/test_quantum_engine.py, tests/test_quantum_finance.py, tests/test_sine_wave_codex.py, tests/test_trinary_logic.py)*


------
https://chatgpt.com/codex/tasks/task_e_68c096e149f483298869ef4c59c04ae1