### PR TITLE
test: cover KS distance edge case

### DIFF
--- a/experiments/hilbert_polya_gue.py
+++ b/experiments/hilbert_polya_gue.py
@@ -29,6 +29,8 @@ def ks_distance(sample: np.ndarray, cdf: Callable[[np.ndarray], np.ndarray]) -> 
     """Return the two-sided Kolmogorov–Smirnov distance between a sample and a CDF."""
     x = np.sort(sample)
     n = x.size
+    if n == 0:
+        raise ValueError("sample must contain at least one element")
     cdf_vals = cdf(x)
     ecdf_right = np.arange(1, n + 1) / n
     ecdf_left = np.arange(0, n) / n

--- a/tests/test_hilbert_polya_gue.py
+++ b/tests/test_hilbert_polya_gue.py
@@ -1,0 +1,13 @@
+import numpy as np
+
+from experiments.hilbert_polya_gue import ks_distance
+
+
+def test_ks_distance_two_sided():
+    sample = np.array([0.1, 0.4, 0.8])
+
+    def uniform_cdf(x):
+        return x
+
+    result = ks_distance(sample, uniform_cdf)
+    assert abs(result - 4 / 15) < 1e-9


### PR DESCRIPTION
## Summary
- ensure `ks_distance` errors on empty samples
- add unit test verifying two-sided KS statistic

## Testing
- `pre-commit run --files experiments/hilbert_polya_gue.py tests/test_hilbert_polya_gue.py`
- `pytest tests/test_hilbert_polya_gue.py`
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c32c1358248329bbae2822743346bc