### PR TITLE
feat: add ok flag to git status response

### DIFF
--- a/srv/blackroad-api/routes/git.js
+++ b/srv/blackroad-api/routes/git.js
@@ -68,6 +68,7 @@ router.get('/status', async (_req, res) => {
     const shortHash = (await runGit(['rev-parse', '--short', 'HEAD'])).stdout.trim();
     const lastCommitMsg = (await runGit(['log', '-1', '--pretty=%s'])).stdout.trim();
     res.json({
+      ok: true,
       branch,
       ahead,
       behind,

--- a/tests/git_api.test.js
+++ b/tests/git_api.test.js
@@ -34,6 +34,7 @@ describe('Git API', () => {
       .get('/api/git/status')
       .set('Cookie', cookie);
     expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
     expect(typeof res.body.branch).toBe('string');
     expect(typeof res.body.shortHash).toBe('string');
     expect(typeof res.body.ahead).toBe('number');


### PR DESCRIPTION
## Summary
- add `ok: true` to successful git status endpoint responses
- test git status endpoint includes `ok` field

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `pytest tests/test_prism_utils.py tests/test_hilbert_polya_gue.py`


------
https://chatgpt.com/codex/tasks/task_e_68c34540e81c8329bc0eead97a9ab1b9