### PR TITLE
Escape user content in lens UI to prevent XSS

### DIFF
--- a/var/www/blackroad/lenses.html
+++ b/var/www/blackroad/lenses.html
@@ -58,6 +58,8 @@ async function list(){
   sel.textContent='';
   arr.forEach(x=>{
     const opt=document.createElement('option');
+    // set both value and text via DOM APIs to avoid HTML injection
+    opt.value=x.lens_id;
     opt.textContent=x.lens_id;
     sel.appendChild(opt);
   });


### PR DESCRIPTION
## Summary
- use DOM APIs to assign option value and label safely for lens IDs

## Testing
- `npm test` *(jest: not found)*
- `npm run lint` *(A config object is using the "root" key, which is not supported in flat config system)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f4f04d648329b09770ace019dbb5