### PR TITLE
refactor: restrict numeric parsing to decimals

### DIFF
--- a/prism_utils.py
+++ b/prism_utils.py
@@ -2,20 +2,23 @@
 
 from __future__ import annotations
 
-import ast
+import re
+
+# Precompiled regex to extract a leading decimal number with optional sign.
+_NUMERIC_PREFIX = re.compile(r"^\s*([+-]?\d+(?:\.\d+)?)")
 
 
 def parse_numeric_prefix(text: str) -> float:
-    """Return the leading numeric value in ``text`` or ``1.0`` if not found.
+    """Return the leading decimal value in ``text`` or ``1.0`` if absent.
 
-    This uses :func:`ast.literal_eval` for safety instead of ``eval`` and
-    accepts inputs like ``"2, something"``. Non-numeric or invalid values
-    default to ``1.0``.
+    Only simple base-10 numbers are supported to avoid evaluating arbitrary
+    Python expressions. Inputs like ``"2, something"`` are accepted. Non-numeric
+    or invalid values default to ``1.0``.
     """
-    try:
-        value = ast.literal_eval(text.split(",", maxsplit=1)[0].strip())
-        if isinstance(value, (int, float)):
-            return float(value)
-    except Exception:
-        pass
+    match = _NUMERIC_PREFIX.match(text)
+    if match:
+        try:
+            return float(match.group(1))
+        except ValueError:
+            pass
     return 1.0

--- a/tests/test_prism_utils.py
+++ b/tests/test_prism_utils.py
@@ -4,8 +4,12 @@ from prism_utils import parse_numeric_prefix
 def test_parse_numeric_prefix_valid():
     assert parse_numeric_prefix("2, rest") == 2.0
     assert parse_numeric_prefix("3.5") == 3.5
+    assert parse_numeric_prefix("-1 stuff") == -1.0
+    assert parse_numeric_prefix("+4") == 4.0
 
 
 def test_parse_numeric_prefix_invalid():
     assert parse_numeric_prefix("abc") == 1.0
     assert parse_numeric_prefix("1a") == 1.0
+    assert parse_numeric_prefix("") == 1.0
+    assert parse_numeric_prefix("+a") == 1.0


### PR DESCRIPTION
## Summary
- tighten numeric parsing with regex to avoid evaluating arbitrary expressions
- expand coverage for parse_numeric_prefix, including sign and empty cases

## Testing
- `pytest tests/test_prism_utils.py`
- `pre-commit run --files prism_utils.py tests/test_prism_utils.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c32fc7c0048329b8776918e6a6dc06