### PR TITLE
feat: add prism architecture docs and tooling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+OPENAI_API_KEY=
+DATABASE_URL=postgres://prism:prism@localhost:5432/prism # pragma: allowlist secret
+S3_BUCKET=prism-artifacts
+PRISM_RUN_ALLOW=node

--- a/.github/workflows/prism-ci.yml
+++ b/.github/workflows/prism-ci.yml
@@ -1,0 +1,40 @@
+name: prism-ci
+
+on:
+  push:
+    paths:
+      - 'prism/**'
+      - '.github/workflows/prism-ci.yml'
+  pull_request:
+    paths:
+      - 'prism/**'
+      - '.github/workflows/prism-ci.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm --prefix prism/server ci
+      - run: npm --prefix prism/server run lint
+      - run: npm --prefix prism/server test -- --coverage
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: pip install -r requirements-dev.txt
+      - run: pytest tests/prism
+      - uses: codecov/codecov-action@v3
+        with:
+          files: prism/server/coverage/coverage-final.json
+      - run: docker build -t ghcr.io/blackroad/prism:${{ github.sha }} prism
+      - if: github.ref == 'refs/heads/main'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - if: github.ref == 'refs/heads/main'
+        run: docker push ghcr.io/blackroad/prism:${{ github.sha }}

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -1,0 +1,24 @@
+name: tag-and-release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version number (x.y.z)'
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: git tag v${{ github.event.inputs.version }}
+      - run: git push origin v${{ github.event.inputs.version }}
+      - run: |
+          echo "## v${{ github.event.inputs.version }}" > CHANGELOG.md
+          git log --pretty=format:'* %s' $(git describe --tags --abbrev=0)..HEAD >> CHANGELOG.md
+      - uses: actions/create-release@v1
+        with:
+          tag_name: v${{ github.event.inputs.version }}
+          release_name: v${{ github.event.inputs.version }}
+          body_path: CHANGELOG.md

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 . "$(dirname "$0")/_/husky.sh" 2>/dev/null || true
-msg=$(cat "$1")
-if ! echo "$msg" | grep -Eq '^(feat|fix|chore|docs|refactor|perf|test)(\(.+\))?:'; then
-  echo "ℹ️ Conventional commit not detected — continuing anyway (advisory)."
+if command -v npx >/dev/null && npx --no-install commitlint --help >/dev/null 2>&1; then
+  npx --no-install commitlint --edit "$1"
+else
+  msg=$(cat "$1")
+  if ! echo "$msg" | grep -Eq '^(feat|fix|chore|docs|refactor|perf|test)(\(.+\))?:'; then
+    echo "ℹ️ Conventional commit not detected — continuing anyway (advisory)."
+  fi
 fi

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 80

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+};

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -1,0 +1,12 @@
+# Environment Variables
+
+| Name              | Description                                  | Default                                                                | Scope   |
+| ----------------- | -------------------------------------------- | ---------------------------------------------------------------------- | ------- |
+| `OPENAI_API_KEY`  | API key for OpenAI integrations              | _none_                                                                 | runtime |
+| `DATABASE_URL`    | Postgres connection string                   | `postgres://user:pass@db:5432/prism` <!-- pragma: allowlist secret --> | server  |
+| `S3_BUCKET`       | S3 bucket for artifacts                      | `prism-artifacts`                                                      | server  |
+| `PRISM_RUN_ALLOW` | Comma list of allowed executables for `/run` | `node`                                                                 | server  |
+
+Store secrets in a manager such as HashiCorp Vault or Doppler; avoid committing
+plain-text secrets. Populate values locally via `.env` and in production through
+your orchestration platform's secret store.

--- a/docs/PRISM_ARCHITECTURE.md
+++ b/docs/PRISM_ARCHITECTURE.md
@@ -1,0 +1,19 @@
+# Prism Service Architecture
+
+The Prism service centers around a Fastify-based TypeScript server that exposes
+SSE and REST endpoints. Incoming run requests are validated with `zod` and
+executed in a controlled child process. Standard output, errors, and lifecycle
+events are published on an in-memory `EventEmitter` bus for real-time clients.
+
+```text
+client --> /run --> validator --> spawn --> event bus --> client
+                    |                         |
+                    v                         v
+                 policy store            file system
+```
+
+Diff application requests follow a similar path. Approved patches are written to
+`prism/work/` only after policy checks and path sanitization. External
+integrations include OpenAI for model-backed features and optional AWS services
+(S3 for artifacts, RDS for persistence). Data flows are ephemeral unless a
+backing database or bucket is configured.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,22 @@
+# Release Strategy
+
+We follow [SemVer](https://semver.org). Increment:
+
+- **MAJOR** for incompatible API changes
+- **MINOR** for backwards-compatible features
+- **PATCH** for backwards-compatible fixes
+
+## Release Notes Template
+
+```
+## vX.Y.Z - YYYY-MM-DD
+### Added
+-
+### Changed
+-
+### Fixed
+-
+```
+
+Tagged releases are created via GitHub Actions (`tag-and-release.yml`) and the
+changelog is derived from commit messages.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,17 @@
+# Testing the Prism Service
+
+## Node Tests
+
+```bash
+npm --prefix prism/server test
+```
+
+## Python Tests
+
+```bash
+pytest tests/prism
+```
+
+Test fixtures live under `tests/prism/fixtures/`. The Node suite uses `vitest`
+while Python uses `pytest`. Both commands run independently so contributors can
+focus on the stacks they touch.

--- a/docs/adr/0001-prism-tech-stack.md
+++ b/docs/adr/0001-prism-tech-stack.md
@@ -1,0 +1,21 @@
+# ADR 0001: Prism Service Tech Stack
+
+## Status
+
+Accepted
+
+## Context
+
+The Prism service requires a lightweight HTTP layer capable of handling
+event streams and JSON APIs with type safety.
+
+## Decision
+
+Use **Node.js** with **TypeScript** and **Fastify**. Validation is handled by
+`zod`, and tests are written with `vitest`.
+
+## Consequences
+
+TypeScript provides compile-time assurances while Fastify keeps runtime
+overhead low. The stack aligns with existing tooling in the repository and
+supports rapid iteration.

--- a/docs/adr/0002-containerization.md
+++ b/docs/adr/0002-containerization.md
@@ -1,0 +1,20 @@
+# ADR 0002: Containerization Strategy
+
+## Status
+
+Accepted
+
+## Context
+
+Developers need a reproducible environment for local development and deployment
+of the Prism service.
+
+## Decision
+
+Provide a dedicated `Dockerfile` and `docker-compose.yml` that orchestrate the
+Prism server alongside Postgres and an S3-compatible store (MinIO) for staging.
+
+## Consequences
+
+Containers ensure parity between development and production. Localstack
+dependencies are optional, and images can be pushed to GHCR via CI.

--- a/infra/prism/main.tf
+++ b/infra/prism/main.tf
@@ -1,0 +1,31 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+resource "aws_s3_bucket" "prism_artifacts" {
+  bucket        = var.s3_bucket
+  force_destroy = true
+  tags = {
+    Environment = "staging"
+    Service     = var.project
+  }
+}
+
+resource "aws_db_instance" "prism" {
+  identifier              = "${var.project}-db"
+  engine                  = "postgres"
+  instance_class          = "db.t3.micro"
+  username                = var.db_username
+  password                = var.db_password
+  allocated_storage       = 20
+  skip_final_snapshot     = true
+}

--- a/infra/prism/outputs.tf
+++ b/infra/prism/outputs.tf
@@ -1,0 +1,7 @@
+output "s3_bucket_name" {
+  value = aws_s3_bucket.prism_artifacts.bucket
+}
+
+output "db_endpoint" {
+  value = aws_db_instance.prism.address
+}

--- a/infra/prism/variables.tf
+++ b/infra/prism/variables.tf
@@ -1,0 +1,27 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "s3_bucket" {
+  description = "Name of staging S3 bucket"
+  type        = string
+}
+
+variable "project" {
+  description = "Project prefix for resources"
+  type        = string
+  default     = "prism"
+}
+
+variable "db_username" {
+  description = "RDS username"
+  type        = string
+}
+
+variable "db_password" {
+  description = "RDS password"
+  type        = string
+  sensitive   = true
+}

--- a/prism/Dockerfile
+++ b/prism/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-bookworm-slim
+WORKDIR /app
+COPY server/package*.json ./server/
+RUN npm --prefix server ci
+COPY server ./server
+RUN npm --prefix server run build
+CMD ["node", "server/dist/index.js"]

--- a/prism/docker-compose.yml
+++ b/prism/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.9'
+services:
+  prism:
+    build: .
+    ports:
+      - '3000:3000'
+    env_file: ../.env
+    depends_on:
+      - db
+      - s3
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_PASSWORD: prism # pragma: allowlist secret
+      POSTGRES_USER: prism
+      POSTGRES_DB: prism
+    ports:
+      - '5432:5432'
+  s3:
+    image: minio/minio
+    environment:
+      MINIO_ROOT_USER: minio
+      MINIO_ROOT_PASSWORD: minio123 # pragma: allowlist secret
+    command: server /data
+    ports:
+      - '9000:9000'

--- a/prism/server/test/policy.test.ts
+++ b/prism/server/test/policy.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import supertest from 'supertest';
+import { buildServer } from '../src/index.js';
+
+// Simple sanity check for the policy endpoint
+// Ensures policy toggling works for approval gating
+
+describe('policy endpoint', () => {
+  it('updates write policy', async () => {
+    const app = buildServer();
+    await app.listen({ port: 0 });
+    await supertest(app.server)
+      .put('/policy')
+      .send({ write: 'review' })
+      .expect(200);
+    const res = await supertest(app.server).get('/policy');
+    await app.close();
+    expect(res.body.write).toBe('review');
+  });
+});

--- a/tests/prism/fixtures/numeric_values.json
+++ b/tests/prism/fixtures/numeric_values.json
@@ -1,0 +1,3 @@
+{
+  "values": ["1.23 apples", "foo"]
+}

--- a/tests/prism/test_parse_numeric_prefix.py
+++ b/tests/prism/test_parse_numeric_prefix.py
@@ -1,0 +1,15 @@
+import json
+from pathlib import Path
+
+from prism_utils import parse_numeric_prefix
+
+
+def load_fixture():
+    fixture_path = Path(__file__).parent / "fixtures" / "numeric_values.json"
+    return json.loads(fixture_path.read_text())
+
+
+def test_parse_numeric_prefix():
+    data = load_fixture()
+    assert parse_numeric_prefix(data["values"][0]) == 1.23
+    assert parse_numeric_prefix(data["values"][1]) == 1.0


### PR DESCRIPTION
## Summary
- document prism architecture and environment variables
- add docker/compose, CI, and release workflows
- provide sample tests and terraform IaC for staging resources

## Testing
- `SKIP=eslint pre-commit run --files .env.example .github/workflows/prism-ci.yml .github/workflows/tag-and-release.yml codecov.yml commitlint.config.js docs/ENV_VARS.md docs/PRISM_ARCHITECTURE.md docs/RELEASE.md docs/TESTING.md docs/adr/0001-prism-tech-stack.md docs/adr/0002-containerization.md infra/prism/main.tf infra/prism/variables.tf infra/prism/outputs.tf prism/Dockerfile prism/docker-compose.yml prism/server/test/policy.test.ts tests/prism/test_parse_numeric_prefix.py tests/prism/fixtures/numeric_values.json .husky/commit-msg`
- `npm --prefix prism/server test`
- `pytest tests/prism/test_parse_numeric_prefix.py`


------
https://chatgpt.com/codex/tasks/task_e_68c4a1a94560832987e2a2a0b1c2b350