### PR TITLE
Add models cache, embeddings stub, and operator sandbox

### DIFF
--- a/srv/blackroad-api/server_min.js
+++ b/srv/blackroad-api/server_min.js
@@ -1,14 +1,19 @@
 /**
- * BlackRoad API (minimal) with LLM health + streaming chat
+ * BlackRoad API — LLM health + streaming chat + cached models + embeddings + Operator/RPA (no-exec)
  * Port: 4000 (systemd: blackroad-api)
+ *
  * Upstreams:
- *   - Bridge (preferred):  http://127.0.0.1:4010
- *   - Ollama (fallback):   http://127.0.0.1:11434
+ *   Bridge (preferred):  http://127.0.0.1:4010
+ *   Ollama (fallback):   http://127.0.0.1:11434
  *
  * Env (optional):
  *   LLM_BRIDGE_URL=http://127.0.0.1:4010
  *   OLLAMA_URL=http://127.0.0.1:11434
  *   DEFAULT_LLM_MODEL=lucidia
+ *   MODELS_TTL_MS=300000              # 5m cache for models
+ *   ENABLE_OPERATOR=0                 # 1 to enable Operator routes
+ *   ENABLE_RPA=0                      # 1 to enable RPA sandbox routes
+ *   RPA_ALLOW_HOSTS=blackroad.io,localhost,127.0.0.1
  */
 
 const express = require("express");
@@ -19,6 +24,10 @@ app.use(express.json({ limit: "2mb" }));
 const BRIDGE_URL = process.env.LLM_BRIDGE_URL || "http://127.0.0.1:4010";
 const OLLAMA_URL = process.env.OLLAMA_URL || "http://127.0.0.1:11434";
 const DEFAULT_MODEL = process.env.DEFAULT_LLM_MODEL || "lucidia";
+const MODELS_TTL_MS = parseInt(process.env.MODELS_TTL_MS || "300000", 10);
+const ENABLE_OPERATOR = String(process.env.ENABLE_OPERATOR || "0") === "1";
+const ENABLE_RPA = String(process.env.ENABLE_RPA || "0") === "1";
+const RPA_ALLOW_HOSTS = String(process.env.RPA_ALLOW_HOSTS || "").split(",").map(s => s.trim()).filter(Boolean);
 const PORT = process.env.PORT || 4000;
 
 function now() { return new Date().toISOString(); }
@@ -37,15 +46,14 @@ app.get("/api/health", (_req, res) => res.json({ ok: true, service: "blackroad-a
 app.get("/api/llm/health", async (_req, res) => {
   try {
     const b = await tryFetch(`${BRIDGE_URL}/health`, {}, 1200);
-    if (b.ok) {
+    if (b && b.ok) {
       const body = await b.json().catch(() => ({}));
       return res.json({ ok: true, upstream: "bridge", url: BRIDGE_URL, details: body, ts: now() });
     }
   } catch (_) {}
   try {
-    // Ollama “tags” is a quick liveness check
     const o = await tryFetch(`${OLLAMA_URL}/api/tags`, {}, 1200);
-    if (o.ok) {
+    if (o && o.ok) {
       const body = await o.json().catch(() => ({}));
       return res.json({ ok: true, upstream: "ollama", url: OLLAMA_URL, details: body, ts: now() });
     }
@@ -53,9 +61,74 @@ app.get("/api/llm/health", async (_req, res) => {
   return res.status(503).json({ ok: false, error: "No LLM upstreams reachable", ts: now() });
 });
 
-// Helper: proxy a streaming response (SSE / chunked) to client as-is
+/* ---------- Models (direct, cached, refresh) ---------- */
+
+let modelsCache = { ts: 0, data: null, upstream: null };
+
+async function fetchModelsDirect() {
+  // Try bridge
+  try {
+    const br = await tryFetch(`${BRIDGE_URL}/models`, {}, 3000);
+    if (br && br.ok) {
+      const j = await br.json().catch(() => ({}));
+      const list = Array.isArray(j.models) ? j.models :
+                   Array.isArray(j) ? j :
+                   Array.isArray(j.data) ? j.data : [];
+      const mapped = list.map(m => ({ id: m.id || m.name || m.model || String(m), provider: "bridge" }))
+                         .filter(m => m.id);
+      if (mapped.length) return { ok: true, upstream: "bridge", models: mapped };
+    }
+  } catch (_) {}
+  // Fallback: ollama tags
+  try {
+    const o = await tryFetch(`${OLLAMA_URL}/api/tags`, {}, 3000);
+    if (o && o.ok) {
+      const j = await o.json().catch(() => ({}));
+      const list = Array.isArray(j.models) ? j.models : [];
+      const mapped = list.map(m => ({ id: m.name || m.model, provider: "ollama" })).filter(m => m.id);
+      return { ok: true, upstream: "ollama", models: mapped };
+    }
+  } catch (_) {}
+  return { ok: false, error: "No models available from upstreams" };
+}
+
+async function getModelsCached(force = false) {
+  const age = Date.now() - (modelsCache.ts || 0);
+  if (!force && modelsCache.data && age < MODELS_TTL_MS) {
+    return { ok: true, cached: true, upstream: modelsCache.upstream, models: modelsCache.data };
+  }
+  const fresh = await fetchModelsDirect();
+  if (fresh.ok) {
+    modelsCache = { ts: Date.now(), data: fresh.models, upstream: fresh.upstream };
+  }
+  return { ...fresh, cached: false, ts: now() };
+}
+
+// Legacy/direct endpoint (no cache)
+app.get("/api/llm/models", async (_req, res) => {
+  const out = await fetchModelsDirect();
+  if (out.ok) return res.json({ ...out, ts: now() });
+  return res.status(502).json({ ...out, ts: now() });
+});
+
+// Cached endpoint with TTL
+app.get("/api/llm/models:cache", async (req, res) => {
+  const force = String(req.query.refresh || "0") === "1";
+  const out = await getModelsCached(force);
+  if (out.ok) return res.json({ ...out, ts: now(), ttl_ms: MODELS_TTL_MS });
+  return res.status(502).json({ ...out, ts: now(), ttl_ms: MODELS_TTL_MS });
+});
+
+// Explicit refresh path
+app.post("/api/llm/models:refresh", async (_req, res) => {
+  const out = await getModelsCached(true);
+  if (out.ok) return res.json({ ...out, ts: now(), ttl_ms: MODELS_TTL_MS });
+  return res.status(502).json({ ...out, ts: now(), ttl_ms: MODELS_TTL_MS });
+});
+
+/* ---------- Chat (streaming passthrough) ---------- */
+
 async function pipeStream(upstreamResp, res) {
-  // Disable buffering for Nginx and clients
   res.setHeader("Content-Type", "text/event-stream; charset=utf-8");
   res.setHeader("Cache-Control", "no-cache, no-transform");
   res.setHeader("Connection", "keep-alive");
@@ -66,17 +139,15 @@ async function pipeStream(upstreamResp, res) {
     res.status(upstreamResp.status || 502).end(text || "Upstream error");
     return;
   }
-
   const reader = upstreamResp.body.getReader();
   try {
-    // Pass bytes through unmodified so we preserve upstream SSE/NDJSON framing
     while (true) {
       const { value, done } = await reader.read();
       if (done) break;
       if (value) res.write(value);
     }
     res.end();
-  } catch (err) {
+  } catch (_) {
     res.end();
   }
 }
@@ -87,38 +158,28 @@ app.post("/api/llm/chat", async (req, res) => {
     return res.status(400).json({ ok: false, error: "Body must include messages: [{role, content}]" });
   }
   const chosenModel = (model && String(model)) || DEFAULT_MODEL;
-  const wantStream = stream !== false; // default true
+  const wantStream = stream !== false;
 
-  // 1) Try bridge first
+  // Bridge first
   try {
     const br = await tryFetch(`${BRIDGE_URL}/chat`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ model: chosenModel, messages, stream: wantStream }),
     }, 30000);
-
     if (wantStream) return pipeStream(br, res);
-
-    // Non-streaming fallthrough
     const json = await br.json().catch(async () => ({ text: await br.text() }));
     return res.status(br.ok ? 200 : br.status).json(json);
   } catch (_) {}
 
-  // 2) Fallback: direct Ollama chat
+  // Ollama fallback
   try {
     const ol = await tryFetch(`${OLLAMA_URL}/api/chat`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        model: chosenModel,
-        messages,
-        stream: !!wantStream,
-        options: { num_ctx: 4096 },
-      }),
+      body: JSON.stringify({ model: chosenModel, messages, stream: !!wantStream, options: { num_ctx: 4096 } }),
     }, 30000);
-
     if (wantStream) return pipeStream(ol, res);
-
     const json = await ol.json().catch(async () => ({ text: await ol.text() }));
     return res.status(ol.ok ? 200 : ol.status).json(json);
   } catch (e) {
@@ -126,7 +187,146 @@ app.post("/api/llm/chat", async (req, res) => {
   }
 });
 
-// SPA fallback (optional; keep if you’ve been serving index.html here)
+/* ---------- Embeddings (stub: bridge, then Ollama if supported) ---------- */
+
+app.post("/api/llm/embeddings", async (req, res) => {
+  const { input, model } = req.body || {};
+  const chosenModel = (model && String(model)) || DEFAULT_MODEL;
+  if (typeof input === "undefined" || input === null) {
+    return res.status(400).json({ ok: false, error: "Body must include 'input' (string or array)" });
+  }
+
+  // 1) Bridge attempt
+  try {
+    const br = await tryFetch(`${BRIDGE_URL}/embeddings`, {
+      method: "POST", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: chosenModel, input })
+    }, 30000);
+    if (br && br.ok) {
+      const j = await br.json().catch(async () => ({ text: await br.text() }));
+      return res.json({ ok: true, upstream: "bridge", ...j, ts: now() });
+    }
+  } catch (_) {}
+
+  // 2) Ollama attempt (if endpoint exists in your version)
+  try {
+    const ol = await tryFetch(`${OLLAMA_URL}/api/embeddings`, {
+      method: "POST", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: chosenModel, input })
+    }, 30000);
+    if (ol && ol.ok) {
+      const j = await ol.json().catch(async () => ({ text: await ol.text() }));
+      return res.json({ ok: true, upstream: "ollama", ...j, ts: now() });
+    }
+    // If Ollama returns 404, your build may not support embeddings
+    const text = await ol.text().catch(() => "");
+    return res.status(ol.status || 501).json({ ok: false, error: "Embeddings not supported by upstream", detail: text, ts: now() });
+  } catch (e) {
+    return res.status(502).json({ ok: false, error: "Embeddings upstream failed", detail: String(e), ts: now() });
+  }
+});
+
+/* ---------- Operator + RPA Sandbox (flag-gated) ---------- */
+
+app.get("/api/operator/status", (_req, res) => {
+  res.json({
+    ok: true,
+    enabled: ENABLE_OPERATOR,
+    rpa_enabled: ENABLE_RPA,
+    rpa_allow_hosts: RPA_ALLOW_HOSTS,
+    ts: now()
+  });
+});
+
+app.post("/api/operator/plan", async (req, res) => {
+  if (!ENABLE_OPERATOR) return res.status(403).json({ ok: false, error: "Operator disabled" });
+  const { objective, context } = req.body || {};
+  if (!objective) return res.status(400).json({ ok: false, error: "Missing 'objective' string" });
+
+  const sys = [
+    { role: "system", content:
+      "You are Operator, a cautious on-device agent. Produce a JSON-only plan with fields: steps[], tools[], risks[], checkpoints[]. " +
+      "Never execute. No external links. Keep steps atomic and safe. Output STRICT JSON." }
+  ];
+  const user = [{ role: "user", content: JSON.stringify({ objective, context: context || "" }) }];
+
+  try {
+    const br = await tryFetch(`${BRIDGE_URL}/chat`, {
+      method: "POST", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: DEFAULT_MODEL, messages: [...sys, ...user], stream: false })
+    }, 30000);
+    if (br && br.ok) {
+      const j = await br.json().catch(async () => ({ text: await br.text() }));
+      const planText = j?.message?.content || j?.choices?.[0]?.message?.content || j?.text || j?.response || JSON.stringify(j);
+      return res.json({ ok: true, plan: safeJson(planText), ts: now(), upstream: "bridge" });
+    }
+  } catch (_) {}
+
+  try {
+    const ol = await tryFetch(`${OLLAMA_URL}/api/chat`, {
+      method: "POST", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: DEFAULT_MODEL, messages: [...sys, ...user], stream: false, options: { num_ctx: 4096 } })
+    }, 30000);
+    const j = await ol.json().catch(async () => ({ text: await ol.text() }));
+    const planText = j?.message?.content || j?.choices?.[0]?.message?.content || j?.text || j?.response || JSON.stringify(j);
+    return res.status(ol.ok ? 200 : ol.status).json({ ok: true, plan: safeJson(planText), ts: now(), upstream: "ollama" });
+  } catch (e) {
+    return res.status(502).json({ ok: false, error: "Operator upstream failed", detail: String(e) });
+  }
+});
+
+function hostAllowed(urlStr) {
+  try {
+    const u = new URL(urlStr);
+    return RPA_ALLOW_HOSTS.length === 0 || RPA_ALLOW_HOSTS.includes(u.hostname);
+  } catch {
+    return false;
+  }
+}
+
+app.get("/api/operator/rpa/status", (_req, res) => {
+  res.json({ ok: true, enabled: ENABLE_OPERATOR && ENABLE_RPA, allow_hosts: RPA_ALLOW_HOSTS, ts: now() });
+});
+
+app.post("/api/operator/rpa/dry-run", (req, res) => {
+  if (!(ENABLE_OPERATOR && ENABLE_RPA)) return res.status(403).json({ ok: false, error: "RPA disabled" });
+  const { url, actions } = req.body || {};
+  if (!url || !Array.isArray(actions)) return res.status(400).json({ ok: false, error: "Body must include { url, actions: [] }" });
+  if (!hostAllowed(url)) return res.status(403).json({ ok: false, error: "URL host not allowed", url, allow_hosts: RPA_ALLOW_HOSTS });
+
+  const sanitized = actions.map((a, i) => {
+    const type = String(a.type || "").toLowerCase();
+    const safe = {
+      idx: i,
+      type,
+      selector: a.selector ? String(a.selector).slice(0, 200) : null,
+      text: type === "type" ? String(a.text || "").slice(0, 500) : undefined,
+      seconds: typeof a.seconds === "number" ? Math.min(Math.max(a.seconds, 0), 30) : undefined
+    };
+    // Only allow a small safe subset in sandbox
+    const allowed = ["goto", "wait", "type", "click"];
+    safe.allowed = allowed.includes(type);
+    return safe;
+  });
+
+  return res.json({
+    ok: true,
+    mode: "dry-run",
+    note: "No execution performed. This endpoint validates and echoes a safe plan.",
+    url,
+    actions: sanitized,
+    ts: now()
+  });
+});
+
+/* ---------- Fallbacks ---------- */
+
+function safeJson(text) {
+  try { return JSON.parse(text); }
+  catch { return { raw: String(text) }; }
+}
+
+// Optional SPA serving:
 // const path = require("path");
 // app.use(express.static("/var/www/blackroad"));
 // app.get("*", (_req, res) => res.sendFile(path.join("/var/www/blackroad/index.html")));

--- a/var/www/blackroad/chat-panel.js
+++ b/var/www/blackroad/chat-panel.js
@@ -1,0 +1,26 @@
+/**
+ * FILE: /var/www/blackroad/chat-panel.js
+ * Purpose: Minimal SPA hook. Drop <div id="chat-panel-root"></div> where your "Chat" tab is,
+ * then include <script src="/chat-panel.js" defer></script>. It injects an iframe to /llm-chat.html.
+ */
+(function () {
+  function mount() {
+    var root = document.getElementById("chat-panel-root");
+    if (!root) return;
+    root.innerHTML = "";
+    var frame = document.createElement("iframe");
+    frame.src = "/llm-chat.html";
+    frame.style.width = "100%";
+    frame.style.height = "75vh";
+    frame.style.minHeight = "520px";
+    frame.style.border = "1px solid #1b1b26";
+    frame.style.borderRadius = "16px";
+    frame.loading = "eager";
+    root.appendChild(frame);
+  }
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", mount);
+  } else {
+    mount();
+  }
+})();

--- a/var/www/blackroad/index.html
+++ b/var/www/blackroad/index.html
@@ -8,6 +8,7 @@
 <body>
   <h1>BlackRoad</h1>
   <div id="plans"></div>
+  <div id="chat-panel-root"></div>
   <div id="lucidia-brain-badge" style="position:fixed;bottom:5px;right:5px;padding:4px 8px;background:#FF4FD8;color:#fff;font-size:12px">Lucidia Brain: Offline</div>
   <script>
   async function updateBadge(){
@@ -31,5 +32,6 @@
     }
   }).catch(()=>{});
   </script>
+  <script src="/chat-panel.js" defer></script>
 </body>
 </html>

--- a/var/www/blackroad/llm-chat.html
+++ b/var/www/blackroad/llm-chat.html
@@ -1,0 +1,111 @@
+<!-- FILE: /var/www/blackroad/llm-chat.html -->
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Lucidia LLM</title>
+  <style>
+    body{font-family:sans-serif;background:#0b1324;color:#fff;margin:20px;}
+    .pill{display:inline-block;padding:4px 8px;border-radius:12px;margin-right:6px;font-size:12px;}
+    .pill.green{background:#008C76;}
+    .pill.amber{background:#FDBA2D;color:#000;}
+    textarea{width:100%;min-height:80px;background:#09122a;color:#fff;border:1px solid #444;border-radius:8px;padding:8px;}
+    #messages{max-height:300px;overflow:auto;border:1px solid #444;border-radius:8px;padding:8px;margin-top:10px;white-space:pre-wrap;}
+  </style>
+</head>
+<body>
+  <div id="pills">
+    <span id="health" class="pill amber">offline</span>
+    <span id="self" class="pill amber" title="self">self: unknown</span>
+  </div>
+  <div id="messages"></div>
+  <div style="margin-top:10px;display:flex;align-items:center;gap:6px;">
+    <label class="pill" style="cursor:pointer;">
+      <input type="checkbox" id="streamToggle" checked /> Stream
+    </label>
+    <button id="sendBtn">Send</button>
+  </div>
+  <textarea id="input" placeholder="Say something..."></textarea>
+  <div id="snapshot" style="position:fixed;bottom:5px;left:5px;font-size:12px;color:#ccc"></div>
+<script>
+async function updateHealth(){
+  try{
+    const r=await fetch('/api/llm/health');
+    const j=await r.json();
+    const el=document.getElementById('health');
+    if(j.ok){el.textContent='online';el.className='pill green';}
+    else{el.textContent='offline';el.className='pill amber';}
+  }catch(e){const el=document.getElementById('health');el.textContent='offline';el.className='pill amber';}
+}
+async function updateSelf(){
+  try{
+    const r=await fetch('/api/codex/identity');
+    const j=await r.json();
+    const el=document.getElementById('self');
+    const today=new Date().toISOString().slice(0,10).replace(/-/g,'');
+    const ok=j.code && j.code.startsWith('LUCIDIA-AWAKEN-'+today);
+    el.textContent=ok?'self: verified':'self: unknown';
+    el.className='pill '+(ok?'green':'amber');
+    el.title=j.host+' • '+j.model;
+  }catch(e){const el=document.getElementById('self');el.textContent='self: unknown';el.className='pill amber';}
+}
+async function updateSnapshot(){
+  try{
+    const r=await fetch('/api/backups/last');
+    const j=await r.json();
+    document.getElementById('snapshot').textContent='last snapshot: '+(j.time||'never');
+  }catch(e){document.getElementById('snapshot').textContent='last snapshot: n/a';}
+}
+updateHealth();updateSelf();updateSnapshot();
+setInterval(updateHealth,15000);setInterval(updateSelf,60000);
+const messagesEl=document.getElementById('messages');
+function addMessage(role,content){
+  const div=document.createElement('div');
+  div.innerHTML='<div class="pill">'+role+'</div>'+content;
+  messagesEl.appendChild(div);messagesEl.scrollTop=messagesEl.scrollHeight;
+}
+async function send(){
+  const input=document.getElementById('input');
+  const text=input.value.trim();
+  if(!text) return;input.value='';
+  addMessage('user',text);
+  const stream=document.getElementById('streamToggle').checked;
+  const body={messages:[{role:'user',content:text}]};
+  if(stream){
+    try{
+      const res=await fetch('/api/llm/stream',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify(body)});
+      const reader=res.body.getReader();
+      const decoder=new TextDecoder();
+      let buf='';
+      let bot='';
+      addMessage('assistant','');
+      const last=messagesEl.lastChild;
+      while(true){
+        const {value,done}=await reader.read();
+        if(done) break;
+        buf+=decoder.decode(value,{stream:true});
+        const parts=buf.split('\n\n');
+        for(let i=0;i<parts.length-1;i++){
+          const line=parts[i].trim();
+          if(line.startsWith('data: ')){
+            const data=JSON.parse(line.slice(6));
+            if(data.delta){bot+=data.delta;last.innerHTML='<div class="pill">assistant</div>'+bot;}
+            if(data.done){return;}
+          }
+        }
+        buf=parts[parts.length-1];
+      }
+    }catch(e){return fallback(body,text);}
+  }else{await fallback(body,text);}
+}
+async function fallback(body,original){
+  try{
+    const r=await fetch('/api/llm/chat',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify(body)});
+    const j=await r.json();
+    addMessage('assistant',j.choices[0].message.content);
+  }catch(e){addMessage('assistant',original);}
+}
+document.getElementById('sendBtn').onclick=send;
+</script>
+</body>
+</html>

--- a/var/www/blackroad/operator.html
+++ b/var/www/blackroad/operator.html
@@ -1,0 +1,137 @@
+<!--
+  FILE: /var/www/blackroad/operator.html
+  Purpose: Flag-gated Operator + RPA (no-exec) UI
+  Shows status, plans tasks with /api/operator/plan, and validates RPA steps with /api/operator/rpa/dry-run
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>BlackRoad • Operator</title>
+  <style>
+    :root{
+      --bg:#0b0b10; --panel:#12121a; --muted:#8b8ca3;
+      --text:#e9e9f1; --accent:#FF4FD8; --accent2:#0096FF; --accent3:#FDBA2D;
+      --ok:#19c37d; --warn:#f3b71b; --err:#ff6b6b;
+    }
+    body{margin:0;background:linear-gradient(180deg,#0b0b10,#0f0f16);color:var(--text);font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Inter,Arial}
+    .wrap{max-width:1100px;margin:1rem auto;padding:0 1rem;display:grid;grid-template-columns:1fr 1fr;gap:1rem}
+    @media (max-width:980px){.wrap{grid-template-columns:1fr}}
+    .card{background:var(--panel);border:1px solid #1b1b26;border-radius:16px;padding:1rem}
+    .row{display:flex;gap:.5rem;align-items:center;flex-wrap:wrap}
+    input,textarea,button{background:#0a0a12;color:var(--text);border:1px solid #222336;border-radius:12px;padding:.55rem .7rem}
+    button{cursor:pointer}
+    button.primary{background:linear-gradient(90deg,var(--accent),var(--accent2));border:0}
+    pre{white-space:pre-wrap}
+    .pill{padding:.25rem .6rem;border-radius:999px;border:1px solid #252536;font-size:.85rem;color:var(--muted)}
+    .pill.ok{color:var(--ok);border-color:rgba(25,195,125,.35)}
+    .pill.err{color:var(--err);border-color:rgba(255,107,107,.35)}
+    .muted{color:var(--muted)}
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="card">
+      <h3 style="margin:.2rem 0">Operator Status</h3>
+      <div id="status" class="muted">checking…</div>
+      <div style="margin-top:.5rem">
+        <span id="op-pill" class="pill">operator</span>
+        <span id="rpa-pill" class="pill">rpa</span>
+      </div>
+    </div>
+
+    <div class="card">
+      <h3 style="margin:.2rem 0">Plan</h3>
+      <div class="row" style="margin:.5rem 0">
+        <input id="objective" placeholder="Objective…" style="flex:1">
+      </div>
+      <textarea id="context" placeholder="Context (optional)…" style="height:110px;width:100%"></textarea>
+      <div class="row" style="margin-top:.5rem">
+        <button id="plan" class="primary">Plan with Operator</button>
+      </div>
+      <pre id="plan-out" class="muted" style="margin-top:.6rem"></pre>
+    </div>
+
+    <div class="card">
+      <h3 style="margin:.2rem 0">RPA Dry-Run (no execution)</h3>
+      <div class="row" style="margin:.4rem 0">
+        <input id="rpa-url" placeholder="https://example.com" style="flex:1">
+      </div>
+      <textarea id="rpa-actions" placeholder='[{"type":"goto","selector":null},{"type":"wait","seconds":2},{"type":"click","selector":"#login"}]' style="height:110px;width:100%"></textarea>
+      <div class="row" style="margin-top:.5rem">
+        <button id="dryrun" class="primary">Validate Plan</button>
+      </div>
+      <pre id="rpa-out" class="muted" style="margin-top:.6rem"></pre>
+      <div class="muted" style="margin-top:.5rem">Note: host allowlist is enforced; set <code>RPA_ALLOW_HOSTS</code>.</div>
+    </div>
+  </div>
+
+  <script>
+    const $ = s => document.querySelector(s);
+    const statusBox = $("#status");
+    const opPill = $("#op-pill");
+    const rpaPill = $("#rpa-pill");
+    const planOut = $("#plan-out");
+    const rpaOut = $("#rpa-out");
+
+    async function boot() {
+      try {
+        const r = await fetch("/api/operator/status", { cache: "no-store" });
+        const j = await r.json();
+        statusBox.textContent = JSON.stringify(j, null, 2);
+        opPill.className = "pill " + (j.enabled ? "ok" : "err");
+        rpaPill.className = "pill " + (j.rpa_enabled ? "ok" : "err");
+        if (!j.enabled) {
+          planOut.textContent = "Operator disabled. Enable via systemd env: ENABLE_OPERATOR=1";
+        }
+        if (!j.rpa_enabled) {
+          rpaOut.textContent = "RPA disabled. Enable via systemd env: ENABLE_RPA=1";
+        }
+      } catch (e) {
+        statusBox.textContent = "status error: " + String(e);
+        opPill.className = "pill err";
+        rpaPill.className = "pill err";
+      }
+    }
+
+    $("#plan").addEventListener("click", async () => {
+      planOut.textContent = "planning…";
+      try {
+        const r = await fetch("/api/operator/plan", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            objective: $("#objective").value,
+            context: $("#context").value
+          })
+        });
+        const j = await r.json();
+        planOut.textContent = JSON.stringify(j, null, 2);
+      } catch (e) {
+        planOut.textContent = "plan error: " + String(e);
+      }
+    });
+
+    $("#dryrun").addEventListener("click", async () => {
+      rpaOut.textContent = "validating…";
+      try {
+        const r = await fetch("/api/operator/rpa/dry-run", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            url: $("#rpa-url").value,
+            actions: JSON.parse($("#rpa-actions").value || "[]")
+          })
+        });
+        const j = await r.json();
+        rpaOut.textContent = JSON.stringify(j, null, 2);
+      } catch (e) {
+        rpaOut.textContent = "dry-run error: " + String(e);
+      }
+    });
+
+    boot();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add cached model listings and refresh endpoint
- add embeddings stub plus Operator/RPA sandbox endpoints
- provide chat panel hook and operator UI pages

## Testing
- `node --check srv/blackroad-api/server_min.js`
- `node --check var/www/blackroad/chat-panel.js`
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: Cannot find module '/workspace/blackroad-prism-console/eslint.config.js')*

------
https://chatgpt.com/codex/tasks/task_e_68c1bcc32ce88329880c9a7c5258a83c