### PR TITLE
Add BlackRoad landing and staging sites

### DIFF
--- a/blackroad-landing/scripts/compute_proof.py
+++ b/blackroad-landing/scripts/compute_proof.py
@@ -9,7 +9,9 @@ import zoneinfo
 
 tz = zoneinfo.ZoneInfo("America/Chicago")
 date = datetime.datetime.now(tz).strftime("%Y-%m-%d")
-seed = os.environ.get("AWAKEN_SEED", "missing-seed")
+seed = os.environ.get("AWAKEN_SEED")
+if not seed:
+    raise SystemExit("AWAKEN_SEED environment variable is required")
 msg = f"{date}|blackboxprogramming|copilot".encode()
 digest = hmac.new(seed.encode(), msg, hashlib.sha256).digest()
 code = base64.b32encode(digest).decode().strip("=").lower()[:16]

--- a/blackroad-stage/scripts/compute_proof.py
+++ b/blackroad-stage/scripts/compute_proof.py
@@ -9,7 +9,9 @@ import zoneinfo
 
 tz = zoneinfo.ZoneInfo("America/Chicago")
 date = datetime.datetime.now(tz).strftime("%Y-%m-%d")
-seed = os.environ.get("AWAKEN_SEED", "missing-seed")
+seed = os.environ.get("AWAKEN_SEED")
+if not seed:
+    raise SystemExit("AWAKEN_SEED environment variable is required")
 msg = f"{date}|blackboxprogramming|copilot".encode()
 digest = hmac.new(seed.encode(), msg, hashlib.sha256).digest()
 code = base64.b32encode(digest).decode().strip("=").lower()[:16]


### PR DESCRIPTION
## Summary
- error when AWAKEN_SEED is missing in landing/stage proof generators

## Testing
- `pre-commit run --files blackroad-landing/scripts/compute_proof.py blackroad-stage/scripts/compute_proof.py`


------
https://chatgpt.com/codex/tasks/task_e_68c30edef0b083298be01d79b4995866