### PR TITLE
fix chat stream endpoint

### DIFF
--- a/var/www/blackroad/llm-chat.html
+++ b/var/www/blackroad/llm-chat.html
@@ -102,7 +102,8 @@ async function send(){
 }
 async function fallback(body,original){
   try{
-    const r=await fetch('/api/llm/chat',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify(body)});
+    const nonStreamBody={...body,stream:false};
+    const r=await fetch('/api/llm/chat',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify(nonStreamBody)});
     const j=await r.json();
     addMessage('assistant',j.choices[0].message.content);
   }catch(e){addMessage('assistant',original);}


### PR DESCRIPTION
## Summary
- target `/api/llm/chat` when streaming from UI
- fall back to non-stream request when `/api/llm/chat` fails
- ensure fallback path uses `stream:false` for JSON retry

## Testing
- `node --check srv/blackroad-api/server_min.js`
- `node --check var/www/blackroad/chat-panel.js`
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c347180e988329abc1f46ae2a26cbb