### PR TITLE
chore: remove stale file path comments

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -1,4 +1,3 @@
-// FILE: /srv/blackroad-api/src/auth.js
 'use strict';
 
 const bcrypt = require('bcrypt');

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,3 @@
-// FILE: /srv/blackroad-api/src/config.js
 'use strict';
 
 require('dotenv').config();

--- a/src/db.js
+++ b/src/db.js
@@ -1,4 +1,3 @@
-// FILE: /srv/blackroad-api/src/db.js
 'use strict';
 
 const fs = require('fs');

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,4 +1,3 @@
-// FILE: /srv/blackroad-api/src/logger.js
 'use strict';
 
 function log(...args) {

--- a/src/rateLimiter.js
+++ b/src/rateLimiter.js
@@ -1,4 +1,3 @@
-// FILE: /srv/blackroad-api/src/rateLimiter.js
 'use strict';
 
 const rateLimit = require('express-rate-limit');

--- a/src/routes/agents.js
+++ b/src/routes/agents.js
@@ -1,4 +1,3 @@
-// FILE: /srv/blackroad-api/src/routes/agents.js
 'use strict';
 
 const express = require('express');

--- a/src/routes/commits.js
+++ b/src/routes/commits.js
@@ -1,4 +1,3 @@
-// FILE: /srv/blackroad-api/src/routes/commits.js
 'use strict';
 
 const express = require('express');

--- a/src/routes/contradictions.js
+++ b/src/routes/contradictions.js
@@ -1,4 +1,3 @@
-// FILE: /srv/blackroad-api/src/routes/contradictions.js
 'use strict';
 
 const express = require('express');

--- a/src/routes/deploy.js
+++ b/src/routes/deploy.js
@@ -1,4 +1,3 @@
-// FILE: /srv/blackroad-api/src/routes/deploy.js
 'use strict';
 
 const express = require('express');

--- a/src/routes/health.js
+++ b/src/routes/health.js
@@ -1,4 +1,3 @@
-// FILE: /srv/blackroad-api/src/routes/health.js
 'use strict';
 
 const express = require('express');

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,4 +1,3 @@
-// FILE: /srv/blackroad-api/src/routes/index.js
 'use strict';
 
 const express = require('express');

--- a/src/routes/json.js
+++ b/src/routes/json.js
@@ -1,4 +1,3 @@
-// FILE: /srv/blackroad-api/src/routes/json.js
 'use strict';
 
 const express = require('express');

--- a/src/routes/llm.js
+++ b/src/routes/llm.js
@@ -1,4 +1,3 @@
-// FILE: /srv/blackroad-api/src/routes/llm.js
 'use strict';
 
 const express = require('express');

--- a/src/routes/logs.js
+++ b/src/routes/logs.js
@@ -1,4 +1,3 @@
-// FILE: /srv/blackroad-api/src/routes/logs.js
 'use strict';
 
 const express = require('express');

--- a/src/routes/metrics.js
+++ b/src/routes/metrics.js
@@ -1,4 +1,3 @@
-// FILE: /srv/blackroad-api/src/routes/metrics.js
 'use strict';
 
 const express = require('express');

--- a/src/routes/notes.js
+++ b/src/routes/notes.js
@@ -1,4 +1,3 @@
-// FILE: /srv/blackroad-api/src/routes/notes.js
 'use strict';
 
 const express = require('express');

--- a/src/routes/projects.js
+++ b/src/routes/projects.js
@@ -1,4 +1,3 @@
-// FILE: /srv/blackroad-api/src/routes/projects.js
 'use strict';
 
 const express = require('express');

--- a/src/routes/roadbook.js
+++ b/src/routes/roadbook.js
@@ -1,4 +1,3 @@
-// FILE: /srv/blackroad-api/src/routes/roadbook.js
 'use strict';
 
 const express = require('express');

--- a/src/routes/timeline.js
+++ b/src/routes/timeline.js
@@ -1,4 +1,3 @@
-// FILE: /srv/blackroad-api/src/routes/timeline.js
 'use strict';
 
 const express = require('express');

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -1,4 +1,3 @@
-// FILE: /srv/blackroad-api/src/routes/users.js
 'use strict';
 
 const express = require('express');

--- a/src/routes/wallet.js
+++ b/src/routes/wallet.js
@@ -1,4 +1,3 @@
-// FILE: /srv/blackroad-api/src/routes/wallet.js
 'use strict';
 
 const express = require('express');

--- a/src/services/agentService.js
+++ b/src/services/agentService.js
@@ -1,4 +1,3 @@
-// FILE: /srv/blackroad-api/src/services/agentService.js
 'use strict';
 
 // Placeholder for future agent orchestration hooks

--- a/src/services/llmService.js
+++ b/src/services/llmService.js
@@ -1,4 +1,3 @@
-// FILE: /srv/blackroad-api/src/services/llmService.js
 'use strict';
 
 const { LUCIDIA_LLM_URL } = require('../config');

--- a/src/services/metricsService.js
+++ b/src/services/metricsService.js
@@ -1,4 +1,3 @@
-// FILE: /srv/blackroad-api/src/services/metricsService.js
 'use strict';
 
 const si = require('systeminformation');

--- a/src/services/notifyService.js
+++ b/src/services/notifyService.js
@@ -1,4 +1,3 @@
-// FILE: /srv/blackroad-api/src/services/notifyService.js
 'use strict';
 
 // Hook Socket.IO here in the future to broadcast wallet/task/timeline updates.

--- a/src/socket.js
+++ b/src/socket.js
@@ -1,4 +1,3 @@
-// FILE: /srv/blackroad-api/src/socket.js
 'use strict';
 
 const { Server } = require('socket.io');

--- a/src/utils/crypto.js
+++ b/src/utils/crypto.js
@@ -1,4 +1,3 @@
-// FILE: /srv/blackroad-api/src/utils/crypto.js
 'use strict';
 
 const crypto = require('crypto');

--- a/src/utils/validate.js
+++ b/src/utils/validate.js
@@ -1,4 +1,3 @@
-// FILE: /srv/blackroad-api/src/utils/validate.js
 'use strict';
 
 function isEmail(s) {


### PR DESCRIPTION
## Summary
- remove leftover file path comments from source files

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c331cc9e6c832982fddd0e5e2a08bf