### PR TITLE
feat: add Atlassian integration helpers

### DIFF
--- a/codex/tools/blackroad_sync_pipeline.py
+++ b/codex/tools/blackroad_sync_pipeline.py
@@ -21,6 +21,8 @@ import os
 import subprocess
 from typing import List
 
+from tools.atlassian import create_jira_issue
+
 # ---------------------------------------------------------------------------
 # Utility helpers
 # ---------------------------------------------------------------------------
@@ -48,13 +50,18 @@ def git_push(message: str = "Sync changes via Codex"):
 # ---------------------------------------------------------------------------
 
 def run_connector_jobs():
-    """Placeholder for connector sync logic.
+    """Run placeholder connector sync jobs with optional Atlassian hook."""
 
-    Implement OAuth flows and webhook listeners for services such as
-    Salesforce, Airtable, Slack and Linear.  This function simply notifies the
-    user that connector jobs should run here.
-    """
     print("[connectors] run background sync jobs here …")
+    try:
+        create_jira_issue(
+            "Automated sync",
+            "Background connector sync triggered by pipeline",
+            os.getenv("ATLASSIAN_PROJECT_KEY", "BR"),
+        )
+        print("[connectors] created JIRA issue")
+    except Exception as exc:  # pragma: no cover - best effort
+        print(f"[connectors] JIRA integration unavailable: {exc}")
 
 # ---------------------------------------------------------------------------
 # Working Copy automation

--- a/tests/test_atlassian.py
+++ b/tests/test_atlassian.py
@@ -1,0 +1,41 @@
+from typing import Any, Dict
+
+import base64
+import pytest
+
+from tools.atlassian import create_jira_issue
+
+
+class DummyResponse:
+    def __init__(self, data: Dict[str, Any]):
+        self._data = data
+
+    def json(self) -> Dict[str, Any]:
+        return self._data
+
+    def raise_for_status(self) -> None:  # pragma: no cover - simple stub
+        return None
+
+
+def test_create_jira_issue(monkeypatch: pytest.MonkeyPatch) -> None:
+    called: Dict[str, Any] = {}
+
+    def fake_post(url: str, *, headers: Dict[str, str], json: Dict[str, Any], timeout: int) -> DummyResponse:
+        called["url"] = url
+        called["headers"] = headers
+        called["json"] = json
+        return DummyResponse({"id": "100"})
+
+    monkeypatch.setenv("ATLASSIAN_BASE_URL", "https://example.atlassian.net")
+    monkeypatch.setenv("ATLASSIAN_EMAIL", "user@example.com")
+    monkeypatch.setenv("ATLASSIAN_API_TOKEN", "token123")
+    monkeypatch.setattr("requests.post", fake_post)
+
+    result = create_jira_issue("test", "desc", "BR")
+    assert result == {"id": "100"}
+    assert called["url"] == "https://example.atlassian.net/rest/api/3/issue"
+    assert called["json"]["fields"]["project"]["key"] == "BR"
+    auth = called["headers"]["Authorization"]
+    assert auth.startswith("Basic ")
+    decoded = base64.b64decode(auth[6:]).decode()
+    assert decoded == "user@example.com:token123"

--- a/tools/atlassian.py
+++ b/tools/atlassian.py
@@ -1,0 +1,60 @@
+"""Minimal Atlassian (JIRA) integration helpers."""
+
+from __future__ import annotations
+
+import base64
+import os
+from typing import Any, Dict
+
+import requests
+
+
+def _auth_header(email: str, token: str) -> str:
+    creds = f"{email}:{token}".encode("utf-8")
+    return base64.b64encode(creds).decode("utf-8")
+
+
+def create_jira_issue(
+    summary: str,
+    description: str,
+    project_key: str,
+    *,
+    issue_type: str = "Task",
+    base_url: str | None = None,
+    email: str | None = None,
+    api_token: str | None = None,
+) -> Dict[str, Any]:
+    """Create an issue in Atlassian JIRA.
+
+    Configuration values are taken from the environment when not
+    explicitly provided:
+
+    ``ATLASSIAN_BASE_URL`` – Base URL of the JIRA instance.
+    ``ATLASSIAN_EMAIL`` – User email for authentication.
+    ``ATLASSIAN_API_TOKEN`` – API token for the user.
+    """
+
+    base_url = base_url or os.getenv("ATLASSIAN_BASE_URL")
+    email = email or os.getenv("ATLASSIAN_EMAIL")
+    api_token = api_token or os.getenv("ATLASSIAN_API_TOKEN")
+    if not base_url or not email or not api_token:
+        raise RuntimeError("Atlassian credentials are not fully configured")
+
+    url = f"{base_url.rstrip('/')}/rest/api/3/issue"
+    headers = {
+        "Authorization": f"Basic {_auth_header(email, api_token)}",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "fields": {
+            "project": {"key": project_key},
+            "summary": summary,
+            "description": description,
+            "issuetype": {"name": issue_type},
+        }
+    }
+    resp = requests.post(url, headers=headers, json=payload, timeout=10)
+    resp.raise_for_status()
+    return resp.json()
+


### PR DESCRIPTION
## Summary
- add minimal Jira helper for creating issues via REST API
- hook pipeline connector step to optionally create Jira tickets
- test Atlassian helper

## Testing
- `pytest tests/test_atlassian.py`
- `npm test` *(fails: 503 Service Unavailable - GET http://verdaccio.internal:4873/jest)*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c34e5ceb1c8329b33eaa6ad884de23