### PR TITLE
fix: anchor subscribe navigation to in-page section

### DIFF
--- a/sites/blackroad/index.html
+++ b/sites/blackroad/index.html
@@ -421,7 +421,7 @@
           <a href="#docs">Docs</a>
           <a href="#portal">Portal</a>
           <a href="#pricing">Pricing</a>
-          <a href="/subscribe" onclick="return go('/subscribe')">Subscribe</a>
+          <a href="#subscribe-section">Subscribe</a>
         </nav>
 
         <button
@@ -751,17 +751,13 @@ chat("Hello, BlackRoad").then(console.log).catch(console.error);
         '/chat': 'Chat placeholder (local-only LLM to be wired later).',
         '/memories': 'Memories placeholder.',
         '/coding': 'Coding portal placeholder.',
-        '/backend': 'Backend portal placeholder.',
-        '/subscribe': 'Subscribe to updates.'
+        '/backend': 'Backend portal placeholder.'
       };
 
       function route() {
         const path = location.pathname.replace(/\/+$/, '') || '/';
         const view = document.getElementById('view');
         if (view) view.textContent = routes[path] || '404 — routed to SPA root. Use header links.';
-        if (path === '/subscribe') {
-          document.getElementById('subscribe-section')?.scrollIntoView({ behavior: 'smooth' });
-        }
       }
       window.addEventListener('popstate', route);
 
@@ -776,12 +772,6 @@ chat("Hello, BlackRoad").then(console.log).catch(console.error);
           form.reset();
         });
       });
-
-      function go(p) {
-        history.pushState({}, '', p);
-        route();
-        return false;
-      }
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- anchor Subscribe nav item to in-page section to avoid 404s
- drop unused SPA route for `/subscribe`

## Testing
- `npm test` *(fails: jest: not found)*
- `npm --prefix sites/blackroad test`


------
https://chatgpt.com/codex/tasks/task_e_68c30f0d62248329b9d5b53d271efae7