### PR TITLE
docs: clarify health sidecar env and comments

### DIFF
--- a/services/health-sidecar/.env.example
+++ b/services/health-sidecar/.env.example
@@ -1,3 +1,7 @@
+# Sample environment variables for the health-sidecar service.
+# Port to serve the health endpoints.
 PORT=8088
+# Root directory where the primary API stores its health file.
 API_ROOT=/var/www/blackroad/api
+# Commit SHA injected by the deploy workflow.
 COMMIT_SHA=

--- a/services/health-sidecar/server.js
+++ b/services/health-sidecar/server.js
@@ -10,13 +10,13 @@ const PORT = process.env.PORT || 8088;
 const API_ROOT = process.env.API_ROOT || '/var/www/blackroad/api';
 const HEALTH_FILE = path.join(API_ROOT, 'health.json');
 
-// simple cache-control for JSON responses
+// Simple cache-control for JSON responses.
 app.use((_req, res, next) => {
   res.set('Cache-Control', 'no-store');
   next();
 });
 
-// GET /api/health (primary)
+// GET /api/health (primary endpoint).
 app.get('/api/health', (_req, res) => {
   let body = {
     status: 'ok',
@@ -37,7 +37,7 @@ app.get('/api/health', (_req, res) => {
   res.json(body);
 });
 
-// Liveness/Readiness endpoints (K8s or uptime monitors)
+// Liveness/readiness endpoints (K8s or uptime monitors).
 app.get('/livez', (_req, res) => res.send('OK'));
 app.get('/readyz', (_req, res) => {
   try {


### PR DESCRIPTION
## Summary
- document env vars for health-sidecar
- refine comments in health sidecar server script

## Testing
- `npm run lint` (fails: Cannot find module '@eslint/js')
- `npm test` (fails: jest not found)


------
https://chatgpt.com/codex/tasks/task_e_68c331bbe8bc8329b76340fa63be5969