### PR TITLE
feat: email list unsubscribe and admin export

### DIFF
--- a/blackroad-website/index.html
+++ b/blackroad-website/index.html
@@ -1,0 +1,235 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>BlackRoad.io — Live</title>
+  <style>
+    :root{--accent:#FF4FD8;--accent2:#0096FF;--accent3:#FDBA2D;--bg:#0b0b12;--fg:#eaeaf2;--muted:#a0a3ad}
+    *{box-sizing:border-box}
+    body{margin:0;background:var(--bg);color:var(--fg);font:16px/1.5 system-ui,Segoe UI,Roboto,Inter,sans-serif}
+    header{padding:24px 16px;border-bottom:1px solid #1c1f2a;background:linear-gradient(180deg,rgba(255,79,216,.08),transparent)}
+    .wrap{max-width:1100px;margin:0 auto;padding:24px 16px}
+    h1{margin:0 0 6px;font-size:28px}
+    .pill{display:inline-block;padding:6px 10px;border:1px solid #272a38;border-radius:999px;color:var(--muted)}
+    nav{display:flex;gap:10px;flex-wrap:wrap;margin-top:14px}
+    a.btn{display:inline-block;text-decoration:none;border:1px solid #272a38;border-radius:14px;padding:10px 14px}
+    a.primary{border-color:transparent;background:linear-gradient(90deg,var(--accent),var(--accent2));color:#0b0b12;font-weight:700}
+    .grid{display:grid;gap:16px;grid-template-columns:repeat(auto-fit,minmax(260px,1fr))}
+    .card{border:1px solid #1e2230;border-radius:18px;padding:16px;background:#0e111b;box-shadow:0 0 0 1px rgba(255,255,255,.02) inset}
+    .tag{font-size:12px;color:var(--muted)}
+    footer{padding:24px 16px;border-top:1px solid #1c1f2a;color:var(--muted)}
+    .ok{color:#5dffa7}.warn{color:#ffdd6b}.bad{color:#ff7d7d}
+    code{background:#101425;border:1px solid #1d2235;border-radius:8px;padding:2px 6px}
+  </style>
+  <script>
+  // If you later set this at build time, the widget will render automatically
+  window.CLOUDFLARE_TURNSTILE_SITEKEY = ""; // optional, leave blank to disable
+  </script>
+  <script>
+  if (window.CLOUDFLARE_TURNSTILE_SITEKEY) {
+    const s = document.createElement('script');
+    s.src = "https://challenges.cloudflare.com/turnstile/v0/api.js";
+    s.async = true;
+    document.head.appendChild(s);
+  }
+  </script>
+  <script>
+    function route(){
+      const path = location.pathname.replace(/\/+$/,'') || '/';
+      const view = document.getElementById('view');
+      const routes = {
+        '/': 'Welcome to BlackRoad.io — site is LIVE via GitHub Pages.',
+        '/login': 'Login placeholder (static).',
+        '/chat': 'Chat placeholder (local-only LLM to be wired later).',
+        '/memories': 'Memories placeholder.',
+        '/coding': 'Coding portal placeholder.',
+        '/backend': 'Backend portal placeholder.',
+        '/subscribe': 'Subscribe to updates.',
+        '/unsubscribe': 'Unsubscribe from updates.',
+        '/admin/subscribers': 'Admin — subscribers dashboard (HMAC required).'
+      };
+      view.textContent = routes[path] || '404 — routed to SPA root. Use header links.';
+    }
+    window.addEventListener('popstate', route);
+    window.addEventListener('DOMContentLoaded', route);
+    function go(p){history.pushState({},'',p);route();return false;}
+    async function checkHealth(){
+      try{
+        const r=await fetch('/health.json',{cache:'no-store'});
+        const j=await r.json();
+        document.getElementById('health').innerHTML = `<span class="ok">●</span> HEALTH ok — ${new Date().toISOString()}`;
+      }catch(e){
+        document.getElementById('health').innerHTML = `<span class="warn">●</span> HEALTH file not found`;
+      }
+    }
+    document.addEventListener('DOMContentLoaded',checkHealth);
+  </script>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <div class="pill">BLACKROAD • Pages Deployment</div>
+      <h1>BlackRoad.io</h1>
+      <nav>
+        <a href="/" class="btn" onclick="return go('/')">Home</a>
+        <a href="/login" class="btn" onclick="return go('/login')">Login</a>
+        <a href="/chat" class="btn" onclick="return go('/chat')">Chat</a>
+        <a href="/memories" class="btn" onclick="return go('/memories')">Memories</a>
+        <a href="/coding" class="btn" onclick="return go('/coding')">Coding</a>
+        <a href="/backend" class="btn" onclick="return go('/backend')">Backend</a>
+        <a href="/subscribe" class="btn" onclick="return go('/subscribe')">Subscribe</a>
+        <a href="/unsubscribe" class="btn" onclick="return go('/unsubscribe')">Unsubscribe</a>
+        <a href="/admin/subscribers" class="btn" onclick="return go('/admin/subscribers')">Admin</a>
+        <a href="health.json" class="btn">Health</a>
+        <a href="https://github.com" target="_blank" class="btn primary">Open Repo</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="wrap">
+    <p id="health" class="tag">Checking health…</p>
+    <div id="view" class="card" style="min-height:90px"></div>
+    <section class="grid" style="margin-top:16px">
+      <div class="card"><div class="tag">Status</div>
+        Static deployment via GitHub Pages. No droplet required. DNS points to GitHub. SPA routing enabled.
+      </div>
+      <div class="card"><div class="tag">Next steps</div>
+        Wire a real API behind <code>/api</code> later (Cloudflare Workers/Pages Functions or your Node API).
+      </div>
+      <div class="card"><div class="tag">Brand</div>
+        Colors: <code>#FF4FD8</code>, <code>#0096FF</code>, <code>#FDBA2D</code>.
+      </div>
+    </section>
+
+    <!-- Subscribe section -->
+    <section id="subscribe-section" class="card" style="margin-top:16px">
+      <div class="tag">Subscribe</div>
+      <form id="subscribe-form" autocomplete="off" style="display:grid;gap:12px;max-width:520px">
+        <label>Name
+          <input id="sub-name" type="text" placeholder="Jane" style="width:100%;padding:10px;border-radius:10px;border:1px solid #272a38;background:#0b0f1b;color:#eaeaf2">
+        </label>
+        <label>Email
+          <input id="sub-email" type="email" required placeholder="you@example.com" style="width:100%;padding:10px;border-radius:10px;border:1px solid #272a38;background:#0b0f1b;color:#eaeaf2">
+        </label>
+        <div style="display:none"><input id="sub-hp" type="text" tabindex="-1" autocomplete="off"></div>
+        <button id="sub-btn" type="submit" style="justify-self:start;border:0;border-radius:14px;padding:10px 14px;background:linear-gradient(90deg,var(--accent),var(--accent2));color:#0b0b12;font-weight:700">Subscribe</button>
+        <div id="sub-msg" class="tag"></div>
+      </form>
+    </section>
+
+    <!-- Unsubscribe section -->
+    <section id="unsubscribe-section" class="card" style="margin-top:16px">
+      <div class="tag">Unsubscribe</div>
+      <form id="unsubscribe-form" autocomplete="email" style="display:grid;gap:12px;max-width:520px">
+        <label>Email
+          <input id="unsub-email" type="email" required placeholder="you@example.com" style="width:100%;padding:10px;border-radius:10px;border:1px solid #272a38;background:#0b0f1b;color:#eaeaf2">
+        </label>
+        <button id="unsub-btn" type="submit" style="justify-self:start;border:0;border-radius:14px;padding:10px 14px;background:linear-gradient(90deg,var(--accent),var(--accent2));color:#0b0b12;font-weight:700">Unsubscribe</button>
+        <div id="unsub-msg" class="tag"></div>
+      </form>
+    </section>
+
+    <!-- Admin subscribers section -->
+    <section id="admin-subscribers" class="card" style="margin-top:16px">
+      <div class="tag">Admin — Subscribers</div>
+      <div style="display:grid;gap:12px;max-width:720px">
+        <label>Admin HMAC
+          <input id="admin-hmac" type="password" placeholder="paste X-Admin-HMAC" style="width:100%;padding:10px;border-radius:10px;border:1px solid #272a38;background:#0b0f1b;color:#eaeaf2">
+        </label>
+        <div style="display:flex;gap:10px;flex-wrap:wrap">
+          <button id="btn-stats" style="border:0;border-radius:14px;padding:10px 14px;background:linear-gradient(90deg,var(--accent),var(--accent2));color:#0b0b12;font-weight:700">Fetch Stats</button>
+          <button id="btn-export" style="border:1px solid #272a38;border-radius:14px;padding:10px 14px;background:#0e111b;color:#eaeaf2">Export CSV</button>
+        </div>
+        <pre id="admin-out" style="white-space:pre-wrap;word-break:break-word;background:#101425;border:1px solid #1d2235;border-radius:8px;padding:12px"></pre>
+      </div>
+    </section>
+
+  </main>
+
+  <footer><div class="wrap">© BlackRoad.io</div></footer>
+
+  <script>
+// Subscribe: attach Turnstile token if present
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('subscribe-form');
+  if (form) {
+    if (window.CLOUDFLARE_TURNSTILE_SITEKEY) {
+      const div = document.createElement('div');
+      div.className = "cf-turnstile";
+      div.setAttribute('data-sitekey', window.CLOUDFLARE_TURNSTILE_SITEKEY);
+      form.appendChild(div);
+    }
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const tokenEl = document.querySelector('.cf-turnstile input[name="cf-turnstile-response"]');
+      const tkn = tokenEl ? tokenEl.value : "";
+      const email = document.getElementById('sub-email').value.trim();
+      const name  = document.getElementById('sub-name').value.trim();
+      const hp    = document.getElementById('sub-hp').value;
+      const msgEl = document.getElementById('sub-msg');
+      const btn   = document.getElementById('sub-btn');
+      msgEl.textContent = '';
+      if (!email || !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)) { msgEl.textContent = 'Please enter a valid email.'; return; }
+      if (hp) { msgEl.textContent = 'Spam detected.'; return; }
+      btn.disabled = true;
+      try {
+        const r = await fetch('/api/subscribe', {
+          method: 'POST',
+          headers: {'Content-Type':'application/json'},
+          body: JSON.stringify({ email, name, turnstile: tkn })
+        });
+        if (r.ok) { msgEl.textContent = 'Check your email to confirm your subscription.'; form.reset(); }
+        else { msgEl.textContent = 'Failed to subscribe: ' + (await r.text()).slice(0,200); }
+      } catch { msgEl.textContent = 'Network error. Try again in a minute.'; }
+      finally { btn.disabled = false; }
+    });
+  }
+
+  // Unsubscribe
+  const uform = document.getElementById('unsubscribe-form');
+  if (uform) {
+    uform.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const email = document.getElementById('unsub-email').value.trim();
+      const msgEl = document.getElementById('unsub-msg');
+      const btn   = document.getElementById('unsub-btn');
+      msgEl.textContent = '';
+      if (!email || !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)) { msgEl.textContent = 'Please enter a valid email.'; return; }
+      btn.disabled = true;
+      try {
+        const r = await fetch('/api/unsubscribe', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ email }) });
+        if (r.ok) { msgEl.textContent = 'If this email exists, a confirmation link has been sent.'; uform.reset(); }
+        else { msgEl.textContent = 'Failed to start unsubscribe: ' + (await r.text()).slice(0,200); }
+      } catch { msgEl.textContent = 'Network error. Try again.'; }
+      finally { btn.disabled = false; }
+    });
+  }
+
+  // Admin dashboard
+  const btnStats = document.getElementById('btn-stats');
+  const btnExport = document.getElementById('btn-export');
+  const adminOut = document.getElementById('admin-out');
+  function adminH() { return document.getElementById('admin-hmac')?.value || ''; }
+  if (btnStats) {
+    btnStats.addEventListener('click', async () => {
+      adminOut.textContent = 'Loading…';
+      const r = await fetch('/api/subscribe/stats', { headers: { 'X-Admin-HMAC': adminH() } });
+      adminOut.textContent = r.ok ? JSON.stringify(await r.json(), null, 2) : (await r.text());
+    });
+  }
+  if (btnExport) {
+    btnExport.addEventListener('click', async () => {
+      const r = await fetch('/api/subscribe/export', { headers: { 'X-Admin-HMAC': adminH() } });
+      if (!r.ok) { adminOut.textContent = await r.text(); return; }
+      const blob = await r.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a'); a.href = url; a.download = 'blackroad-subscribers.csv'; a.click();
+      URL.revokeObjectURL(url);
+      adminOut.textContent = 'CSV downloaded.';
+    });
+  }
+});
+  </script>
+</body>
+</html>

--- a/cf-worker/src/index.js
+++ b/cf-worker/src/index.js
@@ -1,0 +1,211 @@
+export default {
+  async fetch(req, env, ctx) {
+    const url = new URL(req.url);
+    try {
+      if (url.pathname === '/api/subscribe' && req.method === 'POST') {
+        return handleSubscribe(req, env);
+      }
+      if (url.pathname === '/api/subscribe/confirm' && req.method === 'GET') {
+        return handleConfirm(url, env);
+      }
+      if (url.pathname === '/api/unsubscribe' && req.method === 'POST') {
+        return handleUnsubscribeStart(req, env);
+      }
+      if (url.pathname === '/api/unsubscribe/confirm' && req.method === 'GET') {
+        return handleUnsubscribeConfirm(url, env);
+      }
+      if (url.pathname === '/api/subscribe/stats' && req.method === 'GET') {
+        if (!await checkAdmin(req, env)) return text('forbidden', 403);
+        return handleStats(env);
+      }
+      if (url.pathname === '/api/subscribe/export' && req.method === 'GET') {
+        if (!await checkAdmin(req, env)) return text('forbidden', 403);
+        return handleExport(env);
+      }
+      return text('not found', 404);
+    } catch (e) {
+      console.error('Worker error', e);
+      return text('server error', 500);
+    }
+  }
+};
+
+function json(obj, status=200, headers={}) {
+  return new Response(JSON.stringify(obj), { status, headers: { 'content-type': 'application/json', ...cors(), ...headers }});
+}
+function text(t, status=200, headers={}) {
+  return new Response(t, { status, headers: { 'content-type': 'text/plain; charset=utf-8', ...cors(), ...headers }});
+}
+function cors() {
+  return { 'access-control-allow-origin': '*', 'access-control-allow-headers': 'content-type,x-admin-hmac' };
+}
+
+async function handleSubscribe(req, env) {
+  const { email, name, turnstile } = await req.json().catch(() => ({}));
+  if (!validEmail(email)) return text('invalid email', 400);
+  if (env.TURNSTILE_SECRET && !(await verifyTurnstile(turnstile, req, env))) return text('turnstile failed', 400);
+
+  // best-effort hourly rate limit
+  const ip = req.headers.get('CF-Connecting-IP') || '0.0.0.0';
+  const keyRL = `rl:sub:${ip}:${hourKey()}`;
+  const rl = parseInt(await env.BLACKROAD_SUBS.get(keyRL) || '0', 10);
+  if (rl > 20) return text('rate limited', 429);
+  await env.BLACKROAD_SUBS.put(keyRL, String(rl + 1), { expirationTtl: 3600 });
+
+  const ts = new Date().toISOString();
+  const token = await sha256hex(`${email}|confirm|${ts}|${Math.random()}`);
+  const rec = { email: email.toLowerCase(), name: name||'', ts, status: env.DOUBLE_OPT_IN==='true' ? 'pending' : 'active', token };
+  await env.BLACKROAD_SUBS.put(`sub:${rec.email}`, JSON.stringify(rec));
+  if (env.DOUBLE_OPT_IN === 'true') {
+    const confirmUrl = `https://${env.PROJECT}/api/subscribe/confirm?token=${token}&email=${encodeURIComponent(rec.email)}`;
+    await sendMail(env, rec.email, 'Confirm your BlackRoad subscription', confirmText(confirmUrl), confirmHtml(confirmUrl));
+  }
+  return text('ok', 200);
+}
+
+async function handleConfirm(url, env) {
+  const email = (url.searchParams.get('email')||'').toLowerCase();
+  const token = url.searchParams.get('token')||'';
+  const rec = await readRec(env, email);
+  if (!rec) return text('not found', 404);
+  if (rec.token !== token) return text('invalid token', 400);
+  rec.status = 'active';
+  rec.confirmed = new Date().toISOString();
+  await env.BLACKROAD_SUBS.put(key(email), JSON.stringify(rec));
+  return text('subscription confirmed — you may close this tab.', 200);
+}
+
+async function handleUnsubscribeStart(req, env) {
+  const { email } = await req.json().catch(() => ({}));
+  if (!validEmail(email)) return text('invalid email', 400);
+  const rec = await readRec(env, email.toLowerCase());
+  // Don't leak existence; still send a generic message
+  const ts = new Date().toISOString();
+  const token = await sha256hex(`${email}|unsub|${ts}|${Math.random()}`);
+  if (rec) {
+    rec.unsubToken = token;
+    await env.BLACKROAD_SUBS.put(key(email), JSON.stringify(rec));
+    const confirmUrl = `https://${env.PROJECT}/api/unsubscribe/confirm?token=${token}&email=${encodeURIComponent(email.toLowerCase())}`;
+    await sendMail(env, email.toLowerCase(), 'Confirm unsubscribe (BlackRoad)', unsubText(confirmUrl), unsubHtml(confirmUrl));
+  }
+  return text('ok', 200);
+}
+
+async function handleUnsubscribeConfirm(url, env) {
+  const email = (url.searchParams.get('email')||'').toLowerCase();
+  const token = url.searchParams.get('token')||'';
+  const rec = await readRec(env, email);
+  if (!rec) return text('not found', 404);
+  if (rec.unsubToken !== token) return text('invalid token', 400);
+  rec.status = 'unsubscribed';
+  rec.unsubscribed = new Date().toISOString();
+  await env.BLACKROAD_SUBS.put(key(email), JSON.stringify(rec));
+  return text('you are unsubscribed — you may close this tab.', 200);
+}
+
+async function handleStats(env) {
+  let cursor = undefined, total=0, active=0, pending=0, unsub=0;
+  do {
+    const list = await env.BLACKROAD_SUBS.list({ prefix: 'sub:', cursor });
+    for (const k of list.keys) {
+      total++;
+      const rec = JSON.parse(await env.BLACKROAD_SUBS.get(k.name));
+      if (rec.status === 'active') active++;
+      else if (rec.status === 'pending') pending++;
+      else if (rec.status === 'unsubscribed') unsub++;
+    }
+    cursor = list.cursor;
+  } while (cursor);
+  return json({ total, active, pending, unsub });
+}
+
+async function handleExport(env) {
+  let cursor = undefined;
+  const rows = [['email','name','status','ts','confirmed','unsubscribed']];
+  do {
+    const list = await env.BLACKROAD_SUBS.list({ prefix: 'sub:', cursor });
+    for (const k of list.keys) {
+      const r = JSON.parse(await env.BLACKROAD_SUBS.get(k.name));
+      rows.push([r.email||'', r.name||'', r.status||'', r.ts||'', r.confirmed||'', r.unsubscribed||'']);
+    }
+    cursor = list.cursor;
+  } while (cursor);
+  const csv = rows.map(cols => cols.map(escapeCsv).join(',')).join('\n');
+  return new Response(csv, { status: 200, headers: { ...cors(), 'content-type':'text/csv; charset=utf-8', 'content-disposition':'attachment; filename="blackroad-subscribers.csv"' }});
+}
+
+/* helpers */
+function key(email){ return `sub:${email.toLowerCase()}`; }
+async function readRec(env, email){ return email ? JSON.parse(await env.BLACKROAD_SUBS.get(key(email)) || 'null') : null; }
+function validEmail(e){ return !!e && /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(e); }
+function hourKey(){ return new Date().toISOString().slice(0,13); }
+
+async function verifyTurnstile(token, req, env) {
+  try {
+    const form = new FormData();
+    form.append('secret', env.TURNSTILE_SECRET);
+    form.append('response', token || '');
+    form.append('remoteip', req.headers.get('CF-Connecting-IP') || '');
+    const r = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', { method:'POST', body: form });
+    const j = await r.json();
+    return !!j.success;
+  } catch { return false; }
+}
+
+async function sendMail(env, to, subject, textBody, htmlBody) {
+  const res = await fetch('https://api.mailchannels.net/tx/v1/send', {
+    method: 'POST',
+    headers: {'content-type':'application/json'},
+    body: JSON.stringify({
+      personalizations: [{ to: [{ email: to }] }],
+      from: { email: env.FROM_EMAIL, name: env.FROM_NAME || 'BlackRoad' },
+      subject,
+      content: [
+        { type: 'text/plain', value: textBody },
+        { type: 'text/html',  value: htmlBody }
+      ]
+    })
+  });
+  if (!res.ok) {
+    const t = await res.text(); console.warn('MailChannels error', res.status, t.slice(0,200));
+  }
+}
+
+function confirmText(url){ return `Confirm your subscription:\n${url}\n\nIf you didn't request this, ignore this email.`; }
+function unsubText(url){ return `Confirm unsubscribe:\n${url}\n\nIf you didn't request this, ignore this email.`; }
+
+function confirmHtml(url){
+  return `<!doctype html><meta charset="utf-8">
+  <div style="font-family:system-ui,Segoe UI,Roboto,Inter,sans-serif;color:#111">
+    <h2 style="margin:0 0 12px">Confirm your subscription</h2>
+    <p>Click the button below to confirm your email for BlackRoad updates.</p>
+    <p><a href="${url}" style="display:inline-block;padding:12px 18px;border-radius:10px;text-decoration:none;background:linear-gradient(90deg,#FF4FD8,#0096FF);color:#0b0b12;font-weight:700">Confirm</a></p>
+    <p style="color:#555;font-size:12px">If you didn't request this, ignore this email.</p>
+  </div>`;
+}
+function unsubHtml(url){
+  return `<!doctype html><meta charset="utf-8">
+  <div style="font-family:system-ui,Segoe UI,Roboto,Inter,sans-serif;color:#111">
+    <h2 style="margin:0 0 12px">Confirm unsubscribe</h2>
+    <p>Click below to stop receiving BlackRoad emails for this address.</p>
+    <p><a href="${url}" style="display:inline-block;padding:12px 18px;border-radius:10px;text-decoration:none;background:linear-gradient(90deg,#FF4FD8,#0096FF);color:#0b0b12;font-weight:700">Unsubscribe</a></p>
+    <p style="color:#555;font-size:12px">If you didn't request this, ignore this email.</p>
+  </div>`;
+}
+
+async function sha256hex(s) {
+  const d = new TextEncoder().encode(s);
+  const h = await crypto.subtle.digest('SHA-256', d);
+  return [...new Uint8Array(h)].map(b=>b.toString(16).padStart(2,'0')).join('');
+}
+function escapeCsv(v){
+  const s = String(v ?? '');
+  return /[",\n]/.test(s) ? `"${s.replace(/"/g,'""')}"` : s;
+}
+
+async function checkAdmin(req, env) {
+  const sig = req.headers.get('X-Admin-HMAC') || req.headers.get('x-admin-hmac');
+  const secret = env.ADMIN_HMAC || '';
+  return timingSafeEqual(sig || '', secret);
+}
+function timingSafeEqual(a,b){ if (a.length !== b.length) return false; let out=0; for (let i=0;i<a.length;i++) out |= a.charCodeAt(i)^b.charCodeAt(i); return out===0; }

--- a/cf-worker/wrangler.toml
+++ b/cf-worker/wrangler.toml
@@ -1,0 +1,18 @@
+name = "blackroad-subscribe"
+main = "src/index.js"
+compatibility_date = "2024-11-21"
+
+routes = [
+  { pattern = "blackroad.io/api/*", zone_name = "blackroad.io" }
+]
+
+kv_namespaces = [
+  { binding = "BLACKROAD_SUBS", id = "${CF_KV_ID}", preview_id = "${CF_KV_ID}" }
+]
+
+[vars]
+PROJECT = "blackroad.io"
+DOUBLE_OPT_IN = "true"
+FROM_EMAIL = "no-reply@blackroad.io"
+FROM_NAME  = "BlackRoad"
+TURNSTILE_SITEKEY = ""   # optional


### PR DESCRIPTION
## Summary
- add unsubscribe UI, admin dashboard, and Cloudflare Turnstile wiring to static site
- expand Cloudflare Worker with unsubscribe flow, CSV export, HTML emails, and Turnstile verification

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68c24f0cee908329800475cb66e47544