### PR TITLE
docs: clarify numeric prefix parsing

### DIFF
--- a/prism_utils.py
+++ b/prism_utils.py
@@ -4,16 +4,17 @@ from __future__ import annotations
 
 import re
 
-# Precompiled regex to extract a leading decimal number with optional sign.
+# Match an optional sign and decimal number at the start of the string.
 _NUMERIC_PREFIX = re.compile(r"^\s*([+-]?\d+(?:\.\d+)?)")
 
 
 def parse_numeric_prefix(text: str) -> float:
-    """Return the leading decimal value in ``text`` or ``1.0`` if absent.
+    """Extract a leading decimal value from ``text``.
 
-    Only simple base-10 numbers are supported to avoid evaluating arbitrary
-    Python expressions. Inputs like ``"2, something"`` are accepted. Non-numeric
-    or invalid values default to ``1.0``.
+    The regex ignores leading whitespace and accepts an optional ``+`` or ``-``
+    sign and an optional fractional part. If no valid number is found, ``1.0``
+    is returned. Inputs such as ``"-3.5 apples"`` or ``"2, rest"`` are
+    recognized; malformed values default to ``1.0``.
     """
     match = _NUMERIC_PREFIX.match(text)
     if match:

--- a/tests/test_prism_utils.py
+++ b/tests/test_prism_utils.py
@@ -4,6 +4,8 @@ from prism_utils import parse_numeric_prefix
 
 
 def test_parse_numeric_prefix_valid():
+    """It returns the numeric portion when the prefix is well formed."""
+
     assert parse_numeric_prefix("2, rest") == 2.0
     assert parse_numeric_prefix("3.5") == 3.5
     assert parse_numeric_prefix("-1 stuff") == -1.0
@@ -11,6 +13,8 @@ def test_parse_numeric_prefix_valid():
 
 
 def test_parse_numeric_prefix_invalid():
+    """It falls back to ``1.0`` for missing or malformed prefixes."""
+
     assert parse_numeric_prefix("abc") == 1.0
     assert parse_numeric_prefix("1a") == 1.0
     assert parse_numeric_prefix("") == 1.0


### PR DESCRIPTION
## Summary
- clarify regex and docstring for `parse_numeric_prefix`
- add explanatory docstrings to related tests

## Testing
- `pre-commit run --files prism_utils.py tests/test_prism_utils.py`
- `pytest tests/test_prism_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68c33910c9108329850f22b16b2ae95b