### PR TITLE
fix: buffer streaming chunks before parsing SSE/NDJSON

### DIFF
--- a/var/www/blackroad/llm-chat.html
+++ b/var/www/blackroad/llm-chat.html
@@ -323,6 +323,7 @@
 
       let convo = [];
       let controller = null; // AbortController for streaming
+      let streamBuffer = ''; // buffer for partial streaming data
 
       function addMsg(role, text) {
         const div = document.createElement('div');
@@ -397,8 +398,9 @@
 
       function parseAndAppend(pre, chunk) {
         // Accept raw text, SSE "data: ...", or NDJSON lines
-        const text = chunk;
-        const lines = text.split(/\r?\n/);
+        streamBuffer += chunk;
+        const lines = streamBuffer.split(/\r?\n/);
+        streamBuffer = lines.pop();
         for (const line of lines) {
           if (!line) continue;
           if (line.startsWith('data:')) {
@@ -440,6 +442,7 @@
 
         // Stream
         controller = new AbortController();
+        streamBuffer = '';
         streamDot.classList.add('ok');
         try {
           const r = await fetch('/api/llm/chat', {
@@ -460,6 +463,7 @@
             if (value)
               parseAndAppend(botPre, decoder.decode(value, { stream: true }));
           }
+          if (streamBuffer) parseAndAppend(botPre, '\n');
         } catch (e) {
           botPre.textContent += `\n[stream error] ${String(e)}`;
         } finally {


### PR DESCRIPTION
## Summary
- buffer partial SSE/NDJSON lines when streaming chat responses to avoid parsing incomplete chunks
- reset and flush stream buffer for each conversation

## Testing
- `npx prettier srv/blackroad-api/server_min.js var/www/blackroad/llm-chat.html --check`
- `npx eslint srv/blackroad-api/server_min.js` *(fails: Cannot find module '@eslint/js')*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c20984ecf88329b782fdf84d08fda3