### PR TITLE
chore: remove unused import

### DIFF
--- a/scripts/org_audit.py
+++ b/scripts/org_audit.py
@@ -15,7 +15,6 @@ import datetime as dt
 import json
 import os
 import pathlib
-import subprocess
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 


### PR DESCRIPTION
## Summary
- drop unused subprocess import in org audit script

## Testing
- `python -m py_compile scripts/org_audit.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68c32f9707608329b39090626390ee43