### PR TITLE
docs: explain missing git remote

### DIFF
--- a/srv/blackroad-api/routes/git.js
+++ b/srv/blackroad-api/routes/git.js
@@ -25,7 +25,9 @@ router.get('/health', async (_req, res) => {
     try {
       const out = await runGit(['remote', 'get-url', REMOTE_NAME]);
       remoteUrl = out.stdout.trim();
-    } catch {}
+    } catch {
+      // Ignore if the remote is not configured
+    }
     res.json({
       ok: true,
       repoPath: REPO_PATH,


### PR DESCRIPTION
## Summary
- document why git remote lookup can be ignored in health route

## Testing
- `npm test` *(fails: jest not found)*
- `pytest tests/test_prism_utils.py tests/test_hilbert_polya_gue.py`

------
https://chatgpt.com/codex/tasks/task_e_68c3398a8698832980ed043362c4f0f1