### PR TITLE
Add interactive math labs

### DIFF
--- a/sites/blackroad/src/App.jsx
+++ b/sites/blackroad/src/App.jsx
@@ -15,6 +15,10 @@ import QuantumConsciousness from "./pages/QuantumConsciousness.jsx";
 import OptimalTransportLab from "./pages/OptimalTransportLab.jsx";
 import BifurcationLab from "./pages/BifurcationLab.jsx";
 import ContinuedFractionsLab from "./pages/ContinuedFractionsLab.jsx";
+import RiemannMappingToy from "./pages/RiemannMappingToy.jsx";
+import OULab from "./pages/OULab.jsx";
+import VoronoiLloydLab from "./pages/VoronoiLloydLab.jsx";
+import BeliefPropagationLab from "./pages/BeliefPropagationLab.jsx";
 
 function useApiHealth(){
   const [state,setState]=useState({ok:null, info:""});
@@ -106,6 +110,10 @@ function LegacyApp(){
             <Route path="/ot" element={<OptimalTransportLab/>} />
             <Route path="/bifurcate" element={<BifurcationLab/>} />
             <Route path="/cfrac" element={<ContinuedFractionsLab/>} />
+            <Route path="/riemann" element={<RiemannMappingToy/>} />
+            <Route path="/ou" element={<OULab/>} />
+            <Route path="/vor" element={<VoronoiLloydLab/>} />
+            <Route path="/belief" element={<BeliefPropagationLab/>} />
             <Route path="chat" element={<Chat/>} />
             <Route path="canvas" element={<Canvas/>} />
             <Route path="editor" element={<Editor/>} />
@@ -118,6 +126,10 @@ function LegacyApp(){
             <Route path="ot" element={<OptimalTransportLab/>} />
             <Route path="bifurcate" element={<BifurcationLab/>} />
             <Route path="cfrac" element={<ContinuedFractionsLab/>} />
+            <Route path="riemann" element={<RiemannMappingToy/>} />
+            <Route path="ou" element={<OULab/>} />
+            <Route path="vor" element={<VoronoiLloydLab/>} />
+            <Route path="belief" element={<BeliefPropagationLab/>} />
             <Route path="*" element={<div>Not found</div>} />
           </Routes>
         </section>

--- a/sites/blackroad/src/pages/ActiveReflection.jsx
+++ b/sites/blackroad/src/pages/ActiveReflection.jsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react";
+
+export default function ActiveReflection({ title = "Active Reflection", storageKey = "reflect", prompts = [] }) {
+  const [notes, setNotes] = useState(() => {
+    try {
+      const raw = typeof window !== "undefined" ? localStorage.getItem(storageKey) : null;
+      const obj = raw ? JSON.parse(raw) : {};
+      return prompts.map((_, i) => obj[i] || "");
+    } catch {
+      return prompts.map(() => "");
+    }
+  });
+
+  useEffect(() => {
+    try {
+      const obj = {};
+      notes.forEach((v, i) => {
+        obj[i] = v;
+      });
+      if (typeof window !== "undefined") {
+        localStorage.setItem(storageKey, JSON.stringify(obj));
+      }
+    } catch {}
+  }, [notes, storageKey]);
+
+  const update = (i, val) => {
+    const next = notes.slice();
+    next[i] = val;
+    setNotes(next);
+  };
+
+  return (
+    <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+      {title && <h3 className="font-semibold mb-2">{title}</h3>}
+      {prompts.map((p, i) => (
+        <div key={i} className="mb-2">
+          <p className="text-sm mb-1">{p}</p>
+          <textarea
+            className="w-full p-1 rounded bg-white/5 border border-white/10"
+            rows={3}
+            value={notes[i] || ""}
+            onChange={(e) => update(i, e.target.value)}
+          />
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/sites/blackroad/src/pages/BeliefPropagationLab.jsx
+++ b/sites/blackroad/src/pages/BeliefPropagationLab.jsx
@@ -1,0 +1,175 @@
+import { useMemo, useState } from "react";
+import ActiveReflection from "./ActiveReflection.jsx";
+
+/** Graph: A—B—C—D, binary variables.
+ *  Pairwise factors ψ(A,B), ψ(B,C), ψ(C,D) prefer equality with strength alpha.
+ *  Local priors φ(X) bias toward 1 with bias betaX.
+ *  We run a fixed number of sum-product iterations and show marginals.
+ */
+function normalize(v){ const s=v.reduce((a,b)=>a+b,0)||1; return v.map(x=>x/s); }
+
+export default function BeliefPropagationLab(){
+  const [alpha,setAlpha]=useState(2.0);     // pairwise strength (== preference)
+  const [betaA,setBetaA]=useState(0.2);
+  const [betaB,setBetaB]=useState(0.0);
+  const [betaC,setBetaC]=useState(-0.1);
+  const [betaD,setBetaD]=useState(0.6);
+  const [iters,setIters]=useState(12);
+
+  const result = useMemo(()=> runBP({alpha, betas:[betaA,betaB,betaC,betaD], iters}), [alpha,betaA,betaB,betaC,betaD,iters]);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">Belief Propagation — tiny factor graph</h2>
+      <Marginals m={result.m}/>
+      <div className="grid" style={{gridTemplateColumns:"1fr 320px", gap:16}}>
+        <MsgSnap shots={result.shots}/>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <Slider label="pairwise α (equal-prefer)" v={alpha} set={setAlpha} min={-2.0} max={4.0} step={0.1}/>
+          <Slider label="β_A" v={betaA} set={setBetaA} min={-1} max={1} step={0.05}/>
+          <Slider label="β_B" v={betaB} set={setBetaB} min={-1} max={1} step={0.05}/>
+          <Slider label="β_C" v={betaC} set={setBetaC} min={-1} max={1} step={0.05}/>
+          <Slider label="β_D" v={betaD} set={setBetaD} min={-1} max={1} step={0.05}/>
+          <Slider label="iterations" v={iters} set={setIters} min={1} max={50} step={1}/>
+          <ActiveReflection
+            title="Active Reflection — Belief Prop"
+            storageKey="reflect_bp"
+            prompts={[
+              "Raise α: do neighbors align more strongly (marginals move toward 00/11)?",
+              "Flip β_A and β_D to opposite signs: where does the ‘tension’ settle?",
+              "Increase iterations: how fast do beliefs stabilize on this simple chain?"
+            ]}
+          />
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function phi(beta){ // prior φ(x) ∝ exp(beta * x), x∈{0,1}
+  return normalize([ Math.exp(beta*0), Math.exp(beta*1) ]);
+}
+function psi(alpha){ // pairwise ψ(x,y) ∝ exp( alpha * [x==y] )
+  // table: x,y in {0,1}
+  const e= Math.exp(alpha), o= Math.exp(0);
+  return [ [e, o], [o, e] ];
+}
+function runBP({alpha, betas, iters}){
+  const vars=4;
+  const prior = betas.map(phi);
+  const pair = psi(alpha);
+
+  // messages m_{i->j} as arrays [p0,p1]; initialize uniform
+  const msg = {
+    "A->B":[0.5,0.5], "B->A":[0.5,0.5],
+    "B->C":[0.5,0.5], "C->B":[0.5,0.5],
+    "C->D":[0.5,0.5], "D->C":[0.5,0.5],
+  };
+  const shots=[];
+
+  for(let t=0;t<iters;t++){
+    // update in chain order (sum-product)
+    // A->B
+    msg["A->B"] = normalize(sumProd(prior[0], msg["B->A"], pair));
+    // B->A
+    msg["B->A"] = normalize(sumProd(prior[1], msg["C->B"], pair));
+    // B->C
+    msg["B->C"] = normalize(sumProdTwo(prior[1], msg["A->B"], msg["C->B"], pair));
+    // C->B
+    msg["C->B"] = normalize(sumProdTwo(prior[2], msg["B->C"], msg["D->C"], pair));
+    // C->D
+    msg["C->D"] = normalize(sumProd(prior[2], msg["B->C"], pair));
+    // D->C
+    msg["D->C"] = normalize(sumProd(prior[3], msg["C->D"], pair));
+
+    // snapshot marginals
+    shots.push({
+      t,
+      A: marginal(prior[0], [msg["B->A"]]),
+      B: marginal(prior[1], [msg["A->B"], msg["C->B"]]),
+      C: marginal(prior[2], [msg["B->C"], msg["D->C"]]),
+      D: marginal(prior[3], [msg["C->D"]]),
+    });
+  }
+
+  const m = shots[shots.length-1];
+  return {m, shots};
+}
+
+function sumProd(phi_i, msg_from_neighbor, psi){
+  // message i->j (binary): m_j(y) = sum_x φ_i(x) ψ(x,y) ∏_{k∈N(i)\{j}} m_{k->i}(x)
+  const res=[0,0];
+  for(let y=0;y<2;y++){
+    let acc=0;
+    for(let x=0;x<2;x++){
+      const psi_xy = psi[x][y];
+      const prod = phi_i[x] * msg_from_neighbor[x];
+      acc += prod * psi_xy;
+    }
+    res[y]=acc;
+  }
+  return res;
+}
+function sumProdTwo(phi_i, msg1, msg2, psi){
+  const res=[0,0];
+  for(let y=0;y<2;y++){
+    let acc=0;
+    for(let x=0;x<2;x++){
+      const psi_xy = psi[x][y];
+      const prod = phi_i[x] * msg1[x] * msg2[x];
+      acc += prod * psi_xy;
+    }
+    res[y]=acc;
+  }
+  return res;
+}
+function marginal(phi_i, incoming){
+  let v = phi_i.slice();
+  for(const m of incoming){ v=[ v[0]*m[0], v[1]*m[1] ]; }
+  return normalize(v);
+}
+
+function Marginals({m}){
+  const labs=["A","B","C","D"]; const vals=[m.A,m.B,m.C,m.D];
+  return (
+    <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+      <h3 className="font-semibold mb-2">Final marginals P(X=1)</h3>
+      <svg width="100%" viewBox="0 0 640 160">
+        {vals.map((p,i)=>{
+          const v=p[1]; const x=20 + i*150, w=120, h=120;
+          const barH = v*h;
+          return (
+            <g key={i} transform={`translate(${x},20)`}>
+              <rect x="0" y={h-barH} width={w} height={barH} rx="4" ry="4"/>
+              <text x={w/2} y={h+14} textAnchor="middle" fontSize="12">{labs[i]} — {v.toFixed(3)}</text>
+            </g>
+          );
+        })}
+      </svg>
+    </section>
+  );
+}
+function MsgSnap({shots}){
+  const last = shots[shots.length-1];
+  if(!last) return null;
+  const rows = [
+    ["A", last.A], ["B", last.B], ["C", last.C], ["D", last.D]
+  ];
+  return (
+    <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+      <h3 className="font-semibold mb-2">Snapshot (last iter)</h3>
+      <table className="text-sm w-full">
+        <thead><tr><th className="text-left">Var</th><th className="text-left">P(0)</th><th className="text-left">P(1)</th></tr></thead>
+        <tbody>
+          {rows.map(([k,v],i)=><tr key={i}><td>{k}</td><td>{v[0].toFixed(3)}</td><td>{v[1].toFixed(3)}</td></tr>)}
+        </tbody>
+      </table>
+    </section>
+  );
+}
+function Slider({label,v,set,min,max,step}){
+  const show=(typeof v==="number"&&v.toFixed)?v.toFixed(3):v;
+  return (<div className="mb-2"><label className="text-sm opacity-80">{label}: <b>{show}</b></label>
+    <input className="w-full" type="range" min={min} max={max} step={step}
+      value={v} onChange={e=>set(parseFloat(e.target.value))}/></div>);
+}

--- a/sites/blackroad/src/pages/OULab.jsx
+++ b/sites/blackroad/src/pages/OULab.jsx
@@ -1,0 +1,94 @@
+import { useMemo, useState } from "react";
+import ActiveReflection from "./ActiveReflection.jsx";
+
+function rng(seed){ let s=seed|0||2025; return ()=> (s=(1664525*s+1013904223)>>>0)/2**32; }
+function randn(r){ const u=Math.max(r(),1e-12), v=Math.max(r(),1e-12);
+  return Math.sqrt(-2*Math.log(u))*Math.cos(2*Math.PI*v); }
+
+export default function OULab(){
+  const [N,setN]=useState(800);
+  const [dt,setDT]=useState(0.01);
+  const [lambda,setLambda]=useState(1.2);
+  const [mu,setMu]=useState(0.0);
+  const [sigma,setSigma]=useState(0.7);
+  const [seed,setSeed]=useState(42);
+
+  const path = useMemo(()=>{
+    const r=rng(seed); const x=[0];
+    for(let k=1;k<N;k++){
+      const xk = x[k-1] + (-lambda*(x[k-1]-mu))*dt + sigma*Math.sqrt(dt)*randn(r);
+      x.push(xk);
+    }
+    return x;
+  },[N,dt,lambda,mu,sigma,seed]);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">Ornstein–Uhlenbeck SDE — mean reversion</h2>
+      <Series path={path}/>
+      <div className="grid" style={{gridTemplateColumns:"1fr 320px", gap:16}}>
+        <Hist data={path}/>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <Slider label="steps" v={N} set={setN} min={200} max={3000} step={50}/>
+          <Slider label="dt" v={dt} set={setDT} min={0.001} max={0.05} step={0.001}/>
+          <Slider label="λ (reversion)" v={lambda} set={setLambda} min={0.1} max={3.0} step={0.05}/>
+          <Slider label="μ (target)" v={mu} set={setMu} min={-2} max={2} step={0.01}/>
+          <Slider label="σ (noise)" v={sigma} set={setSigma} min={0.1} max={2.0} step={0.01}/>
+          <Slider label="seed" v={seed} set={setSeed} min={1} max={9999} step={1}/>
+          <ActiveReflection
+            title="Active Reflection — OU"
+            storageKey="reflect_ou"
+            prompts={[
+              "Increase λ: does the process ‘snap’ back faster to μ?",
+              "Change σ: histogram variance should scale like σ²/(2λ) at stationarity.",
+              "Decrease dt: does the path look smoother and the histogram stabilize?"
+            ]}
+          />
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function Series({path}){
+  const W=640,H=220,pad=12; const N=path.length;
+  const minY=Math.min(...path), maxY=Math.max(...path);
+  const X=i=> pad + (i/(N-1))*(W-2*pad);
+  const Y=v=> H-pad - ((v-minY)/(maxY-minY+1e-9))*(H-2*pad);
+  return (
+    <svg width="100%" viewBox={`0 0 ${W} ${H}`}>
+      <rect x="0" y="0" width={W} height={H} fill="none"/>
+      {path.map((v,i)=> {
+        const x1=i?X(i-1):X(i), y1=i?Y(path[i-1]):Y(v);
+        const x2=X(i), y2=Y(v);
+        return <line key={i} x1={x1} y1={y1} x2={x2} y2={y2} strokeWidth="2"/>;
+      })}
+    </svg>
+  );
+}
+function Hist({data}){
+  const W=320,H=220,pad=10, bins=50;
+  const mn=Math.min(...data), mx=Math.max(...data);
+  const Hs=Array(bins).fill(0);
+  for(const x of data){
+    const k = Math.min(bins-1, Math.max(0, Math.floor((x-mn)/Math.max(1e-9,mx-mn)*bins)));
+    Hs[k]+=1;
+  }
+  const total=Hs.reduce((a,b)=>a+b,0)||1;
+  const probs=Hs.map(x=>x/total);
+  return (
+    <svg width="100%" viewBox={`0 0 ${W} ${H}`}>
+      {probs.map((p,i)=>{
+        const x=pad + i*((W-2*pad)/bins), w=(W-2*pad)/bins*0.95;
+        const h=(H-2*pad)*p;
+        return <rect key={i} x={x} y={H-pad-h} width={w} height={h} rx="2" ry="2"/>;
+      })}
+    </svg>
+  );
+}
+function Slider({label,v,set,min,max,step}){
+  const show=(typeof v==="number"&&v.toFixed)?v.toFixed(3):v;
+  return (<div className="mb-2"><label className="text-sm opacity-80">{label}: <b>{show}</b></label>
+    <input className="w-full" type="range" min={min} max={max} step={step}
+      value={v} onChange={e=>set(parseFloat(e.target.value))}/></div>);
+}

--- a/sites/blackroad/src/pages/RiemannMappingToy.jsx
+++ b/sites/blackroad/src/pages/RiemannMappingToy.jsx
@@ -1,0 +1,156 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import ActiveReflection from "./ActiveReflection.jsx";
+
+function polar(x,y){ const r=Math.hypot(x,y), t=Math.atan2(y,x); return [r,t]; }
+function fromPolar(r,t){ return [r*Math.cos(t), r*Math.sin(t)]; }
+
+// boundary map: radius r(θ) = 1 + eps * cos(n θ)
+function boundaryMap(theta, eps, n){
+  const r = 1 + eps*Math.cos(n*theta);
+  return fromPolar(r, theta);
+}
+
+export default function RiemannMappingToy(){
+  const [N,setN]=useState(82);        // grid size (odd → center point)
+  const [eps,setEps]=useState(0.22);  // boundary perturbation strength
+  const [mode,setMode]=useState(5);   // n in cos(nθ)
+  const [iters,setIters]=useState(8000);
+  const [levels,setLevels]=useState(10); // how many isolines of “radius”
+
+  const {U,V,mask} = useMemo(()=>solveHarmonicDisk(N, eps, mode, iters), [N,eps,mode,iters]);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">Riemann Mapping (Toy) — harmonic extension on the disk</h2>
+      <MappedGrid U={U} V={V} mask={mask} levels={levels}/>
+      <div className="grid" style={{gridTemplateColumns:"1fr 320px", gap:16}}>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <Slider label="grid N" v={N} set={setN} min={41} max={121} step={2}/>
+          <Slider label="ε (boundary wiggle)" v={eps} set={setEps} min={0.00} max={0.40} step={0.01}/>
+          <Slider label="n (mode)" v={mode} set={setMode} min={2} max={12} step={1}/>
+          <Slider label="Gauss–Seidel iters" v={iters} set={setIters} min={1000} max={20000} step={500}/>
+          <Slider label="grid lines" v={levels} set={setLevels} min={6} max={24} step={1}/>
+        </section>
+        <ActiveReflection
+          title="Active Reflection — Riemann toy"
+          storageKey="reflect_riemann"
+          prompts={[
+            "Increase ε: which interior grid lines get pulled most toward boundary bulges?",
+            "Change mode n: how many ‘petals’ appear and how do they influence interior?",
+            "Raise iterations: what stabilizes first? what continues to refine slowly?"
+          ]}
+        />
+      </div>
+    </div>
+  );
+}
+
+// ----- solver -----
+function solveHarmonicDisk(N, eps, nMode, iters){
+  const U = Array.from({length:N},()=>Array(N).fill(0)); // maps (x,y)->(u,v)
+  const V = Array.from({length:N},()=>Array(N).fill(0));
+  const mask = Array.from({length:N},()=>Array(N).fill(false)); // true if inside disk
+
+  // unit square [-1,1]^2
+  const toCoord = i => -1 + 2*i/(N-1);
+
+  // initialize mask + boundary conditions
+  for(let i=0;i<N;i++){
+    for(let j=0;j<N;j++){
+      const x = toCoord(j), y = toCoord(i);
+      const r = Math.hypot(x,y);
+      if(r <= 1+1e-12){
+        mask[i][j] = true;
+        // on boundary: set mapped boundary position
+        if(Math.abs(r-1) < (2/(N-1))*1.01){
+          const theta = Math.atan2(y,x);
+          const [bx,by] = boundaryMap(theta, eps, nMode);
+          U[i][j] = bx;
+          V[i][j] = by;
+        }else{
+          // interior: start with identity (soft start)
+          U[i][j] = x; V[i][j] = y;
+        }
+      }
+    }
+  }
+
+  // Gauss–Seidel Laplace solve for U and V with fixed boundary
+  for(let k=0;k<iters;k++){
+    for(let i=1;i<N-1;i++){
+      for(let j=1;j<N-1;j++){
+        if(!mask[i][j]) continue;
+        // skip boundary ring (keep fixed)
+        const x = toCoord(j), y = toCoord(i);
+        const r = Math.hypot(x,y);
+        if(Math.abs(r-1) < (2/(N-1))*1.01) continue;
+
+        // 5-point Laplacian averaging
+        U[i][j] = 0.25*(U[i-1][j] + U[i+1][j] + U[i][j-1] + U[i][j+1]);
+        V[i][j] = 0.25*(V[i-1][j] + V[i+1][j] + V[i][j-1] + V[i][j+1]);
+      }
+    }
+  }
+  return {U,V,mask};
+}
+
+// ----- draw mapped grid -----
+function MappedGrid({U,V,mask,levels=12}){
+  const W=640, H=640, pad=12;
+  // gather bounds of mapped region to autoscale
+  const pts=[];
+  for(let i=0;i<U.length;i++) for(let j=0;j<U.length;j++){
+    if(mask[i][j]) pts.push([U[i][j], V[i][j]]);
+  }
+  const xs=pts.map(p=>p[0]), ys=pts.map(p=>p[1]);
+  const minX=Math.min(...xs), maxX=Math.max(...xs);
+  const minY=Math.min(...ys), maxY=Math.max(...ys);
+  const X=x=> pad + (x-minX)/(maxX-minX+1e-9)*(W-2*pad);
+  const Y=y=> H-pad - (y-minY)/(maxY-minY+1e-9)*(H-2*pad);
+
+  // radial/angle isolines in parameter disk
+  const N=U.length;
+  const rings=[...Array(levels).keys()].map(k=> (k+1)/(levels+1)); // radii in (0,1)
+  const rays=[...Array(levels).keys()].map(k=> k*(2*Math.PI/levels));
+
+  const ringPolys = rings.map(r=>{
+    const poly=[];
+    for(let t=0;t<=360;t++){
+      const th = t*(Math.PI/180);
+      const x = r*Math.cos(th), y=r*Math.sin(th);
+      // find nearest grid cell (simple nearest)
+      const i = Math.round((y+1)*(N-1)/2), j = Math.round((x+1)*(N-1)/2);
+      if(i>=0&&i<N&&j>=0&&j<N&&mask[i][j]) poly.push([U[i][j], V[i][j]]);
+    }
+    return poly;
+  });
+  const rayPolys = rays.map(th=>{
+    const poly=[];
+    for(let s=0;s<=200;s++){
+      const r = s/200;
+      const x = r*Math.cos(th), y=r*Math.sin(th);
+      const i = Math.round((y+1)*(N-1)/2), j = Math.round((x+1)*(N-1)/2);
+      if(i>=0&&i<N&&j>=0&&j<N&&mask[i][j]) poly.push([U[i][j], V[i][j]]);
+    }
+    return poly;
+  });
+
+  return (
+    <svg width="100%" viewBox={`0 0 ${W} ${H}`}>
+      <rect x="0" y="0" width={W} height={H} fill="none"/>
+      {ringPolys.map((poly,idx)=>
+        <polyline key={`r${idx}`} points={poly.map(p=>`${X(p[0])},${Y(p[1])}`).join(" ")} fill="none" strokeWidth="1"/>
+      )}
+      {rayPolys.map((poly,idx)=>
+        <polyline key={`t${idx}`} points={poly.map(p=>`${X(p[0])},${Y(p[1])}`).join(" ")} fill="none" strokeWidth="1"/>
+      )}
+    </svg>
+  );
+}
+
+function Slider({label,v,set,min,max,step}){
+  const show = (typeof v==="number"&&v.toFixed) ? v.toFixed(3) : v;
+  return (<div className="mb-2"><label className="text-sm opacity-80">{label}: <b>{show}</b></label>
+    <input className="w-full" type="range" min={min} max={max} step={step}
+      value={v} onChange={e=>set(parseFloat(e.target.value))}/></div>);
+}

--- a/sites/blackroad/src/pages/VoronoiLloydLab.jsx
+++ b/sites/blackroad/src/pages/VoronoiLloydLab.jsx
@@ -1,0 +1,103 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import ActiveReflection from "./ActiveReflection.jsx";
+
+function rng(seed){ let s=seed|0||99; return ()=> (s=(1103515245*s+12345)>>>0)/2**32; }
+
+export default function VoronoiLloydLab(){
+  const [W,H] = [640, 360];
+  const [sites,setSites]=useState(24);
+  const [seed,setSeed]=useState(7);
+  const [grid,setGrid]=useState(2); // subsampling per pixel for smoother centroid
+  const [iters,setIters]=useState(0);
+
+  const {pts} = useMemo(()=>({pts:initSites(sites, W, H, seed)}),[sites,W,H,seed]);
+
+  const cnv=useRef(null);
+  useEffect(()=>{
+    const c=cnv.current; if(!c) return; c.width=W; c.height=H;
+    let P=pts.map(p=>({...p})); // copy
+    for(let t=0;t<iters;t++) P = lloydStep(P, W, H, grid);
+    drawVoronoi(c.getContext("2d", {alpha:false}), P, W, H);
+  },[pts, W, H, grid, iters]);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">Voronoi + Lloyd Relaxation</h2>
+      <canvas ref={cnv} style={{width:"100%"}}/>
+      <div className="grid" style={{gridTemplateColumns:"1fr 320px", gap:16}}>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <Slider label="sites" v={sites} set={setSites} min={6} max={200} step={2}/>
+          <Slider label="seed" v={seed} set={setSeed} min={1} max={9999} step={1}/>
+          <Slider label="grid subsample" v={grid} set={setGrid} min={1} max={6} step={1}/>
+          <Slider label="Lloyd iterations" v={iters} set={setIters} min={0} max={20} step={1}/>
+        </section>
+        <ActiveReflection
+          title="Active Reflection — Voronoi/Lloyd"
+          storageKey="reflect_lloyd"
+          prompts={[
+            "As iterations grow, do cells become more uniform (centroidal)?",
+            "What happens to long skinny cells after a few steps?",
+            "How does subsampling affect centroid accuracy vs compute?"
+          ]}
+        />
+      </div>
+    </div>
+  );
+}
+
+function initSites(n,W,H,seed){
+  const r=rng(seed); const pts=[];
+  for(let i=0;i<n;i++) pts.push({x: r()*W, y: r()*H});
+  return pts;
+}
+
+function lloydStep(P, W, H, sub){
+  // approximate centroids on a coarse grid
+  const cells = P.map(()=>({sx:0, sy:0, c:0}));
+  for(let y=0;y<H;y+=sub) for(let x=0;x<W;x+=sub){
+    let best=0, bd=1e18;
+    for(let i=0;i<P.length;i++){
+      const dx=x-P[i].x, dy=y-P[i].y; const d=dx*dx+dy*dy;
+      if(d<bd){ bd=d; best=i; }
+    }
+    cells[best].sx+=x; cells[best].sy+=y; cells[best].c+=1;
+  }
+  const Q = P.map((p,i)=>{
+    const c=cells[i].c||1;
+    return { x: (cells[i].sx/c), y: (cells[i].sy/c) };
+  });
+  return Q;
+}
+
+function drawVoronoi(ctx, P, W, H){
+  const img = ctx.createImageData(W,H);
+  // precolor sites softly
+  const cols = P.map((_,i)=>{
+    const a = (i*1.618)%1; // golden hue
+    const r=Math.floor(80+160*a), g=Math.floor(120+100*(1-a)), b=Math.floor(200-80*a);
+    return [r,g,b];
+  });
+  for(let y=0;y<H;y++){
+    for(let x=0;x<W;x++){
+      let best=0, bd=1e18;
+      for(let i=0;i<P.length;i++){
+        const dx=x-P[i].x, dy=y-P[i].y; const d=dx*dx+dy*dy;
+        if(d<bd){ bd=d; best=i; }
+      }
+      const off=4*(y*W+x); const c=cols[best];
+      img.data[off]=c[0]; img.data[off+1]=c[1]; img.data[off+2]=c[2]; img.data[off+3]=255;
+    }
+  }
+  ctx.putImageData(img,0,0);
+  // draw sites
+  ctx.beginPath();
+  for(const p of P){ ctx.moveTo(p.x+2,p.y); ctx.arc(p.x,p.y,2,0,Math.PI*2); }
+  ctx.stroke();
+}
+
+function Slider({label,v,set,min,max,step}){
+  const show=(typeof v==="number"&&v.toFixed)?v.toFixed(3):v;
+  return (<div className="mb-2"><label className="text-sm opacity-80">{label}: <b>{show}</b></label>
+    <input className="w-full" type="range" min={min} max={max} step={step}
+      value={v} onChange={e=>set(parseFloat(e.target.value))}/></div>);
+}


### PR DESCRIPTION
## Summary
- add Riemann mapping toy solving Laplace's equation on a disk
- add Ornstein–Uhlenbeck SDE lab with path and histogram
- add Voronoi with Lloyd relaxation and centroid reflections
- add belief propagation lab and reusable ActiveReflection component
- wire new labs into app routes

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c1087e93548329961212446e3688c9