### PR TITLE
fix(chatops): restrict ChatOps commands to pull request comments

### DIFF
--- a/.github/workflows/calm-chatops.yml
+++ b/.github/workflows/calm-chatops.yml
@@ -1,13 +1,14 @@
 name: Calm ChatOps v2
 on: { issue_comment: { types: [created] } }
-permissions: { contents: write, pull-requests: write, issues: write, actions: read }
+permissions:
+  { contents: write, pull-requests: write, issues: write, actions: read }
 jobs:
   chatops:
-    if: startsWith(github.event.comment.body, '/')
+    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/')
     runs-on: ubuntu-latest
     env:
       BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
-      BOT_USER:  ${{ secrets.BOT_USER || 'blackroad-bot' }}
+      BOT_USER: ${{ secrets.BOT_USER || 'blackroad-bot' }}
     steps:
       - uses: actions/checkout@v4
         with: { persist-credentials: false, fetch-depth: 0 }


### PR DESCRIPTION
## Summary
- ensure ChatOps workflow only responds to pull request comments

## Testing
- `pre-commit run --files .github/workflows/calm-chatops.yml`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3399eb93883299c3e7c41b9479f6b