### PR TITLE
Narrow parse errors and expand numeric prefix tests

### DIFF
--- a/prism_utils.py
+++ b/prism_utils.py
@@ -16,6 +16,7 @@ def parse_numeric_prefix(text: str) -> float:
         value = ast.literal_eval(text.split(",", maxsplit=1)[0].strip())
         if isinstance(value, (int, float)):
             return float(value)
-    except Exception:
+    except (ValueError, SyntaxError):
+        # Raised when the leading segment isn't a valid Python literal
         pass
     return 1.0

--- a/tests/test_prism_utils.py
+++ b/tests/test_prism_utils.py
@@ -4,8 +4,12 @@ from prism_utils import parse_numeric_prefix
 def test_parse_numeric_prefix_valid():
     assert parse_numeric_prefix("2, rest") == 2.0
     assert parse_numeric_prefix("3.5") == 3.5
+    assert parse_numeric_prefix(" -7, stuff") == -7.0
+    assert parse_numeric_prefix("1e3") == 1000.0
+    assert parse_numeric_prefix(" 4 ") == 4.0
 
 
 def test_parse_numeric_prefix_invalid():
     assert parse_numeric_prefix("abc") == 1.0
     assert parse_numeric_prefix("1a") == 1.0
+    assert parse_numeric_prefix("") == 1.0


### PR DESCRIPTION
## Summary
- restrict `parse_numeric_prefix` to handle only value/syntax errors
- add tests covering negative values, scientific notation, whitespace, and empty strings

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `pytest tests/test_prism_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68c32f8ade0483298614cac9cb2dda90