### PR TITLE
fix: support esm-only ipfs client

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "ethers": "^6.10.0",
     "bs58": "^5.0.0",
     "json-canonicalize": "^1.0.4",
-    "ipfs-http-client": "^60.0.0"
+    "ipfs-http-client": "^60.0.0",
+    "sqlite3": "^5.1.7"
   },
   "devDependencies": {
     "nodemon": "^3.0.2",

--- a/srv/blackroad-api/modules/truth_quorum.js
+++ b/srv/blackroad-api/modules/truth_quorum.js
@@ -1,7 +1,6 @@
 // Quorum subscriber + API: verifies PinAttestation messages and records quorum.
 // Env: TRUTH_TOPIC (default "truth.garden/v1/announce"), TRUTH_MAX_AGE_SEC (default 7d)
 //      QUORUM_TARGET (default 2) -> when reached, optional LED celebrate.
-const { create } = require('ipfs-http-client');
 const canonicalize = require('json-canonicalize');
 const bs58 = require('bs58');
 const sqlite3 = require('sqlite3').verbose();
@@ -85,6 +84,7 @@ async function celebrateIf(db, cid) {
 }
 
 module.exports = async function attachTruthQuorum({ app }) {
+  const { create } = await import('ipfs-http-client');
   const ipfs = create({ url: IPFS_API });
   const d = db();
 

--- a/srv/truth-subpin/truth_subpin_verify.js
+++ b/srv/truth-subpin/truth_subpin_verify.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 // Verified subpin + device attestation publisher.
-const { create } = require('ipfs-http-client');
 const canonicalize = require('json-canonicalize');
 const bs58 = require('bs58');
 const crypto = require('crypto');
@@ -44,7 +43,7 @@ function verify(o) {
   return true;
 }
 
-const ipfs = create({ url: API });
+let ipfs;
 const ident = ensureIdentity();
 
 async function publishAttestation(cid) {
@@ -62,6 +61,9 @@ async function publishAttestation(cid) {
 }
 
 (async () => {
+  const { create } = await import('ipfs-http-client');
+  ipfs = create({ url: API });
+
   console.log(
     '[subpin-verify] api=%s topic=%s DID=%s allow=%s',
     API,


### PR DESCRIPTION
## Summary
- dynamically import `ipfs-http-client` in quorum and subpin scripts
- add `sqlite3` runtime dependency for truth quorum module

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: A config object is using the "root" key, which is not supported in flat config system.)*


------
https://chatgpt.com/codex/tasks/task_e_68c0e955fcc8832981ef960496f420da