### PR TITLE
fix: stream plain text chunks without buffering

### DIFF
--- a/var/www/blackroad/llm-chat.html
+++ b/var/www/blackroad/llm-chat.html
@@ -161,10 +161,8 @@
                 let finished = false;
                 for (let i = 0; i < lines.length - 1; i++) {
                   const line = lines[i].trim();
-                  if (!line) continue;
-                  const data = line.startsWith('data: ')
-                    ? JSON.parse(line.slice(6))
-                    : JSON.parse(line);
+                  if (!line || !line.startsWith('data:')) continue;
+                  const data = JSON.parse(line.slice(5).trim());
                   if (data.delta) {
                     bot += data.delta;
                     last.innerHTML = '<div class="pill">assistant</div>' + bot;
@@ -178,13 +176,13 @@
                 if (finished) {
                   if (buf.trim()) {
                     const line = buf.trim();
-                    const data = line.startsWith('data: ')
-                      ? JSON.parse(line.slice(6))
-                      : JSON.parse(line);
-                    if (data.delta) {
-                      bot += data.delta;
-                      last.innerHTML =
-                        '<div class="pill">assistant</div>' + bot;
+                    if (line.startsWith('data:')) {
+                      const data = JSON.parse(line.slice(5).trim());
+                      if (data.delta) {
+                        bot += data.delta;
+                        last.innerHTML =
+                          '<div class="pill">assistant</div>' + bot;
+                      }
                     }
                   }
                   return;
@@ -196,12 +194,12 @@
             }
             if (isEvent && buf.trim()) {
               const line = buf.trim();
-              const data = line.startsWith('data: ')
-                ? JSON.parse(line.slice(6))
-                : JSON.parse(line);
-              if (data.delta) {
-                bot += data.delta;
-                last.innerHTML = '<div class="pill">assistant</div>' + bot;
+              if (line.startsWith('data:')) {
+                const data = JSON.parse(line.slice(5).trim());
+                if (data.delta) {
+                  bot += data.delta;
+                  last.innerHTML = '<div class="pill">assistant</div>' + bot;
+                }
               }
             }
           } catch (e) {


### PR DESCRIPTION
## Summary
- skip non-data SSE lines before JSON parsing to avoid abandoning healthy streams

## Testing
- `npx prettier var/www/blackroad/llm-chat.html --check`
- `npx eslint var/www/blackroad/llm-chat.html` *(fails: Cannot find module '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3292cc41c8329884fc47e1842eed5