### PR TITLE
fix: ensure fallback requests non-streaming JSON

### DIFF
--- a/var/www/blackroad/llm-chat.html
+++ b/var/www/blackroad/llm-chat.html
@@ -102,7 +102,11 @@ async function send(){
 }
 async function fallback(body,original){
   try{
-    const r=await fetch('/api/llm/chat',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify(body)});
+    const r=await fetch('/api/llm/chat',{
+      method:'POST',
+      headers:{'content-type':'application/json'},
+      body:JSON.stringify({...body,stream:false})
+    });
     const j=await r.json();
     addMessage('assistant',j.choices[0].message.content);
   }catch(e){addMessage('assistant',original);}


### PR DESCRIPTION
## Summary
- send `stream:false` in `fallback` so chat retry uses JSON response instead of streaming

## Testing
- `node --check srv/blackroad-api/server_min.js`
- `node --check var/www/blackroad/chat-panel.js`
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c34696c1a48329aa2abbf1b1d4056b