### PR TITLE
chore(automation): document pinned action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Use Node.js 20.x
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           cache: npm
@@ -82,7 +82,7 @@ jobs:
           tar -czf release.tar.gz -C release .
 
       - name: Upload artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: release-${{ github.sha }}
           path: release.tar.gz
@@ -96,10 +96,10 @@ jobs:
     environment: production
     steps:
       - name: Checkout
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Download artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: release-${{ github.sha }}
           path: .

--- a/.github/workflows/html-validate.yml
+++ b/.github/workflows/html-validate.yml
@@ -5,10 +5,10 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - id: chk
         run: f="apps/quantum/ternary_consciousness_v3.html"; [ -f "$f" ] && echo ok=1 >> $GITHUB_OUTPUT || echo ok=0 >> $GITHUB_OUTPUT
-      - uses: Cyb3r-Jak3/html5validator-action@41633d488eb36e18fd1a95ffc83daf1bf22a75bd
+      - uses: Cyb3r-Jak3/html5validator-action@41633d488eb36e18fd1a95ffc83daf1bf22a75bd # v7.2.0
         if: steps.chk.outputs.ok == '1'
         with:
           root: .

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -5,10 +5,10 @@ jobs:
   lychee:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - id: chk
         run: f="apps/quantum/ternary_consciousness_v3.html"; [ -f "$f" ] && echo ok=1 >> $GITHUB_OUTPUT || echo ok=0 >> $GITHUB_OUTPUT
-      - uses: lycheeverse/lychee-action@885c65f3dc543b57c898c8099f4e08c8afd178a2
+      - uses: lycheeverse/lychee-action@885c65f3dc543b57c898c8099f4e08c8afd178a2 # v2.6.1
         if: steps.chk.outputs.ok == '1'
         with:
           args: --verbose --no-progress --timeout 20s "apps/quantum/ternary_consciousness_v3.html"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,13 +5,15 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+permissions:
+  contents: read
 
 jobs:
   eslint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
       - run: npm ci


### PR DESCRIPTION
## Summary
- annotate pinned GitHub Actions with their release versions
- restrict token permissions for lint workflow

## Testing
- `pre-commit run --files .github/workflows/ci.yml .github/workflows/lint.yml .github/workflows/links.yml .github/workflows/html-validate.yml`

------
https://chatgpt.com/codex/tasks/task_e_68c342f1d9508329936c9bcd4797d167