### PR TITLE
feat(math-labs): add prime gaps, farey tree, fourier pages

### DIFF
--- a/sites/blackroad/src/App.jsx
+++ b/sites/blackroad/src/App.jsx
@@ -12,6 +12,9 @@ import InfinityMath from "./pages/InfinityMath.jsx";
 import Agents from "./pages/Agents.jsx";
 import Desktop from "./pages/Desktop.jsx";
 import QuantumConsciousness from "./pages/QuantumConsciousness.jsx";
+import PrimeGapsLab from "./pages/PrimeGapsLab.jsx";
+import FareyTreeLab from "./pages/FareyTreeLab.jsx";
+import FourierLab from "./pages/FourierLab.jsx";
 
 function useApiHealth(){
   const [state,setState]=useState({ok:null, info:""});
@@ -100,6 +103,9 @@ function LegacyApp(){
             <Route path="/subscribe" element={<Subscribe/>} />
             <Route path="/lucidia" element={<Lucidia/>} />
             <Route path="/math" element={<InfinityMath/>} />
+            <Route path="/primes" element={<PrimeGapsLab/>} />
+            <Route path="/farey" element={<FareyTreeLab/>} />
+            <Route path="/fourier" element={<FourierLab/>} />
             <Route path="chat" element={<Chat/>} />
             <Route path="canvas" element={<Canvas/>} />
             <Route path="editor" element={<Editor/>} />
@@ -109,6 +115,9 @@ function LegacyApp(){
             <Route path="subscribe" element={<Subscribe/>} />
             <Route path="lucidia" element={<Lucidia/>} />
             <Route path="math" element={<InfinityMath/>} />
+            <Route path="primes" element={<PrimeGapsLab/>} />
+            <Route path="farey" element={<FareyTreeLab/>} />
+            <Route path="fourier" element={<FourierLab/>} />
             <Route path="*" element={<div>Not found</div>} />
           </Routes>
         </section>

--- a/sites/blackroad/src/pages/FareyTreeLab.jsx
+++ b/sites/blackroad/src/pages/FareyTreeLab.jsx
@@ -1,0 +1,81 @@
+import { useMemo, useState } from "react";
+
+/* Stern–Brocot via mediants; depth-limited binary tree between 0/1 and 1/1 */
+function buildSB(depth){
+  const nodes=[{p:0,q:1,label:"0/1",x:0},{p:1,q:1,label:"1/1",x:1}];
+  // store edges and new nodes per level
+  for(let d=0; d<depth; d++){
+    const next=[];
+    for(let i=0;i<nodes.length-1;i++){
+      const a=nodes[i], b=nodes[i+1];
+      const p=a.p+b.p, q=a.q+b.q;
+      const x=(a.x+b.x)/2;
+      next.push(a, {p,q,label:`${p}/${q}`,x}, b);
+    }
+    // dedupe consecutive duplicates
+    const merged=[next[0]];
+    for(let k=1;k<next.length;k++){
+      const prev=merged[merged.length-1], cur=next[k];
+      if(!(prev.p===cur.p && prev.q===cur.q)) merged.push(cur);
+    }
+    nodes.length=0; nodes.push(...merged);
+  }
+  return nodes;
+}
+
+export default function FareyTreeLab(){
+  const [depth,setDepth]=useState(6);
+  const nodes = useMemo(()=>buildSB(depth),[depth]);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">Farey / Stern–Brocot Tree</h2>
+      <Controls label="depth" v={depth} set={setDepth} min={1} max={10} step={1}/>
+      <Tree nodes={nodes}/>
+      <Table nodes={nodes.slice(0,80)}/>
+      <p className="text-sm opacity-80">
+        Every positive rational appears exactly once. Mediants <code>(a+c)/(b+d)</code> sit between <code>a/b</code> and <code>c/d</code>.
+      </p>
+    </div>
+  );
+}
+
+function Controls({label,v,set,min,max,step}){
+  return (
+    <div className="mb-1">
+      <label className="text-sm opacity-80">{label}: <b>{v}</b></label>
+      <input className="w-full" type="range" min={min} max={max} step={step}
+        value={v} onChange={e=>set(parseInt(e.target.value))}/>
+    </div>
+  );
+}
+
+function Tree({nodes}){
+  const W=640,H=160,pad=14;
+  const Y = d=>{
+    // rough level by denominator magnitude (log-ish)
+    const q= d.q; return H - pad - Math.log2(q+1)/(Math.log2(64))*(H-2*pad);
+  };
+  return (
+    <svg width="100%" viewBox={`0 0 ${W} ${H}`}>
+      <line x1={pad} y1={H-pad} x2={W-pad} y2={H-pad}/>
+      {nodes.map((n,i)=>{
+        const x = pad + n.x*(W-2*pad), y = Y(n);
+        return <g key={i}>
+          <circle cx={x} cy={y} r="3"/>
+          <text x={x+4} y={y-4} fontSize="9">{n.label}</text>
+        </g>;
+      })}
+    </svg>
+  );
+}
+function Table({nodes}){
+  return (
+    <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+      <h3 className="font-semibold mb-2">First fractions</h3>
+      <div className="text-xs" style={{columnCount:3, columnGap:16}}>
+        {nodes.map((n,i)=><div key={i}>{n.label}</div>)}
+      </div>
+    </section>
+  );
+}

--- a/sites/blackroad/src/pages/FourierLab.jsx
+++ b/sites/blackroad/src/pages/FourierLab.jsx
@@ -1,0 +1,137 @@
+import { useMemo, useState } from "react";
+
+/* naive DFT for clarity (O(N^2)) */
+function dft(x){
+  const N = x.length; const re=[], im=[];
+  for(let k=0;k<N;k++){
+    let rk=0, ik=0;
+    for(let n=0;n<N;n++){
+      const ang = -2*Math.PI*k*n/N;
+      rk += x[n]*Math.cos(ang);
+      ik += x[n]*Math.sin(ang);
+    }
+    re.push(rk); im.push(ik);
+  }
+  return {re, im, mag: re.map((r,i)=>Math.hypot(r,im[i]))};
+}
+function linspace(N){ return Array.from({length:N},(_,i)=>i/N); }
+function mkSignal(N, comps){
+  const t=linspace(N); const y=new Array(N).fill(0);
+  for(const c of comps){
+    for(let n=0;n<N;n++){
+      y[n]+= c.amp * Math.sin(2*Math.PI*(c.freq*t[n] + c.phase));
+    }
+  }
+  return y;
+}
+function conv(a,b){
+  const N=a.length, M=b.length, y=new Array(N+M-1).fill(0);
+  for(let i=0;i<N;i++) for(let j=0;j<M;j++) y[i+j]+=a[i]*b[j];
+  return y;
+}
+
+export default function FourierLab(){
+  const [N,setN]=useState(128);
+  const [a1,setA1]=useState(1.0), [f1,setF1]=useState(3), [p1,setP1]=useState(0.0);
+  const [a2,setA2]=useState(0.7), [f2,setF2]=useState(7), [p2,setP2]=useState(0.0);
+  const [kernel,setKernel]=useState(5);
+
+  const x = useMemo(()=> mkSignal(N, [
+    {amp:a1, freq:f1, phase:p1},
+    {amp:a2, freq:f2, phase:p2},
+  ]),[N,a1,f1,p1,a2,f2,p2]);
+
+  const k = useMemo(()=>{
+    // simple box or triangular kernel
+    const L = Math.max(1,kernel|0);
+    const arr = Array(L).fill(1/L);
+    return arr;
+  },[kernel]);
+
+  const y = useMemo(()=>conv(x,k),[x,k]);
+  const X = useMemo(()=>dft(x),[x]);
+  const Y = useMemo(()=>dft(y.slice(0,N)),[y,N]);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">Fourier & Convolution Playground</h2>
+      <div className="grid" style={{gridTemplateColumns:'repeat(auto-fit,minmax(280px,1fr))', gap:16}}>
+        <Panel title="Signal x[n]">
+          <SignalPlot y={x}/>
+          <Controls label="N" v={N} set={setN} min={64} max={512} step={64}/>
+          <h4 className="font-semibold mt-2 text-sm">Component 1</h4>
+          <Slider label="amp" v={a1} set={setA1} min={0} max={2} step={0.01}/>
+          <Slider label="freq" v={f1} set={setF1} min={1} max={20} step={1}/>
+          <Slider label="phase" v={p1} set={setP1} min={0} max={1} step={0.01}/>
+          <h4 className="font-semibold mt-2 text-sm">Component 2</h4>
+          <Slider label="amp" v={a2} set={setA2} min={0} max={2} step={0.01}/>
+          <Slider label="freq" v={f2} set={setF2} min={1} max={20} step={1}/>
+          <Slider label="phase" v={p2} set={setP2} min={0} max={1} step={0.01}/>
+        </Panel>
+        <Panel title="Convolution y = x * h">
+          <SignalPlot y={y}/>
+          <Slider label="kernel length" v={kernel} set={setKernel} min={3} max={33} step={2}/>
+        </Panel>
+        <Panel title="|DFT(x)| vs |DFT(y)|">
+          <SpectrumPlot X={X.mag} Y={Y.mag}/>
+          <p className="text-xs opacity-80 mt-2">Convolution in time ≈ multiplication in frequency (smoothing shrinks high-freqs).</p>
+        </Panel>
+      </div>
+    </div>
+  );
+}
+
+function Panel({title,children}){
+  return <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+    <h3 className="font-semibold mb-2">{title}</h3>{children}
+  </section>;
+}
+function Controls(props){ return <Slider {...props}/>; }
+function Slider({label,v,set,min,max,step}){
+  const show = typeof v==='number' && v.toFixed ? v.toFixed(3) : v;
+  return (
+    <div className="mb-1">
+      <label className="text-sm opacity-80">{label}: <b>{show}</b></label>
+      <input className="w-full" type="range" min={min} max={max} step={step}
+             value={v} onChange={e=>set(parseFloat(e.target.value))}/>
+    </div>
+  );
+}
+function SignalPlot({y}){
+  const W=620,H=160,pad=10;
+  const N=y.length;
+  const X=i=> pad + (i/(N-1))*(W-2*pad);
+  const Y=v=> H-pad - ((v - Math.min(...y))/(Math.max(...y)-Math.min(...y)+1e-9))*(H-2*pad);
+  return (
+    <svg width="100%" viewBox={`0 0 ${W} ${H}`}>
+      <rect x="0" y="0" width={W} height={H} fill="none"/>
+      {y.map((v,i)=>{
+        const x1 = i? X(i-1): X(i), y1 = i? Y(y[i-1]): Y(v);
+        const x2 = X(i), y2 = Y(v);
+        return <line key={i} x1={x1} y1={y1} x2={x2} y2={y2} strokeWidth="2"/>;
+      })}
+    </svg>
+  );
+}
+function SpectrumPlot({X,Y}){
+  const W=620,H=160,pad=10;
+  const N=X.length;
+  const maxVal = Math.max(...X, ...Y, 1e-9);
+  return (
+    <svg width="100%" viewBox={`0 0 ${W} ${H}`}>
+      <rect x="0" y="0" width={W} height={H} fill="none"/>
+      {X.map((v,i)=>{
+        const x = pad + i*( (W-2*pad)/N );
+        const w = (W-2*pad)/N * 0.45;
+        const h = (H-2*pad)*v/maxVal;
+        return <rect key={`x${i}`} x={x} y={H-pad-h} width={w} height={h} rx="1" ry="1"/>;
+      })}
+      {Y.map((v,i)=>{
+        const x = pad + i*( (W-2*pad)/N ) + ((W-2*pad)/N)*0.5;
+        const w = (W-2*pad)/N * 0.45;
+        const h = (H-2*pad)*v/maxVal;
+        return <rect key={`y${i}`} x={x} y={H-pad-h} width={w} height={h} rx="1" ry="1"/>;
+      })}
+    </svg>
+  );
+}

--- a/sites/blackroad/src/pages/PrimeGapsLab.jsx
+++ b/sites/blackroad/src/pages/PrimeGapsLab.jsx
@@ -1,0 +1,115 @@
+import { useMemo, useState } from "react";
+
+/* -------- helpers -------- */
+function sieve(n){
+  const isPrime = Array(n+1).fill(true);
+  isPrime[0]=isPrime[1]=false;
+  for(let p=2;p*p<=n;p++){
+    if(isPrime[p]){
+      for(let k=p*p;k<=n;k+=p) isPrime[k]=false;
+    }
+  }
+  const primes=[];
+  for(let i=2;i<=n;i++) if(isPrime[i]) primes.push(i);
+  return primes;
+}
+function gaps(primes){
+  const gs=[];
+  for(let i=1;i<primes.length;i++) gs.push(primes[i]-primes[i-1]);
+  return gs;
+}
+
+export default function PrimeGapsLab(){
+  const [limit,setLimit]=useState(20000);
+  const [bins,setBins]=useState(60);
+
+  const {pr, gp, maxGap, hist} = useMemo(()=>{
+    const pr = sieve(limit);
+    const gp = gaps(pr);
+    const maxGap = gp.length? Math.max(...gp) : 0;
+
+    // histogram up to a reasonable max
+    const gMax = Math.max(10, Math.min(maxGap, 200));
+    const H = Array(bins).fill(0);
+    for(const g of gp){
+      const idx = Math.min(bins-1, Math.floor((g/gMax)*bins));
+      H[idx]+=1;
+    }
+    const total = H.reduce((a,b)=>a+b,0)||1;
+    const hist = H.map(x=>x/total);
+    return {pr, gp, maxGap, hist, gMax};
+  },[limit,bins]);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">Prime Gaps Explorer</h2>
+      <Controls label="limit" v={limit} set={setLimit} min={1000} max={200000} step={1000}/>
+      <Controls label="bins" v={bins} set={setBins} min={20} max={120} step={5}/>
+      <div className="grid" style={{gridTemplateColumns:'repeat(auto-fit,minmax(280px,1fr))', gap:16}}>
+        <Panel title={`Primes ≤ ${limit} (count=${pr.length})`}>
+          <SmallText text={pr.slice(0,64).join(", ") + (pr.length>64?" …":"")}/>
+        </Panel>
+        <Panel title={`Gap histogram (max gap ≈ ${maxGap})`}>
+          <Hist hist={hist}/>
+        </Panel>
+        <Panel title="Max gap vs index">
+          <MaxGapPlot gp={gp}/>
+        </Panel>
+      </div>
+      <p className="text-sm opacity-80">
+        Observe average gap ~ log n, but local gaps fluctuate wildly; large gaps appear near big n.
+      </p>
+    </div>
+  );
+}
+
+function Controls({label,v,set,min,max,step}){
+  return (
+    <div className="mb-1">
+      <label className="text-sm opacity-80">{label}: <b>{v}</b></label>
+      <input className="w-full" type="range" min={min} max={max} step={step}
+             value={v} onChange={e=>set(parseInt(e.target.value))}/>
+    </div>
+  );
+}
+function Panel({title,children}){
+  return <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+    <h3 className="font-semibold mb-2">{title}</h3>{children}
+  </section>;
+}
+function SmallText({text}){ return <div className="text-xs break-words">{text}</div>; }
+
+function Hist({hist}){
+  const W=320,H=140,pad=8;
+  const n=hist.length;
+  return (
+    <svg width="100%" viewBox={`0 0 ${W} ${H}`}>
+      <rect x="0" y="0" width={W} height={H} fill="none"/>
+      {hist.map((v,i)=>{
+        const x=pad + i*((W-2*pad)/n), w=(W-2*pad)/n*0.95, h=(H-2*pad)*v;
+        return <rect key={i} x={x} y={H-pad-h} width={w} height={h} rx="2" ry="2"/>;
+      })}
+    </svg>
+  );
+}
+function MaxGapPlot({gp}){
+  const W=320,H=140,pad=10;
+  let max=0;
+  const xs=[], ys=[];
+  for(let i=0;i<gp.length;i++){
+    if(gp[i]>max) max=gp[i];
+    xs.push(i);
+    ys.push(max);
+  }
+  const X=i=> pad + (i/Math.max(1,gp.length-1))*(W-2*pad);
+  const Y=y=> H-pad - (y/Math.max(1,Math.max(...ys)))*(H-2*pad);
+  return (
+    <svg width="100%" viewBox={`0 0 ${W} ${H}`}>
+      <rect x="0" y="0" width={W} height={H} fill="none"/>
+      {ys.map((y,i)=>{
+        const x1=i?X(i-1):X(i), y1=i?Y(ys[i-1]):Y(y), x2=X(i), y2=Y(y);
+        return <line key={i} x1={x1} y1={y1} x2={x2} y2={y2} strokeWidth="2"/>;
+      })}
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- add PrimeGapsLab with sieve-based prime gap visualization
- add FareyTreeLab for exploring the Stern–Brocot tree
- add FourierLab to experiment with Fourier transforms and convolution
- expose new labs via /primes, /farey, and /fourier routes

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint root key not supported)*
- `npm --prefix sites/blackroad test`
- `npm --prefix sites/blackroad run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c101fa66ec83299f0c32a6c084ee5f