### PR TITLE
feat: add Jira-GitHub integration test script

### DIFF
--- a/scripts/jira_github_integration_test.js
+++ b/scripts/jira_github_integration_test.js
@@ -48,6 +48,7 @@ async function fetchJson(url, options = {}, service) {
   if (service === 'github') {
     headers.Authorization = `Bearer ${GITHUB_TOKEN}`;
     headers.Accept = 'application/vnd.github+json';
+    headers['User-Agent'] = 'jira-github-integration-test-script';
   }
 
   const max = 3;
@@ -103,7 +104,7 @@ async function step(name, fn) {
   let issueKey, browseUrl, ghNumber, ghUrl;
 
   try {
-    const me = await step('Jira auth', async () => {
+    await step('Jira auth', async () => {
       const data = await fetchJson(`${JIRA_BASE_URL}/rest/api/3/myself`, {}, 'jira');
       console.log(`PASS Jira auth: accountId ${data.accountId} displayName ${data.displayName}`);
       return data;
@@ -204,6 +205,7 @@ async function step(name, fn) {
     console.log('PASS All steps completed');
   } catch (err) {
     console.error('Integration test failed');
+    if (err && err.stack) console.error(err.stack);
     process.exit(1);
   }
 })();


### PR DESCRIPTION
## Summary
- add script to test Jira Cloud and GitHub integration end-to-end

## Testing
- `npm test` (fails: 503 Service Unavailable - GET http://verdaccio.internal:4873/jest)
- `npm run lint` (fails: Cannot find module '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68c4c6e2880c8329a030f38f0dae71d6