### PR TITLE
fix(auto-heal): handle filenames starting with dash

### DIFF
--- a/.github/tools/autoheal.sh
+++ b/.github/tools/autoheal.sh
@@ -6,7 +6,7 @@ changed=false
 
 # Convenient helper to add files and mark the repo as changed
 add() {
-  git add "$@"
+  git add -- "$@"
   changed=true
 }
 


### PR DESCRIPTION
## Summary
- protect auto-heal git staging against option-like filenames

## Testing
- `shellcheck .github/tools/autoheal.sh`
- `CI=true npx --yes actionlint .github/workflows/auto-heal.yml` *(fails: 503 Service Unavailable - GET http://verdaccio.internal:4873/actionlint)*
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68c343205f808329b4355bd3d166249e