### PR TITLE
chore: remove unused imports from git API route

### DIFF
--- a/srv/blackroad-api/routes/git.js
+++ b/srv/blackroad-api/routes/git.js
@@ -1,7 +1,5 @@
 const express = require('express');
 const { execFile } = require('child_process');
-const fs = require('fs');
-const path = require('path');
 
 const router = express.Router();
 


### PR DESCRIPTION
## Summary
- remove unused `fs` and `path` imports from the git API route

## Testing
- `npm test` *(fails: jest: not found)*
- `pytest` *(fails: No module named 'torch', sympy, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c331d1183c8329bf207b5b1022813e