### PR TITLE
feat: add interactive math labs

### DIFF
--- a/sites/blackroad/src/App.jsx
+++ b/sites/blackroad/src/App.jsx
@@ -23,6 +23,10 @@ import EikonalLab from "./pages/EikonalLab.jsx";
 import PoissonDiskLab from "./pages/PoissonDiskLab.jsx";
 import LSystemLab from "./pages/LSystemLab.jsx";
 import MinimalSurfaceLab from "./pages/MinimalSurfaceLab.jsx";
+import EigenmapsLab from "./pages/EigenmapsLab.jsx";
+import PoissonBlendLab from "./pages/PoissonBlendLab.jsx";
+import NBodyLab from "./pages/NBodyLab.jsx";
+import WaveletLab from "./pages/WaveletLab.jsx";
 
 function useApiHealth(){
   const [state,setState]=useState({ok:null, info:""});
@@ -122,6 +126,10 @@ function LegacyApp(){
             <Route path="/poisson2" element={<PoissonDiskLab/>} />
             <Route path="/lsys" element={<LSystemLab/>} />
             <Route path="/minimal" element={<MinimalSurfaceLab/>} />
+            <Route path="/eigenmaps" element={<EigenmapsLab/>} />
+            <Route path="/blend" element={<PoissonBlendLab/>} />
+            <Route path="/nbody" element={<NBodyLab/>} />
+            <Route path="/wavelet" element={<WaveletLab/>} />
             <Route path="chat" element={<Chat/>} />
             <Route path="canvas" element={<Canvas/>} />
             <Route path="editor" element={<Editor/>} />
@@ -142,6 +150,10 @@ function LegacyApp(){
             <Route path="poisson2" element={<PoissonDiskLab/>} />
             <Route path="lsys" element={<LSystemLab/>} />
             <Route path="minimal" element={<MinimalSurfaceLab/>} />
+            <Route path="eigenmaps" element={<EigenmapsLab/>} />
+            <Route path="blend" element={<PoissonBlendLab/>} />
+            <Route path="nbody" element={<NBodyLab/>} />
+            <Route path="wavelet" element={<WaveletLab/>} />
             <Route path="*" element={<div>Not found</div>} />
           </Routes>
         </section>

--- a/sites/blackroad/src/pages/EigenmapsLab.jsx
+++ b/sites/blackroad/src/pages/EigenmapsLab.jsx
@@ -1,0 +1,204 @@
+import { useMemo, useState } from "react";
+import ActiveReflection from "./ActiveReflection.jsx";
+
+function rng(seed) {
+  let s = seed | 0 || 2025;
+  return () => (s = (1664525 * s + 1013904223) >>> 0) / 2 ** 32;
+}
+function randn(r) {
+  const u = Math.max(r(), 1e-12),
+    v = Math.max(r(), 1e-12);
+  return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v);
+}
+
+function makeSwissRoll(n, seed) {
+  const r = rng(seed),
+    pts = [];
+  for (let i = 0; i < n; i++) {
+    const t = 1.5 * Math.PI * (1 + 2 * r());
+    const x = t * Math.cos(t),
+      y = 21 * r(),
+      z = t * Math.sin(t);
+    pts.push([x, y, z]);
+  }
+  return pts;
+}
+function pairwiseWeights(pts, k = 10, sigma = 10) {
+  const n = pts.length;
+  const W = Array.from({ length: n }, () => Array(n).fill(0));
+  for (let i = 0; i < n; i++) {
+    const dists = [];
+    for (let j = 0; j < n; j++) {
+      const dx = pts[i][0] - pts[j][0],
+        dy = pts[i][1] - pts[j][1],
+        dz = pts[i][2] - pts[j][2];
+      dists.push([j, dx * dx + dy * dy + dz * dz]);
+    }
+    dists.sort((a, b) => a[1] - b[1]);
+    for (let m = 1; m <= k; m++) {
+      const j = dists[m][0],
+        d = dists[m][1];
+      const w = Math.exp(-d / (2 * sigma * sigma));
+      W[i][j] = W[j][i] = Math.max(W[i][j], w);
+    }
+  }
+  return W;
+}
+function eigenmaps(W, dim = 2) {
+  const n = W.length;
+  const D = Array(n)
+    .fill(0)
+    .map((_, i) => W[i].reduce((a, b) => a + b, 0));
+  // normalized Laplacian Lsym = I - D^{-1/2} W D^{-1/2}
+  const Ms = (v) => {
+    const y = Array(n).fill(0);
+    for (let i = 0; i < n; i++) {
+      let sum = 0;
+      for (let j = 0; j < n; j++) {
+        const wij = W[i][j];
+        if (!wij) continue;
+        sum += (wij / Math.sqrt((D[i] || 1) * (D[j] || 1))) * v[j];
+      }
+      y[i] = v[i] - sum; // I - D^-1/2 W D^-1/2
+    }
+    // center & normalize
+    const mean = y.reduce((a, b) => a + b, 0) / n;
+    for (let i = 0; i < n; i++) y[i] -= mean;
+    const norm = Math.sqrt(y.reduce((a, b) => a + b * b, 0)) || 1;
+    for (let i = 0; i < n; i++) y[i] /= norm;
+    return y;
+  };
+  // power iteration for smallest nontrivial eigenvectors: iterate (I - α Lsym) is tricky; use deflation on Ms
+  const vecs = [];
+  const deflate = (v) => {
+    // Gram-Schmidt against previous vecs
+    let u = v.slice();
+    for (const q of vecs) {
+      const dot = u.reduce((s, x, i) => s + x * q[i], 0);
+      for (let i = 0; i < n; i++) u[i] -= dot * q[i];
+    }
+    const norm = Math.sqrt(u.reduce((s, x) => s + x * x, 0)) || 1;
+    return u.map((x) => x / norm);
+  };
+  let v = Array(n)
+    .fill(0)
+    .map(() => Math.random() * 2 - 1);
+  v = deflate(v);
+  for (let t = 0; t < 120; t++) v = deflate(Ms(v));
+  // Skip trivial eigenvector (constant); build 2 dims
+  vecs.push(v);
+  for (let d = 1; d <= dim; d++) {
+    let z = Array(n)
+      .fill(0)
+      .map(() => Math.random() * 2 - 1);
+    z = deflate(z);
+    for (let t = 0; t < 120; t++) z = deflate(Ms(z));
+    vecs.push(z);
+  }
+  // take last dim vectors as coordinates
+  const Y = Array.from({ length: n }, (_, i) =>
+    vecs.slice(1, dim + 1).map((v) => v[i]),
+  );
+  return Y;
+}
+
+export default function EigenmapsLab() {
+  const [n, setN] = useState(500);
+  const [k, setK] = useState(10);
+  const [sigma, setSigma] = useState(10);
+  const [seed, setSeed] = useState(7);
+
+  const pts3 = useMemo(() => makeSwissRoll(n, seed), [n, seed]);
+  const W = useMemo(() => pairwiseWeights(pts3, k, sigma), [pts3, k, sigma]);
+  const Y = useMemo(() => eigenmaps(W, 2), [W]);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">
+        Graph Laplacian Eigenmaps — Swiss Roll
+      </h2>
+      <Scatter pts={Y} />
+      <div className="grid" style={{ gridTemplateColumns: "1fr 320px", gap: 16 }}>
+        <div />
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <Slider label="points" v={n} set={setN} min={100} max={1200} step={50} />
+          <Slider
+            label="neighbors k"
+            v={k}
+            set={setK}
+            min={4}
+            max={30}
+            step={1}
+          />
+          <Slider
+            label="σ (heat)"
+            v={sigma}
+            set={setSigma}
+            min={2}
+            max={30}
+            step={1}
+          />
+          <Slider
+            label="seed"
+            v={seed}
+            set={setSeed}
+            min={1}
+            max={9999}
+            step={1}
+          />
+          <ActiveReflection
+            title="Active Reflection — Eigenmaps"
+            storageKey="reflect_eigenmaps"
+            prompts={[
+              "Lower k: manifold unwrap stays smooth but may fragment—where first?",
+              "Increase σ: neighborhoods blur—when do loops collapse?",
+              "Why are coordinates only defined up to rotation/scale?",
+            ]}
+          />
+        </section>
+      </div>
+    </div>
+  );
+}
+function Scatter({ pts }) {
+  const W = 640,
+    H = 360,
+    pad = 20;
+  const xs = pts.map((p) => p[0]),
+    ys = pts.map((p) => p[1]);
+  const minX = Math.min(...xs),
+    maxX = Math.max(...xs);
+  const minY = Math.min(...ys),
+    maxY = Math.max(...ys);
+  const X = (x) => pad + ((x - minX) / (maxX - minX + 1e-9)) * (W - 2 * pad);
+  const Y = (y) => H - pad - ((y - minY) / (maxY - minY + 1e-9)) * (H - 2 * pad);
+  return (
+    <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+      <svg width="100%" viewBox={`0 0 ${W} ${H}`}>
+        {pts.map((p, i) => (
+          <circle key={i} cx={X(p[0])} cy={Y(p[1])} r="2" />
+        ))}
+      </svg>
+    </section>
+  );
+}
+function Slider({ label, v, set, min, max, step }) {
+  const show = typeof v === "number" && v.toFixed ? v.toFixed(2) : v;
+  return (
+    <div className="mb-2">
+      <label className="text-sm opacity-80">
+        {label}: <b>{show}</b>
+      </label>
+      <input
+        className="w-full"
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={v}
+        onChange={(e) => set(parseFloat(e.target.value))}
+      />
+    </div>
+  );
+}
+

--- a/sites/blackroad/src/pages/NBodyLab.jsx
+++ b/sites/blackroad/src/pages/NBodyLab.jsx
@@ -1,0 +1,183 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import ActiveReflection from "./ActiveReflection.jsx";
+
+function rk4_step(state, h) {
+  // state = [{m, x:[x,y], v:[vx,vy]}, ...]
+  const acc = (S) =>
+    S.map((bi, i) => {
+      let ax = 0,
+        ay = 0;
+      for (let j = 0; j < S.length; j++) {
+        if (i === j) continue;
+        const bj = S[j];
+        const dx = bj.x[0] - bi.x[0],
+          dy = bj.x[1] - bi.x[1];
+        const r2 = dx * dx + dy * dy + 1e-6,
+          r = Math.sqrt(r2);
+        const f = bj.m / (r2 * r); // G=1
+        ax += f * dx;
+        ay += f * dy;
+      }
+      return [ax, ay];
+    });
+  const add = (A, B, s) =>
+    A.map((b, i) => ({
+      ...b,
+      x: [b.x[0] + s * B[i].x[0], b.x[1] + s * B[i].x[1]],
+      v: [b.v[0] + s * B[i].v[0], b.v[1] + s * B[i].v[1]],
+    }));
+  const der = (S) =>
+    S.map((b, i) => ({ m: b.m, x: [b.v[0], b.v[1]], v: acc(S)[i] }));
+  const k1 = der(state);
+  const k2 = der(add(state, k1, h / 2));
+  const k3 = der(add(state, k2, h / 2));
+  const k4 = der(add(state, k3, h));
+  return state.map((b, i) => ({
+    m: b.m,
+    x: [
+      b.x[0] + (h / 6) * (k1[i].x[0] + 2 * k2[i].x[0] + 2 * k3[i].x[0] + k4[i].x[0]),
+      b.x[1] + (h / 6) * (k1[i].x[1] + 2 * k2[i].x[1] + 2 * k3[i].x[1] + k4[i].x[1]),
+    ],
+    v: [
+      b.v[0] + (h / 6) * (k1[i].v[0] + 2 * k2[i].v[0] + 2 * k3[i].v[0] + k4[i].v[0]),
+      b.v[1] + (h / 6) * (k1[i].v[1] + 2 * k2[i].v[1] + 2 * k3[i].v[1] + k4[i].v[1]),
+    ],
+  }));
+}
+
+export default function NBodyLab() {
+  const [mode, setMode] = useState("two"); // two or three
+  const [h, setH] = useState(0.01);
+  const [trail, setTrail] = useState(600);
+
+  const init = useMemo(() => initState(mode), [mode]);
+  const [state, setState] = useState(init);
+  useEffect(() => setState(init), [init]);
+
+  const cnv = useRef(null);
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    const c = cnv.current;
+    if (!c) return;
+    const ctx = c.getContext("2d", { alpha: false });
+    const W = 640,
+      H = 360;
+    c.width = W;
+    c.height = H;
+    let raf;
+    const S = []; // trails
+    const loop = () => {
+      // step a few times
+      let st = state;
+      for (let s = 0; s < 3; s++) st = rk4_step(st, h);
+      setState(st);
+      setTick((t) => t + 1);
+      S.push(st.map((b) => [b.x[0], b.x[1]]));
+      if (S.length > trail) S.shift();
+      // render
+      ctx.fillStyle = "rgb(10,12,18)";
+      ctx.fillRect(0, 0, W, H);
+      const scale = 70,
+        cx = W / 2,
+        cy = H / 2;
+      // trails
+      ctx.lineWidth = 1;
+      ctx.strokeStyle = "rgba(200,220,255,0.5)";
+      for (let i = 0; i < S.length - 1; i++) {
+        const A = S[i],
+          B = S[i + 1];
+        for (let k = 0; k < st.length; k++) {
+          ctx.beginPath();
+          ctx.moveTo(cx + A[k][0] * scale, cy - A[k][1] * scale);
+          ctx.lineTo(cx + B[k][0] * scale, cy - B[k][1] * scale);
+          ctx.stroke();
+        }
+      }
+      // bodies
+      for (const b of st) {
+        ctx.beginPath();
+        ctx.arc(cx + b.x[0] * scale, cy - b.x[1] * scale, Math.max(2, 3 * Math.cbrt(b.m)), 0, Math.PI * 2);
+        ctx.fillStyle = "rgb(220,240,255)";
+        ctx.fill();
+      }
+      raf = requestAnimationFrame(loop);
+    };
+    loop();
+    return () => cancelAnimationFrame(raf);
+  }, [state, h, trail, mode]);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">N-Body Dance — Newtonian 2/3-body</h2>
+      <canvas ref={cnv} style={{ width: "100%", imageRendering: "pixelated" }} />
+      <div className="grid" style={{ gridTemplateColumns: "1fr 320px", gap: 16 }}>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <Radio name="mode" value={mode} set={setMode} opts={[["two", "two-body"], ["three", "three-body"]]} />
+          <Slider label="step h" v={h} set={setH} min={0.002} max={0.03} step={0.001} />
+          <Slider label="trail len" v={trail} set={setTrail} min={100} max={2000} step={50} />
+          <button
+            className="mt-2 px-3 py-1 rounded bg-white/10 border border-white/10"
+            onClick={() => setState(initState(mode))}
+          >
+            Reset
+          </button>
+        </section>
+        <ActiveReflection
+          title="Active Reflection — N-Body"
+          storageKey="reflect_nbody"
+          prompts={[
+            "Two-body: ellipses if v < escape; tweak h to control energy drift.",
+            "Three-body: do you see transient choreographies?",
+            "Why does shrinking h reduce but not eliminate drift with RK4?",
+          ]}
+        />
+      </div>
+    </div>
+  );
+}
+function initState(mode) {
+  if (mode === "two") {
+    return [
+      { m: 1.0, x: [-0.8, 0], v: [0, 0.6] },
+      { m: 0.5, x: [0.6, 0], v: [0, -1.0] },
+    ];
+  }
+  return [
+    { m: 1.0, x: [-0.9, 0.0], v: [0.0, 0.7] },
+    { m: 0.8, x: [0.6, 0.1], v: [0.0, -0.8] },
+    { m: 0.3, x: [0.1, -0.8], v: [0.9, 0.0] },
+  ];
+}
+function Slider({ label, v, set, min, max, step }) {
+  const show = typeof v === "number" && v.toFixed ? v.toFixed(3) : v;
+  return (
+    <div className="mb-2">
+      <label className="text-sm opacity-80">
+        {label}: <b>{show}</b>
+      </label>
+      <input
+        className="w-full"
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={v}
+        onChange={(e) => set(parseFloat(e.target.value))}
+      />
+    </div>
+  );
+}
+function Radio({ name, value, set, opts }) {
+  return (
+    <div className="flex gap-3 text-sm">
+      {opts.map(([val, lab]) => (
+        <label key={val} className="flex items-center gap-1">
+          <input type="radio" name={name} checked={value === val} onChange={() => set(val)} />
+          {lab}
+        </label>
+      ))}
+    </div>
+  );
+}
+

--- a/sites/blackroad/src/pages/PoissonBlendLab.jsx
+++ b/sites/blackroad/src/pages/PoissonBlendLab.jsx
@@ -1,0 +1,180 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import ActiveReflection from "./ActiveReflection.jsx";
+
+/** We synthesize a 'source' pattern and a 'target' background, define a circular mask,
+ *  then solve ∆u = ∆s inside mask with u = target on boundary (Jacobi relaxation).
+ */
+function makePatterns(N) {
+  const src = Array.from({ length: N }, () => Array(N).fill(0));
+  const dst = Array.from({ length: N }, () => Array(N).fill(0));
+  for (let y = 0; y < N; y++)
+    for (let x = 0; x < N; x++) {
+      const u = x / N,
+        v = y / N;
+      // dst: smooth gradient + gentle waves
+      dst[y][x] = 0.4 + 0.3 * Math.sin(4 * Math.PI * u) * Math.sin(4 * Math.PI * v);
+      // src: a logo-like cross
+      const cx = 0.5,
+        cy = 0.5;
+      const dx = Math.abs(u - cx),
+        dy = Math.abs(v - cy);
+      const cross = dx < 0.08 || dy < 0.08 ? 1 : 0;
+      src[y][x] = 0.2 + 0.7 * cross;
+    }
+  return { src, dst };
+}
+function circleMask(N, r = 0.22, cx = 0.55, cy = 0.52) {
+  const M = Array.from({ length: N }, () => Array(N).fill(false));
+  for (let y = 0; y < N; y++)
+    for (let x = 0; x < N; x++) {
+      const u = x / N,
+        v = y / N;
+      M[y][x] = (u - cx) * (u - cx) + (v - cy) * (v - cy) <= r * r;
+    }
+  return M;
+}
+function blendPoisson(src, dst, mask, iters = 1000) {
+  const N = src.length;
+  const u = Array.from({ length: N }, () => Array(N).fill(0));
+  // initialize u with dst
+  for (let y = 0; y < N; y++) for (let x = 0; x < N; x++) u[y][x] = dst[y][x];
+  // Jacobi relaxation: ∆u = ∆src inside mask; u=dst outside
+  for (let k = 0; k < iters; k++) {
+    const nu = Array.from({ length: N }, () => Array(N).fill(0));
+    for (let y = 1; y < N - 1; y++)
+      for (let x = 1; x < N - 1; x++) {
+        if (!mask[y][x]) {
+          nu[y][x] = u[y][x];
+          continue;
+        }
+        // guidance: Laplacian of src
+        const lapS =
+          4 * src[y][x] - src[y - 1][x] - src[y + 1][x] - src[y][x - 1] - src[y][x + 1];
+        // Jacobi update for Poisson: u = avg(neigh) - lapS/4
+        const avg = 0.25 * (u[y - 1][x] + u[y + 1][x] + u[y][x - 1] + u[y][x + 1]);
+        nu[y][x] = avg - lapS / 4;
+      }
+    // keep boundary fixed to dst
+    for (let y = 0; y < N; y++) {
+      nu[y][0] = dst[y][0];
+      nu[y][N - 1] = dst[y][N - 1];
+    }
+    for (let x = 0; x < N; x++) {
+      nu[0][x] = dst[0][x];
+      nu[N - 1][x] = dst[N - 1][x];
+    }
+    // outside mask = dst
+    for (let y = 1; y < N - 1; y++)
+      for (let x = 1; x < N - 1; x++) if (!mask[y][x]) nu[y][x] = dst[y][x];
+    for (let y = 0; y < N; y++) for (let x = 0; x < N; x++) u[y][x] = nu[y][x];
+  }
+  return u;
+}
+function drawField(ctx, A) {
+  const N = A.length;
+  const img = ctx.createImageData(N, N);
+  let mn = Infinity,
+    mx = -Infinity;
+  for (let y = 0; y < N; y++)
+    for (let x = 0; x < N; x++) {
+      mn = Math.min(mn, A[y][x]);
+      mx = Math.max(mx, A[y][x]);
+    }
+  for (let y = 0; y < N; y++)
+    for (let x = 0; x < N; x++) {
+      const t = (A[y][x] - mn) / (mx - mn + 1e-9);
+      const off = 4 * (y * N + x);
+      const R = Math.floor(40 + 200 * t),
+        G = Math.floor(50 + 180 * (1 - t)),
+        B = Math.floor(220 * (1 - t));
+      img.data[off] = R;
+      img.data[off + 1] = G;
+      img.data[off + 2] = B;
+      img.data[off + 3] = 255;
+    }
+  ctx.putImageData(img, 0, 0);
+}
+
+export default function PoissonBlendLab() {
+  const [N, setN] = useState(160);
+  const [iters, setIters] = useState(700);
+  const { src, dst } = useMemo(() => makePatterns(N), [N]);
+  const mask = useMemo(() => circleMask(N), [N]);
+  const blend = useMemo(() => blendPoisson(src, dst, mask, iters), [src, dst, mask, iters]);
+
+  const cnvS = useRef(null),
+    cnvD = useRef(null),
+    cnvB = useRef(null);
+  useEffect(() => {
+    const cs = cnvS.current,
+      cd = cnvD.current,
+      cb = cnvB.current;
+    if (!cs || !cd || !cb) return;
+    cs.width = cd.width = cb.width = N;
+    cs.height = cd.height = cb.height = N;
+    drawField(cs.getContext("2d", { alpha: false }), src);
+    drawField(cd.getContext("2d", { alpha: false }), dst);
+    drawField(cb.getContext("2d", { alpha: false }), blend);
+  }, [src, dst, blend, N]);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">Poisson Image Blend — Seamless Clone (toy)</h2>
+      <div className="grid" style={{ gridTemplateColumns: "1fr 1fr 1fr", gap: 16 }}>
+        <Panel title="Source">
+          <canvas ref={cnvS} style={{ width: "100%", imageRendering: "pixelated" }} />
+        </Panel>
+        <Panel title="Target">
+          <canvas ref={cnvD} style={{ width: "100%", imageRendering: "pixelated" }} />
+        </Panel>
+        <Panel title="Blended">
+          <canvas ref={cnvB} style={{ width: "100%", imageRendering: "pixelated" }} />
+        </Panel>
+      </div>
+      <div className="grid" style={{ gridTemplateColumns: "1fr 320px", gap: 16 }}>
+        <div />
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <Slider label="grid N" v={N} set={setN} min={96} max={224} step={16} />
+          <Slider label="iterations" v={iters} set={setIters} min={200} max={2000} step={50} />
+          <ActiveReflection
+            title="Active Reflection — Poisson Blend"
+            storageKey="reflect_poisson_blend"
+            prompts={[
+              "Raise iterations: seams fade first near which features?",
+              "Why does copying Laplacian (gradients) transfer structure smoothly?",
+              "How would a user-defined mask change the result?",
+            ]}
+          />
+        </section>
+      </div>
+    </div>
+  );
+}
+function Panel({ title, children }) {
+  return (
+    <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+      <h3 className="font-semibold mb-2">{title}</h3>
+      {children}
+    </section>
+  );
+}
+function Slider({ label, v, set, min, max, step }) {
+  const show = typeof v === "number" && v.toFixed ? v.toFixed(0) : v;
+  return (
+    <div className="mb-2">
+      <label className="text-sm opacity-80">
+        {label}: <b>{show}</b>
+      </label>
+      <input
+        className="w-full"
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={v}
+        onChange={(e) => set(parseFloat(e.target.value))}
+      />
+    </div>
+  );
+}
+

--- a/sites/blackroad/src/pages/WaveletLab.jsx
+++ b/sites/blackroad/src/pages/WaveletLab.jsx
@@ -1,0 +1,175 @@
+import { useMemo, useState } from "react";
+import ActiveReflection from "./ActiveReflection.jsx";
+
+/** Simple DWT (Haar or db2) on power-of-two length. */
+const HAAR = { h: [1 / Math.SQRT2, 1 / Math.SQRT2], g: [1 / Math.SQRT2, -1 / Math.SQRT2] };
+const DB2 = {
+  h: [0.482962913145, 0.836516303738, 0.224143868042, -0.129409522551],
+  g: [-0.129409522551, -0.224143868042, 0.836516303738, -0.482962913145],
+};
+
+function dwt1(x, filt, levels) {
+  let a = x.slice(),
+    coeffs = [];
+  for (let L = 0; L < levels; L++) {
+    const lo = [],
+      hi = [];
+    for (let i = 0; i < a.length; i += 2) {
+      let s = 0,
+        d = 0;
+      for (let k = 0; k < filt.h.length; k++) {
+        const j = (i + k) % a.length;
+        s += filt.h[k] * a[j];
+        d += filt.g[k] * a[j];
+      }
+      lo.push(s);
+      hi.push(d);
+    }
+    coeffs.push(hi);
+    a = lo;
+  }
+  coeffs.push(a); // last approx
+  return coeffs; // [hi1, hi2, ..., approx]
+}
+function idwt1(coeffs, filt) {
+  // inverse assuming orthonormal pairs
+  let a = coeffs[coeffs.length - 1].slice();
+  for (let L = coeffs.length - 2; L >= 0; L--) {
+    const hi = coeffs[L],
+      out = new Array((a.length + hi.length) * 2).fill(0);
+    for (let i = 0; i < a.length; i++) {
+      for (let k = 0; k < filt.h.length; k++) {
+        const j = (2 * i + k) % out.length;
+        out[j] += filt.h[k] * a[i];
+        out[j] += filt.g[k] * hi[i];
+      }
+    }
+    a = out;
+  }
+  return a;
+}
+
+function synthSignal(N) {
+  const x = [];
+  for (let n = 0; n < N; n++) {
+    const t = n / N;
+    x.push(
+      0.6 * Math.sin(6 * Math.PI * t) +
+        0.3 * Math.sin(20 * Math.PI * t) +
+        0.15 * (t > 0.4 && t < 0.6 ? 1 : 0),
+    );
+  }
+  return x;
+}
+
+export default function WaveletLab() {
+  const [N, setN] = useState(256);
+  const [levels, setLevels] = useState(4);
+  const [basis, setBasis] = useState("haar");
+
+  const x = useMemo(() => synthSignal(N), [N]);
+  const filt = basis === "haar" ? HAAR : DB2;
+  const coeffs = useMemo(() => dwt1(x, filt, levels), [x, levels, basis]);
+  const rec = useMemo(() => idwt1(coeffs, filt), [coeffs, basis]);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">Wavelet 1-D Explorer — Haar / db2</h2>
+      <Series title="Signal (x) & Reconstruction" a={x} b={rec} />
+      <CoeffView coeffs={coeffs} />
+      <div className="grid" style={{ gridTemplateColumns: "1fr 320px", gap: 16 }}>
+        <div />
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <Radio name="basis" value={basis} set={setBasis} opts={[["haar", "haar"], ["db2", "db2"]]} />
+          <Slider label="levels" v={levels} set={setLevels} min={1} max={6} step={1} />
+          <Slider label="N" v={N} set={setN} min={64} max={512} step={64} />
+          <ActiveReflection
+            title="Active Reflection — Wavelets"
+            storageKey="reflect_wavelet"
+            prompts={[
+              "Switch Haar↔db2: how do details spread across scales?",
+              "Which levels capture the step (0.4–0.6) vs the sines?",
+              "Why does perfect reconstruction hold (up to float error)?",
+            ]}
+          />
+        </section>
+      </div>
+    </div>
+  );
+}
+function Series({ title, a, b }) {
+  const W = 640,
+    H = 200,
+    pad = 10;
+  const min = Math.min(...a, ...b),
+    max = Math.max(...a, ...b);
+  const X = (i) => pad + (i / (a.length - 1)) * (W - 2 * pad);
+  const Y = (v) => H - pad - ((v - min) / (max - min + 1e-9)) * (H - 2 * pad);
+  const poly = (arr) => arr.map((v, i) => `${X(i)},${Y(v)}`).join(" ");
+  return (
+    <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+      <h3 className="font-semibold mb-2">{title}</h3>
+      <svg width="100%" viewBox={`0 0 ${W} ${H}`}>
+        <polyline points={poly(a)} fill="none" strokeWidth="2" />
+        <polyline points={poly(b)} fill="none" strokeWidth="2" opacity="0.6" />
+      </svg>
+    </section>
+  );
+}
+function CoeffView({ coeffs }) {
+  const H = 120,
+    W = 640,
+    pad = 10;
+  return (
+    <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+      <h3 className="font-semibold mb-2">Detail Coefficients (levels 1..L) & Approx (bottom)</h3>
+      {coeffs.map((c, idx) => {
+        const a = c;
+        const mn = Math.min(...a),
+          mx = Math.max(...a);
+        const X = (i) => pad + (i / (a.length - 1)) * (W - 2 * pad);
+        const Y = (v) => H - pad - ((v - mn) / (mx - mn + 1e-9)) * (H - 2 * pad);
+        return (
+          <svg key={idx} width="100%" viewBox={`0 0 ${W} ${H}`} style={{ marginBottom: 8 }}>
+            <polyline points={a.map((v, i) => `${X(i)},${Y(v)}`).join(" ")} fill="none" strokeWidth="2" />
+            <text x={pad} y={12} fontSize="10">
+              {idx < coeffs.length - 1 ? `detail L${idx + 1}` : `approx`}
+            </text>
+          </svg>
+        );
+      })}
+    </section>
+  );
+}
+function Slider({ label, v, set, min, max, step }) {
+  const show = typeof v === "number" && v.toFixed ? v.toFixed(0) : v;
+  return (
+    <div className="mb-2">
+      <label className="text-sm opacity-80">
+        {label}: <b>{show}</b>
+      </label>
+      <input
+        className="w-full"
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={v}
+        onChange={(e) => set(parseFloat(e.target.value))}
+      />
+    </div>
+  );
+}
+function Radio({ name, value, set, opts }) {
+  return (
+    <div className="flex gap-3 text-sm">
+      {opts.map(([val, lab]) => (
+        <label key={val} className="flex items-center gap-1">
+          <input type="radio" name={name} checked={value === val} onChange={() => set(val)} />
+          {lab}
+        </label>
+      ))}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add Eigenmaps, Poisson Blend, N-Body, and Wavelet labs as standalone pages
- wire new lab routes into the main router

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm test` *(fails: jest not found)*
- `npm --prefix sites/blackroad run lint`
- `npm --prefix sites/blackroad test`


------
https://chatgpt.com/codex/tasks/task_e_68c111a64e588329b39fa7f0494236e1