### PR TITLE
fix(api): add /healthz endpoint

### DIFF
--- a/srv/blackroad-api/server_full.js
+++ b/srv/blackroad-api/server_full.js
@@ -214,10 +214,13 @@ app.use(
 app.get('/', (_, res) => {
   res.sendFile(path.join(WEB_ROOT, 'index.html'));
 });
-app.head('/health', (_req, res) => res.status(200).end());
-app.get('/health', (_req, res) => {
+function sendHealth(_req, res) {
   res.json({ ok: true, version: '1.0.0', uptime: process.uptime() });
-});
+}
+app.head('/health', (_req, res) => res.status(200).end());
+app.get('/health', sendHealth);
+app.head('/healthz', (_req, res) => res.status(200).end());
+app.get('/healthz', sendHealth);
 
 // --- Health
 app.head('/api/health', (_, res) => res.status(200).end());

--- a/tests/api_health.test.js
+++ b/tests/api_health.test.js
@@ -15,6 +15,12 @@ describe('API security and health', () => {
     expect(res.body.ok).toBe(true);
   });
 
+  it('responds to /healthz', async () => {
+    const res = await request(app).get('/healthz');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
   it('responds to /api/health with security headers', async () => {
     const res = await request(app)
       .get('/api/health')


### PR DESCRIPTION
## Summary
- expose `/healthz` handler alongside existing `/health`
- test new `/healthz` route

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68c32af28e0083299341ee3e1a972831