### PR TITLE
docs: document RoadView storage env

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -1,6 +1,9 @@
 # Shared
 JWT_SECRET=change_me_now
 
+# RoadView storage directory (overrides default if set)
+ROADVIEW_STORAGE=/srv/blackroad-api/storage/roadview
+
 # Redis
 REDIS_PASSWORD=change_me_now
 REDIS_URL=redis://:${REDIS_PASSWORD}@redis:6379/0

--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ PORT=4000
 DB_PATH=/srv/blackroad-api/blackroad.db
 
 # RoadView storage directory (overrides default if set)
-ROADVIEW_STORAGE=
+ROADVIEW_STORAGE=/srv/blackroad-api/storage/roadview
 
 # Cookies & JWT
 SESSION_SECRET=change-this-session-secret


### PR DESCRIPTION
## Summary
- document optional `ROADVIEW_STORAGE` path in environment templates

## Testing
- `PRE_COMMIT_ALLOW_NO_TAGS=1 pre-commit run --files server_full.js db/migrations/0003_roadview.sql srv/blackroad-api/.gitignore .env.example .env.docker.example` *(fails: error: pathspec 'v3.3.3' did not match any file(s) known to git)*
- `npm test` *(fails: Invalid package.json: JSONParseError)*
- `node tests/smoke.test.js` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npx eslint server_full.js` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68c345f6594883299d21f233ff00580f