### PR TITLE
fix: guard parse_numeric_prefix against literal_eval edge cases (#10)

### DIFF
--- a/prism_utils.py
+++ b/prism_utils.py
@@ -16,7 +16,8 @@ def parse_numeric_prefix(text: str) -> float:
         value = ast.literal_eval(text.split(",", maxsplit=1)[0].strip())
         if isinstance(value, (int, float)):
             return float(value)
-    except (ValueError, SyntaxError):
-        # Non-numeric or malformed prefixes fall through to the default below.
+    except (ValueError, SyntaxError, MemoryError, RecursionError):
+        # Non-numeric, malformed, or pathological prefixes fall through to the
+        # default below.
         pass
     return 1.0

--- a/tests/test_prism_utils.py
+++ b/tests/test_prism_utils.py
@@ -1,3 +1,7 @@
+import ast
+
+import pytest
+
 from prism_utils import parse_numeric_prefix
 
 
@@ -9,3 +13,12 @@ def test_parse_numeric_prefix_valid():
 def test_parse_numeric_prefix_invalid():
     assert parse_numeric_prefix("abc") == 1.0
     assert parse_numeric_prefix("1a") == 1.0
+
+
+@pytest.mark.parametrize("exc", [RecursionError, MemoryError])
+def test_parse_numeric_prefix_other_errors(monkeypatch, exc):
+    def bad_eval(_):
+        raise exc()
+
+    monkeypatch.setattr(ast, "literal_eval", bad_eval)
+    assert parse_numeric_prefix("2") == 1.0


### PR DESCRIPTION
## Summary
- guard against MemoryError and RecursionError from `ast.literal_eval`
- test error handling when literal evaluation fails

## Testing
- `pre-commit run --files prism_utils.py tests/test_prism_utils.py`
- `pytest tests/test_prism_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68c3442016e0832995567f8c4aa74501