### PR TITLE
test: document auth helper

### DIFF
--- a/tests/api_health.test.js
+++ b/tests/api_health.test.js
@@ -3,6 +3,7 @@ process.env.INTERNAL_TOKEN = 'x';
 process.env.ALLOW_ORIGINS = 'https://example.com';
 const request = require('supertest');
 const { app, server } = require('../srv/blackroad-api/server_full.js');
+// Helper to obtain an auth cookie for requests requiring authentication
 const { getAuthCookie } = require('./helpers/auth');
 
 describe('API security and health', () => {

--- a/tests/git_api.test.js
+++ b/tests/git_api.test.js
@@ -5,6 +5,7 @@ process.env.GIT_REPO_PATH = process.cwd();
 
 const request = require('supertest');
 const { app, server } = require('../srv/blackroad-api/server_full.js');
+// Helper to log in and retrieve the auth cookie for authenticated requests
 const { getAuthCookie } = require('./helpers/auth');
 
 describe('Git API', () => {

--- a/tests/helpers/auth.js
+++ b/tests/helpers/auth.js
@@ -1,5 +1,12 @@
 const request = require('supertest');
 
+/**
+ * Log in to the application using test credentials and return the
+ * authentication cookie so it can be reused in subsequent requests.
+ *
+ * @param {import('express').Express} app - Express app under test.
+ * @returns {Promise<string[]>} cookie headers from the login response
+ */
 async function getAuthCookie(app) {
   const login = await request(app)
     .post('/api/login')


### PR DESCRIPTION
## Summary
- document getAuthCookie helper used in tests
- clarify usage of shared login helper in git and API health tests

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c346df3d38832983138e9dce94953f