### PR TITLE
ci: pin actions in markdown lint workflow

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,16 @@
+name: Markdown Lint
+on:
+  pull_request:
+  push:
+    branches: [main]
+permissions:
+  contents: read
+jobs:
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - uses: DavidAnson/markdownlint-cli2-action@510b996878fc0d1a46c8a04ec86b06dbfba09de7
+        with:
+          config: .markdownlint.yaml
+          globs: '**/*.md'


### PR DESCRIPTION
## Summary
- pin GitHub Actions for markdown lint workflow to specific commit SHAs

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c33979a1808329b9f0ac619011a09f