### PR TITLE
fix: stroke color for lab polylines

### DIFF
--- a/sites/blackroad/src/pages/PendulumLab.jsx
+++ b/sites/blackroad/src/pages/PendulumLab.jsx
@@ -71,8 +71,8 @@ function PhasePlot({traj, field}){
   return (
     <svg width="100%" viewBox={`0 0 ${W} ${H}`}>
       <rect x="0" y="0" width={W} height={H} fill="none"/>
-      {field.map((seg,i)=>(<polyline key={i} points={seg.map(([th,p])=>`${X(th)},${Y(p)}`).join(' ')} fill="none" strokeWidth="0.5" opacity="0.35"/>))}
-      <polyline points={traj.map(([th,p])=>`${X(th)},${Y(p)}`).join(' ')} fill="none" strokeWidth="2"/>
+      {field.map((seg,i)=>(<polyline key={i} points={seg.map(([th,p])=>`${X(th)},${Y(p)}`).join(' ')} fill="none" stroke="currentColor" strokeWidth="0.5" opacity="0.35"/>))}
+      <polyline points={traj.map(([th,p])=>`${X(th)},${Y(p)}`).join(' ')} fill="none" stroke="currentColor" strokeWidth="2"/>
       <text x={pad} y={14} fontSize="10">Phase space (θ, p)</text>
     </svg>
   );

--- a/sites/blackroad/src/pages/PenroseToyLab.jsx
+++ b/sites/blackroad/src/pages/PenroseToyLab.jsx
@@ -94,7 +94,7 @@ function Tiling({tiles, scale0}){
       <rect x="0" y="0" width={W} height={H} fill="none"/>
       {polys.map((poly,i)=>{
         const pts = poly.map(([x,y])=> `${X(x)},${Y(y)}`).join(' ');
-        return <polyline key={i} points={pts} fill="none" strokeWidth="1.5"/>;
+        return <polyline key={i} points={pts} fill="none" stroke="currentColor" strokeWidth="1.5"/>;
       })}
     </svg>
   );


### PR DESCRIPTION
## Summary
- add currentColor stroke for Penrose tiling polylines
- draw phase portrait and trajectory lines in PendulumLab

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68c1f6e144948329b5d38bcefe61c624