### PR TITLE
fix: lazily import ipfs client for truth API

### DIFF
--- a/srv/blackroad-api/modules/truth_api.js
+++ b/srv/blackroad-api/modules/truth_api.js
@@ -32,13 +32,14 @@ async function led(payload) {
   } catch {}
 }
 
-let ipfsClient;
-async function getIpfs() {
-  if (!ipfsClient) {
-    const { create } = await import('ipfs-http-client');
-    ipfsClient = create({ url: process.env.IPFS_API || 'http://127.0.0.1:5001' });
+let ipfsClientPromise;
+function getIpfs() {
+  if (!ipfsClientPromise) {
+    ipfsClientPromise = import('ipfs-http-client').then(({ create }) =>
+      create({ url: process.env.IPFS_API || 'http://127.0.0.1:5001' }),
+    );
   }
-  return ipfsClient;
+  return ipfsClientPromise;
 }
 
 module.exports = function attachTruthApi({ app }) {


### PR DESCRIPTION
## Summary
- cache the `ipfs-http-client` dynamic import in a promise to reuse the ESM client in the CommonJS server
- use the cached client in publish and attest routes

## Testing
- `npm run lint` *(fails: command not found: npm)*
- `npm test` *(fails: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f52dd714832992ec17bde6773669