### PR TITLE
fix: migrate ESLint config to flat format

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,7 +1,0 @@
-module.exports = {
-  root: true,
-  env: { node: true, es2022: true, jest: true },
-  extends: ['eslint:recommended'],
-  parserOptions: { ecmaVersion: 2022, sourceType: 'commonjs' },
-  rules: {},
-};

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,24 @@
+const js = require('@eslint/js');
+
+module.exports = [
+  js.configs.recommended,
+  {
+    files: ['srv/blackroad-api/server_full.js', 'tests/api_health.test.js'],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'commonjs',
+      globals: {
+        require: 'readonly',
+        module: 'readonly',
+        __dirname: 'readonly',
+        process: 'readonly',
+        describe: 'readonly',
+        test: 'readonly',
+        expect: 'readonly',
+        beforeAll: 'readonly',
+        afterAll: 'readonly',
+      },
+    },
+    rules: {},
+  },
+];

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "nodemon srv/blackroad-api/server_full.js",
     "seed": "node scripts/seed_admin.js",
     "prepare": "husky",
-    "lint": "eslint --config .eslintrc.cjs srv/blackroad-api/server_full.js tests/api_health.test.js",
+    "lint": "eslint srv/blackroad-api/server_full.js tests/api_health.test.js",
     "format": "prettier . --write",
     "format:check": "prettier package.json tests/api_health.test.js srv/lucidia-llm/test_app.py var/www/blackroad/.prettierrc.json .prettierrc.json RUNME.sh Makefile .github/workflows/ci.yml CLEANUP_PLAN.md CLEANUP_DECISIONS.md CLEANUP_RESULTS.md ROLLBACK.md CHANGELOG.md --check --ignore-unknown",
     "test": "jest tests/api_health.test.js",
@@ -54,7 +54,7 @@
     "husky": "^9.0.10",
     "lint-staged": "^15.2.7"
   },
-  "lint-staged": {
+    "lint-staged": {
     "*.{js,jsx,mjs,cjs,ts,tsx}": [
       "eslint --fix",
       "prettier -w"


### PR DESCRIPTION
## Summary
- switch to `eslint.config.js` for flat-config support
- update lint script to use new config

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f903acf083298f19e7bca4425082