### PR TITLE
chore: expand hex color codes

### DIFF
--- a/cf-worker/src/index.js
+++ b/cf-worker/src/index.js
@@ -180,7 +180,7 @@ function confirmHtml(url){
     <h2 style="margin:0 0 12px">Confirm your subscription</h2>
     <p>Click the button below to confirm your email for BlackRoad updates.</p>
     <p><a href="${url}" style="display:inline-block;padding:12px 18px;border-radius:10px;text-decoration:none;background:linear-gradient(90deg,#FF4FD8,#0096FF);color:#0b0b12;font-weight:700">Confirm</a></p>
-    <p style="color:#555;font-size:12px">If you didn't request this, ignore this email.</p>
+    <p style="color:#555555;font-size:12px">If you didn't request this, ignore this email.</p>
   </div>`;
 }
 function unsubHtml(url){
@@ -189,7 +189,7 @@ function unsubHtml(url){
     <h2 style="margin:0 0 12px">Confirm unsubscribe</h2>
     <p>Click below to stop receiving BlackRoad emails for this address.</p>
     <p><a href="${url}" style="display:inline-block;padding:12px 18px;border-radius:10px;text-decoration:none;background:linear-gradient(90deg,#FF4FD8,#0096FF);color:#0b0b12;font-weight:700">Unsubscribe</a></p>
-    <p style="color:#555;font-size:12px">If you didn't request this, ignore this email.</p>
+    <p style="color:#555555;font-size:12px">If you didn't request this, ignore this email.</p>
   </div>`;
 }
 

--- a/ternary_consciousness_v3.html
+++ b/ternary_consciousness_v3.html
@@ -17,7 +17,7 @@
         --bg1: #667eea;
         --bg2: #764ba2;
         --ink: #1a1a1a;
-        --ink-soft: #555;
+        --ink-soft: #555555;
         --panel: #fff;
         --panel2: #f7fafc;
         --panel3: #edf2f7;


### PR DESCRIPTION
## Summary
- use full 6-digit hex codes for muted text in emails
- standardize ink-soft color definition to 6-digit hex

## Testing
- `npm test` (fails: jest not found)
- `npm run lint` (fails: Cannot find module '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68c33bea48b48329aa1fa5d6eee31925