### PR TITLE
Add interactive algorithm labs

### DIFF
--- a/sites/blackroad/src/App.jsx
+++ b/sites/blackroad/src/App.jsx
@@ -27,6 +27,10 @@ import EigenmapsLab from "./pages/EigenmapsLab.jsx";
 import PoissonBlendLab from "./pages/PoissonBlendLab.jsx";
 import NBodyLab from "./pages/NBodyLab.jsx";
 import WaveletLab from "./pages/WaveletLab.jsx";
+import AStarLab from "./pages/AStarLab.jsx";
+import TSPLab from "./pages/TSPLab.jsx";
+import GrayScottGalleryLab from "./pages/GrayScottGalleryLab.jsx";
+import RansacPlane3DLab from "./pages/RansacPlane3DLab.jsx";
 
 function useApiHealth(){
   const [state,setState]=useState({ok:null, info:""});
@@ -130,6 +134,10 @@ function LegacyApp(){
             <Route path="/blend" element={<PoissonBlendLab/>} />
             <Route path="/nbody" element={<NBodyLab/>} />
             <Route path="/wavelet" element={<WaveletLab/>} />
+            <Route path="/astar" element={<AStarLab/>} />
+            <Route path="/tsp" element={<TSPLab/>} />
+            <Route path="/gs-gallery" element={<GrayScottGalleryLab/>} />
+            <Route path="/plane3d" element={<RansacPlane3DLab/>} />
             <Route path="chat" element={<Chat/>} />
             <Route path="canvas" element={<Canvas/>} />
             <Route path="editor" element={<Editor/>} />
@@ -154,6 +162,10 @@ function LegacyApp(){
             <Route path="blend" element={<PoissonBlendLab/>} />
             <Route path="nbody" element={<NBodyLab/>} />
             <Route path="wavelet" element={<WaveletLab/>} />
+            <Route path="astar" element={<AStarLab/>} />
+            <Route path="tsp" element={<TSPLab/>} />
+            <Route path="gs-gallery" element={<GrayScottGalleryLab/>} />
+            <Route path="plane3d" element={<RansacPlane3DLab/>} />
             <Route path="*" element={<div>Not found</div>} />
           </Routes>
         </section>

--- a/sites/blackroad/src/pages/AStarLab.jsx
+++ b/sites/blackroad/src/pages/AStarLab.jsx
@@ -1,0 +1,160 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import ActiveReflection from "./ActiveReflection.jsx";
+
+function heapPush(h, node){ h.push(node); up(h, h.length-1); }
+function up(h,i){ while(i>0){ const p=(i-1)>>1; if(h[p].prio<=h[i].prio) break; [h[p],h[i]]=[h[i],h[p]]; i=p; } }
+function heapPop(h){ if(!h.length) return null; const r=h[0]; const v=h.pop(); if(h.length){ h[0]=v; down(h,0); } return r; }
+function down(h,i){ for(;;){ let l=i*2+1,r=i*2+2,m=i; if(l<h.length&&h[l].prio<h[m].prio) m=l; if(r<h.length&&h[r].prio<h[m].prio) m=r; if(m===i) break; [h[i],h[m]]=[h[m],h[i]]; i=m; } }
+
+export default function AStarLab(){
+  const [N,setN]=useState(160);
+  const [brush,setBrush]=useState(3);
+  const [mode,setMode]=useState("wall"); // wall | erase
+  const [heur,setHeur]=useState(true);   // on = A*, off = Dijkstra
+  const [start,setStart]=useState([16,16]);
+  const [goal,setGoal]=useState([140,120]);
+
+  const cnv=useRef(null);
+  const world=useMemo(()=> makeWorld(N),[N]);
+
+  // mouse interactions
+  useEffect(()=>{
+    const c=cnv.current; if(!c) return; c.width=N; c.height=N;
+    const R=()=>c.getBoundingClientRect();
+    let down=false;
+    const P=e=>({x:Math.max(0,Math.min(N-1, Math.floor((e.clientX-R().left)/R().width*N))),
+                 y:Math.max(0,Math.min(N-1, Math.floor((e.clientY-R().top )/R().height*N)))});
+    const paint=(x,y)=>{
+      for(let j=-brush;j<=brush;j++) for(let i=-brush;i<=brush;i++){
+        if(i*i+j*j>brush*brush) continue;
+        const X=Math.max(0,Math.min(N-1,x+i)), Y=Math.max(0,Math.min(N-1,y+j));
+        world.wall[Y][X] = (mode==="wall") ? 1 : 0;
+      }
+    };
+    const md=e=>{
+      down=true; const p=P(e);
+      if(e.shiftKey){ setGoal([p.x,p.y]); return; }
+      if(e.altKey){ setStart([p.x,p.y]); return; }
+      paint(p.x,p.y);
+    };
+    const mv=e=>{ if(!down) return; const p=P(e); paint(p.x,p.y); };
+    const mu=()=>{ down=false; };
+    c.addEventListener("mousedown",md); window.addEventListener("mousemove",mv); window.addEventListener("mouseup",mu);
+    return ()=>{ c.removeEventListener("mousedown",md); window.removeEventListener("mousemove",mv); window.removeEventListener("mouseup",mu); };
+  },[world,mode,brush,N]);
+
+  const result = useMemo(()=> runSearch(world, start, goal, heur),[world,start,goal,heur]);
+
+  useEffect(()=>{
+    const c=cnv.current; if(!c) return; const ctx=c.getContext("2d",{alpha:false});
+    render(ctx, world, result, start, goal);
+  },[world,result,start,goal]);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">A* vs Dijkstra — Grid Pathfinding</h2>
+      <canvas ref={cnv} style={{width:"100%", imageRendering:"pixelated"}}/>
+      <div className="grid" style={{gridTemplateColumns:'1fr 360px', gap:16}}>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <button className="px-2 py-1 rounded bg-white/10 border border-white/10" onClick={()=>reset(world)}>Reset</button>
+          <div className="mt-2 text-sm flex gap-3">
+            <label><input type="radio" checked={mode==="wall"} onChange={()=>setMode("wall")}/> wall</label>
+            <label><input type="radio" checked={mode==="erase"} onChange={()=>setMode("erase")}/> erase</label>
+          </div>
+          <p className="text-xs opacity-70 mt-2">Shift-click: set goal • Alt-click: set start</p>
+        </section>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <Slider label="grid N" v={N} set={setN} min={96} max={224} step={16}/>
+          <Slider label="brush" v={brush} set={setBrush} min={1} max={10} step={1}/>
+          <label className="text-sm flex items-center gap-2 mt-1">
+            <input type="checkbox" checked={heur} onChange={()=>setHeur(v=>!v)}/> Use heuristic (A*) — off = Dijkstra
+          </label>
+          <p className="text-sm mt-2">Visited: <b>{result.visited}</b> • Path len: <b>{result.path.length}</b></p>
+          <ActiveReflection
+            title="Active Reflection — A* vs Dijkstra"
+            storageKey="reflect_astar"
+            prompts={[
+              "Turn heuristic off: expansions explode but path stays same.",
+              "Find mazes where A*’s gain is massive vs straight corridors.",
+              "Heuristic = Manhattan; when is it admissible/tight?"
+            ]}
+          />
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function makeWorld(N){ return {N, wall: Array.from({length:N},()=>Array(N).fill(0))}; }
+function reset(world){ const {N,wall}=world; for(let y=0;y<N;y++) for(let x=0;x<N;x++) wall[y][x]=0; }
+
+function runSearch(world, start, goal, useHeur){
+  const {N,wall}=world;
+  const g=Array.from({length:N},()=>Array(N).fill(Infinity));
+  const came=Array.from({length:N},()=>Array(N).fill(null));
+  const open=[]; const h=(x,y)=> Math.abs(x-goal[0])+Math.abs(y-goal[1]);
+  const s={x:start[0],y:start[1],prio:0}; g[start[1]][start[0]]=0; heapPush(open,s);
+  let visited=0;
+  while(open.length){
+    const cur=heapPop(open); visited++; if(cur.x===goal[0]&&cur.y===goal[1]) break;
+    const dirs=[[1,0],[-1,0],[0,1],[0,-1]];
+    for(const [dx,dy] of dirs){
+      const X=cur.x+dx, Y=cur.y+dy;
+      if(X<0||Y<0||X>=N||Y>=N) continue;
+      if(wall[Y][X]) continue;
+      const newg=g[cur.y][cur.x]+1;
+      if(newg<g[Y][X]){
+        g[Y][X]=newg; came[Y][X]=[cur.x,cur.y];
+        const f=newg + (useHeur ? h(X,Y) : 0);
+        heapPush(open, {x:X,y:Y,prio:f});
+      }
+    }
+  }
+  // reconstruct
+  const path=[]; let x=goal[0], y=goal[1];
+  if(!Number.isFinite(g[y][x])) return {path, visited, g};
+  while(!(x===start[0]&&y===start[1])){
+    path.push([x,y]); const p=came[y][x]; if(!p) break; [x,y]=p;
+  }
+  path.push([start[0],start[1]]); path.reverse();
+  return {path, visited, g};
+}
+
+function render(ctx, world, result, start, goal){
+  const {N,wall}=world; const {g,path}=result;
+  const img=ctx.createImageData(N,N);
+  let mx=0; for(let y=0;y<N;y++) for(let x=0;x<N;x++){ const v=g[y][x]; if(Number.isFinite(v)) mx=Math.max(mx,v); }
+  for(let y=0;y<N;y++){
+    for(let x=0;x<N;x++){
+      const off=4*(y*N+x);
+      if(wall[y][x]){ img.data[off]=18; img.data[off+1]=18; img.data[off+2]=24; img.data[off+3]=255; continue; }
+      if(Number.isFinite(g[y][x])){
+        const t=g[y][x]/(mx+1e-9);
+        img.data[off]=Math.floor(50+205*t);
+        img.data[off+1]=Math.floor(80+150*(1-t));
+        img.data[off+2]=Math.floor(240*(1-t));
+      }else{
+        img.data[off]=40; img.data[off+1]=50; img.data[off+2]=60;
+      }
+      img.data[off+3]=255;
+    }
+  }
+  ctx.putImageData(img,0,0);
+  // path
+  if(path.length){
+    ctx.strokeStyle="#fff"; ctx.lineWidth=2; ctx.beginPath();
+    for(let i=0;i<path.length;i++){ const [x,y]=path[i]; if(i===0) ctx.moveTo(x+0.5,y+0.5); else ctx.lineTo(x+0.5,y+0.5); }
+    ctx.stroke();
+  }
+  // start/goal
+  ctx.fillStyle="#0ff"; ctx.fillRect(start[0]-1,start[1]-1,3,3);
+  ctx.fillStyle="#ff0"; ctx.fillRect(goal[0]-1,goal[1]-1,3,3);
+}
+
+function Slider({label,v,set,min,max,step}){
+  const show = (typeof v==='number'&&v.toFixed) ? v.toFixed(2) : v;
+  return (<div className="mb-2"><label className="text-sm opacity-80">{label}: <b>{show}</b></label>
+    <input className="w-full" type="range" min={min} max={max} step={step}
+      value={v} onChange={e=>set(parseFloat(e.target.value))}/></div>);
+}
+

--- a/sites/blackroad/src/pages/GrayScottGalleryLab.jsx
+++ b/sites/blackroad/src/pages/GrayScottGalleryLab.jsx
@@ -1,0 +1,119 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import ActiveReflection from "./ActiveReflection.jsx";
+
+/** u_t = Du ∇²u - u v^2 + F(1-u)
+ *  v_t = Dv ∇²v + u v^2 - (F+k) v
+ *  (periodic bounds). This gallery provides named presets & controls. */
+function idx(N,x,y){ const X=(x+N)%N, Y=(y+N)%N; return Y*N+X; }
+
+const PRESETS = [
+  {name:"Pearls",    F:0.022, k:0.051},
+  {name:"Mazes",     F:0.029, k:0.057},
+  {name:"Spots",     F:0.037, k:0.065},
+  {name:"Waves",     F:0.026, k:0.055},
+  {name:"Leopard",   F:0.02,  k:0.05 },
+];
+
+export default function GrayScottGalleryLab(){
+  const [N,setN]=useState(160);
+  const [Du,setDu]=useState(0.16), [Dv,setDv]=useState(0.08);
+  const [F,setF]=useState(PRESETS[0].F), [k,setK]=useState(PRESETS[0].k);
+  const [dt,setDT]=useState(1.0);
+  const [running,setRunning]=useState(true);
+  const [seed,setSeed]=useState(42);
+
+  const sim=useMemo(()=> init(N, seed),[N,seed]);
+
+  const cnv=useRef(null);
+  useEffect(()=>{
+    const c=cnv.current; if(!c) return; c.width=N; c.height=N;
+    const ctx=c.getContext("2d",{alpha:false});
+    let raf;
+    const loop=()=>{
+      if(running) evolve(sim, Du, Dv, F, k, dt, 10);
+      render(ctx, sim);
+      raf=requestAnimationFrame(loop);
+    };
+    loop(); return ()=> cancelAnimationFrame(raf);
+  },[sim,Du,Dv,F,k,dt,running,N]);
+
+  const applyPreset = (p)=>{ setF(p.F); setK(p.k); };
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">Gray–Scott Gallery — Presets</h2>
+      <canvas ref={cnv} style={{width:"100%", imageRendering:"pixelated"}}/>
+      <div className="grid" style={{gridTemplateColumns:'1fr 360px', gap:16}}>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          {PRESETS.map(p=>(
+            <button key={p.name} className="mr-2 mb-2 px-2 py-1 rounded bg-white/10 border border-white/10" onClick={()=>applyPreset(p)}>{p.name}</button>
+          ))}
+          <div className="mt-2">
+            <button className="px-2 py-1 rounded bg-white/10 border border-white/10" onClick={()=>setRunning(r=>!r)}>{running?"Pause":"Run"}</button>
+            <button className="ml-2 px-2 py-1 rounded bg-white/10 border border-white/10" onClick={()=>seedSim(sim)}>Reseed</button>
+          </div>
+        </section>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <Slider label="grid N" v={N} set={setN} min={120} max={240} step={20}/>
+          <Slider label="Du" v={Du} set={setDu} min={0.01} max={0.3} step={0.005}/>
+          <Slider label="Dv" v={Dv} set={setDv} min={0.01} max={0.3} step={0.005}/>
+          <Slider label="F"  v={F}  set={setF}  min={0.01} max={0.08} step={0.001}/>
+          <Slider label="k"  v={k}  set={setK}  min={0.03} max={0.08} step={0.001}/>
+          <Slider label="dt" v={dt} set={setDT} min={0.2} max={2.0} step={0.05}/>
+          <ActiveReflection
+            title="Active Reflection — Gray–Scott Gallery"
+            storageKey="reflect_gs_gallery"
+            prompts={[
+              "Each (F,k) regime creates different motifs; explore transitions.",
+              "Du/Dv ratio warps stripe thickness vs dot sizes — notice trends.",
+              "Reseed and pause to compare early vs late morphology."
+            ]}
+          />
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function init(N, seed){
+  const u=new Float32Array(N*N), v=new Float32Array(N*N);
+  for(let y=0;y<N;y++) for(let x=0;x<N;x++){ u[idx(N,x,y)]=1; v[idx(N,x,y)]=0; }
+  seedSim({N,u,v});
+  return {N,u,v,tmpu:new Float32Array(N*N), tmpv:new Float32Array(N*N)};
+}
+function seedSim(sim){
+  const {N,u,v}=sim;
+  for(let y=0;y<N;y++) for(let x=0;x<N;x++){ u[idx(N,x,y)]=1; v[idx(N,x,y)]=0; }
+  // random sprinkles in center
+  for(let y=N/2-10|0; y<N/2+10|0; y++) for(let x=N/2-10|0; x<N/2+10|0; x++){
+    u[idx(N,x,y)] = 0.5 + 0.5*Math.random();
+    v[idx(N,x,y)] = 0.25*Math.random();
+  }
+}
+function lap(U,N,x,y){ return U[idx(N,x-1,y)]+U[idx(N,x+1,y)]+U[idx(N,x,y-1)]+U[idx(N,x,y+1)] - 4*U[idx(N,x,y)]; }
+function evolve(sim,Du,Dv,F,k,dt,sub){
+  const {N,u,v,tmpu,tmpv}=sim; const sdt=dt/sub;
+  for(let s=0;s<sub;s++){
+    for(let y=1;y<N-1;y++) for(let x=1;x<N-1;x++){
+      const i=idx(N,x,y), uvv=u[i]*v[i]*v[i];
+      tmpu[i]= u[i] + sdt*( Du*lap(u,N,x,y) - uvv + F*(1-u[i]) );
+      tmpv[i]= v[i] + sdt*( Dv*lap(v,N,x,y) + uvv - (F+k)*v[i] );
+    }
+    for(let y=1;y<N-1;y++) for(let x=1;x<N-1;x++){ const i=idx(N,x,y); u[i]=tmpu[i]; v[i]=tmpv[i]; }
+  }
+}
+function render(ctx, sim){
+  const {N,u,v}=sim; const img=ctx.createImageData(N,N);
+  for(let y=0;y<N;y++) for(let x=0;x<N;x++){
+    const i=idx(N,x,y); const a=u[i], b=v[i];
+    const R=Math.floor(255*Math.sqrt(Math.max(0,a))), G=Math.floor(255*(0.5*b + 0.5*a)), B=Math.floor(255*Math.sqrt(Math.max(0,b)));
+    const off=4*i; img.data[off]=R; img.data[off+1]=G; img.data[off+2]=B; img.data[off+3]=255;
+  }
+  ctx.putImageData(img,0,0);
+}
+function Slider({label,v,set,min,max,step}){ const show=(typeof v==='number'&&v.toFixed)?v.toFixed(3):v;
+  return (<div className="mb-2"><label className="text-sm opacity-80">{label}: <b>{show}</b></label>
+    <input className="w-full" type="range" min={min} max={max} step={step}
+           value={v} onChange={e=>set(parseFloat(e.target.value))}/></div>);
+}
+

--- a/sites/blackroad/src/pages/RansacPlane3DLab.jsx
+++ b/sites/blackroad/src/pages/RansacPlane3DLab.jsx
@@ -1,0 +1,167 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import ActiveReflection from "./ActiveReflection.jsx";
+
+// Plane: z = ax + by + c. Fit with RANSAC; refine with least squares on inliers.
+
+export default function RansacPlane3DLab(){
+  const [nIn,setNIn]=useState(180);
+  const [nOut,setNOut]=useState(60);
+  const [noise,setNoise]=useState(0.03);
+  const [th,setTh]=useState(0.05);
+  const [iters,setIters]=useState(1200);
+  const [seed,setSeed]=useState(7);
+
+  const data = useMemo(()=> makeData3D(nIn,nOut,noise,seed),[nIn,nOut,noise,seed]);
+  const model = useMemo(()=> ransacPlane(data, th, iters),[data,th,iters]);
+
+  const [yaw,setYaw]=useState(0.7), [pitch,setPitch]=useState(0.4), [spin,setSpin]=useState(0.01);
+  useEffect(()=>{ const id=setInterval(()=> setYaw(y=>y+spin), 16); return ()=>clearInterval(id); },[spin]);
+
+  const W=640,H=360;
+  const cnv=useRef(null);
+  useEffect(()=>{
+    const c=cnv.current; if(!c) return; c.width=W; c.height=H;
+    const ctx=c.getContext("2d",{alpha:false});
+    drawScene(ctx, W, H, data, model, yaw, pitch);
+  },[data,model,yaw,pitch]);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">RANSAC Plane (3-D) — fit + viewing</h2>
+      <canvas ref={cnv} style={{width:"100%"}}/>
+      <div className="grid" style={{gridTemplateColumns:"1fr 360px", gap:16}}>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <Slider label="inliers" v={nIn} set={setNIn} min={40} max={600} step={20}/>
+          <Slider label="outliers" v={nOut} set={setNOut} min={0} max={400} step={20}/>
+          <Slider label="noise σ" v={noise} set={setNoise} min={0} max={0.15} step={0.005}/>
+          <Slider label="threshold" v={th} set={setTh} min={0.01} max={0.12} step={0.002}/>
+          <Slider label="iterations" v={iters} set={setIters} min={100} max={4000} step={100}/>
+          <Slider label="seed" v={seed} set={setSeed} min={1} max={9999} step={1}/>
+        </section>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <Slider label="yaw" v={yaw} set={setYaw} min={-Math.PI} max={Math.PI} step={0.01}/>
+          <Slider label="pitch" v={pitch} set={setPitch} min={-1.2} max={1.2} step={0.01}/>
+          <Slider label="spin" v={spin} set={setSpin} min={0} max={0.05} step={0.001}/>
+          <p className="text-sm mt-2">Inliers: <b>{model.inliers.length}</b> • Plane: <code>z≈{model.a.toFixed(3)}x + {model.b.toFixed(3)}y + {model.c.toFixed(3)}</code></p>
+          <ActiveReflection
+            title="Active Reflection — RANSAC Plane"
+            storageKey="reflect_ransac_plane"
+            prompts={[
+              "Increase outliers: when does plane flip?",
+              "Threshold too tight rejects true inliers; too loose accepts junk.",
+              "Noise ↑ needs more iterations; watch stability of (a,b,c)."
+            ]}
+          />
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function makeData3D(nIn,nOut,noise,seed){
+  let s=seed|0; const R=()=> (s=(1664525*s+1013904223)>>>0)/2**32;
+  // random plane
+  const a=0.4*(R()*2-1), b=0.4*(R()*2-1), c=0.2*(R()*2-1);
+  const inl=Math.max(1,nIn|0), out=Math.max(0,nOut|0);
+  const P=[];
+  for(let i=0;i<inl;i++){
+    const x=(R()*2-1), y=(R()*2-1), z=a*x + b*y + c + noise*(R()*2-1);
+    P.push({x,y,z, inlier:true});
+  }
+  for(let i=0;i<out;i++){
+    P.push({x:(R()*2-1), y:(R()*2-1), z:(R()*2-1), inlier:false});
+  }
+  return {pts:P, true:{a,b,c}};
+}
+function ransacPlane(data, th, iters){
+  const P=data.pts; let best={a:0,b:0,c:0, inliers:[]};
+  const d=(a,b,c,p)=> Math.abs(p.z - (a*p.x + b*p.y + c)) / Math.sqrt(a*a + b*b + 1);
+  for(let k=0;k<iters;k++){
+    // pick 3 unique points
+    const i=(Math.random()*P.length)|0, j=(Math.random()*P.length)|0, l=(Math.random()*P.length)|0;
+    if(i===j||j===l||i===l) continue;
+    const p1=P[i], p2=P[j], p3=P[l];
+    // fit plane through 3 points (solve for a,b,c in z=ax+by+c)
+    const A=[[p1.x,p1.y,1],[p2.x,p2.y,1],[p3.x,p3.y,1]];
+    const z=[p1.z,p2.z,p3.z];
+    const M=inv3(A); if(!M) continue;
+    const a=M[0][0]*z[0]+M[0][1]*z[1]+M[0][2]*z[2];
+    const b=M[1][0]*z[0]+M[1][1]*z[1]+M[1][2]*z[2];
+    const c=M[2][0]*z[0]+M[2][1]*z[1]+M[2][2]*z[2];
+    const inl=[];
+    for(let t=0;t<P.length;t++) if(d(a,b,c,P[t])<th) inl.push(t);
+    if(inl.length>best.inliers.length){
+      // refine LS on inliers
+      const LS = leastSquares(P, inl);
+      best={a:LS.a,b:LS.b,c:LS.c,inliers:inl};
+    }
+  }
+  return best;
+}
+function leastSquares(P, idxs){
+  // normal equations on z=ax+by+c
+  let Sx=0,Sy=0,Sxx=0,Syy=0,Sxy=0,Sz=0,Sxz=0,Syz=0,n=idxs.length;
+  for(const id of idxs){
+    const p=P[id]; Sx+=p.x; Sy+=p.y; Sz+=p.z; Sxx+=p.x*p.x; Syy+=p.y*p.y; Sxy+=p.x*p.y; Sxz+=p.x*p.z; Syz+=p.y*p.z;
+  }
+  // [ [Sxx,Sxy,Sx], [Sxy,Syy,Sy], [Sx,Sy,n] ] * [a,b,c]^T = [Sxz, Syz, Sz]^T
+  const A=[[Sxx,Sxy,Sx],[Sxy,Syy,Sy],[Sx,Sy,n]];
+  const b=[Sxz,Syz,Sz];
+  const M=inv3(A); if(!M) return {a:0,b:0,c:0};
+  const a=M[0][0]*b[0]+M[0][1]*b[1]+M[0][2]*b[2];
+  const b2=M[1][0]*b[0]+M[1][1]*b[1]+M[1][2]*b[2];
+  const c=M[2][0]*b[0]+M[2][1]*b[1]+M[2][2]*b[2];
+  return {a,b:b2,c};
+}
+function inv3(A){
+  const [a,b,c,d,e,f,g,h,i]=[A[0][0],A[0][1],A[0][2],A[1][0],A[1][1],A[1][2],A[2][0],A[2][1],A[2][2]];
+  const det=a*(e*i-f*h)-b*(d*i-f*g)+c*(d*h-e*g); if(Math.abs(det)<1e-12) return null;
+  const inv=[[ (e*i-f*h), -(b*i-c*h), (b*f-c*e)],
+             [-(d*i-f*g),  (a*i-c*g), -(a*f-c*d)],
+             [ (d*h-e*g), -(a*h-b*g), (a*e-b*d)]].map(row=> row.map(v=> v/det));
+  return inv;
+}
+function drawScene(ctx,W,H,data, model, yaw, pitch){
+  ctx.fillStyle="rgb(10,12,18)"; ctx.fillRect(0,0,W,H);
+  const R=(p)=> rotate(p, yaw, pitch);
+  const P=(p)=> proj(R(p), W,H);
+  // axes
+  drawAxes(ctx, W,H, yaw, pitch);
+  // inliers (bright) / outliers (dim)
+  for(const p of data.pts){
+    const q=P(p); ctx.beginPath(); ctx.arc(q[0],q[1], p.inlier? 2.6 : 2, 0, Math.PI*2);
+    ctx.fillStyle = p.inlier? "rgba(200,220,255,0.95)" : "rgba(200,220,255,0.35)"; ctx.fill();
+  }
+  // plane patch
+  if(model.inliers.length){
+    ctx.strokeStyle="#fff"; ctx.lineWidth=1.5;
+    const a=model.a,b=model.b,c=model.c;
+    const poly=[];
+    for(const xy of [[-1,-1],[1,-1],[1,1],[-1,1]]){
+      const x=xy[0], y=xy[1], z=a*x+b*y+c; const q=P({x,y,z}); poly.push(q);
+    }
+    ctx.beginPath(); ctx.moveTo(poly[0][0],poly[0][1]); for(let k=1;k<poly.length;k++) ctx.lineTo(poly[k][0],poly[k][1]); ctx.closePath(); ctx.stroke();
+  }
+}
+function rotate(p, yaw, pitch){
+  const cy=Math.cos(yaw), sy=Math.sin(yaw); const cp=Math.cos(pitch), sp=Math.sin(pitch);
+  // yaw about z, then pitch about x
+  const x1=cy*p.x - sy*p.y, y1=sy*p.x + cy*p.y, z1=p.z;
+  const y2=cp*y1 - sp*z1, z2=sp*y1 + cp*z1;
+  return {x:x1,y:y2,z:z2};
+}
+function proj(p,W,H){ const d=3.2, z=p.z+d; const s=150/z; return [W/2 + s*p.x, H/2 - s*p.y]; }
+function drawAxes(ctx,W,H,yaw,pitch){
+  const axes=[{p:{x:1.2,y:0,z:0},c:"#ff8d8d"},{p:{x:0,y:1.2,z:0},c:"#8dff8d"},{p:{x:0,y:0,z:1.2},c:"#8dbbff"}];
+  const O=proj(rotate({x:0,y:0,z:0},yaw,pitch),W,H);
+  for(const a of axes){
+    const Q=proj(rotate(a.p,yaw,pitch),W,H);
+    ctx.beginPath(); ctx.moveTo(O[0],O[1]); ctx.lineTo(Q[0],Q[1]); ctx.strokeStyle=a.c; ctx.lineWidth=2; ctx.stroke();
+  }
+}
+function Slider({label,v,set,min,max,step}){ const show=(typeof v==='number'&&v.toFixed)?v.toFixed(3):v;
+  return (<div className="mb-2"><label className="text-sm opacity-80">{label}: <b>{show}</b></label>
+   <input className="w-full" type="range" min={min} max={max} step={step}
+    value={v} onChange={e=>set(parseFloat(e.target.value))}/></div>);
+}
+

--- a/sites/blackroad/src/pages/TSPLab.jsx
+++ b/sites/blackroad/src/pages/TSPLab.jsx
@@ -1,0 +1,103 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import ActiveReflection from "./ActiveReflection.jsx";
+
+function rng(seed){ let s=seed|0||7; return ()=> (s=(1664525*s+1013904223)>>>0)/2**32; }
+function dist(a,b){ const dx=a.x-b.x, dy=a.y-b.y; return Math.hypot(dx,dy); }
+
+export default function TSPLab(){
+  const [n,setN]=useState(60);
+  const [seed,setSeed]=useState(7);
+  const [running,setRunning]=useState(true);
+  const [itersPer,setIpf]=useState(200);
+  const [points,setPoints]=useState(()=> makePoints(n,seed));
+  useEffect(()=> setPoints(makePoints(n,seed)),[n,seed]);
+
+  const tour0 = useMemo(()=> nnTour(points),[points]);
+  const [tour,setTour]=useState(tour0);
+  useEffect(()=> setTour(tour0),[tour0]);
+
+  const W=640,H=360;
+  const cnv=useRef(null);
+  useEffect(()=>{
+    const c=cnv.current; if(!c) return; c.width=W; c.height=H;
+    const ctx=c.getContext("2d",{alpha:false});
+    let raf;
+    const loop=()=>{
+      if(running){ for(let i=0;i<itersPer;i++) setTour(t=> twoOptOnce(points, t)); }
+      draw(ctx, W, H, points, tour);
+      raf=requestAnimationFrame(loop);
+    };
+    loop(); return ()=> cancelAnimationFrame(raf);
+  },[points,tour,running,itersPer]);
+
+  const L = useMemo(()=> length(points,tour),[points,tour]);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">Traveling Sales — NN + 2-opt</h2>
+      <canvas ref={cnv} style={{width:"100%"}}/>
+      <div className="grid" style={{gridTemplateColumns:"1fr 360px", gap:16}}>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <button className="px-2 py-1 rounded bg-white/10 border border-white/10" onClick={()=>setRunning(r=>!r)}>{running?"Pause":"Run"}</button>
+          <button className="ml-2 px-2 py-1 rounded bg-white/10 border border-white/10" onClick={()=>{ const P=makePoints(n,seed); setPoints(P); setTour(nnTour(P)); }}>Reseed</button>
+        </section>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <Slider label="points n" v={n} set={setN} min={10} max={300} step={10}/>
+          <Slider label="seed" v={seed} set={setSeed} min={1} max={9999} step={1}/>
+          <Slider label="2-opt iters/frame" v={itersPer} set={setIpf} min={10} max={2000} step={10}/>
+          <p className="text-sm mt-2">Tour length ≈ <b>{L.toFixed(1)}</b></p>
+          <ActiveReflection
+            title="Active Reflection — TSP"
+            storageKey="reflect_tsp"
+            prompts={[
+              "Nearest-neighbor gives quick but suboptimal tours.",
+              "2-opt removes crossings first; later gains shrink.",
+              "Dense clusters: NN can trap you — notice where 2-opt rescues."
+            ]}
+          />
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function makePoints(n,seed){
+  const R=rng(seed); return Array.from({length:n},()=>({x: 30+R()*580, y: 20+R()*320}));
+}
+function nnTour(P){
+  const n=P.length, used=Array(n).fill(false), tour=[0]; used[0]=true;
+  for(let k=1;k<n;k++){
+    const last=tour[tour.length-1]; let best=-1, bd=1e18;
+    for(let i=0;i<n;i++) if(!used[i]){ const d=dist(P[last],P[i]); if(d<bd){bd=d; best=i;} }
+    used[best]=true; tour.push(best);
+  }
+  return tour;
+}
+function length(P, tour){
+  let L=0; for(let i=0;i<tour.length;i++){ const a=P[tour[i]], b=P[tour[(i+1)%tour.length]]; L+=dist(a,b); } return L;
+}
+function twoOptOnce(P, tour){
+  const n=tour.length; if(n<4) return tour;
+  const i = 1 + ((Math.random()*(n-3))|0); const j = i + 1 + ((Math.random()*(n-i-2))|0);
+  const a1=P[tour[i-1]], a2=P[tour[i]], b1=P[tour[j]], b2=P[tour[(j+1)%n]];
+  const delta = (dist(a1,a2)+dist(b1,b2)) - (dist(a1,b1)+dist(a2,b2));
+  if(delta>1e-9){ // improve by reversing [i..j]
+    const t=tour.slice(); for(let k=0;k<((j-i+1)>>1);k++){ [t[i+k], t[j-k]] = [t[j-k], t[i+k]]; } return t;
+  }
+  return tour;
+}
+function draw(ctx,W,H,P,t){
+  ctx.fillStyle="rgb(10,12,18)"; ctx.fillRect(0,0,W,H);
+  // edges
+  ctx.strokeStyle="#fff"; ctx.lineWidth=2; ctx.beginPath();
+  for(let i=0;i<t.length;i++){ const a=P[t[i]], b=P[t[(i+1)%t.length]]; ctx.moveTo(a.x,a.y); ctx.lineTo(b.x,b.y); }
+  ctx.stroke();
+  // points
+  ctx.fillStyle="#bbddff"; for(const p of P){ ctx.beginPath(); ctx.arc(p.x,p.y,3,0,Math.PI*2); ctx.fill(); }
+}
+function Slider({label,v,set,min,max,step}){ const show=(typeof v==='number'&&v.toFixed)?v.toFixed(0):v;
+  return (<div className="mb-2"><label className="text-sm opacity-80">{label}: <b>{show}</b></label>
+    <input className="w-full" type="range" min={min} max={max} step={step}
+           value={v} onChange={e=>set(parseFloat(e.target.value))}/></div>);
+}
+


### PR DESCRIPTION
## Summary
- add A* vs Dijkstra grid pathfinding lab
- add traveling salesman nearest-neighbor with 2-opt demo
- add Gray–Scott reaction–diffusion gallery
- add 3D RANSAC plane fitting lab and routes

## Testing
- `npm --prefix sites/blackroad run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm --prefix sites/blackroad test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c19a54663c8329ba32260d68255078