### PR TITLE
Add interactive algorithm labs

### DIFF
--- a/sites/blackroad/src/App.jsx
+++ b/sites/blackroad/src/App.jsx
@@ -1,114 +1,168 @@
-import { NavLink, Routes, Route } from "react-router-dom";
-import { useEffect, useState } from "react";
-import Chat from "./pages/Chat.jsx";
-import Canvas from "./pages/Canvas.jsx";
-import Editor from "./pages/Editor.jsx";
-import Terminal from "./pages/Terminal.jsx";
-import RoadView from "./pages/RoadView.jsx";
-import Backroad from "./pages/Backroad.jsx";
-import Subscribe from "./pages/Subscribe.jsx";
-import Lucidia from "./pages/Lucidia.jsx";
-import InfinityMath from "./pages/InfinityMath.jsx";
-import Agents from "./pages/Agents.jsx";
-import Desktop from "./pages/Desktop.jsx";
-import QuantumConsciousness from "./pages/QuantumConsciousness.jsx";
+import { NavLink, Routes, Route } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import Chat from './pages/Chat.jsx';
+import Canvas from './pages/Canvas.jsx';
+import Editor from './pages/Editor.jsx';
+import Terminal from './pages/Terminal.jsx';
+import RoadView from './pages/RoadView.jsx';
+import Backroad from './pages/Backroad.jsx';
+import Subscribe from './pages/Subscribe.jsx';
+import Lucidia from './pages/Lucidia.jsx';
+import InfinityMath from './pages/InfinityMath.jsx';
+import Agents from './pages/Agents.jsx';
+import Desktop from './pages/Desktop.jsx';
+import QuantumConsciousness from './pages/QuantumConsciousness.jsx';
+import Kalman1DLab from './pages/Kalman1DLab.jsx';
+import PageRankLab from './pages/PageRankLab.jsx';
+import NewtonFractalLab from './pages/NewtonFractalLab.jsx';
 
-function useApiHealth(){
-  const [state,setState]=useState({ok:null, info:""});
-  useEffect(()=>{ let dead=false;
-    (async()=>{
-      const probe = async (path)=>{
-        try{
-          const r = await fetch(path,{cache:"no-store"});
+function useApiHealth() {
+  const [state, setState] = useState({ ok: null, info: '' });
+  useEffect(() => {
+    let dead = false;
+    (async () => {
+      const probe = async (path) => {
+        try {
+          const r = await fetch(path, { cache: 'no-store' });
           const t = await r.text();
-          let info=""; try{ const j=JSON.parse(t); info=`${j.status||"ok"} • ${j.time||""}`; }catch{}
-          return {ok:r.ok, info};
-        }catch{ return {ok:false, info:""} }
+          let info = '';
+          try {
+            const j = JSON.parse(t);
+            info = `${j.status || 'ok'} • ${j.time || ''}`;
+          } catch {}
+          return { ok: r.ok, info };
+        } catch {
+          return { ok: false, info: '' };
+        }
       };
-      let res = await probe("/api/health");
-      if(!res.ok) res = await probe("/api/health.json");
-      if(!dead) setState(res);
-    })(); return ()=>{dead=true};
-  },[]);
+      let res = await probe('/api/health');
+      if (!res.ok) res = await probe('/api/health.json');
+      if (!dead) setState(res);
+    })();
+    return () => {
+      dead = true;
+    };
+  }, []);
   return state;
 }
 
-function StatusPill(){
-  const {ok, info} = useApiHealth();
-  const tone = ok==null ? "opacity-60" : ok ? "text-green-400" : "text-red-400";
-  const label = ok==null ? "Checking API…" : ok ? "API healthy" : "API error";
-  return <span className={`text-sm ${tone}`}>{label}{info?` — ${info}`:""}</span>;
+function StatusPill() {
+  const { ok, info } = useApiHealth();
+  const tone =
+    ok == null ? 'opacity-60' : ok ? 'text-green-400' : 'text-red-400';
+  const label = ok == null ? 'Checking API…' : ok ? 'API healthy' : 'API error';
+  return (
+    <span className={`text-sm ${tone}`}>
+      {label}
+      {info ? ` — ${info}` : ''}
+    </span>
+  );
 }
 
-export default function App(){
+export default function App() {
   return (
     <Routes>
-      <Route path="/" element={<Desktop/>} />
-      <Route path="/quantum-consciousness" element={<QuantumConsciousness/>} />
-      <Route path="/*" element={<LegacyApp/>} />
+      <Route path="/" element={<Desktop />} />
+      <Route path="/quantum-consciousness" element={<QuantumConsciousness />} />
+      <Route path="/*" element={<LegacyApp />} />
     </Routes>
   );
 }
 
-function LegacyApp(){
+function LegacyApp() {
   return (
     <div className="min-h-screen grid md:grid-cols-[240px_1fr] gap-4 p-4">
       <aside className="sidebar p-3">
         <div className="brand-logo text-2xl mb-4">BlackRoad.io</div>
         <nav className="flex flex-col gap-2">
-          <NavLink className="nav-link" to="/chat">Chat</NavLink>
-          <NavLink className="nav-link" to="/canvas">Canvas</NavLink>
-          <NavLink className="nav-link" to="/editor">Editor</NavLink>
-          <NavLink className="nav-link" to="/terminal">Terminal</NavLink>
-          <NavLink className="nav-link" to="/roadview">RoadView</NavLink>
-          <NavLink className="nav-link" to="/backroad">Backroad</NavLink>
-          <NavLink className="nav-link" to="/agents">Agents</NavLink>
-          <NavLink className="nav-link" to="/subscribe">Subscribe</NavLink>
-          <NavLink className="nav-link" to="/lucidia">Lucidia</NavLink>
+          <NavLink className="nav-link" to="/chat">
+            Chat
+          </NavLink>
+          <NavLink className="nav-link" to="/canvas">
+            Canvas
+          </NavLink>
+          <NavLink className="nav-link" to="/editor">
+            Editor
+          </NavLink>
+          <NavLink className="nav-link" to="/terminal">
+            Terminal
+          </NavLink>
+          <NavLink className="nav-link" to="/roadview">
+            RoadView
+          </NavLink>
+          <NavLink className="nav-link" to="/backroad">
+            Backroad
+          </NavLink>
+          <NavLink className="nav-link" to="/agents">
+            Agents
+          </NavLink>
+          <NavLink className="nav-link" to="/subscribe">
+            Subscribe
+          </NavLink>
+          <NavLink className="nav-link" to="/lucidia">
+            Lucidia
+          </NavLink>
           <NavLink className="nav-link" to="/math">
             <span
               style={{
-                background: "linear-gradient(90deg,#FF4FD8,#0096FF,#FDBA2D)",
-                WebkitBackgroundClip: "text",
-                WebkitTextFillColor: "transparent",
+                background: 'linear-gradient(90deg,#FF4FD8,#0096FF,#FDBA2D)',
+                WebkitBackgroundClip: 'text',
+                WebkitTextFillColor: 'transparent',
               }}
             >
               ∞
-            </span>{" "}
+            </span>{' '}
             Infinity Math
           </NavLink>
         </nav>
-        <div className="mt-6 text-xs text-neutral-400"><StatusPill/></div>
+        <div className="mt-6 text-xs text-neutral-400">
+          <StatusPill />
+        </div>
       </aside>
 
       <main className="space-y-4">
         <header className="panel p-4 flex items-center justify-between">
-          <h1 className="brand-gradient text-xl font-semibold">Co-coding Portal</h1>
-          <a className="btn-primary" href="/api/health" target="_blank" rel="noreferrer">API Health</a>
+          <h1 className="brand-gradient text-xl font-semibold">
+            Co-coding Portal
+          </h1>
+          <a
+            className="btn-primary"
+            href="/api/health"
+            target="_blank"
+            rel="noreferrer"
+          >
+            API Health
+          </a>
         </header>
 
         <section className="card">
           <Routes>
-            <Route path="/" element={<Chat/>} />
-            <Route path="/chat" element={<Chat/>} />
-            <Route path="/canvas" element={<Canvas/>} />
-            <Route path="/editor" element={<Editor/>} />
-            <Route path="/terminal" element={<Terminal/>} />
-            <Route path="/roadview" element={<RoadView/>} />
-            <Route path="/backroad" element={<Backroad/>} />
-            <Route path="/agents" element={<Agents/>} />
-            <Route path="/subscribe" element={<Subscribe/>} />
-            <Route path="/lucidia" element={<Lucidia/>} />
-            <Route path="/math" element={<InfinityMath/>} />
-            <Route path="chat" element={<Chat/>} />
-            <Route path="canvas" element={<Canvas/>} />
-            <Route path="editor" element={<Editor/>} />
-            <Route path="terminal" element={<Terminal/>} />
-            <Route path="roadview" element={<RoadView/>} />
-            <Route path="backroad" element={<Backroad/>} />
-            <Route path="subscribe" element={<Subscribe/>} />
-            <Route path="lucidia" element={<Lucidia/>} />
-            <Route path="math" element={<InfinityMath/>} />
+            <Route path="/" element={<Chat />} />
+            <Route path="/chat" element={<Chat />} />
+            <Route path="/canvas" element={<Canvas />} />
+            <Route path="/editor" element={<Editor />} />
+            <Route path="/terminal" element={<Terminal />} />
+            <Route path="/roadview" element={<RoadView />} />
+            <Route path="/backroad" element={<Backroad />} />
+            <Route path="/agents" element={<Agents />} />
+            <Route path="/subscribe" element={<Subscribe />} />
+            <Route path="/lucidia" element={<Lucidia />} />
+            <Route path="/math" element={<InfinityMath />} />
+            <Route path="/kalman" element={<Kalman1DLab />} />
+            <Route path="/pagerank" element={<PageRankLab />} />
+            <Route path="/newton" element={<NewtonFractalLab />} />
+            <Route path="chat" element={<Chat />} />
+            <Route path="canvas" element={<Canvas />} />
+            <Route path="editor" element={<Editor />} />
+            <Route path="terminal" element={<Terminal />} />
+            <Route path="roadview" element={<RoadView />} />
+            <Route path="backroad" element={<Backroad />} />
+            <Route path="subscribe" element={<Subscribe />} />
+            <Route path="lucidia" element={<Lucidia />} />
+            <Route path="math" element={<InfinityMath />} />
+            <Route path="kalman" element={<Kalman1DLab />} />
+            <Route path="pagerank" element={<PageRankLab />} />
+            <Route path="newton" element={<NewtonFractalLab />} />
             <Route path="*" element={<div>Not found</div>} />
           </Routes>
         </section>

--- a/sites/blackroad/src/pages/Kalman1DLab.jsx
+++ b/sites/blackroad/src/pages/Kalman1DLab.jsx
@@ -1,0 +1,179 @@
+import { useMemo, useState } from 'react';
+
+/** Simple 1D constant-velocity model inside a not-quite-constant world.
+ *  State: x (position). We track one value with Gaussian noise.
+ *  x_k = x_{k-1} + w,    w ~ N(0, Q)
+ *  z_k = x_k + v,        v ~ N(0, R)
+ */
+function rng(seed) {
+  let s = seed | 0 || 2025;
+  return () => (s = (1664525 * s + 1013904223) >>> 0) / 2 ** 32;
+}
+function randn(r) {
+  const u = Math.max(r(), 1e-12),
+    v = Math.max(r(), 1e-12);
+  return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v);
+}
+
+export default function Kalman1DLab() {
+  const [N, setN] = useState(120);
+  const [Q, setQ] = useState(0.03); // process noise var
+  const [R, setR] = useState(0.12); // measurement noise var
+  const [seed, setSeed] = useState(42);
+  const [trend, setTrend] = useState(0.02); // slow drift
+
+  const sim = useMemo(() => {
+    const r = rng(seed);
+    const x = [],
+      z = [];
+    let xk = 0;
+    for (let k = 0; k < N; k++) {
+      // hidden truth evolves with small drift + noise
+      xk = xk + trend + randn(r) * Math.sqrt(Q);
+      x.push(xk);
+      // measurement with noise
+      z.push(xk + randn(r) * Math.sqrt(R));
+    }
+    // Kalman filter (scalar)
+    const xhat = [],
+      P = [];
+    let xh = 0,
+      Pk = 1; // prior
+    for (let k = 0; k < N; k++) {
+      // predict
+      const xh_prior = xh + trend; // model drift included
+      const P_prior = Pk + Q;
+      // update
+      const K = P_prior / (P_prior + R);
+      xh = xh_prior + K * (z[k] - xh_prior);
+      Pk = (1 - K) * P_prior;
+      xhat.push(xh);
+      P.push(Pk);
+    }
+    return { x, z, xhat, P };
+  }, [N, Q, R, seed, trend]);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">Kalman Filter — 1D Tracking</h2>
+      <Controls label="samples" v={N} set={setN} min={40} max={400} step={10} />
+      <Controls
+        label="process var Q"
+        v={Q}
+        set={setQ}
+        min={0.001}
+        max={0.3}
+        step={0.001}
+      />
+      <Controls
+        label="meas var R"
+        v={R}
+        set={setR}
+        min={0.001}
+        max={0.5}
+        step={0.001}
+      />
+      <Controls
+        label="trend/drift"
+        v={trend}
+        set={setTrend}
+        min={-0.05}
+        max={0.05}
+        step={0.001}
+      />
+      <Controls
+        label="seed"
+        v={seed}
+        set={setSeed}
+        min={1}
+        max={9999}
+        step={1}
+      />
+
+      <SeriesPlot truth={sim.x} meas={sim.z} est={sim.xhat} />
+      <UncPlot P={sim.P} />
+      <p className="text-sm opacity-80">
+        Lower R ⇒ trust measurements more; higher Q ⇒ model believes the world
+        changes quickly. The filter balances both to minimize mean-square error.
+      </p>
+    </div>
+  );
+}
+
+function Controls({ label, v, set, min, max, step }) {
+  const show = typeof v === 'number' && v.toFixed ? v.toFixed(3) : v;
+  return (
+    <div className="mb-1">
+      <label className="text-sm opacity-80">
+        {label}: <b>{show}</b>
+      </label>
+      <input
+        className="w-full"
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={v}
+        onChange={(e) => set(parseFloat(e.target.value))}
+      />
+    </div>
+  );
+}
+
+function SeriesPlot({ truth, meas, est }) {
+  const W = 640,
+    H = 220,
+    pad = 12;
+  const N = truth.length;
+  const minY = Math.min(...truth, ...meas, ...est);
+  const maxY = Math.max(...truth, ...meas, ...est);
+  const X = (i) => pad + (i / (N - 1)) * (W - 2 * pad);
+  const Y = (v) =>
+    H - pad - ((v - minY) / (maxY - minY + 1e-9)) * (H - 2 * pad);
+  const poly = (arr) => arr.map((v, i) => `${X(i)},${Y(v)}`).join(' ');
+  return (
+    <svg width="100%" viewBox={`0 0 ${W} ${H}`}>
+      <rect x="0" y="0" width={W} height={H} fill="none" />
+      {/* measurements as faint circles */}
+      {meas.map((v, i) => (
+        <circle key={i} cx={X(i)} cy={Y(v)} r="2" opacity="0.5" />
+      ))}
+      {/* truth (dashed) */}
+      <polyline
+        points={poly(truth)}
+        fill="none"
+        strokeDasharray="4 4"
+        strokeWidth="2"
+      />
+      {/* estimate */}
+      <polyline points={poly(est)} fill="none" strokeWidth="2" />
+      <text x={pad} y={14} fontSize="10">
+        truth (dashed) • estimate (solid) • measurements (dots)
+      </text>
+    </svg>
+  );
+}
+
+function UncPlot({ P }) {
+  const W = 640,
+    H = 120,
+    pad = 12;
+  const N = P.length,
+    maxP = Math.max(...P, 1e-9);
+  const X = (i) => pad + (i / (N - 1)) * (W - 2 * pad);
+  const Y = (v) => H - pad - (v / maxP) * (H - 2 * pad);
+  return (
+    <svg width="100%" viewBox={`0 0 ${W} ${H}`}>
+      <text x={pad} y={12} fontSize="10">
+        posterior variance Pₖ
+      </text>
+      {P.map((v, i) => {
+        const x1 = i ? X(i - 1) : X(i),
+          y1 = i ? Y(P[i - 1]) : Y(v);
+        const x2 = X(i),
+          y2 = Y(v);
+        return <line key={i} x1={x1} y1={y1} x2={x2} y2={y2} strokeWidth="2" />;
+      })}
+    </svg>
+  );
+}

--- a/sites/blackroad/src/pages/NewtonFractalLab.jsx
+++ b/sites/blackroad/src/pages/NewtonFractalLab.jsx
@@ -1,0 +1,191 @@
+import { useEffect, useRef, useState } from 'react';
+
+/** f(z)=z^3 - 1  → roots: 1,  (-1±i√3)/2  */
+function f(z) {
+  return {
+    re: z.re * z.re * z.re - 1,
+    im: 3 * z.re * z.re * z.im - 3 * z.re * z.im * z.im,
+  };
+} // not separating re/im nicely—let's write helpers
+function fc(z) {
+  const a = z.re,
+    b = z.im;
+  return { re: a * a * a - 3 * a * b * b - 1, im: 3 * a * a * b - b * b * b };
+} // z^3 - 1
+function dfc(z) {
+  const a = z.re,
+    b = z.im; // derivative 3z^2
+  return { re: 3 * (a * a - b * b), im: 6 * a * b };
+}
+function sub(a, b) {
+  return { re: a.re - b.re, im: a.im - b.im };
+}
+function add(a, b) {
+  return { re: a.re + b.re, im: a.im + b.im };
+}
+function mul(a, b) {
+  return { re: a.re * b.re - a.im * b.im, im: a.re * b.im + a.im * b.re };
+}
+function div(a, b) {
+  const d = b.re * b.re + b.im * b.im || 1e-12;
+  return {
+    re: (a.re * b.re + a.im * b.im) / d,
+    im: (a.im * b.re - a.re * b.im) / d,
+  };
+}
+function abs2(z) {
+  return z.re * z.re + z.im * z.im;
+}
+
+const ROOTS = [
+  { re: 1, im: 0 },
+  { re: -0.5, im: Math.sqrt(3) / 2 },
+  { re: -0.5, im: -Math.sqrt(3) / 2 },
+];
+
+export default function NewtonFractalLab() {
+  const canvasRef = useRef(null);
+  const [centerX, setCX] = useState(0),
+    [centerY, setCY] = useState(0);
+  const [scale, setScale] = useState(2.2); // half-width of view
+  const [iters, setIters] = useState(40);
+  const [w, h] = [640, 480];
+
+  useEffect(() => {
+    const cnv = canvasRef.current;
+    if (!cnv) return;
+    cnv.width = w;
+    cnv.height = h;
+    const ctx = cnv.getContext('2d', { alpha: false });
+    const img = ctx.createImageData(w, h);
+
+    for (let y = 0; y < h; y++) {
+      for (let x = 0; x < w; x++) {
+        // map pixel to complex plane
+        const zx = centerX + (x / w - 0.5) * 2 * scale;
+        const zy = centerY + ((y / h - 0.5) * 2 * scale * h) / w; // keep aspect
+        let z = { re: zx, im: zy };
+        let k = 0;
+        for (; k < iters; k++) {
+          const fz = fc(z);
+          const dfz = dfc(z);
+          const step = div(fz, dfz);
+          z = sub(z, step);
+          if (abs2(step) < 1e-12) break;
+        }
+        // find nearest root
+        let idx = 0,
+          mind = abs2(sub(z, ROOTS[0]));
+        for (let j = 1; j < ROOTS.length; j++) {
+          const d = abs2(sub(z, ROOTS[j]));
+          if (d < mind) {
+            mind = d;
+            idx = j;
+          }
+        }
+        // color by root and speed (k)
+        const t = k / iters;
+        const base = [
+          [255, 120, 120],
+          [120, 255, 160],
+          [120, 170, 255],
+        ][idx];
+        const r = Math.floor(base[0] * Math.pow(1 - t, 0.6));
+        const g = Math.floor(base[1] * Math.pow(1 - t, 0.6));
+        const b = Math.floor(base[2] * Math.pow(1 - t, 0.6));
+
+        const off = 4 * (y * w + x);
+        img.data[off + 0] = r;
+        img.data[off + 1] = g;
+        img.data[off + 2] = b;
+        img.data[off + 3] = 255;
+      }
+    }
+    ctx.putImageData(img, 0, 0);
+  }, [centerX, centerY, scale, iters, w, h]);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">Newton Fractal — f(z)=z³−1</h2>
+      <canvas
+        ref={canvasRef}
+        style={{ width: '100%', maxWidth: w, height: h }}
+      />
+      <div
+        className="grid"
+        style={{
+          gridTemplateColumns: 'repeat(auto-fit,minmax(240px,1fr))',
+          gap: 16,
+        }}
+      >
+        <Panel title="View">
+          <Slider
+            label="center x"
+            v={centerX}
+            set={setCX}
+            min={-2.0}
+            max={2.0}
+            step={0.01}
+          />
+          <Slider
+            label="center y"
+            v={centerY}
+            set={setCY}
+            min={-2.0}
+            max={2.0}
+            step={0.01}
+          />
+          <Slider
+            label="scale (zoom)"
+            v={scale}
+            set={setScale}
+            min={0.3}
+            max={3.0}
+            step={0.01}
+          />
+        </Panel>
+        <Panel title="Iteration">
+          <Slider
+            label="iterations"
+            v={iters}
+            set={setIters}
+            min={10}
+            max={80}
+            step={1}
+          />
+          <p className="text-xs opacity-80 mt-2">
+            Colors: which root you converge to. Brightness: speed.
+          </p>
+        </Panel>
+      </div>
+    </div>
+  );
+}
+
+function Panel({ title, children }) {
+  return (
+    <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+      <h3 className="font-semibold mb-2">{title}</h3>
+      {children}
+    </section>
+  );
+}
+function Slider({ label, v, set, min, max, step }) {
+  const show = typeof v === 'number' && v.toFixed ? v.toFixed(3) : v;
+  return (
+    <div className="mb-1">
+      <label className="text-sm opacity-80">
+        {label}: <b>{show}</b>
+      </label>
+      <input
+        className="w-full"
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={v}
+        onChange={(e) => set(parseFloat(e.target.value))}
+      />
+    </div>
+  );
+}

--- a/sites/blackroad/src/pages/PageRankLab.jsx
+++ b/sites/blackroad/src/pages/PageRankLab.jsx
@@ -1,0 +1,239 @@
+import { useMemo, useState } from 'react';
+
+function normalizeCols(M) {
+  const n = M.length,
+    m = M[0].length;
+  const out = Array.from({ length: n }, () => Array(m).fill(0));
+  for (let j = 0; j < m; j++) {
+    let s = 0;
+    for (let i = 0; i < n; i++) s += M[i][j];
+    const d = s > 0 ? s : 1;
+    for (let i = 0; i < n; i++) out[i][j] = M[i][j] / d;
+  }
+  return out;
+}
+function matVec(M, v) {
+  const n = M.length,
+    res = new Array(n).fill(0);
+  for (let i = 0; i < n; i++)
+    for (let j = 0; j < n; j++) res[i] += M[i][j] * v[j];
+  return res;
+}
+function addVec(a, b, alpha = 1) {
+  return a.map((x, i) => x + alpha * b[i]);
+}
+function scaleVec(a, c) {
+  return a.map((x) => x * c);
+}
+function l1norm(a) {
+  return a.reduce((s, x) => s + Math.abs(x), 0);
+}
+
+export default function PageRankLab() {
+  const [n, setN] = useState(6);
+  const [density, setDensity] = useState(0.35);
+  const [damp, setDamp] = useState(0.85);
+  const [iters, setIters] = useState(60);
+  const [seed, setSeed] = useState(7);
+
+  // build random directed graph adjacency
+  const adj = useMemo(() => {
+    let s = seed | 0;
+    const rand = () => (s = (1103515245 * s + 12345) >>> 0) / 2 ** 32;
+    const A = Array.from({ length: n }, () => Array(n).fill(0));
+    for (let i = 0; i < n; i++) {
+      for (let j = 0; j < n; j++) {
+        if (i === j) continue;
+        if (rand() < density) A[i][j] = 1;
+      }
+      // ensure at least one outgoing
+      if (A[i].every((v) => v === 0)) {
+        const j = Math.floor((n - 1) * rand());
+        A[i][j >= i ? j + 1 : j] = 1;
+      }
+    }
+    return A;
+  }, [n, density, seed]);
+
+  const pr = useMemo(() => {
+    // column-stochastic P from adjacency (links go out of j to i)
+    const P = normalizeCols(
+      adj.map((row) => row.slice()).transpose?.() || transpose(adj)
+    );
+    const nN = P.length;
+    // Google matrix: G = d*P + (1-d)*(1/n)ee^T
+    const base = 1 / nN;
+    let v = Array(nN).fill(1 / nN);
+    for (let k = 0; k < iters; k++) {
+      const Pv = matVec(P, v);
+      const vnext = addVec(
+        scaleVec(Pv, damp),
+        Array(nN).fill((1 - damp) * base)
+      );
+      if (l1norm(vnext.map((x, i) => x - v[i])) < 1e-10) {
+        v = vnext;
+        break;
+      }
+      v = vnext;
+    }
+    return v;
+  }, [adj, damp, iters]);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">PageRank / Markov Lab</h2>
+      <Controls label="nodes" v={n} set={setN} min={3} max={18} step={1} />
+      <Controls
+        label="density"
+        v={density}
+        set={setDensity}
+        min={0.05}
+        max={0.9}
+        step={0.01}
+      />
+      <Controls
+        label="damping (1-teleport)"
+        v={damp}
+        set={setDamp}
+        min={0.5}
+        max={0.99}
+        step={0.01}
+      />
+      <Controls
+        label="iterations"
+        v={iters}
+        set={setIters}
+        min={10}
+        max={300}
+        step={5}
+      />
+      <Controls
+        label="seed"
+        v={seed}
+        set={setSeed}
+        min={1}
+        max={9999}
+        step={1}
+      />
+      <Graph adj={adj} pr={pr} />
+      <Bar pr={pr} />
+      <p className="text-sm opacity-80">
+        Bigger bar = higher stationary probability. Raise damping to trust links
+        more; lower it for more teleport.
+      </p>
+    </div>
+  );
+}
+
+function Controls({ label, v, set, min, max, step }) {
+  const show = typeof v === 'number' && v.toFixed ? v.toFixed(3) : v;
+  return (
+    <div className="mb-1">
+      <label className="text-sm opacity-80">
+        {label}: <b>{show}</b>
+      </label>
+      <input
+        className="w-full"
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={v}
+        onChange={(e) => set(parseFloat(e.target.value))}
+      />
+    </div>
+  );
+}
+
+function transpose(A) {
+  const n = A.length,
+    m = A[0].length;
+  const T = Array.from({ length: m }, () => Array(n).fill(0));
+  for (let i = 0; i < n; i++) for (let j = 0; j < m; j++) T[j][i] = A[i][j];
+  return T;
+}
+
+function Graph({ adj, pr }) {
+  const W = 640,
+    H = 240,
+    pad = 24,
+    n = adj.length;
+  const R = 80,
+    cx = W / 2,
+    cy = H / 2;
+  const nodes = Array.from({ length: n }, (_, i) => {
+    const ang = (2 * Math.PI * i) / n;
+    return { x: cx + R * Math.cos(ang), y: cy + R * Math.sin(ang) };
+  });
+  return (
+    <svg width="100%" viewBox={`0 0 ${W} ${H}`}>
+      {/* edges */}
+      {adj.map((row, i) =>
+        row.map((v, j) =>
+          v ? <Arrow key={`${i}-${j}`} from={nodes[i]} to={nodes[j]} /> : null
+        )
+      )}
+      {/* nodes */}
+      {nodes.map((p, i) => {
+        const r = 6 + 20 * (pr[i] || 0);
+        return (
+          <g key={i}>
+            <circle cx={p.x} cy={p.y} r={r} />
+            <text x={p.x + 10} y={p.y - 10} fontSize="10">
+              #{i}
+            </text>
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+function Arrow({ from, to }) {
+  const dx = to.x - from.x,
+    dy = to.y - from.y,
+    L = Math.hypot(dx, dy);
+  const ux = dx / L,
+    uy = dy / L;
+  const ax = to.x - ux * 10,
+    ay = to.y - uy * 10;
+  const left = { x: ax - uy * 4, y: ay + ux * 4 };
+  const right = { x: ax + uy * 4, y: ay - ux * 4 };
+  return (
+    <g opacity="0.6">
+      <line x1={from.x} y1={from.y} x2={ax} y2={ay} />
+      <polygon
+        points={`${ax},${ay} ${left.x},${left.y} ${right.x},${right.y}`}
+      />
+    </g>
+  );
+}
+function Bar({ pr }) {
+  const W = 640,
+    H = 120,
+    pad = 10,
+    n = pr.length;
+  const maxV = Math.max(...pr, 1e-9);
+  return (
+    <svg width="100%" viewBox={`0 0 ${W} ${H}`}>
+      {pr.map((v, i) => {
+        const x = pad + i * ((W - 2 * pad) / n);
+        const w = ((W - 2 * pad) / n) * 0.95;
+        const h = (H - 2 * pad) * (v / maxV);
+        return (
+          <rect
+            key={i}
+            x={x}
+            y={H - pad - h}
+            width={w}
+            height={h}
+            rx="2"
+            ry="2"
+          />
+        );
+      })}
+      <text x={pad} y={12} fontSize="10">
+        Stationary distribution (PageRank)
+      </text>
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- Add Kalman filter lab demonstrating 1D tracking with adjustable noise and drift
- Add PageRank lab for exploring stochastic matrices and stationary distributions
- Add Newton fractal lab rendering basins of attraction for z^3-1
- Register new labs in site router

## Testing
- `npm --prefix sites/blackroad run lint` (warnings: NavLink, Route unused etc.)
- `npm test` *(fails: `jest: not found`)*
- `npm --prefix sites/blackroad test`


------
https://chatgpt.com/codex/tasks/task_e_68c102cbdbf48329bf7b29a179cf7761