### PR TITLE
fix: correct RRT* obstacle collision test

### DIFF
--- a/sites/blackroad/src/pages/RRTStarLab.jsx
+++ b/sites/blackroad/src/pages/RRTStarLab.jsx
@@ -9,14 +9,14 @@ function segIntersectsRect(a,b, R){ // axis-aligned rectangle R={x,y,w,h}
   const p=[-dx, dx, -dy, dy];
   const q=[a.x-R.x, R.x+R.w-a.x, a.y-R.y, R.y+R.h-a.y];
   for(let i=0;i<4;i++){
-    if(p[i]===0){ if(q[i]<0) return true; }
+    if(p[i]===0){ if(q[i]<0) return false; }
     else {
       const r=q[i]/p[i];
-      if(p[i]<0){ if(r>t1) return true; if(r>t0) t0=r; }
-      else { if(r<t0) return true; if(r<t1) t1=r; }
+      if(p[i]<0){ if(r>t1) return false; if(r>t0) t0=r; }
+      else { if(r<t0) return false; if(r<t1) t1=r; }
     }
   }
-  return false;
+  return t0<=t1;
 }
 function collision(a,b, obstacles){ for(const R of obstacles){ if(segIntersectsRect(a,b,R)) return true; } return false; }
 


### PR DESCRIPTION
## Summary
- correct Liang–Barsky collision logic in RRT* lab so obstacles block paths

## Testing
- `npm test` *(fails: jest not found)*
- `npx jest tests/api_health.test.js` *(503 Service Unavailable)*
- `npm --prefix sites/blackroad run lint`
- `npm --prefix sites/blackroad test`


------
https://chatgpt.com/codex/tasks/task_e_68c30ea659708329ad1933416599c370