### PR TITLE
fix: keep br-cleanup audit mode read-only

### DIFF
--- a/ops/scripts/br-cleanup.sh
+++ b/ops/scripts/br-cleanup.sh
@@ -84,6 +84,16 @@ npm_ci_if_needed(){
   fi
 }
 
+check_node_install(){
+  local dir="$1"
+  [[ -f "$dir/package.json" ]] || return 0
+  if [[ -d "$dir/node_modules" ]]; then
+    grn "✓ node_modules present in $dir"
+  else
+    ylw "• node_modules missing in $dir"
+  fi
+}
+
 audit(){
   sec "FILES & DIRECTORIES"
   check_file "$ORIGIN_KEY" || true
@@ -106,8 +116,8 @@ audit(){
   else ylw "• ss not found"; fi
 
   sec "NODE INSTALL CHECKS"
-  npm_ci_if_needed "$API_DIR"
-  npm_ci_if_needed "$YJS_DIR"
+  check_node_install "$API_DIR"
+  check_node_install "$YJS_DIR"
 
   sec "DATABASE HEALTH"
   if [[ -f "$API_DB" ]] && have sqlite3; then


### PR DESCRIPTION
## Summary
- avoid installing dependencies during `audit`
- check for missing `node_modules` without side effects

## Testing
- `pre-commit run --files ops/scripts/br-cleanup.sh ops/scripts/README.md`


------
https://chatgpt.com/codex/tasks/task_e_68c0ebb7cb3883299f42a3284f7b5d40