### PR TITLE
Scope Pages deployments to site directories

### DIFF
--- a/.github/workflows/pages-landing.yml
+++ b/.github/workflows/pages-landing.yml
@@ -1,6 +1,8 @@
-name: Deploy Pages + Proof + Circuit Breaker
+name: Deploy Landing Pages + Proof + Circuit Breaker
 on:
-  push: { branches: [main] }
+  push:
+    branches: [main]
+    paths: ['blackroad-landing/**']
   workflow_dispatch:
   schedule:
     - cron: '5 6 * * *' # daily UTC

--- a/.github/workflows/pages-stage.yml
+++ b/.github/workflows/pages-stage.yml
@@ -1,6 +1,8 @@
-name: Deploy Pages + Proof + Circuit Breaker
+name: Deploy Stage Pages + Proof + Circuit Breaker
 on:
-  push: { branches: [main] }
+  push:
+    branches: [main]
+    paths: ['blackroad-stage/**']
   workflow_dispatch:
   schedule:
     - cron: '5 6 * * *' # daily UTC

--- a/.github/workflows/stage-stress.yml
+++ b/.github/workflows/stage-stress.yml
@@ -7,6 +7,7 @@ on:
         default: 'false'
   push:
     branches: [stage]
+    paths: ['blackroad-stage/**']
 permissions: { contents: read }
 concurrency:
   group: blackroad-stage-stress


### PR DESCRIPTION
## Summary
- restore GitHub Pages workflows at repo root so Actions picks them up
- scope landing and stage workflows to their respective directories
- expose stage stress workflow at the root

## Testing
- `pre-commit run --files .github/workflows/pages-landing.yml .github/workflows/pages-stage.yml .github/workflows/stage-stress.yml`
- `npm test` *(fails: jest not found)*
- `pytest` *(fails: ModuleNotFoundError: torch, sympy, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68c30e14cb5c8329973dc726be4b6279