### PR TITLE
fix: reorder boot hooks and refine search reset

### DIFF
--- a/frontend/src/components/RoadChain.jsx
+++ b/frontend/src/components/RoadChain.jsx
@@ -21,12 +21,14 @@ export default function RoadChain(){
     })()
   }, [])
 
-  // Clear stale search results when the query changes, collapsing blocks if empty
+  // Clear errors on query change and collapse blocks when the query is empty
   useEffect(() => {
     const q = query.trim()
-    setResult(null)
     setError('')
-    if (!q) setExpanded({})
+    if (!q) {
+      setResult(null)
+      setExpanded({})
+    }
   }, [query])
 
   function toggle(hash){


### PR DESCRIPTION
## Summary
- define bootstrapping helpers before auth effect to avoid undefined references
- clear search errors on query change while keeping results until query is empty

## Testing
- `npm --prefix backend install`
- `npm --prefix backend test`
- `npm --prefix frontend install`
- `npm --prefix frontend test`
- `npm --prefix frontend run build`
- `curl -s http://localhost:4000/api/roadchain/blocks`
- `curl -s http://localhost:4000/api/roadchain/block/0xdef456`


------
https://chatgpt.com/codex/tasks/task_e_68c36b2194e48329af9dadd0d1d07805