### PR TITLE
Cleanup Python scripts and adjust ESLint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,6 +2,7 @@ module.exports = [
   {
     ignores: [
       ".github/**",
+      ".tools/**",
       "apps/**",
       "backend/**",
       "build/**",


### PR DESCRIPTION
## Summary
- add `.tools/**` to ESLint ignores so hidden tooling files don't trigger warnings

## Testing
- `npm run lint`
- `npm test`
- `python -m py_compile *.py`
- `cd agents && python -m py_compile *.py && python auto_novel_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_68c36a8305d883299bb012d102728f24