### PR TITLE
chore(automation): fix release annotation comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0 https://github.com/actions/checkout/releases/tag/v4.3.0
+        # v4.3.0 https://github.com/actions/checkout/releases/tag/v4.3.0
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
 
       - name: Use Node.js 20.x
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0 https://github.com/actions/setup-node/releases/tag/v4.4.0
+        # v4.4.0 https://github.com/actions/setup-node/releases/tag/v4.4.0
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 20
           cache: npm
@@ -82,7 +84,8 @@ jobs:
           tar -czf release.tar.gz -C release .
 
       - name: Upload artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2 https://github.com/actions/upload-artifact/releases/tag/v4.6.2
+        # v4.6.2 https://github.com/actions/upload-artifact/releases/tag/v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: release-${{ github.sha }}
           path: release.tar.gz
@@ -96,10 +99,12 @@ jobs:
     environment: production
     steps:
       - name: Checkout
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0 https://github.com/actions/checkout/releases/tag/v4.3.0
+        # v4.3.0 https://github.com/actions/checkout/releases/tag/v4.3.0
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
 
       - name: Download artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0 https://github.com/actions/download-artifact/releases/tag/v4.3.0
+        # v4.3.0 https://github.com/actions/download-artifact/releases/tag/v4.3.0
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           name: release-${{ github.sha }}
           path: .

--- a/.github/workflows/html-validate.yml
+++ b/.github/workflows/html-validate.yml
@@ -5,10 +5,12 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0 https://github.com/actions/checkout/releases/tag/v4.3.0
+      - # v4.3.0 https://github.com/actions/checkout/releases/tag/v4.3.0
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - id: chk
         run: f="apps/quantum/ternary_consciousness_v3.html"; [ -f "$f" ] && echo ok=1 >> $GITHUB_OUTPUT || echo ok=0 >> $GITHUB_OUTPUT
-      - uses: Cyb3r-Jak3/html5validator-action@41633d488eb36e18fd1a95ffc83daf1bf22a75bd # v7.2.0 https://github.com/Cyb3r-Jak3/html5validator-action/releases/tag/v7.2.0
+      - # v7.2.0 https://github.com/Cyb3r-Jak3/html5validator-action/releases/tag/v7.2.0
+        uses: Cyb3r-Jak3/html5validator-action@41633d488eb36e18fd1a95ffc83daf1bf22a75bd
         if: steps.chk.outputs.ok == '1'
         with:
           root: .

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -5,10 +5,12 @@ jobs:
   lychee:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0 https://github.com/actions/checkout/releases/tag/v4.3.0
+      - # v4.3.0 https://github.com/actions/checkout/releases/tag/v4.3.0
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - id: chk
         run: f="apps/quantum/ternary_consciousness_v3.html"; [ -f "$f" ] && echo ok=1 >> $GITHUB_OUTPUT || echo ok=0 >> $GITHUB_OUTPUT
-      - uses: lycheeverse/lychee-action@885c65f3dc543b57c898c8099f4e08c8afd178a2 # v2.6.1 https://github.com/lycheeverse/lychee-action/releases/tag/v2.6.1
+      - # v2.6.1 https://github.com/lycheeverse/lychee-action/releases/tag/v2.6.1
+        uses: lycheeverse/lychee-action@885c65f3dc543b57c898c8099f4e08c8afd178a2
         if: steps.chk.outputs.ok == '1'
         with:
           args: --verbose --no-progress --timeout 20s "apps/quantum/ternary_consciousness_v3.html"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,8 +11,10 @@ jobs:
   eslint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0 https://github.com/actions/checkout/releases/tag/v4.3.0
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0 https://github.com/actions/setup-node/releases/tag/v4.4.0
+      - # v4.3.0 https://github.com/actions/checkout/releases/tag/v4.3.0
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+      - # v4.4.0 https://github.com/actions/setup-node/releases/tag/v4.4.0
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 20
       - run: npm ci


### PR DESCRIPTION
## Summary
- move release URLs for pinned actions to their own comment lines in CI, lint, link-check, and HTML validation workflows

## Testing
- `pre-commit run --files .github/workflows/ci.yml .github/workflows/lint.yml .github/workflows/links.yml .github/workflows/html-validate.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c3628830bc83298a779624860a6e63