### PR TITLE
chore(auto-heal): refine step comments

### DIFF
--- a/.github/tools/autoheal.sh
+++ b/.github/tools/autoheal.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Track whether the fixer changed anything
+# Track whether this script changes anything
 changed=false
 git_add() { git add "$@" && changed=true; }
 
-# 0) Ensure Node project & basic scripts
+# Step 1: ensure a Node project exists with basic scripts
 if [ ! -f package.json ]; then
   npm init -y >/dev/null 2>&1 || true
   git_add package.json
@@ -23,7 +23,7 @@ fs.writeFileSync(p, JSON.stringify(j, null, 2));
 JS
 git_add package.json || true
 
-# 1) Lint/format configs
+# Step 2: add baseline lint/format configs
 [ -f .prettierrc.json ] || {
   echo '{ "printWidth": 100, "singleQuote": true, "trailingComma": "es5" }' > .prettierrc.json
   git_add .prettierrc.json
@@ -34,7 +34,7 @@ git_add package.json || true
   git_add eslint.config.js
 }
 
-# 2) Install tools and apply fixes (best effort)
+# Step 3: install tools and apply fixes (best effort)
 npm i -D prettier eslint eslint-config-prettier >/dev/null 2>&1 || true
 npx --yes prettier -w .  >/dev/null 2>&1 || true
 npx --yes eslint . --ext .js,.mjs,.cjs --fix >/dev/null 2>&1 || true
@@ -42,7 +42,7 @@ npx --yes eslint . --ext .js,.mjs,.cjs --fix >/dev/null 2>&1 || true
 # Stage any new changes from format/fix
 git diff --quiet || { git add -A && changed=true; }
 
-# 3) Commit if anything changed
+# Step 4: commit if anything changed
 if $changed; then
   git commit -m "chore(auto-heal): baseline configs + prettier/eslint --fix" || true
   echo "committed=1" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/auto-heal.yml
+++ b/.github/workflows/auto-heal.yml
@@ -34,7 +34,7 @@ jobs:
           [ -z "$BOT_TOKEN" ] && { echo "::warning::No BOT_TOKEN secret; cannot push auto-heal changes."; exit 0; }
           git push "https://${BOT_TOKEN}@github.com/${{ github.repository }}.git" "HEAD:$(git rev-parse --abbrev-ref HEAD)"
 
-      - name: PR comment summary
+      - name: Post auto-heal summary comment
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:


### PR DESCRIPTION
## Summary
- clarify auto-heal script comments with step-based wording
- rename workflow summary step for clearer output

## Testing
- ⚠️ `npm ci --ignore-scripts --no-audit --no-fund` (terminated)
- ⚠️ `npm test` (jest: not found)
- ⚠️ `npm run lint` (Cannot find module '@eslint/js`)


------
https://chatgpt.com/codex/tasks/task_e_68c34ab7c77c83298fd42d5eff2c2edc