### PR TITLE
Add supply chain finance twin modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ sudo bash ops/install.sh
 bash tools/verify-runtime.sh
 ```
 
+## Supply Chain & Finance Twin
+
+```
+python -m cli.console sop:reconcile --demand samples/generated/supply/demand.csv --supply samples/generated/supply/capacity.csv --policy configs/sop/policy.yaml
+python -m cli.console inv:simulate --params configs/supply/inventory.yaml --horizon 90
+python -m cli.console log:optimize --demand artifacts/sop/allocations.csv --lanes fixtures/supply/lanes.csv --constraints configs/supply/log_constraints.yaml
+python -m cli.console procure:award --demand artifacts/sop/allocations.csv --suppliers fixtures/procure/suppliers.csv --policy configs/procure/policy.yaml
+python -m cli.console wc:simulate --demand artifacts/sop/allocations.csv --awards artifacts/procure/award.json --log artifacts/supply/log_plan_*/plan.json --terms configs/finance/terms.yaml
+```
+
 - The installer will:
   - Locate your API (prefers `./srv/blackroad-api`, then `/srv/blackroad-api`, else searches for `server_full.js`)
   - Create `package.json` if missing and **auto-install** any missing npm packages it finds

--- a/cli/console.py
+++ b/cli/console.py
@@ -1,15 +1,22 @@
+import csv
 import json
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
 import typer
+import yaml
 
 from bench import runner as bench_runner
 from bots import available_bots
+from dashboards import sc_ops_fin
+from finance import wc as finance_wc
 from orchestrator import orchestrator, slo_report
 from orchestrator.perf import perf_timer
 from orchestrator.protocols import Task
+from procure import optimizer as procure_opt
+from sop import plan as sop_plan
+from supply import inventory_sim, logistics
 from tools import storage
 
 app = typer.Typer()
@@ -71,9 +78,7 @@ def bot_list():
 
 def _perf_footer(perf: bool, data: dict) -> None:
     if perf:
-        typer.echo(
-            f"time={data.get('elapsed_ms')} rss={data.get('rss_mb')} cache=na exec=inproc"
-        )
+        typer.echo(f"time={data.get('elapsed_ms')} rss={data.get('rss_mb')} cache=na exec=inproc")
 
 
 @app.command("bench:list")
@@ -150,6 +155,163 @@ def slo_gate(
     _perf_footer(perf, p)
     if not ok:
         raise typer.Exit(code=1)
+
+
+def _record_event(name: str, meta: dict) -> None:
+    path = ARTIFACTS / "events.log"
+    entry = {"event": name, **meta, "ts": datetime.utcnow().isoformat()}
+    storage.write(str(path), json.dumps(entry))
+
+
+@app.command("sop:reconcile")
+def sop_reconcile(
+    demand: Path = typer.Option(..., "--demand", exists=True),
+    supply: Path = typer.Option(..., "--supply", exists=True),
+    policy: Path = typer.Option(..., "--policy", exists=True),
+):
+    with open(demand, newline="", encoding="utf-8") as f:
+        rd = list(csv.DictReader(f))
+    demand_objs = [sop_plan.DemandSignal(**{k: r[k] for k in r}) for r in rd]
+    with open(supply, newline="", encoding="utf-8") as f:
+        rs = list(csv.DictReader(f))
+    supply_objs = [sop_plan.SupplyPlan(**{k: r[k] for k in r}) for r in rs]
+    pol = yaml.safe_load(policy.read_text())
+    result = sop_plan.reconcile(demand_objs, supply_objs, pol)
+    out_dir = ARTIFACTS / "sop"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    alloc_path = out_dir / "allocations.csv"
+    with open(alloc_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=["region", "units"])
+        writer.writeheader()
+        for row in result["allocations"]:
+            writer.writerow(row)
+    _record_event("sop_reconcile", {"allocations": str(alloc_path)})
+    typer.echo(json.dumps(result))
+
+
+@app.command("inv:simulate")
+def inv_simulate(
+    params: Path = typer.Option(..., "--params", exists=True),
+    horizon: int = typer.Option(..., "--horizon"),
+):
+    p = yaml.safe_load(params.read_text())
+    summary = inventory_sim.simulate(p, horizon)
+    ts_dir = ARTIFACTS / "supply" / f"inv_sim_{datetime.utcnow().strftime('%Y%m%d%H%M%S')}"
+    ts_dir.mkdir(parents=True, exist_ok=True)
+    (ts_dir / "summary.json").write_text(json.dumps(summary), encoding="utf-8")
+    _record_event("inv_sim_run", {"summary": str(ts_dir / "summary.json")})
+    typer.echo(json.dumps(summary))
+
+
+@app.command("log:optimize")
+def log_optimize(
+    demand: Path = typer.Option(..., "--demand", exists=True),
+    lanes: Path = typer.Option(..., "--lanes", exists=True),
+    constraints: Path = typer.Option(..., "--constraints", exists=True),
+):
+    with open(demand, newline="", encoding="utf-8") as f:
+        allocations = list(csv.DictReader(f))
+    demand_allocs = [{"region": r["region"], "units": int(r["units"])} for r in allocations]
+    with open(lanes, newline="", encoding="utf-8") as f:
+        lane_rows = list(csv.DictReader(f))
+    lane_objs = [
+        logistics.Lane(
+            origin=r["origin"],
+            dest=r["dest"],
+            mode=r["mode"],
+            base_rate=float(r["base_rate"]),
+            fuel_adj=float(r["fuel_adj"]),
+            lead_time=int(r["lead_time"]),
+        )
+        for r in lane_rows
+    ]
+    cons = yaml.safe_load(constraints.read_text())
+    plan = logistics.optimize_lanes(demand_allocs, lane_objs, cons)
+    ts_dir = ARTIFACTS / "supply" / f"log_plan_{datetime.utcnow().strftime('%Y%m%d%H%M%S')}"
+    ts_dir.mkdir(parents=True, exist_ok=True)
+    (ts_dir / "plan.json").write_text(json.dumps(plan), encoding="utf-8")
+    _record_event("log_opt_run", {"plan": str(ts_dir / "plan.json")})
+    if plan["sla_hit_pct"] < cons.get("sla_target", 0):
+        typer.echo("DUTY_SLA")
+        raise typer.Exit(code=1)
+    typer.echo(json.dumps(plan))
+
+
+@app.command("procure:award")
+def procure_award(
+    demand: Path = typer.Option(..., "--demand", exists=True),
+    suppliers: Path = typer.Option(..., "--suppliers", exists=True),
+    policy: Path = typer.Option(..., "--policy", exists=True),
+):
+    with open(demand, newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    dem = {}
+    for r in rows:
+        dem[r.get("sku", "sku")] = dem.get(r.get("sku", "sku"), 0) + int(r["units"])
+    with open(suppliers, newline="", encoding="utf-8") as f:
+        supplier_rows = list(csv.DictReader(f))
+    supplier_objs = [
+        procure_opt.Supplier(
+            supplier=r["supplier"],
+            sku=r["sku"],
+            unit_price=float(r["unit_price"]),
+            moq=int(r["moq"]),
+            lead_time=int(r["lead_time"]),
+            defect_ppm=int(r["defect_ppm"]),
+        )
+        for r in supplier_rows
+    ]
+    pol = yaml.safe_load(policy.read_text())
+    award = procure_opt.choose_mix(dem, supplier_objs, pol)
+    out = ARTIFACTS / "procure"
+    out.mkdir(parents=True, exist_ok=True)
+    json_path = out / "award.json"
+    json_path.write_text(json.dumps(award), encoding="utf-8")
+    _record_event("procure_award", {"award": str(json_path)})
+    if pol.get("dual_source_min_pct", 0) > 0 and len(award["awards"]) < 2:
+        typer.echo("POLICY_AWARD_DUALSOURCE")
+        raise typer.Exit(code=1)
+    typer.echo(json.dumps(award))
+
+
+@app.command("wc:simulate")
+def wc_simulate(
+    demand: Path = typer.Option(..., "--demand", exists=True),
+    awards: Path = typer.Option(..., "--awards", exists=True),
+    log: Path = typer.Option(..., "--log", exists=True),
+    terms: Path = typer.Option(..., "--terms", exists=True),
+):
+    with open(demand, newline="", encoding="utf-8") as f:
+        demand_rows = list(csv.DictReader(f))
+    dem = [{"units": int(r["units"])} for r in demand_rows]
+    awards_data = json.loads(awards.read_text())["awards"]
+    log_plan = json.loads(Path(log).read_text())
+    terms_data = yaml.safe_load(terms.read_text())
+    res = finance_wc.cash_cycle(dem, awards_data, log_plan, terms_data)
+    out_dir = ARTIFACTS / "finance" / f"wc_{datetime.utcnow().strftime('%Y%m%d%H%M%S')}"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "summary.json").write_text(json.dumps(res), encoding="utf-8")
+    _record_event("wc_model_run", {"summary": str(out_dir / "summary.json")})
+    typer.echo(json.dumps(res))
+
+
+@app.command("dash:scopsfin")
+def dash_scopsfin():
+    metrics = {}
+    sop_path = ARTIFACTS / "sop" / "allocations.csv"
+    if sop_path.exists():
+        with open(sop_path, newline="", encoding="utf-8") as f:
+            total = sum(int(r["units"]) for r in csv.DictReader(f))
+        metrics["allocations"] = total
+    inv_glob = list((ARTIFACTS / "supply").glob("inv_sim_*/summary.json"))
+    if inv_glob:
+        metrics.update(json.loads(inv_glob[-1].read_text()))
+    wc_glob = list((ARTIFACTS / "finance").glob("wc_*/summary.json"))
+    if wc_glob:
+        metrics.update(json.loads(wc_glob[-1].read_text()))
+    sc_ops_fin.build(metrics)
+    _record_event("dash_sc_ops_fin_built", {})
+    typer.echo("dashboard built")
 
 
 if __name__ == "__main__":

--- a/configs/finance/terms.yaml
+++ b/configs/finance/terms.yaml
@@ -1,0 +1,4 @@
+DSO: 30
+DPO: 45
+inventory_days: 20
+rebate_receivable_days: 60

--- a/configs/procure/policy.yaml
+++ b/configs/procure/policy.yaml
@@ -1,0 +1,4 @@
+risk_weight: 0.1
+defect_penalty: 10
+dual_source_min_pct: 0.2
+max_supplier_count: 2

--- a/configs/sop/policy.yaml
+++ b/configs/sop/policy.yaml
@@ -1,0 +1,4 @@
+service_target: 0.95
+safety_stock_days: 5
+backorder_allowed: true
+allocation_rule: [NA, EU]

--- a/configs/supply/inventory.yaml
+++ b/configs/supply/inventory.yaml
@@ -1,0 +1,10 @@
+starting_inventory: 120
+reorder_point: 60
+lead_time: 5
+moq: 50
+lot_size: 50
+unit_cost: 5.0
+carrying_cost_pct: 0.1
+logistics_cost_per_unit: 0.5
+demand_series: [30, 20, 40]
+returns_pct: 0.05

--- a/configs/supply/log_constraints.yaml
+++ b/configs/supply/log_constraints.yaml
@@ -1,0 +1,4 @@
+max_air_pct: 0.4
+budget_cap: 1000
+sla_days: 7
+sla_target: 0.9

--- a/contracts/schemas/finance_txn.json
+++ b/contracts/schemas/finance_txn.json
@@ -1,0 +1,9 @@
+{
+  "type": "object",
+  "required": ["week", "cash_in", "cash_out"],
+  "properties": {
+    "week": {"type": "string"},
+    "cash_in": {"type": "number"},
+    "cash_out": {"type": "number"}
+  }
+}

--- a/contracts/schemas/inventory.json
+++ b/contracts/schemas/inventory.json
@@ -1,0 +1,9 @@
+{
+  "type": "object",
+  "required": ["sku", "date", "on_hand"],
+  "properties": {
+    "sku": {"type": "string"},
+    "date": {"type": "string"},
+    "on_hand": {"type": "number"}
+  }
+}

--- a/contracts/schemas/logistics.json
+++ b/contracts/schemas/logistics.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "required": ["origin", "dest", "mode", "units"],
+  "properties": {
+    "origin": {"type": "string"},
+    "dest": {"type": "string"},
+    "mode": {"type": "string"},
+    "units": {"type": "number"},
+    "cost": {"type": "number"}
+  }
+}

--- a/dashboards/sc_ops_fin.py
+++ b/dashboards/sc_ops_fin.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+from typing import Dict
+
+ROOT = Path(__file__).resolve().parents[1]
+ART_DIR = ROOT / "artifacts" / "dashboards"
+
+
+def build(d: Dict) -> None:
+    ART_DIR.mkdir(parents=True, exist_ok=True)
+    md_path = ART_DIR / "sc_ops_fin.md"
+    html_path = ART_DIR / "sc_ops_fin.html"
+    md_content = """# Supply Chain & Finance Twin\n\n"""
+    for k, v in d.items():
+        md_content += f"- {k}: {v}\n"
+    html_content = f"<html><body><pre>{md_content}</pre></body></html>"
+    md_path.write_text(md_content, encoding="utf-8")
+    html_path.write_text(html_content, encoding="utf-8")

--- a/docs/inventory-logistics.md
+++ b/docs/inventory-logistics.md
@@ -1,0 +1,3 @@
+# Inventory and Logistics
+
+Covers inventory simulator and lane optimizer behavior.

--- a/docs/procure-tco.md
+++ b/docs/procure-tco.md
@@ -1,0 +1,3 @@
+# Procurement TCO
+
+Describes supplier mix and total cost of ownership calculations.

--- a/docs/sop-simulator.md
+++ b/docs/sop-simulator.md
@@ -1,0 +1,3 @@
+# S&OP Simulator
+
+Explains policy knobs for reconcile: service_target, safety_stock_days, backorder_allowed, allocation_rule.

--- a/docs/working-capital.md
+++ b/docs/working-capital.md
@@ -1,0 +1,3 @@
+# Working Capital
+
+Cash conversion cycle calculations with examples.

--- a/finance/wc.py
+++ b/finance/wc.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from lake import io as lake_io
+
+
+def cash_cycle(demand, awards, logistics_plan, terms) -> Dict[str, Any]:
+    cogs = sum(a["units"] * a.get("unit_price", 0) for a in awards)
+    revenue = cogs * 1.2  # assume 20% margin
+
+    dso = terms.get("DSO", 0)
+    dpo = terms.get("DPO", 0)
+    inventory_days = terms.get("inventory_days", 0)
+    ccc = dso + inventory_days - dpo
+
+    weeks = max(len(demand), 1)
+    weekly_in = revenue / weeks
+    weekly_out = cogs / weeks
+    cash_curve = []
+    cash = 0
+    for w in range(weeks):
+        cash += weekly_in - weekly_out
+        cash_curve.append({"week": str(w), "cash": round(cash, 2)})
+        lake_io.write("finance_txn", {"week": str(w), "cash_in": weekly_in, "cash_out": weekly_out})
+
+    return {"DSO": dso, "DPO": dpo, "CCC": ccc, "cash_curve": cash_curve}

--- a/fixtures/procure/suppliers.csv
+++ b/fixtures/procure/suppliers.csv
@@ -1,0 +1,3 @@
+supplier,sku,unit_price,moq,lead_time,defect_ppm
+S1,sku,5,50,10,100
+S2,sku,6,30,8,50

--- a/fixtures/supply/lanes.csv
+++ b/fixtures/supply/lanes.csv
@@ -1,0 +1,5 @@
+origin,dest,mode,base_rate,fuel_adj,lead_time
+siteA,NA,sea,1.0,0.1,7
+siteA,NA,air,3.0,0.2,2
+siteA,EU,sea,1.2,0.1,8
+siteA,EU,air,3.5,0.2,3

--- a/lake/io.py
+++ b/lake/io.py
@@ -1,0 +1,39 @@
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+SCHEMA_DIR = Path(__file__).resolve().parents[1] / "contracts" / "schemas"
+LAKE_DIR = Path(__file__).resolve().parents[1] / "artifacts" / "lake"
+
+
+def _load_schema(name: str) -> Dict[str, Any]:
+    schema_path = SCHEMA_DIR / f"{name}.json"
+    if not schema_path.exists():
+        return {}
+    with open(schema_path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _validate(data: Dict[str, Any], schema: Dict[str, Any]) -> None:
+    required = schema.get("required", [])
+    props = schema.get("properties", {})
+    for key in required:
+        if key not in data:
+            raise ValueError(f"missing required field: {key}")
+    for key, val in data.items():
+        if key in props:
+            t = props[key].get("type")
+            if t == "number" and not isinstance(val, (int, float)):
+                raise ValueError(f"{key} must be number")
+            if t == "string" and not isinstance(val, str):
+                raise ValueError(f"{key} must be string")
+
+
+def write(table: str, record: Dict[str, Any]) -> None:
+    schema = _load_schema(table)
+    if schema:
+        _validate(record, schema)
+    dest = LAKE_DIR / f"{table}.jsonl"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with open(dest, "a", encoding="utf-8") as f:
+        f.write(json.dumps(record) + "\n")

--- a/procure/optimizer.py
+++ b/procure/optimizer.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+from lake import io as lake_io
+
+
+@dataclass
+class Supplier:
+    supplier: str
+    sku: str
+    unit_price: float
+    moq: int
+    lead_time: int
+    defect_ppm: int
+
+
+def choose_mix(
+    demand: Dict[str, int], suppliers: List[Supplier], policy: Dict[str, Any]
+) -> Dict[str, Any]:
+    risk_weight = policy.get("risk_weight", 0.0)
+    defect_penalty = policy.get("defect_penalty", 0.0)
+    dual_min = policy.get("dual_source_min_pct", 0.0)
+    max_suppliers = policy.get("max_supplier_count", 1)
+
+    awards = []
+    for sku, units in demand.items():
+        options = [s for s in suppliers if s.sku == sku]
+        options.sort(
+            key=lambda s: s.unit_price
+            + risk_weight * s.lead_time
+            + defect_penalty * (s.defect_ppm / 1e6)
+        )
+        if not options:
+            continue
+        first = options[0]
+        if len(options) > 1 and max_suppliers > 1:
+            second = options[1]
+            second_units = max(int(units * dual_min), second.moq)
+            first_units = units - second_units
+            awards.append(
+                {
+                    "supplier": first.supplier,
+                    "sku": sku,
+                    "units": first_units,
+                    "unit_price": first.unit_price,
+                }
+            )
+            awards.append(
+                {
+                    "supplier": second.supplier,
+                    "sku": sku,
+                    "units": second_units,
+                    "unit_price": second.unit_price,
+                }
+            )
+        else:
+            awards.append(
+                {
+                    "supplier": first.supplier,
+                    "sku": sku,
+                    "units": units,
+                    "unit_price": first.unit_price,
+                }
+            )
+
+    total_cost = sum(a["units"] * a["unit_price"] for a in awards)
+    for a in awards:
+        lake_io.write(
+            "finance_txn", {"week": "0", "cash_in": 0, "cash_out": a["units"] * a["unit_price"]}
+        )
+
+    return {"awards": awards, "tco": round(total_cost, 2)}

--- a/samples/generated/supply/capacity.csv
+++ b/samples/generated/supply/capacity.csv
@@ -1,0 +1,2 @@
+date,sku,site,capacity_units
+2024-01-01,sku,siteA,150

--- a/samples/generated/supply/demand.csv
+++ b/samples/generated/supply/demand.csv
@@ -1,0 +1,3 @@
+date,sku,region,units
+2024-01-01,sku,NA,100
+2024-01-01,sku,EU,80

--- a/sop/plan.py
+++ b/sop/plan.py
@@ -1,0 +1,69 @@
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+
+@dataclass
+class DemandSignal:
+    date: str
+    sku: str
+    region: str
+    units: int
+
+
+@dataclass
+class SupplyPlan:
+    date: str
+    sku: str
+    site: str
+    capacity_units: int
+
+
+def reconcile(
+    demand: List[DemandSignal], supply: List[SupplyPlan], policy: Dict[str, Any]
+) -> Dict[str, Any]:
+    # aggregate demand by region
+    demand_by_region: Dict[str, int] = {}
+    total_demand = 0
+    for d in demand:
+        demand_by_region[d.region] = demand_by_region.get(d.region, 0) + d.units
+        total_demand += d.units
+
+    total_supply = sum(s.capacity_units for s in supply)
+    allocations = []
+    backorders = []
+    remaining = total_supply
+
+    allocation_rule = policy.get("allocation_rule", [])
+    backorder_allowed = policy.get("backorder_allowed", True)
+
+    for region in allocation_rule:
+        dem = demand_by_region.get(region, 0)
+        alloc = min(dem, remaining)
+        if alloc > 0:
+            allocations.append({"region": region, "units": alloc})
+        remaining -= alloc
+        bo = dem - alloc
+        if bo > 0 and backorder_allowed:
+            backorders.append({"region": region, "units": bo})
+        demand_by_region.pop(region, None)
+
+    # any remaining demand not in allocation_rule
+    for region, dem in demand_by_region.items():
+        alloc = min(dem, remaining)
+        if alloc > 0:
+            allocations.append({"region": region, "units": alloc})
+        remaining -= alloc
+        bo = dem - alloc
+        if bo > 0 and backorder_allowed:
+            backorders.append({"region": region, "units": bo})
+
+    allocated_units = sum(a["units"] for a in allocations)
+    service_level = allocated_units / total_demand if total_demand else 0
+    capacity_util = allocated_units / total_supply if total_supply else 0
+
+    return {
+        "allocations": allocations,
+        "backorders": backorders,
+        "service_level": round(service_level, 4),
+        "capacity_util": round(capacity_util, 4),
+    }

--- a/supply/inventory_sim.py
+++ b/supply/inventory_sim.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+from lake import io as lake_io
+
+
+@dataclass
+class SimParams:
+    starting_inventory: int
+    reorder_point: int
+    lead_time: int
+    moq: int
+    lot_size: int
+    unit_cost: float
+    carrying_cost_pct: float
+    logistics_cost_per_unit: float
+    demand_series: list
+    returns_pct: float = 0.0
+
+
+def simulate(params: Dict[str, Any], horizon_days: int) -> Dict[str, Any]:
+    p = SimParams(**params)
+    inventory = p.starting_inventory
+    on_hand_series = []
+    stockouts = 0
+    shipped = 0
+    orders = []  # list of (arrival_day, qty)
+    for day in range(horizon_days):
+        # arrivals
+        arriving = [qty for (arr_day, qty) in orders if arr_day == day]
+        if arriving:
+            inventory += sum(arriving)
+        orders = [(a, q) for (a, q) in orders if a != day]
+
+        demand = p.demand_series[day % len(p.demand_series)]
+        ship = min(demand, inventory)
+        inventory -= ship
+        shipped += ship
+        stockouts += demand - ship
+        returns = ship * p.returns_pct
+        inventory += returns
+        on_hand_series.append(inventory)
+
+        if inventory <= p.reorder_point:
+            qty = max(p.moq, p.lot_size)
+            orders.append((day + p.lead_time, qty))
+
+        lake_io.write("inventory", {"sku": "sku", "date": str(day), "on_hand": inventory})
+
+    avg_on_hand = sum(on_hand_series) / horizon_days
+    turns = shipped / avg_on_hand if avg_on_hand else 0
+    carrying_cost = avg_on_hand * p.unit_cost * p.carrying_cost_pct * (horizon_days / 365)
+    logistics_cost = shipped * p.logistics_cost_per_unit
+
+    summary = {
+        "stockouts": stockouts,
+        "average_on_hand": round(avg_on_hand, 2),
+        "turns": round(turns, 4),
+        "carrying_cost": round(carrying_cost, 2),
+        "logistics_cost": round(logistics_cost, 2),
+    }
+
+    return summary

--- a/supply/logistics.py
+++ b/supply/logistics.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+from lake import io as lake_io
+
+
+@dataclass
+class Lane:
+    origin: str
+    dest: str
+    mode: str
+    base_rate: float
+    fuel_adj: float
+    lead_time: int
+
+
+def optimize_lanes(
+    demand_allocations: List[Dict[str, Any]], lanes: List[Lane], constraints: Dict[str, Any]
+) -> Dict[str, Any]:
+    total_units = sum(d["units"] for d in demand_allocations)
+    max_air_units = total_units * constraints.get("max_air_pct", 1.0)
+    sla_days = constraints.get("sla_days", 999)
+    budget_cap = constraints.get("budget_cap", float("inf"))
+
+    # filter lanes by sla
+    valid_lanes = [ln for ln in lanes if ln.lead_time <= sla_days]
+    plan = []
+    cost_total = 0
+    air_used = 0
+
+    for alloc in demand_allocations:
+        region = alloc["region"]
+        units = alloc["units"]
+        options = [ln for ln in valid_lanes if ln.dest == region]
+        options.sort(key=lambda ln: ln.base_rate * (1 + ln.fuel_adj))
+        for lane in options:
+            if lane.mode == "air" and air_used + units > max_air_units:
+                continue
+            base = units * lane.base_rate
+            surcharge = base * lane.fuel_adj
+            total_cost_lane = base + surcharge
+            if cost_total + total_cost_lane > budget_cap:
+                continue
+            plan.append(
+                {
+                    "origin": lane.origin,
+                    "dest": lane.dest,
+                    "mode": lane.mode,
+                    "units": units,
+                    "cost": round(total_cost_lane, 2),
+                    "fuel_surcharge": round(surcharge, 2),
+                }
+            )
+            cost_total += total_cost_lane
+            if lane.mode == "air":
+                air_used += units
+            lake_io.write("logistics", plan[-1])
+            break
+
+    sla_hit = sum(p["units"] for p in plan) / total_units if total_units else 0
+    fuel_surcharge = sum(p.get("fuel_surcharge", 0) for p in plan)
+    return {
+        "plan": plan,
+        "total_cost": round(cost_total, 2),
+        "sla_hit_pct": round(sla_hit, 4),
+        "fuel_surcharge": round(fuel_surcharge, 2),
+    }

--- a/tests/test_dash_sc_ops_fin.py
+++ b/tests/test_dash_sc_ops_fin.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+from dashboards.sc_ops_fin import build
+
+
+def test_dashboard_build(tmp_path):
+    data = {"service_level": 0.9}
+    build(data)
+    md = Path("artifacts/dashboards/sc_ops_fin.md")
+    assert md.exists()

--- a/tests/test_inventory_sim.py
+++ b/tests/test_inventory_sim.py
@@ -1,0 +1,19 @@
+from supply.inventory_sim import simulate
+
+
+def test_inventory_sim_deterministic():
+    params = {
+        "starting_inventory": 120,
+        "reorder_point": 60,
+        "lead_time": 5,
+        "moq": 50,
+        "lot_size": 50,
+        "unit_cost": 5.0,
+        "carrying_cost_pct": 0.1,
+        "logistics_cost_per_unit": 0.5,
+        "demand_series": [30, 20, 40],
+        "returns_pct": 0.0,
+    }
+    summary = simulate(params, 10)
+    assert summary["stockouts"] >= 0
+    assert summary["average_on_hand"] > 0

--- a/tests/test_lake_io.py
+++ b/tests/test_lake_io.py
@@ -1,0 +1,8 @@
+import pytest
+
+from lake import io
+
+
+def test_lake_validation():
+    with pytest.raises(ValueError):
+        io.write("inventory", {"sku": "x"})

--- a/tests/test_logistics_opt.py
+++ b/tests/test_logistics_opt.py
@@ -1,0 +1,15 @@
+from supply.logistics import Lane, optimize_lanes
+
+
+def test_logistics_plan():
+    demand = [{"region": "NA", "units": 100}, {"region": "EU", "units": 80}]
+    lanes = [
+        Lane("siteA", "NA", "sea", 1.0, 0.1, 7),
+        Lane("siteA", "NA", "air", 3.0, 0.2, 2),
+        Lane("siteA", "EU", "sea", 1.2, 0.1, 8),
+        Lane("siteA", "EU", "air", 3.5, 0.2, 3),
+    ]
+    constraints = {"max_air_pct": 0.5, "budget_cap": 1000, "sla_days": 7, "sla_target": 0.9}
+    plan = optimize_lanes(demand, lanes, constraints)
+    assert plan["total_cost"] > 0
+    assert plan["sla_hit_pct"] <= 1

--- a/tests/test_procure_award.py
+++ b/tests/test_procure_award.py
@@ -1,0 +1,13 @@
+from procure.optimizer import Supplier, choose_mix
+
+
+def test_procure_award():
+    demand = {"sku": 150}
+    suppliers = [
+        Supplier("S1", "sku", 5.0, 50, 10, 100),
+        Supplier("S2", "sku", 6.0, 30, 8, 50),
+    ]
+    policy = {"dual_source_min_pct": 0.2, "max_supplier_count": 2}
+    award = choose_mix(demand, suppliers, policy)
+    assert len(award["awards"]) >= 1
+    assert award["tco"] > 0

--- a/tests/test_sop_reconcile.py
+++ b/tests/test_sop_reconcile.py
@@ -1,0 +1,16 @@
+import pytest
+
+from sop.plan import DemandSignal, SupplyPlan, reconcile
+
+
+def test_reconcile_basic():
+    demand = [
+        DemandSignal("2024-01-01", "sku", "NA", 100),
+        DemandSignal("2024-01-01", "sku", "EU", 80),
+    ]
+    supply = [SupplyPlan("2024-01-01", "sku", "siteA", 150)]
+    policy = {"allocation_rule": ["NA", "EU"], "backorder_allowed": True}
+    result = reconcile(demand, supply, policy)
+    assert result["service_level"] == pytest.approx(150 / 180, rel=1e-3)
+    assert result["capacity_util"] == 1.0
+    assert sum(a["units"] for a in result["allocations"]) == 150

--- a/tests/test_wc_model.py
+++ b/tests/test_wc_model.py
@@ -1,0 +1,11 @@
+from finance.wc import cash_cycle
+
+
+def test_cash_cycle():
+    demand = [{"units": 100}]
+    awards = [{"units": 100, "unit_price": 5}]
+    plan = {"plan": []}
+    terms = {"DSO": 30, "DPO": 45, "inventory_days": 20}
+    res = cash_cycle(demand, awards, plan, terms)
+    assert res["CCC"] == 5
+    assert len(res["cash_curve"]) == 1


### PR DESCRIPTION
## Summary
- implement deterministic S&OP reconcile, inventory simulator, logistics optimizer, procurement award, working-capital model, and dashboard
- wire new CLI commands and lake IO with schema validation
- add configs, fixtures, docs, and tests

## Testing
- `pytest tests/test_sop_reconcile.py tests/test_inventory_sim.py tests/test_logistics_opt.py tests/test_procure_award.py tests/test_wc_model.py tests/test_dash_sc_ops_fin.py tests/test_lake_io.py`
- `pre-commit run --files README.md cli/console.py lake/io.py sop/plan.py supply/inventory_sim.py supply/logistics.py procure/optimizer.py finance/wc.py dashboards/sc_ops_fin.py configs/sop/policy.yaml configs/supply/inventory.yaml configs/supply/log_constraints.yaml configs/procure/policy.yaml configs/finance/terms.yaml fixtures/supply/lanes.csv fixtures/procure/suppliers.csv samples/generated/supply/demand.csv samples/generated/supply/capacity.csv tests/test_sop_reconcile.py tests/test_inventory_sim.py tests/test_logistics_opt.py tests/test_procure_award.py tests/test_wc_model.py tests/test_dash_sc_ops_fin.py tests/test_lake_io.py docs/sop-simulator.md docs/inventory-logistics.md docs/procure-tco.md docs/working-capital.md`


------
https://chatgpt.com/codex/tasks/task_e_68c4e0fee4d48329bb8de1b50c997ab9