### PR TITLE
Add interactive algorithm labs

### DIFF
--- a/sites/blackroad/src/App.jsx
+++ b/sites/blackroad/src/App.jsx
@@ -23,6 +23,10 @@ import EikonalLab from "./pages/EikonalLab.jsx";
 import PoissonDiskLab from "./pages/PoissonDiskLab.jsx";
 import LSystemLab from "./pages/LSystemLab.jsx";
 import MinimalSurfaceLab from "./pages/MinimalSurfaceLab.jsx";
+import RRTSmoothLab from "./pages/RRTSmoothLab.jsx";
+import DiffusionMapsLab from "./pages/DiffusionMapsLab.jsx";
+import PerlinTerrainLab from "./pages/PerlinTerrainLab.jsx";
+import PDELiveLab from "./pages/PDELiveLab.jsx";
 
 function useApiHealth(){
   const [state,setState]=useState({ok:null, info:""});
@@ -118,6 +122,10 @@ function LegacyApp(){
             <Route path="/fluids" element={<StableFluidsLab/>} />
             <Route path="/autodiff" element={<AutoDiffLab/>} />
             <Route path="/conformal" element={<ConformalGridLab/>} />
+            <Route path="/rrt-smooth" element={<RRTSmoothLab/>} />
+            <Route path="/diffmaps" element={<DiffusionMapsLab/>} />
+            <Route path="/terrain" element={<PerlinTerrainLab/>} />
+            <Route path="/pde" element={<PDELiveLab/>} />
             <Route path="/eikonal" element={<EikonalLab/>} />
             <Route path="/poisson2" element={<PoissonDiskLab/>} />
             <Route path="/lsys" element={<LSystemLab/>} />
@@ -138,6 +146,10 @@ function LegacyApp(){
             <Route path="fluids" element={<StableFluidsLab/>} />
             <Route path="autodiff" element={<AutoDiffLab/>} />
             <Route path="conformal" element={<ConformalGridLab/>} />
+            <Route path="rrt-smooth" element={<RRTSmoothLab/>} />
+            <Route path="diffmaps" element={<DiffusionMapsLab/>} />
+            <Route path="terrain" element={<PerlinTerrainLab/>} />
+            <Route path="pde" element={<PDELiveLab/>} />
             <Route path="eikonal" element={<EikonalLab/>} />
             <Route path="poisson2" element={<PoissonDiskLab/>} />
             <Route path="lsys" element={<LSystemLab/>} />

--- a/sites/blackroad/src/pages/DiffusionMapsLab.jsx
+++ b/sites/blackroad/src/pages/DiffusionMapsLab.jsx
@@ -1,0 +1,115 @@
+import { useMemo, useState } from "react";
+import ActiveReflection from "./ActiveReflection.jsx";
+
+function rng(seed){ let s=seed|0||2025; return ()=> (s=(1664525*s+1013904223)>>>0)/2**32; }
+function randn(r){ const u=Math.max(r(),1e-12), v=Math.max(r(),1e-12); return Math.sqrt(-2*Math.log(u))*Math.cos(2*Math.PI*v); }
+
+function twoMoons(n, seed){
+  const r=rng(seed), X=[];
+  for(let i=0;i<n;i++){
+    const t=Math.PI*(r());
+    const x=Math.cos(t), y=Math.sin(t);
+    X.push([x + 0.05*randn(r), y + 0.05*randn(r)]);
+  }
+  for(let i=0;i<n;i++){
+    const t=Math.PI*(r());
+    const x=1 - Math.cos(t), y=-0.5 - Math.sin(t);
+    X.push([x + 0.05*randn(r), y + 0.05*randn(r)]);
+  }
+  return X; // 2n points
+}
+function kernelMarkov(X, sigma){
+  const n=X.length, P=Array.from({length:n},()=>Array(n).fill(0));
+  const row=Array(n).fill(0);
+  for(let i=0;i<n;i++){
+    for(let j=0;j<n;j++){
+      const dx=X[i][0]-X[j][0], dy=X[i][1]-X[j][1];
+      const w=Math.exp(-(dx*dx+dy*dy)/(2*sigma*sigma));
+      P[i][j]=w; row[i]+=w;
+    }
+  }
+  for(let i=0;i<n;i++){ const s=row[i]||1; for(let j=0;j<n;j++) P[i][j]/=s; }
+  return P;
+}
+function topEigenvectors(P, k){
+  const n=P.length;
+  const mult = (v)=>{ const y=Array(n).fill(0); for(let i=0;i<n;i++) for(let j=0;j<n;j++) y[i]+=P[i][j]*v[j]; return y; };
+  const vecs=[], vals=[];
+  // simple power iteration with deflation
+  for(let m=0;m<k;m++){
+    let v=Array(n).fill(0).map(()=>Math.random()*2-1);
+    // GS against earlier
+    const orth = (u)=>{ for(let q=0;q<vecs.length;q++){ const dot=u.reduce((s,x,i)=>s+x*vecs[q][i],0); for(let i=0;i<n;i++) u[i]-=dot*vecs[q][i]; } return u; };
+    v=orth(v); let lam=0;
+    for(let t=0;t<120;t++){
+      let y=mult(v); y=orth(y);
+      const norm=Math.sqrt(y.reduce((s,x)=>s+x*x,0))||1; for(let i=0;i<n;i++) y[i]/=norm;
+      v=y; const Pv=mult(v); lam = v.reduce((s,x,i)=> s + x*Pv[i], 0);
+    }
+    vecs.push(v); vals.push(lam);
+  }
+  return {vecs, vals};
+}
+
+export default function DiffusionMapsLab(){
+  const [n,setN]=useState(200);
+  const [sigma,setSigma]=useState(0.2);
+  const [time,setTime]=useState(1.0);
+  const [seed,setSeed]=useState(7);
+
+  const X = useMemo(()=> twoMoons(n, seed),[n,seed]);
+  const P = useMemo(()=> kernelMarkov(X, sigma),[X,sigma]);
+  const {vecs, vals} = useMemo(()=> topEigenvectors(P, 3),[P]); // vecs[0] ≈ trivial
+  const coords = useMemo(()=>{
+    if(vecs.length<3) return [];
+    const phi1=vecs[1], phi2=vecs[2];
+    const l1=Math.pow(vals[1], time), l2=Math.pow(vals[2], time);
+    return X.map((_,i)=> [ l1*phi1[i], l2*phi2[i] ]);
+  },[vecs,vals,time,X]);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">Diffusion Maps — two moons</h2>
+      <Scatter pts={coords}/>
+      <div className="grid" style={{gridTemplateColumns:"1fr 320px", gap:16}}>
+        <div/>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <Slider label="per moon (n)" v={n} set={setN} min={100} max={600} step={20}/>
+          <Slider label="σ (kernel)" v={sigma} set={setSigma} min={0.05} max={0.6} step={0.01}/>
+          <Slider label="diffusion time t" v={time} set={setTime} min={0.2} max={5} step={0.1}/>
+          <Slider label="seed" v={seed} set={setSeed} min={1} max={9999} step={1}/>
+          <ActiveReflection
+            title="Active Reflection — Diffusion Maps"
+            storageKey="reflect_diffmaps"
+            prompts=[
+              "Small σ: local geometry preserved; when does the embedding fragment?",
+              "Increase t: diffusion “blurs” short-scale detail — what stabilizes?",
+              "Why does the first nontrivial eigenvector already separate the moons?"
+            ]
+          />
+        </section>
+      </div>
+    </div>
+  );
+}
+function Scatter({pts}){
+  const W=640,H=360,pad=20; if(!pts.length) return null;
+  const xs=pts.map(p=>p[0]), ys=pts.map(p=>p[1]);
+  const minX=Math.min(...xs), maxX=Math.max(...xs);
+  const minY=Math.min(...ys), maxY=Math.max(...ys);
+  const X=x=> pad+(x-minX)/(maxX-minX+1e-9)*(W-2*pad);
+  const Y=y=> H-pad-(y-minY)/(maxY-minY+1e-9)*(H-2*pad);
+  return (
+    <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+      <svg width="100%" viewBox={`0 0 ${W} ${H}`}>
+        {pts.map((p,i)=><circle key={i} cx={X(p[0])} cy={Y(p[1])} r="3"/>) }
+      </svg>
+    </section>
+  );
+}
+function Slider({label,v,set,min,max,step}){ const show=(typeof v==='number'&&v.toFixed)?v.toFixed(2):v;
+  return (<div className="mb-2"><label className="text-sm opacity-80">{label}: <b>{show}</b></label>
+  <input className="w-full" type="range" min={min} max={max} step={step}
+  value={v} onChange={e=>set(parseFloat(e.target.value))}/></div>);
+}
+

--- a/sites/blackroad/src/pages/PDELiveLab.jsx
+++ b/sites/blackroad/src/pages/PDELiveLab.jsx
@@ -1,0 +1,129 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import ActiveReflection from "./ActiveReflection.jsx";
+
+export default function PDELiveLab(){
+  const [N,setN]=useState(128);
+  const [mode,setMode]=useState("heat"); // "heat" or "wave"
+  const [alpha,setAlpha]=useState(0.2);  // heat diffusivity
+  const [c,setC]=useState(0.9);         // wave speed (normalized)
+  const [running,setRunning]=useState(true);
+  const [seed,setSeed]=useState(7);
+
+  const cnv=useRef(null);
+  const sim=useMemo(()=> makeSim(N, seed),[N,seed]);
+
+  useEffect(()=>{
+    const c2=cnv.current; if(!c2) return;
+    c2.width=N; c2.height=N;
+    const ctx=c2.getContext("2d",{alpha:false});
+    let raf;
+    const loop=()=>{
+      if(running) step(sim, mode, alpha, c);
+      render(ctx, sim.u);
+      raf=requestAnimationFrame(loop);
+    };
+    loop(); return ()=> cancelAnimationFrame(raf);
+  },[sim, mode, alpha, c, running, N]);
+
+  useEffect(()=>{
+    const c2=cnv.current; if(!c2) return;
+    const rect=c2.getBoundingClientRect();
+    const click=(e)=>{
+      const x=Math.floor((e.clientX-rect.left)/rect.width*N);
+      const y=Math.floor((e.clientY-rect.top)/rect.height*N);
+      seedBump(sim, x, y, mode);
+    };
+    c2.addEventListener("mousedown", click);
+    return ()=> c2.removeEventListener("mousedown", click);
+  },[sim, mode, N]);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">PDE Live — Heat & Wave</h2>
+      <canvas ref={cnv} style={{width:"100%", imageRendering:"pixelated"}}/>
+      <div className="grid" style={{gridTemplateColumns:"1fr 320px", gap:16}}>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <Radio name="mode" value={mode} set={setMode} opts={[["heat","heat"],["wave","wave"]]} />
+          <Slider label="N" v={N} set={setN} min={96} max={192} step={16}/>
+          <Slider label="α (heat)" v={alpha} set={setAlpha} min={0.05} max={0.4} step={0.01}/>
+          <Slider label="c (wave)" v={c} set={setC} min={0.2} max={1.2} step={0.02}/>
+            <button className="mt-2 px-3 py-1 rounded bg-white/10 border border-white/10" onClick={()=>{reset(sim);}}>Reset</button>
+            <button className="ml-2 px-3 py-1 rounded bg-white/10 border border-white/10" onClick={()=>setRunning(r=>!r)}>{running?"Pause":"Run"}</button>
+          <p className="text-xs opacity-70 mt-2">Click canvas to add a bump (heat) or displacement (wave).</p>
+        </section>
+        <ActiveReflection
+          title="Active Reflection — PDE"
+          storageKey="reflect_pde_live"
+          prompts=[
+            "Heat: higher α smooths faster — where do gradients vanish first?",
+            "Wave: CFL stability — what happens if c is large (try near 1.2 vs 0.6)?",
+            "Compare boundary effects: reflections vs diffusion into zero walls."
+          ]
+        />
+      </div>
+    </div>
+  );
+}
+
+function makeSim(N, seed){
+  const u = Array.from({length:N},()=>Array(N).fill(0));
+  const uPrev = Array.from({length:N},()=>Array(N).fill(0));
+  // seed gentle bump
+  for(let y=N/3;y<2*N/3;y++) for(let x=N/3;x<2*N/3;x++){
+    u[y][x] = Math.exp(-((x-N/2)**2+(y-N/2)**2)/(2*(N/12)**2));
+  }
+  for(let y=0;y<N;y++) for(let x=0;x<N;x++) uPrev[y][x]=u[y][x];
+  return {N, u, uPrev};
+}
+function reset(sim){ const {N,u,uPrev}=sim; for(let y=0;y<N;y++) for(let x=0;x<N;x++){ u[y][x]=0; uPrev[y][x]=0; } }
+function seedBump(sim,x,y,mode){
+  const {N,u,uPrev}=sim;
+  const r=N/32; for(let j=-r;j<=r;j++) for(let i=-r;i<=r;i++){
+    const X=Math.max(1, Math.min(N-2, x+i)), Y=Math.max(1, Math.min(N-2, y+j));
+    const v=Math.exp(-(i*i+j*j)/(2*(r*0.6)**2));
+    if(mode==="heat") u[Y][X]+=0.8*v; else u[Y][X]+=1.0*v;
+  }
+  if(mode==="wave"){ for(let y=0;y<N;y++) for(let x=0;x<N;x++) uPrev[y][x]=u[y][x]; }
+}
+function step(sim, mode, alpha, c){
+  const {N,u,uPrev}=sim;
+  const lap = (x,y)=> u[y-1][x]+u[y+1][x]+u[y][x-1]+u[y][x+1]-4*u[y][x];
+  if(mode==="heat"){
+    const dt = 0.2; // stable for alpha<=0.4 with 2D 5-point
+    const nu=Array.from({length:N},()=>Array(N).fill(0));
+    for(let y=1;y<N-1;y++) for(let x=1;x<N-1;x++) nu[y][x]=u[y][x] + alpha*dt*lap(x,y);
+    for(let y=1;y<N-1;y++) for(let x=1;x<N-1;x++) u[y][x]=nu[y][x];
+  }else{
+    const dt=0.18; // modest CFL
+    const nu=Array.from({length:N},()=>Array(N).fill(0));
+    for(let y=1;y<N-1;y++) for(let x=1;x<N-1;x++){
+      const l = lap(x,y);
+      nu[y][x] = 2*u[y][x] - uPrev[y][x] + (c*c*dt*dt)*l;
+    }
+    for(let y=1;y<N-1;y++) for(let x=1;x<N-1;x++){ uPrev[y][x]=u[y][x]; u[y][x]=nu[y][x]; }
+  }
+}
+function render(ctx, U){
+  const N=U.length; const img=ctx.createImageData(N,N);
+  let mn=Infinity,mx=-Infinity; for(let y=0;y<N;y++) for(let x=0;x<N;x++){ mn=Math.min(mn,U[y][x]); mx=Math.max(mx,U[y][x]); }
+  for(let y=0;y<N;y++) for(let x=0;x<N;x++){
+    const z=(U[y][x]-mn)/(mx-mn+1e-9);
+    const off=4*(y*N+x);
+    const R=Math.floor(40+200*z), G=Math.floor(50+180*(1-z)), B=Math.floor(220*(1-z));
+    img.data[off]=R; img.data[off+1]=G; img.data[off+2]=B; img.data[off+3]=255;
+  }
+  ctx.putImageData(img,0,0);
+}
+function Slider({label,v,set,min,max,step}){ const show=(typeof v==='number'&&v.toFixed)?v.toFixed(2):v;
+  return (<div className="mb-2"><label className="text-sm opacity-80">{label}: <b>{show}</b></label>
+  <input className="w-full" type="range" min={min} max={max} step={step}
+  value={v} onChange={e=>set(parseFloat(e.target.value))}/></div>);
+}
+function Radio({name,value,set,opts}){
+  return (<div className="flex gap-3 text-sm">
+    {opts.map(([val,lab])=><label key={val} className="flex items-center gap-1">
+      <input type="radio" name={name} checked={value===val} onChange={()=>set(val)}/>{lab}
+    </label>)}
+  </div>);
+}
+

--- a/sites/blackroad/src/pages/PerlinTerrainLab.jsx
+++ b/sites/blackroad/src/pages/PerlinTerrainLab.jsx
@@ -1,0 +1,107 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import ActiveReflection from "./ActiveReflection.jsx";
+
+function rng(seed){ let s=seed|0||1; return ()=> (s=(1664525*s+1013904223)>>>0)/2**32; }
+function grad2(r){ const a=2*Math.PI*r(); return [Math.cos(a), Math.sin(a)]; }
+function dot(a,b,x,y){ return (x-a[0])*b[0] + (y-a[1])*b[1]; }
+function fade(t){ return t*t*t*(t*(t*6-15)+10); }
+
+function perlin2(x,y, G){
+  const xi=Math.floor(x), yi=Math.floor(y);
+  const xf=x-xi, yf=y-yi;
+  const g00=G.get(`${xi},${yi}`), g10=G.get(`${xi+1},${yi}`),
+        g01=G.get(`${xi},${yi+1}`), g11=G.get(`${xi+1},${yi+1}`);
+  const d00=g00[0]*xf       + g00[1]*yf;
+  const d10=g10[0]*(xf-1)   + g10[1]*yf;
+  const d01=g01[0]*xf       + g01[1]*(yf-1);
+  const d11=g11[0]*(xf-1)   + g11[1]*(yf-1);
+  const u=fade(xf), v=fade(yf);
+  const x1=d00 + u*(d10-d00), x2=d01 + u*(d11-d01);
+  return x1 + v*(x2-x1);
+}
+function fbm(x,y, oct, lac, gain, G){
+  let f=1, a=1, sum=0, norm=0;
+  for(let o=0;o<oct;o++){
+    sum += a*perlin2(x*f,y*f,G); norm += a; f*=lac; a*=gain;
+  }
+  return sum/(norm||1);
+}
+
+export default function PerlinTerrainLab(){
+  const [N,setN]=useState(256);
+  const [oct,setOct]=useState(5);
+  const [lac,setLac]=useState(2.0);
+  const [gain,setGain]=useState(0.5);
+  const [seed,setSeed]=useState(42);
+  const [contours,setContours]=useState(8);
+
+  const grad = useMemo(()=>{
+    const r=rng(seed); const G=new Map();
+    for(let y=-1;y<=N+1;y++) for(let x=-1;x<=N+1;x++) G.set(`${x},${y}`, grad2(r));
+    return G;
+  },[N,seed]);
+
+  const cnv=useRef(null);
+  useEffect(()=>{
+    const c=cnv.current; if(!c) return; c.width=N; c.height=N;
+    const ctx=c.getContext("2d",{alpha:false});
+    const img=ctx.createImageData(N,N);
+    // heightfield
+    let mn=Infinity, mx=-Infinity; const Z=new Float32Array(N*N);
+    for(let y=0;y<N;y++) for(let x=0;x<N;x++){
+      const z=fbm(x/N, y/N, oct, lac, gain, grad);
+      Z[y*N+x]=z; if(z<mn) mn=z; if(z>mx) mx=z;
+    }
+    // color + contours
+    for(let y=0;y<N;y++) for(let x=0;x<N;x++){
+      const z=(Z[y*N+x]-mn)/(mx-mn+1e-9);
+      const shade = Math.pow(z, 1.2);
+      const off=4*(y*N+x);
+      img.data[off]=Math.floor(40+200*shade);
+      img.data[off+1]=Math.floor(50+180*(1-shade));
+      img.data[off+2]=Math.floor(220*(1-shade));
+      img.data[off+3]=255;
+      if(contours>0){
+        const level = Math.floor(z*contours);
+        const eps = 1/Math.max(8, contours*8);
+        const nz = (Z[y*N+Math.min(N-1,x+1)]-mn)/(mx-mn+1e-9);
+        if(Math.floor(nz*contours)!==level && Math.abs(nz-z)>eps){
+          img.data[off]=255; img.data[off+1]=255; img.data[off+2]=255;
+        }
+      }
+    }
+    ctx.putImageData(img,0,0);
+  },[N,oct,lac,gain,grad,contours]);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">Perlin Terrain — fBm heightfield</h2>
+      <canvas ref={cnv} style={{width:"100%", imageRendering:"pixelated"}}/>
+      <div className="grid" style={{gridTemplateColumns:"1fr 320px", gap:16}}>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <Slider label="grid N" v={N} set={setN} min={128} max={384} step={32}/>
+          <Slider label="octaves" v={oct} set={setOct} min={1} max={8} step={1}/>
+          <Slider label="lacunarity" v={lac} set={setLac} min={1.5} max={3.5} step={0.1}/>
+          <Slider label="gain" v={gain} set={setGain} min={0.3} max={0.8} step={0.01}/>
+          <Slider label="contours" v={contours} set={setContours} min={0} max={20} step={1}/>
+          <Slider label="seed" v={seed} set={setSeed} min={1} max={9999} step={1}/>
+        </section>
+        <ActiveReflection
+          title="Active Reflection — Perlin Terrain"
+          storageKey="reflect_perlin"
+          prompts=[
+            "Increase lacunarity: frequencies spread — what happens to texture?",
+            "Lower gain: high-octave contribution shrinks — which features fade?",
+            "Try different seeds: which global structure persists?"
+          ]
+        />
+      </div>
+    </div>
+  );
+}
+function Slider({label,v,set,min,max,step}){ const show=(typeof v==='number'&&v.toFixed)?v.toFixed(2):v;
+  return (<div className="mb-2"><label className="text-sm opacity-80">{label}: <b>{show}</b></label>
+  <input className="w-full" type="range" min={min} max={max} step={step}
+  value={v} onChange={e=>set(parseFloat(e.target.value))}/></div>);
+}
+

--- a/sites/blackroad/src/pages/RRTSmoothLab.jsx
+++ b/sites/blackroad/src/pages/RRTSmoothLab.jsx
@@ -1,0 +1,159 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import ActiveReflection from "./ActiveReflection.jsx";
+
+const W=640, H=400;
+const rngFrom = (seed) => { let s=seed|0||1; return ()=> (s=(1664525*s+1013904223)>>>0)/2**32; };
+const dist = (a,b)=> Math.hypot(a.x-b.x, a.y-b.y);
+
+function segRectHit(a,b,R){
+  // Liang–Barsky clip (returns true if outside -> intersects)
+  let t0=0,t1=1, dx=b.x-a.x, dy=b.y-a.y;
+  const p=[-dx, dx, -dy, dy], q=[a.x-R.x, (R.x+R.w)-a.x, a.y-R.y, (R.y+R.h)-a.y];
+  for(let i=0;i<4;i++){
+    if(p[i]===0){ if(q[i]<0) return true; }
+    else { const r=q[i]/p[i]; if(p[i]<0){ if(r>t1) return true; if(r>t0) t0=r; } else { if(r<t0) return true; if(r<t1) t1=r; } }
+  }
+  return false;
+}
+const collision = (a,b,obs)=> obs.some(R=>segRectHit(a,b,R));
+
+function runRRTStar({start,goal,obs,step,rad,bias,iters,seed}){
+  const R=rngFrom(seed);
+  const nodes=[{x:start.x,y:start.y,parent:-1,cost:0}];
+  for(let k=0;k<iters;k++){
+    const s = (R()<bias)? goal : {x:R()*W, y:R()*H};
+    // nearest
+    let best=0, bd=1e9; for(let i=0;i<nodes.length;i++){ const d=dist(nodes[i],s); if(d<bd){bd=d; best=i;} }
+    const v={ x: nodes[best].x + step*(s.x-nodes[best].x)/Math.max(1e-9,bd),
+              y: nodes[best].y + step*(s.y-nodes[best].y)/Math.max(1e-9,bd),
+              parent: best, cost: nodes[best].cost+step };
+    if(collision(nodes[best], v, obs)) continue;
+    const near=[]; for(let i=0;i<nodes.length;i++) if(dist(nodes[i],v)<=rad && !collision(nodes[i],v,obs)) near.push(i);
+    let parent=best, pcost=nodes[best].cost+dist(nodes[best],v);
+    for(const i of near){ const c=nodes[i].cost+dist(nodes[i],v); if(c<pcost){pcost=c; parent=i;} }
+    v.parent=parent; v.cost=pcost; const idx=nodes.push(v)-1;
+    for(const i of near){ const c=pcost+dist(nodes[i],v); if(c<nodes[i].cost && !collision(nodes[i],v,obs)){ nodes[i].parent=idx; nodes[i].cost=c; } }
+  }
+  // connect to goal
+  let gi=-1, gbest=1e9; for(let i=0;i<nodes.length;i++){
+    const d=dist(nodes[i],goal);
+    if(d<rad && !collision(nodes[i],goal,obs)){
+      const c=nodes[i].cost+d; if(c<gbest){ gbest=c; gi=i; }
+    }
+  }
+  const raw=[]; if(gi>=0){ raw.push({x:goal.x,y:goal.y}); let i=gi; while(i>=0){ raw.push(nodes[i]); i=nodes[i].parent; } }
+  return {nodes, raw: raw.reverse()};
+}
+
+function shortcut(path, obs, attempts=200){
+  if(path.length<3) return path.slice();
+  const P=path.slice();
+  for(let a=0;a<attempts;a++){
+    const i = Math.floor(Math.random()*(P.length-2));
+    const j = i+2 + Math.floor(Math.random()*(P.length-i-2));
+    if(j>=P.length) continue;
+    if(!collision(P[i], P[j], obs)){ P.splice(i+1, j-i-1); }
+  }
+  return P;
+}
+function catmullRom(P, samples=6, alpha=0.5){
+  if(P.length<3) return P.slice();
+  const pts=[];
+  for(let i=0;i<P.length-1;i++){
+    const p0=P[Math.max(0,i-1)], p1=P[i], p2=P[i+1], p3=P[Math.min(P.length-1,i+2)];
+    for(let s=0;s<samples;s++){
+      const t=(s/samples);
+      const tt=t*t, ttt=tt*t;
+      // standard Catmull-Rom (uniform, alpha parameter kept simple)
+      const a0 = -0.5*ttt +    tt - 0.5*t;
+      const a1 =  1.5*ttt - 2.5*tt + 1.0;
+      const a2 = -1.5*ttt + 2.0*tt + 0.5*t;
+      const a3 =  0.5*ttt - 0.5*tt;
+      pts.push({ x: a0*p0.x + a1*p1.x + a2*p2.x + a3*p3.x, y: a0*p0.y + a1*p1.y + a2*p2.y + a3*p3.y });
+    }
+  }
+  pts.push(P[P.length-1]);
+  return pts;
+}
+
+export default function RRTSmoothLab(){
+  const [start,setStart]=useState({x:80,y:300});
+  const [goal,setGoal]=useState({x:560,y:100});
+  const [step,setStep]=useState(18);
+  const [rad,setRad]=useState(48);
+  const [bias,setBias]=useState(0.1);
+  const [iters,setIters]=useState(1800);
+  const [seed,setSeed]=useState(7);
+  const [obs,setObs]=useState([
+    {x:240,y:40,w:32,h:320},{x:360,y:100,w:40,h:200},{x:140,y:160,w:40,h:40},{x:460,y:60,w:28,h:300}
+  ]);
+  const [smoothK,setSmoothK]=useState(300);
+  const [samples,setSamples]=useState(8);
+
+  const result = useMemo(()=> runRRTStar({start,goal,obs,step,rad,bias,iters,seed}),[start,goal,obs,step,rad,bias,iters,seed]);
+  const shortcutPath = useMemo(()=> shortcut(result.raw, obs, smoothK),[result, obs, smoothK]);
+  const splinePath   = useMemo(()=> catmullRom(shortcutPath, samples),[shortcutPath, samples]);
+
+  const cnv=useRef(null);
+  useEffect(()=>{
+    const c=cnv.current; if(!c) return; c.width=W; c.height=H;
+    const ctx=c.getContext("2d",{alpha:false});
+    // bg + obstacles
+    ctx.fillStyle="rgb(10,12,18)"; ctx.fillRect(0,0,W,H);
+    ctx.fillStyle="rgb(30,34,44)"; obs.forEach(R=>ctx.fillRect(R.x,R.y,R.w,R.h));
+    // tree
+    ctx.strokeStyle="rgba(200,220,255,0.25)"; ctx.lineWidth=1; ctx.beginPath();
+    for(let i=1;i<result.nodes.length;i++){ const p=result.nodes[i], q=result.nodes[p.parent]; ctx.moveTo(p.x,p.y); ctx.lineTo(q.x,q.y); }
+    ctx.stroke();
+    // raw path
+    if(result.raw.length>0){
+      ctx.strokeStyle="rgba(255,255,255,0.5)"; ctx.lineWidth=2; ctx.beginPath();
+      result.raw.forEach((p,i)=> i?ctx.lineTo(p.x,p.y):ctx.moveTo(p.x,p.y)); ctx.stroke();
+    }
+    // shortcut
+    if(shortcutPath.length>0){
+      ctx.strokeStyle="#9df"; ctx.lineWidth=2; ctx.beginPath();
+      shortcutPath.forEach((p,i)=> i?ctx.lineTo(p.x,p.y):ctx.moveTo(p.x,p.y)); ctx.stroke();
+    }
+    // spline
+    if(splinePath.length>0){
+      ctx.strokeStyle="#fff"; ctx.lineWidth=3; ctx.beginPath();
+      splinePath.forEach((p,i)=> i?ctx.lineTo(p.x,p.y):ctx.moveTo(p.x,p.y)); ctx.stroke();
+    }
+    // endpoints
+    ctx.fillStyle="#0ff"; ctx.beginPath(); ctx.arc(start.x,start.y,5,0,Math.PI*2); ctx.fill();
+    ctx.fillStyle="#ff0"; ctx.beginPath(); ctx.arc(goal.x,goal.y,5,0,Math.PI*2); ctx.fill();
+  },[result,shortcutPath,splinePath,obs,start,goal]);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">RRT* + Smoothing — shortcut & Catmull-Rom</h2>
+      <canvas ref={cnv} style={{width:"100%", imageRendering:"pixelated"}}/>
+      <div className="grid" style={{gridTemplateColumns:"1fr 320px", gap:16}}>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <Slider label="step" v={step} set={setStep} min={8} max={32} step={1}/>
+          <Slider label="rewire radius" v={rad} set={setRad} min={20} max={80} step={1}/>
+          <Slider label="goal bias" v={bias} set={setBias} min={0} max={0.5} step={0.01}/>
+          <Slider label="iterations" v={iters} set={setIters} min={300} max={6000} step={100}/>
+          <Slider label="seed" v={seed} set={setSeed} min={1} max={9999} step={1}/>
+          <Slider label="shortcut attempts" v={smoothK} set={setSmoothK} min={50} max={2000} step={50}/>
+          <Slider label="spline samples/seg" v={samples} set={setSamples} min={3} max={16} step={1}/>
+        </section>
+        <ActiveReflection
+          title="Active Reflection — RRT* Smoothing"
+          storageKey="reflect_rrt_smooth"
+          prompts=[
+            "Shortcutting removes redundant wiggles — where most impactful?",
+            "Catmull-Rom lengthens path a bit but looks natural — find a sweet spot.",
+            "Change bias/radius: how does tree quality affect smoothing gain?"
+          ]
+        />
+      </div>
+    </div>
+  );
+}
+function Slider({label,v,set,min,max,step}){ const show=(typeof v==='number'&&v.toFixed)?v.toFixed(2):v;
+  return (<div className="mb-2"><label className="text-sm opacity-80">{label}: <b>{show}</b></label>
+  <input className="w-full" type="range" min={min} max={max} step={step} value={v} onChange={e=>set(parseFloat(e.target.value))}/></div>);
+}
+


### PR DESCRIPTION
## Summary
- add RRT* planner demo with path shortcutting and Catmull-Rom smoothing
- add Diffusion Maps two-moons embedding explorer
- add Perlin noise terrain lab and PDE heat/wave simulator
- wire up new labs in site routing

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c114f6b4788329aafa3ead7f35751e