### PR TITLE
docs: fix regex comment grammar

### DIFF
--- a/prism_utils.py
+++ b/prism_utils.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 
-# Match optional leading whitespace, an optional sign, digits, and an optional
+# Matches optional leading whitespace, an optional sign, digits, and an optional
 # fractional part.
 _NUMERIC_PREFIX = re.compile(r"^\s*([+-]?\d+(?:\.\d+)?)")
 


### PR DESCRIPTION
## Summary
- fix grammar in numeric prefix regex comment

## Testing
- `pre-commit run --files prism_utils.py tests/test_prism_utils.py`
- `pytest tests/test_prism_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68c34560df7083298fa44d41413fa20a