### PR TITLE
feat: add sales pipeline and pricing lab

### DIFF
--- a/cli/console.py
+++ b/cli/console.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Optional
 
 import typer
+import yaml
 
 from bench import runner as bench_runner
 from bots import available_bots
@@ -11,6 +12,9 @@ from orchestrator import orchestrator, slo_report
 from orchestrator.perf import perf_timer
 from orchestrator.protocols import Task
 from tools import storage
+
+from sales import catalog as sales_catalog, cpq, deal_desk, quote_pack, winloss
+from pricing import elasticity
 
 app = typer.Typer()
 
@@ -150,6 +154,91 @@ def slo_gate(
     _perf_footer(perf, p)
     if not ok:
         raise typer.Exit(code=1)
+
+
+@app.command("sales:catalog:load")
+def catalog_load(dir: Path = typer.Option(..., "--dir", exists=True, file_okay=False)):
+    sales_catalog.load(dir)
+
+
+@app.command("sales:catalog:show")
+def catalog_show(sku: str = typer.Option(..., "--sku")):
+    data = sales_catalog.show(sku)
+    typer.echo(json.dumps(data, indent=2))
+
+
+@app.command("cpq:price")
+def cpq_price(
+    lines: Path = typer.Option(..., "--lines", exists=True, dir_okay=False),
+    region: str = typer.Option(..., "--region"),
+    currency: str = typer.Option(..., "--currency"),
+    out: Path = typer.Option(Path("artifacts/sales/quote.json"), "--out"),
+):
+    order_lines = json.loads(lines.read_text())
+    cfg = cpq.configure(order_lines)
+    quote = cpq.price(cfg, region, currency, policies={"bundle_discount_pct": 10})
+    cpq.save_quote(quote, out)
+    typer.echo(str(out))
+
+
+@app.command("deal:new")
+def deal_new(
+    account: str = typer.Option(..., "--account"),
+    quote: Path = typer.Option(..., "--quote", exists=True, dir_okay=False),
+    request_disc: float = typer.Option(0, "--request-disc"),
+):
+    deal = deal_desk.new_deal(account, quote, request_disc)
+    typer.echo(deal.id)
+
+
+@app.command("deal:check")
+def deal_check(id: str = typer.Option(..., "--id")):
+    deal = deal_desk.load_deal(id)
+    codes = deal_desk.check_deal(deal)
+    for c in codes:
+        typer.echo(c)
+
+
+@app.command("deal:request-approval")
+def deal_request(id: str = typer.Option(..., "--id"), for_role: str = typer.Option(..., "--for-role")):
+    deal = deal_desk.load_deal(id)
+    deal_desk.request_approval(deal, for_role)
+
+
+@app.command("deal:status")
+def deal_status(id: str = typer.Option(..., "--id")):
+    deal = deal_desk.load_deal(id)
+    typer.echo(deal.status)
+
+
+@app.command("price:simulate")
+def price_simulate(
+    scenarios: Path = typer.Option(..., "--scenarios", exists=True, dir_okay=False),
+    horizon: int = typer.Option(6, "--horizon"),
+):
+    cfg = yaml.safe_load(scenarios.read_text())
+    elasticity.simulate(cfg.get("scenarios", []), horizon)
+
+
+@app.command("quote:pack")
+def quote_pack_cmd(
+    quote: Path = typer.Option(..., "--quote", exists=True, dir_okay=False),
+    account: str = typer.Option(..., "--account"),
+    out: Path = typer.Option(Path("artifacts/sales/pack"), "--out"),
+):
+    quote_pack.build_pack(quote, account, out)
+    typer.echo(str(out))
+
+
+@app.command("sales:winloss")
+def winloss_cmd(
+    from_date: str = typer.Option(..., "--from"),
+    to_date: str = typer.Option(..., "--to"),
+):
+    start = datetime.fromisoformat(from_date)
+    end = datetime.fromisoformat(to_date)
+    path = winloss.build_report(start, end)
+    typer.echo(str(path))
 
 
 if __name__ == "__main__":

--- a/configs/sales/guardrails.yaml
+++ b/configs/sales/guardrails.yaml
@@ -1,0 +1,5 @@
+max_discount_pct: 15
+floor_prices:
+  F500-CORE: 70
+approvals:
+  CFO: {max_discount_pct: 30}

--- a/configs/sales/pricebook.yaml
+++ b/configs/sales/pricebook.yaml
@@ -1,0 +1,10 @@
+pricebook:
+  - sku: F500-CORE
+    base_price: 100
+    tiers:
+      - min_qty: 10
+        unit_price: 90
+      - min_qty: 50
+        unit_price: 80
+    currency: USD
+    region: NA

--- a/configs/sales/products.yaml
+++ b/configs/sales/products.yaml
@@ -1,0 +1,6 @@
+products:
+  - id: P1
+    name: F500 Core
+    family: infra
+    skus: [F500-CORE]
+    constraints: {}

--- a/contracts/schemas/deal.schema.json
+++ b/contracts/schemas/deal.schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "id": {"type": "string"},
+    "account": {"type": "string"},
+    "status": {"type": "string"}
+  },
+  "required": ["id", "account", "status"]
+}

--- a/contracts/schemas/price_sim.schema.json
+++ b/contracts/schemas/price_sim.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "scenarios": {"type": "array"},
+    "horizon": {"type": "integer"}
+  },
+  "required": ["scenarios", "horizon"]
+}

--- a/contracts/schemas/quote.schema.json
+++ b/contracts/schemas/quote.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "lines": {"type": "array"},
+    "total": {"type": "number"}
+  },
+  "required": ["lines", "total"]
+}

--- a/docs/cpq.md
+++ b/docs/cpq.md
@@ -1,0 +1,8 @@
+# CPQ Engine
+
+Deterministic configure-price-quote with volume tiers and bundle discounts.
+
+## Usage
+```bash
+python -m cli.console cpq:price --lines samples/sales/order_lines.json --region NA --currency USD
+```

--- a/docs/deal-desk.md
+++ b/docs/deal-desk.md
@@ -1,0 +1,9 @@
+# Deal Desk
+
+Workflow for reviewing quotes against discount guardrails and managing approvals.
+
+## Commands
+- `deal:new`
+- `deal:check`
+- `deal:request-approval`
+- `deal:status`

--- a/docs/elasticity.md
+++ b/docs/elasticity.md
@@ -1,0 +1,7 @@
+# Elasticity Sandbox
+
+Deterministic simulations of price changes.
+
+```bash
+python -m cli.console price:simulate --scenarios samples/sales/price_scenarios.yaml --horizon 6
+```

--- a/fixtures/sales/elasticity/infra.yaml
+++ b/fixtures/sales/elasticity/infra.yaml
@@ -1,0 +1,3 @@
+base_demand: 100
+elasticity: -1.5
+margin: 0.3

--- a/pricing/elasticity.py
+++ b/pricing/elasticity.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Dict, Any
+import yaml
+import csv
+import json
+
+from sales import catalog
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = ROOT / "fixtures" / "sales" / "elasticity"
+ART = ROOT / "artifacts" / "pricing"
+
+
+@dataclass
+class Scenario:
+    sku: str
+    price_delta_pct: float
+    promo: bool
+
+
+def _curve_for_sku(sku: str) -> Dict[str, Any]:
+    cat = catalog.load_artifact()
+    fam = None
+    for prod in cat.get("products", []):
+        if sku in prod.get("skus", []):
+            fam = prod.get("family")
+            break
+    if fam is None:
+        raise ValueError("unknown sku")
+    data = yaml.safe_load((FIXTURES / f"{fam}.yaml").read_text())
+    return data
+
+
+def simulate(scenarios: List[Dict[str, Any]], horizon_m: int) -> Dict[str, Any]:
+    results = []
+    catalog_data = catalog.load_artifact()
+    base_price_lookup = {p["sku"]: p["base_price"] for p in catalog_data.get("pricebook", [])}
+    for sc in scenarios:
+        curve = _curve_for_sku(sc["sku"])
+        base_demand = curve["base_demand"]
+        elasticity = curve["elasticity"]
+        margin = curve.get("margin", 0)
+        base_price = base_price_lookup[sc["sku"]]
+        price = base_price * (1 + sc.get("price_delta_pct", 0))
+        demand = base_demand * (1 + elasticity * sc.get("price_delta_pct", 0))
+        revenue = demand * price
+        base_revenue = base_demand * base_price
+        margin_new = revenue * margin
+        margin_base = base_revenue * margin
+        results.append(
+            {
+                "sku": sc["sku"],
+                "demand_delta": round(demand - base_demand, 2),
+                "revenue_delta": round(revenue - base_revenue, 2),
+                "margin_delta": round(margin_new - margin_base, 2),
+            }
+        )
+    ART.mkdir(parents=True, exist_ok=True)
+    ts = "sim_0000"
+    out = ART / ts
+    out.mkdir(exist_ok=True)
+    summary_path = out / "summary.md"
+    md = ["| SKU | DemandΔ | RevenueΔ | MarginΔ |", "|---|---:|---:|---:|"]
+    for r in results:
+        md.append(
+            f"|{r['sku']}|{r['demand_delta']:.2f}|{r['revenue_delta']:.2f}|{r['margin_delta']:.2f}|"
+        )
+    summary_path.write_text("\n".join(md))
+    series_path = out / "series.csv"
+    with open(series_path, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["month", "sku", "demand", "revenue"])
+        for month in range(1, horizon_m + 1):
+            for r in results:
+                base_demand = _curve_for_sku(r["sku"]) ["base_demand"]
+                base_price = base_price_lookup[r["sku"]]
+                demand = base_demand + r["demand_delta"]
+                revenue = (base_price + r["revenue_delta"] / base_demand) * demand
+                writer.writerow([month, r["sku"], round(demand, 2), round(revenue, 2)])
+    return {"results": results, "summary_path": str(summary_path), "series_path": str(series_path)}

--- a/sales/catalog.py
+++ b/sales/catalog.py
@@ -1,0 +1,54 @@
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Dict, Any
+import json
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+ARTIFACTS = ROOT / "artifacts" / "sales"
+
+
+@dataclass
+class Product:
+    id: str
+    name: str
+    family: str
+    skus: List[str]
+    constraints: Dict[str, Any]
+
+
+@dataclass
+class PriceBook:
+    sku: str
+    base_price: float
+    tiers: List[Dict[str, float]]
+    currency: str
+    region: str
+
+
+def load(dir_path: Path) -> Dict[str, Any]:
+    products_data = yaml.safe_load((dir_path / "products.yaml").read_text())
+    pricebook_data = yaml.safe_load((dir_path / "pricebook.yaml").read_text())
+    catalog = {
+        "products": products_data.get("products", []),
+        "pricebook": pricebook_data.get("pricebook", []),
+    }
+    ARTIFACTS.mkdir(parents=True, exist_ok=True)
+    with open(ARTIFACTS / "catalog.json", "w", encoding="utf-8") as fh:
+        json.dump(catalog, fh, indent=2)
+    return catalog
+
+
+def load_artifact() -> Dict[str, Any]:
+    path = ARTIFACTS / "catalog.json"
+    if path.exists():
+        return json.loads(path.read_text())
+    return {"products": [], "pricebook": []}
+
+
+def show(sku: str) -> Dict[str, Any]:
+    catalog = load_artifact()
+    for pb in catalog.get("pricebook", []):
+        if pb.get("sku") == sku:
+            return pb
+    return {}

--- a/sales/cpq.py
+++ b/sales/cpq.py
@@ -1,0 +1,70 @@
+from dataclasses import dataclass
+from typing import List, Dict, Any
+from pathlib import Path
+import json
+
+from . import catalog
+
+
+@dataclass
+class ConfiguredLine:
+    sku: str
+    qty: int
+    options: Dict[str, Any]
+
+
+@dataclass
+class PricedLine(ConfiguredLine):
+    unit_price: float
+    line_total: float
+
+
+@dataclass
+class PricedQuote:
+    lines: List[PricedLine]
+    total: float
+
+
+def configure(order_lines: List[Dict[str, Any]]) -> List[ConfiguredLine]:
+    return [ConfiguredLine(**ol) for ol in order_lines]
+
+
+def _price_for_sku(sku: str, qty: int, region: str, currency: str) -> float:
+    catalog_data = catalog.load_artifact()
+    for pb in catalog_data.get("pricebook", []):
+        if pb["sku"] == sku and pb["region"] == region and pb["currency"] == currency:
+            price = pb["base_price"]
+            for tier in sorted(pb.get("tiers", []), key=lambda t: t["min_qty"]):
+                if qty >= tier["min_qty"]:
+                    price = tier["unit_price"]
+            return price
+    raise ValueError(f"No price for {sku}")
+
+
+def price(configured: List[ConfiguredLine], region: str, currency: str, policies: Dict[str, Any] | None = None) -> PricedQuote:
+    policies = policies or {}
+    priced_lines: List[PricedLine] = []
+    for line in configured:
+        unit = _price_for_sku(line.sku, line.qty, region, currency)
+        if line.options.get("bundle") and policies.get("bundle_discount_pct"):
+            unit *= 1 - policies["bundle_discount_pct"] / 100
+        unit = round(unit, 2)
+        line_total = round(unit * line.qty, 2)
+        priced_lines.append(PricedLine(**line.__dict__, unit_price=unit, line_total=line_total))
+    total = round(sum(l.line_total for l in priced_lines), 2)
+    return PricedQuote(lines=priced_lines, total=total)
+
+
+def save_quote(quote: PricedQuote, path: Path) -> None:
+    data = {
+        "lines": [l.__dict__ for l in quote.lines],
+        "total": quote.total,
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2))
+    # simple markdown summary
+    md_lines = ["| SKU | Qty | Unit | Total |", "|---|---:|---:|---:|"]
+    for l in quote.lines:
+        md_lines.append(f"|{l.sku}|{l.qty}|{l.unit_price:.2f}|{l.line_total:.2f}|")
+    md_lines.append(f"|Total|||{quote.total:.2f}|")
+    (path.with_suffix(".md")).write_text("\n".join(md_lines))

--- a/sales/deal_desk.py
+++ b/sales/deal_desk.py
@@ -1,0 +1,77 @@
+from dataclasses import dataclass, asdict
+from datetime import datetime
+from pathlib import Path
+from typing import List, Dict, Any
+import json
+
+from tools import storage
+from . import guardrails
+
+ROOT = Path(__file__).resolve().parents[1]
+ART = ROOT / "artifacts" / "sales" / "deals"
+
+
+@dataclass
+class Deal:
+    id: str
+    account: str
+    quote_path: str
+    requested_discount: float
+    status: str
+    approvals: List[Dict[str, Any]]
+    created_at: str
+
+
+def _next_id() -> str:
+    counter = ROOT / "artifacts" / "sales" / "deal_counter.txt"
+    last = int(storage.read(str(counter)) or 0)
+    new = last + 1
+    storage.write(str(counter), str(new))
+    return f"D{new:03d}"
+
+
+def new_deal(account: str, quote_path: Path, requested_discount: float) -> Deal:
+    deal_id = _next_id()
+    deal = Deal(
+        id=deal_id,
+        account=account,
+        quote_path=str(quote_path),
+        requested_discount=requested_discount,
+        status="pending",
+        approvals=[],
+        created_at=datetime.utcnow().isoformat(),
+    )
+    save_deal(deal)
+    return deal
+
+
+def load_deal(deal_id: str) -> Deal:
+    data = json.loads((ART / f"{deal_id}.json").read_text())
+    return Deal(**data)
+
+
+def save_deal(deal: Deal) -> None:
+    ART.mkdir(parents=True, exist_ok=True)
+    (ART / f"{deal.id}.json").write_text(json.dumps(asdict(deal), indent=2))
+    (ART / f"deal_{deal.id}.md").write_text(f"Deal {deal.id} for {deal.account}\nStatus: {deal.status}\n")
+
+
+def check_deal(deal: Deal) -> List[str]:
+    quote = json.loads(Path(deal.quote_path).read_text())
+    if deal.requested_discount:
+        for line in quote.get("lines", []):
+            line["unit_price"] = round(
+                line["unit_price"] * (1 - deal.requested_discount / 100), 2
+            )
+            line["line_total"] = round(line["unit_price"] * line["qty"], 2)
+    violations = guardrails.check(quote)
+    return [v.code for v in violations]
+
+
+def request_approval(deal: Deal, role: str) -> None:
+    deal.approvals.append({"role": role, "approved": False})
+    save_deal(deal)
+
+
+def status(deal: Deal) -> str:
+    return deal.status

--- a/sales/guardrails.py
+++ b/sales/guardrails.py
@@ -1,0 +1,42 @@
+from dataclasses import dataclass
+from typing import List, Dict, Any
+from pathlib import Path
+import yaml
+
+from . import catalog
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIG = ROOT / "configs" / "sales" / "guardrails.yaml"
+
+
+@dataclass
+class Violation:
+    code: str
+    detail: str
+
+
+def load_rules(path: Path = CONFIG) -> Dict[str, Any]:
+    if path.exists():
+        return yaml.safe_load(path.read_text())
+    return {"max_discount_pct": 0, "floor_prices": {}}
+
+
+def check(quote: Dict[str, Any], rules: Dict[str, Any] | None = None) -> List[Violation]:
+    rules = rules or load_rules()
+    catalog_data = catalog.load_artifact()
+    base_lookup = {p["sku"]: p["base_price"] for p in catalog_data.get("pricebook", [])}
+    violations: List[Violation] = []
+    max_disc = rules.get("max_discount_pct", 0)
+    floors = rules.get("floor_prices", {})
+    for line in quote.get("lines", []):
+        sku = line["sku"]
+        unit = line["unit_price"]
+        base = base_lookup.get(sku, unit)
+        disc_pct = (1 - unit / base) * 100 if base else 0
+        if disc_pct > max_disc:
+            violations.append(Violation("DISC_OVER_MAX", sku))
+        if unit < floors.get(sku, 0):
+            violations.append(Violation("BELOW_FLOOR", sku))
+        if line.get("options", {}).get("bundle_conflict"):
+            violations.append(Violation("BUNDLE_CONFLICT", sku))
+    return violations

--- a/sales/quote_pack.py
+++ b/sales/quote_pack.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+import json
+import os
+from typing import Dict, Any
+
+
+def build_pack(quote_path: Path, account: str, out_dir: Path) -> Dict[str, str]:
+    quote = json.loads(quote_path.read_text())
+    if quote.get("contacts") and os.getenv("PRIVACY_OK") != "1":
+        raise ValueError("DUTY_PRIVACY_QP")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    cover = out_dir / "cover.md"
+    cover.write_text(f"# Quote for {account}\n")
+    table = out_dir / "pricing_table.md"
+    md_lines = ["| SKU | Qty | Unit | Total |", "|---|---:|---:|---:|"]
+    for line in quote.get("lines", []):
+        md_lines.append(
+            f"|{line['sku']}|{line['qty']}|{line['unit_price']:.2f}|{line['line_total']:.2f}|"
+        )
+    md_lines.append(f"|Total|||{quote.get('total',0):.2f}|")
+    table.write_text("\n".join(md_lines))
+    terms = out_dir / "terms.md"
+    terms.write_text("Standard terms apply.")
+    slides = out_dir / "slides.md"
+    slides.write_text("Slides unavailable.")
+    return {
+        "cover": str(cover),
+        "pricing_table": str(table),
+        "terms": str(terms),
+    }

--- a/sales/winloss.py
+++ b/sales/winloss.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+from pathlib import Path
+import json
+from typing import List, Dict
+
+ROOT = Path(__file__).resolve().parents[1]
+ART = ROOT / "artifacts" / "sales" / "deals"
+OUT = ROOT / "artifacts" / "sales"
+
+
+def _parse_date(s: str) -> datetime:
+    return datetime.fromisoformat(s)
+
+
+def build_report(start: datetime, end: datetime) -> Path:
+    wins = losses = 0
+    discounts: List[float] = []
+    for f in ART.glob("*.json"):
+        data = json.loads(f.read_text())
+        created = _parse_date(data.get("created_at"))
+        if not (start <= created <= end):
+            continue
+        discounts.append(data.get("requested_discount", 0))
+        if data.get("status") == "won":
+            wins += 1
+        elif data.get("status") == "lost":
+            losses += 1
+    avg_disc = sum(discounts) / len(discounts) if discounts else 0
+    month = start.strftime("%Y%m")
+    OUT.mkdir(parents=True, exist_ok=True)
+    path = OUT / f"winloss_{month}.md"
+    path.write_text(
+        f"Wins: {wins}\nLosses: {losses}\nAvg discount: {avg_disc:.2f}\n"
+    )
+    return path

--- a/samples/sales/order_lines.json
+++ b/samples/sales/order_lines.json
@@ -1,0 +1,3 @@
+[
+  {"sku": "F500-CORE", "qty": 60, "options": {}}
+]

--- a/samples/sales/price_scenarios.yaml
+++ b/samples/sales/price_scenarios.yaml
@@ -1,0 +1,4 @@
+scenarios:
+  - sku: F500-CORE
+    price_delta_pct: -0.1
+    promo: false

--- a/tests/test_cpq.py
+++ b/tests/test_cpq.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+from sales import catalog, cpq
+
+
+def setup_module(_):
+    catalog.load(Path('configs/sales'))
+
+
+def test_tiering_and_bundle(tmp_path):
+    lines = [{"sku": "F500-CORE", "qty": 50, "options": {"bundle": True}}]
+    cfg = cpq.configure(lines)
+    quote = cpq.price(cfg, "NA", "USD", policies={"bundle_discount_pct": 10})
+    assert quote.lines[0].unit_price == 72.0  # 80 tier with 10% bundle
+    out = tmp_path / "quote.json"
+    cpq.save_quote(quote, out)
+    assert out.exists()
+    assert out.with_suffix('.md').exists()

--- a/tests/test_deal_desk.py
+++ b/tests/test_deal_desk.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+from sales import catalog, cpq, deal_desk
+
+
+def setup_module(_):
+    catalog.load(Path('configs/sales'))
+
+
+def test_deal_flow(tmp_path):
+    lines = [{"sku": "F500-CORE", "qty": 1, "options": {}}]
+    cfg = cpq.configure(lines)
+    quote = cpq.price(cfg, "NA", "USD")
+    qpath = tmp_path / "q.json"
+    cpq.save_quote(quote, qpath)
+    deal = deal_desk.new_deal("ACME", qpath, 20)
+    codes = deal_desk.check_deal(deal)
+    assert "DISC_OVER_MAX" in codes
+    deal_desk.request_approval(deal, "CFO")
+    loaded = deal_desk.load_deal(deal.id)
+    assert loaded.approvals[0]["role"] == "CFO"

--- a/tests/test_elasticity.py
+++ b/tests/test_elasticity.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+import yaml
+
+from sales import catalog
+from pricing import elasticity
+
+
+def setup_module(_):
+    catalog.load(Path('configs/sales'))
+
+
+def test_simulation_deterministic(tmp_path):
+    scenarios = yaml.safe_load(Path('samples/sales/price_scenarios.yaml').read_text())["scenarios"]
+    report = elasticity.simulate(scenarios, 6)
+    r = report["results"][0]
+    assert r["demand_delta"] == 15.0
+    assert r["revenue_delta"] == 350.0
+    assert r["margin_delta"] == 105.0
+    assert Path(report["summary_path"]).exists()
+    assert Path(report["series_path"]).exists()

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -17,3 +17,18 @@ def test_guardrails_missing_fields():
     )
     with pytest.raises(AssertionError):
         assert_guardrails(bad)
+
+from sales import guardrails
+
+
+def test_sales_guardrails_codes():
+    quote = {
+        "lines": [
+            {"sku": "F500-CORE", "qty": 1, "unit_price": 60, "options": {}}
+        ],
+    }
+    rules = {"max_discount_pct": 15, "floor_prices": {"F500-CORE": 70}}
+    violations = guardrails.check(quote, rules)
+    codes = {v.code for v in violations}
+    assert "DISC_OVER_MAX" in codes
+    assert "BELOW_FLOOR" in codes

--- a/tests/test_quote_pack.py
+++ b/tests/test_quote_pack.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+import json
+import pytest
+
+from sales import quote_pack
+
+
+def test_pack_build(tmp_path):
+    quote = {"lines": [], "total": 0}
+    qpath = tmp_path / "quote.json"
+    qpath.write_text(json.dumps(quote))
+    out = tmp_path / "pack"
+    quote_pack.build_pack(qpath, "ACME-001", out)
+    assert (out / "cover.md").exists()
+    assert (out / "pricing_table.md").exists()
+
+
+def test_privacy_gate(tmp_path, monkeypatch):
+    quote = {"lines": [], "total": 0, "contacts": [{"name": "Bob"}]}
+    qpath = tmp_path / "quote.json"
+    qpath.write_text(json.dumps(quote))
+    with pytest.raises(ValueError):
+        quote_pack.build_pack(qpath, "ACME", tmp_path / "pack2")

--- a/tests/test_winloss.py
+++ b/tests/test_winloss.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+from datetime import datetime
+
+from sales import catalog, cpq, deal_desk, winloss
+
+
+def setup_module(_):
+    catalog.load(Path('configs/sales'))
+
+
+def _make_deal(status: str):
+    lines = [{"sku": "F500-CORE", "qty": 1, "options": {}}]
+    cfg = cpq.configure(lines)
+    quote = cpq.price(cfg, "NA", "USD")
+    qpath = Path('artifacts/tmp_quote.json')
+    cpq.save_quote(quote, qpath)
+    deal = deal_desk.new_deal("AC", qpath, 0)
+    deal.status = status
+    deal_desk.save_deal(deal)
+
+
+def test_winloss_report():
+    deals_dir = Path('artifacts/sales/deals')
+    if deals_dir.exists():
+        for f in deals_dir.glob('*.json'):
+            f.unlink()
+    _make_deal('won')
+    _make_deal('lost')
+    start = datetime(2025, 6, 1)
+    end = datetime(2025, 9, 30)
+    path = winloss.build_report(start, end)
+    text = Path(path).read_text()
+    assert "Wins: 1" in text
+    assert "Losses: 1" in text


### PR DESCRIPTION
## Summary
- add deterministic catalog loader and CPQ engine with tiers and bundle pricing
- implement discount guardrails, deal desk workflow, and quote pack builder
- add pricing elasticity simulator and win-loss analytics

## Testing
- `pytest tests/test_cpq.py tests/test_guardrails.py tests/test_deal_desk.py tests/test_elasticity.py tests/test_quote_pack.py tests/test_winloss.py`

------
https://chatgpt.com/codex/tasks/task_e_68c4e1e328dc832982dd0d906f5a3095