### PR TITLE
feat: add desktop-style agent windows

### DIFF
--- a/sites/blackroad/src/pages/Desktop.jsx
+++ b/sites/blackroad/src/pages/Desktop.jsx
@@ -54,7 +54,9 @@ function Window({ id, title, layout, setLayout, children }) {
       >
         <div className="flex items-center justify-between bg-neutral-800 text-white px-2 py-1 cursor-move">
           <span id={`${id}-title`} className="text-sm flex items-center gap-1">
-            <span className="text-green-400">●</span>
+            <span className="text-green-400" aria-hidden="true">
+              ●
+            </span>
             {title}
           </span>
           <div className="space-x-1">


### PR DESCRIPTION
## Summary
- add explicit type, aria-label, and pressed state to Desktop dock buttons for accessibility
- identify draggable windows as dialogs tied to their visible titles
- hide decorative window bullets from assistive tech

## Testing
- `pre-commit run --files sites/blackroad/src/pages/Desktop.jsx`
- `npm test`
- `npm run lint` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npm --prefix sites/blackroad run lint`
- `npm --prefix sites/blackroad test`


------
https://chatgpt.com/codex/tasks/task_e_68c329b751b88329ba13e31ef38aa323