### PR TITLE
feat: add board and investor relations tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,3 +475,14 @@ class MyBot(BaseBot):
     def run(self, task: Task) -> BotResponse:
         ...
 ```
+
+## Board & IR Quickstart
+
+```bash
+python -m cli.console ir:kpi:compute --period 2025Q3
+python -m cli.console ir:kpi:signoff --kpi revenue --period 2025Q3 --request
+python -m cli.console ir:kpi:approve --kpi revenue --period 2025Q3 --as-user U_CFO
+python -m cli.console ir:guidance --period 2025Q4 --assumptions configs/ir/assumptions.yaml
+python -m cli.console ir:earnings:build --period 2025Q3 --as-user U_IR
+python -m cli.console board:pack --month 2025-09
+```

--- a/board/pack.py
+++ b/board/pack.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+from pathlib import Path
+import json
+from datetime import datetime
+
+from ir import kpi_sot
+from ir.utils import IR_ARTIFACTS, log_metric
+
+BOARD_ARTIFACTS = Path(__file__).resolve().parents[1] / "artifacts" / "board"
+BOARD_ARTIFACTS.mkdir(parents=True, exist_ok=True)
+
+
+def build(month: str) -> Path:
+    period = f"{month[:4]}Q{(int(month[5:7])-1)//3 + 1}"
+    kpis = {r["id"]: r["value"] for r in kpi_sot.compute(period)}
+    out_dir = BOARD_ARTIFACTS / f"pack_{month.replace('-', '')}"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "index.md").write_text(f"# Board Pack {month}\n")
+    kpi_lines = "\n".join(f"- {k}: {v}" for k, v in kpis.items())
+    (out_dir / "kpi_table.md").write_text(kpi_lines)
+    (out_dir / "risks.md").write_text("No current risks\n")
+    (out_dir / "program_roadmap.md").write_text("No current programs\n")
+    (out_dir / "finance.md").write_text(f"Revenue {kpis.get('revenue')}\n")
+    log_metric("board_pack_built")
+    return out_dir

--- a/configs/ir/assumptions.yaml
+++ b/configs/ir/assumptions.yaml
@@ -1,0 +1,6 @@
+seasonality: 0.05
+pipeline_quality: 0.9
+supply_constraints: 0.95
+fx: 1.0
+gm_margin: 0.6
+opinc_margin: 0.15

--- a/configs/ir/blackouts.yaml
+++ b/configs/ir/blackouts.yaml
@@ -1,0 +1,5 @@
+quiet_periods:
+  - start: "2025-09-01"
+    end: "2025-09-30"
+blackouts:
+  - "2025-09-12"

--- a/docs/board-pack.md
+++ b/docs/board-pack.md
@@ -1,0 +1,11 @@
+# Board Pack
+
+`python -m cli.console board:pack --month 2025-09` produces a board packet under `artifacts/board/pack_202509/` containing:
+
+- `index.md`
+- `kpi_table.md`
+- `risks.md`
+- `program_roadmap.md`
+- `finance.md`
+
+The pack pulls KPI data from the source-of-truth and aggregates it for monthly board review.

--- a/docs/investor-relations.md
+++ b/docs/investor-relations.md
@@ -1,0 +1,24 @@
+# Investor Relations
+
+This module provides a deterministic, offline workflow for KPI computations, guidance, earnings materials, blackout enforcement, and disclosure logging.
+
+## KPIs
+Run `python -m cli.console ir:kpi:compute --period 2025Q3` to compute the KPI source-of-truth. Results are stored under `artifacts/ir/kpi_<period>.json`.
+
+## Sign-off
+Request sign-off using `python -m cli.console ir:kpi:signoff --kpi revenue --period 2025Q3 --request` and approve with `python -m cli.console ir:kpi:approve --kpi revenue --period 2025Q3 --as-user U_CFO`.
+
+## Guidance
+`python -m cli.console ir:guidance --period 2025Q4 --assumptions configs/ir/assumptions.yaml` writes ranges and narrative.
+
+## Earnings
+`python -m cli.console ir:earnings:build --period 2025Q3 --as-user U_IR` emits a script and deck under `artifacts/ir/earnings_<period>/`.
+
+## Blackouts
+Configured via `configs/ir/blackouts.yaml`. Check with `python -m cli.console ir:blackouts:status --date 2025-09-12`.
+
+## Disclosure Ledger
+Log external statements: `python -m cli.console ir:disclose --type press_note --path artifacts/ir/earnings_2025Q3/script.md --as-user U_IR`.
+
+## FAQ Bot
+Answer approved questions: `python -m cli.console ir:faq --q "What’s Q4 revenue guidance range?" --mode external`.

--- a/ir/blackouts.py
+++ b/ir/blackouts.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+from datetime import date, datetime
+from pathlib import Path
+from typing import List
+import os
+import yaml
+
+from .utils import ROOT
+
+CONFIG_PATH = ROOT / "configs" / "ir" / "blackouts.yaml"
+
+
+def _load() -> dict:
+    if CONFIG_PATH.exists():
+        with open(CONFIG_PATH) as f:
+            return yaml.safe_load(f)
+    return {"quiet_periods": [], "blackouts": []}
+
+
+def status(d: str) -> str:
+    cfg = _load()
+    dt = datetime.fromisoformat(d).date()
+    for bo in cfg.get("blackouts", []):
+        if datetime.fromisoformat(bo).date() == dt:
+            return "IR_BLACKOUT_BLOCK"
+    for qp in cfg.get("quiet_periods", []):
+        qs = datetime.fromisoformat(qp["start"]).date()
+        qe = datetime.fromisoformat(qp["end"]).date()
+        if qs <= dt <= qe:
+            return "IR_QUIET_PERIOD"
+    return "OPEN"
+
+
+def enforce(action: str, d: str | None = None) -> None:
+    d = d or os.environ.get("IR_TODAY") or date.today().isoformat()
+    st = status(d)
+    if st != "OPEN":
+        raise PermissionError(st)

--- a/ir/disclosures.py
+++ b/ir/disclosures.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+from pathlib import Path
+from datetime import datetime
+import json
+import hashlib
+
+from .utils import IR_ARTIFACTS, log_metric
+
+LEDGER = IR_ARTIFACTS / "disclosures.jsonl"
+
+
+def _append(entry: dict) -> None:
+    with LEDGER.open("a") as f:
+        f.write(json.dumps(entry) + "\n")
+    log_metric("ir_disclosure_logged")
+
+
+def log_file(channel: str, path: str, user: str) -> None:
+    p = Path(path)
+    content = p.read_bytes()
+    h = hashlib.sha256(content).hexdigest()
+    entry = {
+        "who": user,
+        "when": datetime.utcnow().isoformat(),
+        "channel": channel,
+        "content_hash": h,
+    }
+    _append(entry)
+
+
+def log_content(channel: str, content: str, user: str) -> None:
+    h = hashlib.sha256(content.encode()).hexdigest()
+    entry = {
+        "who": user,
+        "when": datetime.utcnow().isoformat(),
+        "channel": channel,
+        "content_hash": h,
+    }
+    _append(entry)

--- a/ir/earnings.py
+++ b/ir/earnings.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+from pathlib import Path
+import json
+from datetime import datetime
+
+from .utils import IR_ARTIFACTS, log_metric
+from . import kpi_sot
+
+
+def build(period: str, user: str) -> Path:
+    if not user.startswith("U_IR"):
+        raise PermissionError("IR role required")
+    kpi_path = IR_ARTIFACTS / f"kpi_{period}.json"
+    if not kpi_path.exists():
+        kpi_sot.compute(period)
+    data = json.loads(kpi_path.read_text())
+    out_dir = IR_ARTIFACTS / f"earnings_{period}"
+    (out_dir / "exhibits").mkdir(parents=True, exist_ok=True)
+    revenue = data["revenue"]["value"]
+    gm = data["gm_percent"]["value"]
+    script = f"# Earnings Script {period}\n\n## Highlights\n- Revenue: {revenue}\n\n## Financials\n- GM%: {gm}\n\n## Guidance\nTBD\n\n## Segment view\nTBD\n\n## Q&A seed\nTBD\n"
+    (out_dir / "script.md").write_text(script)
+    (out_dir / "deck.md").write_text(script)
+    log_metric("ir_earnings_built")
+    return out_dir

--- a/ir/faq_bot.py
+++ b/ir/faq_bot.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+from pathlib import Path
+from typing import List
+import json
+import re
+
+from .utils import IR_ARTIFACTS
+from . import blackouts, disclosures, kpi_signoff, kpi_sot
+
+APPROVED_DIRS = [IR_ARTIFACTS]
+
+
+def _approved_docs() -> List[Path]:
+    docs: List[Path] = []
+    for d in APPROVED_DIRS:
+        if d.exists():
+            docs.extend(d.rglob("*.md"))
+    return docs
+
+
+def _is_signed_off(kpi: str) -> bool:
+    path = kpi_signoff.SIGNOFF_PATH
+    if not path.exists():
+        return False
+    for line in path.read_text().splitlines():
+        rec = json.loads(line)
+        if rec["kpi"] == kpi and rec["status"] == "approved":
+            return True
+    return False
+
+
+def answer(q: str, mode: str = "internal", user: str = "U_IR") -> dict:
+    if mode == "external":
+        blackouts.enforce("faq")
+        for k in kpi_sot._registry.keys():
+            if k in q.lower() and not _is_signed_off(k):
+                return {"error": "DUTY_KPI_UNAPPROVED"}
+    tokens = [t for t in re.findall(r"[a-z0-9]+", q.lower()) if t not in {"what", "is", "the"}]
+    for doc in _approved_docs():
+        text = doc.read_text().lower()
+        rel = [tok for tok in tokens if tok in text]
+        if rel:
+            answer = "".join(text.splitlines()[:1])
+            if mode == "external":
+                disclosures.log_content("faq", answer, user)
+            return {"answer": answer, "sources": [str(doc)]}
+    if mode == "external":
+        return {"error": "DUTY_KPI_UNAPPROVED"}
+    return {"answer": "No approved information", "sources": []}

--- a/ir/guidance.py
+++ b/ir/guidance.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+from pathlib import Path
+from datetime import datetime
+import json
+yaml_available = True
+try:
+    import yaml
+except Exception:  # pragma: no cover
+    yaml_available = False
+
+from .utils import IR_ARTIFACTS, log_metric
+
+
+def _prev_period(period: str) -> str:
+    year = int(period[:4])
+    q = int(period[-1])
+    if q == 1:
+        year -= 1
+        q = 4
+    else:
+        q -= 1
+    return f"{year}Q{q}"
+
+
+def run(period: str, assumptions_path: str) -> Path:
+    if not yaml_available:
+        raise RuntimeError("yaml not available")
+    with open(assumptions_path) as f:
+        a = yaml.safe_load(f)
+    prev = _prev_period(period)
+    prev_path = IR_ARTIFACTS / f"kpi_{prev}.json"
+    if prev_path.exists():
+        prev_rev = json.loads(prev_path.read_text())["revenue"]["value"]
+    else:
+        prev_rev = 1000000
+    base = prev_rev * (1 + a.get("seasonality", 0)) * a.get("pipeline_quality", 1) * a.get("supply_constraints", 1) * a.get("fx", 1)
+    ranges = {
+        "revenue": {
+            "base": base,
+            "upside": base * 1.1,
+            "downside": base * 0.9,
+        },
+        "gm_percent": {
+            "base": a.get("gm_margin", 0.6) * 100,
+            "upside": a.get("gm_margin", 0.6) * 100 * 1.05,
+            "downside": a.get("gm_margin", 0.6) * 100 * 0.95,
+        },
+        "op_inc": {
+            "base": base * a.get("opinc_margin", 0.15),
+            "upside": base * a.get("opinc_margin", 0.15) * 1.1,
+            "downside": base * a.get("opinc_margin", 0.15) * 0.9,
+        },
+    }
+    out_dir = IR_ARTIFACTS / f"guidance_{period}"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with (out_dir / "ranges.json").open("w") as f:
+        json.dump(ranges, f, indent=2)
+    narrative = f"Revenue guidance range: {ranges['revenue']['downside']:.0f}-{ranges['revenue']['upside']:.0f}"
+    (out_dir / "narrative.md").write_text(narrative)
+    log_metric("ir_guidance_run")
+    return out_dir

--- a/ir/kpi_signoff.py
+++ b/ir/kpi_signoff.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+from pathlib import Path
+from datetime import datetime
+import json
+from typing import Dict
+
+from .utils import IR_ARTIFACTS, log_metric
+
+SIGNOFF_PATH = IR_ARTIFACTS / "signoff.jsonl"
+
+
+def _append(entry: Dict) -> None:
+    with SIGNOFF_PATH.open("a") as f:
+        f.write(json.dumps(entry) + "\n")
+
+
+def request_signoff(kpi_id: str, period: str, requester: str = "system") -> None:
+    entry = {
+        "kpi": kpi_id,
+        "period": period,
+        "status": "requested",
+        "who": requester,
+        "when": datetime.utcnow().isoformat(),
+    }
+    _append(entry)
+    log_metric("ir_signoff_req")
+
+
+def approve(kpi_id: str, period: str, user: str) -> None:
+    entry = {
+        "kpi": kpi_id,
+        "period": period,
+        "status": "approved",
+        "who": user,
+        "when": datetime.utcnow().isoformat(),
+    }
+    _append(entry)
+    log_metric("ir_signoff_approve")
+
+
+def reject(kpi_id: str, period: str, user: str) -> None:
+    entry = {
+        "kpi": kpi_id,
+        "period": period,
+        "status": "rejected",
+        "who": user,
+        "when": datetime.utcnow().isoformat(),
+    }
+    _append(entry)
+    log_metric("ir_signoff_reject")

--- a/ir/kpi_sot.py
+++ b/ir/kpi_sot.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Callable, Dict, List
+from pathlib import Path
+import json
+
+from .utils import IR_ARTIFACTS, log_metric
+
+@dataclass
+class KPI:
+    id: str
+    definition: str
+    unit: str
+    owner: str
+    calc: Callable[[str], float]
+
+_registry: Dict[str, KPI] = {}
+
+
+def register(kpi: KPI) -> None:
+    _registry[kpi.id] = kpi
+
+
+def _seed(period: str) -> int:
+    year = int(period[:4])
+    q = int(period[-1])
+    return year * 4 + q
+
+# simple deterministic calculators
+
+def _rev(period: str) -> float:
+    s = _seed(period)
+    return 1000000 + s * 1000
+
+def _gm(period: str) -> float:
+    return 60.0
+
+def _nrr(period: str) -> float:
+    return 105.0
+
+def _churn(period: str) -> float:
+    return 2.0
+
+def _wau_mau(period: str) -> float:
+    return 70.0
+
+def _uptime(period: str) -> float:
+    return 99.9
+
+def _mttr(period: str) -> float:
+    return 1.5
+
+def _ccc(period: str) -> float:
+    return 30.0
+
+def _inventory_turns(period: str) -> float:
+    return 8.0
+
+def _placeholder(period: str) -> float:
+    return 0.0
+
+# register ~12 KPIs
+register(KPI("revenue", "Total revenue", "USD", "finance", _rev))
+register(KPI("gm_percent", "Gross margin %", "%", "finance", _gm))
+register(KPI("nrr", "Net revenue retention", "%", "finance", _nrr))
+register(KPI("churn_percent", "Customer churn %", "%", "sales", _churn))
+register(KPI("wau_mau", "WAU/MAU ratio", "%", "product", _wau_mau))
+register(KPI("uptime", "Service uptime", "%", "sre", _uptime))
+register(KPI("mttr", "Mean time to recover", "hours", "sre", _mttr))
+register(KPI("ccc", "Cash conversion cycle", "days", "finance", _ccc))
+register(KPI("inventory_turns", "Inventory turns", "x", "supply", _inventory_turns))
+register(KPI("arpu", "Average revenue per user", "USD", "finance", _placeholder))
+register(KPI("cac", "Customer acquisition cost", "USD", "marketing", _placeholder))
+register(KPI("ltv", "Lifetime value", "USD", "finance", _placeholder))
+
+
+def compute(period: str) -> List[Dict[str, float]]:
+    rows = []
+    for kpi in _registry.values():
+        rows.append({"id": kpi.id, "value": kpi.calc(period), "unit": kpi.unit})
+    out = IR_ARTIFACTS / f"kpi_{period}.json"
+    with out.open("w") as f:
+        json.dump({r["id"]: r for r in rows}, f, indent=2)
+    log_metric("ir_kpi_compute")
+    return rows

--- a/ir/utils.py
+++ b/ir/utils.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+from datetime import datetime
+import json
+
+ROOT = Path(__file__).resolve().parents[1]
+IR_ARTIFACTS = ROOT / "artifacts" / "ir"
+IR_ARTIFACTS.mkdir(parents=True, exist_ok=True)
+
+METRICS_PATH = IR_ARTIFACTS / "metrics.jsonl"
+
+def log_metric(name: str) -> None:
+    entry = {"metric": name, "time": datetime.utcnow().isoformat()}
+    with METRICS_PATH.open("a") as f:
+        f.write(json.dumps(entry) + "\n")

--- a/schemas/board_pack.schema.json
+++ b/schemas/board_pack.schema.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "index": {"type": "string"},
+    "kpi_table": {"type": "string"},
+    "risks": {"type": "string"},
+    "program_roadmap": {"type": "string"},
+    "finance": {"type": "string"}
+  },
+  "required": ["index", "kpi_table", "risks", "program_roadmap", "finance"]
+}

--- a/schemas/ir_disclosure.schema.json
+++ b/schemas/ir_disclosure.schema.json
@@ -1,0 +1,10 @@
+{
+  "type": "object",
+  "properties": {
+    "who": {"type": "string"},
+    "when": {"type": "string"},
+    "channel": {"type": "string"},
+    "content_hash": {"type": "string"}
+  },
+  "required": ["who", "when", "channel", "content_hash"]
+}

--- a/schemas/ir_guidance.schema.json
+++ b/schemas/ir_guidance.schema.json
@@ -1,0 +1,33 @@
+{
+  "type": "object",
+  "properties": {
+    "revenue": {
+      "type": "object",
+      "properties": {
+        "base": {"type": "number"},
+        "upside": {"type": "number"},
+        "downside": {"type": "number"}
+      },
+      "required": ["base", "upside", "downside"]
+    },
+    "gm_percent": {
+      "type": "object",
+      "properties": {
+        "base": {"type": "number"},
+        "upside": {"type": "number"},
+        "downside": {"type": "number"}
+      },
+      "required": ["base", "upside", "downside"]
+    },
+    "op_inc": {
+      "type": "object",
+      "properties": {
+        "base": {"type": "number"},
+        "upside": {"type": "number"},
+        "downside": {"type": "number"}
+      },
+      "required": ["base", "upside", "downside"]
+    }
+  },
+  "required": ["revenue", "gm_percent", "op_inc"]
+}

--- a/schemas/ir_kpi.schema.json
+++ b/schemas/ir_kpi.schema.json
@@ -1,0 +1,14 @@
+{
+  "type": "object",
+  "patternProperties": {
+    ".+": {
+      "type": "object",
+      "properties": {
+        "id": {"type": "string"},
+        "value": {"type": "number"},
+        "unit": {"type": "string"}
+      },
+      "required": ["id", "value", "unit"]
+    }
+  }
+}

--- a/tests/test_board_pack.py
+++ b/tests/test_board_pack.py
@@ -1,0 +1,7 @@
+from board import pack
+
+
+def test_board_pack(tmp_path):
+    out = pack.build("2025-09")
+    for name in ["index.md", "kpi_table.md", "risks.md", "program_roadmap.md", "finance.md"]:
+        assert (out / name).exists()

--- a/tests/test_ir_blackouts.py
+++ b/tests/test_ir_blackouts.py
@@ -1,0 +1,6 @@
+from ir import blackouts
+
+
+def test_blackouts_status():
+    assert blackouts.status("2025-09-12") == "IR_BLACKOUT_BLOCK"
+    assert blackouts.status("2025-10-01") == "OPEN"

--- a/tests/test_ir_disclosures.py
+++ b/tests/test_ir_disclosures.py
@@ -1,0 +1,13 @@
+import json
+from pathlib import Path
+from ir import disclosures
+
+
+def test_disclosure_logged(tmp_path):
+    if disclosures.LEDGER.exists():
+        disclosures.LEDGER.unlink()
+    f = tmp_path / "note.txt"
+    f.write_text("hi")
+    disclosures.log_file("press", str(f), "U_IR")
+    rec = json.loads(disclosures.LEDGER.read_text().strip().splitlines()[-1])
+    assert rec["channel"] == "press"

--- a/tests/test_ir_faq_bot.py
+++ b/tests/test_ir_faq_bot.py
@@ -1,0 +1,18 @@
+import json
+import os
+from ir import faq_bot, guidance, earnings, kpi_sot, kpi_signoff, disclosures
+
+
+def test_faq_external_logs(tmp_path):
+    if disclosures.LEDGER.exists():
+        disclosures.LEDGER.unlink()
+    kpi_sot.compute("2025Q3")
+    kpi_signoff.request_signoff("revenue", "2025Q3")
+    kpi_signoff.approve("revenue", "2025Q3", "U_CFO")
+    guidance.run("2025Q4", "configs/ir/assumptions.yaml")
+    earnings.build("2025Q3", "U_IR")
+    os.environ["IR_TODAY"] = "2025-10-10"
+    res = faq_bot.answer("What's Q4 revenue guidance range?", "external", "U_IR")
+    assert "answer" in res
+    rec = json.loads(disclosures.LEDGER.read_text().splitlines()[-1])
+    assert rec["channel"] == "faq"

--- a/tests/test_ir_guidance.py
+++ b/tests/test_ir_guidance.py
@@ -1,0 +1,12 @@
+import json
+import jsonschema
+from ir import guidance, kpi_sot
+from ir.utils import IR_ARTIFACTS
+
+
+def test_guidance(tmp_path):
+    kpi_sot.compute("2025Q3")
+    guidance.run("2025Q4", "configs/ir/assumptions.yaml")
+    data = json.load(open(IR_ARTIFACTS / "guidance_2025Q4" / "ranges.json"))
+    schema = json.load(open("schemas/ir_guidance.schema.json"))
+    jsonschema.validate(data, schema)

--- a/tests/test_ir_kpi_sot.py
+++ b/tests/test_ir_kpi_sot.py
@@ -1,0 +1,13 @@
+import json
+import jsonschema
+from ir import kpi_sot
+from ir.utils import IR_ARTIFACTS
+
+
+def test_compute_kpis(tmp_path):
+    period = "2025Q3"
+    rows = kpi_sot.compute(period)
+    assert any(r["id"] == "revenue" for r in rows)
+    data = json.loads((IR_ARTIFACTS / f"kpi_{period}.json").read_text())
+    schema = json.load(open("schemas/ir_kpi.schema.json"))
+    jsonschema.validate(data, schema)

--- a/tests/test_ir_signoff.py
+++ b/tests/test_ir_signoff.py
@@ -1,0 +1,12 @@
+import json
+from ir import kpi_signoff
+
+
+def test_signoff_flow(tmp_path):
+    if kpi_signoff.SIGNOFF_PATH.exists():
+        kpi_signoff.SIGNOFF_PATH.unlink()
+    kpi_signoff.request_signoff("revenue", "2025Q3", "tester")
+    kpi_signoff.approve("revenue", "2025Q3", "U_CFO")
+    lines = kpi_signoff.SIGNOFF_PATH.read_text().strip().splitlines()
+    statuses = [json.loads(l)["status"] for l in lines]
+    assert "approved" in statuses


### PR DESCRIPTION
## Summary
- add KPI source-of-truth registry with sign-off workflow
- generate deterministic guidance, earnings, disclosures, and board packs
- enforce IR blackouts and expose local FAQ bot

## Testing
- `pytest tests/test_ir_kpi_sot.py tests/test_ir_signoff.py tests/test_ir_guidance.py tests/test_ir_blackouts.py tests/test_ir_disclosures.py tests/test_board_pack.py tests/test_ir_faq_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68c4e2fdf0148329ab6f6e9f2c9f2a35