### PR TITLE
chore: simplify default jest test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint srv/blackroad-api/server_full.js tests/api_health.test.js tests/git_api.test.js",
     "format": "prettier . --write",
     "format:check": "prettier package.json tests/api_health.test.js srv/lucidia-llm/test_app.py var/www/blackroad/.prettierrc.json .prettierrc.json RUNME.sh Makefile .github/workflows/ci.yml CLEANUP_PLAN.md CLEANUP_DECISIONS.md CLEANUP_RESULTS.md ROLLBACK.md CHANGELOG.md --check --ignore-unknown",
-    "test": "jest tests/api_health.test.js tests/git_api.test.js",
+    "test": "jest",
     "typecheck": "echo 'no typecheck'",
     "health": "node scripts/health.js",
     "dev:site": "npm --prefix sites/blackroad run dev",


### PR DESCRIPTION
## Summary
- run Jest directly via default npm test script

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3398edc9c83299130a8f8fd3dcd9f