### PR TITLE
feat: add interactive labs for path planning and graphs

### DIFF
--- a/sites/blackroad/src/App.jsx
+++ b/sites/blackroad/src/App.jsx
@@ -23,6 +23,10 @@ import EikonalLab from "./pages/EikonalLab.jsx";
 import PoissonDiskLab from "./pages/PoissonDiskLab.jsx";
 import LSystemLab from "./pages/LSystemLab.jsx";
 import MinimalSurfaceLab from "./pages/MinimalSurfaceLab.jsx";
+import RRTStarLab from "./pages/RRTStarLab.jsx";
+import FourierPainterLab from "./pages/FourierPainterLab.jsx";
+import HilbertMortonLab from "./pages/HilbertMortonLab.jsx";
+import IsingMaxCutLab from "./pages/IsingMaxCutLab.jsx";
 
 function useApiHealth(){
   const [state,setState]=useState({ok:null, info:""});
@@ -122,6 +126,10 @@ function LegacyApp(){
             <Route path="/poisson2" element={<PoissonDiskLab/>} />
             <Route path="/lsys" element={<LSystemLab/>} />
             <Route path="/minimal" element={<MinimalSurfaceLab/>} />
+            <Route path="/rrtstar" element={<RRTStarLab/>} />
+            <Route path="/epicycles" element={<FourierPainterLab/>} />
+            <Route path="/hilbert" element={<HilbertMortonLab/>} />
+            <Route path="/maxcut" element={<IsingMaxCutLab/>} />
             <Route path="chat" element={<Chat/>} />
             <Route path="canvas" element={<Canvas/>} />
             <Route path="editor" element={<Editor/>} />
@@ -142,6 +150,10 @@ function LegacyApp(){
             <Route path="poisson2" element={<PoissonDiskLab/>} />
             <Route path="lsys" element={<LSystemLab/>} />
             <Route path="minimal" element={<MinimalSurfaceLab/>} />
+            <Route path="rrtstar" element={<RRTStarLab/>} />
+            <Route path="epicycles" element={<FourierPainterLab/>} />
+            <Route path="hilbert" element={<HilbertMortonLab/>} />
+            <Route path="maxcut" element={<IsingMaxCutLab/>} />
             <Route path="*" element={<div>Not found</div>} />
           </Routes>
         </section>

--- a/sites/blackroad/src/pages/FourierPainterLab.jsx
+++ b/sites/blackroad/src/pages/FourierPainterLab.jsx
@@ -1,0 +1,132 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import ActiveReflection from "./ActiveReflection.jsx";
+
+// simple DFT of a polyline (complex samples), draw epicycles at t∈[0,1)
+function dft(samples){
+  const N=samples.length, out=[];
+  for(let k=-(N>>2); k<=(N>>2); k++){ // a small band around 0
+    let re=0, im=0;
+    for(let n=0;n<N;n++){
+      const ang=-2*Math.PI*k*n/N;
+      re += samples[n][0]*Math.cos(ang) - samples[n][1]*Math.sin(ang);
+      im += samples[n][0]*Math.sin(ang) + samples[n][1]*Math.cos(ang);
+    }
+    re/=N; im/=N; out.push({k, re, im, amp:Math.hypot(re,im), phase:Math.atan2(im,re)});
+  }
+  out.sort((a,b)=> b.amp - a.amp);
+  return out;
+}
+function synth(coeffs, t){
+  let x=0,y=0;
+  for(const c of coeffs){
+    const ang=2*Math.PI*c.k*t + c.phase;
+    x += c.amp*Math.cos(ang);
+    y += c.amp*Math.sin(ang);
+  }
+  return {x,y};
+}
+
+export default function FourierPainterLab(){
+  const [W,H]=[640,360];
+  const [points,setPoints]=useState(()=> heartSamples(W,H));
+  const [terms,setTerms]=useState(40);
+  const coeffsAll = useMemo(()=> dft(points),[points]);
+  const coeffs = useMemo(()=> coeffsAll.slice(0, terms),[coeffsAll,terms]);
+
+  const cnv=useRef(null);
+  useEffect(()=>{
+    const c=cnv.current; if(!c) return; c.width=W; c.height=H;
+    const ctx=c.getContext("2d",{alpha:false});
+    let t=0;
+    const trail=[];
+    const loop=()=>{
+      t=(t+0.003) % 1;
+      // background
+      ctx.fillStyle="rgb(10,12,18)"; ctx.fillRect(0,0,W,H);
+      // epicycles
+      let ox=W/2, oy=H/2;
+      for(const c of coeffs){
+        const ang=2*Math.PI*c.k*t + c.phase;
+        const r=c.amp;
+        const nx=ox + r*Math.cos(ang), ny=oy + r*Math.sin(ang);
+        ctx.beginPath(); ctx.arc(ox,oy,r,0,Math.PI*2); ctx.strokeStyle="rgba(200,220,255,0.15)"; ctx.stroke();
+        ctx.beginPath(); ctx.moveTo(ox,oy); ctx.lineTo(nx,ny); ctx.strokeStyle="rgba(255,255,255,0.7)"; ctx.stroke();
+        ox=nx; oy=ny;
+      }
+      trail.push([ox,oy]); if(trail.length>1200) trail.shift();
+      ctx.beginPath(); for(let i=0;i<trail.length;i++){ if(i===0) ctx.moveTo(trail[i][0],trail[i][1]); else ctx.lineTo(trail[i][0],trail[i][1]); }
+      ctx.strokeStyle="#fff"; ctx.lineWidth=2; ctx.stroke();
+      requestAnimationFrame(loop);
+    };
+    loop();
+  },[W,H,coeffs]);
+
+  // mouse draw new shape
+  useEffect(()=>{
+    const c=cnv.current; if(!c) return;
+    let drawing=false; const newPts=[];
+    const down=e=>{ drawing=true; newPts.length=0; add(e); };
+    const move=e=>{ if(drawing) add(e); };
+    const up=()=>{ drawing=false; if(newPts.length>20) setPoints(resample(newPts, 256)); };
+    function add(e){
+      const r=c.getBoundingClientRect(); const x=e.clientX-r.left, y=e.clientY-r.top;
+      newPts.push([x - W/2, y - H/2]);
+    }
+    c.addEventListener("mousedown",down);
+    window.addEventListener("mousemove",move);
+    window.addEventListener("mouseup",up);
+    return ()=>{ c.removeEventListener("mousedown",down); window.removeEventListener("mousemove",move); window.removeEventListener("mouseup",up); };
+  },[W,H]);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">Fourier Series Painter — epicycles</h2>
+      <canvas ref={cnv} style={{width:"100%", imageRendering:"pixelated"}}/>
+      <div className="grid" style={{gridTemplateColumns:"1fr 320px", gap:16}}>
+        <div />
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <Slider label="# terms" v={terms} set={setTerms} min={5} max={120} step={1}/>
+          <p className="text-sm mt-2">Tip: draw with mouse to feed a new contour; it’ll get resampled & traced.</p>
+          <ActiveReflection
+            title="Active Reflection — Epicycles"
+            storageKey="reflect_epicycles"
+            prompts={[
+              "Increase terms: where does detail return first?",
+              "Why do high |k| terms add fine wiggles vs low terms shaping the whole?",
+              "How does re-centering to canvas center affect DC term?"
+            ]}
+          />
+        </section>
+      </div>
+    </div>
+  );
+}
+function resample(pts, N){
+  // uniform arclength resample
+  let L=[0]; for(let i=1;i<pts.length;i++) L[i]=L[i-1]+Math.hypot(pts[i][0]-pts[i-1][0], pts[i][1]-pts[i-1][1]);
+  const T=L[L.length-1]; if(T===0) return pts;
+  const out=[]; for(let k=0;k<N;k++){
+    const s=k*T/(N-1); let i=1; while(i<L.length && L[i]<s) i++;
+    const t=(s-L[i-1])/(L[i]-L[i-1]||1e-9);
+    const x=pts[i-1][0]*(1-t)+pts[i][0]*t, y=pts[i-1][1]*(1-t)+pts[i][1]*t; out.push([x,y]);
+  }
+  return out;
+}
+function heartSamples(W,H){
+  // param heart curve
+  const N=256, out=[];
+  for(let i=0;i<N;i++){
+    const t=2*Math.PI*i/N;
+    const x=16*Math.pow(Math.sin(t),3);
+    const y=13*Math.cos(t)-5*Math.cos(2*t)-2*Math.cos(3*t)-Math.cos(4*t);
+    out.push([x*7, -y*7]); // scaled and upright
+  }
+  return out;
+}
+function Slider({label,v,set,min,max,step}){
+  const show= (typeof v==='number'&&v.toFixed) ? v.toFixed(0) : v;
+  return (<div className="mb-2"><label className="text-sm opacity-80">{label}: <b>{show}</b></label>
+   <input className="w-full" type="range" min={min} max={max} step={step}
+    value={v} onChange={e=>set(parseFloat(e.target.value))}/></div>);
+}
+

--- a/sites/blackroad/src/pages/HilbertMortonLab.jsx
+++ b/sites/blackroad/src/pages/HilbertMortonLab.jsx
@@ -1,0 +1,82 @@
+import { useMemo, useState } from "react";
+import ActiveReflection from "./ActiveReflection.jsx";
+
+function mortonXY(i, nBits){
+  // deinterleave bits to (x,y)
+  const deB=(v)=>{ v&=0x55555555; v=(v|v>>>1)&0x33333333; v=(v|v>>>2)&0x0F0F0F0F; v=(v|v>>>4)&0x00FF00FF; v=(v|v>>>8)&0x0000FFFF; return v; };
+  const x=deB(i); const y=deB(i>>>1); const mask=(1<<nBits)-1;
+  return [x&mask, y&mask];
+}
+function hilbertXY(i, nBits){
+  // hilbert index to (x,y) (Butz algorithm, simplified for small nBits)
+  let x=0,y=0, t=i;
+  for(let s=1; s<(1<<nBits); s<<=1){
+    const rx = 1 & (t>>>1);
+    const ry = 1 & (t ^ rx);
+    if(ry===0){
+      if(rx===1){ x = s-1 - x; y = s-1 - y; }
+      const tmp=x; x=y; y=tmp;
+    }
+    x += s*rx; y += s*ry; t >>>= 2;
+  }
+  return [x,y];
+}
+
+export default function HilbertMortonLab(){
+  const [bits,setBits]=useState(5); // 32x32
+  const [mode,setMode]=useState("hilbert"); // or morton
+  const N=1<<bits;
+  const pts = useMemo(()=>{
+    const out=[];
+    for(let i=0;i<N*N;i++){
+      const [x,y] = mode==="hilbert" ? hilbertXY(i,bits) : mortonXY(i,bits);
+      out.push([x,y]);
+    }
+    return out;
+  },[bits,mode]);
+
+  const W=640,H=360,pad=20;
+  const X=x=> pad + (x/(N-1))*(W-2*pad);
+  const Y=y=> H-pad - (y/(N-1))*(H-2*pad);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">Hilbert vs Morton (Z-order)</h2>
+      <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+        <svg width="100%" viewBox={`0 0 ${W} ${H}`}>
+          <rect x="0" y="0" width={W} height={H} fill="none"/>
+          {pts.map((p,i)=> i>0 ? <line key={i} x1={X(pts[i-1][0])} y1={Y(pts[i-1][1])} x2={X(p[0])} y2={Y(p[1])} strokeWidth="1"/> : null)}
+        </svg>
+      </section>
+      <div className="grid" style={{gridTemplateColumns:"1fr 320px", gap:16}}>
+        <div/>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <Radio name="mode" value={mode} set={setMode} opts={[["hilbert","hilbert"],["morton","morton (Z)"]]}/>
+          <Slider label="order bits" v={bits} set={setBits} min={3} max={7} step={1}/>
+          <ActiveReflection
+            title="Active Reflection — Space Filling"
+            storageKey="reflect_hilbert"
+            prompts={[
+              "Compare locality: which curve keeps neighbors closer when jumping?",
+              "Increase bits: where do macro patterns repeat self-similarly?",
+              "Why does Hilbert beat Morton for cache locality in many tasks?"
+            ]}
+          />
+        </section>
+      </div>
+    </div>
+  );
+}
+function Slider({label,v,set,min,max,step}){ return (
+  <div className="mb-2"><label className="text-sm opacity-80">{label}: <b>{v}</b></label>
+  <input className="w-full" type="range" min={min} max={max} step={step} value={v}
+   onChange={e=>set(parseInt(e.target.value))}/></div>
+);}
+function Radio({name,value,set,opts}){
+  return (<div className="flex gap-3 text-sm">
+    {opts.map(([val,lab])=><label key={val} className="flex items-center gap-1">
+      <input type="radio" name={name} checked={value===val} onChange={()=>set(val)}/>{lab}
+    </label>)}
+  </div>);
+}
+

--- a/sites/blackroad/src/pages/IsingMaxCutLab.jsx
+++ b/sites/blackroad/src/pages/IsingMaxCutLab.jsx
@@ -1,0 +1,118 @@
+import { useMemo, useRef, useState, useEffect, forwardRef } from "react";
+import ActiveReflection from "./ActiveReflection.jsx";
+
+// Max-Cut ≈ maximize (1/2) Σ w_ij (1 - s_i s_j) with s_i∈{-1,1}
+// Smooth relaxation: s_i ∈ [-1,1], gradient ascent with projection.
+
+function rng(seed){ let s=seed|0||1; return ()=> (s=(1664525*s+1013904223)>>>0)/2**32; }
+
+export default function IsingMaxCutLab(){
+  const [n,setN]=useState(8);
+  const [seed,setSeed]=useState(7);
+  const [iters,setIters]=useState(500);
+  const [lr,setLR]=useState(0.05);
+  const [density,setDen]=useState(0.4);
+
+  const {nodes, W} = useMemo(()=>makeGraph(n, density, seed),[n,density,seed]);
+  const res = useMemo(()=> relaxMaxCut(W, iters, lr, seed),[W,iters,lr,seed]);
+
+  const svgRef=useRef(null);
+  useEffect(()=>{ // allow drag of layout only (doesn't change cut)
+    const svg=svgRef.current; if(!svg) return;
+    let drag=-1, down=false, P=[...nodes];
+    const hit=(x,y)=> P.findIndex(p=> (p.x-x)**2+(p.y-y)**2<12**2);
+    const to= e=>{
+      const r=svg.getBoundingClientRect(); return {x:e.clientX-r.left, y:e.clientY-r.top};
+    };
+    const md=e=>{ const p=to(e); const id=hit(p.x,p.y); if(id>=0){drag=id; down=true;} };
+    const mv=e=>{ if(!down||drag<0) return; const p=to(e); P[drag]={...P[drag], x:p.x, y:p.y}; };
+    const up=()=>{ down=false; drag=-1; };
+    svg.addEventListener("mousedown",md); window.addEventListener("mousemove",mv); window.addEventListener("mouseup",up);
+    return ()=>{ svg.removeEventListener("mousedown",md); window.removeEventListener("mousemove",mv); window.removeEventListener("mouseup",up); };
+  },[nodes]);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">Max-Cut — Ising Relaxation (toy)</h2>
+      <Graph ref={svgRef} nodes={nodes} W={W} spins={res.spins}/>
+      <div className="grid" style={{gridTemplateColumns:"1fr 340px", gap:16}}>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <Slider label="n nodes" v={n} set={setN} min={4} max={16} step={1}/>
+          <Slider label="edge density" v={density} set={setDen} min={0.1} max={0.9} step={0.05}/>
+          <Slider label="iterations" v={iters} set={setIters} min={100} max={2000} step={50}/>
+          <Slider label="learning rate" v={lr} set={setLR} min={0.005} max={0.2} step={0.005}/>
+          <Slider label="seed" v={seed} set={setSeed} min={1} max={9999} step={1}/>
+          <p className="text-sm mt-2">Cut size ≈ <b>{res.cut.toFixed(2)}</b></p>
+        </section>
+        <ActiveReflection
+          title="Active Reflection — Max-Cut"
+          storageKey="reflect_maxcut"
+          prompts={[
+            "Compare random seeds: do you get similar cut values?",
+            "Lower LR: convergence steadier but slower; watch oscillations.",
+            "Why does projecting spins to ±1 at the end improve the discrete cut?"
+          ]}
+        />
+      </div>
+    </div>
+  );
+}
+
+function makeGraph(n, den, seed){
+  const r=rng(seed);
+  const nodes=[]; const W=Array.from({length:n},()=>Array(n).fill(0));
+  // circle layout
+  const R=130, cx=320, cy=180;
+  for(let i=0;i<n;i++){
+    const t=2*Math.PI*i/n;
+    nodes.push({x: cx + R*Math.cos(t), y: cy + R*Math.sin(t)});
+  }
+  for(let i=0;i<n;i++) for(let j=i+1;j<n;j++){
+    if(r()<den){ const w=0.5 + r(); W[i][j]=W[j][i]=w; }
+  }
+  return {nodes, W};
+}
+function relaxMaxCut(W, iters, lr, seed){
+  const n=W.length; const r=rng(seed);
+  let s = Array(n).fill(0).map(()=> r()*2-1); // spins in [-1,1]
+  const energy=()=> 0.5*sum2(W,(i,j)=> W[i][j]*(1 - Math.sign(s[i])*Math.sign(s[j])) );
+  for(let t=0;t<iters;t++){
+    // grad of E ≈ −Σ_j W_ij s_j  (from −sᵀ W s surrogate)
+    const g = Array(n).fill(0);
+    for(let i=0;i<n;i++){ let acc=0; for(let j=0;j<n;j++) acc += W[i][j]*s[j]; g[i]= -2*acc; }
+    for(let i=0;i<n;i++){ s[i]+= lr*g[i]; s[i]=Math.max(-1, Math.min(1, s[i])); }
+  }
+  const spins = s.map(v=> v>=0? 1 : -1);
+  const cut = 0.5*sum2(W,(i,j)=> (spins[i]!==spins[j]? W[i][j] : 0));
+  return {spins, cut};
+}
+function sum2(W, f){ const n=W.length; let S=0; for(let i=0;i<n;i++) for(let j=i+1;j<n;j++) S+=f(i,j); return S; }
+
+const Graph = forwardRef(function Graph({nodes, W, spins}, ref){
+  const Wsvg=640,H=360;
+  return (
+    <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+      <svg ref={ref} width="100%" viewBox={`0 0 ${Wsvg} ${H}`}>
+        <rect x="0" y="0" width={Wsvg} height={H} fill="none"/>
+        {/* edges */}
+        {nodes.map((a,i)=> nodes.map((b,j)=> (j>i && W[i][j]>0) ? (
+          <line key={`${i}-${j}`} x1={a.x} y1={a.y} x2={b.x} y2={b.y} strokeWidth={0.5+W[i][j]} opacity="0.35"/>
+        ) : null))}
+        {/* nodes colored by spin */}
+        {nodes.map((p,i)=>(
+          <g key={i}>
+            <circle cx={p.x} cy={p.y} r="12"/>
+            <text x={p.x-4} y={p.y+4} fontSize="12">{spins[i]>0?"A":"B"}</text>
+          </g>
+        ))}
+      </svg>
+    </section>
+  );
+});
+function Slider({label,v,set,min,max,step}){
+  const show=(typeof v==='number'&&v.toFixed)?v.toFixed(3):v;
+  return (<div className="mb-2"><label className="text-sm opacity-80">{label}: <b>{show}</b></label>
+  <input className="w-full" type="range" min={min} max={max} step={step}
+    value={v} onChange={e=>set(parseFloat(e.target.value))}/></div>);
+}
+

--- a/sites/blackroad/src/pages/RRTStarLab.jsx
+++ b/sites/blackroad/src/pages/RRTStarLab.jsx
@@ -1,0 +1,138 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import ActiveReflection from "./ActiveReflection.jsx";
+
+function dist(a,b){ const dx=a.x-b.x, dy=a.y-b.y; return Math.hypot(dx,dy); }
+function segIntersectsRect(a,b, R){ // axis-aligned rectangle R={x,y,w,h}
+  // Liang-Barsky style clipping (simplified)
+  let t0=0, t1=1;
+  const dx=b.x-a.x, dy=b.y-a.y;
+  const p=[-dx, dx, -dy, dy];
+  const q=[a.x-R.x, R.x+R.w-a.x, a.y-R.y, R.y+R.h-a.y];
+  for(let i=0;i<4;i++){
+    if(p[i]===0){ if(q[i]<0) return true; }
+    else {
+      const r=q[i]/p[i];
+      if(p[i]<0){ if(r>t1) return true; if(r>t0) t0=r; }
+      else { if(r<t0) return true; if(r<t1) t1=r; }
+    }
+  }
+  return false;
+}
+function collision(a,b, obstacles){ for(const R of obstacles){ if(segIntersectsRect(a,b,R)) return true; } return false; }
+
+export default function RRTStarLab(){
+  const [W,H] = [640, 400];
+  const [start,setStart]=useState({x:80,y:200});
+  const [goal,setGoal]=useState({x:560,y:200});
+  const [step,setStep]=useState(16);
+  const [rad,setRad]=useState(42);
+  const [goalBias,setBias]=useState(0.12);
+  const [iters,setIters]=useState(1200);
+  const [seed,setSeed]=useState(7);
+  const [obs,setObs]=useState([
+    {x:230,y:40,w:30,h:320},
+    {x:350,y:120,w:40,h:160},
+    {x:150,y:140,w:40,h:40},
+    {x:450,y:40,w:30,h:320},
+  ]);
+
+  const rng=useMemo(()=>{ let s=seed|0||1; return ()=> (s=(1664525*s+1013904223)>>>0)/2**32; },[seed]);
+
+  const cnv=useRef(null);
+  useEffect(()=>{
+    const c=cnv.current; if(!c) return; c.width=W; c.height=H;
+    const ctx=c.getContext("2d",{alpha:false});
+    // run RRT*
+    const nodes=[{x:start.x,y:start.y,parent:-1,cost:0}];
+    const nIters=iters;
+    for(let k=0;k<nIters;k++){
+      const sample = (rng()<goalBias)? goal : {x:rng()*W, y:rng()*H};
+      // nearest
+      let best=0, bd=1e9;
+      for(let i=0;i<nodes.length;i++){ const d=dist(nodes[i],sample); if(d<bd){bd=d; best=i;} }
+      const dirx=sample.x-nodes[best].x, diry=sample.y-nodes[best].y;
+      const L=Math.hypot(dirx,diry)||1e-9;
+      const newNode={ x: nodes[best].x + step*dirx/L, y: nodes[best].y + step*diry/L, parent: best, cost: nodes[best].cost+step };
+      if(collision(nodes[best], newNode, obs)) continue;
+      // choose parent within radius
+      const near=[];
+      for(let i=0;i<nodes.length;i++) if(dist(nodes[i],newNode)<=rad && !collision(nodes[i],newNode,obs)) near.push(i);
+      let parent=best, pcost=nodes[best].cost+dist(nodes[best],newNode);
+      for(const i of near){
+        const cand=nodes[i].cost+dist(nodes[i],newNode);
+        if(cand<pcost){ pcost=cand; parent=i; }
+      }
+      newNode.parent=parent; newNode.cost=pcost; const idx=nodes.push(newNode)-1;
+      // rewire
+      for(const i of near){
+        const cand=pcost + dist(nodes[i],newNode);
+        if(cand < nodes[i].cost && !collision(nodes[i],newNode,obs)){ nodes[i].parent=idx; nodes[i].cost=cand; }
+      }
+    }
+    // pick goal connection
+    let gi=-1, gbest=1e9;
+    for(let i=0;i<nodes.length;i++){
+      const d=dist(nodes[i],goal);
+      if(d<rad && !collision(nodes[i],goal,obs)){
+        const cost=nodes[i].cost+d;
+        if(cost<gbest){ gbest=cost; gi=i; }
+      }
+    }
+    // draw
+    ctx.fillStyle="rgb(10,12,18)"; ctx.fillRect(0,0,W,H);
+    // obstacles
+    ctx.fillStyle="rgb(28,30,40)";
+    obs.forEach(R=> ctx.fillRect(R.x,R.y,R.w,R.h));
+    // edges
+    ctx.strokeStyle="rgba(200,220,255,0.25)"; ctx.lineWidth=1;
+    ctx.beginPath();
+    for(let i=1;i<nodes.length;i++){
+      const p=nodes[i], q=nodes[p.parent];
+      ctx.moveTo(p.x,p.y); ctx.lineTo(q.x,q.y);
+    }
+    ctx.stroke();
+    // best path
+    if(gi>=0){
+      ctx.strokeStyle="#fff"; ctx.lineWidth=2;
+      ctx.beginPath();
+      ctx.moveTo(goal.x,goal.y); ctx.lineTo(nodes[gi].x,nodes[gi].y);
+      let i=gi; while(i>0){ const p=nodes[i], q=nodes[p.parent]; ctx.lineTo(q.x,q.y); i=p.parent; }
+      ctx.stroke();
+    }
+    // start/goal
+    ctx.fillStyle="#0ff"; ctx.beginPath(); ctx.arc(start.x,start.y,5,0,Math.PI*2); ctx.fill();
+    ctx.fillStyle="#ff0"; ctx.beginPath(); ctx.arc(goal.x,goal.y,5,0,Math.PI*2); ctx.fill();
+  },[W,H,start,goal,step,rad,goalBias,iters,obs,rng]);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">RRT* — path planning</h2>
+      <canvas ref={cnv} style={{width:"100%", imageRendering:"pixelated"}}/>
+      <div className="grid" style={{gridTemplateColumns:"1fr 320px", gap:16}}>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <Slider label="step" v={step} set={setStep} min={6} max={32} step={1}/>
+          <Slider label="rewire radius" v={rad} set={setRad} min={20} max={80} step={1}/>
+          <Slider label="goal bias" v={goalBias} set={setBias} min={0.0} max={0.5} step={0.01}/>
+          <Slider label="iterations" v={iters} set={setIters} min={200} max={5000} step={100}/>
+          <Slider label="seed" v={seed} set={setSeed} min={1} max={9999} step={1}/>
+        </section>
+        <ActiveReflection
+          title="Active Reflection — RRT*"
+          storageKey="reflect_rrtstar"
+          prompts={[
+            "Lower step: more precise trees but slower coverage.",
+            "Raise radius: rewiring improves path optimality — where most?",
+            "Increase goal bias: tree beelines more, but loses exploration."
+          ]}
+        />
+      </div>
+    </div>
+  );
+}
+function Slider({label,v,set,min,max,step}){
+  const show=(typeof v==='number'&&v.toFixed)?v.toFixed(2):v;
+  return (<div className="mb-2"><label className="text-sm opacity-80">{label}: <b>{show}</b></label>
+  <input className="w-full" type="range" min={min} max={max} step={step}
+   value={v} onChange={e=>set(parseFloat(e.target.value))}/></div>);
+}
+


### PR DESCRIPTION
## Summary
- add RRT* path planning lab with tunable parameters and reflection prompts
- add Fourier series epicycle painter with mouse-drawn shapes
- add Hilbert vs Morton space-filling curve explorer
- add Ising Max-Cut relaxation lab and wire up routes for all four

## Testing
- `npm test` *(fails: jest not found)*
- `npm --prefix sites/blackroad run lint`
- `npm --prefix sites/blackroad test`


------
https://chatgpt.com/codex/tasks/task_e_68c1132977c0832992734295ea98276f