### PR TITLE
fix: resolve child promise on onClose errors

### DIFF
--- a/srv/blackroad-api/modules/jobs_locked.js
+++ b/srv/blackroad-api/modules/jobs_locked.js
@@ -269,8 +269,13 @@ function wireChild(job_id, child, onClose) {
     child.stderr?.on('data', (buf) => handleChunk(buf, 'stderr'));
     child.on('close', async (code) => {
       PROCS.delete(job_id);
-      await onClose(code, lastPct);
-      resolve();
+      try {
+        await onClose(code, lastPct);
+      } catch (err) {
+        console.error('onClose error', err);
+      } finally {
+        resolve();
+      }
     });
   });
 }


### PR DESCRIPTION
## Summary
- ensure `wireChild` promise resolves even if `onClose` throws
- log errors from `onClose` to avoid silent failures

## Testing
- `pre-commit run --files srv/blackroad-api/modules/jobs_locked.js` *(fails: Cannot find module '@eslint/js')*
- `SKIP=eslint pre-commit run --files srv/blackroad-api/modules/jobs_locked.js`
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c32a9c16cc832992dba447fe13f328