### PR TITLE
chore(automation): add repo automation with pinned actions

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -4,6 +4,7 @@ on:
     types: [opened, edited, synchronize]
 permissions:
   pull-requests: read
+  checks: write
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add Renovate and Mergify config for dependency automation
- introduce workflows for scorecards, releases, semantic PR titles, and stale issue triage
- pin GitHub Actions to commit SHAs and add missing permissions
- grant checks write access so the Semantic PR workflow can report status

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js`)*
- `npm test` *(fails: npx jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c36c19de488329bbc2d05daccfa1d6