### PR TITLE
fix: skip comment lines in runner host list

### DIFF
--- a/usr/local/bin/fix_runners.sh
+++ b/usr/local/bin/fix_runners.sh
@@ -195,11 +195,11 @@ export GITHUB_TOKEN SCOPE OWNER REPO GH_URL RUNNER_VERSION RUNNER_BASE RUNNER_NA
 
 # Kick off in parallel
 if command -v xargs >/dev/null 2>&1; then
-  cat "$HOSTS_FILE" | grep -v '^\s*$' | grep -v '^\s*#' | xargs -I{} -P "$PARALLEL" bash -lc 'fix_one "$@"' _ {}
+  cat "$HOSTS_FILE" | grep -v '^[[:space:]]*$' | grep -v '^[[:space:]]*#' | xargs -I{} -P "$PARALLEL" bash -lc 'fix_one "$@"' _ {}
 else
   # Fallback: sequential
   while IFS= read -r h; do
-    [[ -z "$h" || "$h" =~ ^# ]] && continue
+    [[ "$h" =~ ^[[:space:]]*$ || "$h" =~ ^[[:space:]]*# ]] && continue
     fix_one "$h"
   done < "$HOSTS_FILE"
 fi


### PR DESCRIPTION
## Summary
- ignore blank and commented lines when enumerating hosts for fix_runners.sh

## Testing
- `bash -n usr/local/bin/fix_runners.sh`
- `npm test` *(fails: command not found: npm)*
- `npm run lint` *(fails: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68c329133eb08329b8a78b8c13f3ad03