### PR TITLE
feat: add new math labs

### DIFF
--- a/sites/blackroad/src/App.jsx
+++ b/sites/blackroad/src/App.jsx
@@ -23,6 +23,10 @@ import EikonalLab from "./pages/EikonalLab.jsx";
 import PoissonDiskLab from "./pages/PoissonDiskLab.jsx";
 import LSystemLab from "./pages/LSystemLab.jsx";
 import MinimalSurfaceLab from "./pages/MinimalSurfaceLab.jsx";
+import PoissonBoltzmannLab from "./pages/PoissonBoltzmannLab.jsx";
+import RidgeRegressionLab from "./pages/RidgeRegressionLab.jsx";
+import KernelPCALab from "./pages/KernelPCALab.jsx";
+import BrushfirePathLab from "./pages/BrushfirePathLab.jsx";
 
 function useApiHealth(){
   const [state,setState]=useState({ok:null, info:""});
@@ -120,10 +124,14 @@ function LegacyApp(){
             <Route path="/conformal" element={<ConformalGridLab/>} />
             <Route path="/eikonal" element={<EikonalLab/>} />
             <Route path="/poisson2" element={<PoissonDiskLab/>} />
-            <Route path="/lsys" element={<LSystemLab/>} />
-            <Route path="/minimal" element={<MinimalSurfaceLab/>} />
-            <Route path="chat" element={<Chat/>} />
-            <Route path="canvas" element={<Canvas/>} />
+              <Route path="/lsys" element={<LSystemLab/>} />
+              <Route path="/minimal" element={<MinimalSurfaceLab/>} />
+              <Route path="/pb" element={<PoissonBoltzmannLab/>} />
+              <Route path="/ridge" element={<RidgeRegressionLab/>} />
+              <Route path="/kpca" element={<KernelPCALab/>} />
+              <Route path="/brushfire" element={<BrushfirePathLab/>} />
+              <Route path="chat" element={<Chat/>} />
+              <Route path="canvas" element={<Canvas/>} />
             <Route path="editor" element={<Editor/>} />
             <Route path="terminal" element={<Terminal/>} />
             <Route path="roadview" element={<RoadView/>} />
@@ -140,9 +148,13 @@ function LegacyApp(){
             <Route path="conformal" element={<ConformalGridLab/>} />
             <Route path="eikonal" element={<EikonalLab/>} />
             <Route path="poisson2" element={<PoissonDiskLab/>} />
-            <Route path="lsys" element={<LSystemLab/>} />
-            <Route path="minimal" element={<MinimalSurfaceLab/>} />
-            <Route path="*" element={<div>Not found</div>} />
+              <Route path="lsys" element={<LSystemLab/>} />
+              <Route path="minimal" element={<MinimalSurfaceLab/>} />
+              <Route path="pb" element={<PoissonBoltzmannLab/>} />
+              <Route path="ridge" element={<RidgeRegressionLab/>} />
+              <Route path="kpca" element={<KernelPCALab/>} />
+              <Route path="brushfire" element={<BrushfirePathLab/>} />
+              <Route path="*" element={<div>Not found</div>} />
           </Routes>
         </section>
       </main>

--- a/sites/blackroad/src/pages/BrushfirePathLab.jsx
+++ b/sites/blackroad/src/pages/BrushfirePathLab.jsx
@@ -1,0 +1,152 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import ActiveReflection from "./ActiveReflection.jsx";
+
+/** Paint walls; Shift-click goal, Alt-click start.
+ *  Compute integer distance via BFS (4-neighbor), then steepest descent path. */
+export default function BrushfirePathLab(){
+  const [N,setN]=useState(160);
+  const [brush,setBrush]=useState(3);
+  const [mode,setMode]=useState("wall"); // wall | erase
+  const [start,setStart]=useState([16,16]);
+  const [goal,setGoal]=useState([140,120]);
+
+  const cnv=useRef(null);
+  const sim=useMemo(()=> makeGrid(N),[N]);
+
+  // mouse paint + set start/goal
+  useEffect(()=>{
+    const c=cnv.current; if(!c) return; c.width=N; c.height=N;
+    const rect=()=>c.getBoundingClientRect();
+    let down=false;
+    const pos=(e)=>({x:Math.max(0,Math.min(N-1,Math.floor((e.clientX-rect().left)/rect().width*N))),
+                     y:Math.max(0,Math.min(N-1,Math.floor((e.clientY-rect().top )/rect().height*N)))});
+    const md=(e)=>{ down=true; const p=pos(e);
+      if(e.shiftKey){ setGoal([p.x,p.y]); return; }
+      if(e.altKey){ setStart([p.x,p.y]); return; }
+      paint(sim,p.x,p.y,brush, mode==="wall"?1:0);
+    };
+    const mv=(e)=>{ if(!down) return; const p=pos(e); paint(sim,p.x,p.y,brush, mode==="wall"?1:0); };
+    const mu=()=>{ down=false; };
+    c.addEventListener("mousedown",md); window.addEventListener("mousemove",mv); window.addEventListener("mouseup",mu);
+    return ()=>{ c.removeEventListener("mousedown",md); window.removeEventListener("mousemove",mv); window.removeEventListener("mouseup",mu); };
+  },[sim,mode,brush,N]);
+
+  const {dist, path} = useMemo(()=>{
+    const dist=bfs(sim,start,goal);
+    const p = extract(sim, dist, start, goal);
+    return {dist, path:p};
+  },[sim,start,goal]);
+
+  useEffect(()=>{
+    const c=cnv.current; if(!c) return; const ctx=c.getContext("2d",{alpha:false});
+    render(ctx, sim, dist, path, start, goal);
+  },[sim,dist,path,start,goal]);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">Voronoi / Brushfire Path — BFS distance</h2>
+      <canvas ref={cnv} style={{width:"100%", imageRendering:"pixelated"}}/>
+      <div className="grid" style={{gridTemplateColumns:"1fr 360px", gap:16}}>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <button className="px-3 py-1 rounded bg-white/10 border border-white/10" onClick={()=>reset(sim)}>Reset</button>
+          <div className="mt-2 text-sm flex gap-3">
+            <label><input type="radio" checked={mode==="wall"} onChange={()=>setMode("wall")}/> wall</label>
+            <label><input type="radio" checked={mode==="erase"} onChange={()=>setMode("erase")}/> erase</label>
+          </div>
+        </section>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <Slider label="grid N" v={N} set={setN} min={96} max={224} step={16}/>
+          <Slider label="brush" v={brush} set={setBrush} min={1} max={10} step={1}/>
+          <p className="text-xs opacity-70 mt-2">Shift-click to set <b>goal</b>, Alt-click to set <b>start</b>.</p>
+          <ActiveReflection
+            title="Active Reflection — Brushfire"
+            storageKey="reflect_brushfire"
+            prompts={[
+              "Corridors centerline effect: path hugs cells of increasing distance.",
+              "Obstacles split distance fronts like Voronoi bisectors.",
+              "How does path differ from continuous eikonal geodesic?"
+            ]}
+          />
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function makeGrid(N){
+  const occ=Array.from({length:N},()=>Array(N).fill(0));
+  return {N, occ};
+}
+function reset(sim){ const {N,occ}=sim; for(let y=0;y<N;y++) for(let x=0;x<N;x++) occ[y][x]=0; }
+function paint(sim,x,y,r, val){
+  const {N,occ}=sim; for(let j=-r;j<=r;j++) for(let i=-r;i<=r;i++){
+    const X=Math.max(0,Math.min(N-1,x+i)), Y=Math.max(0,Math.min(N-1,y+j));
+    if(i*i+j*j<=r*r) occ[Y][X]=val;
+  }
+}
+function bfs(sim,start,goal){
+  const {N,occ}=sim; const INF=1e9;
+  const d=Array.from({length:N},()=>Array(N).fill(INF));
+  const q=[]; const push=(x,y)=>{d[y][x]=0; q.push([x,y]);};
+  push(goal[0],goal[1]);
+  const dirs=[[1,0],[-1,0],[0,1],[0,-1]];
+  while(q.length){
+    const [x,y]=q.shift();
+    for(const [dx,dy] of dirs){
+      const X=x+dx, Y=y+dy;
+      if(X<0||Y<0||X>=N||Y>=N) continue;
+      if(occ[Y][X]) continue; // blocked
+      const nd=d[y][x]+1;
+      if(nd<d[Y][X]){ d[Y][X]=nd; q.push([X,Y]); }
+    }
+  }
+  return d;
+}
+function extract(sim, d, start, goal){
+  const {N,occ}=sim; const path=[];
+  let [x,y]=start.map(Math.round);
+  const dirs=[[1,0],[-1,0],[0,1],[0,-1]];
+  if(d[y][x]===1e9) return path;
+  path.push([x,y]);
+  for(let k=0;k<N*N;k++){
+    if(x===goal[0] && y===goal[1]) break;
+    let best=[x,y], bd=d[y][x];
+    for(const [dx,dy] of dirs){
+      const X=x+dx, Y=y+dy;
+      if(X<0||Y<0||X>=N||Y>=N) continue;
+      if(d[Y][X]<bd){ bd=d[Y][X]; best=[X,Y]; }
+    }
+    if(best[0]===x && best[1]===y) break;
+    [x,y]=best; path.push([x,y]);
+  }
+  return path;
+}
+function render(ctx, sim, d, path, start, goal){
+  const {N,occ}=sim;
+  const img=ctx.createImageData(N,N);
+  let mx=0; for(let y=0;y<N;y++) for(let x=0;x<N;x++) if(d[y][x]<1e9) mx=Math.max(mx,d[y][x]);
+  for(let y=0;y<N;y++) for(let x=0;x<N;x++){
+    const off=4*(y*N+x);
+    if(occ[y][x]){ img.data[off]=18; img.data[off+1]=18; img.data[off+2]=24; img.data[off+3]=255; continue; }
+    const t=d[y][x]===1e9? 0 : d[y][x]/(mx+1e-9);
+    img.data[off]=Math.floor(50+205*t);
+    img.data[off+1]=Math.floor(80+150*(1-t));
+    img.data[off+2]=Math.floor(240*(1-t));
+    img.data[off+3]=255;
+  }
+  ctx.putImageData(img,0,0);
+  // path
+  if(path.length){
+    ctx.strokeStyle="#fff"; ctx.lineWidth=2; ctx.beginPath();
+    for(let i=0;i<path.length;i++){ const [x,y]=path[i]; if(i===0) ctx.moveTo(x+0.5,y+0.5); else ctx.lineTo(x+0.5,y+0.5); }
+    ctx.stroke();
+  }
+  // start/goal
+  ctx.fillStyle="#0ff"; ctx.fillRect(start[0]-1,start[1]-1,3,3);
+  ctx.fillStyle="#ff0"; ctx.fillRect(goal[0]-1,goal[1]-1,3,3);
+}
+function Slider({label,v,set,min,max,step}){ const show=(typeof v==="number"&&v.toFixed)?v.toFixed(2):v;
+  return (<div className="mb-2"><label className="text-sm opacity-80">{label}: <b>{show}</b></label>
+  <input className="w-full" type="range" min={min} max={max} step={step}
+         value={v} onChange={e=>set(parseFloat(e.target.value))}/></div>);
+}

--- a/sites/blackroad/src/pages/KernelPCALab.jsx
+++ b/sites/blackroad/src/pages/KernelPCALab.jsx
@@ -1,0 +1,114 @@
+import { useMemo, useState } from "react";
+import ActiveReflection from "./ActiveReflection.jsx";
+
+function rng(seed){ let s=seed|0||2025; return ()=> (s=(1664525*s+1013904223)>>>0)/2**32; }
+function randn(r){ const u=Math.max(r(),1e-12), v=Math.max(r(),1e-12); return Math.sqrt(-2*Math.log(u))*Math.cos(2*Math.PI*v); }
+
+function twoMoons(n, seed){
+  const r=rng(seed), X=[];
+  for(let i=0;i<n;i++){ const t=Math.PI*r(); X.push([Math.cos(t)+0.1*randn(r), Math.sin(t)+0.1*randn(r)]); }
+  for(let i=0;i<n;i++){ const t=Math.PI*r(); X.push([1-Math.cos(t)+0.1*randn(r), -Math.sin(t)-0.5+0.1*randn(r)]); }
+  return X;
+}
+function circles(n, seed){
+  const r=rng(seed), X=[];
+  for(let i=0;i<n;i++){ const t=2*Math.PI*r(); X.push([Math.cos(t)+0.05*randn(r), Math.sin(t)+0.05*randn(r)]); }
+  for(let i=0;i<n;i++){ const t=2*Math.PI*r(); X.push([0.5*Math.cos(t), 0.5*Math.sin(t)]); }
+  return X;
+}
+function rbfKernel(X, sigma){
+  const n=X.length; const K=Array.from({length:n},()=>Array(n).fill(0));
+  for(let i=0;i<n;i++) for(let j=0;j<n;j++){
+    const dx=X[i][0]-X[j][0], dy=X[i][1]-X[j][1]; K[i][j]=Math.exp(-(dx*dx+dy*dy)/(2*sigma*sigma));
+  }
+  // center: Kc = K - 1K/n - K1/n + 11K11 / n^2
+  const row=Array(n).fill(0); for(let i=0;i<n;i++) for(let j=0;j<n;j++) row[i]+=K[i][j];
+  const col=row.slice(); const tot=row.reduce((a,b)=>a+b,0);
+  const Kc=Array.from({length:n},()=>Array(n).fill(0));
+  for(let i=0;i<n;i++) for(let j=0;j<n;j++) Kc[i][j]=K[i][j] - row[i]/n - col[j]/n + tot/(n*n);
+  return Kc;
+}
+function topEigen(K, k){
+  const n=K.length;
+  const mult=(v)=>{ const y=Array(n).fill(0); for(let i=0;i<n;i++) for(let j=0;j<n;j++) y[i]+=K[i][j]*v[j]; return y; };
+  const vecs=[], vals=[];
+  for(let m=0;m<k;m++){
+    let v=Array(n).fill(0).map(()=>Math.random()*2-1);
+    const gs=(u)=>{ for(const q of vecs){ const dot=u.reduce((s,x,i)=>s+x*q[i],0); for(let i=0;i<n;i++) u[i]-=dot*q[i]; } 
+      const norm=Math.sqrt(u.reduce((s,x)=>s+x*x,0))||1; return u.map(x=>x/norm); };
+    for(let t=0;t<200;t++){ v=gs(mult(v)); }
+    const Kv=mult(v); const lam=v.reduce((s,x,i)=>s+x*Kv[i],0);
+    vecs.push(v); vals.push(lam);
+  }
+  return {vecs, vals};
+}
+
+export default function KernelPCALab(){
+  const [shape,setShape]=useState("moons");
+  const [n,setN]=useState(200);
+  const [sigma,setSigma]=useState(0.3);
+  const [seed,setSeed]=useState(7);
+
+  const X = useMemo(()=> shape==="moons" ? twoMoons(n,seed) : circles(n,seed),[shape,n,seed]);
+  const K = useMemo(()=> rbfKernel(X, sigma),[X,sigma]);
+  const {vecs, vals} = useMemo(()=> topEigen(K, 3),[K]);
+
+  const Y = useMemo(()=>{
+    if(vecs.length<2) return [];
+    // project: y_i = [ sqrt(λ1) v1_i, sqrt(λ2) v2_i ]
+    const s1=Math.sqrt(Math.max(1e-12, vals[0])), s2=Math.sqrt(Math.max(1e-12, vals[1]));
+    return X.map((_,i)=> [ s1*vecs[0][i], s2*vecs[1][i] ]);
+  },[vecs,vals,X]);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">Kernel PCA — RBF embedding</h2>
+      <Scatter pts={Y}/>
+      <div className="grid" style={{gridTemplateColumns:"1fr 320px", gap:16}}>
+        <div/>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <Radio name="shape" value={shape} set={setShape} opts={[["moons","two moons"],["circles","two circles"]]}/>
+          <Slider label="per class n" v={n} set={setN} min={80} max={500} step={20}/>
+          <Slider label="σ (kernel)" v={sigma} set={setSigma} min={0.05} max={1.0} step={0.01}/>
+          <Slider label="seed" v={seed} set={setSeed} min={1} max={9999} step={1}/>
+          <ActiveReflection
+            title="Active Reflection — Kernel PCA"
+            storageKey="reflect_kpca"
+            prompts={[
+              "Small σ: local geometry; large σ: global averaging — when do clusters meld?",
+              "Compare moons vs circles: which needs nonlinear features?",
+              "Why are coordinates up to rotation/scale (eigenvector freedom)?"
+            ]}
+          />
+        </section>
+      </div>
+    </div>
+  );
+}
+function Scatter({pts}){
+  const W=640,H=360,pad=20; if(!pts.length) return null;
+  const xs=pts.map(p=>p[0]), ys=pts.map(p=>p[1]);
+  const minX=Math.min(...xs), maxX=Math.max(...xs);
+  const minY=Math.min(...ys), maxY=Math.max(...ys);
+  const Xv=x=> pad+(x-minX)/(maxX-minX+1e-9)*(W-2*pad);
+  const Yv=y=> H-pad-(y-minY)/(maxY-minY+1e-9)*(H-2*pad);
+  return (
+    <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+      <svg width="100%" viewBox={`0 0 ${W} ${H}`}>
+        {pts.map((p,i)=> <circle key={i} cx={Xv(p[0])} cy={Yv(p[1])} r="3"/>) }
+      </svg>
+    </section>
+  );
+}
+function Radio({name,value,set,opts}){
+  return (<div className="flex gap-3 text-sm">
+    {opts.map(([val,lab])=> <label key={val} className="flex items-center gap-1">
+      <input type="radio" name={name} checked={value===val} onChange={()=>set(val)}/>{lab}
+    </label>)}
+  </div>);
+}
+function Slider({label,v,set,min,max,step}){ const show=(typeof v==='number'&&v.toFixed)?v.toFixed(2):v;
+  return (<div className="mb-2"><label className="text-sm opacity-80">{label}: <b>{show}</b></label>
+  <input className="w-full" type="range" min={min} max={max} step={step}
+    value={v} onChange={e=>set(parseFloat(e.target.value))}/></div>);
+}

--- a/sites/blackroad/src/pages/PoissonBoltzmannLab.jsx
+++ b/sites/blackroad/src/pages/PoissonBoltzmannLab.jsx
@@ -1,0 +1,139 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import ActiveReflection from "./ActiveReflection.jsx";
+
+/** Solve ∇²ψ = κ² sinh(ψ) with Dirichlet patches (painted electrodes).
+ *  Picard–Gauss–Seidel: ψ←avg(neigh) − (h² κ² /4) sinh(ψ_old).
+ */
+export default function PoissonBoltzmannLab(){
+  const [N,setN]=useState(160);
+  const [kappa,setKappa]=useState(1.2);
+  const [sweeps,setSweeps]=useState(40);
+  const [mode,setMode]=useState("paint"); // paint | erase
+  const [volts,setVolts]=useState(1.0);
+  const [arrows,setArrows]=useState(18);
+
+  const cnv=useRef(null);
+  const sim=useMemo(()=> makeSim(N),[N]);
+
+  // painting electrodes
+  useEffect(()=>{
+    const c=cnv.current; if(!c) return; c.width=N; c.height=N;
+    const r=()=>c.getBoundingClientRect();
+    let down=false;
+    const P=(e)=>({x:Math.max(0,Math.min(N-1,Math.floor((e.clientX-r().left)/r().width*N))),
+                   y:Math.max(0,Math.min(N-1,Math.floor((e.clientY-r().top )/r().height*N)))});
+    const paint=(x,y)=>{
+      const R=4;
+      for(let j=-R;j<=R;j++) for(let i=-R;i<=R;i++){
+        const X=Math.max(1,Math.min(N-2,x+i)), Y=Math.max(1,Math.min(N-2,y+j));
+        if(i*i+j*j<=R*R){
+          if(mode==="paint"){ sim.mask[Y][X]=true; sim.psi[Y][X]=volts; }
+          else { sim.mask[Y][X]=false; }
+        }
+      }
+    };
+    const md=(e)=>{ down=true; const p=P(e); paint(p.x,p.y); };
+    const mv=(e)=>{ if(down){ const p=P(e); paint(p.x,p.y); } };
+    const mu=()=>{ down=false; };
+    c.addEventListener("mousedown",md);
+    window.addEventListener("mousemove",mv);
+    window.addEventListener("mouseup",mu);
+    return ()=>{ c.removeEventListener("mousedown",md); window.removeEventListener("mousemove",mv); window.removeEventListener("mouseup",mu); };
+  },[sim,mode,volts,N]);
+
+  // solve + render loop
+  useEffect(()=>{
+    const c=cnv.current; if(!c) return; const ctx=c.getContext("2d",{alpha:false});
+    let raf;
+    const loop=()=>{
+      solve(sim, kappa, sweeps);
+      render(ctx, sim, arrows);
+      raf=requestAnimationFrame(loop);
+    };
+    loop(); return ()=> cancelAnimationFrame(raf);
+  },[sim,kappa,sweeps,arrows]);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">Poisson–Boltzmann — Nonlinear Electrostatics</h2>
+      <canvas ref={cnv} style={{width:"100%", imageRendering:"pixelated"}}/>
+      <div className="grid" style={{gridTemplateColumns:"1fr 360px", gap:16}}>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <button className="px-3 py-1 rounded bg-white/10 border border-white/10" onClick={()=>reset(sim)}>Reset</button>
+          <div className="mt-2 text-sm flex gap-3">
+            <label><input type="radio" checked={mode==="paint"} onChange={()=>setMode("paint")}/> paint</label>
+            <label><input type="radio" checked={mode==="erase"} onChange={()=>setMode("erase")}/> erase</label>
+          </div>
+        </section>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <Slider label="paint ψ" v={volts} set={setVolts} min={-2} max={2} step={0.05}/>
+          <Slider label="κ (salt strength)" v={kappa} set={setKappa} min={0.2} max={2.4} step={0.05}/>
+          <Slider label="sweeps/frame" v={sweeps} set={setSweeps} min={5} max={120} step={5}/>
+          <Slider label="field arrows" v={arrows} set={setArrows} min={8} max={32} step={1}/>
+          <Slider label="grid N" v={N} set={setN} min={96} max={224} step={16}/>
+          <ActiveReflection
+            title="Active Reflection — Poisson–Boltzmann"
+            storageKey="reflect_pb"
+            prompts={[
+              "Paint +ψ and −ψ plates: note screening vs Laplace case.",
+              "Increase κ: Debye screening shortens field range.",
+              "Nonlinearity: large |ψ| makes contours asymmetrical."
+            ]}
+          />
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function makeSim(N){
+  const psi=Array.from({length:N},()=>Array(N).fill(0));
+  const mask=Array.from({length:N},()=>Array(N).fill(false));
+  // grounded borders
+  for(let i=0;i<N;i++){ mask[0][i]=mask[N-1][i]=mask[i][0]=mask[i][N-1]=true; psi[0][i]=psi[N-1][i]=psi[i][0]=psi[i][N-1]=0; }
+  return {N, psi, mask};
+}
+function reset(sim){ const {N,psi,mask}=sim; for(let y=0;y<N;y++) for(let x=0;x<N;x++){ psi[y][x]=0; mask[y][x]=false; } for(let i=0;i<N;i++){ mask[0][i]=mask[N-1][i]=mask[i][0]=mask[i][N-1]=true; } }
+function solve(sim, kappa, sweeps){
+  const {N,psi,mask}=sim; const h2=(1); // grid step scaled to 1 pixel
+  const alpha = 0.25*kappa*kappa*h2;
+  for(let k=0;k<sweeps;k++){
+    for(let y=1;y<N-1;y++){
+      for(let x=1;x<N-1;x++){
+        if(mask[y][x]) continue;
+        // Picard linearization using current ψ[y][x]
+        psi[y][x] = 0.25*(psi[y-1][x]+psi[y+1][x]+psi[y][x-1]+psi[y][x+1]) - alpha*Math.sinh(psi[y][x]);
+      }
+    }
+  }
+}
+function render(ctx, sim, arrows){
+  const {N,psi,mask}=sim;
+  const img=ctx.createImageData(N,N);
+  let mn=Infinity,mx=-Infinity; for(let y=0;y<N;y++) for(let x=0;x<N;x++){ mn=Math.min(mn,psi[y][x]); mx=Math.max(mx,psi[y][x]); }
+  for(let y=0;y<N;y++) for(let x=0;x<N;x++){
+    const t=(psi[y][x]-mn)/(mx-mn+1e-9);
+    const off=4*(y*N+x);
+    img.data[off]=Math.floor(40+200*t);
+    img.data[off+1]=Math.floor(50+180*(1-t));
+    img.data[off+2]=Math.floor(220*(1-t));
+    img.data[off+3]=255;
+    if(mask[y][x]){ img.data[off]=255; img.data[off+1]=255; img.data[off+2]=255; }
+  }
+  ctx.putImageData(img,0,0);
+  // Field E = −∇ψ
+  ctx.strokeStyle="#fff"; ctx.lineWidth=1;
+  const G=arrows;
+  for(let j=0;j<G;j++) for(let i=0;i<G;i++){
+    const x=Math.floor((i+0.5)*N/G), y=Math.floor((j+0.5)*N/G);
+    const dpx=(psi[y][Math.min(N-1,x+1)]-psi[y][Math.max(0,x-1)])*0.5;
+    const dpy=(psi[Math.min(N-1,y+1)][x]-psi[Math.max(0,y-1)][x])*0.5;
+    const Ex=-dpx, Ey=-dpy;
+    const s=2.0; ctx.beginPath(); ctx.moveTo(x+0.5,y+0.5); ctx.lineTo(x+0.5+s*Ex,y+0.5+s*Ey); ctx.stroke();
+  }
+}
+function Slider({label,v,set,min,max,step}){ const show=(typeof v==="number"&&v.toFixed)?v.toFixed(2):v;
+  return (<div className="mb-2"><label className="text-sm opacity-80">{label}: <b>{show}</b></label>
+  <input className="w-full" type="range" min={min} max={max} step={step}
+         value={v} onChange={e=>set(parseFloat(e.target.value))}/></div>);
+}

--- a/sites/blackroad/src/pages/RidgeRegressionLab.jsx
+++ b/sites/blackroad/src/pages/RidgeRegressionLab.jsx
@@ -1,0 +1,167 @@
+import { useMemo, useState } from "react";
+import ActiveReflection from "./ActiveReflection.jsx";
+
+/** Fit y ~ poly_d(x) with ridge λ; show prediction vs truth and error vs λ. */
+
+function design(X, d){
+  return X.map(x=>{
+    const row=[]; for(let k=0;k<=d;k++) row.push(Math.pow(x,k)); return row;
+  });
+}
+function matMul(A,B){ const m=A.length, n=A[0].length, p=B[0].length; const C=Array.from({length:m},()=>Array(p).fill(0));
+  for(let i=0;i<m;i++) for(let k=0;k<n;k++) for(let j=0;j<p;j++) C[i][j]+=A[i][k]*B[k][j];
+  return C;
+}
+function matT(A){ const m=A.length, n=A[0].length; const T=Array.from({length:n},()=>Array(m).fill(0));
+  for(let i=0;i<m;i++) for(let j=0;j<n;j++) T[j][i]=A[i][j]; return T;
+}
+function eye(n){ const I=Array.from({length:n},()=>Array(n).fill(0)); for(let i=0;i<n;i++) I[i][i]=1; return I; }
+function addMat(A,B){ return A.map((r,i)=> r.map((v,j)=> v+B[i][j])); }
+function invGauss(A){
+  const n=A.length; const M=A.map(r=>r.slice()); const I=eye(n);
+  for(let col=0; col<n; col++){
+    // pivot
+    let piv=col; for(let r=col+1;r<n;r++) if(Math.abs(M[r][col])>Math.abs(M[piv][col])) piv=r;
+    if(Math.abs(M[piv][col])<1e-12) continue;
+    [M[col],M[piv]]=[M[piv],M[col]]; [I[col],I[piv]]=[I[piv],I[col]];
+    const f=M[col][col];
+    for(let j=0;j<n;j++){ M[col][j]/=f; I[col][j]/=f; }
+    for(let r=0;r<n;r++){
+      if(r===col) continue;
+      const g=M[r][col];
+      for(let j=0;j<n;j++){ M[r][j]-=g*M[col][j]; I[r][j]-=g*I[col][j]; }
+    }
+  }
+  return I;
+}
+function ridgeFit(X, y, lam){
+  const XT=matT(X); const A=addMat(matMul(XT,X), scaleMat(eye(X[0].length), lam));
+  const b=matMul(XT, y.map(v=>[v]));
+  const Ainv=invGauss(A); const w=matMul(Ainv, b); return w.map(r=>r[0]);
+}
+function scaleMat(A,s){ return A.map(r=>r.map(v=>v*s)); }
+
+function f_true(x){ return Math.sin(2*Math.PI*x) + 0.5*Math.cos(5*Math.PI*x); }
+function makeData(n, noise, seed=7){
+  let s=seed|0; const R=()=> (s=(1664525*s+1013904223)>>>0)/2**32;
+  const X=Array.from({length:n},()=> R()); const y=X.map(x=> f_true(x) + noise*(R()*2-1));
+  return {X,y};
+}
+function predict(w, d, xs){ return xs.map(x=> w.reduce((s,wi,i)=> s + wi*Math.pow(x,i), 0)); }
+function mse(yhat, y){ const n=y.length; let e=0; for(let i=0;i<n;i++) e+=(yhat[i]-y[i])**2; return e/n; }
+
+export default function RidgeRegressionLab(){
+  const [n,setN]=useState(30);
+  const [noise,setNoise]=useState(0.2);
+  const [deg,setDeg]=useState(12);
+  const [lambda,setLambda]=useState(1e-2);
+  const [seed,setSeed]=useState(7);
+
+  const {X,y} = useMemo(()=> makeData(n, noise, seed),[n,noise,seed]);
+  const grid = useMemo(()=> Array.from({length:300},(_,i)=> i/299),[]);
+  const lamGrid = useMemo(()=> Array.from({length:40},(_,i)=> Math.pow(10, -4 + i*(8/39))),[]); // 1e-4..1e4
+
+  const fit = useMemo(()=>{
+    const Phi = design(X, deg); const w=ridgeFit(Phi, y, lambda);
+    const yhat = predict(w,deg,X);
+    const PhiTest = design(grid, deg); const ygrid=predict(w,deg,grid);
+    const eTrain = mse(yhat,y);
+    const yTrueGrid = grid.map(f_true); const eTest = mse(ygrid, yTrueGrid);
+    return {w, ygrid, eTrain, eTest};
+  },[X,y,deg,lambda,grid]);
+
+  const curves = useMemo(()=>{
+    const Phi=design(X,deg);
+    const yTrueGrid=grid.map(f_true);
+    const errs=lamGrid.map(L=>{
+      const w=ridgeFit(Phi,y,L);
+      const yhat=predict(w,deg,X);
+      const eTr=mse(yhat,y);
+      const ygrid=predict(w,deg,grid);
+      const eTe=mse(ygrid, yTrueGrid);
+      return [L,eTr,eTe];
+    });
+    return errs;
+  },[X,y,deg,lamGrid,grid]);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">Ridge Regression — Bias/Variance Feel</h2>
+      <FitPlot grid={grid} ygrid={fit.ygrid}/>
+      <ErrPlot errs={curves} lambda={lambda}/>
+      <div className="grid" style={{gridTemplateColumns:"1fr 360px", gap:16}}>
+        <div/>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <Slider label="samples n" v={n} set={setN} min={10} max={120} step={5}/>
+          <Slider label="noise" v={noise} set={setNoise} min={0.0} max={0.6} step={0.01}/>
+          <Slider label="degree d" v={deg} set={setDeg} min={1} max={20} step={1}/>
+          <Slider label="λ (ridge)" v={lambda} set={setLambda} min={1e-4} max={1e4} step={0.001} log/>
+          <Slider label="seed" v={seed} set={setSeed} min={1} max={9999} step={1}/>
+          <p className="text-sm mt-2">Train MSE: <b>{fit.eTrain.toFixed(3)}</b> • Test MSE: <b>{fit.eTest.toFixed(3)}</b></p>
+          <ActiveReflection
+            title="Active Reflection — Ridge"
+            storageKey="reflect_ridge"
+            prompts={[
+              "Vary λ: watch bias↑ / variance↓ as λ grows.",
+              "At high degree, small λ overfits; ridge cures it — where’s sweet spot?",
+              "Noise↑ raises irreducible error — how do curves shift?"
+            ]}
+          />
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function FitPlot({grid, ygrid}){
+  const W=640,H=280,pad=16;
+  const yTrue=grid.map(f_true);
+  const minY=Math.min(...yTrue,...ygrid), maxY=Math.max(...yTrue,...ygrid);
+  const X=i=> pad + (i/(grid.length-1))*(W-2*pad);
+  const Y=v=> H-pad - ((v-minY)/(maxY-minY+1e-9))*(H-2*pad);
+  const poly=(a)=> a.map((v,i)=>`${X(i)},${Y(v)}`).join(" ");
+  return (
+    <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+      <h3 className="font-semibold mb-2">Prediction vs Truth</h3>
+      <svg width="100%" viewBox={`0 0 ${W} ${H}`}>
+        <polyline points={poly(yTrue)} fill="none" strokeWidth="2"/>
+        <polyline points={poly(ygrid)} fill="none" strokeWidth="2" opacity="0.7"/>
+      </svg>
+    </section>
+  );
+}
+function ErrPlot({errs, lambda}){
+  const W=640,H=220,pad=16;
+  const Xlog=L=> pad + (Math.log10(L)-(-4))/(8)*(W-2*pad);
+  const Yerr=e=> H-pad - (1 - 1/(1+e))*(H-2*pad); // squash
+  const selX=Xlog(lambda);
+  return (
+    <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+      <h3 className="font-semibold mb-2">MSE vs λ (log)</h3>
+      <svg width="100%" viewBox={`0 0 ${W} ${H}`}>
+        {/* train */}
+        <path d={`M ${errs.map(([L,eTr])=> `${Xlog(L)},${Yerr(eTr)}`).join(" L ")}`} fill="none" strokeWidth="2"/>
+        {/* test */}
+        <path d={`M ${errs.map(([L,_,eTe])=> `${Xlog(L)},${Yerr(eTe)}`).join(" L ")}`} fill="none" strokeWidth="2" opacity="0.7"/>
+        <line x1={selX} x2={selX} y1={pad} y2={H-pad} strokeWidth="1.5" />
+      </svg>
+    </section>
+  );
+}
+function Slider({label,v,set,min,max,step,log=false}){
+  const display = ()=> log ? v.toExponential(2) : (typeof v==="number"&&v.toFixed ? v.toFixed(3):v);
+  const change = (e)=>{
+    const raw=parseFloat(e.target.value);
+    set(log ? Math.pow(10, raw) : raw);
+  };
+  const val = log ? Math.log10(v) : v;
+  const minv = log ? Math.log10(min) : min;
+  const maxv = log ? Math.log10(max) : max;
+  const stepv= log ? (Math.log10(max)-Math.log10(min))/500 : step;
+  return (
+    <div className="mb-2">
+      <label className="text-sm opacity-80">{label}: <b>{display()}</b></label>
+      <input className="w-full" type="range" min={minv} max={maxv} step={stepv} value={val} onChange={change}/>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Poisson–Boltzmann electrostatics demo
- add ridge regression bias/variance explorer
- add kernel PCA visualization
- add brushfire path planner
- register new lab routes in app

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c12642b1d8832997451cc1080534f7