### PR TITLE
fix: address repo doctor loop and tidy dangerfile

### DIFF
--- a/.danger/dangerfile.js
+++ b/.danger/dangerfile.js
@@ -4,7 +4,7 @@
 
 // PR quality checks executed by Danger.js
 
-const files = danger.git.modified_files.concat(danger.git.created_files);
+const files = [...danger.git.modified_files, ...danger.git.created_files];
 const big = files.filter((f) => f.endsWith('.html') || f.endsWith('.js'));
 
 if (big.length > 0) {

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,4 @@ repos:
       - id: eslint
         args: ['--fix']
         files: "\\.(js|jsx|ts|tsx)$"
+        additional_dependencies: ['@eslint/js']

--- a/.tools/doctor/repo-doctor.sh
+++ b/.tools/doctor/repo-doctor.sh
@@ -27,17 +27,17 @@ fi
 # 3) JS quick syntax
 section "JavaScript Syntax"
 errs=0
-while read -r f; do
+while IFS= read -r f; do
   node -c "$f" >/dev/null 2>&1 || { echo "❌ $f" >> "$OUT"; errs=$((errs+1)); }
-done < <(grep -RIl --include="*.js" . || true)
+done < <(git ls-files -- '*.js')
 [ "$errs" = "0" ] && line "✅ no syntax errors detected"
 
 # 4) License headers (sample check)
 section "License Headers (sample)"
 miss=0
-for f in $(git ls-files | grep -E '\.(js|yml|yaml|html)$'); do
+while IFS= read -r f; do
   grep -q "Copyright" "$f" || miss=$((miss+1))
-done
+done < <(git ls-files -- '*.js' '*.yml' '*.yaml' '*.html')
 line "Files without explicit copyright: ${miss}"
 
 # 5) Big files


### PR DESCRIPTION
## Summary
- simplify Danger.js file aggregation with array spread
- audit tracked files in repo doctor via `git ls-files` and safe `while read` loops
- add `@eslint/js` to satisfy ESLint configuration

## Testing
- `pre-commit run --files .danger/dangerfile.js .tools/doctor/repo-doctor.sh .pre-commit-config.yaml`
- `bash .tools/doctor/repo-doctor.sh repo-doctor-report.md`


------
https://chatgpt.com/codex/tasks/task_e_68c347dbbce88329a0fe9e477c45889e