### PR TITLE
fix: parse scientific notation prefixes

### DIFF
--- a/prism_utils.py
+++ b/prism_utils.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import ast
 import re
 
-_NUMERIC_PREFIX_RE = re.compile(r"^\s*([+-]?(?:\d+(?:\.\d*)?|\.\d+))")
+_NUMERIC_PREFIX_RE = re.compile(r"^\s*([+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?)")
 
 
 def parse_numeric_prefix(text: str) -> float:

--- a/tests/test_prism_utils.py
+++ b/tests/test_prism_utils.py
@@ -6,6 +6,8 @@ def test_parse_numeric_prefix_valid():
     assert parse_numeric_prefix("3.5") == 3.5
     assert parse_numeric_prefix("2 rest") == 2.0
     assert parse_numeric_prefix(" -4.2 extra") == -4.2
+    assert parse_numeric_prefix("2e3") == 2000.0
+    assert parse_numeric_prefix("-1.5e-2 extra") == -0.015
 
 
 def test_parse_numeric_prefix_invalid():


### PR DESCRIPTION
## Summary
- allow optional exponent in `_NUMERIC_PREFIX_RE` so scientific notation is parsed correctly
- test scientific-notation inputs like `2e3` and `-1.5e-2`

## Testing
- `pre-commit run --files prism_utils.py tests/test_prism_utils.py main.py`
- `pytest tests/test_prism_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68c344997f6c83298d887c48cd1b54ae