### PR TITLE
docs: label quantum snippet block endings

### DIFF
--- a/.tools/quantum/console_only_snippet.js
+++ b/.tools/quantum/console_only_snippet.js
@@ -39,4 +39,4 @@
     console.error('[runtime] Global error:', msg, src, line, col);
   };
 })();
-/// ==== CONSOLE-ONLY CHECKS END ====
+// ==== CONSOLE-ONLY CHECKS END (Block N) ====

--- a/.tools/quantum/perf_budget_snippet.js
+++ b/.tools/quantum/perf_budget_snippet.js
@@ -44,4 +44,4 @@
     } catch {}
   }
 })();
-/// ==== PERF BUDGET END ====
+// ==== PERF BUDGET END (Block M) ====

--- a/.tools/quantum/runtime_badge_snippet.html
+++ b/.tools/quantum/runtime_badge_snippet.html
@@ -100,4 +100,4 @@
   setState();
 })();
 </script>
-<!-- ==== RUNTIME BADGE END ==== -->
+<!-- ==== RUNTIME BADGE END (Block J) ==== -->


### PR DESCRIPTION
## Summary
- document block IDs in runtime badge snippet
- include block IDs in console-only and perf budget snippets

## Testing
- `npm test` *(fails: command not found: npm)*
- `npm run lint` *(fails: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68c338e917d4832990eaf5f2c6255a98