### PR TITLE
Add offline MDM and data governance layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,3 +491,12 @@ python -m cli.console close:sox:check --period 2025-09
 python -m cli.console close:packet --period 2025-09
 python -m cli.console close:sign --period 2025-09 --role CFO --as-user U_CFO
 ```
+
+## Master Data & Governance Quickstart
+
+```bash
+python -m cli.console mdm:stage --domain account --file fixtures/mdm/account.csv
+python -m cli.console mdm:match --domain account --config configs/mdm/match_account.yaml
+python -m cli.console mdm:golden --domain account --policy configs/mdm/survivorship_account.yaml
+python -m cli.console mdm:dq --domain account --config configs/mdm/dq_account.yaml
+```

--- a/cli/console.py
+++ b/cli/console.py
@@ -19,6 +19,16 @@ from healthchecks import synthetic as hc_synth
 from change import calendar as change_calendar
 from status import generator as status_gen
 import time
+from mdm import (
+    domains as mdm_domains,
+    match as mdm_match,
+    survivorship as mdm_survivorship,
+    quality as mdm_quality,
+    catalog as mdm_catalog,
+    steward as mdm_steward,
+    lineage_diff as mdm_lineage_diff,
+    changes as mdm_changes,
+)
 
 from close import calendar as close_calendar, journal as close_journal, recon as close_recon, flux as close_flux, sox as close_sox, packet as close_packet
 
@@ -347,6 +357,66 @@ def close_packet_cmd(period: str = typer.Option(..., "--period")):
 def close_sign(period: str = typer.Option(..., "--period"), role: str = typer.Option(..., "--role"), as_user: str = typer.Option(..., "--as-user")):
     close_packet.sign(period, role, as_user)
     typer.echo("signed")
+
+
+@app.command("mdm:stage")
+def mdm_stage(domain: str = typer.Option(..., "--domain"), file: Path = typer.Option(..., "--file", exists=True)):
+    mdm_domains.stage(domain, file)
+    typer.echo("staged")
+
+
+@app.command("mdm:match")
+def mdm_match_cmd(domain: str = typer.Option(..., "--domain"), config: Path = typer.Option(..., "--config", exists=True)):
+    mdm_match.match(domain, config)
+    typer.echo("matched")
+
+
+@app.command("mdm:golden")
+def mdm_golden(domain: str = typer.Option(..., "--domain"), policy: Path = typer.Option(..., "--policy", exists=True)):
+    mdm_survivorship.merge(domain, policy)
+    typer.echo("golden")
+
+
+@app.command("mdm:dq")
+def mdm_dq_cmd(domain: str = typer.Option(..., "--domain"), config: Path = typer.Option(..., "--config", exists=True)):
+    mdm_quality.dq(domain, config)
+    typer.echo("dq")
+
+
+@app.command("mdm:catalog:build")
+def mdm_catalog_build():
+    mdm_catalog.build()
+    typer.echo("catalog")
+
+
+@app.command("mdm:steward:queue")
+def mdm_steward_queue(domain: str = typer.Option(..., "--domain")):
+    mdm_steward.queue(domain)
+    typer.echo("queued")
+
+
+@app.command("mdm:lineage:diff")
+def mdm_lineage_diff_cmd(domain: str = typer.Option(..., "--domain")):
+    mdm_lineage_diff.diff(domain)
+    typer.echo("diff")
+
+
+@app.command("mdm:change:new")
+def mdm_change_new(domain: str = typer.Option(..., "--domain"), type: str = typer.Option(..., "--type"), payload: Path = typer.Option(..., "--payload", exists=True)):
+    chg = mdm_changes.new(domain, type, payload)
+    typer.echo(chg.id)
+
+
+@app.command("mdm:change:approve")
+def mdm_change_approve(id: str = typer.Option(..., "--id"), as_user: str = typer.Option(..., "--as-user")):
+    mdm_changes.approve(id, as_user)
+    typer.echo("approved")
+
+
+@app.command("mdm:change:apply")
+def mdm_change_apply(id: str = typer.Option(..., "--id")):
+    mdm_changes.apply(id)
+    typer.echo("applied")
 
 @app.command("status:build")
 def status_build():

--- a/configs/mdm/catalog.yaml
+++ b/configs/mdm/catalog.yaml
@@ -1,0 +1,11 @@
+entries:
+  - domain: account
+    field: name
+    type: string
+    owners: [data_steward]
+    pii: false
+  - domain: account
+    field: email
+    type: string
+    owners: [data_steward]
+    pii: true

--- a/configs/mdm/dq_account.yaml
+++ b/configs/mdm/dq_account.yaml
@@ -1,0 +1,8 @@
+rules:
+  - rule: REQUIRED
+    field: email
+  - rule: UNIQUE
+    field: source_id
+  - rule: NOT_NULL_RATIO
+    field: email
+    min: 0.5

--- a/configs/mdm/dq_contact.yaml
+++ b/configs/mdm/dq_contact.yaml
@@ -1,0 +1,6 @@
+rules:
+  - rule: REQUIRED
+    field: email
+  - rule: REGEX
+    field: email
+    pattern: .+@.+\..+

--- a/configs/mdm/match_account.yaml
+++ b/configs/mdm/match_account.yaml
@@ -1,0 +1,4 @@
+weights:
+  name: 1.0
+thresholds:
+  auto_merge: 1.0

--- a/configs/mdm/match_contact.yaml
+++ b/configs/mdm/match_contact.yaml
@@ -1,0 +1,4 @@
+weights:
+  email: 1.0
+thresholds:
+  auto_merge: 1.0

--- a/configs/mdm/survivorship_account.yaml
+++ b/configs/mdm/survivorship_account.yaml
@@ -1,0 +1,3 @@
+precedence:
+  - CRM
+  - Billing

--- a/configs/mdm/survivorship_contact.yaml
+++ b/configs/mdm/survivorship_contact.yaml
@@ -1,0 +1,2 @@
+precedence:
+  - CRM

--- a/docs/data-catalog.md
+++ b/docs/data-catalog.md
@@ -1,0 +1,3 @@
+# Data Catalog
+
+Generated catalog lists governed fields, their types and PII status for each domain.

--- a/docs/mdm.md
+++ b/docs/mdm.md
@@ -1,0 +1,3 @@
+# Master Data Management
+
+This module stages raw records, performs deterministic matching and merges golden records based on source precedence. Data quality checks and lineage diffs keep datasets governed offline.

--- a/fixtures/mdm/account.csv
+++ b/fixtures/mdm/account.csv
@@ -1,0 +1,3 @@
+source,source_id,name,email,phone,updated_at
+CRM,1,Acme Corp,info@acme.com,555-111,2024-01-01
+Billing,2,ACME Corp,info@acme.com,555111,2024-01-02

--- a/fixtures/mdm/contact.csv
+++ b/fixtures/mdm/contact.csv
@@ -1,0 +1,3 @@
+source,source_id,first_name,last_name,email,updated_at
+CRM,1,Alice,Smith,alice@example.com,2024-01-01
+CRM,2,Bob,Jones,,2024-01-03

--- a/fixtures/mdm/product.csv
+++ b/fixtures/mdm/product.csv
@@ -1,0 +1,2 @@
+source,source_id,name,updated_at
+ERP,1,Gizmo,2024-01-05

--- a/fixtures/mdm/vendor.csv
+++ b/fixtures/mdm/vendor.csv
@@ -1,0 +1,2 @@
+source,source_id,name,updated_at
+ERP,1,Supplier,2024-01-06

--- a/mdm/__init__.py
+++ b/mdm/__init__.py
@@ -1,0 +1,1 @@
+"""Master Data Management utilities."""

--- a/mdm/catalog.py
+++ b/mdm/catalog.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+from tools import artifacts, storage
+
+ROOT = Path(__file__).resolve().parents[0].parents[0]
+CONFIG = ROOT / "configs" / "mdm" / "catalog.yaml"
+ARTIFACTS = ROOT / "artifacts" / "mdm"
+
+
+def load_yaml(path: Path) -> Any:
+    import yaml
+
+    return yaml.safe_load(path.read_text())
+
+
+def build(config_path: Path = CONFIG) -> List[Dict[str, Any]]:
+    cfg = load_yaml(config_path)
+    entries = cfg.get("entries", [])
+    artifacts.validate_and_write(str(ARTIFACTS / "catalog.json"), entries, None)
+    lines = ["|domain|field|type|pii|", "|---|---|---|---|"]
+    for e in entries:
+        lines.append(f"|{e['domain']}|{e['field']}|{e['type']}|{e.get('pii', False)}|")
+    artifacts.validate_and_write(str(ARTIFACTS / "catalog.md"), "\n".join(lines), None)
+    return entries
+

--- a/mdm/changes.py
+++ b/mdm/changes.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict
+
+from tools import artifacts, storage
+
+ROOT = Path(__file__).resolve().parents[0].parents[0]
+ARTIFACTS = ROOT / "artifacts" / "mdm"
+
+
+@dataclass
+class Change:
+    id: str
+    domain: str
+    type: str
+    payload: Dict[str, Any]
+    reason: str | None = None
+    status: str = "draft"
+
+    def to_json(self) -> Dict[str, Any]:
+        return self.__dict__
+
+
+def _next_id() -> str:
+    counter_path = ARTIFACTS / "changes" / "counter.txt"
+    cnt = int(storage.read(str(counter_path)) or 0) + 1
+    artifacts.validate_and_write(str(counter_path), str(cnt), None)
+    return f"CHG-{cnt:03d}"
+
+
+def new(domain: str, type: str, payload_file: Path, reason: str | None = None) -> Change:
+    payload = json.loads(storage.read(str(payload_file))) if payload_file.exists() else {}
+    chg = Change(id=_next_id(), domain=domain, type=type, payload=payload, reason=reason)
+    out = ARTIFACTS / "changes" / f"{chg.id}.json"
+    artifacts.validate_and_write(str(out), chg.to_json(), None)
+    return chg
+
+
+def approve(id: str, as_user: str) -> Change:
+    path = ARTIFACTS / "changes" / f"{id}.json"
+    data = json.loads(storage.read(str(path)))
+    data["status"] = "approved"
+    artifacts.validate_and_write(str(path), data, None)
+    return Change(**data)
+
+
+def _dq_clean(domain: str) -> bool:
+    dq_dir = ARTIFACTS / "dq"
+    files = sorted(dq_dir.glob(f"{domain}_*.json"))
+    if not files:
+        return True
+    data = json.loads(files[-1].read_text())
+    for check in data.get("checks", []):
+        if check["violations"]:
+            return False
+    return True
+
+
+def apply(id: str) -> Change:
+    path = ARTIFACTS / "changes" / f"{id}.json"
+    data = json.loads(storage.read(str(path)))
+    if data.get("status") != "approved":
+        raise ValueError("not approved")
+    if not _dq_clean(data["domain"]):
+        raise ValueError("MDM_DQ_BLOCK")
+    data["status"] = "applied"
+    artifacts.validate_and_write(str(path), data, None)
+    return Change(**data)
+

--- a/mdm/domains.py
+++ b/mdm/domains.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import csv
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Dict, Any
+
+from tools import artifacts, storage
+
+ROOT = Path(__file__).resolve().parents[0].parents[0]
+ARTIFACTS = ROOT / "artifacts" / "mdm"
+
+
+def _norm_text(val: str) -> str:
+    return val.strip().casefold()
+
+
+def _norm_phone(val: str) -> str:
+    digits = ''.join(ch for ch in val if ch.isdigit())
+    return digits
+
+
+def normalize_row(row: Dict[str, str]) -> Dict[str, Any]:
+    out: Dict[str, Any] = {}
+    for k, v in row.items():
+        if v is None:
+            out[k] = v
+            continue
+        if k in {"phone", "phone_number"}:
+            out[k] = _norm_phone(v)
+        else:
+            out[k] = _norm_text(v)
+    return out
+
+
+@dataclass
+class StagedSet:
+    domain: str
+    rows: List[Dict[str, Any]]
+
+    def to_json(self) -> Dict[str, Any]:
+        return {"domain": self.domain, "rows": self.rows}
+
+
+def stage(domain: str, file: Path) -> StagedSet:
+    with open(file, "r", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        rows = [normalize_row(r) for r in reader]
+    data = StagedSet(domain=domain, rows=rows)
+    out_path = ARTIFACTS / "staged" / f"{domain}.json"
+    artifacts.validate_and_write(str(out_path), data.to_json(), None)
+    return data
+

--- a/mdm/lineage_diff.py
+++ b/mdm/lineage_diff.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List
+
+from tools import artifacts, storage
+
+ROOT = Path(__file__).resolve().parents[0].parents[0]
+ARTIFACTS = ROOT / "artifacts" / "mdm"
+
+
+def load_golden(domain: str) -> List[Dict[str, Any]]:
+    content = storage.read(str(ARTIFACTS / "golden" / f"{domain}.json"))
+    data = json.loads(content) if content else {}
+    return data.get("rows", [])
+
+
+def diff(domain: str) -> Dict[str, Any]:
+    current = load_golden(domain)
+    prev_path = ARTIFACTS / "lineage" / f"prev_{domain}.json"
+    prev_rows = []
+    if prev_path.exists():
+        prev_rows = json.loads(prev_path.read_text()).get("rows", [])
+    prev_ids = { (r.get("source"), r.get("source_id")) for r in prev_rows }
+    curr_ids = { (r.get("source"), r.get("source_id")) for r in current }
+    adds = list(curr_ids - prev_ids)
+    removes = list(prev_ids - curr_ids)
+    summary = {"adds": len(adds), "removes": len(removes)}
+    ts = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+    out_path = ARTIFACTS / "lineage" / f"{domain}_{ts}.json"
+    artifacts.validate_and_write(str(out_path), summary, None)
+    artifacts.validate_and_write(str(prev_path), {"rows": current}, None)
+    artifacts.validate_and_write(str(ARTIFACTS / "impact.md"), f"adds={summary['adds']} removes={summary['removes']}", None)
+    return summary
+

--- a/mdm/match.py
+++ b/mdm/match.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Any, Tuple
+
+from tools import artifacts, storage
+
+ROOT = Path(__file__).resolve().parents[0].parents[0]
+ARTIFACTS = ROOT / "artifacts" / "mdm"
+
+
+def load_staged(domain: str) -> List[Dict[str, Any]]:
+    content = storage.read(str(ARTIFACTS / "staged" / f"{domain}.json"))
+    if not content:
+        return []
+    data = json.loads(content)
+    return data.get("rows", [])
+
+
+@dataclass
+class MatchConfig:
+    weights: Dict[str, float]
+    auto_merge: float
+
+
+def load_config(path: Path) -> MatchConfig:
+    import yaml
+
+    cfg = yaml.safe_load(path.read_text())
+    weights = cfg.get("weights", {})
+    thresholds = cfg.get("thresholds", {})
+    return MatchConfig(weights=weights, auto_merge=thresholds.get("auto_merge", 1.0))
+
+
+def score_pair(a: Dict[str, Any], b: Dict[str, Any], weights: Dict[str, float]) -> float:
+    score = 0.0
+    for field, weight in weights.items():
+        if a.get(field) and a.get(field) == b.get(field):
+            score += weight
+    return score
+
+
+def cluster(rows: List[Dict[str, Any]], cfg: MatchConfig) -> List[Dict[str, Any]]:
+    n = len(rows)
+    seen = [False] * n
+    clusters = []
+    for i in range(n):
+        if seen[i]:
+            continue
+        group = [i]
+        seen[i] = True
+        for j in range(i + 1, n):
+            if score_pair(rows[i], rows[j], cfg.weights) >= cfg.auto_merge:
+                group.append(j)
+                seen[j] = True
+        clusters.append({"members": group})
+    return clusters
+
+
+def match(domain: str, config: Path) -> List[Dict[str, Any]]:
+    cfg = load_config(config)
+    rows = load_staged(domain)
+    clusters = cluster(rows, cfg)
+    out_path = ARTIFACTS / "matches" / f"{domain}.json"
+    artifacts.validate_and_write(str(out_path), {"domain": domain, "clusters": clusters}, None)
+    return clusters
+

--- a/mdm/quality.py
+++ b/mdm/quality.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Dict, List
+from datetime import datetime
+
+from tools import artifacts, storage
+
+ROOT = Path(__file__).resolve().parents[0].parents[0]
+ARTIFACTS = ROOT / "artifacts" / "mdm"
+
+
+def load_yaml(path: Path) -> Any:
+    import yaml
+
+    return yaml.safe_load(path.read_text())
+
+
+def load_golden(domain: str) -> List[Dict[str, Any]]:
+    content = storage.read(str(ARTIFACTS / "golden" / f"{domain}.json"))
+    data = json.loads(content) if content else {}
+    return data.get("rows", [])
+
+
+def run_rule(rule: Dict[str, Any], rows: List[Dict[str, Any]]) -> List[str]:
+    code = rule["rule"].upper()
+    field = rule.get("field")
+    violations: List[str] = []
+    if code == "REQUIRED":
+        for idx, r in enumerate(rows):
+            if not r.get(field):
+                violations.append(f"row{idx}")
+    elif code == "UNIQUE":
+        seen = {}
+        for idx, r in enumerate(rows):
+            val = r.get(field)
+            if val in seen:
+                violations.append(f"row{idx}")
+            else:
+                seen[val] = idx
+    elif code == "REGEX":
+        pattern = re.compile(rule.get("pattern", ""))
+        for idx, r in enumerate(rows):
+            if r.get(field) and not pattern.match(r[field]):
+                violations.append(f"row{idx}")
+    elif code == "ENUM":
+        allowed = set(rule.get("set", []))
+        for idx, r in enumerate(rows):
+            if r.get(field) not in allowed:
+                violations.append(f"row{idx}")
+    elif code == "NOT_NULL_RATIO":
+        min_ratio = float(rule.get("min", 1.0))
+        not_null = sum(1 for r in rows if r.get(field))
+        ratio = not_null / len(rows) if rows else 1.0
+        if ratio < min_ratio:
+            violations.append("ratio")
+    return violations
+
+
+def dq(domain: str, config: Path) -> Dict[str, Any]:
+    rows = load_golden(domain)
+    cfg = load_yaml(config)
+    results: Dict[str, Any] = {"domain": domain, "checks": []}
+    for rule in cfg.get("rules", []):
+        violations = run_rule(rule, rows)
+        results["checks"].append({"code": rule["rule"], "violations": violations})
+    ts = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+    out_path = ARTIFACTS / "dq" / f"{domain}_{ts}.json"
+    artifacts.validate_and_write(str(out_path), results, None)
+    summary = "\n".join(f"{c['code']}:{len(c['violations'])}" for c in results["checks"])
+    artifacts.validate_and_write(str(ARTIFACTS / "dq_summary.md"), summary, None)
+    return results
+

--- a/mdm/steward.py
+++ b/mdm/steward.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List, Dict, Any
+
+from tools import artifacts, storage
+
+ROOT = Path(__file__).resolve().parents[0].parents[0]
+ARTIFACTS = ROOT / "artifacts" / "mdm"
+
+
+def latest_dq_file(domain: str) -> Path | None:
+    dq_dir = ARTIFACTS / "dq"
+    if not dq_dir.exists():
+        return None
+    files = sorted(dq_dir.glob(f"{domain}_*.json"))
+    return files[-1] if files else None
+
+
+def queue(domain: str, owner: str = "steward", sla_days: int = 5) -> List[Dict[str, Any]]:
+    dq_file = latest_dq_file(domain)
+    if not dq_file:
+        return []
+    data = json.loads(dq_file.read_text())
+    items: List[Dict[str, Any]] = []
+    for check in data.get("checks", []):
+        if check["violations"]:
+            items.append({
+                "domain": domain,
+                "code": check["code"],
+                "owner": owner,
+                "sla_days": sla_days,
+            })
+    out_path = ARTIFACTS / "steward_queue.json"
+    artifacts.validate_and_write(str(out_path), items, None)
+    return items
+

--- a/mdm/survivorship.py
+++ b/mdm/survivorship.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Any, List
+
+from tools import artifacts, storage
+
+ROOT = Path(__file__).resolve().parents[0].parents[0]
+ARTIFACTS = ROOT / "artifacts" / "mdm"
+
+
+def load_yaml(path: Path) -> Dict[str, Any]:
+    import yaml
+
+    return yaml.safe_load(path.read_text())
+
+
+def load_staged(domain: str) -> List[Dict[str, Any]]:
+    content = storage.read(str(ARTIFACTS / "staged" / f"{domain}.json"))
+    data = json.loads(content) if content else {}
+    return data.get("rows", [])
+
+
+def load_clusters(domain: str) -> List[Dict[str, Any]]:
+    content = storage.read(str(ARTIFACTS / "matches" / f"{domain}.json"))
+    data = json.loads(content) if content else {}
+    return data.get("clusters", [])
+
+
+def select_row(rows: List[Dict[str, Any]], members: List[int], precedence: List[str]) -> Dict[str, Any]:
+    candidates = [rows[i] for i in members]
+    for src in precedence:
+        for r in candidates:
+            if r.get("source") == src.casefold():
+                return r
+    # fallback to most recent updated_at
+    return max(candidates, key=lambda r: r.get("updated_at", ""))
+
+
+def merge(domain: str, policy: Path) -> List[Dict[str, Any]]:
+    pol = load_yaml(policy)
+    precedence = pol.get("precedence", [])
+    rows = load_staged(domain)
+    clusters = load_clusters(domain)
+    golden: List[Dict[str, Any]] = []
+    used = set()
+    for cluster in clusters:
+        members = cluster.get("members", [])
+        row = select_row(rows, members, precedence)
+        golden.append(row)
+        used.update(members)
+    for i, r in enumerate(rows):
+        if i not in used:
+            golden.append(r)
+    out_path = ARTIFACTS / "golden" / f"{domain}.json"
+    prev_content = storage.read(str(out_path))
+    artifacts.validate_and_write(str(out_path), {"domain": domain, "rows": golden}, None)
+    diff_path = ARTIFACTS / "golden" / f"{domain}_diff.md"
+    prev_rows = len(json.loads(prev_content).get("rows", [])) if prev_content else 0
+    diff_summary = f"prev={prev_rows} curr={len(golden)}"
+    artifacts.validate_and_write(str(diff_path), diff_summary, None)
+    return golden
+

--- a/tests/test_mdm_changes.py
+++ b/tests/test_mdm_changes.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import json
+
+from mdm import domains, match, survivorship, quality, changes
+
+
+def setup_account():
+    domains.stage('account', Path('fixtures/mdm/account.csv'))
+    match.match('account', Path('configs/mdm/match_account.yaml'))
+    survivorship.merge('account', Path('configs/mdm/survivorship_account.yaml'))
+    quality.dq('account', Path('configs/mdm/dq_account.yaml'))
+
+
+def test_change_lifecycle(tmp_path: Path):
+    setup_account()
+    payload = tmp_path / 'p.json'
+    payload.write_text('{}')
+    chg = changes.new('account', 'merge', payload)
+    assert chg.status == 'draft'
+    changes.approve(chg.id, 'U_DATA_STEWARD')
+    applied = changes.apply(chg.id)
+    assert applied.status == 'applied'

--- a/tests/test_mdm_dq.py
+++ b/tests/test_mdm_dq.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+from mdm import domains, match, survivorship, quality
+
+
+def setup_account():
+    domains.stage('account', Path('fixtures/mdm/account.csv'))
+    match.match('account', Path('configs/mdm/match_account.yaml'))
+    survivorship.merge('account', Path('configs/mdm/survivorship_account.yaml'))
+
+
+def setup_contact():
+    domains.stage('contact', Path('fixtures/mdm/contact.csv'))
+    match.match('contact', Path('configs/mdm/match_contact.yaml'))
+    survivorship.merge('contact', Path('configs/mdm/survivorship_contact.yaml'))
+
+
+def test_dq_account_clean():
+    setup_account()
+    res = quality.dq('account', Path('configs/mdm/dq_account.yaml'))
+    assert all(len(c['violations']) == 0 for c in res['checks'])
+
+
+def test_dq_contact_violation():
+    setup_contact()
+    res = quality.dq('contact', Path('configs/mdm/dq_contact.yaml'))
+    assert any(c['violations'] for c in res['checks'])

--- a/tests/test_mdm_lineage.py
+++ b/tests/test_mdm_lineage.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+from mdm import domains, match, survivorship, lineage_diff
+
+
+def test_lineage_diff_adds():
+    prev = Path('artifacts/mdm/lineage/prev_account.json')
+    if prev.exists():
+        prev.unlink()
+    domains.stage('account', Path('fixtures/mdm/account.csv'))
+    match.match('account', Path('configs/mdm/match_account.yaml'))
+    survivorship.merge('account', Path('configs/mdm/survivorship_account.yaml'))
+    summary = lineage_diff.diff('account')
+    assert summary['adds'] == 1

--- a/tests/test_mdm_match.py
+++ b/tests/test_mdm_match.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+from mdm import domains, match
+
+
+def test_match_clusters_two_records():
+    domains.stage('account', Path('fixtures/mdm/account.csv'))
+    clusters = match.match('account', Path('configs/mdm/match_account.yaml'))
+    assert len(clusters) == 1
+    assert clusters[0]['members'] == [0,1]

--- a/tests/test_mdm_stage.py
+++ b/tests/test_mdm_stage.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+import json
+
+from mdm import domains
+
+
+def test_stage_normalizes(tmp_path: Path):
+    file = Path('fixtures/mdm/account.csv')
+    staged = domains.stage('account', file)
+    out_file = Path('artifacts/mdm/staged/account.json')
+    data = json.loads(out_file.read_text())
+    assert data['rows'][0]['name'] == 'acme corp'
+    assert data['rows'][0]['phone'] == '555111'

--- a/tests/test_mdm_survivorship.py
+++ b/tests/test_mdm_survivorship.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+import json
+
+from mdm import domains, match, survivorship
+
+
+def test_survivorship_picks_preferred_source():
+    domains.stage('account', Path('fixtures/mdm/account.csv'))
+    match.match('account', Path('configs/mdm/match_account.yaml'))
+    golden = survivorship.merge('account', Path('configs/mdm/survivorship_account.yaml'))
+    assert golden[0]['source'] == 'crm'
+    assert len(golden) == 1


### PR DESCRIPTION
## Summary
- add deterministic master data management modules for staging, matching, golden record merging, and data quality checks
- wire up mdm commands in CLI and provide fixtures and configs
- document quickstart and add tests for core mdm flows

## Testing
- `pytest tests/test_mdm_*.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c516a135508329b06760ee11bd4547