### PR TITLE
fix: buffer streaming chat chunks before parsing

### DIFF
--- a/var/www/blackroad/llm-chat.html
+++ b/var/www/blackroad/llm-chat.html
@@ -323,7 +323,6 @@
 
       let convo = [];
       let controller = null; // AbortController for streaming
-      let streamBuffer = ''; // buffer for partial streaming data
 
       function addMsg(role, text) {
         const div = document.createElement('div');
@@ -396,40 +395,43 @@
         }
       }
 
-      function parseAndAppend(pre, chunk) {
-        // Accept raw text, SSE "data: ...", or NDJSON lines
-        streamBuffer += chunk;
-        const lines = streamBuffer.split(/\r?\n/);
-        streamBuffer = lines.pop();
-        for (const line of lines) {
-          if (!line) continue;
-          if (line.startsWith('data:')) {
-            const payload = line.slice(5).trim();
-            if (!payload || payload === '[DONE]') continue;
-            let printed = false;
-            try {
-              const j = JSON.parse(payload);
-              const candidates = [
-                j?.delta,
-                j?.text,
-                j?.response,
-                j?.message?.content,
-                j?.choices?.[0]?.delta?.content,
-                j?.choices?.[0]?.message?.content,
-                j?.choices?.[0]?.text,
-              ].filter(Boolean);
-              if (candidates.length) {
-                pre.textContent += candidates[0];
-                printed = true;
-              }
-            } catch {}
-            if (!printed) pre.textContent += payload;
-          } else {
-            // plain chunk
-            pre.textContent += line;
+      function createParser(pre) {
+        let buffer = '';
+        return (chunk) => {
+          // Accept raw text, SSE "data: ...", or NDJSON lines
+          buffer += chunk;
+          const lines = buffer.split(/\r?\n/);
+          buffer = lines.pop();
+          for (const line of lines) {
+            if (!line) continue;
+            if (line.startsWith('data:')) {
+              const payload = line.slice(5).trim();
+              if (!payload || payload === '[DONE]') continue;
+              let printed = false;
+              try {
+                const j = JSON.parse(payload);
+                const candidates = [
+                  j?.delta,
+                  j?.text,
+                  j?.response,
+                  j?.message?.content,
+                  j?.choices?.[0]?.delta?.content,
+                  j?.choices?.[0]?.message?.content,
+                  j?.choices?.[0]?.text,
+                ].filter(Boolean);
+                if (candidates.length) {
+                  pre.textContent += candidates[0];
+                  printed = true;
+                }
+              } catch {}
+              if (!printed) pre.textContent += payload;
+            } else {
+              // plain chunk
+              pre.textContent += line;
+            }
           }
-        }
-        messagesEl.scrollTop = messagesEl.scrollHeight;
+          messagesEl.scrollTop = messagesEl.scrollHeight;
+        };
       }
 
       async function send() {
@@ -442,7 +444,7 @@
 
         // Stream
         controller = new AbortController();
-        streamBuffer = '';
+        const append = createParser(botPre);
         streamDot.classList.add('ok');
         try {
           const r = await fetch('/api/llm/chat', {
@@ -460,10 +462,9 @@
           while (true) {
             const { value, done } = await reader.read();
             if (done) break;
-            if (value)
-              parseAndAppend(botPre, decoder.decode(value, { stream: true }));
+            if (value) append(decoder.decode(value, { stream: true }));
           }
-          if (streamBuffer) parseAndAppend(botPre, '\n');
+          append('\n');
         } catch (e) {
           botPre.textContent += `\n[stream error] ${String(e)}`;
         } finally {


### PR DESCRIPTION
## Summary
- maintain a per-stream buffer to parse complete SSE/NDJSON lines

## Testing
- `npx prettier srv/blackroad-api/server_min.js var/www/blackroad/llm-chat.html --check`
- `npx eslint srv/blackroad-api/server_min.js` *(fails: Cannot find module '@eslint/js')*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3212c79948329b209c6742f0892bf