### PR TITLE
docs: refine parse_numeric_prefix test comments

### DIFF
--- a/tests/test_prism_utils.py
+++ b/tests/test_prism_utils.py
@@ -1,15 +1,15 @@
-"""Unit tests for helper functions in ``prism_utils``."""
+"""Test helper functions in `prism_utils`."""
 
 from prism_utils import parse_numeric_prefix
 
 
 def test_parse_numeric_prefix_valid():
-    """Return the numeric part when valid values are provided."""
+    """Return numeric prefix for valid input."""
     assert parse_numeric_prefix("2, rest") == 2.0
     assert parse_numeric_prefix("3.5") == 3.5
 
 
 def test_parse_numeric_prefix_invalid():
-    """Fall back to ``1.0`` when the prefix is invalid."""
+    """Return ``1.0`` when the prefix is invalid."""
     assert parse_numeric_prefix("abc") == 1.0
     assert parse_numeric_prefix("1a") == 1.0


### PR DESCRIPTION
## Summary
- streamline parse_numeric_prefix test docstrings in imperative style

## Testing
- `ruff check main.py tests/test_prism_utils.py prism_utils.py`
- `pytest` *(fails: 18 errors during collection)*
- `pytest tests/test_prism_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c36a54ceb8832986d83e19093d9f19