### PR TITLE
fix: enforce admin HMAC for protected endpoints

### DIFF
--- a/cf-worker/src/index.js
+++ b/cf-worker/src/index.js
@@ -204,8 +204,10 @@ function escapeCsv(v){
 }
 
 async function checkAdmin(req, env) {
+  const secret = env.ADMIN_HMAC;
+  if (!secret) return false;
   const sig = req.headers.get('X-Admin-HMAC') || req.headers.get('x-admin-hmac');
-  const secret = env.ADMIN_HMAC || '';
-  return timingSafeEqual(sig || '', secret);
+  if (!sig) return false;
+  return timingSafeEqual(sig, secret);
 }
 function timingSafeEqual(a,b){ if (a.length !== b.length) return false; let out=0; for (let i=0;i<a.length;i++) out |= a.charCodeAt(i)^b.charCodeAt(i); return out===0; }


### PR DESCRIPTION
## Summary
- require ADMIN_HMAC for stats/export endpoints to avoid unintended access

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68c30e5c9ff88329ab046950d9d4191b