### PR TITLE
Handle missing getloadavg in /api/state

### DIFF
--- a/srv/aicodecloud/app.py
+++ b/srv/aicodecloud/app.py
@@ -1,6 +1,7 @@
-from flask import Flask, jsonify
-import time
 import os
+import time
+
+from flask import Flask
 
 app = Flask(__name__)
 _start_time = time.time()
@@ -10,7 +11,7 @@ def _system_state():
     uptime = time.time() - _start_time
     try:
         load1m = os.getloadavg()[0]
-    except OSError:
+    except (AttributeError, OSError):
         load1m = 0.0
     if load1m < 0.5:
         load_state = "calm"
@@ -20,6 +21,7 @@ def _system_state():
         load_state = "stressed"
     try:
         import psutil
+
         mem_percent = psutil.virtual_memory().percent
     except Exception:
         mem_percent = 0.0

--- a/tests/test_aicodecloud_state.py
+++ b/tests/test_aicodecloud_state.py
@@ -1,0 +1,15 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "srv"))
+from aicodecloud.app import app  # type: ignore
+
+
+def test_state_endpoint_handles_missing_getloadavg(monkeypatch):
+    monkeypatch.delattr(os, "getloadavg", raising=False)
+    with app.test_client() as client:
+        response = client.get("/api/state")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["load1m"] == 0.0


### PR DESCRIPTION
## Summary
- guard `/api/state` against missing `os.getloadavg`
- add regression test for systems without `getloadavg`

## Testing
- `pre-commit run --files srv/aicodecloud/app.py tests/test_aicodecloud_state.py`
- `pytest tests/test_aicodecloud_state.py`
- `pytest` *(fails: module import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e90a00a88329b03feb820ac63124