### PR TITLE
fix: narrow parse errors

### DIFF
--- a/prism_utils.py
+++ b/prism_utils.py
@@ -6,12 +6,13 @@ import ast
 
 
 def parse_numeric_prefix(text: str) -> float:
-    """Return the leading numeric value in ``text`` or ``1.0`` if absent.
+    """Return the leading numeric value in ``text`` or ``1.0`` if parsing fails.
 
-    This uses :func:`ast.literal_eval` for safety instead of ``eval`` and
-    accepts inputs like ``"2, something"``. Only ``ValueError`` and
-    ``SyntaxError`` are suppressed—such as for empty strings, non-numeric
-    tokens, or malformed expressions—and the default ``1.0`` is returned.
+    The prefix may include negatives or decimals. The function uses
+    :func:`ast.literal_eval` for safety instead of ``eval`` and evaluates the
+    substring before the first comma. Only ``ValueError`` and ``SyntaxError``
+    are suppressed—covering empty strings, whitespace, non-numeric tokens, or
+    malformed expressions—and the default ``1.0`` is returned in those cases.
     """
     try:
         value = ast.literal_eval(text.split(",", maxsplit=1)[0].strip())

--- a/tests/test_prism_utils.py
+++ b/tests/test_prism_utils.py
@@ -11,6 +11,7 @@ from prism_utils import parse_numeric_prefix
         ("2, rest", 2.0),
         ("3.5", 3.5),
         ("-4, things", -4.0),
+        ("-0.5", -0.5),
     ],
 )
 def test_parse_numeric_prefix_valid(text: str, expected: float) -> None:


### PR DESCRIPTION
## Summary
- clarify docstring for `parse_numeric_prefix` and note negative/decimal support
- extend `parse_numeric_prefix` tests with negative decimal case

## Testing
- `pre-commit run --files prism_utils.py tests/test_prism_utils.py`
- `pytest tests/test_prism_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c36aa5d5288329b3dce5deede29193