### PR TITLE
feat: add benchmark suite and SLO tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ When you're ready to share changes:
 
 ---
 
+## Performance
+
+```bash
+python -m cli.console bench:run --name "Treasury-BOT" --iter 30 --warmup 5
+python -m cli.console slo:report
+python -m cli.console slo:gate --fail-on regressions
+```
+
+---
+
 ## Notes & assumptions
 
 - Stack recorded in memory (Aug 2025): SPA on `/var/www/blackroad/index.html`, Express API on port **4000**

--- a/bench/runner.py
+++ b/bench/runner.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import csv
+import json
+import random
+from datetime import datetime
+from pathlib import Path
+from statistics import mean, stdev
+from typing import Dict, List, Optional
+
+import yaml  # type: ignore[import-untyped]
+
+import settings
+from orchestrator import orchestrator
+from orchestrator.env_stamp import create_env_stamp
+from orchestrator.protocols import Task
+from orchestrator.slo import SLO_CATALOG
+from tools import storage
+
+ARTIFACTS = Path("artifacts/bench")
+METRICS_PATH = Path("artifacts/metrics.jsonl")
+SCENARIOS_DIR = Path("bench/scenarios")
+
+
+def list_scenarios() -> List[str]:
+    names = []
+    for p in SCENARIOS_DIR.glob("*.yml"):
+        cfg = yaml.safe_load(p.read_text())
+        names.append(cfg.get("bot", p.stem))
+    return names
+
+
+def load_scenario(name: str) -> Dict:
+    path = SCENARIOS_DIR / f"{name.lower().replace(' ', '-')}.yml"
+    data = yaml.safe_load(path.read_text())
+    return data
+
+
+def _quantile(sorted_samples: List[int], q: float) -> int:
+    if not sorted_samples:
+        return 0
+    pos = (len(sorted_samples) - 1) * q
+    lower = sorted_samples[int(pos)]
+    upper = sorted_samples[min(int(pos) + 1, len(sorted_samples) - 1)]
+    return int(lower + (upper - lower) * (pos - int(pos)))
+
+
+def run_bench(name: str, iterations: int = 20, warmup: int = 5, cache: str = "na", export_csv: Optional[Path] = None) -> Dict:
+    random.seed(getattr(settings, "RANDOM_SEED", 0))
+    scenario = load_scenario(name)
+    bot = scenario["bot"]
+    goal = scenario["goal"]
+    ctx = scenario.get("context", {})
+    bench_dir = ARTIFACTS / bot
+    bench_dir.mkdir(parents=True, exist_ok=True)
+    summary_path = bench_dir / "summary.json"
+    prev_path = bench_dir / "previous_summary.json"
+    if summary_path.exists():
+        summary_path.replace(prev_path)
+    env_path = create_env_stamp(bench_dir / "env.json")
+
+    timings: List[int] = []
+    rss_samples: List[int] = []
+    for i in range(warmup + iterations):
+        task = Task(id=f"BENCH{i}", goal=goal, context=ctx, created_at=datetime.utcnow())
+        response = orchestrator.route(task, bot)
+        if i >= warmup:
+            timings.append(response.elapsed_ms or 0)
+            rss_samples.append(response.rss_mb or 0)
+    sorted_times = sorted(timings)
+    p50 = _quantile(sorted_times, 0.5)
+    p90 = _quantile(sorted_times, 0.9)
+    p95 = _quantile(sorted_times, 0.95)
+    mean_t = int(mean(timings)) if timings else 0
+    stdev_t = int(stdev(timings)) if len(timings) > 1 else 0
+    mean_rss = int(mean(rss_samples)) if rss_samples else 0
+    slo = SLO_CATALOG.get(bot)
+    summary = {
+        "name": bot,
+        "iterations": iterations,
+        "p50": p50,
+        "p90": p90,
+        "p95": p95,
+        "min": min(sorted_times) if sorted_times else 0,
+        "max": max(sorted_times) if sorted_times else 0,
+        "mean": mean_t,
+        "stdev": stdev_t,
+        "rss_mean": mean_rss,
+        "cache": cache,
+        "env": str(env_path),
+        "timestamp": datetime.utcnow().isoformat(),
+    }
+    if slo:
+        summary["slo"] = {
+            "p50_target": slo.p50_ms,
+            "p95_target": slo.p95_ms,
+            "max_mem_mb": slo.max_mem_mb,
+        }
+        summary["pass_p95"] = p95 <= slo.p95_ms
+    timings_path = bench_dir / "timings.csv"
+    with open(timings_path, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["iteration", "elapsed_ms", "rss_mb"])
+        for idx, (t, r) in enumerate(zip(timings, rss_samples)):
+            writer.writerow([idx, t, r])
+    summary_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    if export_csv:
+        export_csv.parent.mkdir(parents=True, exist_ok=True)
+        export_csv.write_text(timings_path.read_text(), encoding="utf-8")
+    storage.write(str(METRICS_PATH), {"event": "bench_run", "name": bot, "pass": summary.get("pass_p95", True)})
+    if prev_path.exists():
+        prev = json.loads(prev_path.read_text())
+        delta = prev.get("mean", 0) - mean_t
+        with open(bench_dir / "cache_savings.md", "w", encoding="utf-8") as fh:
+            fh.write("|metric|previous|current|delta|\n")
+            fh.write("|---|---|---|---|\n")
+            fh.write(f"|mean_ms|{prev.get('mean',0)}|{mean_t}|{delta}|\n")
+    return summary
+
+
+def run_all() -> Dict[str, Dict]:
+    results = {}
+    for name in list_scenarios():
+        results[name] = run_bench(name)
+    return results

--- a/bench/scenarios/treasury-bot.yml
+++ b/bench/scenarios/treasury-bot.yml
@@ -1,0 +1,4 @@
+bot: Treasury-BOT
+goal: Generate 13-week cash view
+context: {}
+intent: finance

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,25 @@
+# Performance Benchmarks
+
+This project ships a deterministic benchmark suite and service level objectives (SLOs) for each bot.
+
+## Benchmarks
+
+List scenarios:
+
+```
+python -m cli.console bench:list
+```
+
+Run a specific bot benchmark:
+
+```
+python -m cli.console bench:run --name "Treasury-BOT" --iter 30 --warmup 5
+```
+
+Generate reports for all bots:
+
+```
+python -m cli.console slo:report
+```
+
+Use `--perf` on any command to print a timing footer. Benchmarks write results under `artifacts/bench` and compare them against SLO targets. The `slo:gate` command fails if p95 latency regresses by more than 10%.

--- a/orchestrator/env_stamp.py
+++ b/orchestrator/env_stamp.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import platform
+import sys
+from pathlib import Path
+
+import settings
+
+
+def _file_hash(path: Path) -> str:
+    data = path.read_bytes() if path.exists() else b""
+    return hashlib.sha256(data).hexdigest()
+
+
+def create_env_stamp(path: Path) -> Path:
+    env = {
+        "python": sys.version,
+        "platform": platform.platform(),
+        "dependency_hash": _file_hash(Path("requirements.txt")),
+        "settings_digest": hashlib.sha256(str(vars(settings)).encode()).hexdigest(),
+        "random_seed": getattr(settings, "RANDOM_SEED", 0),
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(env, indent=2), encoding="utf-8")
+    return path

--- a/orchestrator/perf.py
+++ b/orchestrator/perf.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import contextlib
+import os
+import time
+from typing import Dict, Generator, Optional
+
+PAGE_SIZE = os.sysconf("SC_PAGE_SIZE") if hasattr(os, "sysconf") else 4096
+
+
+def _rss_mb() -> Optional[int]:
+    """Best-effort RSS in megabytes using /proc/self/statm."""
+    try:
+        with open("/proc/self/statm", "r", encoding="utf-8") as fh:
+            parts = fh.read().split()
+        pages = int(parts[1])
+        return int(pages * PAGE_SIZE / (1024 * 1024))
+    except Exception:
+        return None
+
+
+@contextlib.contextmanager
+def perf_timer(label: str) -> Generator[Dict[str, Optional[int]], None, None]:
+    """Measure elapsed ms and rss at context exit."""
+    start = time.monotonic()
+    data: Dict[str, Optional[int]] = {}
+    try:
+        yield data
+    finally:
+        end = time.monotonic()
+        data["elapsed_ms"] = int((end - start) * 1000)
+        data["rss_mb"] = _rss_mb()

--- a/orchestrator/protocols.py
+++ b/orchestrator/protocols.py
@@ -1,5 +1,6 @@
 from datetime import datetime
-from typing import List, Dict, Optional
+from typing import Dict, List, Optional
+
 from pydantic import BaseModel
 
 
@@ -19,3 +20,9 @@ class BotResponse(BaseModel):
     artifacts: List[str]
     next_actions: List[str]
     ok: bool
+    elapsed_ms: Optional[int] = None
+    rss_mb: Optional[int] = None
+    slo_name: Optional[str] = None
+    p50_target: Optional[int] = None
+    p95_target: Optional[int] = None
+    max_mem_mb: Optional[int] = None

--- a/orchestrator/slo.py
+++ b/orchestrator/slo.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict
+
+import yaml  # type: ignore[import-untyped]
+
+
+@dataclass
+class SLO:
+    name: str
+    p50_ms: int
+    p95_ms: int
+    max_mem_mb: int
+
+
+_DEFAULTS: Dict[str, SLO] = {
+    "Treasury-BOT": SLO("Treasury-BOT", p50_ms=100, p95_ms=200, max_mem_mb=256),
+    "RevOps-BOT": SLO("RevOps-BOT", p50_ms=120, p95_ms=250, max_mem_mb=256),
+    "SRE-BOT": SLO("SRE-BOT", p50_ms=100, p95_ms=200, max_mem_mb=256),
+}
+
+
+def _load_overrides() -> Dict[str, SLO]:
+    path = Path("config/slo.yaml")
+    catalog = dict(_DEFAULTS)
+    if path.exists():
+        data = yaml.safe_load(path.read_text()) or {}
+        for name, cfg in data.items():
+            catalog[name] = SLO(name=name, **cfg)
+    return catalog
+
+
+SLO_CATALOG: Dict[str, SLO] = _load_overrides()

--- a/orchestrator/slo_report.py
+++ b/orchestrator/slo_report.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+from .slo import SLO_CATALOG
+
+ARTIFACTS = Path("artifacts/bench")
+
+
+def _load_summary(path: Path) -> Dict:
+    return json.loads(path.read_text()) if path.exists() else {}
+
+
+def collect() -> List[Dict]:
+    results: List[Dict] = []
+    for bot_dir in ARTIFACTS.glob("*/summary.json"):
+        data = _load_summary(bot_dir)
+        bot = str(data.get("name", ""))
+        prev = _load_summary(bot_dir.with_name("previous_summary.json"))
+        if prev:
+            data["previous"] = prev
+        data["target"] = SLO_CATALOG.get(bot)
+        results.append(data)
+    return results
+
+
+def build_report() -> None:
+    rows = collect()
+    lines = ["|bot|p50|p95|target_p95|pass|timestamp|", "|---|---|---|---|---|---|"]
+    for r in rows:
+        slo = r.get("slo", {})
+        pass_flag = r.get("pass_p95", True)
+        lines.append(
+            f"|{r['name']}|{r['p50']}|{r['p95']}|{slo.get('p95_target', '')}|{pass_flag}|{r['timestamp']}|")
+    table = "\n".join(lines)
+    md_path = ARTIFACTS / "_index.md"
+    html_path = ARTIFACTS / "_index.html"
+    md_path.write_text(table + "\n", encoding="utf-8")
+    html_path.write_text("<pre>\n" + table + "\n</pre>\n", encoding="utf-8")
+
+
+def gate(fail_on: str = "regressions") -> bool:
+    rows = collect()
+    failures = []
+    regressions = []
+    for r in rows:
+        slo = r.get("slo", {})
+        if r.get("p95", 0) > int(slo.get("p95_target", 0) * 1.1):
+            failures.append(r["name"])
+        prev = r.get("previous")
+        if prev and r.get("p95", 0) > prev.get("p95", 0):
+            regressions.append(r["name"])
+    if failures or (fail_on == "regressions" and regressions):
+        return False
+    return True

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,1 @@
+RANDOM_SEED = 1337

--- a/tests/test_bench_runner.py
+++ b/tests/test_bench_runner.py
@@ -1,0 +1,29 @@
+import contextlib
+import json
+
+from bench import runner
+from orchestrator import orchestrator
+
+
+def make_timer(values):
+    def _timer(label):
+        val = values.pop(0)
+        @contextlib.contextmanager
+        def cm():
+            data = {"elapsed_ms": val, "rss_mb": 1}
+            yield data
+        return cm()
+    return _timer
+
+
+def test_run_bench_creates_artifacts(tmp_path, monkeypatch):
+    monkeypatch.setattr(runner, "ARTIFACTS", tmp_path)
+    monkeypatch.setattr(runner, "METRICS_PATH", tmp_path / "metrics.jsonl")
+    monkeypatch.setattr(orchestrator, "_memory_path", tmp_path / "mem.jsonl")
+    monkeypatch.setattr(orchestrator, "perf_timer", make_timer([5, 20, 30, 40]))
+    runner.run_bench("Treasury-BOT", iterations=3, warmup=1)
+    summary = json.loads((tmp_path / "Treasury-BOT" / "summary.json").read_text())
+    assert summary["p50"] == 30
+    assert summary["p95"] == 39
+    assert summary["iterations"] == 3
+    assert (tmp_path / "Treasury-BOT" / "timings.csv").exists()

--- a/tests/test_cache_impact.py
+++ b/tests/test_cache_impact.py
@@ -1,0 +1,19 @@
+from bench import runner
+from orchestrator import orchestrator
+from tests.test_bench_runner import make_timer
+
+
+def test_cache_impact_delta(tmp_path, monkeypatch):
+    monkeypatch.setattr(runner, "ARTIFACTS", tmp_path)
+    monkeypatch.setattr(runner, "METRICS_PATH", tmp_path / "metrics.jsonl")
+    monkeypatch.setattr(orchestrator, "_memory_path", tmp_path / "mem.jsonl")
+    # first run (baseline)
+    monkeypatch.setattr(orchestrator, "perf_timer", make_timer([5, 30, 30, 30]))
+    runner.run_bench("Treasury-BOT", iterations=3, warmup=1, cache="off")
+    # second run (faster)
+    monkeypatch.setattr(orchestrator, "perf_timer", make_timer([5, 10, 10, 10]))
+    runner.run_bench("Treasury-BOT", iterations=3, warmup=1, cache="on")
+    delta_path = tmp_path / "Treasury-BOT" / "cache_savings.md"
+    assert delta_path.exists()
+    text = delta_path.read_text()
+    assert "mean_ms" in text

--- a/tests/test_env_stamp.py
+++ b/tests/test_env_stamp.py
@@ -1,0 +1,13 @@
+import json
+
+from orchestrator.env_stamp import create_env_stamp
+
+
+def test_env_stamp_fields(tmp_path):
+    path = create_env_stamp(tmp_path / "env.json")
+    data = json.loads(path.read_text())
+    assert "python" in data
+    assert "platform" in data
+    assert "dependency_hash" in data
+    assert "settings_digest" in data
+    assert "random_seed" in data

--- a/tests/test_perf_timer.py
+++ b/tests/test_perf_timer.py
@@ -1,0 +1,10 @@
+import time
+
+from orchestrator.perf import perf_timer
+
+
+def test_perf_timer_elapsed_and_rss_non_negative():
+    with perf_timer("t") as p:
+        time.sleep(0.01)
+    assert p["elapsed_ms"] >= 10
+    assert p["rss_mb"] is None or p["rss_mb"] >= 0

--- a/tests/test_slo_gate.py
+++ b/tests/test_slo_gate.py
@@ -1,0 +1,17 @@
+from bench import runner
+from orchestrator import orchestrator, slo_report
+from tests.test_bench_runner import make_timer
+
+
+def test_slo_gate_regression(tmp_path, monkeypatch):
+    monkeypatch.setattr(runner, "ARTIFACTS", tmp_path)
+    monkeypatch.setattr(runner, "METRICS_PATH", tmp_path / "metrics.jsonl")
+    monkeypatch.setattr(orchestrator, "_memory_path", tmp_path / "mem.jsonl")
+    monkeypatch.setattr(slo_report, "ARTIFACTS", tmp_path)
+    # baseline
+    monkeypatch.setattr(orchestrator, "perf_timer", make_timer([5, 20, 30, 40]))
+    runner.run_bench("Treasury-BOT", iterations=3, warmup=1)
+    # regression run
+    monkeypatch.setattr(orchestrator, "perf_timer", make_timer([5, 100, 100, 100]))
+    runner.run_bench("Treasury-BOT", iterations=3, warmup=1)
+    assert not slo_report.gate("regressions")

--- a/tests/test_slo_report.py
+++ b/tests/test_slo_report.py
@@ -1,0 +1,26 @@
+import json
+
+from bench import runner
+from orchestrator import orchestrator, slo_report
+from tests.test_bench_runner import make_timer
+
+
+def test_slo_report_table(tmp_path, monkeypatch):
+    monkeypatch.setattr(runner, "ARTIFACTS", tmp_path)
+    monkeypatch.setattr(runner, "METRICS_PATH", tmp_path / "metrics.jsonl")
+    monkeypatch.setattr(orchestrator, "_memory_path", tmp_path / "mem.jsonl")
+    monkeypatch.setattr(orchestrator, "perf_timer", make_timer([5, 20, 30, 40]))
+    runner.run_bench("Treasury-BOT", iterations=3, warmup=1)
+    monkeypatch.setattr(slo_report, "ARTIFACTS", tmp_path)
+    slo_report.build_report()
+    md = (tmp_path / "_index.md").read_text()
+    assert "Treasury-BOT" in md
+    assert "True" in md
+    # flip to failing
+    summary = json.loads((tmp_path / "Treasury-BOT" / "summary.json").read_text())
+    summary["p95"] = 1000
+    summary["pass_p95"] = False
+    (tmp_path / "Treasury-BOT" / "summary.json").write_text(json.dumps(summary))
+    slo_report.build_report()
+    md = (tmp_path / "_index.md").read_text()
+    assert "False" in md


### PR DESCRIPTION
## Summary
- add SLO catalog and perf timer for orchestrator routes
- introduce deterministic bench runner with env stamps and cache delta
- wire CLI commands for bench and SLO reports with documentation

## Testing
- `ruff check orchestrator bench cli/console.py settings.py tests/test_perf_timer.py tests/test_bench_runner.py tests/test_slo_report.py tests/test_slo_gate.py tests/test_cache_impact.py tests/test_env_stamp.py`
- `mypy orchestrator bench cli/console.py`
- `pytest tests/test_perf_timer.py tests/test_bench_runner.py tests/test_slo_report.py tests/test_slo_gate.py tests/test_cache_impact.py tests/test_env_stamp.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4dd8bc75c832993e084a5b2816b4f