### PR TITLE
Add interactive geometry and optics labs

### DIFF
--- a/sites/blackroad/src/App.jsx
+++ b/sites/blackroad/src/App.jsx
@@ -19,6 +19,10 @@ import QuatJuliaLab from "./pages/QuatJuliaLab.jsx";
 import StableFluidsLab from "./pages/StableFluidsLab.jsx";
 import AutoDiffLab from "./pages/AutoDiffLab.jsx";
 import ConformalGridLab from "./pages/ConformalGridLab.jsx";
+import EikonalPathLab from "./pages/EikonalPathLab.jsx";
+import PowerDiagramLab from "./pages/PowerDiagramLab.jsx";
+import FourierOpticsLab from "./pages/FourierOpticsLab.jsx";
+import CircleInversionLab from "./pages/CircleInversionLab.jsx";
 
 function useApiHealth(){
   const [state,setState]=useState({ok:null, info:""});
@@ -114,6 +118,10 @@ function LegacyApp(){
             <Route path="/fluids" element={<StableFluidsLab/>} />
             <Route path="/autodiff" element={<AutoDiffLab/>} />
             <Route path="/conformal" element={<ConformalGridLab/>} />
+            <Route path="/geo" element={<EikonalPathLab/>} />
+            <Route path="/power" element={<PowerDiagramLab/>} />
+            <Route path="/optics" element={<FourierOpticsLab/>} />
+            <Route path="/invert" element={<CircleInversionLab/>} />
             <Route path="chat" element={<Chat/>} />
             <Route path="canvas" element={<Canvas/>} />
             <Route path="editor" element={<Editor/>} />
@@ -130,6 +138,10 @@ function LegacyApp(){
             <Route path="fluids" element={<StableFluidsLab/>} />
             <Route path="autodiff" element={<AutoDiffLab/>} />
             <Route path="conformal" element={<ConformalGridLab/>} />
+            <Route path="geo" element={<EikonalPathLab/>} />
+            <Route path="power" element={<PowerDiagramLab/>} />
+            <Route path="optics" element={<FourierOpticsLab/>} />
+            <Route path="invert" element={<CircleInversionLab/>} />
             <Route path="*" element={<div>Not found</div>} />
           </Routes>
         </section>

--- a/sites/blackroad/src/pages/CircleInversionLab.jsx
+++ b/sites/blackroad/src/pages/CircleInversionLab.jsx
@@ -1,0 +1,109 @@
+import { useEffect, useRef, useState } from "react";
+import ActiveReflection from "./ActiveReflection.jsx";
+
+function inv(p, c, R){
+  const dx=p[0]-c[0], dy=p[1]-c[1];
+  const d2=dx*dx+dy*dy || 1e-12;
+  const k=(R*R)/d2;
+  return [ c[0]+dx*k, c[1]+dy*k ];
+}
+
+export default function CircleInversionLab(){
+  const [W,H]=[640,480];
+  const [C1,setC1]=useState([ -0.6, 0.0 ]), [R1,setR1]=useState(0.7);
+  const [C2,setC2]=useState([  0.6, 0.0 ]), [R2,setR2]=useState(0.7);
+  const [C3,setC3]=useState([  0.0, 0.0 ]), [R3,setR3]=useState(0.45);
+  const [depth,setDepth]=useState(9);
+  const [seeds,setSeeds]=useState(500);
+
+  const cnv=useRef(null);
+  useEffect(()=>{
+    const c=cnv.current; if(!c) return; c.width=W; c.height=H;
+    const ctx=c.getContext("2d",{alpha:false});
+    draw(ctx, W, H, {C1,R1,C2,R2,C3,R3,depth,seeds});
+  },[C1,R1,C2,R2,C3,R3,depth,seeds]);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">Circle Inversion Kaleidoscope — orbit toy</h2>
+      <canvas ref={cnv} style={{width:"100%", imageRendering:"pixelated"}}/>
+      <div className="grid" style={{gridTemplateColumns:'1fr 340px', gap:16}}>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <Two label="C1 (x,y)" v={C1} set={setC1} min={-1.2} max={1.2} step={0.01}/>
+          <Slider label="R1" v={R1} set={setR1} min={0.2} max={1.2} step={0.01}/>
+          <Two label="C2 (x,y)" v={C2} set={setC2} min={-1.2} max={1.2} step={0.01}/>
+          <Slider label="R2" v={R2} set={setR2} min={0.2} max={1.2} step={0.01}/>
+          <Two label="C3 (x,y)" v={C3} set={setC3} min={-1.2} max={1.2} step={0.01}/>
+          <Slider label="R3" v={R3} set={setR3} min={0.2} max={1.2} step={0.01}/>
+          <Slider label="depth" v={depth} set={setDepth} min={3} max={16} step={1}/>
+          <Slider label="#seeds" v={seeds} set={setSeeds} min={100} max={4000} step={50}/>
+        </section>
+        <ActiveReflection
+          title="Active Reflection — Inversion"
+          storageKey="reflect_inversion"
+          prompts={[
+            "Tweak radii/centers: when do symmetric rosettes emerge?",
+            "Increase depth: how does complexity vs. density trade off?",
+            "What geometric loci stay invariant under a chosen inversion?"
+          ]}
+        />
+      </div>
+    </div>
+  );
+}
+
+function draw(ctx, W, H, S){
+  const {C1,R1,C2,R2,C3,R3,depth,seeds}=S;
+  ctx.clearRect(0,0,W,H);
+  // to/from screen
+  const X=x=> W/2 + x*(W*0.42);
+  const Y=y=> H/2 - y*(W*0.42);
+  // soft background
+  ctx.fillStyle="rgb(10,12,18)"; ctx.fillRect(0,0,W,H);
+
+  const circles=[{c:C1,R:R1},{c:C2,R:R2},{c:C3,R:R3}];
+
+  // draw orbits
+  ctx.beginPath();
+  for(let s=0;s<seeds;s++){
+    let p=[ (Math.random()*2-1)*0.9, (Math.random()*2-1)*0.9 ];
+    for(let k=0;k<depth;k++){
+      const j=(s+k)%3; // cycle inversions
+      p = inv(p, circles[j].c, circles[j].R);
+      if(Math.hypot(p[0],p[1])>5) break; // avoid blow-up
+      if(k>2){ ctx.lineTo(X(p[0]),Y(p[1])); }
+      else { ctx.moveTo(X(p[0]),Y(p[1])); }
+    }
+  }
+  ctx.strokeStyle="#bbddff"; ctx.lineWidth=0.6; ctx.stroke();
+
+  // draw circles (light)
+  ctx.strokeStyle="rgba(255,255,255,0.25)"; ctx.lineWidth=1;
+  for(const {c,R} of circles){
+    ctx.beginPath();
+    ctx.arc(X(c[0]),Y(c[1]), R*(W*0.42), 0, Math.PI*2);
+    ctx.stroke();
+  }
+}
+
+function Slider({label,v,set,min,max,step}){
+  const show=(typeof v==='number'&&v.toFixed)?v.toFixed(3):v;
+  return (<div className="mb-2"><label className="text-sm opacity-80">{label}: <b>{show}</b></label>
+  <input className="w-full" type="range" min={min} max={max} step={step}
+         value={v} onChange={e=>set(parseFloat(e.target.value))}/></div>);
+}
+function Two({label,v,set,min,max,step}){
+  const [x,y]=v;
+  return (
+    <div className="mb-2">
+      <label className="text-sm opacity-80 block">{label}</label>
+      <div className="flex items-center gap-2">
+        <input type="range" min={min} max={max} step={step} value={x}
+          onChange={e=>set([parseFloat(e.target.value), y])} className="w-full"/>
+        <input type="range" min={min} max={max} step={step} value={y}
+          onChange={e=>set([x, parseFloat(e.target.value)])} className="w-full"/>
+      </div>
+    </div>
+  );
+}
+

--- a/sites/blackroad/src/pages/EikonalPathLab.jsx
+++ b/sites/blackroad/src/pages/EikonalPathLab.jsx
@@ -1,0 +1,182 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import ActiveReflection from "./ActiveReflection.jsx";
+
+export default function EikonalPathLab(){
+  const [N,setN]=useState(128);
+  const [iters,setIters]=useState(60);
+  const [brush,setBrush]=useState(3);
+  const [mode,setMode]=useState("walls"); // paint walls or erase
+  const [goal,setGoal]=useState([64,64]);
+  const [start,setStart]=useState([16,16]);
+  const cnv=useRef(null);
+  const sim=useMemo(()=>makeSim(N, goal),[N]);
+
+  useEffect(()=>{
+    const c=cnv.current; if(!c) return;
+    c.width=N; c.height=N;
+    const ctx=c.getContext("2d",{alpha:false});
+    let down=false;
+    const onDown=e=>{ down=true; handle(e,true); };
+    const onUp=()=>{ down=false; };
+    const onMove=e=>{ if(down) handle(e,false); };
+    function handle(e,click){
+      const r=c.getBoundingClientRect();
+      const x=Math.floor((e.clientX-r.left)/r.width*N);
+      const y=Math.floor((e.clientY-r.top)/r.height*N);
+      if(e.shiftKey && click){ setGoal([x,y]); return; }
+      if(e.altKey && click){ setStart([x,y]); return; }
+      paint(sim,x,y,brush, mode==="walls"?2:0);
+    }
+    c.addEventListener("mousedown",onDown);
+    window.addEventListener("mouseup",onUp);
+    window.addEventListener("mousemove",onMove);
+    return ()=>{ c.removeEventListener("mousedown",onDown); window.removeEventListener("mouseup",onUp); window.removeEventListener("mousemove",onMove); };
+  },[sim,N,brush,mode]);
+
+  useEffect(()=>{
+    // recompute distances with current goal
+    resetDistances(sim, goal);
+  },[goal, sim]);
+
+  useEffect(()=>{
+    const c=cnv.current; if(!c) return;
+    const ctx=c.getContext("2d",{alpha:false});
+    const draw=()=>{
+      solve(sim,iters);
+      render(ctx, sim, start, goal, extractPath(sim, start, goal));
+      requestAnimationFrame(draw);
+    };
+    draw();
+  },[sim,iters,start,goal]);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">Eikonal Geodesic — walls, start/goal (Shift=goal, Alt=start)</h2>
+      <canvas ref={cnv} style={{width:"100%", imageRendering:"pixelated"}}/>
+      <div className="grid" style={{gridTemplateColumns:'1fr 320px', gap:16}}>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <Radio name="mode" value={mode} set={setMode} opts={[["walls","paint walls"],["erase","erase"]]} />
+          <Slider label="grid N" v={N} set={setN} min={64} max={256} step={16}/>
+          <Slider label="sweeps" v={iters} set={setIters} min={8} max={200} step={4}/>
+          <Slider label="brush" v={brush} set={setBrush} min={1} max={10} step={1}/>
+          <button className="mt-2 px-3 py-1 rounded bg-white/10 border border-white/10" onClick={()=>{clearWalls(sim); resetDistances(sim, goal);}}>Clear walls</button>
+          <p className="text-sm mt-2">Tip: Shift-click sets goal • Alt-click sets start.</p>
+        </section>
+        <ActiveReflection
+          title="Active Reflection — Eikonal Geodesic"
+          storageKey="reflect_eikonal_path"
+          prompts={[
+            "Draw narrow corridors: does the path ‘snap’ to their centerlines?",
+            "Move the goal: how does the distance slope steer descent?",
+            "Increase sweeps: where do errors/facets reduce most noticeably?"
+          ]}
+        />
+      </div>
+    </div>
+  );
+}
+
+function makeSim(N, goal=[N>>1,N>>1]){
+  const u=Array.from({length:N},()=>Array(N).fill(1e6));
+  const type=Array.from({length:N},()=>Array(N).fill(0)); // 0 free, 2 wall
+  const s={N,u,type}; resetDistances(s, goal); return s;
+}
+function clearWalls(sim){ const {N,type}=sim; for(let y=0;y<N;y++) for(let x=0;x<N;x++) if(type[y][x]===2) type[y][x]=0; }
+function resetDistances(sim, goal){
+  const {N,u,type}=sim;
+  for(let y=0;y<N;y++) for(let x=0;x<N;x++) u[y][x]=type[y][x]===2?1e6:1e6;
+  const [gx,gy]=goal.map(v=>Math.max(0,Math.min(N-1,v)));
+  if(type[gy][gx]!==2) u[gy][gx]=0;
+}
+function paint(sim,x,y,r,kind){
+  const {N,type,u}=sim;
+  for(let j=-r;j<=r;j++) for(let i=-r;i<=r;i++){
+    const X=Math.max(0,Math.min(N-1,x+i)), Y=Math.max(0,Math.min(N-1,y+j));
+    if(i*i+j*j<=r*r){ type[Y][X]=kind; if(kind===0 && u[Y][X]===1e6) u[Y][X]=1e6; }
+  }
+}
+function solve(sim,sweeps){
+  const {N,u,type}=sim;
+  for(let s=0;s<sweeps;s++){
+    sweep(0,N,1, 0,N,1); sweep(N-1,-1,-1, 0,N,1);
+    sweep(0,N,1, N-1,-1,-1); sweep(N-1,-1,-1, N-1,-1,-1);
+  }
+  function sweep(x0,x1,dx, y0,y1,dy){
+    for(let y=y0;y!=y1;y+=dy) for(let x=x0;x!=x1;x+=dx){
+      if(type[y][x]===2) { u[y][x]=1e6; continue; }
+      if(u[y][x]===0) continue;
+      const ux=Math.min(get(x-1,y), get(x+1,y));
+      const uy=Math.min(get(x,y-1), get(x,y+1));
+      let a=Math.min(ux,uy), b=Math.max(ux,uy), v;
+      if(b-a>=1) v=a+1; else v=(a+b+Math.sqrt(Math.max(0,2-(a-b)*(a-b))))/2;
+      if(v<u[y][x]) u[y][x]=v;
+    }
+  }
+  function get(x,y){
+    if(x<0||y<0||x>=N||y>=N) return 1e6;
+    if(type[y][x]===2) return 1e6;
+    return u[y][x];
+  }
+}
+function grad(u,x,y){
+  const N=u.length;
+  const cx=(u[y][Math.min(N-1,x+1)]-u[y][Math.max(0,x-1)])/2;
+  const cy=(u[Math.min(N-1,y+1)][x]-u[Math.max(0,y-1)][x])/2;
+  return [cx,cy];
+}
+function extractPath(sim, start, goal){
+  const {u,N,type}=sim;
+  let [x,y]=start.map(v=>Math.max(0,Math.min(N-1,Math.round(v))));
+  const g=[Math.round(goal[0]),Math.round(goal[1])];
+  const path=[[x,y]];
+  for(let k=0;k<4000;k++){
+    if(x===g[0] && y===g[1]) break;
+    const [gx,gy]=grad(u,x,y);
+    const len=Math.hypot(gx,gy)||1e-9;
+    const nx=x - gx/len, ny=y - gy/len; // steepest descent
+    const xi=Math.max(0,Math.min(N-1,Math.round(nx)));
+    const yi=Math.max(0,Math.min(N-1,Math.round(ny)));
+    if(type[yi][xi]===2) break;
+    if(xi===x && yi===y) break;
+    x=xi; y=yi; path.push([x,y]);
+    if(path.length>1e4) break;
+  }
+  return path;
+}
+function render(ctx, sim, start, goal, path){
+  const {N,u,type}=sim;
+  const img=ctx.createImageData(N,N);
+  let mx=0; for(let y=0;y<N;y++) for(let x=0;x<N;x++){ const v=u[y][x]; if(v<1e6) mx=Math.max(mx,v); }
+  for(let y=0;y<N;y++) for(let x=0;x<N;x++){
+    const off=4*(y*N+x);
+    if(type[y][x]===2){ img.data[off]=18; img.data[off+1]=18; img.data[off+2]=24; img.data[off+3]=255; continue; }
+    const t=u[y][x]===1e6?0:(u[y][x]/(mx+1e-9));
+    const R=Math.floor(50+205*t), G=Math.floor(80+150*(1-t)), B=Math.floor(240*(1-t));
+    img.data[off]=R; img.data[off+1]=G; img.data[off+2]=B; img.data[off+3]=255;
+  }
+  ctx.putImageData(img,0,0);
+  // draw path
+  ctx.beginPath();
+  for(let i=0;i<path.length;i++){
+    const [x,y]=path[i];
+    if(i===0) ctx.moveTo(x+0.5,y+0.5); else ctx.lineTo(x+0.5,y+0.5);
+  }
+  ctx.lineWidth=2; ctx.strokeStyle="#fff"; ctx.stroke();
+  // draw start/goal
+  const drawDot=(p,c)=>{ ctx.fillStyle=c; ctx.fillRect(p[0]-1,p[1]-1,3,3); };
+  drawDot(start,"#0ff"); drawDot(goal,"#ff0");
+}
+function Slider({label,v,set,min,max,step}){
+  const show=(typeof v==='number'&&v.toFixed)?v.toFixed(3):v;
+  return (<div className="mb-2"><label className="text-sm opacity-80">{label}: <b>{show}</b></label>
+    <input className="w-full" type="range" min={min} max={max} step={step}
+      value={v} onChange={e=>set(parseFloat(e.target.value))}/></div>);
+}
+function Radio({name,value,set,opts}){
+  return (<div className="flex gap-3 text-sm">
+    {opts.map(([val,lab])=><label key={val} className="flex items-center gap-1">
+      <input type="radio" name={name} checked={value===val} onChange={()=>set(val)}/>{lab}
+    </label>)}
+  </div>);
+}
+

--- a/sites/blackroad/src/pages/FourierOpticsLab.jsx
+++ b/sites/blackroad/src/pages/FourierOpticsLab.jsx
@@ -1,0 +1,112 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import ActiveReflection from "./ActiveReflection.jsx";
+
+export default function FourierOpticsLab(){
+  const [N,setN]=useState(128);
+  const [ap,setAp]=useState("circle");
+  const [param,setParam]=useState(0.3); // radius or slit width
+  const cnvA=useRef(null), cnvF=useRef(null);
+
+  const A = useMemo(()=>makeAperture(N, ap, param),[N,ap,param]);
+  const F = useMemo(()=>dft2(A),[A]); // returns magnitude
+
+  useEffect(()=>{ drawField(cnvA.current, A, false); drawField(cnvF.current, F, true); },[A,F]);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">Fourier Optics — Aperture vs Diffraction</h2>
+      <div className="grid" style={{gridTemplateColumns:'1fr 1fr', gap:16}}>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <h3 className="font-semibold mb-2">Aperture</h3>
+          <canvas ref={cnvA} style={{width:"100%", imageRendering:"pixelated"}}/>
+        </section>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <h3 className="font-semibold mb-2">Diffraction (|F|², log)</h3>
+          <canvas ref={cnvF} style={{width:"100%", imageRendering:"pixelated"}}/>
+        </section>
+      </div>
+      <div className="grid" style={{gridTemplateColumns:'1fr 320px', gap:16}}>
+        <div />
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <Radio name="ap" value={ap} set={setAp} opts={[["circle","circle"],["slit","slit"],["rect","rect"],["checker","checker"]]} />
+          <Slider label="param" v={param} set={setParam} min={0.05} max={0.5} step={0.01}/>
+          <Slider label="grid N" v={N} set={setN} min={64} max={192} step={16}/>
+          <ActiveReflection
+            title="Active Reflection — Fourier Optics"
+            storageKey="reflect_fourier"
+            prompts={[
+              "Circle aperture → Airy pattern; slit → sinc fringes. Do you see reciprocity?",
+              "Halve aperture width: do fringes spread (Fourier duality)?",
+              "What symmetries of aperture appear in the diffraction?"
+            ]}
+          />
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function makeAperture(N, ap, p){
+  const A=Array.from({length:N},()=>Array(N).fill(0));
+  for(let y=0;y<N;y++) for(let x=0;x<N;x++){
+    const X=(x+0.5)/N-0.5, Y=(y+0.5)/N-0.5;
+    let v=0;
+    if(ap==="circle") v=(Math.hypot(X,Y)<=p)?1:0;
+    else if(ap==="slit") v=(Math.abs(X)<=p*0.2)?1:0;
+    else if(ap==="rect") v=(Math.abs(X)<=p && Math.abs(Y)<=p*0.6)?1:0;
+    else if(ap==="checker"){ const s=p*4; v=((Math.floor((X+0.5)/s)+Math.floor((Y+0.5)/s))%2===0)?1:0; }
+    A[y][x]=v;
+  }
+  return A;
+}
+function dft2(A){
+  const N=A.length, M=A[0].length;
+  const mag=Array.from({length:N},()=>Array(M).fill(0));
+  for(let u=0;u<N;u++){
+    for(let v=0;v<M;v++){
+      let re=0, im=0;
+      for(let y=0;y<N;y++) for(let x=0;x<M;x++){
+        const ang=-2*Math.PI*(u*x/N + v*y/M);
+        const c=Math.cos(ang), s=Math.sin(ang);
+        re += A[y][x]*c; im += A[y][x]*s;
+      }
+      const m = re*re + im*im;
+      mag[u][v]=m;
+    }
+  }
+  // shift to center & log scale
+  const B=Array.from({length:N},()=>Array(M).fill(0));
+  let mx=0; for(let u=0;u<N;u++) for(let v=0;v<M;v++) mx=Math.max(mx,mag[u][v]);
+  for(let u=0;u<N;u++) for(let v=0;v<M;v++){
+    const us=(u+N/2|0)%N, vs=(v+M/2|0)%M;
+    B[us][vs]=Math.log(1+mag[u][v]/(mx+1e-9));
+  }
+  return B;
+}
+function drawField(canvas, A, hot){
+  if(!canvas) return; const N=A.length, M=A[0].length; canvas.width=N; canvas.height=M;
+  const ctx=canvas.getContext("2d",{alpha:false}); const img=ctx.createImageData(N,M);
+  let mx=0; for(let y=0;y<N;y++) for(let x=0;x<N;x++) mx=Math.max(mx,A[y][x]);
+  for(let y=0;y<N;y++) for(let x=0;x<N;x++){
+    const t=A[y][x]/(mx+1e-9);
+    const off=4*(y*N+x);
+    // gentle palette
+    const R=Math.floor(40+200*t), G=Math.floor(50+180*(1-t)), B=Math.floor(220*(1-t));
+    img.data[off]=R; img.data[off+1]=G; img.data[off+2]=B; img.data[off+3]=255;
+  }
+  ctx.putImageData(img,0,0);
+}
+function Radio({name,value,set,opts}){
+  return (<div className="flex gap-3 text-sm">
+    {opts.map(([val,lab])=><label key={val} className="flex items-center gap-1">
+      <input type="radio" name={name} checked={value===val} onChange={()=>set(val)}/>{lab}
+    </label>)}
+  </div>);
+}
+function Slider({label,v,set,min,max,step}){
+  const show=(typeof v==='number'&&v.toFixed)?v.toFixed(3):v;
+  return (<div className="mb-2"><label className="text-sm opacity-80">{label}: <b>{show}</b></label>
+    <input className="w-full" type="range" min={min} max={max} step={step}
+      value={v} onChange={e=>set(parseFloat(e.target.value))}/></div>);
+}
+

--- a/sites/blackroad/src/pages/PowerDiagramLab.jsx
+++ b/sites/blackroad/src/pages/PowerDiagramLab.jsx
@@ -1,0 +1,109 @@
+import { useMemo, useRef, useState, useEffect } from "react";
+import ActiveReflection from "./ActiveReflection.jsx";
+
+function rng(seed){ let s=seed|0||2025; return ()=> (s=(1664525*s+1013904223)>>>0)/2**32; }
+
+export default function PowerDiagramLab(){
+  const [W,H]=[640,360];
+  const [n,setN]=useState(10);
+  const [seed,setSeed]=useState(7);
+  const [weights,setWeights]=useState(Array(10).fill(0));
+  const [spread,setSpread]=useState(0.8);
+  const [jitter,setJitter]=useState(0.02);
+
+  const {pts, baseW} = useMemo(()=>initSites(n,seed,spread),[n,seed,spread]);
+  useEffect(()=>{ setWeights(Array(n).fill(0)); },[n]);
+
+  const cnv=useRef(null);
+  useEffect(()=>{
+    const c=cnv.current; if(!c) return; c.width=W; c.height=H;
+    const ctx=c.getContext("2d",{alpha:false});
+    render(ctx, W, H, pts, weights);
+  },[pts, weights]);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">Power Diagram — weighted Voronoi</h2>
+      <canvas ref={cnv} style={{width:"100%", imageRendering:"pixelated"}}/>
+      <div className="grid" style={{gridTemplateColumns:"1fr 340px", gap:16}}>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <Slider label="sites" v={n} set={setN} min={3} max={40} step={1}/>
+          <Slider label="spread" v={spread} set={setSpread} min={0.3} max={1.0} step={0.01}/>
+          <Slider label="seed" v={seed} set={setSeed} min={1} max={9999} step={1}/>
+          <p className="text-sm mt-2">Weights (drag):</p>
+          {Array.from({length:n},(_,i)=>(
+            <div key={i} className="flex items-center gap-2">
+              <span className="text-xs opacity-70 w-6">#{i}</span>
+              <input type="range" min={-0.2} max={0.2} step={0.005}
+                value={weights[i] ?? 0}
+                onChange={e=>{
+                  const w=weights.slice(); w[i]=parseFloat(e.target.value);
+                  setWeights(w);
+                }} className="w-full"/>
+            </div>
+          ))}
+          <p className="text-xs opacity-70 mt-2">Weight enters as −w in power distance (larger weight ⇒ larger cell).</p>
+        </section>
+        <ActiveReflection
+          title="Active Reflection — Power Diagram"
+          storageKey="reflect_power"
+          prompts={[
+            "Increase a site’s weight: does its cell expand linearly or nonlinearly?",
+            "What happens when two weights equalize—straight boundaries?",
+            "Try many sites: do cells equilibrate toward similar areas?"
+          ]}
+        />
+      </div>
+    </div>
+  );
+}
+
+function initSites(n,seed,spread){
+  const r=rng(seed);
+  const pts=[];
+  for(let i=0;i<n;i++){
+    const x=0.5 + spread*(r()-0.5);
+    const y=0.5 + spread*(r()-0.5);
+    pts.push([x,y]);
+  }
+  return {pts, baseW:Array(n).fill(0)};
+}
+function render(ctx, W, H, pts, weights){
+  const img=ctx.createImageData(W,H);
+  const cols=pts.map((_,i)=> color(i));
+  for(let y=0;y<H;y++){
+    for(let x=0;x<W;x++){
+      const X=(x+0.5)/W, Y=(y+0.5)/H;
+      let best=0, bv=Infinity;
+      for(let i=0;i<pts.length;i++){
+        const dx=X-pts[i][0], dy=Y-pts[i][1];
+        const p = dx*dx + dy*dy - (weights[i]||0);
+        if(p<bv){ bv=p; best=i; }
+      }
+      const off=4*(y*W+x);
+      const c=cols[best];
+      img.data[off]=c[0]; img.data[off+1]=c[1]; img.data[off+2]=c[2]; img.data[off+3]=255;
+    }
+  }
+  ctx.putImageData(img,0,0);
+  // draw sites
+  ctx.beginPath();
+  for(let i=0;i<pts.length;i++){
+    const x=pts[i][0]*W, y=pts[i][1]*H;
+    ctx.moveTo(x+2,y); ctx.arc(x,y,2,0,Math.PI*2);
+  }
+  ctx.strokeStyle="#000"; ctx.stroke();
+}
+function color(i){
+  const h=(i*0.618033)%1, s=0.6, v=0.95;
+  const a=h*6, k=(n)=>Math.max(0, Math.min(1, Math.abs((a-n)%6-3)-1));
+  const r=v*(1 - s*k(5)), g=v*(1 - s*k(3)), b=v*(1 - s*k(1));
+  return [Math.floor(255*r),Math.floor(255*g),Math.floor(255*b)];
+}
+function Slider({label,v,set,min,max,step}){
+  const show=(typeof v==='number'&&v.toFixed)?v.toFixed(3):v;
+  return (<div className="mb-2"><label className="text-sm opacity-80">{label}: <b>{show}</b></label>
+    <input className="w-full" type="range" min={min} max={max} step={step}
+      value={v} onChange={e=>set(parseFloat(e.target.value))}/></div>);
+}
+


### PR DESCRIPTION
## Summary
- Add EikonalPathLab for distance-field geodesic paths with wall painting
- Add PowerDiagramLab for weighted Voronoi diagrams
- Add FourierOpticsLab to visualize apertures and their diffraction patterns
- Add CircleInversionLab for iterative circle inversion kaleidoscopes
- Wire up routes for the new labs in the site router

## Testing
- `npm test` *(fails: jest not found)*
- `npm --prefix sites/blackroad run lint`
- `npm --prefix sites/blackroad test`


------
https://chatgpt.com/codex/tasks/task_e_68c10dc2a7d483299b522daaee9d5392