### PR TITLE
Add simulation labs for pathfinding, shading, tracking, and flow

### DIFF
--- a/sites/blackroad/src/App.jsx
+++ b/sites/blackroad/src/App.jsx
@@ -31,6 +31,10 @@ import PoissonBoltzmannLab from './pages/PoissonBoltzmannLab.jsx';
 import RidgeRegressionLab from './pages/RidgeRegressionLab.jsx';
 import KernelPCALab from './pages/KernelPCALab.jsx';
 import BrushfirePathLab from './pages/BrushfirePathLab.jsx';
+import BlueNoiseTSPLab from './pages/BlueNoiseTSPLab.jsx';
+import BezierShadedSurfaceLab from './pages/BezierShadedSurfaceLab.jsx';
+import Kalman2DTrackerLab from './pages/Kalman2DTrackerLab.jsx';
+import VorticityStreamLab from './pages/VorticityStreamLab.jsx';
 
 function useApiHealth() {
   const [state, setState] = useState({ ok: null, info: '' });
@@ -182,7 +186,11 @@ function LegacyApp() {
             <Route path="/pb" element={<PoissonBoltzmannLab />} />
             <Route path="/ridge" element={<RidgeRegressionLab />} />
             <Route path="/kpca" element={<KernelPCALab />} />
-            <Route path="/brushfire" element={<BrushfirePathLab />} />
+             <Route path="/brushfire" element={<BrushfirePathLab />} />
+             <Route path="/blue-tsp" element={<BlueNoiseTSPLab />} />
+             <Route path="/bezier-lit" element={<BezierShadedSurfaceLab />} />
+             <Route path="/kf-2d" element={<Kalman2DTrackerLab />} />
+             <Route path="/vorticity" element={<VorticityStreamLab />} />
             <Route path="chat" element={<Chat />} />
             <Route path="canvas" element={<Canvas />} />
             <Route path="editor" element={<Editor />} />
@@ -210,8 +218,12 @@ function LegacyApp() {
             <Route path="pb" element={<PoissonBoltzmannLab />} />
             <Route path="ridge" element={<RidgeRegressionLab />} />
             <Route path="kpca" element={<KernelPCALab />} />
-            <Route path="brushfire" element={<BrushfirePathLab />} />
-            <Route path="*" element={<div>Not found</div>} />
+             <Route path="brushfire" element={<BrushfirePathLab />} />
+             <Route path="blue-tsp" element={<BlueNoiseTSPLab />} />
+             <Route path="bezier-lit" element={<BezierShadedSurfaceLab />} />
+             <Route path="kf-2d" element={<Kalman2DTrackerLab />} />
+             <Route path="vorticity" element={<VorticityStreamLab />} />
+             <Route path="*" element={<div>Not found</div>} />
           </Routes>
         </section>
       </main>

--- a/sites/blackroad/src/pages/BezierShadedSurfaceLab.jsx
+++ b/sites/blackroad/src/pages/BezierShadedSurfaceLab.jsx
@@ -1,0 +1,119 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import ActiveReflection from "./ActiveReflection.jsx";
+
+// Bicubic Bézier (4x4 control grid). Shade with lambertian from light dir.
+function B(i,t){ return i===0?(1-t)**3 : i===1?3*t*(1-t)**2 : i===2?3*t*t*(1-t) : t**3; }
+function dB(i,t){ // derivative
+  return i===0? -3*(1-t)**2 : i===1? 3*(1-t)**2 - 6*t*(1-t) : i===2? 6*t*(1-t) - 3*t*t : 3*t*t;
+}
+function evalSurf(P,u,v){ // returns [x(u,v), y(u,v), z(u,v)] on param square mapped to [-1,1]^2
+  let z=0; for(let i=0;i<4;i++) for(let j=0;j<4;j++) z += P[i][j]*B(i,u)*B(j,v);
+  const x=-1+2*v, y=-1+2*u; return [x,y,z];
+}
+function evalDeriv(P,u,v){
+  let zu=0, zv=0; for(let i=0;i<4;i++) for(let j=0;j<4;j++){ zu += P[i][j]*dB(i,u)*B(j,v); zv += P[i][j]*B(i,u)*dB(j,v); }
+  // Param mapping: x=-1+2v, y=-1+2u → dx/dv=2, dy/du=2. Surface S=[x(v),y(u),z(u,v)]
+  const Su=[0, 2, zu];  // ∂S/∂u (y changes, z_u)
+  const Sv=[2, 0, zv];  // ∂S/∂v (x changes, z_v)
+  // normal = Su × Sv
+  const nx= Su[1]*Sv[2]-Su[2]*Sv[1];
+  const ny= Su[2]*Sv[0]-Su[0]*Sv[2];
+  const nz= Su[0]*Sv[1]-Su[1]*Sv[0];
+  const nlen=Math.hypot(nx,ny,nz)||1e-9;
+  return [nx/nlen, ny/nlen, nz/nlen];
+}
+
+export default function BezierShadedSurfaceLab(){
+  const [P,setP]=useState(()=>{
+    // gentle hill
+    return [
+      [0, 0.1, 0.1, 0],
+      [0.1, 0.5, 0.5, 0.1],
+      [0.1, 0.5, 0.5, 0.1],
+      [0, 0.1, 0.1, 0],
+    ];
+  });
+  const [light,setLight]=useState([0.6, 0.6, 0.5]); // normalized later
+  const [grid,setGrid]=useState(28);
+
+  const W=640,H=360;
+  const cnv=useRef(null);
+  const tris = useMemo(()=>{
+    // tesselate into quads → 2 triangles per cell
+    const L=[];
+    for(let i=0;i<grid;i++){
+      const u0=i/grid, u1=(i+1)/grid;
+      for(let j=0;j<grid;j++){
+        const v0=j/grid, v1=(j+1)/grid;
+        const p00=evalSurf(P,u0,v0), n00=evalDeriv(P,u0,v0);
+        const p10=evalSurf(P,u1,v0), n10=evalDeriv(P,u1,v0);
+        const p11=evalSurf(P,u1,v1), n11=evalDeriv(P,u1,v1);
+        const p01=evalSurf(P,u0,v1), n01=evalDeriv(P,u0,v1);
+        L.push({p:[p00,p10,p11], n:[n00,n10,n11]});
+        L.push({p:[p00,p11,p01], n:[n00,n11,n01]});
+      }
+    }
+    return L;
+  },[P,grid]);
+
+  useEffect(()=>{
+    const c=cnv.current; if(!c) return; c.width=W; c.height=H;
+    const ctx=c.getContext("2d",{alpha:false});
+    ctx.fillStyle="rgb(10,12,18)"; ctx.fillRect(0,0,W,H);
+    const lightN=(()=>{ const L=light; const Lm=Math.hypot(...L)||1e-9; return [L[0]/Lm, L[1]/Lm, L[2]/Lm]; })();
+    const proj=(x,y,z)=>{ const d=3.2, zc=z+d; const s=140/zc; return [W/2 + s*x, H/2 - s*y]; };
+    // simple painter: draw back-to-front by avg z
+    const sorted = tris.map(t=> ({...t, z:(t.p[0][2]+t.p[1][2]+t.p[2][2])/3})).sort((a,b)=> b.z-a.z);
+    for(const t of sorted){
+      const shade = t.n.map(n=> Math.max(0, n[0]*lightN[0]+n[1]*lightN[1]+n[2]*lightN[2]));
+      const avg=(shade[0]+shade[1]+shade[2])/3;
+      const col = `rgb(${Math.floor(40+215*avg)},${Math.floor(60+180*(1-avg))},${Math.floor(220*(1-avg))})`;
+      ctx.fillStyle=col; ctx.beginPath();
+      const q0=proj(...t.p[0]), q1=proj(...t.p[1]), q2=proj(...t.p[2]);
+      ctx.moveTo(q0[0],q0[1]); ctx.lineTo(q1[0],q1[1]); ctx.lineTo(q2[0],q2[1]); ctx.closePath(); ctx.fill();
+    }
+  },[tris,light,W,H]);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">Bézier Surface — Gouraud-ish Shading</h2>
+      <canvas ref={cnv} style={{width:"100%"}}/>
+      <div className="grid" style={{gridTemplateColumns:"1fr 360px", gap:16}}>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <p className="text-sm">Drag sliders to move light; increase grid for smoother shading.</p>
+        </section>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <Slider label="grid tesselation" v={grid} set={setGrid} min={8} max={60} step={1}/>
+          <Vec label="light (x,y,z)" v={light} set={setLight} min={-1.2} max={1.2} step={0.02}/>
+          <ActiveReflection
+            title="Active Reflection — Shaded Bézier"
+            storageKey="reflect_bezier_shaded"
+            prompts={[
+              "Normals from ∂S/∂u×∂S/∂v set the brightness.",
+              "Bias light upward vs lateral; which edges pop?",
+              "Refining the grid smooths shading but costs draw calls."
+            ]}
+          />
+        </section>
+      </div>
+    </div>
+  );
+}
+function Slider({label,v,set,min,max,step}){ const show=(typeof v==="number"&&v.toFixed)?v.toFixed(2):v;
+  return (<div className="mb-2"><label className="text-sm opacity-80">{label}: <b>{show}</b></label>
+    <input className="w-full" type="range" min={min} max={max} step={step}
+      value={v} onChange={e=>set(parseFloat(e.target.value))}/></div>);
+}
+function Vec({label,v,set,min,max,step}){
+  const [x,y,z]=v;
+  return (
+    <div className="mb-2">
+      <label className="text-sm opacity-80">{label}</label>
+      <div className="grid" style={{gridTemplateColumns:"1fr 1fr 1fr", gap:8}}>
+        <input type="range" min={min} max={max} step={step} value={x} onChange={e=>set([parseFloat(e.target.value),y,z])}/>
+        <input type="range" min={min} max={max} step={step} value={y} onChange={e=>set([x,parseFloat(e.target.value),z])}/>
+        <input type="range" min={min} max={max} step={step} value={z} onChange={e=>set([x,y,parseFloat(e.target.value)])}/>
+      </div>
+    </div>
+  );
+}

--- a/sites/blackroad/src/pages/BlueNoiseTSPLab.jsx
+++ b/sites/blackroad/src/pages/BlueNoiseTSPLab.jsx
@@ -1,0 +1,125 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import ActiveReflection from "./ActiveReflection.jsx";
+
+// --- Poisson disk (Bridson), then NN + 2-opt on resulting points ----
+function rng(seed){ let s=seed|0||7; return ()=> (s=(1664525*s+1013904223)>>>0)/2**32; }
+function bridson(width,height,r,k,seed){
+  const rand=rng(seed);
+  const cell=r/Math.SQRT2, gw=Math.ceil(width/cell), gh=Math.ceil(height/cell);
+  const grid=new Int32Array(gw*gh).fill(-1), pts=[], active=[];
+  const add=(p)=>{ pts.push(p); active.push(p); grid[((p.y/cell)|0)*gw + ((p.x/cell)|0)] = pts.length-1; };
+  add({x: width*0.5, y: height*0.5});
+  while(active.length){
+    const idx=(rand()*active.length)|0; const p=active[idx]; let placed=false;
+    for(let t=0;t<k;t++){
+      const a=2*Math.PI*rand(), rr=r*(1+rand());
+      const q={x:p.x + rr*Math.cos(a), y:p.y + rr*Math.sin(a)};
+      if(q.x<0||q.y<0||q.x>=width||q.y>=height) continue;
+      const gx=(q.x/cell)|0, gy=(q.y/cell)|0; let ok=true;
+      for(let j=-2;j<=2;j++) for(let i=-2;i<=2;i++){
+        const X=gx+i, Y=gy+j; if(X<0||Y<0||X>=gw||Y>=gh) continue;
+        const id=grid[Y*gw+X]; if(id>=0){ const d=hyp(pts[id],q); if(d<r){ ok=false; break; } }
+      }
+      if(!ok) continue;
+      add(q); placed=true; break;
+    }
+    if(!placed) active.splice(idx,1);
+  }
+  return pts;
+}
+const hyp=(a,b)=> Math.hypot(a.x-b.x, a.y-b.y);
+function nnTour(P){
+  if(P.length===0) return [];
+  const n=P.length, used=new Array(n).fill(false), tour=[0]; used[0]=true;
+  for(let m=1;m<n;m++){
+    const last=tour[tour.length-1]; let best=-1, bd=1e18;
+    for(let i=0;i<n;i++) if(!used[i]){ const d=hyp(P[last],P[i]); if(d<bd){bd=d; best=i;} }
+    used[best]=true; tour.push(best);
+  }
+  return tour;
+}
+function twoOptOnce(P, T){
+  const n=T.length; if(n<4) return T;
+  const i=1 + ((Math.random()*(n-3))|0), j=i+1+((Math.random()*(n-i-2))|0);
+  const a1=P[T[i-1]], a2=P[T[i]], b1=P[T[j]], b2=P[T[(j+1)%n]];
+  const delta=(hyp(a1,a2)+hyp(b1,b2)) - (hyp(a1,b1)+hyp(a2,b2));
+  if(delta>1e-9){ const t=T.slice(); for(let k=0;k<((j-i+1)>>1);k++){ [t[i+k],t[j-k]]=[t[j-k],t[i+k]]; } return t; }
+  return T;
+}
+function length(P,T){ let L=0; for(let i=0;i<T.length;i++) L+=hyp(P[T[i]], P[T[(i+1)%T.length]]); return L; }
+
+export default function BlueNoiseTSPLab(){
+  const [W,H]=[640,360];
+  const [r,setR]=useState(20);
+  const [k,setK]=useState(30);
+  const [seed,setSeed]=useState(7);
+  const [itersPer,setIpf]=useState(400);
+  const [running,setRun]=useState(true);
+
+  const points = useMemo(()=> bridson(W,H,r,k,seed),[W,H,r,k,seed]);
+  const tour0  = useMemo(()=> nnTour(points),[points]);
+  const [tour,setTour]=useState(tour0);
+  useEffect(()=> setTour(tour0),[tour0]);
+
+  const L = useMemo(()=> length(points,tour),[points,tour]);
+
+  const cnv=useRef(null);
+  useEffect(()=>{
+    const c=cnv.current; if(!c) return; c.width=W; c.height=H;
+    const ctx=c.getContext("2d",{alpha:false});
+    let raf;
+    const loop=()=>{
+      if(running){ for(let i=0;i<itersPer;i++) setTour(t=> twoOptOnce(points,t)); }
+      draw(ctx,W,H,points,tour);
+      raf=requestAnimationFrame(loop);
+    };
+    loop(); return ()=> cancelAnimationFrame(raf);
+  },[points,tour,running,itersPer]);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">Blue-Noise TSP — Poisson-disk → 2-opt</h2>
+      <canvas ref={cnv} style={{width:"100%"}}/>
+      <p className="text-sm">Points: <b>{points.length}</b> • Tour length ≈ <b>{L.toFixed(1)}</b></p>
+      <div className="grid" style={{gridTemplateColumns:"1fr 360px", gap:16}}>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <button className="px-2 py-1 rounded bg-white/10 border border-white/10" onClick={()=>setRun(r=>!r)}>{running?"Pause":"Run"}</button>
+          <button className="ml-2 px-2 py-1 rounded bg-white/10 border border-white/10" onClick={()=>{ /* reseed */ }}>
+            (Change sliders to reseed)
+          </button>
+        </section>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <Slider label="Poisson radius r" v={r} set={setR} min={8} max={40} step={1}/>
+          <Slider label="tries k" v={k} set={setK} min={5} max={60} step={1}/>
+          <Slider label="2-opt iters/frame" v={itersPer} set={setIpf} min={20} max={3000} step={20}/>
+          <Slider label="seed" v={seed} set={setSeed} min={1} max={9999} step={1}/>
+          <ActiveReflection
+            title="Active Reflection — Blue-Noise TSP"
+            storageKey="reflect_blue_tsp"
+            prompts={[
+              "Larger r ⇒ fewer points ⇒ shorter tours (but less detail).",
+              "2-opt rapidly removes crossings; late gains slow down.",
+              "Blue-noise sampling yields evenly spaced cities — compare to random."
+            ]}
+          />
+        </section>
+      </div>
+    </div>
+  );
+}
+function draw(ctx,W,H,P,T){
+  ctx.fillStyle="rgb(10,12,18)"; ctx.fillRect(0,0,W,H);
+  // edges
+  if(T.length){
+    ctx.strokeStyle="#fff"; ctx.lineWidth=2; ctx.beginPath();
+    for(let i=0;i<T.length;i++){ const a=P[T[i]], b=P[T[(i+1)%T.length]]; ctx.moveTo(a.x,a.y); ctx.lineTo(b.x,b.y); }
+    ctx.stroke();
+  }
+  // points
+  ctx.fillStyle="#bbddff"; for(const p of P){ ctx.beginPath(); ctx.arc(p.x,p.y,2.3,0,Math.PI*2); ctx.fill(); }
+}
+function Slider({label,v,set,min,max,step}){ const show=(typeof v==='number'&&v.toFixed)?v.toFixed(2):v;
+  return (<div className="mb-2"><label className="text-sm opacity-80">{label}: <b>{show}</b></label>
+    <input className="w-full" type="range" min={min} max={max} step={step}
+           value={v} onChange={e=>set(parseFloat(e.target.value))}/></div>);
+}

--- a/sites/blackroad/src/pages/Kalman2DTrackerLab.jsx
+++ b/sites/blackroad/src/pages/Kalman2DTrackerLab.jsx
@@ -1,0 +1,123 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import ActiveReflection from "./ActiveReflection.jsx";
+
+/** Constant-velocity model, piecewise turn maneuvers.  z_k = [x,y] + noise.
+ *  State x=[px, py, vx, vy].  KF equations in 2-D.
+ */
+export default function Kalman2DTrackerLab(){
+  const [T,setT]=useState(800);
+  const [dt,setDT]=useState(0.1);
+  const [q,setQ]=useState(0.05);     // process noise spectral density
+  const [r,setR]=useState(2.0);      // measurement noise std
+  const [seed,setSeed]=useState(7);
+
+  const sim = useMemo(()=> simulate(T,dt,seed),[T,dt,seed]);
+  const filt= useMemo(()=> kalmanFilter(sim, dt, q, r),[sim,dt,q,r]);
+
+  const W=640,H=360;
+  const cnv=useRef(null);
+  useEffect(()=>{
+    const c=cnv.current; if(!c) return; c.width=W; c.height=H;
+    const ctx=c.getContext("2d",{alpha:false});
+    draw(ctx,W,H,sim,filt);
+  },[sim,filt,W,H]);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">Kalman 2-D Tracker — Maneuvers</h2>
+      <canvas ref={cnv} style={{width:"100%"}}/>
+      <div className="grid" style={{gridTemplateColumns:"1fr 360px", gap:16}}>
+        <div/>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <Slider label="steps T" v={T} set={setT} min={200} max={2000} step={50}/>
+          <Slider label="dt" v={dt} set={setDT} min={0.02} max={0.2} step={0.01}/>
+          <Slider label="process q" v={q} set={setQ} min={0.001} max={0.2} step={0.001}/>
+          <Slider label="meas std r" v={r} set={setR} min={0.2} max={5} step={0.1}/>
+          <Slider label="seed" v={seed} set={setSeed} min={1} max={9999} step={1}/>
+          <ActiveReflection
+            title="Active Reflection — Kalman 2-D"
+            storageKey="reflect_kf2d"
+            prompts={[
+              "Lower r → filter trusts measurements (noisier estimate).",
+              "Higher q → filter allows more maneuvering; watch lag drop.",
+              "During turns, CV model lags; tune q to reduce bias."
+            ]}
+          />
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function simulate(T,dt,seed){
+  let s=seed|0; const R=()=> (s=(1664525*s+1013904223)>>>0)/2**32;
+  const truth=[], meas=[];
+  let px=80, py=180, v=50; let ang=0;
+  for(let k=0;k<T;k++){
+    if(k%120===0 && k>0) ang += (R()<0.5?1:-1)*0.6; // occasional turn
+    px += v*dt*Math.cos(ang); py += v*dt*Math.sin(ang);
+    truth.push([px,py]);
+    const zx=px +  rnorm(R,2.0), zy=py + rnorm(R,2.0);
+    meas.push([zx,zy]);
+  }
+  return {truth, meas};
+}
+function rnorm(R,std){ const u=Math.max(R(),1e-12), v=Math.max(R(),1e-12); return std*Math.sqrt(-2*Math.log(u))*Math.cos(2*Math.PI*v); }
+
+function kalmanFilter(sim,dt,q,r){
+  const F=[[1,0,dt,0],[0,1,0,dt],[0,0,1,0],[0,0,0,1]];
+  const H=[[1,0,0,0],[0,1,0,0]];
+  const G=[[0.5*dt*dt,0],[0,0.5*dt*dt],[dt,0],[0,dt]];
+  const Q = mul(G, mul([[q,0],[0,q]], T(G)));      // process cov
+  const Rm=[[r*r,0],[0,r*r]];
+  let x=[sim.meas[0][0], sim.meas[0][1], 0, 0];    // init at first measurement
+  let P= eye(4,1e3);
+  const est=[];
+
+  for(let k=0;k<sim.meas.length;k++){
+    // predict
+    x = vecAdd( mulVec(F,x), [0,0,0,0] );
+    P = add( mul(F, mul(P, T(F))), Q );
+    // update
+    const z = sim.meas[k];
+    const y = vecSub( z, mulVec(H,x) );
+    const S = add( mul(H, mul(P, T(H))), Rm );
+    const K = mul( mul(P, T(H)), inv2(S) );
+    x = vecAdd( x, mulVec(K, y) );
+    P = mul( add( eye(4), scale( mul(K,H), -1)), P );
+    est.push([x[0],x[1]]);
+  }
+  return {est};
+}
+
+function eye(n,s=1){ const I=Array.from({length:n},()=>Array(n).fill(0)); for(let i=0;i<n;i++) I[i][i]=s; return I; }
+function add(A,B){ return A.map((r,i)=> r.map((v,j)=> v+B[i][j])); }
+function scale(A,s){ return A.map(r=>r.map(v=>v*s)); }
+function mul(A,B){ const m=A.length,n=A[0].length,p=B[0].length; const C=Array.from({length:m},()=>Array(p).fill(0));
+  for(let i=0;i<m;i++) for(let k=0;k<n;k++) for(let j=0;j<p;j++) C[i][j]+=A[i][k]*B[k][j]; return C; }
+function mulVec(A,v){ const m=A.length,n=A[0].length; const w=new Array(m).fill(0); for(let i=0;i<m;i++) for(let j=0;j<n;j++) w[i]+=A[i][j]*v[j]; return w; }
+function T(A){ const m=A.length,n=A[0].length; const B=Array.from({length:n},()=>Array(m).fill(0)); for(let i=0;i<m;i++) for(let j=0;j<n;j++) B[j][i]=A[i][j]; return B; }
+function vecAdd(a,b){ return a.map((v,i)=> v+(b[i]||0)); }
+function vecSub(a,b){ return a.map((v,i)=> v-(b[i]||0)); }
+function inv2(A){ // 2x2
+  const [a,b,c,d]=[A[0][0],A[0][1],A[1][0],A[1][1]]; const det=a*d-b*c || 1e-12;
+  return [[ d/det, -b/det],[-c/det, a/det]];
+}
+
+function draw(ctx,W,H,sim,filt){
+  ctx.fillStyle="rgb(10,12,18)"; ctx.fillRect(0,0,W,H);
+  // truth
+  ctx.strokeStyle="#8dff8d"; ctx.lineWidth=2; ctx.beginPath();
+  sim.truth.forEach(([x,y],i)=> i?ctx.lineTo(x,y):ctx.moveTo(x,y)); ctx.stroke();
+  // measurements
+  ctx.fillStyle="rgba(255,122,122,0.5)";
+  for(const [x,y] of sim.meas){ ctx.beginPath(); ctx.arc(x,y,2,0,Math.PI*2); ctx.fill(); }
+  // estimate
+  ctx.strokeStyle="#79b6ff"; ctx.lineWidth=2; ctx.beginPath();
+  filt.est.forEach(([x,y],i)=> i?ctx.lineTo(x,y):ctx.moveTo(x,y)); ctx.stroke();
+}
+function Slider({label,v,set,min,max,step}){ const show=(typeof v==="number"&&v.toFixed)?v.toFixed(2):v;
+  return (<div className="mb-2"><label className="text-sm opacity-80">{label}: <b>{show}</b></label>
+    <input className="w-full" type="range" min={min} max={max} step={step}
+      value={v} onChange={e=>set(parseFloat(e.target.value))}/></div>);
+}

--- a/sites/blackroad/src/pages/VorticityStreamLab.jsx
+++ b/sites/blackroad/src/pages/VorticityStreamLab.jsx
@@ -1,0 +1,158 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import ActiveReflection from "./ActiveReflection.jsx";
+
+/** Incompressible 2-D:
+ *   ω_t + u·∇ω = ν ∇²ω
+ *   ∇²ψ = −ω,  u = (ψ_y, −ψ_x)
+ * Semi-Lagrangian advection + Gauss–Seidel Poisson solve for ψ.
+ */
+function clamp(a,l,h){ return a<l?l : a>h?h : a; }
+function idx(N,x,y){ return (y*N + x); }
+
+export default function VorticityStreamLab(){
+  const [N,setN]=useState(128);
+  const [nu,setNu]=useState(0.0008);
+  const [dt,setDT]=useState(0.8);
+  const [running,setRun]=useState(true);
+
+  const sim=useMemo(()=> init(N),[N]);
+
+  const cnv=useRef(null);
+  useEffect(()=>{
+    const c=cnv.current; if(!c) return; c.width=N; c.height=N;
+    const ctx=c.getContext("2d",{alpha:false});
+    let raf;
+    const loop=()=>{
+      if(running){ step(sim, dt, nu); }
+      render(ctx, sim);
+      raf=requestAnimationFrame(loop);
+    };
+    loop(); return ()=> cancelAnimationFrame(raf);
+  },[sim,dt,nu,running,N]);
+
+  // inject vortex on click
+  useEffect(()=>{
+    const c=cnv.current; if(!c) return; const rect=()=>c.getBoundingClientRect();
+    const add=(e)=>{
+      const x=clamp(Math.floor((e.clientX-rect().left)/rect().width*N),1,N-2);
+      const y=clamp(Math.floor((e.clientY-rect().top )/rect().height*N),1,N-2);
+      inject(sim,x,y, 60*(e.shiftKey? -1: +1));
+    };
+    c.addEventListener("mousedown",add); return ()=> c.removeEventListener("mousedown",add);
+  },[sim,N]);
+
+  return (
+    <div className="p-4 space-y-3">
+      <h2 className="text-xl font-semibold">Navier–Stokes — Vorticity & Streamfunction</h2>
+      <canvas ref={cnv} style={{width:"100%", imageRendering:"pixelated"}}/>
+      <div className="grid" style={{gridTemplateColumns:"1fr 360px", gap:16}}>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <button className="px-2 py-1 rounded bg-white/10 border border-white/10" onClick={()=>setRun(r=>!r)}>{running?"Pause":"Run"}</button>
+          <button className="ml-2 px-2 py-1 rounded bg-white/10 border border-white/10" onClick={()=>reset(sim)}>Reset</button>
+        </section>
+        <section className="p-3 rounded-lg bg-white/5 border border-white/10">
+          <Slider label="grid N" v={N} set={setN} min={96} max={192} step={16}/>
+          <Slider label="ν (viscosity)" v={nu} set={setNu} min={0.0002} max={0.002} step={0.0001}/>
+          <Slider label="dt" v={dt} set={setDT} min={0.2} max={1.2} step={0.05}/>
+          <ActiveReflection
+            title="Active Reflection — Vorticity–Stream"
+            storageKey="reflect_vorticity"
+            prompts={[
+              "Shift-click injects counter-rotating vortex; watch pairing.",
+              "Lower ν → longer-lived vortices; higher ν diffuses quickly.",
+              "Semi-Lagrangian advection is unconditionally stable but diffusive."
+            ]}
+          />
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function init(N){
+  return {
+    N,
+    w: new Float32Array(N*N),         // vorticity
+    psi: new Float32Array(N*N),       // streamfunction
+    u: new Float32Array(N*N),         // u = +psi_y
+    v: new Float32Array(N*N),         // v = -psi_x
+    tmp: new Float32Array(N*N)
+  };
+}
+function reset(sim){ sim.w.fill(0); sim.psi.fill(0); sim.u.fill(0); sim.v.fill(0); }
+function inject(sim,x,y,str){ // add compact vorticity blob
+  const {N,w}=sim; const r=N/24;
+  for(let j=-r;j<=r;j++) for(let i=-r;i<=r;i++){
+    const X=clamp(x+i,1,N-2), Y=clamp(y+j,1,N-2);
+    const d=i*i+j*j; if(d>r*r) continue;
+    w[idx(N,X,Y)] += str*Math.exp(-d/(r*0.6));
+  }
+}
+function laplacian(N,A,i,j){
+  return A[idx(N,i-1,j)] + A[idx(N,i+1,j)] + A[idx(N,i,j-1)] + A[idx(N,i,j+1)] - 4*A[idx(N,i,j)];
+}
+function solvePoisson(sim){ // ∇²ψ = −ω with Gauss–Seidel
+  const {N,psi,w}=sim;
+  for(let it=0; it<60; it++){
+    for(let j=1;j<N-1;j++) for(let i=1;i<N-1;i++){
+      psi[idx(N,i,j)] = 0.25*( psi[idx(N,i-1,j)] + psi[idx(N,i+1,j)] + psi[idx(N,i,j-1)] + psi[idx(N,i,j+1)] + w[idx(N,i,j)] );
+    }
+  }
+}
+function velocity(sim){
+  const {N,psi,u,v}=sim;
+  for(let j=1;j<N-1;j++) for(let i=1;i<N-1;i++){
+    u[idx(N,i,j)] = (psi[idx(N,i,j+1)] - psi[idx(N,i,j-1)])*0.5;
+    v[idx(N,i,j)] = -(psi[idx(N,i+1,j)] - psi[idx(N,i-1,j)])*0.5;
+  }
+}
+function advect(sim,dt){
+  const {N,w,u,v,tmp}=sim;
+  for(let j=1;j<N-1;j++) for(let i=1;i<N-1;i++){
+    const x=i - dt*u[idx(N,i,j)], y=j - dt*v[idx(N,i,j)];
+    const i0=clamp(Math.floor(x),1,N-2), j0=clamp(Math.floor(y),1,N-2);
+    const fx=x-i0, fy=y-j0;
+    const w00=w[idx(N,i0,j0)], w10=w[idx(N,i0+1,j0)], w01=w[idx(N,i0,j0+1)], w11=w[idx(N,i0+1,j0+1)];
+    tmp[idx(N,i,j)] = (1-fx)*(1-fy)*w00 + fx*(1-fy)*w10 + (1-fx)*fy*w01 + fx*fy*w11;
+  }
+  w.set(tmp);
+}
+function diffuse(sim,dt,nu){
+  const {N,w}=sim, a=nu*dt;
+  for(let it=0; it<20; it++){
+    for(let j=1;j<N-1;j++) for(let i=1;i<N-1;i++){
+      w[idx(N,i,j)] = ( w[idx(N,i,j)] + a*( w[idx(N,i-1,j)] + w[idx(N,i+1,j)] + w[idx(N,i,j-1)] + w[idx(N,i,j+1)] ) ) / (1+4*a);
+    }
+  }
+}
+function step(sim,dt,nu){
+  solvePoisson(sim);
+  velocity(sim);
+  advect(sim,dt);
+  diffuse(sim,dt,nu);
+}
+function render(ctx, sim){
+  const {N,w,u,v}=sim;
+  const img=ctx.createImageData(N,N);
+  let mn=1e9,mx=-1e9; for(let i=0;i<w.length;i++){ if(w[i]<mn) mn=w[i]; if(w[i]>mx) mx=w[i]; }
+  for(let j=0;j<N;j++) for(let i=0;i<N;i++){
+    const wv=(w[idx(N,i,j)]-mn)/(mx-mn+1e-9);
+    const off=4*(j*N+i);
+    img.data[off]=Math.floor(40+200*wv);
+    img.data[off+1]=Math.floor(50+180*(1-wv));
+    img.data[off+2]=Math.floor(220*(1-wv));
+    img.data[off+3]=255;
+  }
+  ctx.putImageData(img,0,0);
+  // sparse velocity arrows
+  ctx.strokeStyle="#fff"; ctx.lineWidth=1;
+  for(let j=8;j<N;j+=16) for(let i=8;i<N;i+=16){
+    const px=i+0.5, py=j+0.5, ux=u[idx(N,i,j)], vy=v[idx(N,i,j)];
+    ctx.beginPath(); ctx.moveTo(px,py); ctx.lineTo(px+ux*4, py+vy*4); ctx.stroke();
+  }
+}
+function Slider({label,v,set,min,max,step}){ const show=(typeof v==='number'&&v.toFixed)?v.toFixed(3):v;
+  return (<div className="mb-2"><label className="text-sm opacity-80">{label}: <b>{show}</b></label>
+          <input className="w-full" type="range" min={min} max={max} step={step}
+                 value={v} onChange={e=>set(parseFloat(e.target.value))}/></div>);
+}


### PR DESCRIPTION
## Summary
- add Blue Noise TSP lab with Poisson-disk sampling and 2-opt
- add Bézier surface shading lab with Gouraud-style lighting
- add Kalman 2-D tracker lab with maneuvering model
- add Vorticity–Stream lab for 2-D incompressible flow
- register new labs with routes in the app

## Testing
- `npm --prefix sites/blackroad run lint`
- `npm --prefix sites/blackroad run test`
- `npm test` *(fails: jest not found; npm install timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68c19e22d95c832994a46fb9ab44d80e