### PR TITLE
test: expand Git API tests and tidy route imports

### DIFF
--- a/srv/blackroad-api/routes/git.js
+++ b/srv/blackroad-api/routes/git.js
@@ -1,7 +1,5 @@
 const express = require('express');
 const { execFile } = require('child_process');
-const fs = require('fs');
-const path = require('path');
 
 const router = express.Router();
 

--- a/tests/git_api.test.js
+++ b/tests/git_api.test.js
@@ -24,4 +24,21 @@ describe('Git API', () => {
     expect(typeof res.body.repoPath).toBe('string');
     expect(res.body.readOnly).toBe(true);
   });
+
+  it('returns git status info', async () => {
+    const login = await request(app)
+      .post('/api/login')
+      .send({ username: 'root', password: 'Codex2025' });
+    const cookie = login.headers['set-cookie'];
+    const res = await request(app)
+      .get('/api/git/status')
+      .set('Cookie', cookie);
+    expect(res.status).toBe(200);
+    expect(typeof res.body.branch).toBe('string');
+    expect(res.body.counts).toBeDefined();
+    expect(res.body.counts).toHaveProperty('staged');
+    expect(res.body.counts).toHaveProperty('unstaged');
+    expect(res.body.counts).toHaveProperty('untracked');
+    expect(typeof res.body.isDirty).toBe('boolean');
+  });
 });


### PR DESCRIPTION
## Summary
- remove unused imports in git route
- add test coverage for git status endpoint

## Testing
- `pytest tests/test_prism_utils.py tests/test_hilbert_polya_gue.py`
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c32feb3e588329bdbaeda93d014910