### PR TITLE
Add offline knowledge graph and reasoning engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,3 +465,15 @@ class MyBot(BaseBot):
     def run(self, task: Task) -> BotResponse:
         ...
 ```
+
+## Knowledge Graph
+
+Offline provenance tracking and query engine.
+
+Example commands:
+
+```
+python -m cli.console kg:stats
+python -m cli.console kg:query --file samples/kql/last_treasury_runs.kql
+python -m cli.console chain:run --plan configs/chain_examples/uptime_then_release.yaml
+```

--- a/cli/console.py
+++ b/cli/console.py
@@ -1,14 +1,20 @@
 import json
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
+from typing import Dict, List, Optional
 
 import typer
+import yaml
 
-from orchestrator.protocols import Task
-from orchestrator import orchestrator
-from tools import storage
 from bots import available_bots
+from kg.chainer import PlanStep, execute_plan
+from kg.model import KnowledgeGraph
+from kg.provenance import capture_event
+from kg.query import run as kql_run
+from kg.rules import run_rules
+from orchestrator import orchestrator
+from orchestrator.protocols import Task
+from tools import storage
 
 app = typer.Typer()
 
@@ -33,6 +39,7 @@ def task_create(
     task_id = _next_task_id()
     task = Task(id=task_id, goal=goal, context=ctx, created_at=datetime.utcnow())
     storage.write(str(ARTIFACTS / task_id / "task.json"), task.model_dump(mode="json"))
+    capture_event({"type": "task", "id": task_id, "goal": goal})
     typer.echo(task_id)
 
 
@@ -45,6 +52,16 @@ def task_route(
     task = Task(**task_data)
     response = orchestrator.route(task, bot)
     storage.write(str(ARTIFACTS / id / "response.json"), response.model_dump(mode="json"))
+    capture_event(
+        {
+            "type": "artifact",
+            "task_id": id,
+            "bot": bot,
+            "path": str(ARTIFACTS / id / "response.json"),
+            "intent": task.goal,
+            "artifact_type": "response",
+        }
+    )
     typer.echo(response.summary)
 
 
@@ -65,6 +82,48 @@ def task_status(id: str = typer.Option(..., "--id")):
 def bot_list():
     for name, cls in available_bots().items():
         typer.echo(f"{name}\t{cls.mission}")
+
+
+@app.command("kg:stats")
+def kg_stats():
+    kg = KnowledgeGraph()
+    labels: Dict[str, int] = {}
+    for node in kg.nodes.values():
+        labels[node["label"]] = labels.get(node["label"], 0) + 1
+    edges: Dict[str, int] = {}
+    for e in kg.edges.values():
+        for etype, targets in e.items():
+            edges[etype] = edges.get(etype, 0) + len(targets)
+    typer.echo(json.dumps({"nodes": labels, "edges": edges}))
+
+
+@app.command("kg:query")
+def kg_query(file: Path = typer.Option(..., "--file", exists=True, dir_okay=False)):
+    text = Path(file).read_text()
+    res = kql_run(text)
+    typer.echo(json.dumps(res))
+
+
+@app.command("kg:neighbors")
+def kg_neighbors(
+    id: str = typer.Option(..., "--id"), edge: Optional[str] = typer.Option(None, "--edge")
+):
+    kg = KnowledgeGraph()
+    for n in kg.neighbors(id, edge):
+        typer.echo(n)
+
+
+@app.command("kg:rules")
+def kg_rules_cmd(file: Path = typer.Option(..., "--file", exists=True, dir_okay=False)):
+    findings = run_rules(str(file))
+    typer.echo(json.dumps([f.__dict__ for f in findings]))
+
+
+@app.command("chain:run")
+def chain_run(plan: Path = typer.Option(..., "--plan", exists=True, dir_okay=False)):
+    data = yaml.safe_load(Path(plan).read_text())
+    steps: List[PlanStep] = [PlanStep(**s) for s in data.get("steps", [])]
+    execute_plan(steps)
 
 
 if __name__ == "__main__":

--- a/configs/chain_examples/uptime_then_release.yaml
+++ b/configs/chain_examples/uptime_then_release.yaml
@@ -1,0 +1,9 @@
+steps:
+  - bot: 'SRE-BOT'
+    intent: 'error_budget'
+    input_selector: |
+      MATCH (s:Service) WHERE s.name="CoreAPI" RETURN s.name
+  - bot: 'Change/Release-BOT'
+    intent: 'release_checklist'
+    input_selector: |
+      MATCH (a:Artifact)-[:PRODUCED_BY]->(b:Bot[name="SRE-BOT"]) RETURN a.path

--- a/configs/kg_rules.yaml
+++ b/configs/kg_rules.yaml
@@ -1,0 +1,7 @@
+rules:
+  - name: orphan_artifacts
+    match: 'MATCH (a:Artifact) WHERE a.task_id=NULL RETURN a.id'
+    action: 'flag:orphan'
+  - name: risky_decisions_without_review
+    match: 'MATCH (d:Decision)-[:DERIVED_FROM]->(a:Artifact) WHERE d.risk>="high" AND NOT EXISTS(d.review_id) RETURN d.id'
+    action: 'alert'

--- a/docs/chaining.md
+++ b/docs/chaining.md
@@ -1,0 +1,17 @@
+# Chaining
+
+Compose multiple bots deterministically using KQL selectors.
+
+Example plan YAML:
+
+```
+steps:
+  - bot: "SRE-BOT"
+    intent: "error_budget"
+    input_selector: |
+      MATCH (s:Service) WHERE s.name="CoreAPI" RETURN s.name
+  - bot: "Change/Release-BOT"
+    intent: "release_checklist"
+    input_selector: |
+      MATCH (a:Artifact)-[:PRODUCED_BY]->(b:Bot[name="SRE-BOT"]) RETURN a.path
+```

--- a/docs/knowledge-graph.md
+++ b/docs/knowledge-graph.md
@@ -1,0 +1,14 @@
+# Knowledge Graph
+
+Offline in-memory graph capturing tasks, artifacts and bots.
+
+## Nodes
+
+Task, Artifact, Bot, Dataset, Metric, Decision, Cohort, Incident, ProgramItem, User/Tenant.
+
+## Example
+
+```
+python -m cli.console kg:stats
+python -m cli.console kg:query --file samples/kql/last_treasury_runs.kql
+```

--- a/docs/kql.md
+++ b/docs/kql.md
@@ -1,0 +1,12 @@
+# KQL-lite
+
+Simple query language over the knowledge graph.
+
+Example:
+
+```
+MATCH (a:Artifact)-[:PRODUCED_BY]->(b:Bot[name="Treasury-BOT"])
+WHERE a.type="response"
+RETURN a.path, b.name
+LIMIT 20
+```

--- a/kg/__init__.py
+++ b/kg/__init__.py
@@ -1,0 +1,1 @@
+"""Knowledge graph package."""

--- a/kg/chainer.py
+++ b/kg/chainer.py
@@ -1,0 +1,57 @@
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+from tools import storage
+
+from .model import KG_ARTIFACTS, KnowledgeGraph, _inc_metric
+from .provenance import _next_artifact_id, capture_event
+from .query import run as run_query
+
+CHAIN_MAX_FANOUT = 5
+
+
+@dataclass
+class PlanStep:
+    bot: str
+    intent: str
+    input_selector: str
+
+
+def execute_plan(plan: List[PlanStep]) -> List[str]:
+    kg = KnowledgeGraph()
+    prev: List[str] = []
+    final: List[str] = []
+    for step in plan:
+        kg = KnowledgeGraph()
+        if step.bot == "Change/Release-BOT":
+            findings_path = KG_ARTIFACTS / "findings.json"
+            if Path(findings_path).exists():
+                findings = json.loads(storage.read(str(findings_path)) or "[]")
+                if any(f.get("severity") == "critical" for f in findings):
+                    raise RuntimeError("KG_POLICY_BLOCK")
+        rows = run_query(step.input_selector, kg)
+        rows = sorted(rows, key=lambda r: list(r.values())[0])[:CHAIN_MAX_FANOUT]
+        new_ids: List[str] = []
+        for row in rows:
+            inp = list(row.values())[0]
+            art_id = _next_artifact_id()
+            capture_event(
+                {
+                    "type": "artifact",
+                    "id": art_id,
+                    "bot": step.bot,
+                    "intent": step.intent,
+                    "input": inp,
+                }
+            )
+            if prev:
+                kg = KnowledgeGraph()
+                for p in prev:
+                    kg.add_edge(art_id, "DERIVED_FROM", p)
+            new_ids.append(art_id)
+        prev = new_ids
+        final = new_ids
+        _inc_metric("kg_chain_run")
+    return final

--- a/kg/model.py
+++ b/kg/model.py
@@ -1,0 +1,75 @@
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from tools import storage
+
+ROOT = Path(__file__).resolve().parents[1]
+KG_ARTIFACTS = ROOT / "artifacts" / "kg"
+GRAPH_PATH = KG_ARTIFACTS / "graph.json"
+EVENTS_PATH = KG_ARTIFACTS / "events.jsonl"
+METRIC_PATH = KG_ARTIFACTS / "metrics.json"
+
+
+def _inc_metric(name: str) -> None:
+    data = json.loads(storage.read(str(METRIC_PATH)) or "{}")
+    data[name] = data.get(name, 0) + 1
+    storage.write(str(METRIC_PATH), data)
+
+
+def _log_event(payload: Dict[str, Any]) -> None:
+    payload = {"ts": datetime.utcnow().isoformat(), **payload}
+    storage.write(str(EVENTS_PATH), payload)
+
+
+class KnowledgeGraph:
+    """Simple in-memory knowledge graph with persistence."""
+
+    def __init__(self) -> None:
+        self.nodes: Dict[str, Dict[str, Any]] = {}
+        self.edges: Dict[str, Dict[str, List[str]]] = {}
+        if GRAPH_PATH.exists():
+            self.load()
+
+    def add_node(self, node_id: str, label: str, **props: Any) -> None:
+        self.nodes[node_id] = {"label": label, "props": props}
+        _inc_metric("kg_node_add")
+        _log_event({"event": "kg_update", "node": node_id})
+        self.save()
+
+    def add_edge(self, src: str, edge_type: str, dst: str) -> None:
+        self.edges.setdefault(src, {}).setdefault(edge_type, [])
+        if dst not in self.edges[src][edge_type]:
+            self.edges[src][edge_type].append(dst)
+        _inc_metric("kg_edge_add")
+        _log_event({"event": "kg_update", "edge": [src, edge_type, dst]})
+        self.save()
+
+    def neighbors(self, node_id: str, type: Optional[str] = None) -> List[str]:
+        rels = self.edges.get(node_id, {})
+        if type:
+            return rels.get(type, [])
+        result: List[str] = []
+        for lst in rels.values():
+            result.extend(lst)
+        return result
+
+    def find(self, label: str, props: Dict[str, Any]) -> List[str]:
+        out: List[str] = []
+        for nid, data in self.nodes.items():
+            if data["label"] != label:
+                continue
+            if all(data["props"].get(k) == v for k, v in props.items()):
+                out.append(nid)
+        return out
+
+    def save(self) -> None:
+        storage.write(str(GRAPH_PATH), {"nodes": self.nodes, "edges": self.edges})
+
+    def load(self) -> None:
+        raw = storage.read(str(GRAPH_PATH))
+        if raw:
+            data = json.loads(raw)
+            self.nodes = data.get("nodes", {})
+            self.edges = data.get("edges", {})

--- a/kg/provenance.py
+++ b/kg/provenance.py
@@ -1,0 +1,72 @@
+import json
+from typing import Any, Dict
+
+from tools import storage
+
+from .model import KG_ARTIFACTS, ROOT, KnowledgeGraph
+
+
+def _next_artifact_id() -> str:
+    counter_path = KG_ARTIFACTS / "last_artifact_id.txt"
+    last = int(storage.read(str(counter_path)) or 0)
+    new = last + 1
+    storage.write(str(counter_path), str(new))
+    return f"A{new:04d}"
+
+
+def capture_event(event: Dict[str, Any]) -> KnowledgeGraph:
+    """Update the KG based on a normalized event."""
+    kg = KnowledgeGraph()
+    etype = event.get("type")
+    if etype == "task":
+        kg.add_node(
+            event["id"], "Task", **{k: v for k, v in event.items() if k not in {"type", "id"}}
+        )
+    elif etype == "artifact":
+        art_id = event.get("id") or _next_artifact_id()
+        props = {k: v for k, v in event.items() if k not in {"type", "id", "task_id", "bot"}}
+        kg.add_node(art_id, "Artifact", **props)
+        if tid := event.get("task_id"):
+            kg.add_edge(art_id, "DERIVED_FROM", tid)
+        if bot := event.get("bot"):
+            kg.add_node(bot, "Bot", name=bot)
+            kg.add_edge(art_id, "PRODUCED_BY", bot)
+    elif etype == "decision":
+        kg.add_node(
+            event["id"],
+            "Decision",
+            **{k: v for k, v in event.items() if k not in {"type", "id", "artifact_id"}},
+        )
+        if aid := event.get("artifact_id"):
+            kg.add_edge(event["id"], "DERIVED_FROM", aid)
+    elif etype == "metric":
+        kg.add_node(
+            event["id"],
+            "Metric",
+            **{k: v for k, v in event.items() if k not in {"type", "id", "artifact_id"}},
+        )
+        if aid := event.get("artifact_id"):
+            kg.add_edge(event["id"], "DERIVED_FROM", aid)
+    return kg
+
+
+def rebuild_from_memory(memory_path: str = "orchestrator/memory.jsonl") -> KnowledgeGraph:
+    path = ROOT / memory_path
+    kg = KnowledgeGraph()
+    if not path.exists():
+        return kg
+    for line in storage.read(str(path)).splitlines():
+        record = json.loads(line)
+        task = record.get("task", {})
+        capture_event({"type": "task", "id": task.get("id"), "goal": task.get("goal")})
+        art_id = _next_artifact_id()
+        capture_event(
+            {
+                "type": "artifact",
+                "id": art_id,
+                "task_id": task.get("id"),
+                "bot": record.get("bot"),
+                "path": f"artifacts/{task.get('id')}/response.json",
+            }
+        )
+    return kg

--- a/kg/query.py
+++ b/kg/query.py
@@ -1,0 +1,126 @@
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+from .model import KnowledgeGraph, _inc_metric
+
+
+def _parse_node(text: str) -> Tuple[str, str, Dict[str, Any]]:
+    m = re.match(r"\((\w+):(\w+)(\[(.*)\])?\)", text.strip())
+    var, label, _, props_str = m.groups()
+    props: Dict[str, Any] = {}
+    if props_str:
+        for part in props_str.split(","):
+            if not part.strip():
+                continue
+            k, v = part.split("=")
+            props[k.strip()] = v.strip().strip('"')
+    return var, label, props
+
+
+def _match_pattern(pattern: str, kg: KnowledgeGraph) -> List[Dict[str, str]]:
+    if "-[:" in pattern:
+        left, rest = pattern.split("-[:", 1)
+        edge_type, right = rest.split("]->")
+        a = _parse_node(left)
+        b = _parse_node(right)
+        results: List[Dict[str, str]] = []
+        for nid, data in kg.nodes.items():
+            var_a, label_a, props_a = a
+            if data["label"] != label_a:
+                continue
+            if any(data["props"].get(k) != v for k, v in props_a.items()):
+                continue
+            for dst in kg.edges.get(nid, {}).get(edge_type, []):
+                node_b = kg.nodes.get(dst)
+                if not node_b:
+                    continue
+                var_b, label_b, props_b = b
+                if node_b["label"] != label_b:
+                    continue
+                if any(node_b["props"].get(k) != v for k, v in props_b.items()):
+                    continue
+                results.append({var_a: nid, var_b: dst})
+        return results
+    else:
+        var, label, props = _parse_node(pattern)
+        results = []
+        for nid, data in kg.nodes.items():
+            if data["label"] != label:
+                continue
+            if any(data["props"].get(k) != v for k, v in props.items()):
+                continue
+            results.append({var: nid})
+        return results
+
+
+def _eval_cond(cond: str, row: Dict[str, str], kg: KnowledgeGraph) -> bool:
+    cond = cond.strip()
+    if cond.upper().startswith("NOT EXISTS"):
+        m = re.match(r"NOT EXISTS\((\w+)\.(\w+)\)", cond, re.IGNORECASE)
+        var, prop = m.groups()
+        node = kg.nodes.get(row.get(var, ""), {})
+        return prop not in node.get("props", {})
+    m = re.match(r"(\w+)\.(\w+)\s*(=|>=|<=|~)\s*(.*)", cond)
+    var, prop, op, value = m.groups()
+    value = value.strip().strip('"')
+    if value.upper() == "NULL":
+        value = None
+    node = kg.nodes[row[var]]["props"]
+    actual = node.get(prop)
+    if op == "=":
+        return actual == value
+    if op == ">=":
+        return actual is not None and str(actual) >= value
+    if op == "<=":
+        return actual is not None and str(actual) <= value
+    if op == "~":
+        return isinstance(actual, str) and value in actual
+    return False
+
+
+def run(query: str, kg: Optional[KnowledgeGraph] = None) -> List[Dict[str, Any]]:
+    kg = kg or KnowledgeGraph()
+    _inc_metric("kg_query")
+    q = query.strip()
+    limit = None
+    m = re.search(r"LIMIT\s+(\d+)", q, re.IGNORECASE)
+    if m:
+        limit = int(m.group(1))
+    m = re.search(r"RETURN\s+(.+?)(?:\s+LIMIT|$)", q, re.IGNORECASE | re.DOTALL)
+    fields = [f.strip() for f in m.group(1).split(",")]
+    m = re.search(r"WHERE\s+(.+?)\s+RETURN", q, re.IGNORECASE | re.DOTALL)
+    where = []
+    connectors: List[str] = []
+    if m:
+        parts = re.split(r"\s+(AND|OR)\s+", m.group(1))
+        where = parts[0::2]
+        connectors = parts[1::2]
+    m = re.search(r"MATCH\s+(.+?)(?:\s+WHERE|\s+RETURN)", q, re.IGNORECASE | re.DOTALL)
+    pattern = m.group(1).strip()
+    rows = _match_pattern(pattern, kg)
+    filtered: List[Dict[str, str]] = []
+    for row in rows:
+        ok = True
+        if where:
+            result = _eval_cond(where[0], row, kg)
+            for conn, cond in zip(connectors, where[1:]):
+                if conn.upper() == "AND":
+                    result = result and _eval_cond(cond, row, kg)
+                else:
+                    result = result or _eval_cond(cond, row, kg)
+            ok = result
+        if ok:
+            filtered.append(row)
+    out_rows: List[Dict[str, Any]] = []
+    for row in filtered[: limit or None]:
+        out: Dict[str, Any] = {}
+        for field in fields:
+            var, prop = field.split(".")
+            nid = row[var]
+            if prop == "id":
+                out[field] = nid
+            else:
+                out[field] = kg.nodes[nid]["props"].get(prop)
+        out_rows.append(out)
+    out_rows.sort(key=lambda r: tuple(r.get(fields[0], "")) if fields else ())
+    return out_rows

--- a/kg/rules.py
+++ b/kg/rules.py
@@ -1,0 +1,57 @@
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+import yaml
+
+from tools import storage
+
+from .model import KG_ARTIFACTS, KnowledgeGraph, _inc_metric
+from .query import run as run_query
+
+
+@dataclass
+class Finding:
+    rule: str
+    node_id: str
+    severity: str
+
+
+def run_rules(rules_yaml: str) -> List[Finding]:
+    kg = KnowledgeGraph()
+    spec = yaml.safe_load(Path(rules_yaml).read_text())
+    findings: List[Finding] = []
+    for rule in spec.get("rules", []):
+        rows = run_query(rule["match"], kg)
+        action = rule.get("action", "")
+        for row in rows:
+            node_id = next(iter(row.values()))
+            severity = "critical" if action == "alert" else "info"
+            findings.append(Finding(rule["name"], node_id, severity))
+            if action.startswith("flag:"):
+                tag = action.split(":", 1)[1]
+                node = kg.nodes.get(node_id, {})
+                flags = node.setdefault("props", {}).setdefault("flags", [])
+                if tag not in flags:
+                    flags.append(tag)
+                kg.save()
+            elif action.startswith("annotate:"):
+                payload = action.split(":", 1)[1]
+                ann = yaml.safe_load(payload) or {}
+                node = kg.nodes.get(node_id, {})
+                node.setdefault("props", {}).update(ann)
+                kg.save()
+            elif action == "alert":
+                storage.write(
+                    str(KG_ARTIFACTS / "alerts.jsonl"),
+                    {"node": node_id, "rule": rule["name"]},
+                )
+        _inc_metric("kg_rule_run")
+    storage.write(
+        str(KG_ARTIFACTS / "findings.json"),
+        json.dumps([f.__dict__ for f in findings]),
+    )
+    for _ in findings:
+        _inc_metric("kg_rule_finding")
+    return findings

--- a/kg/visualize.py
+++ b/kg/visualize.py
@@ -1,0 +1,26 @@
+import shutil
+from typing import Optional
+
+from tools import storage
+
+from .model import KG_ARTIFACTS, KnowledgeGraph
+
+
+def export(kg: Optional[KnowledgeGraph] = None) -> None:
+    kg = kg or KnowledgeGraph()
+    dot_lines = ["digraph G {"]
+    for src, edges in kg.edges.items():
+        for etype, targets in edges.items():
+            for dst in targets:
+                dot_lines.append(f'  "{src}" -> "{dst}" [label="{etype}"];')
+    dot_lines.append("}")
+    if shutil.which("dot"):
+        storage.write(str(KG_ARTIFACTS / "kg_export.dot"), "\n".join(dot_lines))
+    lines = []
+    for nid, data in kg.nodes.items():
+        lines.append(f"### {nid} ({data['label']})")
+        for etype, targets in kg.edges.get(nid, {}).items():
+            for dst in targets:
+                lines.append(f"- {etype} -> {dst}")
+        lines.append("")
+    storage.write(str(KG_ARTIFACTS / "kg_export.md"), "\n".join(lines))

--- a/policy/regulated.yaml
+++ b/policy/regulated.yaml
@@ -1,0 +1,2 @@
+requires:
+  kg_rules_clean: true

--- a/samples/kql/last_treasury_runs.kql
+++ b/samples/kql/last_treasury_runs.kql
@@ -1,0 +1,3 @@
+MATCH (a:Artifact)-[:PRODUCED_BY]->(b:Bot[name="Treasury-BOT"])
+RETURN a.path, b.name
+LIMIT 5

--- a/samples/kql/risky_decisions.kql
+++ b/samples/kql/risky_decisions.kql
@@ -1,0 +1,3 @@
+MATCH (d:Decision)-[:DERIVED_FROM]->(a:Artifact)
+WHERE d.risk>="high" AND NOT EXISTS(d.review_id)
+RETURN d.id

--- a/schemas/kg_edge.schema.json
+++ b/schemas/kg_edge.schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["src", "type", "dst"],
+  "properties": {
+    "src": { "type": "string" },
+    "type": { "type": "string" },
+    "dst": { "type": "string" }
+  }
+}

--- a/schemas/kg_finding.schema.json
+++ b/schemas/kg_finding.schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["rule", "node_id", "severity"],
+  "properties": {
+    "rule": { "type": "string" },
+    "node_id": { "type": "string" },
+    "severity": { "type": "string" }
+  }
+}

--- a/schemas/kg_node.schema.json
+++ b/schemas/kg_node.schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["id", "label", "props"],
+  "properties": {
+    "id": { "type": "string" },
+    "label": { "type": "string" },
+    "props": { "type": "object" }
+  }
+}

--- a/tests/test_chainer.py
+++ b/tests/test_chainer.py
@@ -1,0 +1,32 @@
+import shutil
+
+from kg.chainer import PlanStep, execute_plan
+from kg.model import KG_ARTIFACTS, KnowledgeGraph
+
+
+def reset():
+    if KG_ARTIFACTS.exists():
+        shutil.rmtree(KG_ARTIFACTS)
+
+
+def test_chain_edges():
+    reset()
+    kg = KnowledgeGraph()
+    kg.add_node("S1", "Service", name="CoreAPI")
+    plan = [
+        PlanStep(
+            bot="SRE-BOT",
+            intent="error_budget",
+            input_selector='MATCH (s:Service) WHERE s.name="CoreAPI" RETURN s.name',
+        ),
+        PlanStep(
+            bot="Change/Release-BOT",
+            intent="release_checklist",
+            input_selector='MATCH (a:Artifact)-[:PRODUCED_BY]->(b:Bot[name="SRE-BOT"]) RETURN a.id',
+        ),
+    ]
+    execute_plan(plan)
+    kg = KnowledgeGraph()
+    arts = [n for n, d in kg.nodes.items() if d["label"] == "Artifact"]
+    assert len(arts) == 2
+    assert kg.neighbors(arts[1], "DERIVED_FROM") == [arts[0]]

--- a/tests/test_kg_build.py
+++ b/tests/test_kg_build.py
@@ -1,0 +1,20 @@
+import shutil
+
+from kg.model import KG_ARTIFACTS, KnowledgeGraph
+from kg.provenance import capture_event
+
+
+def reset():
+    if KG_ARTIFACTS.exists():
+        shutil.rmtree(KG_ARTIFACTS)
+
+
+def test_nodes_edges_emitted():
+    reset()
+    capture_event({"type": "task", "id": "T1", "goal": "demo"})
+    capture_event({"type": "artifact", "task_id": "T1", "bot": "Treasury-BOT", "path": "p1"})
+    kg = KnowledgeGraph()
+    assert kg.find("Task", {"goal": "demo"}) == ["T1"]
+    artifact_id = next(n for n, d in kg.nodes.items() if d["label"] == "Artifact")
+    assert "Treasury-BOT" in kg.neighbors(artifact_id, "PRODUCED_BY")
+    assert "T1" in kg.neighbors(artifact_id, "DERIVED_FROM")

--- a/tests/test_kg_policies.py
+++ b/tests/test_kg_policies.py
@@ -1,0 +1,31 @@
+import shutil
+
+import pytest
+
+from kg.chainer import PlanStep, execute_plan
+from kg.model import KG_ARTIFACTS, KnowledgeGraph
+from kg.provenance import capture_event
+from kg.rules import run_rules
+
+
+def reset():
+    if KG_ARTIFACTS.exists():
+        shutil.rmtree(KG_ARTIFACTS)
+
+
+def test_policy_blocks_release():
+    reset()
+    capture_event({"type": "artifact", "id": "A1", "bot": "Treasury-BOT", "path": "p"})
+    capture_event({"type": "decision", "id": "D1", "artifact_id": "A1", "risk": "high"})
+    run_rules("configs/kg_rules.yaml")
+    kg = KnowledgeGraph()
+    kg.add_node("S1", "Service", name="CoreAPI")
+    plan = [
+        PlanStep(
+            bot="Change/Release-BOT",
+            intent="release_checklist",
+            input_selector='MATCH (s:Service) WHERE s.name="CoreAPI" RETURN s.name',
+        ),
+    ]
+    with pytest.raises(RuntimeError):
+        execute_plan(plan)

--- a/tests/test_kql_parser.py
+++ b/tests/test_kql_parser.py
@@ -1,0 +1,60 @@
+import shutil
+
+from kg.model import KG_ARTIFACTS
+from kg.provenance import capture_event
+from kg.query import run as kql_run
+
+
+def reset():
+    if KG_ARTIFACTS.exists():
+        shutil.rmtree(KG_ARTIFACTS)
+
+
+def build_sample():
+    capture_event({"type": "task", "id": "T1", "goal": "demo"})
+    capture_event(
+        {
+            "type": "artifact",
+            "id": "A0001",
+            "task_id": "T1",
+            "bot": "Treasury-BOT",
+            "path": "p1",
+            "artifact_type": "response",
+            "date": "2025-07-02",
+        }
+    )
+    capture_event(
+        {
+            "type": "artifact",
+            "id": "A0002",
+            "task_id": "T1",
+            "bot": "Treasury-BOT",
+            "path": "p2",
+            "artifact_type": "response",
+            "date": "2025-07-03",
+        }
+    )
+    capture_event({"type": "decision", "id": "D1", "artifact_id": "A0002", "risk": "high"})
+
+
+def test_filters_and_limit():
+    reset()
+    build_sample()
+    q = (
+        'MATCH (a:Artifact)-[:PRODUCED_BY]->(b:Bot[name="Treasury-BOT"]) '
+        'WHERE a.date>="2025-07-02" RETURN a.path, b.name LIMIT 2'
+    )
+    res = kql_run(q)
+    assert res[0]["a.path"] == "p1"
+    assert len(res) == 2
+
+
+def test_not_exists():
+    reset()
+    build_sample()
+    q = (
+        "MATCH (d:Decision)-[:DERIVED_FROM]->(a:Artifact) "
+        'WHERE d.risk>="high" AND NOT EXISTS(d.review_id) RETURN d.id'
+    )
+    res = kql_run(q)
+    assert res == [{"d.id": "D1"}]

--- a/tests/test_rules_engine.py
+++ b/tests/test_rules_engine.py
@@ -1,0 +1,23 @@
+import json
+import shutil
+
+from kg.model import KG_ARTIFACTS
+from kg.provenance import capture_event
+from kg.rules import run_rules
+
+
+def reset():
+    if KG_ARTIFACTS.exists():
+        shutil.rmtree(KG_ARTIFACTS)
+
+
+def test_rules_flag_and_alert():
+    reset()
+    capture_event({"type": "artifact", "id": "A1", "bot": "Treasury-BOT", "path": "p"})
+    capture_event({"type": "decision", "id": "D1", "artifact_id": "A1", "risk": "high"})
+    findings = run_rules("configs/kg_rules.yaml")
+    names = [f.rule for f in findings]
+    assert "orphan_artifacts" in names
+    assert "risky_decisions_without_review" in names
+    data = json.loads(open(KG_ARTIFACTS / "findings.json").read())
+    assert any(f["severity"] == "critical" for f in data)

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -1,0 +1,18 @@
+import shutil
+
+from kg.model import KG_ARTIFACTS
+from kg.provenance import capture_event
+from kg.visualize import export
+
+
+def reset():
+    if KG_ARTIFACTS.exists():
+        shutil.rmtree(KG_ARTIFACTS)
+
+
+def test_visual_files():
+    reset()
+    capture_event({"type": "task", "id": "T1"})
+    capture_event({"type": "artifact", "task_id": "T1", "bot": "Treasury-BOT", "path": "p"})
+    export()
+    assert (KG_ARTIFACTS / "kg_export.md").exists()


### PR DESCRIPTION
## Summary
- implement in-memory KnowledgeGraph with persistence, provenance capture, and querying
- add rule engine, chaining executor, and visualization utilities
- document KG usage and provide sample configs/queries

## Testing
- `pytest tests/test_kg_build.py tests/test_kql_parser.py tests/test_rules_engine.py tests/test_chainer.py tests/test_visualize.py tests/test_kg_policies.py`
- `pre-commit run --files README.md cli/console.py docs/chaining.md docs/knowledge-graph.md docs/kql.md kg/__init__.py kg/model.py kg/provenance.py kg/query.py kg/rules.py kg/chainer.py kg/visualize.py policy/regulated.yaml configs/kg_rules.yaml configs/chain_examples/uptime_then_release.yaml samples/kql/last_treasury_runs.kql samples/kql/risky_decisions.kql schemas/kg_node.schema.json schemas/kg_edge.schema.json schemas/kg_finding.schema.json tests/test_chainer.py tests/test_kg_build.py tests/test_kg_policies.py tests/test_kql_parser.py tests/test_rules_engine.py tests/test_visualize.py`


------
https://chatgpt.com/codex/tasks/task_e_68c4df34067883298c107a6ddc296f0d