### PR TITLE
Fix module docstring placement

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+"""Streamlit app for the BlackRoad Prism Generator with GPT and voice input."""
+
 import io
 import os
 import tempfile
@@ -10,8 +12,6 @@ from openai import OpenAI
 from streamlit.runtime.uploaded_file_manager import UploadedFile
 
 from prism_utils import parse_numeric_prefix
-
-"""Streamlit app for the BlackRoad Prism Generator with GPT and voice input."""
 
 st.set_page_config(layout="wide")
 st.title("BlackRoad Prism Generator with GPT + Voice Console")


### PR DESCRIPTION
## Summary
- move Streamlit console's module docstring to top of `main.py`

## Testing
- `pre-commit run --files main.py`
- `pytest tests/test_prism_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68c32fe474fc83299919711a1b0f106f