### PR TITLE
feat: add display sleep/wake control page

### DIFF
--- a/srv/blackroad-api/modules/partner_relay_mtls.js
+++ b/srv/blackroad-api/modules/partner_relay_mtls.js
@@ -17,7 +17,14 @@ module.exports = function attachPartnerRelay({ app }) {
   try { ORIGIN_KEY = fs.readFileSync(ORIGIN_KEY_PATH, 'utf8').trim(); } catch { console.warn('[partner] WARN: origin.key not found'); }
   try { if (!fs.existsSync(LOG_DIR)) fs.mkdirSync(LOG_DIR, {recursive:true}); } catch {}
 
-  const TYPES = new Set(['led.emotion','display.show','display.clear','fan.set']);
+  const TYPES = new Set([
+    'led.emotion',
+    'display.show',
+    'display.clear',
+    'display.sleep',
+    'display.wake',
+    'fan.set'
+  ]);
 
   function audit(obj){
     try { fs.appendFileSync(LOG_FILE, JSON.stringify(obj)+'\n'); } catch {}


### PR DESCRIPTION
## Summary
- add `display.sleep` and `display.wake` to partner relay allowlist

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: A config object is using the "root" key, which is not supported in flat config system.)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ebae385483299dde516bc1782b0c