### PR TITLE
feat: add job board and worker bots

### DIFF
--- a/AGENT_WORKBOARD.md
+++ b/AGENT_WORKBOARD.md
@@ -10,6 +10,8 @@
 - [ ] Label issues/PRs (`LabelBot`)
 - [ ] Request reviews (`ReviewBot`)
 - [ ] Send notifications (`NotificationBot`)
+- [ ] Assign tasks from job board (`WorkerBot`)
+- [ ] Watch for idle periods (`IdleBot`)
 
 ## In Progress
 <!-- Agents move tasks here when running -->

--- a/agents/idle_bot.py
+++ b/agents/idle_bot.py
@@ -1,0 +1,26 @@
+"""Bot that reports whether tasks are available."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+AGENTS_DIR = Path(__file__).resolve().parent
+if str(AGENTS_DIR) not in sys.path:
+    sys.path.append(str(AGENTS_DIR))
+
+from job_board import JobBoard
+
+
+class IdleBot:
+    """Notify if the job board has no tasks."""
+
+    def status(self) -> str:
+        """Return ``"tasks available"`` or ``"idle"``."""
+        board = JobBoard()
+        return "tasks available" if board.next_task() else "idle"
+
+
+if __name__ == "__main__":
+    bot = IdleBot()
+    print("IdleBot status:", bot.status())

--- a/agents/job_board.py
+++ b/agents/job_board.py
@@ -1,0 +1,39 @@
+"""Simple job board for agent tasks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Optional
+
+
+class JobBoard:
+    """Read and provide tasks from ``AGENT_WORKBOARD.md``."""
+
+    def __init__(self, path: Optional[Path] = None) -> None:
+        self.path = path or Path(__file__).resolve().parents[1] / "AGENT_WORKBOARD.md"
+
+    def tasks(self) -> List[str]:
+        """Return a list of pending task descriptions."""
+        lines = self.path.read_text().splitlines()
+        in_todo = False
+        tasks: List[str] = []
+        for line in lines:
+            if line.startswith("## To Do"):
+                in_todo = True
+                continue
+            if line.startswith("##") and in_todo:
+                break
+            if in_todo and line.strip().startswith("- [ ]"):
+                task = line.split("]", 1)[1].strip()
+                tasks.append(task)
+        return tasks
+
+    def next_task(self) -> Optional[str]:
+        """Return the next pending task or ``None`` if none exist."""
+        tasks = self.tasks()
+        return tasks[0] if tasks else None
+
+
+if __name__ == "__main__":
+    board = JobBoard()
+    print("Next task:", board.next_task() or "No tasks found.")

--- a/agents/worker_bot.py
+++ b/agents/worker_bot.py
@@ -1,0 +1,31 @@
+"""Bot that retrieves tasks from the job board."""
+
+from __future__ import annotations
+
+from typing import Optional
+import sys
+from pathlib import Path
+
+AGENTS_DIR = Path(__file__).resolve().parent
+if str(AGENTS_DIR) not in sys.path:
+    sys.path.append(str(AGENTS_DIR))
+
+from job_board import JobBoard
+
+
+class WorkerBot:
+    """Assign itself the next available job."""
+
+    def __init__(self, name: str = "WorkerBot") -> None:
+        self.name = name
+
+    def work(self) -> str:
+        """Return the task the bot will work on or ``"idle"``."""
+        board = JobBoard()
+        task: Optional[str] = board.next_task()
+        return task or "idle"
+
+
+if __name__ == "__main__":
+    bot = WorkerBot()
+    print(f"{bot.name} task:", bot.work())


### PR DESCRIPTION
## Summary
- expand agent workboard with new worker and idle tasks
- add job board utility for reading AGENT_WORKBOARD tasks
- introduce WorkerBot and IdleBot to consume job board tasks

## Testing
- `python -m py_compile agents/*.py`
- `python agents/auto_novel_agent.py`
- `python test_agents.py` *(fails: status_bot.py: import_failed, pull_request_bot.py: import_failed, droplet_repair_agent.py: import_failed, pr_cleanup_bot.py: import_failed, review_bot.py: import_failed, resolve_merge_manager.py: import_failed, safe_resolve_merge_manager.py: import_failed, label_bot.py: import_failed, milestone_bot.py: import_failed, athena.py: import_failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c33a21f3a483299b13966e80ab3c60