### PR TITLE
fix: support whitespace and signed numbers in parser

### DIFF
--- a/prism_utils.py
+++ b/prism_utils.py
@@ -11,8 +11,9 @@ _NUMERIC_PREFIX_RE = re.compile(r"^\s*([+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\
 def parse_numeric_prefix(text: str) -> float:
     """Return the leading numeric value in ``text`` or ``1.0`` if not found.
 
-    The function extracts an optional sign and numeric token at the start of
-    ``text`` using a regular expression. The extracted token is parsed with
+    The function extracts an optional sign and numeric token—supporting
+    integers, decimals, and scientific notation—at the start of ``text`` using
+    a regular expression. The extracted token is parsed with
     :func:`ast.literal_eval` for safety. If the token cannot be parsed or is
     absent, ``1.0`` is returned.
     """


### PR DESCRIPTION
## Summary
- broaden `parse_numeric_prefix` to accept whitespace, +/- signs, and scientific notation using regex
- document that `parse_numeric_prefix` handles integers, decimals, and scientific notation
- add tests for spaced, negative, and exponential prefixes

## Testing
- `pre-commit run --files prism_utils.py tests/test_prism_utils.py main.py`
- `pytest tests/test_prism_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68c3677ad1e08329a3b3d47c43d0d6dc