### PR TITLE
docs(codex): clarify repo discovery comments

### DIFF
--- a/bin/codex-grab
+++ b/bin/codex-grab
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Optional: GitHub token (needed for private repos & higher rate limits)
+# Optional: set GITHUB_TOKEN (or GH_TOKEN) for private repos or higher rate limits
 # export GITHUB_TOKEN=ghp_xxx
 
-# Optional: your SSH key/known_hosts are already wired by the wizard; nothing else needed here.
+# SSH keys and known_hosts are configured by the wizard; no additional setup needed.
 
 python3 codex/tools/codex_repo_discover.py "$@"

--- a/codex/tools/codex_repo_discover.py
+++ b/codex/tools/codex_repo_discover.py
@@ -1,17 +1,18 @@
 #!/usr/bin/env python3
-"""
-Codex Repo Discover + Sync (GitHub)
-- Lists all repositories for a GitHub user/org (default: blackboxprogramming)
-- Merges them into codex/config/repos.json (auth=ssh by default)
-- Clones/Pulls every repo into codex/repos/
-- Writes codex/runtime/manifests/codex_repos_manifest.json
-- Emits minimal Codex events (repo.sync.ok / repo.sync.errors)
+"""Discover and sync GitHub repositories into Codex.
+
+- List repositories for a GitHub user or org (default: blackboxprogramming)
+- Merge them into ``codex/config/repos.json`` (``auth=ssh`` by default)
+- Clone or pull each repo into ``codex/repos/``
+- Write ``codex/runtime/manifests/codex_repos_manifest.json``
+- Emit minimal Codex events (``repo.sync.ok`` / ``repo.sync.errors``)
 
 Requirements:
   - Python 3.9+
   - git CLI available
-  - (Recommended) SSH key + pinned known_hosts via your existing wizard
-  - GITHUB_TOKEN (optional) for private repos/higher rate limits
+  - (Recommended) SSH key and pinned ``known_hosts`` via your existing wizard
+  - ``GITHUB_TOKEN``, ``GH_TOKEN``, or ``PERSONAL_ACCESS_TOKEN`` (optional) for private
+    repositories or higher rate limits
 
 Usage:
   python3 codex/tools/codex_repo_discover.py \
@@ -19,48 +20,68 @@ Usage:
       --include-private \
       --exclude-forks
 """
-import json, os, sys, time, shlex, subprocess, argparse
-from pathlib import Path
-from datetime import datetime
-from urllib.request import Request, urlopen
-from urllib.error import HTTPError, URLError
 
-BASE                = Path("codex")
-CFG_PATH            = BASE / "config" / "repos.json"
-MANIFEST_DIR        = BASE / "runtime" / "manifests"
-MANIFEST_PATH       = MANIFEST_DIR / "codex_repos_manifest.json"
-EVENTS_DIR          = BASE / "runtime" / "events"
-REPO_BASE_DEFAULT   = BASE / "repos"
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+BASE = Path("codex")
+CFG_PATH = BASE / "config" / "repos.json"
+MANIFEST_DIR = BASE / "runtime" / "manifests"
+MANIFEST_PATH = MANIFEST_DIR / "codex_repos_manifest.json"
+EVENTS_DIR = BASE / "runtime" / "events"
+REPO_BASE_DEFAULT = BASE / "repos"
 
 API_ROOT = "https://api.github.com"
 
-def now_utc(): return datetime.utcnow().isoformat() + "Z"
-def ensure_dir(p: Path): p.mkdir(parents=True, exist_ok=True)
+
+def now_utc():
+    return datetime.utcnow().isoformat() + "Z"
+
+
+def ensure_dir(p: Path):
+    p.mkdir(parents=True, exist_ok=True)
+
+
 def load_json(p: Path, default=None):
-    try: return json.loads(p.read_text())
-    except Exception: return default
+    try:
+        return json.loads(p.read_text())
+    except Exception:
+        return default
+
 
 def save_json(p: Path, obj):
     ensure_dir(p.parent)
     p.write_text(json.dumps(obj, indent=2))
 
+
 def run(cmd, cwd=None, env=None, check=True):
-    if isinstance(cmd, str): cmd = shlex.split(cmd)
-    p = subprocess.Popen(cmd, cwd=cwd, env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    if isinstance(cmd, str):
+        cmd = shlex.split(cmd)
+    p = subprocess.Popen(
+        cmd, cwd=cwd, env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+    )
     out, _ = p.communicate()
     if check and p.returncode != 0:
         raise RuntimeError(f"$ {' '.join(cmd)}\n{out}")
     return out
 
+
 def gh_request(url, token=None):
-    hdrs = {
-        "Accept": "application/vnd.github+json",
-        "User-Agent": "codex-repo-discover/1.0"
-    }
+    hdrs = {"Accept": "application/vnd.github+json", "User-Agent": "codex-repo-discover/1.0"}
     if token:
         hdrs["Authorization"] = f"Bearer {token}"
     req = Request(url, headers=hdrs)
     return urlopen(req, timeout=30)
+
 
 def gh_list_repos(owner, token=None, include_private=False):
     # Works for both users and orgs: GET /users/{owner}/repos and /orgs/{owner}/repos behave similarly.
@@ -90,36 +111,38 @@ def gh_list_repos(owner, token=None, include_private=False):
         all_repos = [r for r in all_repos if not r.get("private")]
     return all_repos
 
+
 def to_cfg_entry(repo, default_branch="main"):
-    name   = repo["name"]
+    name = repo["name"]
     # Prefer SSH URL so we leverage your pinned known_hosts & SSH key
-    ssh_url = repo.get("ssh_url")               # git@github.com:owner/name.git
-    branch  = repo.get("default_branch") or default_branch
+    ssh_url = repo.get("ssh_url")  # git@github.com:owner/name.git
+    branch = repo.get("default_branch") or default_branch
     return {
         "name": name,
         "url": ssh_url,
         "branch": branch,
         "auth": "ssh",
         "read_only": False,
-        "shallow": True
+        "shallow": True,
     }
+
 
 def merge_into_repos_json(new_entries, base_dir: Path, default_branch="main"):
     cfg = load_json(CFG_PATH) or {
         "base_dir": str(base_dir),
-        "git_ssh_key": os.environ.get("CODEX_SSH_KEY","~/.ssh/id_ed25519"),
+        "git_ssh_key": os.environ.get("CODEX_SSH_KEY", "~/.ssh/id_ed25519"),
         "git_ssh_strict_hostkey": True,
         "default_branch": default_branch,
-        "repositories": []
+        "repositories": [],
     }
     existing = {r["name"]: r for r in cfg.get("repositories", [])}
     updated = 0
-    added   = 0
+    added = 0
     for e in new_entries:
         if e["name"] in existing:
             # update URL/branch/auth/shallow but keep read_only flag if set
             old = existing[e["name"]]
-            old.update({k: e[k] for k in ("url","branch","auth","shallow")})
+            old.update({k: e[k] for k in ("url", "branch", "auth", "shallow")})
             existing[e["name"]] = old
             updated += 1
         else:
@@ -128,6 +151,7 @@ def merge_into_repos_json(new_entries, base_dir: Path, default_branch="main"):
     cfg["repositories"] = sorted(existing.values(), key=lambda r: r["name"].lower())
     save_json(CFG_PATH, cfg)
     return cfg, added, updated
+
 
 def build_git_env(cfg):
     env = os.environ.copy()
@@ -140,46 +164,47 @@ def build_git_env(cfg):
             "-o StrictHostKeyChecking=yes"
         )
     else:
-        env["GIT_SSH_COMMAND"] = (
-            f"ssh -i {shlex.quote(key)} -o StrictHostKeyChecking=accept-new"
-        )
+        env["GIT_SSH_COMMAND"] = f"ssh -i {shlex.quote(key)} -o StrictHostKeyChecking=accept-new"
     return env
+
 
 def repo_state(repo_dir: Path):
     try:
-        sha = run(["git","rev-parse","HEAD"], cwd=repo_dir).strip()
-        br  = run(["git","rev-parse","--abbrev-ref","HEAD"], cwd=repo_dir).strip()
+        sha = run(["git", "rev-parse", "HEAD"], cwd=repo_dir).strip()
+        br = run(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=repo_dir).strip()
         return sha, br
     except Exception:
         return None, None
 
+
 def clone_or_pull(entry, base: Path, env):
-    name   = entry["name"]
-    url    = entry["url"]
+    name = entry["name"]
+    url = entry["url"]
     branch = entry.get("branch") or "main"
-    shallow= entry.get("shallow", True)
+    shallow = entry.get("shallow", True)
 
     repo_dir = base / name
     ensure_dir(base)
 
     if not repo_dir.exists():
-        cmd = ["git","clone","--branch",branch]
-        if shallow: cmd += ["--depth","1","--no-single-branch"]
+        cmd = ["git", "clone", "--branch", branch]
+        if shallow:
+            cmd += ["--depth", "1", "--no-single-branch"]
         cmd += [url, str(repo_dir)]
         run(cmd, env=env)
         action = "cloned"
     else:
-        if not (repo_dir/".git").exists():
+        if not (repo_dir / ".git").exists():
             raise RuntimeError(f"{repo_dir} exists but is not a git repo")
-        run(["git","remote","set-url","origin",url], cwd=repo_dir, env=env)
-        run(["git","fetch","origin",branch], cwd=repo_dir, env=env)
-        run(["git","checkout",branch], cwd=repo_dir, env=env)
+        run(["git", "remote", "set-url", "origin", url], cwd=repo_dir, env=env)
+        run(["git", "fetch", "origin", branch], cwd=repo_dir, env=env)
+        run(["git", "checkout", branch], cwd=repo_dir, env=env)
         # prefer fast-forward only
         try:
-            run(["git","merge","--ff-only",f"origin/{branch}"], cwd=repo_dir, env=env)
+            run(["git", "merge", "--ff-only", f"origin/{branch}"], cwd=repo_dir, env=env)
         except Exception:
             # fallback: rebase to keep history linear
-            run(["git","rebase",f"origin/{branch}"], cwd=repo_dir, env=env)
+            run(["git", "rebase", f"origin/{branch}"], cwd=repo_dir, env=env)
         action = "updated"
 
     sha, br = repo_state(repo_dir)
@@ -189,21 +214,28 @@ def clone_or_pull(entry, base: Path, env):
         "branch": br or branch,
         "head": sha or "",
         "url": url,
-        "auth": entry.get("auth","ssh"),
+        "auth": entry.get("auth", "ssh"),
         "read_only": bool(entry.get("read_only", False)),
-        "action": action
+        "action": action,
     }
+
 
 def emit(kind, payload):
     ensure_dir(EVENTS_DIR)
     fn = EVENTS_DIR / f"{datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')}_{kind}.jsonl"
     with fn.open("a") as f:
-        f.write(json.dumps({
-            "id": f"{kind}:{int(time.time()*1000)}",
-            "kind": kind,
-            "ts": now_utc(),
-            "payload": payload
-        }) + "\n")
+        f.write(
+            json.dumps(
+                {
+                    "id": f"{kind}:{int(time.time()*1000)}",
+                    "kind": kind,
+                    "ts": now_utc(),
+                    "payload": payload,
+                }
+            )
+            + "\n"
+        )
+
 
 def main():
     ap = argparse.ArgumentParser()
@@ -214,23 +246,33 @@ def main():
     ap.add_argument("--default-branch", default="main")
     args = ap.parse_args()
 
-    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN") or os.environ.get("PERSONAL_ACCESS_TOKEN")
+    token = (
+        os.environ.get("GITHUB_TOKEN")
+        or os.environ.get("GH_TOKEN")
+        or os.environ.get("PERSONAL_ACCESS_TOKEN")
+    )
 
     # 1) Discover
     try:
         repos = gh_list_repos(args.owner, token=token, include_private=args.include_private)
     except HTTPError as e:
-        print(f"GitHub API error: {e}", file=sys.stderr); sys.exit(1)
+        print(f"GitHub API error: {e}", file=sys.stderr)
+        sys.exit(1)
     except URLError as e:
-        print(f"Network error: {e}", file=sys.stderr); sys.exit(1)
+        print(f"Network error: {e}", file=sys.stderr)
+        sys.exit(1)
 
     if args.exclude_forks:
         repos = [r for r in repos if not r.get("fork")]
 
-    entries = [to_cfg_entry(r, default_branch=args.default_branch) for r in repos if r.get("ssh_url")]
+    entries = [
+        to_cfg_entry(r, default_branch=args.default_branch) for r in repos if r.get("ssh_url")
+    ]
 
     # 2) Merge into repos.json
-    cfg, added, updated = merge_into_repos_json(entries, Path(args.base_dir), default_branch=args.default_branch)
+    cfg, added, updated = merge_into_repos_json(
+        entries, Path(args.base_dir), default_branch=args.default_branch
+    )
     print(f"Discovered: {len(entries)} | Added: {added} | Updated: {updated}")
 
     # 3) Sync (clone/pull)
@@ -241,7 +283,9 @@ def main():
     results, errors = [], []
     for entry in cfg["repositories"]:
         # only process repos from this owner; skip others already present in config
-        if not (entry["url"] or "").endswith(f"{args.owner}.git") and f":{args.owner}/" not in (entry["url"] or ""):
+        if not (entry["url"] or "").endswith(f"{args.owner}.git") and f":{args.owner}/" not in (
+            entry["url"] or ""
+        ):
             continue
         try:
             res = clone_or_pull(entry, base, env)
@@ -257,7 +301,7 @@ def main():
         "generated_at": now_utc(),
         "base_dir": str(base),
         "repos": results,
-        "errors": errors
+        "errors": errors,
     }
     save_json(MANIFEST_PATH, manifest)
 
@@ -268,6 +312,7 @@ def main():
     else:
         emit("repo.sync.ok", {"count": len(results)})
         print(f"\nAll good. Manifest written:\n  {MANIFEST_PATH}")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- clarify environment token guidance in codex repo discovery script
- note SSH key/known_hosts setup in codex-grab helper
- organize imports and refresh docstring

## Testing
- `pre-commit run --files bin/codex-grab codex/tools/codex_repo_discover.py`
- `python -m py_compile codex/tools/codex_repo_discover.py`
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c32fd470e48329bf3a6302f76d5a0a