### PR TITLE
docs: clarify numeric prefix comments

### DIFF
--- a/prism_utils.py
+++ b/prism_utils.py
@@ -4,15 +4,15 @@ from __future__ import annotations
 
 import re
 
-# Regex for a decimal number, allowing leading whitespace, optional sign and fraction.
+# Matches a decimal number with optional leading whitespace, sign, and fractional part.
 _NUMERIC_PREFIX = re.compile(r"^\s*([+-]?\d+(?:\.\d+)?)")
 
 
 def parse_numeric_prefix(text: str) -> float:
-    """Extracts the leading decimal value from ``text``.
+    """Return the leading decimal value in ``text``.
 
-    Allows leading whitespace, an optional sign, and an optional fractional
-    part, ignoring trailing characters. Returns ``1.0`` when no valid number is
+    Allows leading whitespace, an optional sign, and fractional part while
+    ignoring trailing characters. Returns ``1.0`` when no valid number is
     found.
     """
     match = _NUMERIC_PREFIX.match(text)

--- a/tests/test_prism_utils.py
+++ b/tests/test_prism_utils.py
@@ -1,4 +1,4 @@
-"""Tests for parse_numeric_prefix."""
+"""Tests for ``parse_numeric_prefix``."""
 
 from prism_utils import parse_numeric_prefix
 


### PR DESCRIPTION
## Summary
- refine numeric-prefix regex comment to say it matches optional whitespace, sign, and fractional part
- reword `parse_numeric_prefix` docstring in imperative mood
- note the target function in test module docstring

## Testing
- `pre-commit run --files prism_utils.py tests/test_prism_utils.py`
- `pytest tests/test_prism_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68c36ab415a08329aac8c8d77571a275