### PR TITLE
docs: adopt imperative test docstrings

### DIFF
--- a/tests/test_prism_utils.py
+++ b/tests/test_prism_utils.py
@@ -4,12 +4,12 @@ from prism_utils import parse_numeric_prefix
 
 
 def test_parse_numeric_prefix_valid():
-    """It returns the numeric part when valid values are provided."""
+    """Return the numeric part when valid values are provided."""
     assert parse_numeric_prefix("2, rest") == 2.0
     assert parse_numeric_prefix("3.5") == 3.5
 
 
 def test_parse_numeric_prefix_invalid():
-    """It falls back to ``1.0`` when the prefix is invalid."""
+    """Fall back to ``1.0`` when the prefix is invalid."""
     assert parse_numeric_prefix("abc") == 1.0
     assert parse_numeric_prefix("1a") == 1.0


### PR DESCRIPTION
## Summary
- adopt imperative style in `parse_numeric_prefix` test docstrings

## Testing
- `ruff check main.py tests/test_prism_utils.py prism_utils.py`
- `pytest`
- `pytest tests/test_prism_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68c367c3e0948329a1b572065f003762