### PR TITLE
feat: add roadchain portal

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -48,7 +48,7 @@ export default function App(){
 
   useEffect(() => { streamRef.current = stream }, [stream])
 
-  // Bootstrap authentication token from local storage
+  // Restore auth token from local storage on load
   useEffect(()=>{
     const token = localStorage.getItem('token')
     if (token) setToken(token)
@@ -61,7 +61,7 @@ export default function App(){
           connectSocket()
         }
       } catch(e){
-        // Reset state and log the failure
+        // Reset state on auth failure and log for debugging
         resetState()
         console.error('User not authenticated:', e)
       }

--- a/frontend/src/components/RoadChain.jsx
+++ b/frontend/src/components/RoadChain.jsx
@@ -14,13 +14,14 @@ export default function RoadChain(){
         const b = await fetchBlocks()
         setBlocks(b)
       }catch(e){
-        // Surface initial fetch issues so they aren't missed during debugging
+        // Log and display initial block fetch failures
         console.error('Failed to fetch initial blocks', e)
         setError('Failed to fetch initial blocks')
       }
     })()
   }, [])
 
+  // Clear stale search results when the query is empty or whitespace
   useEffect(() => {
     if (!query.trim()) {
       setResult(null)


### PR DESCRIPTION
## Summary
- refine auth bootstrap and error comments in the main app
- document search reset behavior and clarify block fetch errors in RoadChain explorer

## Testing
- `npm --prefix backend install`
- `npm --prefix backend test`
- `npm --prefix frontend install`
- `npm --prefix frontend test`
- `npm --prefix frontend run build`
- `curl -s http://localhost:4000/api/roadchain/blocks`
- `curl -s http://localhost:4000/api/roadchain/block/0xdef456`


------
https://chatgpt.com/codex/tasks/task_e_68c0f055900c832993ceded6ad412a62