### PR TITLE
Refactor console app and add numeric parser tests

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,64 +1,51 @@
-import streamlit as st
-from openai import OpenAI
-import numpy as np
-import matplotlib.pyplot as plt
-import ast
-"""Streamlit app for BlackRoad Prism Generator with GPT and voice input."""
-
 import io
 import os
 import tempfile
 
 import matplotlib.pyplot as plt
 import numpy as np
-import openai
-import streamlit as st
-import whisper
-import ast
-
-
-@st.cache_resource
-def load_whisper_model():
-    """Load the Whisper model once and reuse across reruns."""
-    return whisper.load_model("base")
-
-client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
-api_key = os.getenv("OPENAI_API_KEY")
-if api_key:
-    client = OpenAI(api_key=api_key)
-else:
-    client = None
-    st.warning("OpenAI API key not set. Set OPENAI_API_KEY to enable responses.")
-client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
-client = OpenAI(api_key=api_key) if api_key else None
-client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
-
-# Cache the Whisper model so it's loaded only once
-@st.cache_resource
-def load_whisper_model():
-    return whisper.load_model("base")
 import streamlit as st
 import whisper
 from openai import OpenAI
+from streamlit.runtime.uploaded_file_manager import UploadedFile
 
-# Configure OpenAI client
-_api_key = os.getenv("OPENAI_API_KEY")
-if not _api_key:
-    st.warning("OPENAI_API_KEY not set; responses will be unavailable.")
-    client = None
-else:
-    client = OpenAI(api_key=_api_key)
+from prism_utils import parse_numeric_prefix
 
-@st.cache_resource
-def get_whisper_model():
-    """Load and cache the Whisper model to avoid reloading on each request."""
-    return whisper.load_model("base")
-
-openai.api_key = os.getenv("OPENAI_API_KEY")
+"""Streamlit app for the BlackRoad Prism Generator with GPT and voice input."""
 
 st.set_page_config(layout="wide")
 st.title("BlackRoad Prism Generator with GPT + Voice Console")
 
+# Configure OpenAI client
+_api_key = os.getenv("OPENAI_API_KEY")
+client = OpenAI(api_key=_api_key) if _api_key else None
+if client is None:
+    st.warning("OpenAI API key not set. Set OPENAI_API_KEY to enable responses.")
+
+
+@st.cache_resource
+def get_whisper_model():
+    """Load and cache the Whisper model."""
+    return whisper.load_model("base")
+
+
+def transcribe_audio(uploaded_file: UploadedFile) -> str:
+    """Transcribe an uploaded audio file using Whisper."""
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as tmp:
+        tmp.write(uploaded_file.read())
+        tmp_path = tmp.name
+    try:
+        model = get_whisper_model()
+        result = model.transcribe(tmp_path)
+    finally:
+        try:
+            os.remove(tmp_path)
+        except OSError:
+            pass
+    return result["text"]
+
+
+# Initialize chat history
 if "chat_history" not in st.session_state:
     st.session_state.chat_history = [
         {
@@ -71,161 +58,45 @@ if "chat_history" not in st.session_state:
     ]
 
 st.markdown(
-    """
-#### Speak or type an idea, formula, or question. The AI will respond and project a hologram:
-"""
+    "#### Speak or type an idea, formula, or question. The AI will respond and project a hologram:"
 )
-
-@st.cache_resource
-def load_whisper_model():
-    """Load the Whisper model once to avoid repeated initialization."""
-    return whisper.load_model("base")
-
-
-def parse_numeric_prefix(text: str) -> float:
-    """Return the leading numeric value in ``text`` or ``1.0`` if not found."""
-    try:
-        value = ast.literal_eval(text.split(",", maxsplit=1)[0].strip())
-        if isinstance(value, (int, float)):
-            return float(value)
-    except Exception:
-        pass
-    return 1.0
-
-
-# Audio input
-@st.cache_resource
-def load_whisper_model():
-    """Load Whisper model once and cache for subsequent requests."""
-    return whisper.load_model("base")
-
 
 audio_file = st.file_uploader("Upload your voice (mp3 or wav)", type=["mp3", "wav"])
 if audio_file is not None:
-    suffix = os.path.splitext(audio_file.name)[1] or ".wav"
-    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as temp_audio:
-        temp_audio.write(audio_file.read())
-    """#### Speak or type an idea, formula, or question. The AI will respond and project a hologram:"""
-)
-
-
-def _transcribe_audio(uploaded_file: st.runtime.uploaded_file_manager.UploadedFile) -> str:
-    """Transcribe an uploaded audio file using Whisper and clean up the temp file."""
-    with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as temp_audio:
-        temp_audio.write(uploaded_file.read())
-        temp_audio_path = temp_audio.name
-    model = load_whisper_model()
-    result = model.transcribe(temp_audio_path)
-    os.remove(temp_audio_path)
-    os.unlink(temp_audio_path)
-
-    if "whisper_model" not in st.session_state:
-        st.session_state.whisper_model = whisper.load_model("base")
-    model = st.session_state.whisper_model
-    result = model.transcribe(temp_audio_path)
-    os.remove(temp_audio_path)
-
-    model = get_whisper_model()
-    result = model.transcribe(temp_audio_path)
-    os.unlink(temp_audio_path)
-    user_input = result["text"]
-    return result["text"]
-
-
-audio_file = st.file_uploader("Upload your voice (mp3 or wav)", type=["mp3", "wav"])
-if audio_file is not None:
-    user_input = _transcribe_audio(audio_file)
+    user_input = transcribe_audio(audio_file)
     st.markdown(f"**You said:** {user_input}")
-    try:
-        model = load_whisper_model()
-        result = model.transcribe(temp_audio_path)
-        user_input = result["text"]
-        st.markdown(f"**You said:** {user_input}")
-    finally:
-        try:
-            os.remove(temp_audio_path)
-        except OSError:
-            pass
 else:
     user_input = st.text_input("Or type here")
 
 if user_input:
-    try:
-        if not client:
-            st.error("OpenAI API key not set.")
-            raise RuntimeError("missing api key")
-
+    if not client:
+        st.error("OpenAI API key not set.")
+    else:
         st.session_state.chat_history.append({"role": "user", "content": user_input})
-
-        # GPT response with full history
         response = client.chat.completions.create(
             model="gpt-4o-mini",
-        if client is None:
-            raise ValueError("OpenAI API key is not configured")
-        response = client.chat.completions.create(
-        if not openai.api_key:
-            raise RuntimeError("OpenAI API key not configured.")
-
-        st.session_state.chat_history.append({"role": "user", "content": user_input})
-
-        response = openai.ChatCompletion.create(
-            model="gpt-4",
             messages=st.session_state.chat_history,
         )
         assistant_reply = response.choices[0].message.content
         st.session_state.chat_history.append({"role": "assistant", "content": assistant_reply})
-        if client:
-            response = client.chat.completions.create(
-                model="gpt-4o-mini",
-                messages=st.session_state.chat_history,
-            )
-            assistant_reply = response.choices[0].message.content
-        else:
-            assistant_reply = "OpenAI API key not provided."
-
-        st.session_state.chat_history.append({"role": "assistant", "content": assistant_reply})
         st.markdown(f"**Venture Console AI:** {assistant_reply}")
 
-        result = parse_numeric_prefix(user_input)
-        try:
-            result = float(user_input.split(",")[0])
-        except ValueError:
-            result = 1.0
-
+        magnitude = parse_numeric_prefix(user_input)
         fig = plt.figure(figsize=(6, 4))
         ax = fig.add_subplot(111, projection="3d")
-        X = np.linspace(-5, 5, 100)
-        Y = np.linspace(-5, 5, 100)
-        X, Y = np.meshgrid(X, Y)
-        Z = np.sin(np.sqrt(X**2 + Y**2)) * result
-
-        ax.plot_surface(X, Y, Z, cmap="plasma")
+        x = np.linspace(-5, 5, 100)
+        y = np.linspace(-5, 5, 100)
+        x, y = np.meshgrid(x, y)
+        z = np.sin(np.sqrt(x**2 + y**2)) * magnitude
+        ax.plot_surface(x, y, z, cmap="plasma")
         ax.axis("off")
 
         buf = io.BytesIO()
         plt.savefig(buf, format="png")
         buf.seek(0)
         st.image(buf)
-        with io.BytesIO() as buf:
-            plt.savefig(buf, format="png")
-            buf.seek(0)
-            st.image(buf)
         plt.close(fig)
 
-    except Exception as e:
-        if str(e) != "missing api key":
-            st.error(f"Error: {e}")
-
 st.markdown("---")
 st.markdown("**BlackRoad Prism Console** | Live UI Simulation")
-st.image("72BF9767-A2EE-4CB6-93F4-4D738108BC4B.png", caption="Live Console Interface")
-    except Exception as e:  # pragma: no cover - Streamlit handles runtime errors
-        st.error(f"Error: {e}")
-
-st.markdown("---")
-st.markdown("**BlackRoad Prism Console** | Live UI Simulation")
-st.image(
-    "72BF9767-A2EE-4CB6-93F4-4D738108BC4B.png",
-    caption="Live Console Interface",
-)
 st.image("72BF9767-A2EE-4CB6-93F4-4D738108BC4B.png", caption="Live Console Interface")

--- a/prism_utils.py
+++ b/prism_utils.py
@@ -1,0 +1,21 @@
+"""Utility functions for the BlackRoad Prism console."""
+
+from __future__ import annotations
+
+import ast
+
+
+def parse_numeric_prefix(text: str) -> float:
+    """Return the leading numeric value in ``text`` or ``1.0`` if not found.
+
+    This uses :func:`ast.literal_eval` for safety instead of ``eval`` and
+    accepts inputs like ``"2, something"``. Non-numeric or invalid values
+    default to ``1.0``.
+    """
+    try:
+        value = ast.literal_eval(text.split(",", maxsplit=1)[0].strip())
+        if isinstance(value, (int, float)):
+            return float(value)
+    except Exception:
+        pass
+    return 1.0

--- a/tests/test_prism_utils.py
+++ b/tests/test_prism_utils.py
@@ -1,0 +1,11 @@
+from prism_utils import parse_numeric_prefix
+
+
+def test_parse_numeric_prefix_valid():
+    assert parse_numeric_prefix("2, rest") == 2.0
+    assert parse_numeric_prefix("3.5") == 3.5
+
+
+def test_parse_numeric_prefix_invalid():
+    assert parse_numeric_prefix("abc") == 1.0
+    assert parse_numeric_prefix("1a") == 1.0


### PR DESCRIPTION
## Summary
- streamline prism console script and remove duplicated logic
- extract safe numeric parsing helper and cover with tests

## Testing
- `pre-commit run --files main.py prism_utils.py tests/test_prism_utils.py`
- `python3 -m py_compile main.py prism_utils.py tests/test_prism_utils.py`
- `pytest tests/test_prism_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68c32b87c1f083299fa5f0102b8b562d