### PR TITLE
fix: reset auth early and clear search state

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -48,21 +48,22 @@ export default function App(){
 
   useEffect(() => { streamRef.current = stream }, [stream])
 
-  // Restore auth token from local storage on load and clear state if missing
-  useEffect(()=>{
+  // Restore auth token from local storage on load and reset when missing
+  useEffect(() => {
     const token = localStorage.getItem('token')
-    setToken(token || '')
-    ;(async ()=>{
+    if (!token) {
+      // Clear any lingering state when no token exists
+      resetState()
+      return
+    }
+    setToken(token)
+    ;(async () => {
       try {
-        if (token) {
-          const u = await me()
-          setUser(u)
-          await bootData()
-          connectSocket()
-        } else {
-          resetState()
-        }
-      } catch(e){
+        const u = await me()
+        setUser(u)
+        await bootData()
+        connectSocket()
+      } catch (e) {
         // Reset state on auth failure and log for debugging
         resetState()
         console.error('User not authenticated:', e)

--- a/frontend/src/components/RoadChain.jsx
+++ b/frontend/src/components/RoadChain.jsx
@@ -21,13 +21,12 @@ export default function RoadChain(){
     })()
   }, [])
 
-  // Clear stale search results and collapse blocks when the query is empty or whitespace
+  // Clear stale search results when the query changes, collapsing blocks if empty
   useEffect(() => {
-    if (!query.trim()) {
-      setResult(null)
-      setError('')
-      setExpanded({})
-    }
+    const q = query.trim()
+    setResult(null)
+    setError('')
+    if (!q) setExpanded({})
   }, [query])
 
   function toggle(hash){


### PR DESCRIPTION
## Summary
- reset app state early when no auth token exists to avoid bootstrapping with stale data
- clear RoadChain search results and errors whenever query changes, only collapsing blocks on empty input

## Testing
- `npm --prefix backend install`
- `npm --prefix backend test`
- `npm --prefix frontend install`
- `npm --prefix frontend test`
- `npm --prefix frontend run build`
- `curl -s http://localhost:4000/api/roadchain/blocks`
- `curl -s http://localhost:4000/api/roadchain/block/0xdef456`


------
https://chatgpt.com/codex/tasks/task_e_68c361bab4a48329a4716010e2a0386d