### PR TITLE
chore: skip quantum deploy workflow on pull requests

### DIFF
--- a/.github/workflows/deploy-quantum.yml
+++ b/.github/workflows/deploy-quantum.yml
@@ -5,11 +5,6 @@ on:
     paths:
       - 'apps/quantum/**'
       - '.github/workflows/deploy-quantum.yml'
-  pull_request:
-    branches: [main]
-    paths:
-      - 'apps/quantum/**'
-      - '.github/workflows/deploy-quantum.yml'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- avoid deploying quantum app for pull_request events lacking secrets by removing the pull_request trigger

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: Cannot find module '@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_68c3428e7ae88329bc129e3e338e95c3