### PR TITLE
feat: add R&D innovation layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,3 +491,9 @@ python -m cli.console close:sox:check --period 2025-09
 python -m cli.console close:packet --period 2025-09
 python -m cli.console close:sign --period 2025-09 --role CFO --as-user U_CFO
 ```
+
+## R&D Lab Quickstart
+
+```bash
+python -m cli.console rnd:idea:new --title "Example" --problem x --solution y --owner U1 --tags demo
+```

--- a/cli/console.py
+++ b/cli/console.py
@@ -23,6 +23,13 @@ import time
 from close import calendar as close_calendar, journal as close_journal, recon as close_recon, flux as close_flux, sox as close_sox, packet as close_packet
 
 app = typer.Typer()
+from rnd import ideas as rnd_ideas
+from rnd import experiments as rnd_exp
+from rnd import radar as rnd_radar
+from rnd import ip as rnd_ip
+from rnd import notes as rnd_notes
+from rnd import merge as rnd_merge
+from rnd import dashboard as rnd_dashboard
 
 ROOT = Path(__file__).resolve().parents[1]
 ARTIFACTS = ROOT / "artifacts"
@@ -352,6 +359,100 @@ def close_sign(period: str = typer.Option(..., "--period"), role: str = typer.Op
 def status_build():
     status_gen.build()
     typer.echo("built")
+
+if __name__ == "__main__":
+
+@app.command("rnd:idea:new")
+def rnd_idea_new(title: str = typer.Option(..., "--title"), problem: str = typer.Option(..., "--problem"), solution: str = typer.Option(..., "--solution"), owner: str = typer.Option(..., "--owner"), tags: str = typer.Option("", "--tags"), status: str = typer.Option("new", "--status")):
+    idea = rnd_ideas.new(title, problem, solution, owner, [t.strip() for t in tags.split(",") if t.strip()], status)
+    typer.echo(idea.id)
+
+
+@app.command("rnd:idea:score")
+def rnd_idea_score(id: str = typer.Option(..., "--id")):
+    idea = next((i for i in rnd_ideas.list() if i.id == id), None)
+    if not idea:
+        raise typer.Exit(code=1)
+    typer.echo(str(rnd_ideas.score(idea)))
+
+
+@app.command("rnd:idea:list")
+def rnd_idea_list(status: Optional[str] = typer.Option(None, "--status")):
+    for i in rnd_ideas.list(status):
+        typer.echo(f"{i.id}\t{i.title}\t{i.status}")
+
+
+@app.command("rnd:exp:design")
+def rnd_exp_design(idea: str = typer.Option(..., "--idea"), hypothesis: str = typer.Option(..., "--hypothesis"), method: str = typer.Option(..., "--method")):
+    exp = rnd_exp.design(idea, hypothesis, method)
+    typer.echo(exp.id)
+
+
+@app.command("rnd:exp:run")
+def rnd_exp_run_cmd(id: str = typer.Option(..., "--id")):
+    rnd_exp.run(id)
+    typer.echo("ran")
+
+
+@app.command("rnd:exp:decide")
+def rnd_exp_decide(id: str = typer.Option(..., "--id"), decision: str = typer.Option(..., "--decision"), reason: str = typer.Option(..., "--reason")):
+    rnd_exp.decide(id, decision, reason)
+    typer.echo("ok")
+
+
+@app.command("rnd:radar:build")
+def rnd_radar_build():
+    rnd_radar.build()
+    typer.echo("built")
+
+
+@app.command("rnd:radar:add")
+def rnd_radar_add(tech: str = typer.Option(..., "--tech"), ring: str = typer.Option(..., "--ring"), quadrant: str = typer.Option(..., "--quadrant"), rationale: str = typer.Option(..., "--rationale")):
+    rnd_radar.add(tech, ring, quadrant, rationale)
+    typer.echo("added")
+
+
+@app.command("rnd:radar:list")
+def rnd_radar_list(quadrant: Optional[str] = typer.Option(None, "--quadrant")):
+    for e in rnd_radar.list(quadrant):
+        typer.echo(f"{e.tech}\t{e.ring}\t{e.quadrant}")
+
+
+@app.command("rnd:ip:new")
+def rnd_ip_new(idea: str = typer.Option(..., "--idea"), title: str = typer.Option(..., "--title"), inventors: str = typer.Option(..., "--inventors"), jurisdictions: str = typer.Option(..., "--jurisdictions")):
+    disc = rnd_ip.new(idea, title, inventors.split(","), jurisdictions.split(","))
+    typer.echo(disc.id)
+
+
+@app.command("rnd:ip:update")
+def rnd_ip_update(id: str = typer.Option(..., "--id"), status: str = typer.Option(..., "--status")):
+    rnd_ip.update(id, status)
+    typer.echo("ok")
+
+
+@app.command("rnd:notes:index")
+def rnd_notes_index_cmd():
+    rnd_notes.index()
+    typer.echo("indexed")
+
+
+@app.command("rnd:notes:link")
+def rnd_notes_link(idea: str = typer.Option(..., "--idea"), note: Path = typer.Option(..., "--note", exists=True)):
+    rnd_notes.link(idea, str(note))
+    typer.echo("linked")
+
+
+@app.command("rnd:merge")
+def rnd_merge_cmd(idea: str = typer.Option(..., "--idea")):
+    rnd_merge.merge(idea)
+    typer.echo("merged")
+
+
+@app.command("rnd:dashboard")
+def rnd_dashboard_cmd():
+    rnd_dashboard.build()
+    typer.echo("built")
+
 
 if __name__ == "__main__":
     app()

--- a/configs/rnd/radar.yaml
+++ b/configs/rnd/radar.yaml
@@ -1,0 +1,12 @@
+- last_review: '2025-09-13'
+  owner: cli
+  quadrant: Languages
+  rationale: fast
+  ring: Adopt
+  tech: Rust
+- last_review: '2025-09-13'
+  owner: cli
+  quadrant: Languages
+  rationale: r
+  ring: Trial
+  tech: Go

--- a/configs/rnd/scoring.yaml
+++ b/configs/rnd/scoring.yaml
@@ -1,0 +1,6 @@
+weights:
+  impact: 0.4
+  confidence: 0.3
+  effort: 0.1
+  strategic_fit: 0.1
+  risk: -0.1

--- a/contracts/schemas/rnd_experiments.json
+++ b/contracts/schemas/rnd_experiments.json
@@ -1,0 +1,15 @@
+{
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["id", "idea_id", "status"],
+    "properties": {
+      "id": {"type": "string"},
+      "idea_id": {"type": "string"},
+      "hypothesis": {"type": "string"},
+      "method": {"type": "string"},
+      "status": {"type": "string"},
+      "decision": {"type": ["string", "null"]}
+    }
+  }
+}

--- a/contracts/schemas/rnd_ideas.json
+++ b/contracts/schemas/rnd_ideas.json
@@ -1,0 +1,15 @@
+{
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["id", "title", "owner", "status", "tags", "created_at"],
+    "properties": {
+      "id": {"type": "string"},
+      "title": {"type": "string"},
+      "owner": {"type": "string"},
+      "status": {"type": "string"},
+      "tags": {"type": "array", "items": {"type": "string"}},
+      "created_at": {"type": "string"}
+    }
+  }
+}

--- a/contracts/schemas/rnd_ip.json
+++ b/contracts/schemas/rnd_ip.json
@@ -1,0 +1,18 @@
+{
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["id", "idea_id", "title", "inventors", "jurisdictions", "status", "hash"],
+    "properties": {
+      "id": {"type": "string"},
+      "idea_id": {"type": "string"},
+      "title": {"type": "string"},
+      "inventors": {"type": "array", "items": {"type": "string"}},
+      "prior_art": {"type": "array", "items": {"type": "string"}},
+      "jurisdictions": {"type": "array", "items": {"type": "string"}},
+      "status": {"type": "string"},
+      "created_at": {"type": "string"},
+      "hash": {"type": "string"}
+    }
+  }
+}

--- a/contracts/schemas/rnd_merge.json
+++ b/contracts/schemas/rnd_merge.json
@@ -1,0 +1,9 @@
+{
+  "type": "object",
+  "required": ["idea_id", "experiment_id", "decision"],
+  "properties": {
+    "idea_id": {"type": "string"},
+    "experiment_id": {"type": "string"},
+    "decision": {"type": "string"}
+  }
+}

--- a/contracts/schemas/rnd_notes_index.json
+++ b/contracts/schemas/rnd_notes_index.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "index": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {"type": "string"}
+      }
+    }
+  },
+  "required": ["index"]
+}

--- a/contracts/schemas/rnd_radar.json
+++ b/contracts/schemas/rnd_radar.json
@@ -1,0 +1,15 @@
+{
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["tech", "ring", "quadrant", "rationale", "owner", "last_review"],
+    "properties": {
+      "tech": {"type": "string"},
+      "ring": {"type": "string"},
+      "quadrant": {"type": "string"},
+      "rationale": {"type": "string"},
+      "owner": {"type": "string"},
+      "last_review": {"type": "string"}
+    }
+  }
+}

--- a/docs/rnd-innovation.md
+++ b/docs/rnd-innovation.md
@@ -1,0 +1,6 @@
+# R&D Innovation Flow
+
+1. Capture ideas.
+2. Design and run experiments.
+3. Log IP and research notes.
+4. Update tech radar and merge into the roadmap.

--- a/fixtures/rnd/experiments/E001.json
+++ b/fixtures/rnd/experiments/E001.json
@@ -1,0 +1,1 @@
+{"improvement": 0.18}

--- a/notes/rnd/fast_charge.md
+++ b/notes/rnd/fast_charge.md
@@ -1,0 +1,3 @@
+tags: battery,edge
+
+Fast charge research note.

--- a/rnd/__init__.py
+++ b/rnd/__init__.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ARTIFACTS = ROOT / "artifacts" / "rnd"
+LAKE = ROOT / "artifacts" / "lake"
+CONFIGS = ROOT / "configs" / "rnd"
+NOTES_DIR = ROOT / "notes" / "rnd"
+FIXTURES = ROOT / "fixtures" / "rnd" / "experiments"
+
+ARTIFACTS.mkdir(parents=True, exist_ok=True)
+LAKE.mkdir(parents=True, exist_ok=True)
+CONFIGS.mkdir(parents=True, exist_ok=True)
+NOTES_DIR.mkdir(parents=True, exist_ok=True)

--- a/rnd/dashboard.py
+++ b/rnd/dashboard.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from collections import Counter, defaultdict
+from statistics import mean
+
+from tools import storage, metrics
+from . import ARTIFACTS, LAKE
+from . import ideas, experiments, radar, ip
+
+DASH_MD = ARTIFACTS / "dashboard.md"
+DASH_HTML = ARTIFACTS / "dashboard.html"
+
+
+def build() -> None:
+    idea_list = ideas.list()
+    funnel = Counter(i.status for i in idea_list)
+    tag_scores = defaultdict(list)
+    for i in idea_list:
+        s = ideas.score(i)
+        for t in i.tags:
+            tag_scores[t].append(s)
+    avg_score = {t: mean(v) for t, v in tag_scores.items()}
+    exp_data = json.loads(storage.read(str(LAKE / "rnd_experiments.json")) or "[]")
+    exp_status = Counter(e.get("status") for e in exp_data)
+    radar_data = json.loads(storage.read(str(LAKE / "rnd_radar.json")) or "[]")
+    radar_counts = Counter(e.get("ring") for e in radar_data)
+    ip_data = json.loads(storage.read(str(LAKE / "rnd_ip.json")) or "[]")
+    ip_counts = Counter(d.get("status") for d in ip_data)
+    lines = ["# R&D Dashboard", "", "## Ideas", str(dict(funnel)), "", "## Avg Score by Tag", str(avg_score), "", "## Experiments", str(dict(exp_status)), "", "## Radar", str(dict(radar_counts)), "", "## IP", str(dict(ip_counts))]
+    md = "\n".join(lines) + "\n"
+    storage.write(str(DASH_MD), md)
+    storage.write(str(DASH_HTML), f"<html><body><pre>{md}</pre></body></html>")
+    metrics.emit("rnd_dashboard_built")

--- a/rnd/experiments.py
+++ b/rnd/experiments.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, asdict
+from datetime import datetime
+from pathlib import Path
+from typing import List
+
+from tools import storage, metrics, artifacts
+from . import ROOT, ARTIFACTS, LAKE, FIXTURES
+
+COUNTER = ARTIFACTS / "last_experiment_id.txt"
+LAKE_TABLE = LAKE / "rnd_experiments.json"
+SCHEMA = "contracts/schemas/rnd_experiments.json"
+WIP_LIMIT = 2
+
+
+@dataclass
+class Experiment:
+    id: str
+    idea_id: str
+    hypothesis: str
+    method: str
+    metrics: List[str]
+    fixtures: str
+    status: str = "design"
+    decision: str | None = None
+
+
+def _next_id() -> str:
+    last = int(storage.read(str(COUNTER)) or 0)
+    new = last + 1
+    storage.write(str(COUNTER), str(new))
+    return f"E{new:03d}"
+
+
+def _write_meta(exp: Experiment) -> None:
+    path = ARTIFACTS / "experiments" / exp.id / "experiment.json"
+    storage.write(str(path), asdict(exp))
+
+
+def design(idea_id: str, hypothesis: str, method: str) -> Experiment:
+    exp_id = _next_id()
+    exp = Experiment(
+        id=exp_id,
+        idea_id=idea_id,
+        hypothesis=hypothesis,
+        method=method,
+        metrics=[],
+        fixtures=str(FIXTURES / exp_id),
+    )
+    plan_path = ARTIFACTS / "experiments" / exp_id / "plan.md"
+    content = f"# Experiment {exp_id}\n\n## Hypothesis\n{hypothesis}\n\n## Method\n{method}\n"
+    storage.write(str(plan_path), content)
+    _write_meta(exp)
+    _append_lake(exp)
+    return exp
+
+
+def _append_lake(exp: Experiment) -> None:
+    existing = json.loads(storage.read(str(LAKE_TABLE)) or "[]")
+    existing = [e for e in existing if e.get("id") != exp.id]
+    existing.append(asdict(exp))
+    artifacts.validate_and_write(str(LAKE_TABLE), existing, SCHEMA)
+
+
+def _count_running() -> int:
+    existing = json.loads(storage.read(str(LAKE_TABLE)) or "[]")
+    return sum(1 for e in existing if e.get("status") == "running")
+
+
+def run(exp_id: str) -> Path:
+    if _count_running() >= WIP_LIMIT:
+        raise RuntimeError("RND_WIP_LIMIT")
+    meta_path = ARTIFACTS / "experiments" / exp_id / "experiment.json"
+    data = json.loads(storage.read(str(meta_path)))
+    exp = Experiment(**data)
+    exp.status = "running"
+    _write_meta(exp)
+    fixture_file = Path(exp.fixtures)
+    results = {}
+    if fixture_file.is_dir():
+        for f in fixture_file.glob("*.json"):
+            results.update(json.loads(storage.read(str(f))))
+    elif fixture_file.with_suffix(".json").exists():
+        results.update(json.loads(storage.read(str(fixture_file.with_suffix(".json")))))
+    res_path = ARTIFACTS / "experiments" / exp_id / "results.json"
+    storage.write(str(res_path), results)
+    exp.status = "analyzed"
+    _write_meta(exp)
+    _append_lake(exp)
+    metrics.emit("rnd_exp_run")
+    return res_path
+
+
+def decide(exp_id: str, decision: str, reason: str) -> None:
+    meta_path = ARTIFACTS / "experiments" / exp_id / "experiment.json"
+    data = json.loads(storage.read(str(meta_path)))
+    exp = Experiment(**data)
+    exp.status = "decision"
+    exp.decision = decision
+    dec_path = ARTIFACTS / "experiments" / exp_id / "decision.md"
+    storage.write(str(dec_path), f"{decision}\n\n{reason}\n")
+    _write_meta(exp)
+    _append_lake(exp)

--- a/rnd/ideas.py
+++ b/rnd/ideas.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, asdict
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional
+
+import yaml
+
+from tools import storage, metrics, artifacts
+from . import ROOT, ARTIFACTS, LAKE, CONFIGS
+
+IDEAS_QUEUE = ARTIFACTS / "ideas.jsonl"
+BACKLOG = ARTIFACTS / "backlog.md"
+COUNTER = ARTIFACTS / "last_idea_id.txt"
+LAKE_TABLE = LAKE / "rnd_ideas.json"
+SCHEMA = "contracts/schemas/rnd_ideas.json"
+
+
+@dataclass
+class Idea:
+    id: str
+    title: str
+    problem: str
+    solution: str
+    owner: str
+    tags: List[str]
+    created_at: str
+    status: str = "new"
+
+
+def _next_id() -> str:
+    last = int(storage.read(str(COUNTER)) or 0)
+    new = last + 1
+    storage.write(str(COUNTER), str(new))
+    return f"I{new:03d}"
+
+
+def _load_weights() -> dict:
+    cfg_path = CONFIGS / "scoring.yaml"
+    data = yaml.safe_load(storage.read(str(cfg_path))) or {}
+    return data.get("weights", {})
+
+
+def _feature_hash(seed: str) -> int:
+    return int(hashlib.sha256(seed.encode("utf-8")).hexdigest(), 16) % 101
+
+
+def score(idea: Idea) -> int:
+    weights = _load_weights()
+    total = 0.0
+    weight_sum = 0.0
+    for k, w in weights.items():
+        val = _feature_hash(f"{idea.id}-{k}")
+        total += val * w
+        if w > 0:
+            weight_sum += w
+    if weight_sum == 0:
+        return 0
+    s = total / weight_sum
+    return max(0, min(100, int(s)))
+
+
+def _append_backlog(idea: Idea) -> None:
+    header = "| id | title | owner | status |\n|---|---|---|---|\n"
+    if not BACKLOG.exists():
+        storage.write(str(BACKLOG), header)
+    row = f"| {idea.id} | {idea.title} | {idea.owner} | {idea.status} |\n"
+    with open(BACKLOG, "a", encoding="utf-8") as fh:
+        fh.write(row)
+
+
+def _write_lake(record: dict) -> None:
+    existing = json.loads(storage.read(str(LAKE_TABLE)) or "[]")
+    existing.append(record)
+    artifacts.validate_and_write(str(LAKE_TABLE), existing, SCHEMA)
+
+
+def new(
+    title: str,
+    problem: str,
+    solution: str,
+    owner: str,
+    tags: List[str],
+    status: str = "new",
+) -> Idea:
+    idea_id = _next_id()
+    idea = Idea(
+        id=idea_id,
+        title=title,
+        problem=problem,
+        solution=solution,
+        owner=owner,
+        tags=tags,
+        created_at=datetime.utcnow().isoformat(),
+        status=status,
+    )
+    storage.write(str(IDEAS_QUEUE), asdict(idea))
+    _append_backlog(idea)
+    _write_lake(asdict(idea))
+    metrics.emit("rnd_idea_created")
+    return idea
+
+
+def list(status: Optional[str] = None) -> List[Idea]:
+    ideas: List[Idea] = []
+    for line in storage.read(str(IDEAS_QUEUE)).splitlines():
+        if line.strip():
+            data = json.loads(line)
+            ideas.append(Idea(**data))
+    if status:
+        ideas = [i for i in ideas if i.status == status]
+    return ideas

--- a/rnd/ip.py
+++ b/rnd/ip.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+import hashlib, json
+from dataclasses import dataclass, asdict
+from datetime import datetime
+from typing import List
+from tools import storage, metrics, artifacts
+from . import ARTIFACTS, LAKE
+
+COUNTER = ARTIFACTS / "last_disclosure_id.txt"
+LAKE_TABLE = LAKE / "rnd_ip.json"
+SCHEMA = "contracts/schemas/rnd_ip.json"
+
+@dataclass
+class Disclosure:
+    id: str
+    idea_id: str
+    title: str
+    inventors: List[str]
+    prior_art: List[str]
+    jurisdictions: List[str]
+    status: str
+    created_at: str
+    hash: str
+
+
+def _next_id() -> str:
+    last = int(storage.read(str(COUNTER)) or 0)
+    new = last + 1
+    storage.write(str(COUNTER), str(new))
+    return f"D{new:03d}"
+
+
+def _hash(data: dict) -> str:
+    content = json.dumps(data, sort_keys=True)
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def _write(disclosure: Disclosure) -> None:
+    path = ARTIFACTS / "ip" / f"{disclosure.id}.json"
+    artifacts.validate_and_write(str(path), asdict(disclosure))
+
+
+def _append_lake(disclosure: Disclosure) -> None:
+    existing = json.loads(storage.read(str(LAKE_TABLE)) or "[]")
+    existing = [d for d in existing if d.get("id") != disclosure.id]
+    existing.append(asdict(disclosure))
+    artifacts.validate_and_write(str(LAKE_TABLE), existing, SCHEMA)
+
+
+def new(idea_id: str, title: str, inventors: List[str], jurisdictions: List[str], prior_art: List[str] | None = None) -> Disclosure:
+    disc_id = _next_id()
+    data = {
+        "id": disc_id,
+        "idea_id": idea_id,
+        "title": title,
+        "inventors": inventors,
+        "prior_art": prior_art or [],
+        "jurisdictions": jurisdictions,
+        "status": "draft",
+        "created_at": datetime.utcnow().isoformat(),
+    }
+    data["hash"] = _hash(data)
+    disclosure = Disclosure(**data)
+    _write(disclosure)
+    _append_lake(disclosure)
+    metrics.emit("rnd_ip_logged")
+    _append_docket(disclosure)
+    return disclosure
+
+
+def _append_docket(disclosure: Disclosure) -> None:
+    path = ARTIFACTS / "ip" / "dockets.md"
+    header = "| id | idea | title | status |\n|---|---|---|---|\n"
+    if not path.exists():
+        storage.write(str(path), header)
+    row = f"| {disclosure.id} | {disclosure.idea_id} | {disclosure.title} | {disclosure.status} |\n"
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write(row)
+
+
+def update(disc_id: str, status: str) -> None:
+    path = ARTIFACTS / "ip" / f"{disc_id}.json"
+    data = json.loads(storage.read(str(path)))
+    if status == "filed" and not (ARTIFACTS / "ip" / "legal_ok.txt").exists():
+        raise RuntimeError("LEGAL_APPROVAL_REQUIRED")
+    data["status"] = status
+    data["hash"] = _hash(data)
+    disclosure = Disclosure(**data)
+    _write(disclosure)
+    _append_lake(disclosure)

--- a/rnd/merge.py
+++ b/rnd/merge.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tools import storage, metrics, artifacts
+from . import ARTIFACTS, ROOT
+
+LAKE_PATH = ARTIFACTS / "merge"
+PROGRAM_BOARD = ROOT / "program" / "board.json"
+MERGE_SCHEMA = "contracts/schemas/rnd_merge.json"
+
+
+def merge(idea_id: str) -> None:
+    exp_dir = ARTIFACTS / "experiments"
+    exp = None
+    for path in exp_dir.glob("E*/experiment.json"):
+        data = json.loads(storage.read(str(path)))
+        if data.get("idea_id") == idea_id:
+            exp = data
+            break
+    if not exp or not exp.get("decision"):
+        raise RuntimeError("DUTY_EXP_DECISION_MISSING")
+    item = {
+        "idea_id": idea_id,
+        "experiment_id": exp["id"],
+        "decision": exp["decision"],
+    }
+    artifacts.validate_and_write(str(LAKE_PATH / f"{idea_id}.json"), item, MERGE_SCHEMA)
+    board = json.loads(storage.read(str(PROGRAM_BOARD)) or "[]")
+    board.append(item)
+    storage.write(str(PROGRAM_BOARD), json.dumps(board))
+    metrics.emit("rnd_merge_proposed")

--- a/rnd/notes.py
+++ b/rnd/notes.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Dict, List
+
+from tools import storage, artifacts
+from . import NOTES_DIR, ARTIFACTS, LAKE
+
+INDEX_PATH = ARTIFACTS / "notes" / "index.json"
+CATALOG_PATH = ARTIFACTS / "notes" / "catalog.md"
+LINKS_PATH = ARTIFACTS / "notes" / "links.json"
+LAKE_TABLE = LAKE / "rnd_notes_index.json"
+SCHEMA = "contracts/schemas/rnd_notes_index.json"
+PII_RE = re.compile(r"[\w.]+@[\w.]+")
+
+
+def index() -> Dict[str, List[str]]:
+    notes = {}
+    inverted: Dict[str, List[str]] = {}
+    for note in NOTES_DIR.glob("*.md"):
+        text = note.read_text(encoding="utf-8")
+        if PII_RE.search(text) and not (ARTIFACTS / "notes" / "privacy.ok").exists():
+            raise RuntimeError("DUTY_PRIVACY_RND")
+        words = set(re.findall(r"[a-zA-Z]+", text.lower()))
+        tags = []
+        for line in text.splitlines():
+            if line.startswith("tags:"):
+                tags = [t.strip() for t in line.split(":", 1)[1].split(",") if t.strip()]
+                break
+        rel = str(note.relative_to(Path.cwd()))
+        notes[rel] = {"tags": tags}
+        for w in words:
+            inverted.setdefault(w, []).append(rel)
+    artifacts.validate_and_write(str(INDEX_PATH), {"index": inverted, "notes": notes}, SCHEMA)
+    rows = ["| note | tags |", "|---|---|"]
+    for path, meta in sorted(notes.items()):
+        rows.append(f"| {path} | {', '.join(meta['tags'])} |")
+    storage.write(str(CATALOG_PATH), "\n".join(rows) + "\n")
+    artifacts.validate_and_write(str(LAKE_TABLE), {"index": inverted}, SCHEMA)
+    return inverted
+
+
+def link(idea_id: str, note_path: str) -> None:
+    data = json.loads(storage.read(str(LINKS_PATH)) or "{}")
+    data.setdefault(idea_id, []).append(note_path)
+    artifacts.validate_and_write(str(LINKS_PATH), data)

--- a/rnd/radar.py
+++ b/rnd/radar.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, asdict
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional
+
+import yaml
+
+from tools import storage, metrics, artifacts
+from . import ARTIFACTS, LAKE, CONFIGS
+
+CONFIG_PATH = CONFIGS / "radar.yaml"
+LAKE_TABLE = LAKE / "rnd_radar.json"
+SCHEMA = "contracts/schemas/rnd_radar.json"
+ALLOWED_RINGS = {"Adopt", "Trial", "Assess", "Hold"}
+ALLOWED_QUADRANTS = {"Languages", "Platforms", "Tools", "Techniques"}
+
+
+@dataclass
+class RadarEntry:
+    tech: str
+    ring: str
+    quadrant: str
+    rationale: str
+    owner: str
+    last_review: str
+
+
+def _load() -> List[RadarEntry]:
+    if CONFIG_PATH.exists():
+        data = yaml.safe_load(storage.read(str(CONFIG_PATH))) or []
+    else:
+        data = []
+    return [RadarEntry(**d) for d in data]
+
+
+def _save(entries: List[RadarEntry]) -> None:
+    yaml_data = [asdict(e) for e in entries]
+    storage.write(str(CONFIG_PATH), yaml.dump(yaml_data))
+
+
+def add(tech: str, ring: str, quadrant: str, rationale: str, owner: str = "cli") -> None:
+    if ring not in ALLOWED_RINGS or quadrant not in ALLOWED_QUADRANTS:
+        raise ValueError("invalid ring/quadrant")
+    entries = _load()
+    entry = RadarEntry(
+        tech=tech,
+        ring=ring,
+        quadrant=quadrant,
+        rationale=rationale,
+        owner=owner,
+        last_review=datetime.utcnow().date().isoformat(),
+    )
+    entries.append(entry)
+    _save(entries)
+
+
+def build() -> None:
+    entries = _load()
+    for e in entries:
+        if e.ring not in ALLOWED_RINGS or e.quadrant not in ALLOWED_QUADRANTS:
+            raise ValueError("invalid entry")
+    entries.sort(key=lambda x: x.tech.lower())
+    rows = ["| tech | ring | quadrant | owner | last_review |", "|---|---|---|---|---|"]
+    for e in entries:
+        rows.append(f"| {e.tech} | {e.ring} | {e.quadrant} | {e.owner} | {e.last_review} |")
+    md = "\n".join(rows) + "\n"
+    md_path = ARTIFACTS / "radar.md"
+    storage.write(str(md_path), md)
+    html = "<html><body><pre>" + md + "</pre></body></html>"
+    storage.write(str(ARTIFACTS / "radar.html"), html)
+    json_data = [asdict(e) for e in entries]
+    artifacts.validate_and_write(str(ARTIFACTS / "radar.json"), json_data)
+    artifacts.validate_and_write(str(LAKE_TABLE), json_data, SCHEMA)
+    metrics.emit("rnd_radar_built")
+
+
+def list(quadrant: Optional[str] = None) -> List[RadarEntry]:
+    entries = _load()
+    if quadrant:
+        entries = [e for e in entries if e.quadrant == quadrant]
+    return entries

--- a/tests/test_rnd_contracts.py
+++ b/tests/test_rnd_contracts.py
@@ -1,0 +1,37 @@
+import json
+import shutil
+import jsonschema
+from rnd import ideas, experiments, radar, ip, notes
+from rnd import ARTIFACTS, LAKE
+
+
+def _clean():
+    shutil.rmtree(ARTIFACTS, ignore_errors=True)
+    shutil.rmtree(LAKE, ignore_errors=True)
+    ARTIFACTS.mkdir(parents=True, exist_ok=True)
+    LAKE.mkdir(parents=True, exist_ok=True)
+    (notes.NOTES_DIR).mkdir(parents=True, exist_ok=True)
+    # ensure sample note
+    (notes.NOTES_DIR / "sample.md").write_text("tags: test\ncontent")
+
+
+def test_contract_validation():
+    _clean()
+    idea = ideas.new("c", "p", "s", "u", [])
+    exp = experiments.design(idea.id, "h", "m")
+    experiments.run(exp.id)
+    ip.new(idea.id, "t", ["U"], ["US"])
+    radar.add("Go", "Trial", "Languages", "r")
+    radar.build()
+    notes.index()
+    checks = [
+        ("artifacts/lake/rnd_ideas.json", "contracts/schemas/rnd_ideas.json"),
+        ("artifacts/lake/rnd_experiments.json", "contracts/schemas/rnd_experiments.json"),
+        ("artifacts/lake/rnd_ip.json", "contracts/schemas/rnd_ip.json"),
+        ("artifacts/lake/rnd_radar.json", "contracts/schemas/rnd_radar.json"),
+        ("artifacts/lake/rnd_notes_index.json", "contracts/schemas/rnd_notes_index.json"),
+    ]
+    for path, schema in checks:
+        data = json.loads(open(path).read())
+        sch = json.loads(open(schema).read())
+        jsonschema.validate(data, sch)

--- a/tests/test_rnd_experiments.py
+++ b/tests/test_rnd_experiments.py
@@ -1,0 +1,24 @@
+import json
+import shutil
+from rnd import ideas, experiments
+
+
+def _clean():
+    shutil.rmtree(experiments.ARTIFACTS, ignore_errors=True)
+    shutil.rmtree(experiments.LAKE, ignore_errors=True)
+    experiments.ARTIFACTS.mkdir(parents=True, exist_ok=True)
+    experiments.LAKE.mkdir(parents=True, exist_ok=True)
+
+
+def test_run_and_decide():
+    _clean()
+    idea = ideas.new("Adaptive", "p", "s", "u", [])
+    exp = experiments.design(idea.id, "h", "m")
+    plan = experiments.ARTIFACTS / "experiments" / exp.id / "plan.md"
+    assert plan.exists()
+    experiments.run(exp.id)
+    res = experiments.ARTIFACTS / "experiments" / exp.id / "results.json"
+    assert res.exists()
+    experiments.decide(exp.id, "invest", "reason")
+    dec = experiments.ARTIFACTS / "experiments" / exp.id / "decision.md"
+    assert dec.exists()

--- a/tests/test_rnd_ideas.py
+++ b/tests/test_rnd_ideas.py
@@ -1,0 +1,25 @@
+import shutil
+from rnd import ideas
+
+
+def _clean():
+    shutil.rmtree(ideas.ARTIFACTS, ignore_errors=True)
+    shutil.rmtree(ideas.LAKE, ignore_errors=True)
+    ideas.ARTIFACTS.mkdir(parents=True, exist_ok=True)
+    ideas.LAKE.mkdir(parents=True, exist_ok=True)
+
+
+def test_scoring_deterministic():
+    _clean()
+    idea = ideas.new("Adaptive charging", "p", "s", "u", ["battery"])
+    s1 = ideas.score(idea)
+    s2 = ideas.score(idea)
+    assert s1 == s2
+
+
+def test_list_filter():
+    _clean()
+    ideas.new("a", "p", "s", "u", [], status="new")
+    ideas.new("b", "p", "s", "u", [], status="screening")
+    lst = ideas.list("screening")
+    assert len(lst) == 1 and lst[0].title == "b"

--- a/tests/test_rnd_ip.py
+++ b/tests/test_rnd_ip.py
@@ -1,0 +1,25 @@
+import json
+import shutil
+import pytest
+from rnd import ip
+
+
+def _clean():
+    shutil.rmtree(ip.ARTIFACTS, ignore_errors=True)
+    shutil.rmtree(ip.LAKE, ignore_errors=True)
+    ip.ARTIFACTS.mkdir(parents=True, exist_ok=True)
+    ip.LAKE.mkdir(parents=True, exist_ok=True)
+
+
+def test_ip_log_and_update():
+    _clean()
+    disc = ip.new("I001", "Fast", ["U1"], ["US"])
+    path = ip.ARTIFACTS / "ip" / f"{disc.id}.json"
+    data = json.loads(path.read_text())
+    old_hash = data["hash"]
+    ip.update(disc.id, "submitted")
+    data2 = json.loads(path.read_text())
+    assert data2["status"] == "submitted"
+    assert data2["hash"] != old_hash
+    with pytest.raises(RuntimeError):
+        ip.update(disc.id, "filed")

--- a/tests/test_rnd_merge.py
+++ b/tests/test_rnd_merge.py
@@ -1,0 +1,34 @@
+import json
+import shutil
+import pytest
+from tools import storage
+from rnd import ideas, experiments, merge
+
+
+def _clean():
+    shutil.rmtree(merge.ARTIFACTS, ignore_errors=True)
+    merge.ARTIFACTS.mkdir(parents=True, exist_ok=True)
+    board = merge.ROOT / "program" / "board.json"
+    if board.exists():
+        board.unlink()
+    shutil.rmtree(experiments.ARTIFACTS, ignore_errors=True)
+    experiments.ARTIFACTS.mkdir(parents=True, exist_ok=True)
+    shutil.rmtree(experiments.LAKE, ignore_errors=True)
+    experiments.LAKE.mkdir(parents=True, exist_ok=True)
+
+
+def test_merge_and_gate():
+    _clean()
+    idea = ideas.new("a", "p", "s", "u", [])
+    exp = experiments.design(idea.id, "h", "m")
+    experiments.run(exp.id)
+    experiments.decide(exp.id, "invest", "reason")
+    merge.merge(idea.id)
+    path = merge.ARTIFACTS / "merge" / f"{idea.id}.json"
+    assert path.exists()
+    board = json.loads(storage.read(str(merge.ROOT / "program" / "board.json")))
+    assert board and board[0]["idea_id"] == idea.id
+    idea2 = ideas.new("b", "p", "s", "u", [])
+    exp2 = experiments.design(idea2.id, "h", "m")
+    with pytest.raises(RuntimeError):
+        merge.merge(idea2.id)

--- a/tests/test_rnd_radar.py
+++ b/tests/test_rnd_radar.py
@@ -1,0 +1,20 @@
+import shutil
+from rnd import radar
+
+
+def _clean():
+    shutil.rmtree(radar.CONFIGS, ignore_errors=True)
+    radar.CONFIGS.mkdir(parents=True, exist_ok=True)
+    shutil.rmtree(radar.ARTIFACTS, ignore_errors=True)
+    radar.ARTIFACTS.mkdir(parents=True, exist_ok=True)
+    shutil.rmtree(radar.LAKE, ignore_errors=True)
+    radar.LAKE.mkdir(parents=True, exist_ok=True)
+
+
+def test_radar_build():
+    _clean()
+    radar.add("Rust", "Adopt", "Languages", "fast")
+    radar.build()
+    assert (radar.ARTIFACTS / "radar.md").exists()
+    lst = radar.list("Languages")
+    assert any(e.tech == "Rust" for e in lst)


### PR DESCRIPTION
## Summary
- add deterministic idea intake with scoring and backlog
- track experiments, tech radar, IP log, notes, roadmap merge and dashboard
- expose new R&D CLI commands and docs

## Testing
- `pytest tests/test_rnd_ideas.py tests/test_rnd_experiments.py tests/test_rnd_radar.py tests/test_rnd_ip.py tests/test_rnd_merge.py tests/test_rnd_contracts.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5162251008329ac2c048f25983f9c