### PR TITLE
docs: add implementation plan for enterprise integrations

### DIFF
--- a/docs/company/README.md
+++ b/docs/company/README.md
@@ -1,0 +1,5 @@
+# Company Documentation
+
+This directory collects corporate and planning documents for BlackRoad.
+
+- [Implementation Plan for Enterprise Tool Integrations](implementation-plan.md)

--- a/docs/company/implementation-plan.md
+++ b/docs/company/implementation-plan.md
@@ -1,0 +1,77 @@
+# Implementation Plan for Enterprise Tool Integrations
+
+This guide outlines a phased approach for setting up Mag7-scale tool integrations with Ameriprise-level compliance. It serves as a corporate reference for building and scaling BlackRoad's MasterPack workflows.
+
+## 1. Assessment & Preparation (Week 1–2)
+
+- **Objectives:** Identify bottlenecks, map current tools, and align goals.
+- **Actions:**
+  - Conduct SWOT analysis and document baseline metrics.
+  - Map tools to needs (e.g., Slack for comms, Salesforce for CRM, QuickBooks for tracking).
+  - Define KPIs such as “30% reduction in manual entry.”
+  - Assign roles including an Integration Lead and Compliance Officer.
+- **Compliance Tip:** Verify data retention and encryption standards for each tool.
+
+## 2. Detailed Planning (Week 3–6)
+
+- **Objectives:** Build a roadmap with milestones, resources, and risk management.
+- **Actions:**
+  - Create a layered plan (Base, Growth, Infrastructure, Innovation).
+  - Schedule milestones (e.g., Q4 2025 Slack↔Asana integration).
+  - Budget for tool licenses and compliance audits.
+  - Maintain a risk register for API limits and other issues.
+  - Document timelines in tools like Asana or Monday.com.
+- **Compliance Tip:** Embed audit-trail tasks such as quarterly financial reviews.
+
+## 3. Integration Setup (Week 7–14)
+
+- **Objectives:** Connect systems, automate workflows, and secure data flows.
+- **Actions:**
+  - Select an integration platform (Zapier, MuleSoft, etc.).
+  - Configure flows (e.g., GitHub → Slack → Asana, Stripe ↔ NetSuite).
+  - Test bidirectional sync and log errors.
+  - Implement SSO and encryption for all connections.
+  - Build data pipelines with tools like Fivetran feeding Snowflake.
+- **Compliance Tip:** Keep encrypted logs (Splunk/Datadog) for financial transactions.
+
+## 4. Execution & Monitoring (Ongoing)
+
+- **Objectives:** Deploy integrations, track performance, and collect feedback.
+- **Actions:**
+  - Pilot the Base layer first and iterate.
+  - Monitor uptime (>99%), latency, and failures via dashboards.
+  - Hold weekly retrospectives and capture actions in Asana.
+  - Enable auto-scaling as usage grows.
+  - Perform quarterly financial audits with evidence logs.
+- **Compliance Tip:** Automate alerts for audit trail anomalies.
+
+## 5. Iteration & Scaling (Quarterly)
+
+- **Objectives:** Refine processes, extend features, and maintain compliance.
+- **Actions:**
+  - Review metrics to target 50% productivity gains.
+  - Add advanced features like AI-driven analytics.
+  - Prepare infrastructure for 10k+ users (load tests, sharding).
+  - Update SOPs and documentation in version control.
+  - Refresh compliance policies annually.
+- **Compliance Tip:** Run automated security scans and IRS-alignment audits.
+
+## Risks & Mitigations
+
+| Risk                        | Mitigation                                                   |
+| --------------------------- | ------------------------------------------------------------ |
+| Overly complex integrations | Start with phased pilots and training.                       |
+| Data breaches               | Apply zero-trust architecture and regular penetration tests. |
+| Non-compliance              | Automate audit logs and schedule reviews.                    |
+| Integration downtime        | Use redundant paths and alerting thresholds.                 |
+
+## Next Steps for BlackRoad
+
+1. Launch Phase 1 assessment and assign stakeholders in Asana.
+2. Prototype the first integration (Slack↔Asana) with success metrics.
+3. Establish compliance audit procedures based on Ameriprise standards.
+4. Review progress after 30 days and expand to Growth layer integrations.
+
+---
+
+_This document is for internal planning and does not constitute legal or financial advice._


### PR DESCRIPTION
## Summary
- add a `docs/company` section to house corporate documentation
- include an implementation plan for Mag7-scale tool integrations with Ameriprise-level compliance

## Testing
- `pre-commit run --files docs/company/README.md docs/company/implementation-plan.md`
- `npm test` *(fails: 503 Service Unavailable - GET http://verdaccio.internal:4873/jest)*

------
https://chatgpt.com/codex/tasks/task_e_68c4770b39b88329904ae964d8ab3aec