### PR TITLE
fix: flag deletions in allowed-writes gate

### DIFF
--- a/srv/blackroad-api/modules/jobs_locked.js
+++ b/srv/blackroad-api/modules/jobs_locked.js
@@ -88,6 +88,9 @@ function diffChanged(before, after){
     const b = before.get(k);
     if (!b || b!==v) changed.push(k);
   }
+  for (const k of before.keys()){
+    if (!after.has(k)) changed.push(k);
+  }
   return changed;
 }
 function passesAllowedWrites(changed, patterns){


### PR DESCRIPTION
## Summary
- include removals when diffing snapshots so destructive deletes outside allow-listed paths are caught by allowed-writes gate

## Testing
- `npm run lint` *(fails: A config object is using the "root" key, which is not supported in flat config system)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e867d11c8329ac61ad1e9d8c0f03