### PR TITLE
Add Wave 5 prompt pack configuration

### DIFF
--- a/manifest.csv
+++ b/manifest.csv
@@ -1,3 +1,4 @@
 path,sha256,figure_ids
 data/raw/synthetic_consciousness.csv,c355f3083dddb041fd17575978d9b7f0b0261fa14722ae0273e9e1319df828e1,
 data/raw/Rohonc_Codex_-_Page_Marker_Features.csv,22bfa55330d89c7b4c071a26954ff79f5258984bf6284a7d4700ab58acc1c394,
+prompts/prompt_pack_wave5.yaml,92a29c2124e0eb4aa104bd44a7ce986d036ae1a3704b4d559614b47a7aeeab20,

--- a/prompts/prompt_pack_wave5.yaml
+++ b/prompts/prompt_pack_wave5.yaml
@@ -1,4 +1,4 @@
-# Prompt Pack — Wave 5 (Developer Mode, Pre-Filled for BlackRoad)
+# Prompt Pack - Wave 5 (Developer Mode, Pre-Filled for BlackRoad)
 channels:
   - '#announcements'
   - '#releases'
@@ -11,11 +11,11 @@ channels:
   - '#support-war-room'
 
 projects:
-  - 'Implementation – MasterPack'
-  - 'GRC – Evidence Calendar'
+  - 'Implementation - MasterPack'
+  - 'GRC - Evidence Calendar'
   - 'Release Train'
   - 'Customer Onboarding'
-  - 'OKRs – Company 2025'
+  - 'OKRs - Company 2025'
 
 service_account_placeholders:
   - 'SERVICE_ACCOUNT_ID_1'


### PR DESCRIPTION
## Summary
- add Prompt Pack — Wave 5 config with channel and project lists

## Testing
- `pre-commit run --files prompts/prompt_pack_wave5.yaml`
- `pytest` *(fails: Could not resolve authentication method, 7 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c486bcedd08329833aa0797843b240