### PR TITLE
chore(ci): pin action versions

### DIFF
--- a/.github/workflows/html-validate.yml
+++ b/.github/workflows/html-validate.yml
@@ -5,11 +5,16 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
       - id: chk
         run: f="apps/quantum/ternary_consciousness_v3.html"; [ -f "$f" ] && echo ok=1 >> $GITHUB_OUTPUT || echo ok=0 >> $GITHUB_OUTPUT
-      - uses: Cyb3r-Jak3/html5validator-action@v7
+      - uses: Cyb3r-Jak3/html5validator-action@41633d488eb36e18fd1a95ffc83daf1bf22a75bd # v7.2.0
         if: steps.chk.outputs.ok == '1'
-        with: { root: ., paths: apps/quantum/ternary_consciousness_v3.html, blacklist: node_modules }
+        with:
+          {
+            root: .,
+            paths: apps/quantum/ternary_consciousness_v3.html,
+            blacklist: node_modules,
+          }
       - if: steps.chk.outputs.ok != '1'
         run: echo "ℹ️ HTML missing, skipping." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,16 +1,22 @@
 name: Broken Links
-on: { pull_request: {}, schedule: [ { cron: "0 2 * * *" } ] }
-permissions: { contents: read }
+on:
+  pull_request: {}
+  schedule:
+    - cron: '0 2 * * *'
+permissions:
+  contents: read
 jobs:
   lychee:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
       - id: chk
         run: f="apps/quantum/ternary_consciousness_v3.html"; [ -f "$f" ] && echo ok=1 >> $GITHUB_OUTPUT || echo ok=0 >> $GITHUB_OUTPUT
-      - uses: lycheeverse/lychee-action@v2
+      - uses: lycheeverse/lychee-action@885c65f3dc543b57c898c8099f4e08c8afd178a2 # v2
         if: steps.chk.outputs.ok == '1'
-        with: { args: --verbose --no-progress --timeout 20s "apps/quantum/ternary_consciousness_v3.html" }
-        env: { GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} }
+        with:
+          args: --verbose --no-progress --timeout 20s "apps/quantum/ternary_consciousness_v3.html"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - if: steps.chk.outputs.ok != '1'
         run: echo "ℹ️ Link check skipped (no HTML)." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,19 +1,19 @@
 name: Super-Linter
-on: { pull_request: {}, push: { branches: [ main ] } }
+on: { pull_request: {}, push: { branches: [main] } }
 permissions: { contents: read }
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with: { fetch-depth: 0 }
-      - uses: github/super-linter/slim@v6
+      - uses: github/super-linter/slim@4e51915f4a812abf59fed160bb14595c0a38a9e7 # v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: main
           VALIDATE_ALL_CODEBASE: true
           LOG_LEVEL: warn
-          FILTER_REGEX_EXCLUDE: "node_modules/|dist/|build/"
+          FILTER_REGEX_EXCLUDE: 'node_modules/|dist/|build/'
           VALIDATE_HTML: true
           VALIDATE_MARKDOWN: true
           VALIDATE_YAML: true


### PR DESCRIPTION
## Summary
- pin GitHub action steps to specific commit SHAs in lint and validation workflows

## Testing
- `pre-commit run --files .github/workflows/super-linter.yml .github/workflows/links.yml .github/workflows/html-validate.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c3397fd7388329b6908d6c7511f756