### PR TITLE
chore(auto-heal): address PR feedback

### DIFF
--- a/.github/tools/autoheal.sh
+++ b/.github/tools/autoheal.sh
@@ -1,8 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
-changed=false; add(){ git add "$@" && changed=true; }
-if [ ! -f package.json ]; then npm init -y >/dev/null 2>&1 || true; add package.json; fi
-node - <<'JS' && changed=true || true
+
+# Track if any files were modified
+changed=false
+
+# Convenient helper to add files and mark the repo as changed
+add() {
+  git add "$@"
+  changed=true
+}
+
+if [ ! -f package.json ]; then
+  npm init -y >/dev/null 2>&1 || true
+  add package.json
+fi
+
+if node - <<'JS'; then
 const fs=require("fs"), p="package.json";
 const j=JSON.parse(fs.readFileSync(p,"utf8")); j.scripts=j.scripts||{};
 j.scripts.test   ||= "echo \"No tests specified\" && exit 0";
@@ -10,11 +23,32 @@ j.scripts.lint   ||= "eslint . --ext .js,.mjs,.cjs";
 j.scripts.format ||= "prettier -w .";
 fs.writeFileSync(p, JSON.stringify(j,null,2));
 JS
+  changed=true
+fi
 add package.json || true
-[ -f .prettierrc.json ] || { echo '{ "printWidth": 100, "singleQuote": true, "trailingComma": "es5" }' > .prettierrc.json; add .prettierrc.json; }
-[ -f eslint.config.js ] || { echo 'export default [];' > eslint.config.js; add eslint.config.js; }
+
+[ -f .prettierrc.json ] || {
+  echo '{ "printWidth": 100, "singleQuote": true, "trailingComma": "es5" }' > .prettierrc.json
+  add .prettierrc.json
+}
+
+[ -f eslint.config.js ] || {
+  echo 'export default [];' > eslint.config.js
+  add eslint.config.js
+}
+
 npm i -D prettier eslint eslint-config-prettier >/dev/null 2>&1 || true
-npx --yes prettier -w .  >/dev/null 2>&1 || true
+npx --yes prettier -w . >/dev/null 2>&1 || true
 npx --yes eslint . --ext .js,.mjs,.cjs --fix >/dev/null 2>&1 || true
-git diff --quiet || { git add -A && changed=true; }
-if $changed; then git commit -m "chore(auto-heal): baseline + prettier/eslint --fix" || true; echo "committed=1" >> "$GITHUB_OUTPUT"; else echo "committed=0" >> "$GITHUB_OUTPUT"; fi
+
+git diff --quiet || {
+  git add -A
+  changed=true
+}
+
+if $changed; then
+  git commit -m "chore(auto-heal): baseline + prettier/eslint --fix" || true
+  echo "committed=1" >> "$GITHUB_OUTPUT"
+else
+  echo "committed=0" >> "$GITHUB_OUTPUT"
+fi

--- a/.github/workflows/auto-heal.yml
+++ b/.github/workflows/auto-heal.yml
@@ -12,14 +12,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with: { persist-credentials: false, ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref }} }
+        with:
+          persist-credentials: false
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref }}
       - run: |
           git config user.name  "${{ secrets.BOT_USER || 'blackroad-bot' }}"
           git config user.email "${{ secrets.BOT_USER || 'blackroad-bot' }}@users.noreply.github.com"
       - id: heal
         run: .github/tools/autoheal.sh
       - if: steps.heal.outputs.committed == '1'
-        env: { BOT_TOKEN: ${{ secrets.BOT_TOKEN }} }
+        env:
+          BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
         run: |
           [ -z "$BOT_TOKEN" ] && { echo "::notice::No BOT_TOKEN"; exit 0; }
           git push "https://${BOT_TOKEN}@github.com/${{ github.repository }}.git" "HEAD:$(git rev-parse --abbrev-ref HEAD)"


### PR DESCRIPTION
## Summary
- refactor auto-heal script for readability and robustness
- format auto-heal workflow with clearer `checkout` and push steps

## Testing
- `shellcheck .github/tools/autoheal.sh`
- `CI=true npx --yes actionlint .github/workflows/auto-heal.yml` *(fails: 503 Service Unavailable - GET http://verdaccio.internal:4873/actionlint)*
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c3398739808329ab9011a455d256bd