### PR TITLE
fix: support scientific notation in parser

### DIFF
--- a/prism_utils.py
+++ b/prism_utils.py
@@ -6,16 +6,19 @@ import ast
 import re
 
 # Match optional sign, integer/decimal part, and optional exponent.
-_NUMERIC_PREFIX_RE = re.compile(r"^\s*([+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?)")
+_NUMERIC_PREFIX_RE = re.compile(
+    r"^\s*([+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?)(?![eE])"
+)
 
 
 def parse_numeric_prefix(text: str) -> float:
     """Return the leading numeric value in ``text`` or ``1.0`` if not found.
 
     The function extracts an optional sign and numeric token at the start of
-    ``text`` using a regular expression. The extracted token is parsed with
-    :func:`ast.literal_eval` for safety. If the token cannot be parsed or is
-    absent, ``1.0`` is returned.
+    ``text`` using a regular expression. Tokens may include decimal mantissas
+    and scientific-notation exponents (``1e-3`` or ``.5E+2``). The extracted
+    token is parsed with :func:`ast.literal_eval` for safety. If the token
+    cannot be parsed or is absent, ``1.0`` is returned.
     """
     match = _NUMERIC_PREFIX_RE.match(text)
     if not match:

--- a/tests/test_prism_utils.py
+++ b/tests/test_prism_utils.py
@@ -8,8 +8,11 @@ def test_parse_numeric_prefix_valid():
     assert parse_numeric_prefix(" -4.2 extra") == -4.2
     assert parse_numeric_prefix("2e3") == 2000.0
     assert parse_numeric_prefix("-1.5e-2 extra") == -0.015
+    assert parse_numeric_prefix(".5E+3 stuff") == 500.0
+    assert parse_numeric_prefix("6.02E23 molecules") == 6.02e23
 
 
 def test_parse_numeric_prefix_invalid():
     assert parse_numeric_prefix("abc") == 1.0
     assert parse_numeric_prefix("1a") == 1.0
+    assert parse_numeric_prefix("7e+") == 1.0


### PR DESCRIPTION
## Summary
- extend numeric prefix regex to parse scientific notation
- test parsing for exponential prefixes

## Testing
- `pre-commit run --files prism_utils.py tests/test_prism_utils.py main.py`
- `pytest tests/test_prism_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68c343873de483298c4598472d9d8dad