### PR TITLE
fix: derive git status ok flag from dirty state

### DIFF
--- a/srv/blackroad-api/routes/git.js
+++ b/srv/blackroad-api/routes/git.js
@@ -5,7 +5,8 @@ const router = express.Router();
 
 const REPO_PATH = process.env.GIT_REPO_PATH || '/srv/blackroad';
 const REMOTE_NAME = process.env.GIT_REMOTE_NAME || 'origin';
-const ALLOW_GIT_ACTIONS = String(process.env.ALLOW_GIT_ACTIONS || 'false').toLowerCase() === 'true';
+const ALLOW_GIT_ACTIONS =
+  String(process.env.ALLOW_GIT_ACTIONS || 'false').toLowerCase() === 'true';
 
 function runGit(args) {
   return new Promise((resolve, reject) => {
@@ -63,10 +64,15 @@ router.get('/status', async (_req, res) => {
       }
     }
     const isDirty = staged > 0 || unstaged > 0 || untracked > 0;
-    const shortHash = (await runGit(['rev-parse', '--short', 'HEAD'])).stdout.trim();
-    const lastCommitMsg = (await runGit(['log', '-1', '--pretty=%s'])).stdout.trim();
+    const ok = !isDirty;
+    const shortHash = (
+      await runGit(['rev-parse', '--short', 'HEAD'])
+    ).stdout.trim();
+    const lastCommitMsg = (
+      await runGit(['log', '-1', '--pretty=%s'])
+    ).stdout.trim();
     res.json({
-      ok: true,
+      ok,
       branch,
       ahead,
       behind,

--- a/tests/git_api.test.js
+++ b/tests/git_api.test.js
@@ -1,4 +1,4 @@
-process.env.SESSION_SECRET = 'test-secret';
+process.env.SESSION_SECRET = 'test-secret'; // pragma: allowlist secret
 process.env.INTERNAL_TOKEN = 'x';
 process.env.ALLOW_ORIGINS = 'https://example.com';
 process.env.GIT_REPO_PATH = process.cwd();
@@ -14,11 +14,9 @@ describe('Git API', () => {
   it('returns git health info', async () => {
     const login = await request(app)
       .post('/api/login')
-      .send({ username: 'root', password: 'Codex2025' });
+      .send({ username: 'root', password: 'Codex2025' }); // pragma: allowlist secret
     const cookie = login.headers['set-cookie'];
-    const res = await request(app)
-      .get('/api/git/health')
-      .set('Cookie', cookie);
+    const res = await request(app).get('/api/git/health').set('Cookie', cookie);
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
     expect(typeof res.body.repoPath).toBe('string');
@@ -28,13 +26,12 @@ describe('Git API', () => {
   it('returns git status info', async () => {
     const login = await request(app)
       .post('/api/login')
-      .send({ username: 'root', password: 'Codex2025' });
+      .send({ username: 'root', password: 'Codex2025' }); // pragma: allowlist secret
     const cookie = login.headers['set-cookie'];
-    const res = await request(app)
-      .get('/api/git/status')
-      .set('Cookie', cookie);
+    const res = await request(app).get('/api/git/status').set('Cookie', cookie);
     expect(res.status).toBe(200);
-    expect(res.body.ok).toBe(true);
+    expect(typeof res.body.ok).toBe('boolean');
+    expect(res.body.ok).toBe(!res.body.isDirty);
     expect(typeof res.body.branch).toBe('string');
     expect(res.body.counts).toBeDefined();
     expect(res.body.counts).toHaveProperty('staged');


### PR DESCRIPTION
## Summary
- derive `ok` flag for git status from dirty state
- assert `ok` reflects repository dirtiness in tests

## Testing
- `pre-commit run --files srv/blackroad-api/routes/git.js tests/git_api.test.js` *(fails: Cannot find module '@eslint/js')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c33bdaf12c832992b695973a1cb87d