### PR TITLE
feat: add roadchain portal

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -48,17 +48,19 @@ export default function App(){
 
   useEffect(() => { streamRef.current = stream }, [stream])
 
-  // Restore auth token from local storage on load
+  // Restore auth token from local storage on load and clear state if missing
   useEffect(()=>{
     const token = localStorage.getItem('token')
-    if (token) setToken(token)
-    (async ()=>{
+    setToken(token || '')
+    ;(async ()=>{
       try {
         if (token) {
           const u = await me()
           setUser(u)
           await bootData()
           connectSocket()
+        } else {
+          resetState()
         }
       } catch(e){
         // Reset state on auth failure and log for debugging

--- a/frontend/src/components/RoadChain.jsx
+++ b/frontend/src/components/RoadChain.jsx
@@ -21,11 +21,12 @@ export default function RoadChain(){
     })()
   }, [])
 
-  // Clear stale search results when the query is empty or whitespace
+  // Clear stale search results and collapse blocks when the query is empty or whitespace
   useEffect(() => {
     if (!query.trim()) {
       setResult(null)
       setError('')
+      setExpanded({})
     }
   }, [query])
 


### PR DESCRIPTION
## Summary
- reset app state when no auth token exists to avoid stale data on load
- collapse RoadChain blocks when queries are cleared for a fresh search view

## Testing
- `npm --prefix backend install`
- `npm --prefix backend test`
- `npm --prefix frontend install`
- `npm --prefix frontend test`
- `npm --prefix frontend run build`
- `curl -v http://localhost:4000/api/roadchain/blocks` *(connection refused)*
- `curl -v http://localhost:4000/api/roadchain/block/0xdef456` *(connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68c345e279a4832988995833fac7c753