### PR TITLE
Scope Pages deployments to site directories

### DIFF
--- a/.github/workflows/pages-stage.yml
+++ b/.github/workflows/pages-stage.yml
@@ -24,8 +24,6 @@ jobs:
         working-directory: blackroad-stage
         env:
           AWAKEN_SEED: ${{ secrets.AWAKEN_SEED }}
-          GODADDY_API_KEY: ${{ secrets.GODADDY_API_KEY }}
-          GODADDY_API_SECRET: ${{ secrets.GODADDY_API_SECRET }}
         run: |
           set -eux
           mkdir -p health
@@ -34,34 +32,8 @@ jobs:
           printf '{"ok":true,"service":"blackroad","version":"0.1.0","proof":"%s"}' "$PROOF" > health.json
           cp health.json health/index.json || true
           sed -i "s|%%PROOF%%|$PROOF|g" index.html || true
-          # Optional: write DNS TXT via GoDaddy API
-          if [ -n "${GODADDY_API_KEY:-}" ] && [ -n "${GODADDY_API_SECRET:-}" ]; then
-            curl -fsS -X PUT \
-              -H "Authorization: sso-key $GODADDY_API_KEY:$GODADDY_API_SECRET" \
-              -H "Content-Type: application/json" \
-              -d "[{\"data\":\"$PROOF\",\"ttl\":600}]" \
-              "https://api.godaddy.com/v1/domains/blackroad.io/records/TXT/stage-proof" || true
-          else
-            echo "::notice title=DNS::Set TXT stage-proof.blackroad.io = $PROOF (TTL 600)"
-          fi
       - name: Upload stage build artifact
         uses: actions/upload-artifact@v4
         with:
           name: blackroad-stage
           path: blackroad-stage
-      - name: Circuit-breaker health check (STAGE)
-        run: |
-          ok=0
-          for i in $(seq 1 30); do
-            sleep 2
-            html=$(curl -fsS https://stage.blackroad.io/ || true)
-            api=$(curl -fsS https://stage.blackroad.io/health.json || true)
-            txt=$(dig +short TXT stage-proof.blackroad.io @8.8.8.8 | tr -d '"')
-            echo "Probe $i html=${#html} api=$api txt=$txt"
-            echo "$html" | grep -q "<!-- BLACKROAD OK -->" || { echo "no marker"; continue; }
-            echo "$api" | jq -e '.ok==true and .service=="blackroad"' >/dev/null || { echo "bad health"; continue; }
-            want=$(jq -r .proof <<<"$api")
-            [ -n "$want" ] && [ "$txt" = "$want" ] || { echo "txt mismatch ($txt != $want)"; continue; }
-            ok=$((ok+1)); [ $ok -ge 2 ] && exit 0
-          done
-          echo "Circuit-breaker: not healthy yet"; exit 1


### PR DESCRIPTION
## Summary
- prevent stage workflow from publishing to GitHub Pages and overwriting production site
- skip DNS proof update and circuit-breaker check when stage site isn't deployed

## Testing
- `pre-commit run --files .github/workflows/pages-stage.yml`
- `npm test` *(fails: jest not found)*
- `pytest` *(fails: ModuleNotFoundError: torch)*

------
https://chatgpt.com/codex/tasks/task_e_68c348eaf4208329b89f9fb9681b9760