### PR TITLE
build: bump lint-staged to 16.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "eslint": "^9.12.0",
         "prettier": "^3.3.3",
         "husky": "^9.0.10",
-        "lint-staged": "^15.2.7"
+        "lint-staged": "^16.1.5"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "eslint": "^9.12.0",
     "prettier": "^3.3.3",
     "husky": "^9.0.10",
-    "lint-staged": "^15.2.7"
+    "lint-staged": "^16.1.5"
   },
     "lint-staged": {
     "*.{js,jsx,mjs,cjs,ts,tsx}": [


### PR DESCRIPTION
## Summary
- bump lint-staged dev dependency to 16.1.5

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3307cb0e483298fcad7696b8fe1ab