### PR TITLE
docs: clean quantum readme and placeholder

### DIFF
--- a/apps/quantum/README.md
+++ b/apps/quantum/README.md
@@ -1,9 +1,11 @@
 # Ternary Quantum Consciousness (v3)
 
 <!-- BADGES START -->
+
 [![Deploy](https://github.com/blackboxprogramming/BlackRoad/actions/workflows/deploy-quantum.yml/badge.svg)](../../actions/workflows/deploy-quantum.yml)
 [![CodeQL](https://github.com/blackboxprogramming/BlackRoad/actions/workflows/codeql.yml/badge.svg)](../../actions/workflows/codeql.yml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/blackboxprogramming/BlackRoad/badge)](https://securityscorecards.dev/viewer/?uri=github.com/blackboxprogramming/BlackRoad)
+
 <!-- BADGES END -->
 
 Interactive qutrit lab: Lindbladian dynamics (γφ, γrel), von Neumann entropy S(ρ), selectable observables (Pauli-like/Gell-Mann), Hamiltonian editor, session recording + CSV, barycentric visualization.
@@ -12,10 +14,6 @@ Interactive qutrit lab: Lindbladian dynamics (γφ, γrel), von Neumann entropy 
 
 Open `apps/quantum/ternary_consciousness_v3.html` in a browser (no build step required).
 
-Interactive qutrit lab: Lindbladian dynamics (γφ, γrel), von Neumann entropy S(ρ), selectable observables (Pauli-like/Gell-Mann), Hamiltonian editor, session recording + CSV, barycentric visualization.
-
-## Run
-Open `apps/quantum/ternary_consciousness_v3.html` in a browser (no build step required).
 - Keyboard: Space=Play/Pause, R=Reset, M=Measure, 1–4=Presets
 - Sliders + selects drive state, evolution model, and observables.
 
@@ -28,9 +26,6 @@ Open `apps/quantum/ternary_consciousness_v3.html` in a browser (no build step re
 
 ## Files
 
-- `apps/quantum/ternary_consciousness_v3.html` — standalone app
-- `.github/workflows/deploy-quantum.yml` — CI/CD to server via rsync
-How to use, math notes (S(ρ)=−Tr ρ log ρ, P=Tr ρ²), Lindblad params (γφ, γrel), CSV export, and keyboard shortcuts.
 - `apps/quantum/ternary_consciousness_v3.html` — standalone app
 - `.github/workflows/deploy-quantum.yml` — CI/CD to server via rsync
 

--- a/apps/quantum/ternary_consciousness_v3.html
+++ b/apps/quantum/ternary_consciousness_v3.html
@@ -1,1 +1,12 @@
-<!doctype html><html lang="en"><head><meta charset="utf-8"/><title>Ternary Quantum Consciousness Framework</title><meta name="viewport" content="width=device-width,initial-scale=1"/></head><body><h1>🧠 Ternary Quantum Consciousness Framework</h1><p>Installer placeholder.</p></body></html>
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Ternary Quantum Consciousness Framework</title>
+  </head>
+  <body>
+    <h1>🧠 Ternary Quantum Consciousness Framework</h1>
+    <p>Interactive qutrit lab coming soon.</p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- tidy quantum app README and eliminate duplicate sections
- format quantum placeholder HTML for clarity

## Testing
- `npm test` *(fails: jest: not found)*
- `npx prettier apps/quantum/README.md apps/quantum/ternary_consciousness_v3.html -c`


------
https://chatgpt.com/codex/tasks/task_e_68c330777ff48329885dd5663e798121