### PR TITLE
feat: add executive analytics and autopilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,17 @@ When you're ready to share changes:
    ```bash
    git commit -m "feat: describe your change"
    ```
+
+## Executive Autopilot
+
+Offline analytics helpers:
+
+```bash
+python -m cli.console cohort:new --name apac_flagship --criteria samples/cohorts/apac_flagship.json
+python -m cli.console anomaly:run --rules configs/anomaly_rules.yaml --window W
+python -m cli.console decide:plan --anomalies artifacts/anomalies/latest.json --goals configs/goals.yaml --constraints configs/constraints.yaml
+python -m cli.console narrative:build --plan artifacts/decisions/plan_*.json --out artifacts/reports/exec_latest
+```
 3. Push the branch:
    ```bash
    git push origin <branch-name>

--- a/alerts/local.py
+++ b/alerts/local.py
@@ -1,0 +1,41 @@
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import List
+
+from tools import storage
+
+from analytics.utils import increment, log_event
+
+ROOT = Path(__file__).resolve().parents[1]
+ART = ROOT / "artifacts" / "alerts"
+SEVERITY_ORDER = {"low": 1, "medium": 2, "high": 3, "critical": 4}
+
+
+def trigger(source: str, file: Path, min_severity: str) -> List[dict]:
+    data = json.loads(file.read_text())
+    ART.mkdir(parents=True, exist_ok=True)
+    emitted: List[dict] = []
+    for item in data:
+        if SEVERITY_ORDER[item["severity"]] >= SEVERITY_ORDER[min_severity]:
+            event = {
+                "ts": datetime.utcnow().isoformat(),
+                "source": source,
+                "severity": item["severity"],
+                "message": f"{item['metric']} {item['group']}",
+            }
+            storage.write(str(ART / "alerts.jsonl"), event)
+            emitted.append(event)
+            print(f"{event['severity'].upper()}: {event['message']}")
+    if emitted:
+        increment("alerts_emitted")
+        log_event({"type": "alert", "source": source, "count": len(emitted)})
+    return emitted
+
+
+def list_alerts(limit: int = 20) -> List[dict]:
+    path = ART / "alerts.jsonl"
+    if not path.exists():
+        return []
+    lines = path.read_text().strip().splitlines()[-limit:]
+    return [json.loads(l) for l in lines]

--- a/analytics/__init__.py
+++ b/analytics/__init__.py
@@ -1,0 +1,1 @@
+"""Executive analytics modules."""

--- a/analytics/anomaly_rules.py
+++ b/analytics/anomaly_rules.py
@@ -1,0 +1,97 @@
+import ast
+import json
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+import yaml
+
+from .utils import increment, log_event, validate
+
+ROOT = Path(__file__).resolve().parents[1]
+DATA_DIR = ROOT / "samples" / "metrics"
+ART = ROOT / "artifacts" / "anomalies"
+
+
+class SafeEval(ast.NodeVisitor):
+    allowed = (
+        ast.Expression,
+        ast.Compare,
+        ast.Name,
+        ast.Load,
+        ast.BinOp,
+        ast.UnaryOp,
+        ast.Num,
+        ast.operator,
+        ast.unaryop,
+        ast.cmpop,
+    )
+
+    def visit(self, node):  # type: ignore[override]
+        if not isinstance(node, self.allowed):
+            raise ValueError("unsafe expression")
+        return super().visit(node)
+
+
+def _eval(expr: str, ctx: Dict[str, float]) -> bool:
+    tree = ast.parse(expr, mode="eval")
+    SafeEval().visit(tree)
+    return bool(eval(compile(tree, "<expr>", "eval"), {"__builtins__": {}}, ctx))
+
+
+def _load_series(metric: str, group_by: str) -> Dict[str, List[Dict[str, float]]]:
+    data = json.loads(Path(DATA_DIR / f"{metric}_{group_by}.json").read_text())
+    buckets: Dict[str, List[Dict[str, float]]] = defaultdict(list)
+    for row in data:
+        buckets[row[group_by]].append(row)
+    for rows in buckets.values():
+        rows.sort(key=lambda r: r["date"])
+    return buckets
+
+
+def detect_anomalies(metric: str, group_by: str, window: str, rule: Dict[str, str]) -> List[Dict]:
+    series = _load_series(metric, group_by)
+    anomalies: List[Dict] = []
+    for grp, rows in series.items():
+        if len(rows) < 5:
+            continue
+        trailing = rows[-5:-1]
+        mean = sum(r["value"] for r in trailing) / len(trailing)
+        current = rows[-1]["value"]
+        prev = rows[-2]["value"]
+        pct_drop = (mean - current) / mean * 100 if mean else 0
+        delta = current - prev
+        ctx = {"value": current, "pct_drop": pct_drop, "delta": delta}
+        if _eval(rule["condition"], ctx):
+            anomalies.append(
+                {
+                    "metric": metric,
+                    "group": grp,
+                    "severity": rule["severity"],
+                    "value": current,
+                    "pct_drop": round(pct_drop, 2),
+                }
+            )
+    return anomalies
+
+
+def run_rules(rules_path: Path, window: str) -> List[Dict]:
+    rules = yaml.safe_load(rules_path.read_text())["rules"]
+    all_anoms: List[Dict] = []
+    for rule in rules:
+        all_anoms.extend(
+            detect_anomalies(rule["metric"], rule["group_by"], window, rule)
+        )
+    ts = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+    ART.mkdir(parents=True, exist_ok=True)
+    out_path = ART / f"{ts}.json"
+    storage_path = ART / "latest.json"
+    out_path.write_text(json.dumps(all_anoms, indent=2))
+    storage_path.write_text(json.dumps(all_anoms, indent=2))
+    summary = ART / f"{ts}.md"
+    summary.write_text("\n".join(f"- {a['metric']} {a['group']}" for a in all_anoms))
+    validate(all_anoms, "anomaly.schema.json")
+    increment("anomaly_detect")
+    log_event({"type": "anomaly_detect", "rules": str(rules_path), "lineage": [r.get("metric") for r in rules]})
+    return all_anoms

--- a/analytics/cohorts.py
+++ b/analytics/cohorts.py
@@ -1,0 +1,61 @@
+import json
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+from tools import storage
+
+from .utils import increment, log_event
+
+ROOT = Path(__file__).resolve().parents[1]
+COHORTS_DIR = ROOT / "artifacts" / "cohorts"
+DATA_DIR = ROOT / "samples" / "data"
+
+
+def define_cohort(name: str, criteria: Dict[str, str]) -> None:
+    path = COHORTS_DIR / f"{name}.json"
+    storage.write(str(path), criteria)
+
+
+def _period(ts: str, window: str) -> str:
+    dt = datetime.fromisoformat(ts)
+    if window == "M":
+        return dt.strftime("%Y-%m")
+    if window == "W":
+        return f"{dt.isocalendar().year}-W{dt.isocalendar().week:02d}"
+    if window == "Q":
+        q = (dt.month - 1) // 3 + 1
+        return f"{dt.year}-Q{q}"
+    raise ValueError("unknown window")
+
+
+METRIC_FUNCS = {
+    "revenue": lambda rows: sum(r["revenue"] for r in rows),
+    "gross_margin_pct": lambda rows: round(
+        (sum(r["revenue"] - r["cost"] for r in rows) / sum(r["revenue"] for r in rows)) * 100,
+        2,
+    ),
+    "nps": lambda rows: round(sum(r["nps"] for r in rows) / len(rows), 2),
+    "return_rate": lambda rows: round(sum(r["return_rate"] for r in rows) / len(rows), 4),
+    "uptime": lambda rows: round(sum(r["uptime"] for r in rows) / len(rows), 3),
+    "mttr": lambda rows: round(sum(r["mttr"] for r in rows) / len(rows), 2),
+}
+
+
+def cohort_view(table: str, cohort_name: str, metrics: List[str], window: str) -> List[Dict[str, float]]:
+    criteria = json.loads(storage.read(str(COHORTS_DIR / f"{cohort_name}.json")))
+    rows = json.loads(Path(DATA_DIR / f"{table}.json").read_text())
+    filtered = [r for r in rows if all(r.get(k) == v for k, v in criteria.items())]
+    buckets: Dict[str, List[Dict]] = defaultdict(list)
+    for r in filtered:
+        buckets[_period(r["date"], window)].append(r)
+    out: List[Dict[str, float]] = []
+    for period, bucket in sorted(buckets.items()):
+        rec = {"period": period}
+        for m in metrics:
+            rec[m] = METRIC_FUNCS[m](bucket)
+        out.append(rec)
+    increment("cohort_run")
+    log_event({"type": "cohort_run", "cohort": cohort_name, "table": table})
+    return out

--- a/analytics/decide.py
+++ b/analytics/decide.py
@@ -1,0 +1,61 @@
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+import yaml
+
+from .utils import increment, log_event, validate
+
+ROOT = Path(__file__).resolve().parents[1]
+ART = ROOT / "artifacts" / "decisions"
+
+HEURISTICS = {
+    "uptime": {
+        "action": "Roll out SRE mitigation",
+        "bot": "sre_bot",
+        "owner": "bob",
+        "credits": 8,
+        "impact": 4,
+    },
+    "revenue": {
+        "action": "Adjust Pricing",
+        "bot": "pricing_bot",
+        "owner": "alice",
+        "credits": 10,
+        "impact": 5,
+    },
+}
+
+
+def choose_actions(goals: List[str], constraints: Dict[str, int], candidates: List[Dict]) -> Dict:
+    budget = constraints["credit_budget"]
+    k = constraints["max_concurrent"]
+    chosen: List[Dict] = []
+    spent = 0
+    for cand in sorted(candidates, key=lambda c: (-c["impact"], c["action"])):
+        if spent + cand["credits"] <= budget and len(chosen) < k:
+            chosen.append(cand)
+            spent += cand["credits"]
+    raci = {c["bot"]: c["owner"] for c in chosen}
+    return {"actions": chosen, "raci": raci}
+
+
+def plan_actions(anomalies_path: Path, goals_path: Path, constraints_path: Path) -> Path:
+    anomalies = json.loads(anomalies_path.read_text())
+    goals = yaml.safe_load(goals_path.read_text()).get("goals", [])
+    constraints = yaml.safe_load(constraints_path.read_text())
+    candidates: List[Dict] = []
+    for anom in anomalies:
+        h = HEURISTICS.get(anom["metric"])
+        if h:
+            candidates.append(h.copy())
+    plan = choose_actions(goals, constraints, candidates)
+    ts = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+    ART.mkdir(parents=True, exist_ok=True)
+    out_path = ART / f"plan_{ts}.json"
+    out_path.write_text(json.dumps(plan, indent=2))
+    validate(plan, "plan.schema.json")
+    increment("decision_plan")
+    log_event({"type": "decision_plan", "anomalies": str(anomalies_path)})
+    return out_path

--- a/analytics/narrative.py
+++ b/analytics/narrative.py
@@ -1,0 +1,57 @@
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import List
+
+from .utils import increment, log_event, validate
+
+ROOT = Path(__file__).resolve().parents[1]
+ART = ROOT / "artifacts" / "reports"
+
+
+def build_report(plan_path: Path, out_prefix: Path) -> None:
+    plan = json.loads(plan_path.read_text())
+    anomalies_path = ROOT / "artifacts" / "anomalies" / "latest.json"
+    cohorts_dir = ROOT / "artifacts" / "cohorts"
+    anomalies = json.loads(anomalies_path.read_text()) if anomalies_path.exists() else []
+    cohort_files = list(cohorts_dir.glob("*.json"))
+    cohort_names = [f.stem for f in cohort_files]
+    sections = [
+        {"title": "What happened", "body": f"Anomalies: {len(anomalies)}"},
+        {"title": "Why it matters", "body": "Impacting key KPIs"},
+        {"title": "What we're doing", "body": ", ".join(a["action"] for a in plan.get("actions", [])) or "No actions"},
+        {"title": "Risks & Next Steps", "body": "Monitor cohorts: " + ", ".join(cohort_names)},
+    ]
+    data = {"sections": sections}
+    validate(data, "narrative.schema.json")
+    ts = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+    ART.mkdir(parents=True, exist_ok=True)
+    out_prefix.parent.mkdir(parents=True, exist_ok=True)
+    md_path = out_prefix.with_suffix(".md")
+    md_lines = [f"# Executive Report {ts}", ""]
+    for s in sections:
+        md_lines.append(f"## {s['title']}")
+        md_lines.append(s["body"])
+        md_lines.append("")
+    md_path.write_text("\n".join(md_lines))
+    try:
+        from pptx import Presentation  # type: ignore
+
+        ppt_path = out_prefix.with_suffix(".pptx")
+        pres = Presentation()
+        for s in sections:
+            slide = pres.slides.add_slide(pres.slide_layouts[1])
+            slide.shapes.title.text = s["title"]
+            slide.shapes.placeholders[1].text = s["body"]
+        pres.save(ppt_path)
+    except Exception:
+        slides_md = out_prefix.with_name(out_prefix.name + "_slides.md")
+        slide_lines: List[str] = []
+        for s in sections:
+            slide_lines.append(f"# {s['title']}")
+            slide_lines.append(s["body"])
+            slide_lines.append("")
+        slides_md.write_text("\n".join(slide_lines))
+    (out_prefix.with_suffix(".json")).write_text(json.dumps(data, indent=2))
+    increment("narrative_built")
+    log_event({"type": "narrative_built", "plan": str(plan_path)})

--- a/analytics/utils.py
+++ b/analytics/utils.py
@@ -1,0 +1,31 @@
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+
+from tools import storage
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMAS = ROOT / "schemas"
+MEMORY = ROOT / "orchestrator" / "memory.jsonl"
+METRICS = ROOT / "artifacts" / "metrics.json"
+
+
+def validate(instance: Any, schema_name: str) -> None:
+    schema_path = SCHEMAS / schema_name
+    schema = json.loads(schema_path.read_text())
+    jsonschema.validate(instance=instance, schema=schema)
+
+
+def log_event(event: dict) -> None:
+    text = json.dumps(event, sort_keys=True)
+    sig = hashlib.sha256(text.encode("utf-8")).hexdigest()
+    storage.write(str(MEMORY), {**event, "signature": sig})
+
+
+def increment(metric: str) -> None:
+    data = json.loads(storage.read(str(METRICS)) or "{}")
+    data[metric] = data.get(metric, 0) + 1
+    storage.write(str(METRICS), data)

--- a/cli/console.py
+++ b/cli/console.py
@@ -1,7 +1,7 @@
 import json
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
+from typing import Optional, List
 
 import typer
 
@@ -9,6 +9,11 @@ from orchestrator.protocols import Task
 from orchestrator import orchestrator
 from tools import storage
 from bots import available_bots
+from analytics.cohorts import define_cohort, cohort_view
+from analytics.anomaly_rules import run_rules
+from analytics.decide import plan_actions
+from analytics.narrative import build_report
+from alerts.local import trigger, list_alerts
 
 app = typer.Typer()
 
@@ -65,6 +70,66 @@ def task_status(id: str = typer.Option(..., "--id")):
 def bot_list():
     for name, cls in available_bots().items():
         typer.echo(f"{name}\t{cls.mission}")
+
+
+@app.command("cohort:new")
+def cohort_new(name: str = typer.Option(..., "--name"), criteria: Path = typer.Option(..., "--criteria", exists=True)):
+    define_cohort(name, json.loads(criteria.read_text()))
+    typer.echo("OK")
+
+
+@app.command("cohort:run")
+def cohort_run(
+    table: str = typer.Option(..., "--table"),
+    name: str = typer.Option(..., "--name"),
+    metrics: str = typer.Option(..., "--metrics"),
+    window: str = typer.Option("M", "--window"),
+):
+    mets: List[str] = [m.strip() for m in metrics.split(",") if m.strip()]
+    res = cohort_view(table, name, mets, window)
+    out_dir = ARTIFACTS / "cohorts"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"{name}_{datetime.utcnow().strftime('%Y%m%d%H%M%S')}.json"
+    out_path.write_text(json.dumps(res, indent=2))
+    (out_dir / "latest.json").write_text(json.dumps(res, indent=2))
+    typer.echo(json.dumps(res))
+
+
+@app.command("anomaly:run")
+def anomaly_run(rules: Path = typer.Option(..., "--rules", exists=True), window: str = typer.Option("W", "--window")):
+    res = run_rules(rules, window)
+    typer.echo(json.dumps(res))
+
+
+@app.command("decide:plan")
+def decide_plan(
+    anomalies: Path = typer.Option(..., "--anomalies", exists=True),
+    goals: Path = typer.Option(..., "--goals", exists=True),
+    constraints: Path = typer.Option(..., "--constraints", exists=True),
+):
+    path = plan_actions(anomalies, goals, constraints)
+    typer.echo(str(path))
+
+
+@app.command("narrative:build")
+def narrative_build(plan: Path = typer.Option(..., "--plan", exists=True), out: Path = typer.Option(..., "--out")):
+    build_report(plan, out)
+    typer.echo("built")
+
+
+@app.command("alerts:trigger")
+def alerts_trigger(
+    source: str = typer.Option(..., "--source"),
+    file: Path = typer.Option(..., "--file", exists=True),
+    min_severity: str = typer.Option("high", "--min-severity"),
+):
+    trigger(source, file, min_severity)
+
+
+@app.command("alerts:list")
+def alerts_list(limit: int = typer.Option(20, "--limit")):
+    for e in list_alerts(limit):
+        typer.echo(json.dumps(e))
 
 
 if __name__ == "__main__":

--- a/configs/anomaly_rules.yaml
+++ b/configs/anomaly_rules.yaml
@@ -1,0 +1,9 @@
+rules:
+  - metric: revenue
+    group_by: region
+    condition: "pct_drop >= 10"
+    severity: high
+  - metric: uptime
+    group_by: service
+    condition: "value < 99.9"
+    severity: critical

--- a/configs/constraints.yaml
+++ b/configs/constraints.yaml
@@ -1,0 +1,2 @@
+credit_budget: 15
+max_concurrent: 2

--- a/configs/goals.yaml
+++ b/configs/goals.yaml
@@ -1,0 +1,4 @@
+goals:
+  - increase_gm_pct
+  - reduce_churn
+  - improve_uptime

--- a/docs/executive-analytics.md
+++ b/docs/executive-analytics.md
@@ -1,0 +1,30 @@
+# Executive Analytics & Autopilot
+
+This module provides offline cohort analysis, rule-based anomaly detection, a small decision engine, and narrative report generation.
+
+## Cohorts
+- Define with `python -m cli.console cohort:new --name apac_flagship --criteria samples/cohorts/apac_flagship.json`
+- Run with `python -m cli.console cohort:run --table crm_opps --name apac_flagship --metrics revenue,gross_margin_pct --window M`
+
+## Anomaly Rules DSL
+Example `configs/anomaly_rules.yaml`:
+```yaml
+rules:
+  - metric: revenue
+    group_by: region
+    condition: "pct_drop >= 10"
+    severity: high
+```
+Run via:
+`python -m cli.console anomaly:run --rules configs/anomaly_rules.yaml --window W`
+
+## Planner
+Generate a plan from anomalies:
+`python -m cli.console decide:plan --anomalies artifacts/anomalies/latest.json --goals configs/goals.yaml --constraints configs/constraints.yaml`
+
+## Narrative Reports
+Build executive reports and slides:
+`python -m cli.console narrative:build --plan artifacts/decisions/plan_*.json --out artifacts/reports/exec_<ts>`
+
+## Samples
+Outputs include JSON artifacts validated against schemas in `/schemas`.

--- a/samples/cohorts/apac_flagship.json
+++ b/samples/cohorts/apac_flagship.json
@@ -1,0 +1,5 @@
+{
+  "region": "APAC",
+  "product": "Flagship",
+  "signup_month": "2025-07"
+}

--- a/samples/cohorts/emea_flagship.json
+++ b/samples/cohorts/emea_flagship.json
@@ -1,0 +1,5 @@
+{
+  "region": "EMEA",
+  "product": "Flagship",
+  "signup_month": "2025-07"
+}

--- a/samples/data/crm_opps.json
+++ b/samples/data/crm_opps.json
@@ -1,0 +1,50 @@
+[
+  {
+    "date": "2025-07-15",
+    "region": "APAC",
+    "product": "Flagship",
+    "signup_month": "2025-07",
+    "revenue": 1000,
+    "cost": 600,
+    "nps": 40,
+    "return_rate": 0.1,
+    "uptime": 99.9,
+    "mttr": 2
+  },
+  {
+    "date": "2025-08-15",
+    "region": "APAC",
+    "product": "Flagship",
+    "signup_month": "2025-07",
+    "revenue": 1200,
+    "cost": 700,
+    "nps": 45,
+    "return_rate": 0.05,
+    "uptime": 99.8,
+    "mttr": 1
+  },
+  {
+    "date": "2025-07-15",
+    "region": "EMEA",
+    "product": "Flagship",
+    "signup_month": "2025-07",
+    "revenue": 900,
+    "cost": 500,
+    "nps": 50,
+    "return_rate": 0.08,
+    "uptime": 99.9,
+    "mttr": 1
+  },
+  {
+    "date": "2025-08-15",
+    "region": "APAC",
+    "product": "Basic",
+    "signup_month": "2025-07",
+    "revenue": 800,
+    "cost": 500,
+    "nps": 42,
+    "return_rate": 0.07,
+    "uptime": 99.7,
+    "mttr": 3
+  }
+]

--- a/samples/metrics/revenue_region.json
+++ b/samples/metrics/revenue_region.json
@@ -1,0 +1,12 @@
+[
+  {"date": "2025-01-01", "region": "APAC", "value": 100},
+  {"date": "2025-01-08", "region": "APAC", "value": 110},
+  {"date": "2025-01-15", "region": "APAC", "value": 120},
+  {"date": "2025-01-22", "region": "APAC", "value": 130},
+  {"date": "2025-01-29", "region": "APAC", "value": 90},
+  {"date": "2025-01-01", "region": "EMEA", "value": 100},
+  {"date": "2025-01-08", "region": "EMEA", "value": 100},
+  {"date": "2025-01-15", "region": "EMEA", "value": 100},
+  {"date": "2025-01-22", "region": "EMEA", "value": 100},
+  {"date": "2025-01-29", "region": "EMEA", "value": 100}
+]

--- a/samples/metrics/uptime_service.json
+++ b/samples/metrics/uptime_service.json
@@ -1,0 +1,12 @@
+[
+  {"date": "2025-01-01", "service": "api", "value": 99.95},
+  {"date": "2025-01-08", "service": "api", "value": 99.96},
+  {"date": "2025-01-15", "service": "api", "value": 99.97},
+  {"date": "2025-01-22", "service": "api", "value": 99.98},
+  {"date": "2025-01-29", "service": "api", "value": 99.99},
+  {"date": "2025-01-01", "service": "db", "value": 99.95},
+  {"date": "2025-01-08", "service": "db", "value": 99.94},
+  {"date": "2025-01-15", "service": "db", "value": 99.96},
+  {"date": "2025-01-22", "service": "db", "value": 99.97},
+  {"date": "2025-01-29", "service": "db", "value": 99.8}
+]

--- a/schemas/anomaly.schema.json
+++ b/schemas/anomaly.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["metric", "group", "severity", "value"],
+    "properties": {
+      "metric": {"type": "string"},
+      "group": {"type": "string"},
+      "severity": {"type": "string"},
+      "value": {"type": "number"},
+      "pct_drop": {"type": "number"}
+    }
+  }
+}

--- a/schemas/narrative.schema.json
+++ b/schemas/narrative.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["sections"],
+  "properties": {
+    "sections": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["title", "body"],
+        "properties": {
+          "title": {"type": "string"},
+          "body": {"type": "string"}
+        }
+      }
+    }
+  }
+}

--- a/schemas/plan.schema.json
+++ b/schemas/plan.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["actions", "raci"],
+  "properties": {
+    "actions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["action", "bot", "owner", "credits", "impact"],
+        "properties": {
+          "action": {"type": "string"},
+          "bot": {"type": "string"},
+          "owner": {"type": "string"},
+          "credits": {"type": "number"},
+          "impact": {"type": "number"}
+        }
+      }
+    },
+    "raci": {
+      "type": "object",
+      "additionalProperties": {"type": "string"}
+    }
+  }
+}

--- a/tests/test_exec_autopilot.py
+++ b/tests/test_exec_autopilot.py
@@ -1,0 +1,42 @@
+import json
+from pathlib import Path
+
+from analytics.cohorts import define_cohort, cohort_view
+from analytics.anomaly_rules import run_rules
+from analytics.decide import plan_actions
+from analytics.narrative import build_report
+from alerts.local import trigger, list_alerts
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_cohort_analysis():
+    define_cohort("apac_flagship", json.loads((ROOT / "samples/cohorts/apac_flagship.json").read_text()))
+    define_cohort("emea_flagship", json.loads((ROOT / "samples/cohorts/emea_flagship.json").read_text()))
+    res = cohort_view("crm_opps", "apac_flagship", ["revenue", "gross_margin_pct"], "M")
+    assert res[0]["revenue"] == 1000
+    assert res[1]["gross_margin_pct"] == 41.67
+    res2 = cohort_view("crm_opps", "emea_flagship", ["revenue"], "M")
+    assert res2[0]["revenue"] == 900
+
+
+def test_anomaly_and_plan_and_narrative(tmp_path):
+    anomalies = run_rules(ROOT / "configs/anomaly_rules.yaml", "W")
+    assert any(a["metric"] == "revenue" and a["group"] == "APAC" for a in anomalies)
+    assert any(a["metric"] == "uptime" and a["group"] == "db" for a in anomalies)
+    anomalies_path = ROOT / "artifacts/anomalies/latest.json"
+    plan_path = plan_actions(anomalies_path, ROOT / "configs/goals.yaml", ROOT / "configs/constraints.yaml")
+    plan = json.loads(plan_path.read_text())
+    assert len(plan["actions"]) == 1
+    out = ROOT / "artifacts/reports/exec_test"
+    build_report(plan_path, out)
+    assert out.with_suffix(".md").exists()
+    slides = out.with_name(out.name + "_slides.md")
+    assert slides.exists()
+
+
+def test_alerts():
+    anomalies_path = ROOT / "artifacts/anomalies/latest.json"
+    trigger("anomalies", anomalies_path, "high")
+    alerts = list_alerts(5)
+    assert any(a["source"] == "anomalies" for a in alerts)


### PR DESCRIPTION
## Summary
- add cohort analysis, anomaly detection, decision planning, narrative generation, and local alerts
- expose new CLI commands for cohort, anomaly, decide, narrative, alerts
- document executive analytics usage and provide sample configs and schemas

## Testing
- `pytest tests/test_exec_autopilot.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4de7e381883298e3e75213c5927e3