### PR TITLE
fix: add graph stream endpoint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,14 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/prism/server"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/prism/apps/web"
+    schedule:
+      interval: "daily"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary
- stream graph updates over SSE at `/graph/stream`
- emit graph node events from the in-memory store
- expand Dependabot config to cover new packages

## Testing
- `cd prism/server && npm test`
- `cd prism/apps/web && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3629068a8832995afc32e0e029fec