### PR TITLE
docs: clarify numeric prefix comments

### DIFF
--- a/prism_utils.py
+++ b/prism_utils.py
@@ -4,15 +4,17 @@ from __future__ import annotations
 
 import re
 
-# Match an optional sign and digits with an optional fractional part.
+# Match optional leading whitespace, an optional sign, digits, and an optional
+# fractional part.
 _NUMERIC_PREFIX = re.compile(r"^\s*([+-]?\d+(?:\.\d+)?)")
 
 
 def parse_numeric_prefix(text: str) -> float:
     """Extract the leading decimal value from ``text``.
 
-    Accepts an optional sign and fractional part, ignoring trailing
-    characters. Returns ``1.0`` when no valid number is found.
+    Allows leading whitespace, an optional sign, and an optional fractional
+    part, ignoring trailing characters. Returns ``1.0`` when no valid number is
+    found.
     """
     match = _NUMERIC_PREFIX.match(text)
     if match:

--- a/tests/test_prism_utils.py
+++ b/tests/test_prism_utils.py
@@ -1,4 +1,4 @@
-"""Unit tests for `parse_numeric_prefix` utility."""
+"""Tests for parse_numeric_prefix."""
 
 from prism_utils import parse_numeric_prefix
 
@@ -8,6 +8,7 @@ def test_parse_numeric_prefix_valid():
     assert parse_numeric_prefix("3.5") == 3.5
     assert parse_numeric_prefix("-1 stuff") == -1.0
     assert parse_numeric_prefix("+4") == 4.0
+    assert parse_numeric_prefix(" 7") == 7.0
 
 
 def test_parse_numeric_prefix_invalid():


### PR DESCRIPTION
## Summary
- mention leading whitespace in numeric prefix parsing comments and docstring
- test parsing of numeric prefixes with leading whitespace

## Testing
- `pre-commit run --files prism_utils.py tests/test_prism_utils.py`
- `pytest tests/test_prism_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68c3439dfb688329b8766706d45865ac