### PR TITLE
docs: add backbone equation reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # BlackRoad.io — Dependency & Ops Bundle
+
 Date: 2025-08-22
 
 Requires Node.js 20 or later.
@@ -9,6 +10,7 @@ your API, install missing npm packages, set up env defaults, and (optionally) bo
 LLM stub on port **8000** if none is running.
 
 **What’s included**
+
 - `ops/install.sh` — one-shot setup for `/srv/blackroad-api` (or detected API path)
 - `tools/dep-scan.js` — scans JS/TS for `require()`/`import` usage and installs missing packages
 - `tools/verify-runtime.sh` — quick health checks (API on 4000, LLM on 8000)
@@ -23,11 +25,14 @@ LLM stub on port **8000** if none is running.
 ---
 
 ## Quick start
+
 **On your workstation**
-1) Unzip this at the **root of your working copy** (where your repo root lives).
-2) Commit and push.
+
+1. Unzip this at the **root of your working copy** (where your repo root lives).
+2. Commit and push.
 
 **On the server**
+
 ```bash
 cd /path/to/your/working/copy
 sudo bash ops/install.sh
@@ -42,6 +47,7 @@ bash tools/verify-runtime.sh
   - Check if `127.0.0.1:8000` is serving `/health`. If not, it prints a one-liner to launch the stub.
 
 ## Git workflow
+
 When you're ready to share changes:
 
 1. Stage your updates:
@@ -59,6 +65,7 @@ When you're ready to share changes:
 4. Open a Pull Request and review the CI results.
 
 ## Developing with VS Code and Docker on macOS
+
 1. Start [Docker Desktop for Mac](https://docs.docker.com/desktop/install/mac/).
 2. Install [Visual Studio Code](https://code.visualstudio.com/) and the **Dev Containers** extension.
 3. Open this repository in VS Code and select **Reopen in Container** to use `.devcontainer/devcontainer.json`.
@@ -67,6 +74,7 @@ When you're ready to share changes:
 ---
 
 ## Notes & assumptions
+
 - Stack recorded in memory (Aug 2025): SPA on `/var/www/blackroad/index.html`, Express API on port **4000**
   at `/srv/blackroad-api` with SQLite; LLM service on **127.0.0.1:8000**; NGINX proxies `/api` and `/ws`.
 - This bundle does **not** ship `node_modules/` (native builds vary by machine). Instead, it generates
@@ -105,6 +113,7 @@ curl -X POST http://localhost:4000/api/subscribe/checkout \
 curl -H "Cookie: brsid=..." http://localhost:4000/api/subscribe/portal
 # Webhooks are received at /api/stripe/webhook and must include the Stripe signature header.
 ```
+
 ## Unified Sync Pipeline
 
 Use `scripts/blackroad_sync.sh` to drive a chat-style deployment flow.
@@ -115,16 +124,19 @@ Example:
 ```
 
 The script also understands:
+
 - "Refresh working copy and redeploy"
 - "Rebase branch and update site"
 - "Sync Salesforce -> Airtable -> Droplet"
 
 It pulls from GitHub, triggers connector webhooks, updates a Working Copy checkout, and
 executes a remote refresh command on the droplet.
+
 ### BlackRoad Sync CLI
+
 `codex/tools/blackroad_sync.py` scaffolds a chat-friendly pipeline that mirrors
 commands like "Push latest to BlackRoad.io" or "Refresh working copy and
-redeploy".  Each sub-command currently logs the intended action:
+redeploy". Each sub-command currently logs the intended action:
 
 ```bash
 python codex/tools/blackroad_sync.py push
@@ -184,6 +196,7 @@ python scripts/blackroad_ci.py "Sync Salesforce -> Airtable -> Droplet"
 
 Connector and deployment steps are stubs; configure environment variables and
 extend the script to interact with real services.
+
 # BlackRoad Prism Console
 
 This repository contains assorted utilities for the BlackRoad project.
@@ -203,7 +216,9 @@ python scripts/blackroad_pipeline.py "Push latest to BlackRoad.io"
 
 The phrases recognised by the controller can be listed by invoking the
 script with an unknown command.
+
 ## Sync & Deploy
+
 ## Codex Sync/Deploy
 
 An experimental control surface lives at `codex/tools/blackroad_pipeline.py`.
@@ -273,6 +288,7 @@ into real connectors and infrastructure.
 - **Labeler/Stale/Lock**: repo hygiene.
 - **Auto-merge**: merges labeled PRs when checks pass.
 - **CodeQL/Snyk/Scorecard**: security analysis.
+
 ## Deployment
 
 Run the scaffolded end-to-end sync script to push local changes and deploy them
@@ -317,6 +333,7 @@ scripts/blackroad_codex.sh sync
 ```
 
 Set `REMOTE`, `BRANCH`, and `DROPLET_HOST` to customize targets. Provide `SLACK_WEBHOOK` to post updates.
+
 ## BlackRoad Sync & Deploy
 
 Run `scripts/blackroad_sync.sh` to push the latest changes to GitHub and roll them out to the droplet. The script accepts natural language commands, for example:
@@ -327,6 +344,7 @@ scripts/blackroad_sync.sh "Refresh working copy and redeploy"
 ```
 
 Set `WORKING_COPY_SSH`, `DROPLET_SSH`, and optionally `SLACK_WEBHOOK` environment variables before running. Logs are written to `blackroad_sync.log`.
+
 ## Codex Sync & Deploy
 
 An initial scaffold for the end-to-end BlackRoad deployment flow lives in
@@ -346,6 +364,7 @@ python3 scripts/blackroad_sync.py deploy --host user@droplet
 
 The script only prints the operations it would perform, acting as a
 placeholder for future automation.
+
 ---
 
 ## Codex Deploy Flow
@@ -387,3 +406,7 @@ scripts/blackroad_sync.py push -m "feat: update site"
 scripts/blackroad_sync.py refresh
 scripts/blackroad_sync.py sync-connectors
 ```
+
+## Backbone Equations Reference
+
+See [docs/blackroad-equation-backbone.md](docs/blackroad-equation-backbone.md) for a curated list of one hundred foundational equations across mathematics, physics, computer science, and engineering.

--- a/docs/blackroad-equation-backbone.md
+++ b/docs/blackroad-equation-backbone.md
@@ -1,0 +1,124 @@
+# BlackRoad Backbone: 100 Essential Equations
+
+This document lists one hundred foundational equations spanning mathematics, physics, computer science, and applied engineering. They form a reference backbone for BlackRoad research and study.
+
+## Pure Mathematics
+
+1. Pythagorean theorem
+2. Euler's identity $e^{i\pi} + 1 = 0$
+3. Fundamental theorem of calculus
+4. Taylor series expansion
+5. Binomial theorem
+6. Cauchy–Riemann equations
+7. Green's theorem
+8. Stokes' theorem
+9. Divergence theorem (Gauss' law in math form)
+10. Fourier series
+11. Fourier transform
+12. Laplace transform
+13. Zeta function $\zeta(s)$
+14. Riemann hypothesis statement $\zeta(s) = 0$
+15. Prime number theorem
+16. Gaussian integral
+17. Euler characteristic $V - E + F = 2$
+18. Group commutator $[A,B] = AB - BA$
+19. Eigenvalue equation $Av = \lambda v$
+20. Singular value decomposition
+
+## Classical Physics & Mechanics
+
+21. Newton's second law $F = ma$
+22. Universal gravitation $F = G \frac{m_1 m_2}{r^2}$
+23. Work–energy theorem
+24. Conservation of momentum $\vec{p} = m\vec{v}$
+25. Conservation of angular momentum
+26. Hooke's law $F = -kx$
+27. Lagrangian $\mathcal{L} = T - V$
+28. Euler–Lagrange equation
+29. Hamiltonian formulation
+30. Hamilton's equations
+31. Noether's theorem relation
+32. Wave equation
+33. Navier–Stokes equation
+34. Bernoulli's equation (fluid flow)
+35. Lorenz equations (chaos)
+
+## Relativity
+
+36. Lorentz transformations
+37. Length contraction $L = L_0/\gamma$
+38. Time dilation $\Delta t' = \gamma \Delta t$
+39. Relativistic momentum $p = \gamma mv$
+40. Energy–mass equivalence $E = mc^2$
+41. Einstein's field equations
+42. Schwarzschild metric (black holes)
+43. Geodesic equation
+44. Friedmann equations (cosmology)
+45. Hubble's law $v = H_0 d$
+
+## Quantum Mechanics
+
+46. Schrödinger equation
+47. Born rule $P = |\psi|^2$
+48. Heisenberg uncertainty principle
+49. Operator commutator $[x,p] = i\hbar$
+50. Pauli matrices
+51. Dirac equation
+52. Klein–Gordon equation
+53. Feynman path integral formulation
+54. Quantum harmonic oscillator eigenvalues
+55. Hydrogen atom spectrum formula
+56. Fermi–Dirac distribution
+57. Bose–Einstein distribution
+58. Quantum tunneling probability
+59. Density matrix formalism
+60. Lindblad master equation
+
+## Thermodynamics & Statistical Mechanics
+
+61. Ideal gas law $PV = nRT$
+62. First law of thermodynamics
+63. Second law of thermodynamics $\Delta S \ge 0$
+64. Boltzmann entropy $S = k_B \ln W$
+65. Gibbs free energy
+66. Helmholtz free energy
+67. Partition function $Z = \sum e^{-E_i/k_B T}$
+68. Maxwell relations
+69. Clausius inequality
+70. Carnot efficiency
+
+## Information, Computer Science, and Logic
+
+71. Shannon entropy
+72. Bayes' theorem
+73. Logistic function
+74. Logistic map (chaos in iteration)
+75. Log-likelihood
+76. Gradient descent update rule
+77. Backpropagation chain rule
+78. Turing halting problem statement
+79. Kolmogorov complexity
+80. RSA encryption formula
+
+## Applied Science & Engineering
+
+81. Black–Scholes equation (finance)
+82. Lotka–Volterra equations (predator-prey)
+83. SIR epidemic model
+84. Diffusion equation
+85. Heat equation
+86. Poisson's equation
+87. Laplace's equation
+88. Helmholtz equation
+89. Wave dispersion relation
+90. Doppler effect formula
+91. Bragg's law (crystallography)
+92. Fourier's law of heat conduction
+93. Ohm's law $V = IR$
+94. Kirchhoff's circuit laws
+95. Faraday's law of induction
+96. Ampère–Maxwell law
+97. Gauss's law for electric fields
+98. Gauss's law for magnetic fields
+99. Maxwell's equations unified form
+100.  Planck's radiation law


### PR DESCRIPTION
## Summary
- add canonical list of 100 foundational equations across math, physics, CS and engineering
- link the new backbone equation reference from the main README

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npx prettier docs/blackroad-equation-backbone.md README.md --check`


------
https://chatgpt.com/codex/tasks/task_e_68c2f7d718dc83298b8a5d1b353ecdf2