### PR TITLE
chore: expand jest config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,5 +3,8 @@ module.exports = {
   testEnvironment: 'node',
   verbose: true,
   roots: ['<rootDir>/tests'],
-  testMatch: ['**/*.test.js'],
+  testMatch: [
+    '**/?(*.)+(spec|test).[jt]s?(x)',
+    '**/?(*.)+(spec|test).mjs',
+  ],
 };

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint srv/blackroad-api/server_full.js tests/api_health.test.js tests/git_api.test.js",
     "format": "prettier . --write",
     "format:check": "prettier package.json tests/api_health.test.js srv/lucidia-llm/test_app.py var/www/blackroad/.prettierrc.json .prettierrc.json RUNME.sh Makefile .github/workflows/ci.yml CLEANUP_PLAN.md CLEANUP_DECISIONS.md CLEANUP_RESULTS.md ROLLBACK.md CHANGELOG.md --check --ignore-unknown",
-    "test": "jest",
+    "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
     "typecheck": "echo 'no typecheck'",
     "health": "node scripts/health.js",
     "dev:site": "npm --prefix sites/blackroad run dev",


### PR DESCRIPTION
## Summary
- support spec and mjs files in Jest config
- run tests with cross-env and Node ESM flags

## Testing
- `npm test` *(fails: cross-env not found)*
- `pre-commit run --files jest.config.js package.json` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3379e00a883299b4dea05dd3820a3