### PR TITLE
fix: stream plain text chunks immediately

### DIFF
--- a/var/www/blackroad/llm-chat.html
+++ b/var/www/blackroad/llm-chat.html
@@ -76,6 +76,8 @@ async function send(){
       const res=await fetch('/api/llm/stream',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify(body)});
       const reader=res.body.getReader();
       const decoder=new TextDecoder();
+      const type=res.headers.get('content-type')||'';
+      const evt=type.includes('event-stream')||type.includes('ndjson');
       let buf='';
       let bot='';
       addMessage('assistant','');
@@ -83,18 +85,24 @@ async function send(){
       while(true){
         const {value,done}=await reader.read();
         if(done) break;
-        buf+=decoder.decode(value,{stream:true});
-        const parts=buf.split('\n\n');
-        for(let i=0;i<parts.length-1;i++){
-          const line=parts[i].trim();
-          if(line.startsWith('data: ')){
-            const data=JSON.parse(line.slice(6));
-            if(data.delta){bot+=data.delta;last.innerHTML='<div class="pill">assistant</div>'+bot;}
-            if(data.done){return;}
+        if(evt){
+          buf+=decoder.decode(value,{stream:true});
+          let idx;
+          while((idx=buf.indexOf('\n\n'))>=0){
+            const line=buf.slice(0,idx).trim();
+            buf=buf.slice(idx+2);
+            if(line.startsWith('data: ')){
+              const data=JSON.parse(line.slice(6));
+              if(data.delta){bot+=data.delta;last.innerHTML='<div class="pill">assistant</div>'+bot;}
+              if(data.done){return;}
+            }
           }
+        }else{
+          bot+=decoder.decode(value,{stream:true});
+          last.innerHTML='<div class="pill">assistant</div>'+bot;
         }
-        buf=parts[parts.length-1];
       }
+      if(evt&&buf){bot+=buf;last.innerHTML='<div class="pill">assistant</div>'+bot;}
     }catch(e){return fallback(body,text);}
   }else{await fallback(body,text);}
 }


### PR DESCRIPTION
## Summary
- detect event-stream vs plain text responses in chat client
- stream plain text chunks without waiting for newline terminators
- flush any leftover buffer after event-stream finishes

## Testing
- `npx prettier srv/blackroad-api/server_min.js var/www/blackroad/llm-chat.html --check`
- `npx eslint srv/blackroad-api/server_min.js` *(fails: Cannot find module '@eslint/js')*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c30f6d3e1c832990a8e7773c1a01a3