### PR TITLE
fix: propagate branch list errors in cleanup bot

### DIFF
--- a/agents/cleanup_bot.py
+++ b/agents/cleanup_bot.py
@@ -44,7 +44,7 @@ class CleanupBot:
             )
         except CalledProcessError as exc:
             logging.error("Failed to list merged branches: %s", exc)
-            return []
+            raise RuntimeError("Could not list merged branches") from exc
         branches: List[str] = []
         for line in result.stdout.splitlines():
             name = line.strip().lstrip("*").strip()
@@ -112,7 +112,11 @@ def main(argv: List[str] | None = None) -> int:
     # --- Logging setup ---
     logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(message)s")
 
-    bot = CleanupBot.from_merged(base=args.base, dry_run=args.dry_run)
+    try:
+        bot = CleanupBot.from_merged(base=args.base, dry_run=args.dry_run)
+    except RuntimeError as exc:
+        logging.error("%s", exc)
+        return 1
     if not bot.branches:
         logging.info("No merged branches to clean up.")
         return 0


### PR DESCRIPTION
## Summary
- raise a runtime error when `git branch --merged` fails
- exit with non-zero status if merged branch enumeration fails

## Testing
- `cd agents && python -m py_compile *.py && cd ..`
- `python agents/auto_novel_agent.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch'; ModuleNotFoundError: No module named 'sympy'; ImportError: No module named 'lucidia_reason'; ModuleNotFoundError: No module named 'anthropic'; ImportError: cannot import name 'app'; ModuleNotFoundError: No module named 'networkx'; ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_68c0f569dd488329b973e8a6d0e9d0ea