### PR TITLE
fix: exempt normalize endpoint from request guard

### DIFF
--- a/srv/blackroad-api/modules/requestGuard.js
+++ b/srv/blackroad-api/modules/requestGuard.js
@@ -3,13 +3,16 @@ const fs = require('fs');
 module.exports = function requestGuard(app){
   const keyPath = process.env.ORIGIN_KEY_PATH || '/srv/secrets/origin.key';
   let ORIGIN_KEY = ''; try { ORIGIN_KEY = fs.readFileSync(keyPath,'utf8').trim(); } catch {}
+  const SKIP = ['/api/normalize'];
   app.use((req,res,next)=>{
+    if (SKIP.includes(req.path)) return next();
     // parse JSON (small, safe)
     if (req.method !== 'GET' && (req.headers['content-type']||'').includes('application/json')) {
       let b=''; req.on('data',d=>b+=d); req.on('end',()=>{ try{ req.body = JSON.parse(b||'{}'); }catch{ req.body={}; } ; next(); });
     } else next();
   });
   app.use((req,res,next)=>{
+    if (SKIP.includes(req.path)) return next();
     const ip = req.socket.remoteAddress || '';
     if (ip.startsWith('127.') || ip==='::1') return next();
     const k = req.get('X-BlackRoad-Key') || '';


### PR DESCRIPTION
## Summary
- exempt `/api/normalize` from request guard so browsers can reach `br_jsond`

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: "root" key not supported in flat config)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ec2fb3548329ab0f34964610aa1d