### PR TITLE
docs: refine health-sidecar comments

### DIFF
--- a/services/health-sidecar/.env.example
+++ b/services/health-sidecar/.env.example
@@ -1,7 +1,10 @@
 # sample environment variables for the health-sidecar service
-# port to serve the health endpoints
+
+# port for health endpoints
 PORT=8088
-# root directory where the primary API stores its health file
+
+# root directory for the primary api health file
 API_ROOT=/var/www/blackroad/api
-# commit SHA injected by the deploy workflow
+
+# commit sha injected by the deploy workflow
 COMMIT_SHA=

--- a/services/health-sidecar/server.js
+++ b/services/health-sidecar/server.js
@@ -10,13 +10,13 @@ const PORT = process.env.PORT || 8088;
 const API_ROOT = process.env.API_ROOT || '/var/www/blackroad/api';
 const HEALTH_FILE = path.join(API_ROOT, 'health.json');
 
-// simple cache-control for JSON responses
+// cache control for json responses
 app.use((_req, res, next) => {
   res.set('Cache-Control', 'no-store');
   next();
 });
 
-// GET /api/health (primary endpoint)
+// primary health endpoint
 app.get('/api/health', (_req, res) => {
   let body = {
     status: 'ok',
@@ -37,7 +37,7 @@ app.get('/api/health', (_req, res) => {
   res.json(body);
 });
 
-// liveness/readiness endpoints (k8s or uptime monitors)
+// liveness and readiness endpoints for k8s or uptime monitors
 app.get('/livez', (_req, res) => res.send('OK'));
 app.get('/readyz', (_req, res) => {
   try {


### PR DESCRIPTION
## Summary
- streamline env var comments for health-sidecar service
- align server script comments with repository style

## Testing
- `npm run lint` (fails: Cannot find module '@eslint/js')
- `npm test` (fails: Cannot find module 'jest')

------
https://chatgpt.com/codex/tasks/task_e_68c36b6a8ddc8329a01e765c1a154c23