### PR TITLE
fix: deduplicate comment bot retry helper

### DIFF
--- a/agents/comment_bot.py
+++ b/agents/comment_bot.py
@@ -14,27 +14,6 @@ from dataclasses import dataclass
 from typing import Optional
 
 import requests
-import time
-
-
-def post_with_retry(url, json, headers, timeout=10, max_retries=3):
-    """POST request with retry for transient errors."""
-    for attempt in range(max_retries):
-        try:
-            response = requests.post(url, json=json, headers=headers, timeout=timeout)
-            response.raise_for_status()
-            return response
-        except (requests.ConnectionError, requests.Timeout):
-            if attempt < max_retries - 1:
-                time.sleep(2 ** attempt)
-                continue
-            raise
-        except requests.HTTPError as exc:
-            code = getattr(exc.response, "status_code", None)
-            if code in {502, 503, 504} and attempt < max_retries - 1:
-                time.sleep(2 ** attempt)
-                continue
-            raise
 
 
 def post_with_retry(url, json, headers, timeout: int = 10, max_retries: int = 3):


### PR DESCRIPTION
## Summary
- remove duplicate `post_with_retry` helper and extra `time` import

## Testing
- `python -m py_compile *.py`
- `python agents/auto_novel_agent.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68c339927d0c83299a8717c05ee29c10