### PR TITLE
fix: harden RRT* collision detection

### DIFF
--- a/sites/blackroad/src/pages/RRTStarLab.jsx
+++ b/sites/blackroad/src/pages/RRTStarLab.jsx
@@ -9,14 +9,20 @@ function segIntersectsRect(a,b, R){ // axis-aligned rectangle R={x,y,w,h}
   const p=[-dx, dx, -dy, dy];
   const q=[a.x-R.x, R.x+R.w-a.x, a.y-R.y, R.y+R.h-a.y];
   for(let i=0;i<4;i++){
-    if(p[i]===0){ if(q[i]<0) return false; }
-    else {
+    if(p[i]===0){
+      if(q[i]<0) return false;
+    } else {
       const r=q[i]/p[i];
-      if(p[i]<0){ if(r>t1) return false; if(r>t0) t0=r; }
-      else { if(r<t0) return false; if(r<t1) t1=r; }
+      if(p[i]<0){
+        if(r>t1) return false;
+        if(r>t0) t0=r;
+      } else {
+        if(r<t0) return false;
+        if(r<t1) t1=r;
+      }
     }
   }
-  return t0<=t1;
+  return t0<=t1 && t1>=0 && t0<=1;
 }
 function collision(a,b, obstacles){ for(const R of obstacles){ if(segIntersectsRect(a,b,R)) return true; } return false; }
 


### PR DESCRIPTION
## Summary
- tighten Liang–Barsky clipping so only actual intersections return true
- guard against out-of-range segment parameters in RRT* obstacle checks

## Testing
- `npm test` (jest: not found)
- `npx jest tests/api_health.test.js` (503 Service Unavailable)
- `npm --prefix sites/blackroad run lint`
- `npm --prefix sites/blackroad test`


------
https://chatgpt.com/codex/tasks/task_e_68c320fd4b488329b67c5c165fd41c72