### PR TITLE
fix: validate diff paths

### DIFF
--- a/prism/server/src/routes/diffs.ts
+++ b/prism/server/src/routes/diffs.ts
@@ -37,7 +37,11 @@ export default async function diffsRoutes(fastify: FastifyInstance) {
     const workRoot = path.resolve(process.cwd(), '../work');
     for (const d of body.diffs) {
       const result = applyPatch('', d.patch);
-      const target = path.join(workRoot, d.path);
+      const target = path.resolve(workRoot, d.path);
+      if (!target.startsWith(workRoot + path.sep)) {
+        reply.code(400).send({ error: 'Invalid path' });
+        return;
+      }
       fs.mkdirSync(path.dirname(target), { recursive: true });
       fs.writeFileSync(target, result);
       const event: PrismEvent = {

--- a/prism/server/test/diffs.test.ts
+++ b/prism/server/test/diffs.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import supertest from 'supertest';
+import { createPatch } from 'diff';
+import { createHash } from 'crypto';
 import { createServer } from '../src/server';
 
 describe('diffs API', () => {
@@ -9,6 +11,20 @@ describe('diffs API', () => {
     const res = await supertest(app.server).post('/diffs/propose').send({ files: { 'hello.txt': 'hi' } });
     expect(res.body.length).toBeGreaterThan(0);
     expect(res.body[0].patch).toContain('hi');
+    await app.close();
+  });
+
+  it('rejects paths outside work root', async () => {
+    const app = await createServer(':memory:');
+    await app.ready();
+    const diff = {
+      path: '../evil.txt',
+      beforeSha: createHash('sha1').update('').digest('hex'),
+      afterSha: createHash('sha1').update('bad').digest('hex'),
+      patch: createPatch('../evil.txt', '', 'bad')
+    };
+    const res = await supertest(app.server).post('/diffs/apply').send({ diffs: [diff], message: 'test' });
+    expect(res.status).toBe(400);
     await app.close();
   });
 });


### PR DESCRIPTION
## Summary
- reject paths escaping work root when applying diffs
- test diff apply rejects path traversal

## Testing
- `pnpm -C prism/server exec eslint .`
- `pnpm -C prism/apps/web exec eslint .`
- `pnpm -C prism/server test`
- `pnpm -C server test` *(fails: ENOENT: no such file or directory, lstat '/workspace/blackroad-prism-console/server')*

------
https://chatgpt.com/codex/tasks/task_e_68c356d9515c8329b6d0ef9b5915c485