### PR TITLE
feat: add basic provider registry and health routes

### DIFF
--- a/config/providers.yaml
+++ b/config/providers.yaml
@@ -1,0 +1,17 @@
+# Model provider configuration
+providers:
+  openai:
+    display_name: "OpenAI / ChatGPT"
+    env_key: "OPENAI_API_KEY"
+  anthropic:
+    display_name: "Anthropic / Claude"
+    env_key: "ANTHROPIC_API_KEY"
+  google:
+    display_name: "Google / Gemini"
+    env_key: "GOOGLE_API_KEY"
+  xai:
+    display_name: "xAI / Grok"
+    env_key: "XAI_API_KEY"
+  holo:
+    display_name: "Custom / Holo"
+    env_key: "HOLO_API_KEY"

--- a/srv/blackroad-api/lib/providers.js
+++ b/srv/blackroad-api/lib/providers.js
@@ -1,0 +1,39 @@
+const fs = require('fs');
+const path = require('path');
+const yaml = require('yaml');
+
+const CONFIG_PATH =
+  process.env.PROVIDERS_CONFIG ||
+  path.join(__dirname, '../../config/providers.yaml');
+
+let cache;
+
+function loadConfig() {
+  if (!cache) {
+    const file = fs.readFileSync(CONFIG_PATH, 'utf8');
+    const data = yaml.parse(file);
+    cache = data.providers || {};
+  }
+  return cache;
+}
+
+function listProviders() {
+  const cfg = loadConfig();
+  return Object.entries(cfg).map(([id, info]) => ({
+    id,
+    display_name: info.display_name,
+    status: process.env[info.env_key] ? 'ready' : 'missing_key',
+  }));
+}
+
+function providerHealth(name) {
+  const cfg = loadConfig();
+  const info = cfg[name];
+  if (!info) return null;
+  return {
+    id: name,
+    ok: Boolean(process.env[info.env_key]),
+  };
+}
+
+module.exports = { listProviders, providerHealth };

--- a/srv/blackroad-api/routes/providers.js
+++ b/srv/blackroad-api/routes/providers.js
@@ -1,0 +1,21 @@
+const express = require('express');
+const { listProviders, providerHealth } = require('../lib/providers');
+
+const router = express.Router();
+
+router.get('/', (_req, res) => {
+  res.json(listProviders());
+});
+
+router.get('/:name/health', (req, res) => {
+  const info = providerHealth(req.params.name);
+  if (!info) return res.status(404).json({ error: 'unknown_provider' });
+  res.json(info);
+});
+
+router.post('/:name/test', (req, res) => {
+  const { prompt } = req.body || {};
+  res.json({ provider: req.params.name, prompt, result: 'not implemented' });
+});
+
+module.exports = router;

--- a/srv/blackroad-api/server_full.js
+++ b/srv/blackroad-api/server_full.js
@@ -31,6 +31,7 @@ const notify = require('./lib/notify');
 const logger = require('./lib/log');
 const attachLlmRoutes = require('./routes/admin_llm');
 const gitRouter = require('./routes/git');
+const providersRouter = require('./routes/providers');
 
 // --- Config
 const PORT = parseInt(process.env.PORT || '4000', 10);
@@ -493,6 +494,7 @@ for (const row of qSeed) {
 
 // Git API
 app.use('/api/git', requireAuth, gitRouter);
+app.use('/v1/providers', providersRouter);
 
 // Helpers
 function listRows(t) {

--- a/tests/providers.test.js
+++ b/tests/providers.test.js
@@ -1,0 +1,24 @@
+process.env.SESSION_SECRET = 'test-secret';
+process.env.INTERNAL_TOKEN = 'x';
+process.env.ALLOW_ORIGINS = 'https://example.com';
+const request = require('supertest');
+const { app, server } = require('../srv/blackroad-api/server_full.js');
+
+describe('Provider registry', () => {
+  afterAll((done) => {
+    server.close(done);
+  });
+
+  it('lists configured providers', async () => {
+    const res = await request(app).get('/v1/providers');
+    expect(res.status).toBe(200);
+    const names = res.body.map((p) => p.id);
+    expect(names).toContain('openai');
+  });
+
+  it('returns health for a provider', async () => {
+    const res = await request(app).get('/v1/providers/openai/health');
+    expect(res.status).toBe(200);
+    expect(typeof res.body.ok).toBe('boolean');
+  });
+});


### PR DESCRIPTION
## Summary
- add `providers.yaml` for listing model providers
- expose `/v1/providers` API with health and test endpoints
- test provider listing and health check

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `CI=1 npm test tests/providers.test.js` *(hangs without output)*

------
https://chatgpt.com/codex/tasks/task_e_68c49d4921b48329b44a462341acbe2d