### PR TITLE
Add interactive math labs and routes

### DIFF
--- a/sites/blackroad/src/App.jsx
+++ b/sites/blackroad/src/App.jsx
@@ -12,6 +12,9 @@ import InfinityMath from "./pages/InfinityMath.jsx";
 import Agents from "./pages/Agents.jsx";
 import Desktop from "./pages/Desktop.jsx";
 import QuantumConsciousness from "./pages/QuantumConsciousness.jsx";
+import OptimalTransportLab from "./pages/OptimalTransportLab.jsx";
+import BifurcationLab from "./pages/BifurcationLab.jsx";
+import ContinuedFractionsLab from "./pages/ContinuedFractionsLab.jsx";
 
 function useApiHealth(){
   const [state,setState]=useState({ok:null, info:""});
@@ -100,6 +103,9 @@ function LegacyApp(){
             <Route path="/subscribe" element={<Subscribe/>} />
             <Route path="/lucidia" element={<Lucidia/>} />
             <Route path="/math" element={<InfinityMath/>} />
+            <Route path="/ot" element={<OptimalTransportLab/>} />
+            <Route path="/bifurcate" element={<BifurcationLab/>} />
+            <Route path="/cfrac" element={<ContinuedFractionsLab/>} />
             <Route path="chat" element={<Chat/>} />
             <Route path="canvas" element={<Canvas/>} />
             <Route path="editor" element={<Editor/>} />
@@ -109,6 +115,9 @@ function LegacyApp(){
             <Route path="subscribe" element={<Subscribe/>} />
             <Route path="lucidia" element={<Lucidia/>} />
             <Route path="math" element={<InfinityMath/>} />
+            <Route path="ot" element={<OptimalTransportLab/>} />
+            <Route path="bifurcate" element={<BifurcationLab/>} />
+            <Route path="cfrac" element={<ContinuedFractionsLab/>} />
             <Route path="*" element={<div>Not found</div>} />
           </Routes>
         </section>

--- a/sites/blackroad/src/pages/BifurcationLab.jsx
+++ b/sites/blackroad/src/pages/BifurcationLab.jsx
@@ -1,0 +1,92 @@
+import { useMemo, useState } from "react";
+
+function simulate(r, iters=1200, burn=200, x0=0.123456){
+  let x = x0;
+  const pts=[];
+  for(let i=0;i<iters;i++){
+    x = r*x*(1-x);
+    if(i>=burn) pts.push(x);
+  }
+  return pts;
+}
+function lyapunov(r, iters=2000, burn=500, x0=0.123456){
+  let x=x0, s=0;
+  for(let i=0;i<iters;i++){
+    x = r*x*(1-x);
+    if(i>=burn){
+      const der = Math.abs(r*(1-2*x));
+      s += Math.log(der + 1e-12);
+    }
+  }
+  return s/(iters-burn);
+}
+
+export default function BifurcationLab(){
+  const [rMin,setRMin] = useState(2.5);
+  const [rMax,setRMax] = useState(4.0);
+  const [cols,setCols] = useState(400);
+
+  const data = useMemo(()=>{
+    const arr=[];
+    for(let j=0;j<cols;j++){
+      const r = rMin + (rMax-rMin)*j/(cols-1);
+      const ys = simulate(r);
+      arr.push({r, ys, lyap: lyapunov(r)});
+    }
+    return arr;
+  },[rMin,rMax,cols]);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">Logistic Map — Bifurcation & Lyapunov</h2>
+      <div className="grid" style={{gridTemplateColumns:'1fr 280px', gap:16}}>
+        <BifurcationPlot data={data}/>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <h3 className="font-semibold mb-2">Controls</h3>
+          <Slider label="r min" v={rMin} set={setRMin} min={2.5} max={4.0} step={0.01}/>
+          <Slider label="r max" v={rMax} set={setRMax} min={2.5} max={4.0} step={0.01}/>
+          <Slider label="columns" v={cols} set={setCols} min={150} max={1000} step={50}/>
+          <p className="text-sm opacity-80 mt-2">Lyapunov &gt; 0 ≈ chaos.</p>
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function Slider({label,v,set,min,max,step}){
+  return (
+    <div className="mb-2">
+      <label className="text-sm opacity-80">{label}: <b>{v.toFixed(3)}</b></label>
+      <input className="w-full" type="range" min={min} max={max} step={step}
+             value={v} onChange={e=>set(parseFloat(e.target.value))}/>
+    </div>
+  );
+}
+
+function BifurcationPlot({data}){
+  const W=640, H=360, pad=8;
+  const xScale = (r, rMin=data[0].r, rMax=data[data.length-1].r)=>
+      pad + (W-2*pad)*(r-rMin)/(rMax-rMin);
+  return (
+    <svg width="100%" viewBox={`0 0 ${W} ${H}`}>
+      <rect x="0" y="0" width={W} height={H} fill="none" />
+      {data.map((col, j)=>(
+        <g key={j} opacity={0.8}>
+          {col.ys.map((y,i)=>{
+            const x = xScale(col.r);
+            const ypix = (H-2*pad)*(1-y)+pad;
+            return <circle key={i} cx={x} cy={ypix} r={0.25} />;
+          })}
+          {/* Lyapunov color bar along bottom */}
+          {(()=>{
+            const yb = H-2; const x = xScale(col.r); const w=(W-16)/data.length;
+            const l = col.lyap; // color by sign
+            const alpha = Math.min(1, Math.abs(l)*3);
+            const fill = l>0 ? `rgba(255,0,0,${alpha})` : `rgba(0,0,255,${alpha})`;
+            return <rect x={x} y={yb} width={w} height={2} style={{fill}} />;
+          })()}
+        </g>
+      ))}
+    </svg>
+  );
+}

--- a/sites/blackroad/src/pages/ContinuedFractionsLab.jsx
+++ b/sites/blackroad/src/pages/ContinuedFractionsLab.jsx
@@ -1,0 +1,93 @@
+import { useMemo, useState } from "react";
+
+function cfrac(x, maxK=12){
+  // simple continued fraction expansion
+  const a=[]; let y=x;
+  for(let k=0;k<maxK;k++){
+    const ak = Math.floor(y);
+    a.push(ak);
+    const frac = y-ak;
+    if(frac < 1e-12) break;
+    y = 1/frac;
+  }
+  return a;
+}
+function convergents(a){
+  // build p/q from continued fraction coefficients
+  const res=[];
+  let p0=1, q0=0, p1=a[0], q1=1;
+  res.push({p:p1,q:q1});
+  for(let k=1;k<a.length;k++){
+    const ak = a[k];
+    const p = ak*p1 + p0;
+    const q = ak*q1 + q0;
+    res.push({p,q});
+    p0=p1; q0=q1; p1=p; q1=q;
+  }
+  return res;
+}
+
+export default function ContinuedFractionsLab(){
+  const [val,setVal] = useState(Math.PI);
+  const [maxK,setMaxK] = useState(12);
+
+  const a = useMemo(()=>cfrac(val, maxK),[val,maxK]);
+  const conv = useMemo(()=>convergents(a),[a]);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">Continued Fractions — Best Rational Approximations</h2>
+      <div className="grid" style={{gridTemplateColumns:"1fr 320px", gap:16}}>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <table className="w-full text-sm">
+            <thead><tr className="opacity-80">
+              <th className="text-left">k</th><th className="text-left">p/q</th><th className="text-left">value</th><th className="text-left">|x−p/q|</th>
+            </tr></thead>
+            <tbody>
+              {conv.map((c,i)=>{
+                const valpq = c.p/c.q;
+                const err = Math.abs(val - valpq);
+                return (
+                  <tr key={i}>
+                    <td>{i}</td>
+                    <td>{c.p}/{c.q}</td>
+                    <td>{valpq.toPrecision(10)}</td>
+                    <td>{err.toExponential(3)}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </section>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <h3 className="font-semibold mb-2">Controls</h3>
+          <Num label="x" v={val} set={setVal}/>
+          <Slider label="max terms" v={maxK} set={setMaxK} min={3} max={24} step={1}/>
+          <p className="text-sm opacity-80 mt-2">
+            Try φ≈1.61803398875 or √2≈1.41421356237 or π≈3.1415926535.
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function Num({label,v,set}){
+  return (
+    <div className="mb-2">
+      <label className="text-sm opacity-80">{label}: </label>
+      <input className="w-full p-2 rounded bg-white/10 border border-white/10"
+             type="text" value={v}
+             onChange={e=>set(parseFloat(e.target.value)||0)} />
+    </div>
+  );
+}
+function Slider({label,v,set,min,max,step}){
+  return (
+    <div className="mb-2">
+      <label className="text-sm opacity-80">{label}: <b>{v}</b></label>
+      <input className="w-full" type="range" min={min} max={max} step={step}
+             value={v} onChange={e=>set(parseInt(e.target.value))}/>
+    </div>
+  );
+}

--- a/sites/blackroad/src/pages/OptimalTransportLab.jsx
+++ b/sites/blackroad/src/pages/OptimalTransportLab.jsx
@@ -1,0 +1,141 @@
+import { useMemo, useState } from "react";
+
+function clamp01(x){ return Math.max(0, Math.min(1, x)); }
+function linspace(n){ return Array.from({length:n}, (_,i)=>i/(n-1)); }
+function normalize(arr){
+  const s = arr.reduce((a,b)=>a+b,0) || 1;
+  return arr.map(x=>x/s);
+}
+function cdf(pdf){
+  let s=0; return pdf.map(x=>{ s+=x; return s; });
+}
+function w1(pdfA, pdfB){
+  // W1 in 1D = integral |CDF_A - CDF_B|
+  const CA = cdf(pdfA), CB = cdf(pdfB);
+  const n = CA.length;
+  let area = 0;
+  for (let i=1;i<n;i++){
+    const dx = 1/(n-1);
+    const y0 = Math.abs(CA[i-1]-CB[i-1]);
+    const y1 = Math.abs(CA[i]-CB[i]);
+    area += 0.5*(y0+y1)*dx; // trapezoid
+  }
+  return area;
+}
+function lerp(a,b,t){ return a + (b-a)*t; }
+
+export default function OptimalTransportLab(){
+  const [nBins,setNBins] = useState(64);
+  const [spreadA,setSpreadA] = useState(0.08);
+  const [centerA,setCenterA] = useState(0.30);
+  const [spreadB,setSpreadB] = useState(0.08);
+  const [centerB,setCenterB] = useState(0.70);
+  const [t,setT] = useState(0.5);
+
+  const x = useMemo(()=>linspace(nBins),[nBins]);
+
+  // Make two Gaussians (truncated) then normalize to PDFs
+  const pdfA = useMemo(()=>{
+    const s2 = spreadA*spreadA + 1e-9;
+    const arr = x.map(u=>Math.exp(-(u-centerA)*(u-centerA)/(2*s2)));
+    return normalize(arr);
+  },[x,centerA,spreadA]);
+
+  const pdfB = useMemo(()=>{
+    const s2 = spreadB*spreadB + 1e-9;
+    const arr = x.map(u=>Math.exp(-(u-centerB)*(u-centerB)/(2*s2)));
+    return normalize(arr);
+  },[x,centerB,spreadB]);
+
+  // Monge 1-D interpolation: shift mass along quantiles ⇒ CDF⁻¹( (1−t)·p + t·q ) 
+  // Implementation trick: construct a transport map by matching cumulative mass.
+  const interp = useMemo(()=>{
+    const CA = cdf(pdfA), CB = cdf(pdfB);
+    // Build inverse CDFs (quantile functions)
+    const invCdf = (C) => (q)=>{
+      // binary search over grid to find smallest u with C(u) >= q
+      let lo=0, hi=C.length-1;
+      while(lo<hi){
+        const mid=(lo+hi)>>1;
+        if(C[mid] >= q) hi=mid; else lo=mid+1;
+      }
+      return lo/(C.length-1);
+    };
+    const QA = invCdf(CA), QB = invCdf(CB);
+
+    // Displacement interpolation in 1-D: x_t(q) = (1−t)*QA(q) + t*QB(q)
+    // Then pushforward uniform q ∈ [0,1] through x_t to make a histogram.
+    const NB = x.length;
+    const counts = new Array(NB).fill(0);
+    const samples = 2048;
+    for(let i=0;i<samples;i++){
+      const q = (i+0.5)/samples;
+      const pos = lerp(QA(q), QB(q), t);
+      const bin = Math.max(0, Math.min(NB-1, Math.round(pos*(NB-1))));
+      counts[bin] += 1;
+    }
+    return normalize(counts);
+  },[pdfA,pdfB,x,t]);
+
+  const dist = useMemo(()=>w1(pdfA, pdfB),[pdfA,pdfB]);
+
+  return (
+    <div className="p-4 space-y-4">
+      <h2 className="text-xl font-semibold">Optimal Transport Lab — 1D Wasserstein-1</h2>
+      <p className="opacity-80 text-sm">
+        W<sub>1</sub>(A,B) ≈ {dist.toFixed(4)} (area between CDFs). The middle plot is the displacement geodesic PDF at t.
+      </p>
+
+      <Controls label="Bins" v={nBins} set={setNBins} min={16} max={256} step={16}/>
+      <div className="grid" style={{gridTemplateColumns:'repeat(auto-fit,minmax(280px,1fr))',gap:16}}>
+        <Panel title="Source A">
+          <Controls label="Center A" v={centerA} set={setCenterA} min={0.0} max={1.0} step={0.01}/>
+          <Controls label="Spread A" v={spreadA} set={setSpreadA} min={0.02} max={0.25} step={0.01}/>
+          <BarChart xs={x} ys={pdfA}/>
+        </Panel>
+        <Panel title="Geodesic at t">
+          <Controls label="t" v={t} set={setT} min={0.0} max={1.0} step={0.01}/>
+          <BarChart xs={x} ys={interp}/>
+        </Panel>
+        <Panel title="Target B">
+          <Controls label="Center B" v={centerB} set={setCenterB} min={0.0} max={1.0} step={0.01}/>
+          <Controls label="Spread B" v={spreadB} set={setSpreadB} min={0.02} max={0.25} step={0.01}/>
+          <BarChart xs={x} ys={pdfB}/>
+        </Panel>
+      </div>
+    </div>
+  );
+}
+
+function Panel({title,children}){
+  return (
+    <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+      <h3 className="font-semibold mb-2">{title}</h3>
+      {children}
+    </section>
+  );
+}
+function Controls({label,v,set,min,max,step}){
+  return (
+    <div className="mb-2">
+      <label className="text-sm opacity-80">{label}: <b>{typeof v==='number'?v.toFixed(3):v}</b></label>
+      <input type="range" className="w-full" min={min} max={max} step={step} value={v}
+             onChange={e=>set(parseFloat(e.target.value))}/>
+    </div>
+  );
+}
+function BarChart({xs,ys}){
+  // Simple SVG columns
+  const W=320, H=120, pad=8;
+  return (
+    <svg width="100%" viewBox={`0 0 ${W} ${H}`}>
+      <rect x="0" y="0" width={W} height={H} fill="none" />
+      {ys.map((y,i)=>{
+        const x = pad + i*( (W-2*pad)/ys.length );
+        const w = (W-2*pad)/ys.length * 0.95;
+        const h = (H-2*pad)*y;
+        return <rect key={i} x={x} y={H-pad-h} width={w} height={h} rx="2" ry="2" />;
+      })}
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- add OptimalTransportLab for visualizing 1D Wasserstein distance and geodesic interpolation
- include BifurcationLab to explore logistic map bifurcations and Lyapunov exponents
- add ContinuedFractionsLab showing best rational approximations and wire all labs to routes

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: A config object is using the "root" key, which is not supported in flat config system)*
- `npm --prefix sites/blackroad run lint`
- `npm --prefix sites/blackroad test`

------
https://chatgpt.com/codex/tasks/task_e_68c100a1da6c832997baaf06244a8065