### PR TITLE
fix: narrow parse errors

### DIFF
--- a/prism_utils.py
+++ b/prism_utils.py
@@ -6,12 +6,12 @@ import ast
 
 
 def parse_numeric_prefix(text: str) -> float:
-    """Return the leading numeric value in ``text`` or ``1.0`` if not found.
+    """Return the leading numeric value in ``text`` or ``1.0`` if absent.
 
     This uses :func:`ast.literal_eval` for safety instead of ``eval`` and
-    accepts inputs like ``"2, something"``. Non-numeric or invalid values
-    would raise ``ValueError`` or ``SyntaxError``, but these are suppressed
-    and result in a default return of ``1.0``.
+    accepts inputs like ``"2, something"``. Only ``ValueError`` and
+    ``SyntaxError`` are suppressed—such as for empty strings, non-numeric
+    tokens, or malformed expressions—and the default ``1.0`` is returned.
     """
     try:
         value = ast.literal_eval(text.split(",", maxsplit=1)[0].strip())

--- a/tests/test_prism_utils.py
+++ b/tests/test_prism_utils.py
@@ -18,7 +18,7 @@ def test_parse_numeric_prefix_valid(text: str, expected: float) -> None:
     assert parse_numeric_prefix(text) == expected
 
 
-@pytest.mark.parametrize("text", ["abc", "1a", "("])
+@pytest.mark.parametrize("text", ["", "   ", "abc", "1a", "("])
 def test_parse_numeric_prefix_invalid(text: str) -> None:
     """Fall back to ``1.0`` when parsing fails."""
     assert parse_numeric_prefix(text) == 1.0


### PR DESCRIPTION
## Summary
- clarify parse_numeric_prefix docstring for empty or malformed inputs
- test blank and whitespace prefixes

## Testing
- `pre-commit run --files prism_utils.py tests/test_prism_utils.py`
- `pytest tests/test_prism_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c363f0cba08329a57a4a51df31c103