### PR TITLE
feat: add offline experimentation and growth toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,3 +475,13 @@ class MyBot(BaseBot):
     def run(self, task: Task) -> BotResponse:
         ...
 ```
+
+## Growth & Experimentation Quickstart
+
+Run an experiment offline:
+
+```
+python -m cli.console exp:new --id EXP01 --name "Paywall copy" --feature paywall_v2 --variants A,B --split 0.5,0.5 --unit user
+python -m cli.console exp:assign --id EXP01 --unit user --value 12345
+python -m cli.console exp:analyze --id EXP01 --metrics configs/experiments/metrics.yaml
+```

--- a/cli/console.py
+++ b/cli/console.py
@@ -19,6 +19,9 @@ from change import calendar as change_calendar
 from status import generator as status_gen
 import time
 
+from experiments import ab_engine, flag_analytics, registry as exp_registry, rollout, review_pack
+from growth import loops as growth_loops, funnels as growth_funnels
+
 app = typer.Typer()
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -239,6 +242,102 @@ def change_conflicts(service: str = typer.Option(..., "--service")):
             typer.echo(i)
         raise typer.Exit(code=1)
     typer.echo("ok")
+
+
+@app.command("exp:new")
+def exp_new(
+    id: str = typer.Option(..., "--id"),
+    name: str = typer.Option(..., "--name"),
+    feature: str = typer.Option(..., "--feature"),
+    variants: str = typer.Option(..., "--variants"),
+    split: str = typer.Option(..., "--split"),
+    unit: str = typer.Option(..., "--unit"),
+):
+    exp = exp_registry.Experiment(
+        id=id,
+        name=name,
+        feature=feature,
+        start="", end="",
+        unit=unit,
+        variants=variants.split(","),
+        split=[float(x) for x in split.split(",")],
+    )
+    exp_registry.register_experiment(exp)
+    typer.echo("ok")
+
+
+@app.command("exp:assign")
+def exp_assign(
+    id: str = typer.Option(..., "--id"),
+    unit: str = typer.Option(..., "--unit"),
+    value: str = typer.Option(..., "--value"),
+):
+    reg = exp_registry.load_registry()
+    exp = reg[id]
+    v = exp_registry.assign_variant(exp, value)
+    typer.echo(v)
+
+
+@app.command("exp:analyze")
+def exp_analyze(
+    id: str = typer.Option(..., "--id"),
+    metrics: Path = typer.Option(..., "--metrics"),
+):
+    reg = exp_registry.load_registry()
+    exp = reg[id]
+    res = ab_engine.analyze(exp, str(metrics))
+    typer.echo(res["decision"])
+
+
+@app.command("flag:impact")
+def flag_impact(
+    feature: str = typer.Option(..., "--feature"),
+    window: int = typer.Option(14, "--window"),
+):
+    res = flag_analytics.impact(feature, window)
+    typer.echo(json.dumps(res))
+
+
+@app.command("rollout:plan")
+def rollout_plan(
+    feature: str = typer.Option(..., "--feature"),
+    stages: str = typer.Option(..., "--stages"),
+):
+    plan = rollout.plan(feature, [int(s) for s in stages.split(",")])
+    typer.echo(json.dumps(plan))
+
+
+@app.command("rollout:gate")
+def rollout_gate(
+    feature: str = typer.Option(..., "--feature"),
+    stage: int = typer.Option(..., "--stage"),
+):
+    typer.echo(rollout.gate(feature, stage))
+
+
+@app.command("growth:simulate")
+def growth_simulate(
+    horizon: int = typer.Option(..., "--horizon"),
+    config: Path = typer.Option(..., "--config"),
+):
+    res = growth_loops.simulate(horizon, str(config))
+    typer.echo(json.dumps(res["WAU"][-1]))
+
+
+@app.command("funnel:build")
+def funnel_build(
+    steps: str = typer.Option(..., "--steps"),
+    start: str = typer.Option(..., "--from"),
+    end: str = typer.Option(..., "--to"),
+):
+    res = growth_funnels.build(steps.split(","), start, end)
+    typer.echo(json.dumps(res))
+
+
+@app.command("exp:review")
+def exp_review(id: str = typer.Option(..., "--id")):
+    res = review_pack.build(id)
+    typer.echo(json.dumps(res))
 
 
 @app.command("status:build")

--- a/configs/experiments/guardrails.yaml
+++ b/configs/experiments/guardrails.yaml
@@ -1,0 +1,2 @@
+purchase_value:
+  max_degradation_pct: 0.1

--- a/configs/experiments/metrics.yaml
+++ b/configs/experiments/metrics.yaml
@@ -1,0 +1,4 @@
+activation_rate: activation_rate
+conversion: conversion
+arpu: arpu
+ttv: ttv

--- a/configs/growth/loops.yaml
+++ b/configs/growth/loops.yaml
@@ -1,0 +1,4 @@
+acquire: 10
+activate: 0.5
+retain: 0.8
+refer: 0.1

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -1,0 +1,3 @@
+# Experiments
+
+This module provides a deterministic experiment registry and offline A/B testing engine.

--- a/docs/feature-rollouts.md
+++ b/docs/feature-rollouts.md
@@ -1,0 +1,3 @@
+# Feature Rollouts
+
+Guardrailed rollout utilities for feature flags.

--- a/docs/growth-funnels.md
+++ b/docs/growth-funnels.md
@@ -1,0 +1,3 @@
+# Growth Funnels
+
+Tools for building onboarding and paywall funnels from event data.

--- a/experiments/ab_engine.py
+++ b/experiments/ab_engine.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import json
+import statistics
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict
+
+import yaml
+
+from .registry import ARTIFACTS, Experiment, assign_variant
+
+ROOT = Path(__file__).resolve().parents[1]
+EVENTS = ROOT / "fixtures" / "product" / "events.jsonl"
+
+
+def analyze(exp: Experiment, metrics_config: str) -> Dict:
+    # metrics_config unused but kept for API compatibility
+    data = [json.loads(line) for line in EVENTS.read_text().splitlines() if line.strip()]
+    users_variant = {}
+    for d in data:
+        u = str(d["user"])
+        if u not in users_variant:
+            users_variant[u] = assign_variant(exp, u)
+    counts = {v: defaultdict(int) for v in exp.variants}
+    revenue = {v: 0.0 for v in exp.variants}
+    signup_time = {v: {} for v in exp.variants}
+    ttv_values = {v: [] for v in exp.variants}
+    for d in data:
+        u = str(d["user"])
+        v = users_variant[u]
+        if v not in exp.variants:
+            continue
+        event = d["event"]
+        ts = d["ts"]
+        if event == "signup":
+            counts[v]["signup"] += 1
+            signup_time[v][u] = ts
+        elif event == "activation":
+            counts[v]["activation"] += 1
+        elif event == "paywall":
+            counts[v]["paywall"] += 1
+        elif event == "purchase":
+            counts[v]["purchase"] += 1
+            revenue[v] += d.get("value", 0)
+            if u in signup_time[v]:
+                try:
+                    start = signup_time[v][u]
+                    diff = (
+                        __import__("datetime").datetime.fromisoformat(ts)
+                        - __import__("datetime").datetime.fromisoformat(start)
+                    ).days
+                    ttv_values[v].append(diff)
+                except Exception:
+                    pass
+        elif event == "retention":
+            counts[v]["retention"] += 1
+    # compute time-to-value from ttv_values
+    results = {}
+    for v in exp.variants:
+        act_rate = counts[v]["activation"] / counts[v]["signup"] if counts[v]["signup"] else 0
+        conversion = counts[v]["purchase"] / counts[v]["paywall"] if counts[v]["paywall"] else 0
+        arpu = revenue[v] / counts[v]["signup"] if counts[v]["signup"] else 0
+        ttv = statistics.mean(ttv_values[v]) if ttv_values[v] else 0
+        results[v] = {
+            "activation_rate": act_rate,
+            "conversion": conversion,
+            "arpu": arpu,
+            "ttv": ttv,
+        }
+    A, B = exp.variants[:2]
+    metric_table = {}
+    for m in ["activation_rate", "conversion", "arpu", "ttv"]:
+        av = results[A][m]
+        bv = results[B][m]
+        lift = (bv - av) / av if av else 0
+        metric_table[m] = {"A": av, "B": bv, "lift": lift}
+    decision = "ship" if all(metric_table[m]["lift"] >= 0 for m in ["activation_rate", "conversion", "arpu"]) else "hold"
+    out = {"metrics": metric_table, "decision": decision}
+    out_dir = ARTIFACTS / exp.id
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "result.json").write_text(json.dumps(out, indent=2))
+    md_lines = ["|metric|A|B|lift|", "|---|---|---|---|"]
+    for m, v in metric_table.items():
+        md_lines.append(f"|{m}|{v['A']:.2f}|{v['B']:.2f}|{v['lift']:.2f}|")
+    md_lines.append(f"Decision: {decision}")
+    (out_dir / "result.md").write_text("\n".join(md_lines))
+    return out

--- a/experiments/flag_analytics.py
+++ b/experiments/flag_analytics.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import json
+import statistics
+from pathlib import Path
+from typing import Dict
+
+ROOT = Path(__file__).resolve().parents[1]
+EVENTS = ROOT / "fixtures" / "product" / "events.jsonl"
+
+
+def impact(feature: str, window: int) -> Dict:
+    data = [json.loads(line) for line in EVENTS.read_text().splitlines() if line.strip()]
+    with_flag = [d.get("value", 0) for d in data if feature in d.get("feature_flags", []) and d.get("event") == "purchase"]
+    without_flag = [d.get("value", 0) for d in data if feature not in d.get("feature_flags", []) and d.get("event") == "purchase"]
+    avg_with = statistics.mean(with_flag) if with_flag else 0
+    avg_without = statistics.mean(without_flag) if without_flag else 0
+    diff = avg_with - avg_without
+    return {"with": avg_with, "without": avg_without, "diff": diff}

--- a/experiments/registry.py
+++ b/experiments/registry.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import random
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List
+
+from tools import storage
+
+ROOT = Path(__file__).resolve().parents[1]
+ARTIFACTS = ROOT / "artifacts" / "experiments"
+REGISTRY_PATH = ARTIFACTS / "registry.json"
+
+
+@dataclass
+class Experiment:
+    id: str
+    name: str
+    feature: str
+    start: str
+    end: str
+    unit: str
+    variants: List[str]
+    split: List[float]
+    hypothesis: str = ""
+    metrics: List[str] = field(default_factory=list)
+
+
+def load_registry() -> Dict[str, Experiment]:
+    if REGISTRY_PATH.exists():
+        data = json.loads(REGISTRY_PATH.read_text())
+        return {k: Experiment(**v) for k, v in data.items()}
+    return {}
+
+
+def save_registry(registry: Dict[str, Experiment]) -> None:
+    ARTIFACTS.mkdir(parents=True, exist_ok=True)
+    data = {k: v.__dict__ for k, v in registry.items()}
+    REGISTRY_PATH.write_text(json.dumps(data, indent=2))
+
+
+def register_experiment(exp: Experiment) -> None:
+    registry = load_registry()
+    registry[exp.id] = exp
+    save_registry(registry)
+
+
+def assign_variant(exp: Experiment, unit_value: str) -> str:
+    """Deterministically assign a unit to a variant."""
+    seed = int(hashlib.md5(f"{exp.id}:{unit_value}".encode()).hexdigest(), 16)
+    rnd = random.Random(seed)
+    r = rnd.random()
+    cumulative = 0.0
+    for variant, weight in zip(exp.variants, exp.split):
+        cumulative += weight
+        if r < cumulative:
+            return variant
+    return "holdout"

--- a/experiments/review_pack.py
+++ b/experiments/review_pack.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict
+
+from tools import storage
+
+from .registry import ARTIFACTS, load_registry
+
+
+def build(exp_id: str) -> Dict:
+    registry = load_registry()
+    exp = registry[exp_id]
+    result_path = ARTIFACTS / exp_id / "result.json"
+    result = json.loads(result_path.read_text()) if result_path.exists() else {}
+    decision = result.get("decision", "hold")
+    out_dir = ARTIFACTS / f"review_{exp_id}"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "index.md").write_text(f"Experiment {exp_id} decision: {decision}")
+    storage.write(str(ARTIFACTS / "decisions.jsonl"), {"id": exp_id, "decision": decision})
+    return {"decision": decision}

--- a/experiments/rollout.py
+++ b/experiments/rollout.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List
+
+import yaml
+
+from .flag_analytics import impact
+
+ROOT = Path(__file__).resolve().parents[1]
+GUARDRAILS = ROOT / "configs" / "experiments" / "guardrails.yaml"
+
+
+def plan(feature: str, stages: List[int]) -> Dict:
+    return {"feature": feature, "stages": stages}
+
+
+def gate(feature: str, stage: int) -> str:
+    imp = impact(feature, 14)
+    cfg = yaml.safe_load(GUARDRAILS.read_text())
+    thr = cfg.get("purchase_value", {}).get("max_degradation_pct", 1)
+    baseline = imp["without"]
+    if baseline and (imp["diff"] < -baseline * thr):
+        return "BLOCK(GUARDRAIL_PURCHASE_VALUE)"
+    return "OK"

--- a/fixtures/product/events.jsonl
+++ b/fixtures/product/events.jsonl
@@ -1,0 +1,10 @@
+{"ts":"2025-07-01T00:00:00","user":1,"event":"signup","value":0,"feature_flags":["paywall_v2"],"cohort":[]}
+{"ts":"2025-07-02T00:00:00","user":1,"event":"activation","value":0,"feature_flags":["paywall_v2"],"cohort":[]}
+{"ts":"2025-07-03T00:00:00","user":1,"event":"paywall","value":0,"feature_flags":["paywall_v2"],"cohort":[]}
+{"ts":"2025-07-04T00:00:00","user":1,"event":"purchase","value":100,"feature_flags":["paywall_v2"],"cohort":[]}
+{"ts":"2025-07-01T00:00:00","user":5,"event":"signup","value":0,"feature_flags":[],"cohort":[]}
+{"ts":"2025-07-02T00:00:00","user":5,"event":"activation","value":0,"feature_flags":[],"cohort":[]}
+{"ts":"2025-07-03T00:00:00","user":5,"event":"paywall","value":0,"feature_flags":[],"cohort":[]}
+{"ts":"2025-07-04T00:00:00","user":5,"event":"purchase","value":50,"feature_flags":[],"cohort":[]}
+{"ts":"2025-07-05T00:00:00","user":1,"event":"retention","value":0,"feature_flags":["paywall_v2"],"cohort":[]}
+{"ts":"2025-07-05T00:00:00","user":5,"event":"retention","value":0,"feature_flags":[],"cohort":[]}

--- a/growth/funnels.py
+++ b/growth/funnels.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+ROOT = Path(__file__).resolve().parents[1]
+EVENTS = ROOT / "fixtures" / "product" / "events.jsonl"
+ARTIFACTS = ROOT / "artifacts" / "growth" / "funnels"
+
+
+def build(steps: List[str], start: str, end: str) -> Dict:
+    data = [json.loads(line) for line in EVENTS.read_text().splitlines() if line.strip()]
+    start_dt = datetime.fromisoformat(start)
+    end_dt = datetime.fromisoformat(end)
+    user_events = defaultdict(dict)
+    for d in data:
+        ts = datetime.fromisoformat(d["ts"])
+        if not (start_dt <= ts <= end_dt):
+            continue
+        user_events[d["user"]][d["event"]] = ts
+    counts = []
+    prev = None
+    for step in steps:
+        c = sum(1 for u, ev in user_events.items() if step in ev and (prev is None or prev in ev))
+        counts.append(c)
+        prev = step
+    drop = [1 - counts[i]/counts[i-1] if i>0 and counts[i-1] else 0 for i in range(len(counts))]
+    ARTIFACTS.mkdir(parents=True, exist_ok=True)
+    (ARTIFACTS / "table.csv").write_text("step,count,dropoff\n" + "\n".join(f"{s},{c},{d:.2f}" for s,c,d in zip(steps,counts,drop)))
+    (ARTIFACTS / "report.md").write_text("\n".join(f"{s}: {c}" for s,c in zip(steps,counts)))
+    return {"counts": counts, "dropoff": drop}

--- a/growth/loops.py
+++ b/growth/loops.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import json
+import yaml
+from pathlib import Path
+from typing import Dict
+
+ROOT = Path(__file__).resolve().parents[1]
+ARTIFACTS = ROOT / "artifacts" / "growth"
+
+
+def simulate(horizon_weeks: int, config_path: str) -> Dict:
+    cfg = yaml.safe_load(Path(config_path).read_text())
+    acquire = cfg.get("acquire", 0)
+    activate_rate = cfg.get("activate", 0)
+    retain_rate = cfg.get("retain", 0)
+    refer_rate = cfg.get("refer", 0)
+    users = 0
+    wau = []
+    for _ in range(horizon_weeks):
+        new_users = int(acquire * (1 + refer_rate))
+        activated = int(new_users * activate_rate)
+        users = int(users * retain_rate) + activated
+        wau.append(users)
+    report = {"WAU": wau, "MAU": wau[-4:]}
+    out_dir = ARTIFACTS / f"sim_{horizon_weeks}"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "series.csv").write_text("week,value\n" + "\n".join(f"{i},{v}" for i, v in enumerate(wau)))
+    (out_dir / "summary.md").write_text(f"final {users}")
+    return report

--- a/tests_phase32/test_ab_engine.py
+++ b/tests_phase32/test_ab_engine.py
@@ -1,0 +1,23 @@
+from experiments import registry, ab_engine
+
+
+def setup_exp():
+    exp = registry.Experiment(
+        id="EXP01",
+        name="Paywall copy",
+        feature="paywall_v2",
+        start="",
+        end="",
+        unit="user",
+        variants=["A", "B"],
+        split=[0.5, 0.5],
+    )
+    registry.register_experiment(exp)
+    return exp
+
+
+def test_ab_metrics(tmp_path):
+    exp = setup_exp()
+    res = ab_engine.analyze(exp, "configs/experiments/metrics.yaml")
+    assert "activation_rate" in res["metrics"]
+    assert res["decision"] in {"ship", "hold"}

--- a/tests_phase32/test_exp_registry.py
+++ b/tests_phase32/test_exp_registry.py
@@ -1,0 +1,21 @@
+from experiments import registry
+
+
+def test_deterministic_assignment(tmp_path):
+    exp = registry.Experiment(
+        id="EXP01",
+        name="t",
+        feature="f",
+        start="",
+        end="",
+        unit="user",
+        variants=["A", "B"],
+        split=[0.5, 0.5],
+    )
+    registry.register_experiment(exp)
+    reg = registry.load_registry()
+    exp_loaded = reg["EXP01"]
+    v1 = registry.assign_variant(exp_loaded, "12345")
+    v2 = registry.assign_variant(exp_loaded, "12345")
+    assert v1 == v2
+    assert v1 in ["A", "B"]

--- a/tests_phase32/test_flag_analytics.py
+++ b/tests_phase32/test_flag_analytics.py
@@ -1,0 +1,6 @@
+from experiments import flag_analytics
+
+
+def test_flag_impact():
+    res = flag_analytics.impact("paywall_v2", 14)
+    assert round(res["diff"], 1) == 50.0

--- a/tests_phase32/test_funnels.py
+++ b/tests_phase32/test_funnels.py
@@ -1,0 +1,12 @@
+from growth import funnels
+
+
+def test_funnel_build():
+    res = funnels.build([
+        "signup",
+        "activation",
+        "paywall",
+        "purchase",
+    ], "2025-07-01T00:00:00", "2025-07-05T00:00:00")
+    assert res["counts"][0] == 2
+    assert res["dropoff"][1] == 0

--- a/tests_phase32/test_growth_sim.py
+++ b/tests_phase32/test_growth_sim.py
@@ -1,0 +1,6 @@
+from growth import loops
+
+
+def test_growth_sim():
+    res = loops.simulate(4, "configs/growth/loops.yaml")
+    assert res["WAU"][-1] == 14

--- a/tests_phase32/test_review_pack.py
+++ b/tests_phase32/test_review_pack.py
@@ -1,0 +1,22 @@
+import json
+from experiments import registry, ab_engine, review_pack
+
+
+def test_review_pack(tmp_path):
+    exp = registry.Experiment(
+        id="EXP01",
+        name="Paywall copy",
+        feature="paywall_v2",
+        start="",
+        end="",
+        unit="user",
+        variants=["A", "B"],
+        split=[0.5, 0.5],
+    )
+    registry.register_experiment(exp)
+    ab_engine.analyze(exp, "configs/experiments/metrics.yaml")
+    res = review_pack.build("EXP01")
+    log = (registry.ARTIFACTS / "decisions.jsonl").read_text().strip().splitlines()[-1]
+    entry = json.loads(log)
+    assert entry["id"] == "EXP01"
+    assert "decision" in res

--- a/tests_phase32/test_rollout_gate.py
+++ b/tests_phase32/test_rollout_gate.py
@@ -1,0 +1,6 @@
+from experiments import rollout
+
+
+def test_gate_ok_and_block():
+    assert rollout.gate("paywall_v2", 5) == "OK"
+    assert rollout.gate("missing_feature", 5).startswith("BLOCK")


### PR DESCRIPTION
## Summary
- implement deterministic experiment registry with variant assignment
- add offline A/B engine, flag analytics, rollout gate, growth simulator and funnel builder
- expose new CLI commands and provide docs and fixtures

## Testing
- `pytest tests_phase32/test_exp_registry.py tests_phase32/test_ab_engine.py tests_phase32/test_flag_analytics.py tests_phase32/test_rollout_gate.py tests_phase32/test_growth_sim.py tests_phase32/test_funnels.py tests_phase32/test_review_pack.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4e471c1c08329bcc7e5664741e02c