### PR TITLE
docs: clarify OpenAI client comment

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,9 +16,9 @@ from prism_utils import parse_numeric_prefix
 st.set_page_config(layout="wide")
 st.title("BlackRoad Prism Generator with GPT + Voice Console")
 
-# Configure the OpenAI client
-_api_key = os.getenv("OPENAI_API_KEY")
-client = OpenAI(api_key=_api_key) if _api_key else None
+# Configure the OpenAI client only when an API key is available
+openai_api_key = os.getenv("OPENAI_API_KEY")
+client = OpenAI(api_key=openai_api_key) if openai_api_key else None
 if client is None:
     st.warning("OpenAI API key not set. Set OPENAI_API_KEY to enable responses.")
 


### PR DESCRIPTION
## Summary
- rename variable to `openai_api_key` and explain that the client is only created when the API key is present

## Testing
- `ruff check main.py tests/test_prism_utils.py prism_utils.py`
- `pytest` *(errors during collection: 18)*
- `pytest tests/test_prism_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68c348bc5d948329a704311e39dd3e7f