### PR TITLE
Add models cache, embeddings stub, and operator sandbox

### DIFF
--- a/var/www/blackroad/llm-chat.html
+++ b/var/www/blackroad/llm-chat.html
@@ -73,7 +73,8 @@ async function send(){
   const body={messages:[{role:'user',content:text}]};
   if(stream){
     try{
-      const res=await fetch('/api/llm/stream',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify(body)});
+      const res=await fetch('/api/llm/chat',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify({...body,stream:true})});
+      if(!res.ok) return fallback(body,text);
       const reader=res.body.getReader();
       const decoder=new TextDecoder();
       let buf='';


### PR DESCRIPTION
## Summary
- route chat UI stream mode to `/api/llm/chat` with `stream` flag and handle non-OK responses by falling back to standard chat

## Testing
- `node --check srv/blackroad-api/server_min.js`
- `node --check var/www/blackroad/chat-panel.js`
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68c32109271483299c58a5bd028ead0a