### PR TITLE
feat: add configurable working copy refresh

### DIFF
--- a/docs/blackroad-sync.md
+++ b/docs/blackroad-sync.md
@@ -23,10 +23,12 @@ python codex/tools/blackroad_sync.py "Push latest to BlackRoad.io"
 
 Extend each function in `codex/tools/blackroad_sync.py` with real OAuth flows,
 webhook listeners and deployment logic as the infrastructure evolves.
+
 # BlackRoad.io Sync & Deploy
 
 The `scripts/blackroad_sync.sh` helper provides a chat-first interface to keep
 BlackRoad.io in sync across GitHub, connectors, Working Copy and the droplet.
+
 # BlackRoad Codex Sync & Deploy
 
 `codex/tools/blackroad_deploy.py` provides a scaffold for end-to-end
@@ -50,6 +52,7 @@ Working Copy refreshes, and droplet deployment behind a chat-style CLI.
 - `AIRTABLE_WEBHOOK` – hook to trigger Airtable jobs
 - `SLACK_WEBHOOK` – Slack Incoming Webhook for status updates
 - `WORKING_COPY_SSH` and `WORKING_COPY_PATH` – remote path for iOS Working Copy
+- `WORKING_COPY_CMD` – optional command to refresh a Working Copy client
 - `DROPLET_SSH` – SSH target for the deployment server
 
 The droplet deploy step expects the site to live at `/srv/blackroad` and will
@@ -59,6 +62,7 @@ Use the `all` command to push, sync connectors, refresh the working copy and
 deploy in a single flow.
 python3 codex/tools/blackroad_deploy.py "Push latest to BlackRoad.io"
 python3 codex/tools/blackroad_deploy.py "Refresh working copy and redeploy"
+
 ```
 
 Without an argument the script will prompt for a command.
@@ -73,3 +77,4 @@ Without an argument the script will prompt for a command.
 
 The script is a starting point; expand the connector and deployment steps
 to match production infrastructure.
+```

--- a/scripts/blackroad_sync.py
+++ b/scripts/blackroad_sync.py
@@ -69,7 +69,18 @@ def sync_connectors(ctx: PipelineContext) -> bool:
 
 
 def refresh_working_copy(ctx: PipelineContext) -> bool:
-    """Refresh Working Copy mirror at the designated path."""
+    """Refresh the iOS Working Copy mirror.
+
+    If ``WORKING_COPY_CMD`` is set in the environment, that command is executed
+    to allow custom integration with the Working Copy app (for example via
+    x-callback-url).  Otherwise the function falls back to running ``git pull``
+    in the configured ``WORKING_COPY_PATH``.
+    """
+    cmd = os.getenv("WORKING_COPY_CMD")
+    if cmd:
+        LOG.info("Refreshing Working Copy via command: %s", cmd)
+        return run(cmd)
+
     wc = ctx.working_copy
     wc.mkdir(parents=True, exist_ok=True)
     LOG.info("Refreshing Working Copy mirror at %s", wc)


### PR DESCRIPTION
## Summary
- allow `WORKING_COPY_CMD` to refresh iOS Working Copy in `scripts/blackroad_sync.py`
- document `WORKING_COPY_CMD` environment variable in sync guide

## Testing
- `pre-commit run --files scripts/blackroad_sync.py docs/blackroad-sync.md`
- `pytest` *(fails: 18 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c34e670b1c83298f70ab0fb26f5645