### PR TITLE
docs: polish numeric prefix comments

### DIFF
--- a/prism_utils.py
+++ b/prism_utils.py
@@ -4,13 +4,12 @@ from __future__ import annotations
 
 import re
 
-# Matches optional leading whitespace, an optional sign, digits, and an optional
-# fractional part.
+# Regex for a decimal number, allowing leading whitespace, optional sign and fraction.
 _NUMERIC_PREFIX = re.compile(r"^\s*([+-]?\d+(?:\.\d+)?)")
 
 
 def parse_numeric_prefix(text: str) -> float:
-    """Extract the leading decimal value from ``text``.
+    """Extracts the leading decimal value from ``text``.
 
     Allows leading whitespace, an optional sign, and an optional fractional
     part, ignoring trailing characters. Returns ``1.0`` when no valid number is


### PR DESCRIPTION
## Summary
- simplify regex comment to describe decimal matching with optional whitespace, sign, and fraction
- phrase `parse_numeric_prefix` docstring in third person for clarity

## Testing
- `pre-commit run --files prism_utils.py tests/test_prism_utils.py`
- `pytest tests/test_prism_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68c363db2ea883299b52638dcb1cf135