### PR TITLE
fix: allow normalize API before request guard

### DIFF
--- a/srv/blackroad-api/server_full.js
+++ b/srv/blackroad-api/server_full.js
@@ -153,6 +153,7 @@ fs.mkdirSync(path.dirname(DB_PATH), { recursive: true });
 // --- App & server
 const app = express();
 require('./modules/jsonEnvelope')(app);
+require('./modules/jsonify_proxy')({ app });
 require('./modules/requestGuard')(app);
 const server = http.createServer(app);
 const io = new SocketIOServer(server, {
@@ -165,7 +166,6 @@ const io = new SocketIOServer(server, {
 require('./modules/partner_relay_mtls')({ app });
 require('./modules/projects')({ app });
 require('./modules/pr_proxy')({ app });
-require('./modules/jsonify_proxy')({ app });
 
 const emitter = new EventEmitter();
 const jobs = new Map();


### PR DESCRIPTION
## Summary
- register `/api/normalize` proxy before request guard so web clients bypass auth

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: A config object is using the "root" key, which is not supported in flat config system)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ec25adfc83299d214c9968ce03d7