### PR TITLE
fix: avoid duplicate job spawn and add migrations

### DIFF
--- a/srv/blackroad-api/db_migrations/012_jobs_tables.sql
+++ b/srv/blackroad-api/db_migrations/012_jobs_tables.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS jobs (
+  job_id TEXT PRIMARY KEY,
+  project_id TEXT,
+  kind TEXT,
+  cmd TEXT,
+  args_json TEXT,
+  env_json TEXT,
+  status TEXT,
+  progress REAL DEFAULT 0,
+  exit_code INTEGER,
+  started_at INTEGER,
+  finished_at INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS job_events (
+  job_id TEXT,
+  seq INTEGER,
+  ts INTEGER,
+  type TEXT,
+  data TEXT,
+  PRIMARY KEY(job_id, seq)
+);

--- a/srv/blackroad-api/modules/jobs.js
+++ b/srv/blackroad-api/modules/jobs.js
@@ -117,8 +117,7 @@ module.exports = function attachJobs({ app }){
     return child;
   }
 
-  async function runSingle(job_id, cwd, cmd, args, env){
-    const child = spawnTracked(job_id, cmd, args, { cwd, env: { ...process.env, ...env }, shell:false });
+  async function runSingle(job_id, child){
     let lastPct = 0;
     child.stdout.on('data', async (buf)=>{
       const s = buf.toString();
@@ -263,7 +262,7 @@ module.exports = function attachJobs({ app }){
     } else {
       const child = spawnTracked(id, cmd, args, { cwd, env: { ...process.env, ...env }, shell:false });
       await run(d, `UPDATE jobs SET pid=? WHERE job_id=?`, [child.pid, id]);
-      runSingle(id, cwd, cmd, args, env); // handles close & LEDs
+      runSingle(id, child); // handles close & LEDs
     }
     return id;
   }


### PR DESCRIPTION
## Summary
- use the initially spawned process in `runSingle` to prevent duplicate job execution
- add migrations creating `jobs` and `job_events` tables

## Testing
- `npm test` *(fails: command not found: npm)*
- `npm run lint` *(fails: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e896ab648329b427d9631fbae00b