### PR TITLE
docs: add initial openapi spec

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,0 +1,185 @@
+openapi: 3.1.0
+info:
+  title: BlackRoad API
+  version: '1.0.0'
+  description: |
+    OpenAPI specification for the BlackRoad API service including health,
+    memory, and logging endpoints.
+servers:
+  - url: http://localhost:4000
+paths:
+  /health:
+    get:
+      summary: Liveness probe
+      responses:
+        '200':
+          description: Service is running
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  version:
+                    type: string
+                    example: '1.0.0'
+                  uptime:
+                    type: number
+                    format: float
+                    example: 12.34
+  /api/health:
+    get:
+      summary: Readiness check including API and LLM bridge
+      responses:
+        '200':
+          description: API and bridge status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  version:
+                    type: string
+                  uptime:
+                    type: number
+                    format: float
+                  services:
+                    type: object
+                    properties:
+                      api:
+                        type: boolean
+                        example: true
+                      llm:
+                        type: boolean
+                        example: true
+        '502':
+          description: One or more services unavailable
+  /api/llm/health:
+    get:
+      summary: LLM bridge health
+      responses:
+        '200':
+          description: Bridge reachable
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+        '502':
+          description: Bridge unreachable
+  /api/memory/index:
+    post:
+      summary: Index a memory document
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+                  description: Optional document identifier
+                text:
+                  type: string
+                  description: Text content to index
+                source:
+                  type: string
+                  nullable: true
+                tags:
+                  type: array
+                  items:
+                    type: string
+      responses:
+        '200':
+          description: Document indexed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  id:
+                    type: string
+                    description: Identifier of the stored document
+        '400':
+          description: Invalid request
+  /api/memory/search:
+    post:
+      summary: Search indexed memory
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                q:
+                  type: string
+                  description: Query text
+                top_k:
+                  type: integer
+                  minimum: 1
+                  maximum: 20
+      responses:
+        '200':
+          description: Search results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        score:
+                          type: number
+                        text:
+                          type: string
+                        meta:
+                          type: object
+        '400':
+          description: Invalid request
+  /api/contradictions:
+    get:
+      summary: List logged contradictions
+      responses:
+        '200':
+          description: Recent contradictions
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  contradictions:
+                    type: array
+                    items:
+                      type: object
+  /api/events:
+    get:
+      summary: List recent events
+      responses:
+        '200':
+          description: Recent events
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  events:
+                    type: array
+                    items:
+                      type: object


### PR DESCRIPTION
## Summary
- document health and memory endpoints in OpenAPI 3.1 spec
- stub API definitions for future contradictions and event logs

## Testing
- `pre-commit run --files api/openapi.yaml`
- `npm test` *(fails: 503 Service Unavailable - GET http://verdaccio.internal:4873/jest)*

------
https://chatgpt.com/codex/tasks/task_e_68c49e188a5c8329b038c533098ea98e