### PR TITLE
feat: add slack webhook notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,9 @@ python codex/tools/blackroad_sync.py sync
 ```
 
 Extend the script with real webhooks, Slack posts, or droplet deployments as
-needed.
+needed. For example, `scripts/blackroad_ci.py` will post connector sync
+updates to Slack when a `SLACK_WEBHOOK_URL` environment variable points to an
+incoming webhook.
 
 ---
 


### PR DESCRIPTION
## Summary
- add Slack webhook integration to CI connector sync
- document `SLACK_WEBHOOK_URL` usage in README

## Testing
- `pre-commit run --files scripts/blackroad_ci.py README.md`
- `pytest -q` *(fails: 18 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c34e5705008329aeced7004afbc349