### PR TITLE
feat: add deterministic aiops self-healing layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,3 +475,14 @@ class MyBot(BaseBot):
     def run(self, task: Task) -> BotResponse:
         ...
 ```
+
+## AIOps & Self-Healing Quickstart
+
+```bash
+python -m cli.console aiops:correlate
+python -m cli.console aiops:plan --correlations artifacts/aiops/correlations_*.json
+python -m cli.console aiops:execute --plan artifacts/aiops/plan.json --dry-run
+python -m cli.console aiops:canary --base artifacts/healthchecks/CoreAPI/baseline.json --canary artifacts/healthchecks/CoreAPI/latest.json
+python -m cli.console aiops:baseline:record && python -m cli.console aiops:drift:check
+python -m cli.console aiops:budget --service CoreAPI --window 30d && python -m cli.console aiops:window --service CoreAPI --action remediate
+```

--- a/aiops/__init__.py
+++ b/aiops/__init__.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+# Shared paths and in-memory metrics for AIOps modules
+ROOT = Path(__file__).resolve().parents[1]
+ARTIFACTS = ROOT / "artifacts"
+
+# simple in-memory metrics counter used by modules and tests
+METRICS = {
+    "aiops_correlations": 0,
+    "aiops_plans": 0,
+    "aiops_execs": 0,
+    "aiops_exec_blocked": 0,
+    "aiops_drift_detected": 0,
+    "aiops_budget_alerts": 0,
+}
+
+
+def _inc(metric: str, amount: int = 1) -> None:
+    """Increment a metric in the in-memory store."""
+    METRICS[metric] = METRICS.get(metric, 0) + amount

--- a/aiops/canary.py
+++ b/aiops/canary.py
@@ -1,0 +1,56 @@
+"""Offline canary analysis."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict
+from datetime import datetime
+
+import yaml
+
+from . import ARTIFACTS, ROOT, _inc
+
+CONFIG = ROOT / "configs" / "aiops" / "canary.yaml"
+
+
+def _load_thresholds() -> Dict[str, float]:
+    with open(CONFIG, "r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+    return data.get("thresholds", {})
+
+
+def analyze(
+    base_path: Path,
+    canary_path: Path,
+    artifacts_dir: Path = ARTIFACTS,
+) -> dict:
+    """Compare two metric snapshots and output diff."""
+    with open(base_path, "r", encoding="utf-8") as fh:
+        base = json.load(fh)
+    with open(canary_path, "r", encoding="utf-8") as fh:
+        canary = json.load(fh)
+
+    thr = _load_thresholds()
+    deltas = {}
+    failed = False
+    for key in ["latency_p50", "latency_p95", "error_rate"]:
+        b = base.get(key, 0)
+        c = canary.get(key, 0)
+        delta = c - b
+        deltas[key] = delta
+        if abs(delta) > thr.get(key, float("inf")):
+            failed = True
+    result = "FAIL" if failed else "PASS"
+
+    ts = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+    out_dir = artifacts_dir / "aiops" / f"canary_{ts}"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with open(out_dir / "diff.json", "w", encoding="utf-8") as fh:
+        json.dump({"deltas": deltas, "result": result}, fh, indent=2)
+    with open(out_dir / "report.md", "w", encoding="utf-8") as fh:
+        fh.write(f"Result: {result}\n")
+        for k, v in deltas.items():
+            fh.write(f"{k}: {v}\n")
+
+    _inc("aiops_correlations")  # reuse metric for simplicity
+    return {"deltas": deltas, "result": result}

--- a/aiops/config_drift.py
+++ b/aiops/config_drift.py
@@ -1,0 +1,60 @@
+"""Config drift detection."""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Tuple
+
+from . import ARTIFACTS, _inc
+
+BASELINE = ARTIFACTS / "aiops" / "config_baseline.json"
+
+SEVERITY_RULES = {"version": "critical"}
+
+
+def record_baseline(snapshot: Dict, artifacts_dir: Path = ARTIFACTS) -> None:
+    out_dir = artifacts_dir / "aiops"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    path = out_dir / "config_baseline.json"
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(snapshot, fh, indent=2)
+
+
+def _diff(base: Dict, curr: Dict, prefix: str = "") -> Dict[str, Tuple[object, object]]:
+    changes: Dict[str, Tuple[object, object]] = {}
+    keys = set(base) | set(curr)
+    for k in keys:
+        p = f"{prefix}{k}"
+        if k not in base:
+            changes[p] = (None, curr[k])
+        elif k not in curr:
+            changes[p] = (base[k], None)
+        elif isinstance(base[k], dict) and isinstance(curr[k], dict):
+            changes.update(_diff(base[k], curr[k], p + "."))
+        elif base[k] != curr[k]:
+            changes[p] = (base[k], curr[k])
+    return changes
+
+
+def compare(snapshot: Dict = None, artifacts_dir: Path = ARTIFACTS) -> dict:
+    path = artifacts_dir / "aiops" / "config_baseline.json"
+    if not path.exists():
+        raise FileNotFoundError("baseline not recorded")
+    with open(path, "r", encoding="utf-8") as fh:
+        base = json.load(fh)
+    curr = snapshot if snapshot is not None else base
+    diffs = _diff(base, curr)
+    items = []
+    for k, (b, c) in diffs.items():
+        items.append({"path": k, "baseline": b, "current": c, "severity": SEVERITY_RULES.get(k, "warning")})
+    ts = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+    out_dir = artifacts_dir / "aiops"
+    with open(out_dir / f"drift_{ts}.json", "w", encoding="utf-8") as fh:
+        json.dump({"diff": items}, fh, indent=2)
+    with open(out_dir / "drift.md", "w", encoding="utf-8") as fh:
+        for i in items:
+            fh.write(f"- {i['path']}: {i['baseline']} -> {i['current']} ({i['severity']})\n")
+    if items:
+        _inc("aiops_drift_detected")
+    return {"diff": items}

--- a/aiops/correlation.py
+++ b/aiops/correlation.py
@@ -1,0 +1,96 @@
+"""Rule based correlation engine.
+
+The correlate function evaluates rule definitions against event sources and
+produces correlation artifacts.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+import yaml
+
+from . import ARTIFACTS, ROOT, _inc
+
+CONFIG = ROOT / "configs" / "aiops" / "correlation.yaml"
+
+
+def _load_rules() -> List[dict]:
+    with open(CONFIG, "r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+    return data.get("rules", [])
+
+
+def _match(event: dict, cond: dict, now: datetime) -> bool:
+    for k, v in cond.get("match", {}).items():
+        if event.get(k) != v:
+            return False
+    if "within_minutes" in cond:
+        ts = datetime.fromisoformat(event.get("timestamp"))
+        delta = abs((now - ts).total_seconds()) / 60
+        if delta > cond["within_minutes"]:
+            return False
+    return True
+
+
+def correlate(
+    now: Optional[datetime] = None,
+    sources: Optional[Dict[str, Iterable[dict]]] = None,
+    artifacts_dir: Path = ARTIFACTS,
+) -> List[dict]:
+    """Run correlation rules and write artifacts.
+
+    Parameters
+    ----------
+    now: datetime
+        Reference time for time based rule evaluation.
+    sources: dict
+        Mapping of source name to iterable of events.
+    artifacts_dir: Path
+        Location where correlation artifacts will be written.
+    """
+    now = now or datetime.utcnow()
+    if sources is None:
+        sources = {}
+        for name in ["incidents", "healthchecks", "changes", "anomalies", "synthetic"]:
+            path = artifacts_dir / f"{name}.json"
+            if path.exists():
+                with open(path, "r", encoding="utf-8") as fh:
+                    sources[name] = json.load(fh)
+            else:
+                sources[name] = []
+
+    rules = _load_rules()
+    corrs: List[dict] = []
+    for rule in rules:
+        matched: Dict[str, dict] = {}
+        for cond in rule.get("when", []):
+            src = cond["source"]
+            events = sources.get(src, [])
+            found = None
+            for ev in events:
+                if _match(ev, cond, now):
+                    found = ev
+                    break
+            if not found:
+                matched = {}
+                break
+            matched[src] = found
+        if matched:
+            item = {"rule": rule.get("name"), **rule.get("emit", {}), "matched": matched}
+            corrs.append(item)
+
+    out_dir = artifacts_dir / "aiops"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    ts = now.strftime("%Y%m%d%H%M%S")
+    json_path = out_dir / f"correlations_{ts}.json"
+    with open(json_path, "w", encoding="utf-8") as fh:
+        json.dump(corrs, fh, indent=2)
+    with open(out_dir / "summary.md", "w", encoding="utf-8") as fh:
+        for c in corrs:
+            fh.write(f"- {c['rule']} => {c.get('kind')}\n")
+
+    _inc("aiops_correlations", len(corrs))
+    return corrs

--- a/aiops/maintenance.py
+++ b/aiops/maintenance.py
@@ -1,0 +1,27 @@
+"""Maintenance window utilities."""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional
+
+from . import ARTIFACTS
+
+CALENDAR = ARTIFACTS / "maintenance.json"
+
+
+def next_window(
+    service: str,
+    action: str,
+    calendar: Optional[List[dict]] = None,
+) -> Optional[dict]:
+    if calendar is None:
+        if CALENDAR.exists():
+            with open(CALENDAR, "r", encoding="utf-8") as fh:
+                calendar = json.load(fh)
+        else:
+            calendar = []
+    windows = [w for w in calendar if w.get("service") == service and w.get("action") in {action, "*"}]
+    windows.sort(key=lambda w: w.get("start"))
+    return windows[0] if windows else None

--- a/aiops/remediation.py
+++ b/aiops/remediation.py
@@ -1,0 +1,86 @@
+"""Auto remediation planner and executor."""
+from __future__ import annotations
+
+import glob
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from . import ARTIFACTS, _inc
+from . import maintenance
+
+# mapping from correlation kind to runbook action name
+RUNBOOKS = {
+    "brownout": {"action": "restart_coreapi"},
+}
+
+
+def plan(
+    correlations: Iterable[dict],
+    artifacts_dir: Path = ARTIFACTS,
+) -> dict:
+    """Create a remediation plan for the given correlations."""
+    actions: List[dict] = []
+    for c in correlations:
+        rb = RUNBOOKS.get(c.get("kind"))
+        if rb:
+            actions.append({"correlation": c, "action": rb["action"]})
+    plan_data = {"actions": actions}
+    out_dir = artifacts_dir / "aiops"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with open(out_dir / "plan.json", "w", encoding="utf-8") as fh:
+        json.dump(plan_data, fh, indent=2)
+    _inc("aiops_plans")
+    return plan_data
+
+
+def execute(
+    plan_path: Path,
+    dry_run: bool = False,
+    artifacts_dir: Path = ARTIFACTS,
+) -> dict:
+    """Execute a remediation plan."""
+    with open(plan_path, "r", encoding="utf-8") as fh:
+        plan_data = json.load(fh)
+
+    now = datetime.utcnow()
+    exec_dir = artifacts_dir / "aiops" / f"exec_{now.strftime('%Y%m%d%H%M%S')}"
+    exec_dir.mkdir(parents=True, exist_ok=True)
+    log_path = exec_dir / "log.jsonl"
+    results: List[dict] = []
+
+    blocked = os.getenv("AIOPS_BLOCK_REMEDIATION") == "1"
+    for act in plan_data.get("actions", []):
+        service = act["correlation"].get("matched", {}).get("healthchecks", {}).get("service")
+        win = maintenance.next_window(service, "remediate")
+        if blocked or (win and datetime.utcnow().isoformat() < win.get("start", "")):
+            status = "blocked"
+            blocked = True
+            _inc("aiops_exec_blocked")
+        elif dry_run:
+            status = "dry-run"
+        else:
+            status = "executed"
+        entry = {"action": act["action"], "status": status}
+        results.append(entry)
+        with open(log_path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(entry) + "\n")
+
+    with open(exec_dir / "summary.md", "w", encoding="utf-8") as fh:
+        for r in results:
+            fh.write(f"- {r['action']}: {r['status']}\n")
+
+    if not blocked:
+        _inc("aiops_execs")
+    return {"results": results, "blocked": blocked}
+
+
+def load_correlations(pattern: str) -> List[dict]:
+    """Utility to load correlation files matching a glob pattern."""
+    data: List[dict] = []
+    for path in glob.glob(pattern):
+        with open(path, "r", encoding="utf-8") as fh:
+            data.extend(json.load(fh))
+    return data

--- a/aiops/slo_budget.py
+++ b/aiops/slo_budget.py
@@ -1,0 +1,42 @@
+"""SLO budget utilities."""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict
+
+from . import ARTIFACTS, _inc
+
+
+def budget_status(
+    service: str,
+    window: str,
+    data: Dict = None,
+    artifacts_dir: Path = ARTIFACTS,
+) -> dict:
+    """Compute error budget status for a service."""
+    if data is None:
+        path = artifacts_dir / "slo" / f"{service}.json"
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    target = data.get("target", 1.0)
+    errors = data.get("errors", 0.0)
+    total_budget = max(1.0 - target, 1e-9)
+    remaining = max(total_budget - errors, 0.0)
+    remaining_pct = remaining / total_budget
+    state = "ok"
+    if remaining_pct == 0:
+        state = "burning"
+    elif remaining_pct < 0.5:
+        state = "warn"
+
+    ts = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+    out_dir = artifacts_dir / "aiops"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out = {"service": service, "window": window, "remaining_pct": remaining_pct, "state": state}
+    with open(out_dir / f"slo_budget_{ts}.json", "w", encoding="utf-8") as fh:
+        json.dump(out, fh, indent=2)
+    if state != "ok":
+        _inc("aiops_budget_alerts")
+    return out

--- a/cli/console.py
+++ b/cli/console.py
@@ -11,6 +11,12 @@ from orchestrator import orchestrator, slo_report
 from orchestrator.perf import perf_timer
 from orchestrator.protocols import Task
 from tools import storage
+from aiops import canary as aiops_canary
+from aiops import config_drift as aiops_drift
+from aiops import correlation as aiops_correlation
+from aiops import maintenance as aiops_maintenance
+from aiops import remediation as aiops_remediation
+from aiops import slo_budget as aiops_budget
 
 app = typer.Typer()
 
@@ -150,6 +156,54 @@ def slo_gate(
     _perf_footer(perf, p)
     if not ok:
         raise typer.Exit(code=1)
+
+
+@app.command("aiops:correlate")
+def aiops_correlate():
+    aiops_correlation.correlate(datetime.utcnow())
+
+
+@app.command("aiops:plan")
+def aiops_plan(correlations: str = typer.Option(..., "--correlations")):
+    corr = aiops_remediation.load_correlations(correlations)
+    aiops_remediation.plan(corr)
+
+
+@app.command("aiops:execute")
+def aiops_execute(
+    plan: Path = typer.Option(..., "--plan", exists=True, dir_okay=False),
+    dry_run: bool = typer.Option(False, "--dry-run"),
+):
+    aiops_remediation.execute(plan, dry_run)
+
+
+@app.command("aiops:canary")
+def aiops_canary_cmd(
+    base: Path = typer.Option(..., "--base", exists=True, dir_okay=False),
+    canary: Path = typer.Option(..., "--canary", exists=True, dir_okay=False),
+):
+    aiops_canary.analyze(base, canary)
+
+
+@app.command("aiops:baseline:record")
+def aiops_baseline_record():
+    aiops_drift.record_baseline({})
+
+
+@app.command("aiops:drift:check")
+def aiops_drift_check():
+    aiops_drift.compare()
+
+
+@app.command("aiops:budget")
+def aiops_budget_cmd(service: str = typer.Option(..., "--service"), window: str = typer.Option(..., "--window")):
+    aiops_budget.budget_status(service, window)
+
+
+@app.command("aiops:window")
+def aiops_window(service: str = typer.Option(..., "--service"), action: str = typer.Option(..., "--action")):
+    w = aiops_maintenance.next_window(service, action)
+    typer.echo(json.dumps(w) if w else "null")
 
 
 if __name__ == "__main__":

--- a/configs/aiops/canary.yaml
+++ b/configs/aiops/canary.yaml
@@ -1,0 +1,4 @@
+thresholds:
+  latency_p50: 20
+  latency_p95: 20
+  error_rate: 0.05

--- a/configs/aiops/correlation.yaml
+++ b/configs/aiops/correlation.yaml
@@ -1,0 +1,11 @@
+rules:
+  - name: coreapi_brownout
+    when:
+      - source: healthchecks
+        match: {service: "CoreAPI", status: "degraded"}
+      - source: incidents
+        match: {service: "CoreAPI", severity: "high"}
+      - source: changes
+        within_minutes: 60
+        match: {service: "CoreAPI", type: "deploy"}
+    emit: {kind: "brownout", priority: "p1"}

--- a/docs/aiops.md
+++ b/docs/aiops.md
@@ -1,0 +1,29 @@
+# AIOps & Self-Healing
+
+This module provides deterministic, offline tooling for analysing system health
+and planning safe remediations.
+
+## Correlation rules
+Rules in `configs/aiops/correlation.yaml` link incidents, health checks and
+change events. The `aiops:correlate` CLI writes correlation artifacts and
+increments the `aiops_correlations` metric.
+
+## Remediation mapping
+`aiops/remediation.py` maps correlation kinds to runbook actions. Plans are
+written to `artifacts/aiops/plan.json` and executed locally with guardrails for
+maintenance windows and optional blocking via the `AIOPS_BLOCK_REMEDIATION`
+environment variable.
+
+## Canary thresholds
+Offline canary analysis compares baseline and canary metrics using thresholds
+from `configs/aiops/canary.yaml` and stores reports under
+`artifacts/aiops/canary_<ts>/`.
+
+## Config drift
+Baselines are recorded with `aiops:baseline:record` and checked with
+`aiops:drift:check`. Differences are emitted to `artifacts/aiops/drift_<ts>.json`
+with per-field severities.
+
+## SLO budgets
+`aiops:slo_budget` computes remaining error budget percentages for a service and
+marks the state as `ok`, `warn` or `burning`.

--- a/schemas/aiops_budget.schema.json
+++ b/schemas/aiops_budget.schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["service", "remaining_pct", "state"],
+  "properties": {
+    "service": {"type": "string"},
+    "remaining_pct": {"type": "number"},
+    "state": {"type": "string"}
+  }
+}

--- a/schemas/aiops_canary.schema.json
+++ b/schemas/aiops_canary.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["deltas", "result"],
+  "properties": {
+    "deltas": {"type": "object"},
+    "result": {"type": "string"}
+  }
+}

--- a/schemas/aiops_correlation.schema.json
+++ b/schemas/aiops_correlation.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["rule", "kind"],
+    "properties": {
+      "rule": {"type": "string"},
+      "kind": {"type": "string"}
+    }
+  }
+}

--- a/schemas/aiops_drift.schema.json
+++ b/schemas/aiops_drift.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["diff"],
+  "properties": {
+    "diff": {"type": "array"}
+  }
+}

--- a/schemas/aiops_plan.schema.json
+++ b/schemas/aiops_plan.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["actions"],
+  "properties": {
+    "actions": {"type": "array"}
+  }
+}

--- a/tests/test_aiops_canary.py
+++ b/tests/test_aiops_canary.py
@@ -1,0 +1,21 @@
+import json
+from pathlib import Path
+
+from aiops import canary
+
+
+def _write(path: Path, data: dict):
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(data, fh)
+
+
+def test_canary_pass_fail(tmp_path: Path):
+    base = tmp_path / "base.json"
+    can = tmp_path / "canary.json"
+    _write(base, {"latency_p50": 100, "latency_p95": 200, "error_rate": 0.01})
+    _write(can, {"latency_p50": 110, "latency_p95": 210, "error_rate": 0.02})
+    res = canary.analyze(base, can, artifacts_dir=tmp_path)
+    assert res["result"] == "PASS"
+    _write(can, {"latency_p50": 130, "latency_p95": 250, "error_rate": 0.2})
+    res = canary.analyze(base, can, artifacts_dir=tmp_path)
+    assert res["result"] == "FAIL"

--- a/tests/test_aiops_config_drift.py
+++ b/tests/test_aiops_config_drift.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+from aiops import config_drift
+
+
+def test_baseline_and_drift(tmp_path: Path):
+    baseline = {"service": "CoreAPI", "version": 1}
+    config_drift.record_baseline(baseline, artifacts_dir=tmp_path)
+    drift = config_drift.compare({"service": "CoreAPI", "version": 2}, artifacts_dir=tmp_path)
+    assert drift["diff"][0]["path"] == "version"

--- a/tests/test_aiops_correlation.py
+++ b/tests/test_aiops_correlation.py
@@ -1,0 +1,36 @@
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from aiops import correlation
+
+
+def test_correlation(tmp_path: Path):
+    now = datetime.utcnow()
+    sources = {
+        "healthchecks": [
+            {
+                "service": "CoreAPI",
+                "status": "degraded",
+                "timestamp": (now - timedelta(minutes=1)).isoformat(),
+            }
+        ],
+        "incidents": [
+            {
+                "service": "CoreAPI",
+                "severity": "high",
+                "timestamp": (now - timedelta(minutes=2)).isoformat(),
+            }
+        ],
+        "changes": [
+            {
+                "service": "CoreAPI",
+                "type": "deploy",
+                "timestamp": (now - timedelta(minutes=3)).isoformat(),
+            }
+        ],
+    }
+    res = correlation.correlate(now, sources, artifacts_dir=tmp_path)
+    assert res and res[0]["kind"] == "brownout"
+    files = list((tmp_path / "aiops").glob("correlations_*.json"))
+    assert files

--- a/tests/test_aiops_maintenance.py
+++ b/tests/test_aiops_maintenance.py
@@ -1,0 +1,10 @@
+from aiops import maintenance
+
+
+def test_next_window_selection():
+    calendar = [
+        {"service": "CoreAPI", "action": "remediate", "start": "2024-01-02T00:00:00", "end": "2024-01-02T01:00:00", "reason": "patch"},
+        {"service": "CoreAPI", "action": "remediate", "start": "2024-01-01T00:00:00", "end": "2024-01-01T01:00:00", "reason": "nightly"},
+    ]
+    win = maintenance.next_window("CoreAPI", "remediate", calendar)
+    assert win["reason"] == "nightly"

--- a/tests/test_aiops_remediation.py
+++ b/tests/test_aiops_remediation.py
@@ -1,0 +1,24 @@
+import os
+from pathlib import Path
+
+from aiops import remediation
+
+CORR = [{"kind": "brownout", "matched": {"healthchecks": {"service": "CoreAPI"}}}]
+
+
+def test_plan_and_execute(tmp_path: Path):
+    plan = remediation.plan(CORR, artifacts_dir=tmp_path)
+    assert plan["actions"]
+    plan_path = tmp_path / "aiops" / "plan.json"
+    assert plan_path.exists()
+    res = remediation.execute(plan_path, dry_run=True, artifacts_dir=tmp_path)
+    assert res["results"][0]["status"] == "dry-run"
+
+
+def test_execute_blocked(tmp_path: Path, monkeypatch):
+    plan = remediation.plan(CORR, artifacts_dir=tmp_path)
+    plan_path = tmp_path / "aiops" / "plan.json"
+    monkeypatch.setenv("AIOPS_BLOCK_REMEDIATION", "1")
+    res = remediation.execute(plan_path, dry_run=False, artifacts_dir=tmp_path)
+    assert res["blocked"]
+    assert res["results"][0]["status"] == "blocked"

--- a/tests/test_aiops_slo_budget.py
+++ b/tests/test_aiops_slo_budget.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+from aiops import slo_budget
+
+
+def test_budget_states(tmp_path: Path):
+    data_ok = {"target": 0.99, "errors": 0.002}
+    res = slo_budget.budget_status("CoreAPI", "30d", data=data_ok, artifacts_dir=tmp_path)
+    assert res["state"] == "ok"
+    data_burn = {"target": 0.99, "errors": 0.02}
+    res = slo_budget.budget_status("CoreAPI", "30d", data=data_burn, artifacts_dir=tmp_path)
+    assert res["state"] == "burning"


### PR DESCRIPTION
## Summary
- add event correlation engine with rule-driven YAML configuration
- plan and execute remediation actions with maintenance window checks
- support offline canary diffing, config drift detection, SLO budgets and maintenance windows

## Testing
- `pytest tests/test_aiops_*.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4e2807d1483298a581c434f38d804