### PR TITLE
fix: ensure display.clear terminates viewers individually

### DIFF
--- a/srv/display-agent/display_agent.py
+++ b/srv/display-agent/display_agent.py
@@ -130,7 +130,8 @@ def loop():
                 if t == "display.show":
                     show(p)
                 elif t == "display.clear":
-                    subprocess.call(["pkill", "-9", "feh", "mpv", "chromium-browser"])
+                    for proc in ("feh", "mpv", "chromium-browser"):
+                        subprocess.call(["pkill", "-9", proc])
                 elif t == "display.sleep":
                     screen_sleep()
                 elif t == "display.wake":


### PR DESCRIPTION
## Summary
- call `pkill` separately for `feh`, `mpv`, and `chromium-browser` in `display.clear`

## Testing
- `SKIP=eslint pre-commit run --files srv/display-agent/display_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0eba1e76883298d21efb660736dff