### PR TITLE
fix: address repo doctor loop and tidy dangerfile

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,4 @@ repos:
       - id: eslint
         args: ['--fix']
         files: "\\.(js|jsx|ts|tsx)$"
+        additional_dependencies: ['@eslint/js']


### PR DESCRIPTION
## Summary
- simplify Dangerfile file aggregation with array spread
- use safe `git ls-files` loops in repo doctor for syntax and license checks
- add `@eslint/js` dependency for ESLint pre-commit hook

## Testing
- `pre-commit run --files .danger/dangerfile.js .tools/doctor/repo-doctor.sh .pre-commit-config.yaml`
- `bash .tools/doctor/repo-doctor.sh repo-doctor-report.md`


------
https://chatgpt.com/codex/tasks/task_e_68c34b1263b883298fd450435c5d3ce7