### PR TITLE
feat: add desktop-style agent windows

### DIFF
--- a/sites/blackroad/src/pages/Desktop.jsx
+++ b/sites/blackroad/src/pages/Desktop.jsx
@@ -50,10 +50,10 @@ function Window({ id, title, layout, setLayout, children }) {
       <div
         className="flex flex-col h-full bg-white border shadow-lg"
         role="dialog"
-        aria-label={title}
+        aria-labelledby={`${id}-title`}
       >
         <div className="flex items-center justify-between bg-neutral-800 text-white px-2 py-1 cursor-move">
-          <span className="text-sm flex items-center gap-1">
+          <span id={`${id}-title`} className="text-sm flex items-center gap-1">
             <span className="text-green-400">●</span>
             {title}
           </span>


### PR DESCRIPTION
## Summary
- identify each draggable window as a dialog and link its title with `aria-labelledby`
- add a visual pressed state for dock buttons so users can see which windows are active

## Testing
- `pre-commit run --files sites/blackroad/src/pages/Desktop.jsx`
- `npm test`
- `npm run lint` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npm --prefix sites/blackroad run lint`
- `npm --prefix sites/blackroad test`


------
https://chatgpt.com/codex/tasks/task_e_68c0ea94b3cc832981f1f9ce2939d7b0