### PR TITLE
Add BlackRoad landing and staging sites

### DIFF
--- a/blackroad-landing/.github/workflows/pages.yml
+++ b/blackroad-landing/.github/workflows/pages.yml
@@ -1,0 +1,66 @@
+name: Deploy Pages + Proof + Circuit Breaker
+on:
+  push: { branches: [main] }
+  workflow_dispatch:
+  schedule:
+    - cron: '5 6 * * *' # daily UTC
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+concurrency:
+  group: blackroad-pages
+  cancel-in-progress: false # queue, don't stampede
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.x' }
+      - name: Generate daily proof & bake files
+        env:
+          AWAKEN_SEED: ${{ secrets.AWAKEN_SEED }}
+          GODADDY_API_KEY: ${{ secrets.GODADDY_API_KEY }}
+          GODADDY_API_SECRET: ${{ secrets.GODADDY_API_SECRET }}
+        run: |
+          set -eux
+          mkdir -p health
+          python3 scripts/compute_proof.py > proof.txt || echo "LUCIDIA-AWAKEN-00000000-missingseed" > proof.txt
+          PROOF=$(cat proof.txt)
+          printf '{"ok":true,"service":"blackroad","version":"0.1.0","proof":"%s"}' "$PROOF" > health.json
+          cp health.json health/index.json || true
+          sed -i "s|%%PROOF%%|$PROOF|g" index.html || true
+          # Optional: write DNS TXT via GoDaddy API
+          if [ -n "${GODADDY_API_KEY:-}" ] && [ -n "${GODADDY_API_SECRET:-}" ]; then
+            curl -fsS -X PUT \
+              -H "Authorization: sso-key $GODADDY_API_KEY:$GODADDY_API_SECRET" \
+              -H "Content-Type: application/json" \
+              -d "[{\"data\":\"$PROOF\",\"ttl\":600}]" \
+              "https://api.godaddy.com/v1/domains/blackroad.io/records/TXT/blackroad-proof" || true
+          else
+            echo "::notice title=DNS::Set TXT blackroad-proof.blackroad.io = $PROOF (TTL 600)"
+          fi
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with: { path: . }
+      - name: Deploy to Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+      - name: Circuit-breaker health check (PROD)
+        run: |
+          ok=0
+          for i in $(seq 1 30); do
+            sleep 2
+            html=$(curl -fsS https://www.blackroad.io/ || true)
+            api=$(curl -fsS https://www.blackroad.io/health.json || true)
+            txt=$(dig +short TXT blackroad-proof.blackroad.io @8.8.8.8 | tr -d '"')
+            echo "Probe $i html=${#html} api=$api txt=$txt"
+            echo "$html" | grep -q "<!-- BLACKROAD OK -->" || { echo "no marker"; continue; }
+            echo "$api" | jq -e '.ok==true and .service=="blackroad"' >/dev/null || { echo "bad health"; continue; }
+            want=$(jq -r .proof <<<"$api")
+            [ -n "$want" ] && [ "$txt" = "$want" ] || { echo "txt mismatch ($txt != $want)"; continue; }
+            ok=$((ok+1)); [ $ok -ge 2 ] && exit 0
+          done
+          echo "Circuit-breaker: not healthy yet"; exit 1

--- a/blackroad-landing/CNAME
+++ b/blackroad-landing/CNAME
@@ -1,0 +1,1 @@
+www.blackroad.io

--- a/blackroad-landing/health.json
+++ b/blackroad-landing/health.json
@@ -1,0 +1,1 @@
+{ "ok": true, "service": "blackroad", "version": "0.1.0", "proof": "BOOTSTRAP" }

--- a/blackroad-landing/index.html
+++ b/blackroad-landing/index.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>BlackRoad</title>
+    <style>
+      :root {
+        --accent: #ff4fd8;
+        --accent-2: #0096ff;
+        --accent-3: #fdba2d;
+      }
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        background: #0b0b0f;
+        color: #eaeaf0;
+        font-family: Inter, system-ui, sans-serif;
+      }
+      .wrap {
+        min-height: 100dvh;
+        display: grid;
+        place-items: center;
+      }
+      .card {
+        padding: 24px;
+        border: 1px solid #222;
+        border-radius: 16px;
+        background: linear-gradient(180deg, #0f0f16, #0b0b0f);
+      }
+      .badge {
+        display: inline-block;
+        padding: 6px 10px;
+        border-radius: 9999px;
+        background: var(--accent);
+        color: #0b0b0f;
+        font-weight: 700;
+      }
+      a {
+        color: var(--accent-2);
+        text-decoration: none;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- BLACKROAD OK -->
+    <div class="wrap">
+      <div class="card">
+        <div class="badge">BlackRoad</div>
+        <h1>We’re online.</h1>
+        <p>Daily proof: <code id="proof">%%PROOF%%</code></p>
+        <p><a href="/health.json">/health.json</a></p>
+        <small>Palette: #FF4FD8 · #0096FF · #FDBA2D</small>
+      </div>
+    </div>
+  </body>
+</html>

--- a/blackroad-landing/scripts/compute_proof.py
+++ b/blackroad-landing/scripts/compute_proof.py
@@ -1,0 +1,16 @@
+# ruff: noqa: I001
+import base64
+import datetime
+import hashlib
+import hmac
+import os
+import zoneinfo
+
+
+tz = zoneinfo.ZoneInfo("America/Chicago")
+date = datetime.datetime.now(tz).strftime("%Y-%m-%d")
+seed = os.environ.get("AWAKEN_SEED", "missing-seed")
+msg = f"{date}|blackboxprogramming|copilot".encode()
+digest = hmac.new(seed.encode(), msg, hashlib.sha256).digest()
+code = base64.b32encode(digest).decode().strip("=").lower()[:16]
+print(f"LUCIDIA-AWAKEN-{date.replace('-', '')}-{code}")

--- a/blackroad-stage/.github/workflows/pages.yml
+++ b/blackroad-stage/.github/workflows/pages.yml
@@ -1,0 +1,66 @@
+name: Deploy Pages + Proof + Circuit Breaker
+on:
+  push: { branches: [main] }
+  workflow_dispatch:
+  schedule:
+    - cron: '5 6 * * *' # daily UTC
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+concurrency:
+  group: blackroad-pages
+  cancel-in-progress: false # queue, don't stampede
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.x' }
+      - name: Generate daily proof & bake files
+        env:
+          AWAKEN_SEED: ${{ secrets.AWAKEN_SEED }}
+          GODADDY_API_KEY: ${{ secrets.GODADDY_API_KEY }}
+          GODADDY_API_SECRET: ${{ secrets.GODADDY_API_SECRET }}
+        run: |
+          set -eux
+          mkdir -p health
+          python3 scripts/compute_proof.py > proof.txt || echo "LUCIDIA-AWAKEN-00000000-missingseed" > proof.txt
+          PROOF=$(cat proof.txt)
+          printf '{"ok":true,"service":"blackroad","version":"0.1.0","proof":"%s"}' "$PROOF" > health.json
+          cp health.json health/index.json || true
+          sed -i "s|%%PROOF%%|$PROOF|g" index.html || true
+          # Optional: write DNS TXT via GoDaddy API
+          if [ -n "${GODADDY_API_KEY:-}" ] && [ -n "${GODADDY_API_SECRET:-}" ]; then
+            curl -fsS -X PUT \
+              -H "Authorization: sso-key $GODADDY_API_KEY:$GODADDY_API_SECRET" \
+              -H "Content-Type: application/json" \
+              -d "[{\"data\":\"$PROOF\",\"ttl\":600}]" \
+              "https://api.godaddy.com/v1/domains/blackroad.io/records/TXT/stage-proof" || true
+          else
+            echo "::notice title=DNS::Set TXT stage-proof.blackroad.io = $PROOF (TTL 600)"
+          fi
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with: { path: . }
+      - name: Deploy to Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+      - name: Circuit-breaker health check (STAGE)
+        run: |
+          ok=0
+          for i in $(seq 1 30); do
+            sleep 2
+            html=$(curl -fsS https://stage.blackroad.io/ || true)
+            api=$(curl -fsS https://stage.blackroad.io/health.json || true)
+            txt=$(dig +short TXT stage-proof.blackroad.io @8.8.8.8 | tr -d '"')
+            echo "Probe $i html=${#html} api=$api txt=$txt"
+            echo "$html" | grep -q "<!-- BLACKROAD OK -->" || { echo "no marker"; continue; }
+            echo "$api" | jq -e '.ok==true and .service=="blackroad"' >/dev/null || { echo "bad health"; continue; }
+            want=$(jq -r .proof <<<"$api")
+            [ -n "$want" ] && [ "$txt" = "$want" ] || { echo "txt mismatch ($txt != $want)"; continue; }
+            ok=$((ok+1)); [ $ok -ge 2 ] && exit 0
+          done
+          echo "Circuit-breaker: not healthy yet"; exit 1

--- a/blackroad-stage/.github/workflows/stress.yml
+++ b/blackroad-stage/.github/workflows/stress.yml
@@ -1,0 +1,27 @@
+name: Stage Stress (safe)
+on:
+  workflow_dispatch:
+    inputs:
+      STRESS:
+        description: 'true to hammer stage'
+        default: 'false'
+  push:
+    branches: [stage]
+permissions: { contents: read }
+concurrency:
+  group: blackroad-stage-stress
+  cancel-in-progress: true
+jobs:
+  stress:
+    if: ${{ github.event.inputs.STRESS == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Warm-up check
+        run: |
+          curl -fsS https://stage.blackroad.io/ >/dev/null
+          curl -fsS https://stage.blackroad.io/health.json >/dev/null
+      - name: Safe load (autocannon)
+        run: |
+          npm i -g autocannon
+          autocannon -d 30 -c 20 https://stage.blackroad.io/health.json
+          autocannon -d 30 -c 50 https://stage.blackroad.io/

--- a/blackroad-stage/CNAME
+++ b/blackroad-stage/CNAME
@@ -1,0 +1,1 @@
+stage.blackroad.io

--- a/blackroad-stage/health.json
+++ b/blackroad-stage/health.json
@@ -1,0 +1,1 @@
+{ "ok": true, "service": "blackroad", "version": "0.1.0", "proof": "BOOTSTRAP" }

--- a/blackroad-stage/index.html
+++ b/blackroad-stage/index.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>BlackRoad</title>
+    <style>
+      :root {
+        --accent: #ff4fd8;
+        --accent-2: #0096ff;
+        --accent-3: #fdba2d;
+      }
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        background: #0b0b0f;
+        color: #eaeaf0;
+        font-family: Inter, system-ui, sans-serif;
+      }
+      .wrap {
+        min-height: 100dvh;
+        display: grid;
+        place-items: center;
+      }
+      .card {
+        padding: 24px;
+        border: 1px solid #222;
+        border-radius: 16px;
+        background: linear-gradient(180deg, #0f0f16, #0b0b0f);
+      }
+      .badge {
+        display: inline-block;
+        padding: 6px 10px;
+        border-radius: 9999px;
+        background: var(--accent);
+        color: #0b0b0f;
+        font-weight: 700;
+      }
+      a {
+        color: var(--accent-2);
+        text-decoration: none;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- BLACKROAD OK -->
+    <div class="wrap">
+      <div class="card">
+        <div class="badge">BlackRoad</div>
+        <h1>We’re online.</h1>
+        <p>Daily proof: <code id="proof">%%PROOF%%</code></p>
+        <p><a href="/health.json">/health.json</a></p>
+        <small>Palette: #FF4FD8 · #0096FF · #FDBA2D</small>
+      </div>
+    </div>
+  </body>
+</html>

--- a/blackroad-stage/scripts/compute_proof.py
+++ b/blackroad-stage/scripts/compute_proof.py
@@ -1,0 +1,16 @@
+# ruff: noqa: I001
+import base64
+import datetime
+import hashlib
+import hmac
+import os
+import zoneinfo
+
+
+tz = zoneinfo.ZoneInfo("America/Chicago")
+date = datetime.datetime.now(tz).strftime("%Y-%m-%d")
+seed = os.environ.get("AWAKEN_SEED", "missing-seed")
+msg = f"{date}|blackboxprogramming|copilot".encode()
+digest = hmac.new(seed.encode(), msg, hashlib.sha256).digest()
+code = base64.b32encode(digest).decode().strip("=").lower()[:16]
+print(f"LUCIDIA-AWAKEN-{date.replace('-', '')}-{code}")


### PR DESCRIPTION
## Summary
- add BlackRoad landing repo with Pages deploy, DNS proof, and circuit breaker
- mirror staging repo and add stress harness workflow

## Testing
- `pre-commit run --files blackroad-landing/CNAME blackroad-landing/index.html blackroad-landing/health.json blackroad-landing/scripts/compute_proof.py blackroad-landing/.github/workflows/pages.yml blackroad-stage/CNAME blackroad-stage/index.html blackroad-stage/health.json blackroad-stage/scripts/compute_proof.py blackroad-stage/.github/workflows/pages.yml blackroad-stage/.github/workflows/stress.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c2267f0e708329910153d5c9fa26a7