### PR TITLE
feat: add program board and scheduler with retail pack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,10 @@ target/
 **/target/
 *.db
 *.sqlite
+program/board.json
+orchestrator/tasks.json
+orchestrator/metrics.jsonl
+orchestrator/schedule.log.jsonl
 
 # Never commit SSH private keys
 id_ed25519

--- a/README.md
+++ b/README.md
@@ -432,3 +432,51 @@ cd apps/prismweb
 npm install
 npm run dev
 ```
+
+## Program Board
+
+The CLI exposes a lightweight portfolio view that persists to `program/board.json`.
+Example:
+
+```bash
+python -m cli.console program:add --id P001 --title "APAC Launch" --owner "Regional-Ops" --bot "Regional-Ops-BOT" --start 2025-10-01 --due 2026-01-15
+python -m cli.console program:list
+python -m cli.console program:roadmap
+```
+
+Roadmap output is rendered as an ASCII Gantt chart with 13 week buckets.
+
+## Dependencies & Scheduling
+
+Tasks may depend on other tasks and be scheduled for a specific time.  The
+polling scheduler will run tasks whose dependencies are complete:
+
+```bash
+python -m cli.console scheduler:run --every-seconds 5
+```
+
+Metrics about dependency blocks and schedule SLAs are written to
+`orchestrator/metrics.jsonl`.
+
+## CSV Import/Export
+
+Bulk task management is supported with CSV files.  Columns:
+
+`id, goal, context_json, depends_on_csv, scheduled_for_iso, bot`
+
+```bash
+python -m cli.console task:import --csv samples/sample_tasks.csv
+python -m cli.console task:export --csv out.csv
+```
+
+Sample files live under `samples/`.
+
+## Retail Industry Pack
+
+The repository ships with a minimal retail example consisting of two bots:
+
+- **Merchandising-BOT** – plans seasonal assortments from sales history.
+- **Store-Ops-BOT** – generates labor plans and checklists for promotions.
+
+Fixtures are under `fixtures/retail/` and an example workflow is available at
+`examples/retail_launch.md`.

--- a/bots/__init__.py
+++ b/bots/__init__.py
@@ -1,0 +1,28 @@
+"""Bot registry and auto-discovery."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from pathlib import Path
+from typing import Dict
+
+from orchestrator.protocols import BaseBot
+
+BOT_REGISTRY: Dict[str, BaseBot] = {}
+
+
+def _discover() -> None:
+    pkg_path = Path(__file__).parent
+    for mod in pkg_path.glob("*_bot.py"):
+        module = import_module(f"bots.{mod.stem}")
+        bot_cls = getattr(module, "Bot", None)
+        if bot_cls is None:
+            continue
+        bot: BaseBot = bot_cls()
+        BOT_REGISTRY[bot.NAME] = bot
+
+
+_discover()
+
+__all__ = ["BOT_REGISTRY"]
+

--- a/bots/merchandising_bot.py
+++ b/bots/merchandising_bot.py
@@ -1,0 +1,26 @@
+"""Retail merchandising bot."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Dict
+
+from orchestrator.protocols import Task
+
+FIXTURES = Path("fixtures/retail/sales_history.csv")
+
+
+class Bot:
+    NAME = "Merchandising-BOT"
+    SUPPORTED_TASKS = ["plan_assortment"]
+
+    def run(self, task: Task) -> Dict[str, int]:
+        counts: Dict[str, int] = {}
+        if FIXTURES.exists():
+            with FIXTURES.open() as f:
+                reader = csv.DictReader(f)
+                for row in reader:
+                    counts[row["sku"]] = counts.get(row["sku"], 0) + int(row["qty"])
+        return counts
+

--- a/bots/store_ops_bot.py
+++ b/bots/store_ops_bot.py
@@ -1,0 +1,27 @@
+"""Retail store operations bot."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Any, Dict, List
+
+from orchestrator.protocols import Task
+
+FIXTURES = Path("fixtures/retail/store_sizes.csv")
+
+
+class Bot:
+    NAME = "Store-Ops-BOT"
+    SUPPORTED_TASKS = ["plan_promotion"]
+
+    def run(self, task: Task) -> Dict[str, Any]:
+        plan: List[Dict[str, Any]] = []
+        if FIXTURES.exists():
+            with FIXTURES.open() as f:
+                reader = csv.DictReader(f)
+                for row in reader:
+                    labor = int(row["size"]) // 10
+                    plan.append({"store": row["store"], "labor_hours": labor})
+        return {"labor_plan": plan, "checklist": ["prep", "staff"]}
+

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,0 +1,2 @@
+"""Command line entry points."""
+

--- a/cli/console.py
+++ b/cli/console.py
@@ -1,0 +1,182 @@
+"""Lightweight CLI for program and task management."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+from datetime import datetime
+from pathlib import Path
+from typing import List
+
+from bots import BOT_REGISTRY
+from orchestrator import Task, load_tasks, save_tasks
+from orchestrator.scheduler import schedule_poll
+from program import ProgramBoard, ProgramItem
+
+_spec = importlib.util.spec_from_file_location(
+    "csv_io", Path(__file__).resolve().parent.parent / "io" / "csv_io.py"
+)
+assert _spec and _spec.loader
+_csv_io = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_csv_io)
+export_tasks = _csv_io.export_tasks
+import_tasks = _csv_io.import_tasks
+
+
+def _parse_ids(value: str | None) -> List[str]:
+    if not value:
+        return []
+    return [v.strip() for v in value.split(",") if v.strip()]
+
+
+def cmd_program_add(argv: List[str]) -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--id", required=True)
+    p.add_argument("--title", required=True)
+    p.add_argument("--owner", required=True)
+    p.add_argument("--bot", required=True)
+    p.add_argument("--start")
+    p.add_argument("--due")
+    args = p.parse_args(argv)
+
+    item = ProgramItem(
+        id=args.id,
+        title=args.title,
+        owner=args.owner,
+        bot=args.bot,
+        start=datetime.fromisoformat(args.start).date() if args.start else None,
+        due=datetime.fromisoformat(args.due).date() if args.due else None,
+        depends_on=[],
+    )
+    board = ProgramBoard()
+    board.add(item)
+
+
+def cmd_program_update(argv: List[str]) -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--id", required=True)
+    p.add_argument("--status")
+    p.add_argument("--depends_on")
+    args = p.parse_args(argv)
+    fields = {}
+    if args.status:
+        fields["status"] = args.status
+    if args.depends_on:
+        fields["depends_on"] = _parse_ids(args.depends_on)
+    board = ProgramBoard()
+    board.update(args.id, **fields)
+
+
+def cmd_program_list(argv: List[str]) -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--status")
+    args = p.parse_args(argv)
+    board = ProgramBoard()
+    items = board.list(args.status)
+    for item in items:
+        print(f"{item.id}: {item.title} [{item.status}]")
+
+
+def cmd_program_roadmap(argv: List[str]) -> None:
+    board = ProgramBoard()
+    print(board.as_markdown_roadmap())
+
+
+def cmd_task_create(argv: List[str]) -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--id", required=True)
+    p.add_argument("--goal", required=True)
+    p.add_argument("--bot", required=True)
+    p.add_argument("--depends-on")
+    p.add_argument("--at")
+    args = p.parse_args(argv)
+
+    task = Task(
+        id=args.id,
+        goal=args.goal,
+        bot=args.bot,
+        depends_on=_parse_ids(args.depends_on),
+        scheduled_for=datetime.fromisoformat(args.at) if args.at else None,
+    )
+    tasks = load_tasks()
+    tasks.append(task)
+    save_tasks(tasks)
+
+
+def cmd_task_import(argv: List[str]) -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--csv", required=True)
+    args = p.parse_args(argv)
+    tasks = load_tasks()
+    new_tasks = import_tasks(args.csv)
+    tasks.extend(new_tasks)
+    save_tasks(tasks)
+
+    board = ProgramBoard()
+    for t in new_tasks:
+        board.add(
+            ProgramItem(
+                id=t.id,
+                title=t.goal,
+                owner="import",
+                bot=t.bot,
+                status="planned",
+                depends_on=t.depends_on,
+            )
+        )
+
+
+def cmd_task_export(argv: List[str]) -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--csv", required=True)
+    args = p.parse_args(argv)
+    export_tasks(args.csv, load_tasks())
+
+
+def cmd_bot_run(argv: List[str]) -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--bot", required=True)
+    p.add_argument("--goal", required=True)
+    args = p.parse_args(argv)
+    bot = BOT_REGISTRY[args.bot]
+    task = Task(id="manual", goal=args.goal, bot=args.bot)
+    result = bot.run(task)
+    print(result)
+
+
+def cmd_scheduler_run(argv: List[str]) -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--every-seconds", type=int, default=0)
+    p.parse_args(argv)
+    schedule_poll(datetime.utcnow())
+
+
+COMMANDS = {
+    "program:add": cmd_program_add,
+    "program:update": cmd_program_update,
+    "program:list": cmd_program_list,
+    "program:roadmap": cmd_program_roadmap,
+    "task:create": cmd_task_create,
+    "task:import": cmd_task_import,
+    "task:export": cmd_task_export,
+    "bot:run": cmd_bot_run,
+    "scheduler:run": cmd_scheduler_run,
+}
+
+
+def main(argv: List[str] | None = None) -> None:
+    import sys
+
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if not argv:
+        return
+    cmd = argv[0]
+    handler = COMMANDS.get(cmd)
+    if handler is None:
+        raise SystemExit(f"unknown command: {cmd}")
+    handler(argv[1:])
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()
+

--- a/examples/retail_launch.md
+++ b/examples/retail_launch.md
@@ -1,0 +1,4 @@
+# Retail Launch Workflow
+
+1. Merchandising-BOT plans seasonal assortment.
+2. Store-Ops-BOT uses merchandising output to prepare store operations.

--- a/fixtures/retail/sales_history.csv
+++ b/fixtures/retail/sales_history.csv
@@ -1,0 +1,4 @@
+sku,qty
+SKU1,10
+SKU2,5
+SKU1,7

--- a/fixtures/retail/store_sizes.csv
+++ b/fixtures/retail/store_sizes.csv
@@ -1,0 +1,3 @@
+store,size
+StoreA,1000
+StoreB,1500

--- a/io/csv_io.py
+++ b/io/csv_io.py
@@ -1,0 +1,63 @@
+"""CSV import/export helpers for tasks."""
+
+from __future__ import annotations
+
+import csv
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import List
+
+from orchestrator.protocols import Task
+
+
+def import_tasks(csv_path: str | Path) -> List[Task]:
+    tasks: List[Task] = []
+    with open(csv_path, newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            context = json.loads(row.get("context_json") or "{}")
+            depends_on = [d.strip() for d in (row.get("depends_on_csv") or "").split(";") if d.strip()]
+            if not depends_on:
+                depends_on = [d.strip() for d in (row.get("depends_on_csv") or "").split(",") if d.strip()]
+            sched = row.get("scheduled_for_iso")
+            scheduled = datetime.fromisoformat(sched) if sched else None
+            tasks.append(
+                Task(
+                    id=row["id"],
+                    goal=row["goal"],
+                    context=context,
+                    depends_on=depends_on,
+                    scheduled_for=scheduled,
+                    bot=row.get("bot", ""),
+                )
+            )
+    return tasks
+
+
+def export_tasks(csv_path: str | Path, tasks: List[Task]) -> None:
+    fieldnames = [
+        "id",
+        "goal",
+        "context_json",
+        "depends_on_csv",
+        "scheduled_for_iso",
+        "bot",
+        "status",
+    ]
+    with open(csv_path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for t in tasks:
+            writer.writerow(
+                {
+                    "id": t.id,
+                    "goal": t.goal,
+                    "context_json": json.dumps(t.context),
+                    "depends_on_csv": ",".join(t.depends_on),
+                    "scheduled_for_iso": t.scheduled_for.isoformat() if t.scheduled_for else "",
+                    "bot": t.bot,
+                    "status": t.status,
+                }
+            )
+

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -1,0 +1,15 @@
+"""Task orchestrator utilities."""
+
+from .protocols import BaseBot, BotExecutionError, Task
+from .router import route_task
+from .tasks import load_tasks, save_tasks
+
+__all__ = [
+    "Task",
+    "BotExecutionError",
+    "BaseBot",
+    "load_tasks",
+    "save_tasks",
+    "route_task",
+]
+

--- a/orchestrator/metrics.py
+++ b/orchestrator/metrics.py
@@ -1,0 +1,23 @@
+"""Simple JSON lines metrics logging for the orchestrator."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+METRICS_PATH = Path("orchestrator/metrics.jsonl")
+
+
+def log_metric(metric_type: str, task_id: str, **extra: Any) -> None:
+    METRICS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    record = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "type": metric_type,
+        "task_id": task_id,
+    }
+    record.update(extra)
+    with METRICS_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(record) + "\n")
+

--- a/orchestrator/protocols.py
+++ b/orchestrator/protocols.py
@@ -1,0 +1,37 @@
+"""Protocols and dataclasses for task orchestration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
+
+
+class BotExecutionError(Exception):
+    """Raised when a bot cannot execute a task."""
+
+    def __init__(self, reason: str, details: Any | None = None):
+        super().__init__(reason)
+        self.reason = reason
+        self.details = details
+
+
+@dataclass
+class Task:
+    id: str
+    goal: str
+    bot: str
+    context: Dict[str, Any] = field(default_factory=dict)
+    status: str = "pending"
+    depends_on: List[str] = field(default_factory=list)
+    scheduled_for: Optional[datetime] = None
+
+
+@runtime_checkable
+class BaseBot(Protocol):
+    NAME: str
+    SUPPORTED_TASKS: List[str]
+
+    def run(self, task: Task) -> Any:  # pragma: no cover - implementation specific
+        ...
+

--- a/orchestrator/router.py
+++ b/orchestrator/router.py
@@ -1,0 +1,30 @@
+"""Routing helpers for executing tasks with bots."""
+
+from __future__ import annotations
+
+from typing import List
+
+from .metrics import log_metric
+from .protocols import BotExecutionError, Task
+
+
+def dependencies_met(task: Task, tasks: List[Task]) -> bool:
+    done_ids = {t.id for t in tasks if t.status == "done"}
+    return all(dep in done_ids for dep in task.depends_on)
+
+
+def route_task(task: Task, tasks: List[Task]) -> None:
+    from bots import BOT_REGISTRY
+
+    if not dependencies_met(task, tasks):
+        log_metric("dependency_block", task.id)
+        raise BotExecutionError("dependencies_not_met")
+
+    bot = BOT_REGISTRY.get(task.bot)
+    if bot is None:
+        raise BotExecutionError("bot_not_found")
+
+    bot.run(task)
+    task.status = "done"
+    log_metric("scheduled_run", task.id)
+

--- a/orchestrator/scheduler.py
+++ b/orchestrator/scheduler.py
@@ -1,0 +1,43 @@
+"""Polling scheduler for orchestrator tasks."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from .metrics import log_metric
+from .protocols import BotExecutionError
+from .router import route_task
+from .tasks import load_tasks, save_tasks
+
+SCHEDULE_LOG = Path("orchestrator/schedule.log.jsonl")
+
+
+def schedule_poll(now: datetime) -> None:
+    tasks = load_tasks()
+    changed = False
+    for task in tasks:
+        if task.status != "pending":
+            continue
+        if task.scheduled_for and task.scheduled_for <= now:
+            if task.scheduled_for and now - task.scheduled_for > timedelta(minutes=15):
+                log_metric("schedule_sla_breach", task.id)
+            try:
+                route_task(task, tasks)
+            except BotExecutionError:
+                continue
+            else:
+                SCHEDULE_LOG.parent.mkdir(parents=True, exist_ok=True)
+                record = {
+                    "task_id": task.id,
+                    "ran_at": now.isoformat(),
+                }
+                with SCHEDULE_LOG.open("a", encoding="utf-8") as f:
+                    import json
+
+                    f.write(json.dumps(record) + "\n")
+                changed = True
+
+    if changed:
+        save_tasks(tasks)
+

--- a/orchestrator/tasks.py
+++ b/orchestrator/tasks.py
@@ -1,0 +1,35 @@
+"""Persistence helpers for task storage."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from datetime import datetime
+from pathlib import Path
+from typing import List
+
+from tools.storage import load_json, save_json
+
+from .protocols import Task
+
+TASKS_PATH = Path("orchestrator/tasks.json")
+
+
+def load_tasks() -> List[Task]:
+    data = load_json(TASKS_PATH, [])
+    tasks: List[Task] = []
+    for raw in data:
+        if raw.get("scheduled_for"):
+            raw["scheduled_for"] = datetime.fromisoformat(raw["scheduled_for"])
+        tasks.append(Task(**raw))
+    return tasks
+
+
+def save_tasks(tasks: List[Task]) -> None:
+    data = []
+    for task in tasks:
+        row = asdict(task)
+        if row["scheduled_for"]:
+            row["scheduled_for"] = row["scheduled_for"].isoformat()
+        data.append(row)
+    save_json(TASKS_PATH, data)
+

--- a/program/__init__.py
+++ b/program/__init__.py
@@ -1,0 +1,6 @@
+"""Program management utilities."""
+
+from .board import ProgramBoard, ProgramItem
+
+__all__ = ["ProgramBoard", "ProgramItem"]
+

--- a/program/board.py
+++ b/program/board.py
@@ -1,0 +1,131 @@
+"""In-memory program board with simple JSON persistence."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import date
+from pathlib import Path
+from typing import Dict, List, Literal, Optional
+
+from orchestrator.protocols import BotExecutionError
+from tools.storage import load_json, save_json
+
+BOARD_PATH = Path("program/board.json")
+
+
+@dataclass
+class ProgramItem:
+    id: str
+    title: str
+    owner: str
+    bot: str
+    status: Literal["planned", "in_progress", "blocked", "done"] = "planned"
+    start: Optional[date] = None
+    due: Optional[date] = None
+    depends_on: List[str] = field(default_factory=list)
+
+
+class ProgramBoard:
+    """Collection of :class:`ProgramItem` instances with persistence helpers."""
+
+    def __init__(self) -> None:
+        self.items: Dict[str, ProgramItem] = {}
+        for raw in load_json(BOARD_PATH, []):
+            if raw.get("start"):
+                raw["start"] = date.fromisoformat(raw["start"])
+            if raw.get("due"):
+                raw["due"] = date.fromisoformat(raw["due"])
+            item = ProgramItem(**raw)
+            self.items[item.id] = item
+
+    # ------------------------------------------------------------------
+    # Persistence helpers
+    def _save(self) -> None:
+        data = []
+        for item in self.items.values():
+            row = asdict(item)
+            if row["start"]:
+                row["start"] = row["start"].isoformat()
+            if row["due"]:
+                row["due"] = row["due"].isoformat()
+            data.append(row)
+        save_json(BOARD_PATH, data)
+
+    # ------------------------------------------------------------------
+    # CRUD operations
+    def add(self, item: ProgramItem) -> None:
+        self.items[item.id] = item
+        self._save()
+
+    def update(self, id: str, **fields) -> None:
+        item = self.items[id]
+        for key, value in fields.items():
+            if key in {"start", "due"} and isinstance(value, str):
+                value = date.fromisoformat(value)
+            setattr(item, key, value)
+        self._save()
+
+    def get(self, id: str) -> Optional[ProgramItem]:
+        return self.items.get(id)
+
+    def list(self, filter_by_status: Optional[str] = None) -> List[ProgramItem]:
+        items = list(self.items.values())
+        if filter_by_status:
+            items = [i for i in items if i.status == filter_by_status]
+        return items
+
+    # ------------------------------------------------------------------
+    def critical_path(self) -> List[str]:
+        """Return task IDs in dependency order using a topological sort.
+
+        Raises
+        ------
+        BotExecutionError
+            If a dependency cycle is detected.
+        """
+
+        # Kahn's algorithm
+        deps = {item.id: set(item.depends_on) for item in self.items.values()}
+        ready = [i for i, d in deps.items() if not d]
+        order: List[str] = []
+
+        while ready:
+            node = ready.pop(0)
+            order.append(node)
+            for other, d in deps.items():
+                if node in d:
+                    d.remove(node)
+                    if not d:
+                        ready.append(other)
+            deps.pop(node, None)
+
+        if deps:  # remaining nodes => cycle
+            raise BotExecutionError("dependency_cycle", details=list(deps.keys()))
+        return order
+
+    # ------------------------------------------------------------------
+    def as_markdown_roadmap(self) -> str:
+        """Render the board as a Markdown table with a tiny ASCII Gantt chart."""
+
+        items = self.list()
+        if not items:
+            return "(empty board)"
+
+        # Establish 13 week window
+        starts = [i.start for i in items if i.start]
+        board_start = min(starts) if starts else date.today()
+
+        lines = ["|ID|Title|Status|Gantt|", "|---|---|---|---|"]
+        header_weeks = " ".join(f"Wk{w:02d}" for w in range(1, 14))
+        lines.append(f"| | | |{header_weeks}|")
+
+        for item in items:
+            s = item.start or board_start
+            e = item.due or s
+            start_idx = max(0, min(12, (s - board_start).days // 7))
+            end_idx = max(0, min(12, (e - board_start).days // 7))
+            bar = "".join("#" if start_idx <= i <= end_idx else "." for i in range(13))
+            lines.append(f"|{item.id}|{item.title}|{item.status}|{bar}|")
+
+        return "\n".join(lines)
+

--- a/samples/sample_tasks.csv
+++ b/samples/sample_tasks.csv
@@ -1,0 +1,3 @@
+id,goal,context_json,depends_on_csv,scheduled_for_iso,bot
+T001,Plan fall assortment,{},,2025-01-01T09:00:00,Merchandising-BOT
+T002,Plan promotion weekend,{},T001,2025-01-02T09:00:00,Store-Ops-BOT

--- a/tests/test_csv_io.py
+++ b/tests/test_csv_io.py
@@ -1,0 +1,24 @@
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "csv_io", Path(__file__).resolve().parent.parent / "io" / "csv_io.py"
+)
+csv_io = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(csv_io)
+export_tasks = csv_io.export_tasks
+import_tasks = csv_io.import_tasks
+
+
+def test_round_trip(tmp_path):
+    csv_in = tmp_path / "tasks.csv"
+    csv_in.write_text(
+        "id,goal,context_json,depends_on_csv,scheduled_for_iso,bot\n"
+        "T1,Goal1,{},,2025-01-01T00:00:00,Merchandising-BOT\n"
+    )
+    tasks = import_tasks(csv_in)
+    assert tasks[0].id == "T1"
+    csv_out = tmp_path / "out.csv"
+    export_tasks(csv_out, tasks)
+    assert "T1" in csv_out.read_text()
+

--- a/tests/test_industry_pack.py
+++ b/tests/test_industry_pack.py
@@ -1,0 +1,15 @@
+from bots import BOT_REGISTRY
+from orchestrator import Task
+
+
+def test_merchandising_bot():
+    bot = BOT_REGISTRY["Merchandising-BOT"]
+    result = bot.run(Task(id="1", goal="plan", bot="Merchandising-BOT"))
+    assert "SKU1" in result
+
+
+def test_store_ops_bot():
+    bot = BOT_REGISTRY["Store-Ops-BOT"]
+    result = bot.run(Task(id="2", goal="ops", bot="Store-Ops-BOT"))
+    assert result["labor_plan"]
+

--- a/tests/test_program_board.py
+++ b/tests/test_program_board.py
@@ -1,0 +1,26 @@
+import pytest
+
+from orchestrator.protocols import BotExecutionError
+from program.board import ProgramBoard, ProgramItem
+
+
+def test_crud(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    board = ProgramBoard()
+    item = ProgramItem(id="P1", title="Launch", owner="Ops", bot="Bot1")
+    board.add(item)
+    assert board.get("P1").title == "Launch"
+    board.update("P1", status="done")
+    assert board.list("done")[0].id == "P1"
+
+
+def test_topo_and_cycle(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    board = ProgramBoard()
+    board.add(ProgramItem(id="A", title="A", owner="o", bot="b"))
+    board.add(ProgramItem(id="B", title="B", owner="o", bot="b", depends_on=["A"]))
+    assert board.critical_path() == ["A", "B"]
+    board.update("A", depends_on=["B"])
+    with pytest.raises(BotExecutionError):
+        board.critical_path()
+

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+
+from orchestrator import Task
+from orchestrator.metrics import METRICS_PATH
+from orchestrator.scheduler import schedule_poll
+from orchestrator.tasks import load_tasks, save_tasks
+
+
+def test_dependency_block(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    t1 = Task(id="T1", goal="A", bot="Merchandising-BOT")
+    t2 = Task(
+        id="T2",
+        goal="B",
+        bot="Store-Ops-BOT",
+        depends_on=["T1"],
+        scheduled_for=datetime.utcnow(),
+    )
+    save_tasks([t1, t2])
+    schedule_poll(datetime.utcnow())
+    tasks = load_tasks()
+    assert tasks[1].status == "pending"
+    assert METRICS_PATH.exists()
+    assert any("dependency_block" in line for line in METRICS_PATH.read_text().splitlines())
+
+
+def test_ready_task_runs(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    t1 = Task(id="T1", goal="A", bot="Merchandising-BOT", status="done")
+    t2 = Task(
+        id="T2",
+        goal="B",
+        bot="Store-Ops-BOT",
+        depends_on=["T1"],
+        scheduled_for=datetime.utcnow(),
+    )
+    save_tasks([t1, t2])
+    schedule_poll(datetime.utcnow())
+    tasks = load_tasks()
+    assert tasks[1].status == "done"
+

--- a/tools/storage.py
+++ b/tools/storage.py
@@ -1,0 +1,37 @@
+"""Lightweight JSON storage helpers used by CLI modules."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: Path, default: Any) -> Any:
+    """Load JSON data from *path* if it exists, otherwise return *default*.
+
+    Parameters
+    ----------
+    path:
+        Location of the JSON file.
+    default:
+        Value returned when the file does not yet exist.
+    """
+
+    if path.exists():
+        with path.open("r", encoding="utf-8") as f:
+            return json.load(f)
+    return default
+
+
+def save_json(path: Path, data: Any) -> None:
+    """Persist *data* as JSON to *path*.
+
+    The parent directory is created if necessary.  Datetime and date objects
+    are serialised using their ISO representation via ``default=str``.
+    """
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, default=str)
+


### PR DESCRIPTION
## Summary
- add persistent Program Board with ASCII roadmap and critical path detection
- implement task dependencies, scheduler, and CSV import/export
- introduce Retail industry bots and CLI support

## Testing
- `ruff check program orchestrator io bots cli tests/test_program_board.py tests/test_scheduler.py tests/test_csv_io.py tests/test_industry_pack.py`
- `mypy program orchestrator bots cli io/csv_io.py --explicit-package-bases`
- `pytest tests/test_program_board.py tests/test_scheduler.py tests/test_csv_io.py tests/test_industry_pack.py -q`
- `python -m cli.console task:import --csv samples/sample_tasks.csv`
- `python -m cli.console program:list`
- `python -m cli.console program:roadmap`
- `python -m cli.console scheduler:run --every-seconds 1`
- `python -m cli.console bot:run --bot "Merchandising-BOT" --goal "Plan fall assortment"`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pytest --cov=orchestrator --cov=bots --cov=program --cov=io tests/test_program_board.py tests/test_scheduler.py tests/test_csv_io.py tests/test_industry_pack.py -q` *(fails: unrecognized arguments: --cov=orchestrator --cov=bots --cov=program --cov=io)*

------
https://chatgpt.com/codex/tasks/task_e_68c4da397bd883299d46594314e34299