### PR TITLE
fix: narrow parse errors

### DIFF
--- a/prism_utils.py
+++ b/prism_utils.py
@@ -10,8 +10,8 @@ def parse_numeric_prefix(text: str) -> float:
 
     This uses :func:`ast.literal_eval` for safety instead of ``eval`` and
     accepts inputs like ``"2, something"``. Non-numeric or invalid values
-    raise ``ValueError`` or ``SyntaxError``, which are suppressed and
-    result in a default return of ``1.0``.
+    would raise ``ValueError`` or ``SyntaxError``, but these are suppressed
+    and result in a default return of ``1.0``.
     """
     try:
         value = ast.literal_eval(text.split(",", maxsplit=1)[0].strip())

--- a/tests/test_prism_utils.py
+++ b/tests/test_prism_utils.py
@@ -1,12 +1,24 @@
+"""Tests for :mod:`prism_utils`."""
+
+import pytest
+
 from prism_utils import parse_numeric_prefix
 
 
-def test_parse_numeric_prefix_valid():
-    assert parse_numeric_prefix("2, rest") == 2.0
-    assert parse_numeric_prefix("3.5") == 3.5
-    assert parse_numeric_prefix("-4, things") == -4.0
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("2, rest", 2.0),
+        ("3.5", 3.5),
+        ("-4, things", -4.0),
+    ],
+)
+def test_parse_numeric_prefix_valid(text: str, expected: float) -> None:
+    """Return parsed value for valid numeric prefixes."""
+    assert parse_numeric_prefix(text) == expected
 
 
-def test_parse_numeric_prefix_invalid():
-    assert parse_numeric_prefix("abc") == 1.0
-    assert parse_numeric_prefix("1a") == 1.0
+@pytest.mark.parametrize("text", ["abc", "1a", "("])
+def test_parse_numeric_prefix_invalid(text: str) -> None:
+    """Fall back to ``1.0`` when parsing fails."""
+    assert parse_numeric_prefix(text) == 1.0


### PR DESCRIPTION
## Summary
- clarify parse_numeric_prefix docstring about suppressed ValueError/SyntaxError
- parametrize parse_numeric_prefix tests and cover SyntaxError case

## Testing
- `pre-commit run --files prism_utils.py tests/test_prism_utils.py`
- `pytest tests/test_prism_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c34409db408329b73172cf31a97def