### PR TITLE
fix(api): include ok flag in git status response

### DIFF
--- a/srv/blackroad-api/routes/git.js
+++ b/srv/blackroad-api/routes/git.js
@@ -66,6 +66,7 @@ router.get('/status', async (_req, res) => {
     const shortHash = (await runGit(['rev-parse', '--short', 'HEAD'])).stdout.trim();
     const lastCommitMsg = (await runGit(['log', '-1', '--pretty=%s'])).stdout.trim();
     res.json({
+      ok: true,
       branch,
       ahead,
       behind,
@@ -75,7 +76,7 @@ router.get('/status', async (_req, res) => {
       lastCommitMsg,
     });
   } catch (e) {
-    res.status(500).json({ error: e.message });
+    res.status(500).json({ ok: false, error: e.message });
   }
 });
 

--- a/tests/git_api.test.js
+++ b/tests/git_api.test.js
@@ -34,6 +34,7 @@ describe('Git API', () => {
       .get('/api/git/status')
       .set('Cookie', cookie);
     expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
     expect(typeof res.body.branch).toBe('string');
     expect(res.body.counts).toBeDefined();
     expect(res.body.counts).toHaveProperty('staged');


### PR DESCRIPTION
## Summary
- include explicit `ok` flag in git status endpoint and provide `ok: false` on errors
- assert ok flag in git status integration test

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install jest supertest --loglevel=verbose` *(fails: fetch GET http://verdaccio.internal:4873/bcrypt 503)*

------
https://chatgpt.com/codex/tasks/task_e_68c3390494cc83298662d2d0fba8393f