### PR TITLE
docs: normalize health-sidecar comments

### DIFF
--- a/services/health-sidecar/.env.example
+++ b/services/health-sidecar/.env.example
@@ -1,7 +1,7 @@
-# Sample environment variables for the health-sidecar service.
-# Port to serve the health endpoints.
+# sample environment variables for the health-sidecar service
+# port to serve the health endpoints
 PORT=8088
-# Root directory where the primary API stores its health file.
+# root directory where the primary API stores its health file
 API_ROOT=/var/www/blackroad/api
-# Commit SHA injected by the deploy workflow.
+# commit SHA injected by the deploy workflow
 COMMIT_SHA=

--- a/services/health-sidecar/server.js
+++ b/services/health-sidecar/server.js
@@ -10,13 +10,13 @@ const PORT = process.env.PORT || 8088;
 const API_ROOT = process.env.API_ROOT || '/var/www/blackroad/api';
 const HEALTH_FILE = path.join(API_ROOT, 'health.json');
 
-// Simple cache-control for JSON responses.
+// simple cache-control for JSON responses
 app.use((_req, res, next) => {
   res.set('Cache-Control', 'no-store');
   next();
 });
 
-// GET /api/health (primary endpoint).
+// GET /api/health (primary endpoint)
 app.get('/api/health', (_req, res) => {
   let body = {
     status: 'ok',
@@ -37,7 +37,7 @@ app.get('/api/health', (_req, res) => {
   res.json(body);
 });
 
-// Liveness/readiness endpoints (K8s or uptime monitors).
+// liveness/readiness endpoints (k8s or uptime monitors)
 app.get('/livez', (_req, res) => res.send('OK'));
 app.get('/readyz', (_req, res) => {
   try {


### PR DESCRIPTION
## Summary
- standardize health-sidecar sample env comments
- match server comment style with repository conventions

## Testing
- `npm run lint` (fails: Cannot find module '@eslint/js')
- `npm test` (fails: jest not found)


------
https://chatgpt.com/codex/tasks/task_e_68c343d0268483299dd27215e6618f15