### PR TITLE
feat: parse decimals without leading zero

### DIFF
--- a/prism_utils.py
+++ b/prism_utils.py
@@ -5,16 +5,20 @@ from __future__ import annotations
 import re
 
 # Match an optional sign and decimal number at the start of the string.
-_NUMERIC_PREFIX = re.compile(r"^\s*([+-]?\d+(?:\.\d+)?)")
+#
+# The pattern also accepts numbers like ``.5`` or ``-.25`` that omit the
+# leading ``0`` before the decimal point.
+_NUMERIC_PREFIX = re.compile(r"^\s*([+-]?(?:\d+(?:\.\d+)?|\.\d+))")
 
 
 def parse_numeric_prefix(text: str) -> float:
     """Extract a leading decimal value from ``text``.
 
     The regex ignores leading whitespace and accepts an optional ``+`` or ``-``
-    sign and an optional fractional part. If no valid number is found, ``1.0``
-    is returned. Inputs such as ``"-3.5 apples"`` or ``"2, rest"`` are
-    recognized; malformed values default to ``1.0``.
+    sign and an optional fractional part. Numbers lacking a leading zero, such
+    as ``".5 kg"`` or ``"-.25"``, are also recognized. If no valid number is
+    found, ``1.0`` is returned. Inputs such as ``"-3.5 apples"`` or ``"2, rest"``
+    are recognized; malformed values default to ``1.0``.
     """
     match = _NUMERIC_PREFIX.match(text)
     if match:

--- a/tests/test_prism_utils.py
+++ b/tests/test_prism_utils.py
@@ -10,6 +10,8 @@ def test_parse_numeric_prefix_valid():
     assert parse_numeric_prefix("3.5") == 3.5
     assert parse_numeric_prefix("-1 stuff") == -1.0
     assert parse_numeric_prefix("+4") == 4.0
+    assert parse_numeric_prefix(".5 pears") == 0.5
+    assert parse_numeric_prefix("-.25") == -0.25
 
 
 def test_parse_numeric_prefix_invalid():


### PR DESCRIPTION
## Summary
- support numeric prefixes like `.5` and `-.25` in `parse_numeric_prefix`
- test decimal parsing without a leading zero

## Testing
- `pytest tests/test_prism_utils.py`
- `pre-commit run --files prism_utils.py tests/test_prism_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68c361e4f0d08329a771df7519e1b992