### PR TITLE
Add offline strategy and OKR governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ LLM stub on port **8000** if none is running.
 - `srv/lucidia-llm/` — minimal FastAPI echo stub (only used if you don’t already run an LLM on 8000)
 - `srv/lucia-llm/` — same stub (duplicate dir name for compatibility with earlier scripts)
 
+## Strategy & OKR Governance
+
+Minimal offline tooling to manage objectives, bets, scorecards, reviews, trade-offs, and memos.
+
 > Nothing here overwrites your existing code. The scripts are defensive: they detect paths,
 > **merge** deps, and only generate files if missing.
 

--- a/cli/console.py
+++ b/cli/console.py
@@ -12,6 +12,12 @@ from orchestrator import orchestrator, slo_report
 from orchestrator.perf import perf_timer
 from orchestrator.protocols import Task
 from tools import storage
+from strategy import okr as strat_okr
+from strategy import bets as strat_bets
+from strategy import scorecard as strat_scorecard
+from strategy import reviews as strat_reviews
+from strategy import tradeoffs as strat_tradeoffs
+from strategy import memos as strat_memos
 from services import catalog as svc_catalog
 from services import deps as svc_deps
 from runbooks import executor as rb_executor
@@ -449,6 +455,80 @@ def mfg_mrp_cmd(demand: Path = typer.Option(..., "--demand", exists=True), inven
 def status_build():
     status_gen.build()
     typer.echo("built")
+
+
+# Strategy commands
+
+@app.command("okr:new:obj")
+def okr_new_obj(level: str = typer.Option(..., "--level"), owner: str = typer.Option(..., "--owner"), period: str = typer.Option(..., "--period"), text: str = typer.Option(..., "--text")):
+    obj = strat_okr.new_objective(level, owner, period, text)
+    typer.echo(obj.id)
+
+
+@app.command("okr:new:kr")
+def okr_new_kr(obj: str = typer.Option(..., "--obj"), metric: str = typer.Option(..., "--metric"), target: float = typer.Option(..., "--target"), unit: str = typer.Option(..., "--unit"), scoring: str = typer.Option(..., "--scoring")):
+    kr = strat_okr.new_key_result(obj, metric, target, unit, scoring)
+    typer.echo(kr.id)
+
+
+@app.command("okr:link")
+def okr_link(child: str = typer.Option(..., "--child"), parent: str = typer.Option(..., "--parent")):
+    strat_okr.link(child, parent)
+    typer.echo("linked")
+
+
+@app.command("okr:validate")
+def okr_validate(period: str = typer.Option(..., "--period")):
+    ok = strat_okr.validate(period)
+    typer.echo("ok" if ok else "invalid")
+
+
+@app.command("bets:new")
+def bets_new(title: str = typer.Option(..., "--title"), owner: str = typer.Option(..., "--owner"), period: str = typer.Option(..., "--period"), est_cost: float = typer.Option(..., "--est_cost"), est_impact: float = typer.Option(..., "--est_impact"), risk: str = typer.Option(..., "--risk"), ttv: int = typer.Option(..., "--ttv")):
+    bet = strat_bets.new_bet(title, owner, period, est_cost, est_impact, risk, ttv)
+    typer.echo(bet.id)
+
+
+@app.command("bets:rank")
+def bets_rank(period: str = typer.Option(..., "--period"), scoring: Path = typer.Option(..., "--scoring", exists=False)):
+    strat_bets.rank(period, scoring)
+    typer.echo("ranked")
+
+
+@app.command("scorecard:build")
+def scorecard_build(period: str = typer.Option(..., "--period"), level: str = typer.Option(..., "--level"), owner: str = typer.Option(..., "--owner")):
+    strat_scorecard.build(period, level, owner)
+    typer.echo("built")
+
+
+@app.command("review:prepare")
+def review_prepare(date: str = typer.Option(..., "--date")):
+    strat_reviews.prepare(date)
+    typer.echo("prepared")
+
+
+@app.command("review:packet")
+def review_packet(date: str = typer.Option(..., "--date")):
+    strat_reviews.packet(date)
+    typer.echo("packet")
+
+
+@app.command("tradeoff:select")
+def tradeoff_select(period: str = typer.Option(..., "--period"), budget: float = typer.Option(..., "--budget")):
+    strat_tradeoffs.select(period, budget)
+    typer.echo("selected")
+
+
+@app.command("tradeoff:frontier")
+def tradeoff_frontier(period: str = typer.Option(..., "--period")):
+    strat_tradeoffs.frontier(period)
+    typer.echo("frontier")
+
+
+@app.command("memo:build")
+def memo_build(period: str = typer.Option(..., "--period"), theme: str = typer.Option(..., "--theme")):
+    strat_memos.build(period, theme)
+    typer.echo("memo")
 
 if __name__ == "__main__":
     app()

--- a/configs/strategy/bet_scoring.yaml
+++ b/configs/strategy/bet_scoring.yaml
@@ -1,0 +1,8 @@
+weights:
+  impact: 1.0
+  cost: 0.5
+  risk:
+    low: 0
+    med: 10
+    high: 20
+  speed: 0.2

--- a/configs/strategy/policies.yaml
+++ b/configs/strategy/policies.yaml
@@ -1,0 +1,2 @@
+min_invest:
+  security: 20

--- a/configs/strategy/rhythm.yaml
+++ b/configs/strategy/rhythm.yaml
@@ -1,0 +1,3 @@
+weekly:
+  - "Review scorecards"
+  - "Discuss bets"

--- a/contracts/schemas/bets.json
+++ b/contracts/schemas/bets.json
@@ -1,0 +1,1 @@
+{"type":"object","required":["id","period"]}

--- a/contracts/schemas/okr_links.json
+++ b/contracts/schemas/okr_links.json
@@ -1,0 +1,1 @@
+{"type":"object","required":["child","parent","period"]}

--- a/contracts/schemas/okrs.json
+++ b/contracts/schemas/okrs.json
@@ -1,0 +1,1 @@
+{"type":"object","required":["id"]}

--- a/contracts/schemas/reviews.json
+++ b/contracts/schemas/reviews.json
@@ -1,0 +1,1 @@
+{"type":"object","required":["date","agenda"]}

--- a/contracts/schemas/scorecards.json
+++ b/contracts/schemas/scorecards.json
@@ -1,0 +1,1 @@
+{"type":"object","required":["period","level","owner"]}

--- a/contracts/schemas/strategy_memos.json
+++ b/contracts/schemas/strategy_memos.json
@@ -1,0 +1,1 @@
+{"type":"object","required":["period","theme"]}

--- a/contracts/schemas/tradeoffs.json
+++ b/contracts/schemas/tradeoffs.json
@@ -1,0 +1,1 @@
+{"type":"object","required":["period","selected"]}

--- a/docs/strategy-okr.md
+++ b/docs/strategy-okr.md
@@ -1,0 +1,3 @@
+# Strategy OKR
+
+Describes the OKR cascade and scoring.

--- a/docs/strategy-rhythm.md
+++ b/docs/strategy-rhythm.md
@@ -1,0 +1,3 @@
+# Strategy Rhythm
+
+Describes review cadence and packets.

--- a/fixtures/strategy/bets_2025Q4.json
+++ b/fixtures/strategy/bets_2025Q4.json
@@ -1,0 +1,3 @@
+[
+  {"title":"APAC partner program","owner":"CRO","period":"2025Q4","est_cost_credits":50,"est_impact_score":90,"risk":"med","time_to_value_weeks":8,"theme":"growth"}
+]

--- a/fixtures/strategy/okrs_2025Q4.json
+++ b/fixtures/strategy/okrs_2025Q4.json
@@ -1,0 +1,3 @@
+[
+  {"id":"O001","level":"company","owner":"CEO","period":"2025Q4","text":"Win APAC profitably","links":[]}
+]

--- a/strategy/__init__.py
+++ b/strategy/__init__.py
@@ -1,0 +1,1 @@
+"""Strategy governance modules."""

--- a/strategy/bets.py
+++ b/strategy/bets.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import List
+
+import yaml
+
+from tools import metrics, storage
+from . import utils
+
+
+@dataclass
+class Bet:
+    id: str
+    title: str
+    owner: str
+    period: str
+    theme: str
+    est_cost_credits: float
+    est_impact_score: float
+    risk: str
+    time_to_value_weeks: int
+    score: float | None = None
+
+
+def _period_dir(period: str) -> Path:
+    return utils.ARTIFACTS / f"bets_{period}"
+
+
+def _load(period: str) -> List[dict]:
+    return utils.load_json_list(_period_dir(period) / "bets.json")
+
+
+def new_bet(title: str, owner: str, period: str, est_cost: float, est_impact: float, risk: str, ttv: int, theme: str = "") -> Bet:
+    bets = _load(period)
+    bet_id = utils.next_id("B", bets)
+    bet = Bet(
+        id=bet_id,
+        title=title,
+        owner=owner,
+        period=period,
+        theme=theme,
+        est_cost_credits=est_cost,
+        est_impact_score=est_impact,
+        risk=risk,
+        time_to_value_weeks=ttv,
+    )
+    bets.append(asdict(bet))
+    utils.write_json_list(_period_dir(period) / "bets.json", bets)
+    metrics.emit("bets_created")
+    utils.validate_and_write("bets", asdict(bet))
+    return bet
+
+
+def _score(bet: Bet, cfg: dict, max_ttv: int = 52) -> float:
+    w = cfg.get("weights", {})
+    risk_pen = w.get("risk", {}).get(bet.risk, 0)
+    speed_bonus = (max_ttv - bet.time_to_value_weeks) * w.get("speed", 0)
+    score = bet.est_impact_score * w.get("impact", 1) - bet.est_cost_credits * w.get("cost", 1) - risk_pen + speed_bonus
+    return score
+
+
+def rank(period: str, cfg_path: Path) -> List[Bet]:
+    # duty of care: require KR baseline file
+    baseline = Path("fixtures/strategy/okrs_{period}.json".format(period=period))
+    if not baseline.exists():
+        raise RuntimeError("DUTY_KR_BASELINE_MISSING")
+    bets = [Bet(**b) for b in _load(period)]
+    cfg = yaml.safe_load(storage.read(str(cfg_path))) if cfg_path.exists() else {}
+    for bet in bets:
+        bet.score = _score(bet, cfg)
+    bets.sort(key=lambda b: (-b.score, b.id))
+    lines = [f"{b.id}\t{b.title}\t{b.score:.2f}" for b in bets]
+    utils.write_json_list(_period_dir(period) / "bets.json", [asdict(b) for b in bets])
+    utils._ensure_dir(_period_dir(period) / "ranked.md")
+    storage.write(str(_period_dir(period) / "ranked.md"), "\n".join(lines))
+    metrics.emit("bets_ranked")
+    for b in bets:
+        utils.validate_and_write("bets", asdict(b))
+    return bets

--- a/strategy/memos.py
+++ b/strategy/memos.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from tools import storage, metrics
+from . import utils
+
+
+@dataclass
+class Memo:
+    period: str
+    theme: str
+    body: str
+
+
+def build(period: str, theme: str) -> Memo:
+    body = "\n".join([
+        "# Context",
+        "# What Changed",
+        "# Options",
+        "# Recommendation",
+        "# Risks",
+        "# Next Steps",
+    ])
+    out_dir = utils.ARTIFACTS / "memos" / period
+    utils._ensure_dir(out_dir / "tmp")
+    storage.write(str(out_dir / f"{theme}.md"), body)
+    metrics.emit("memos_built")
+    utils.validate_and_write("strategy_memos", {"period": period, "theme": theme})
+    return Memo(period=period, theme=theme, body=body)

--- a/strategy/okr.py
+++ b/strategy/okr.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import List
+
+from tools import metrics
+from . import utils
+
+
+@dataclass
+class Objective:
+    id: str
+    level: str
+    owner: str
+    period: str
+    text: str
+    links: List[str]
+
+
+@dataclass
+class KeyResult:
+    id: str
+    objective_id: str
+    metric: str
+    target: float
+    current: float
+    unit: str
+    confidence: float
+    scoring: str
+
+
+def _period_dir(period: str) -> Path:
+    return utils.ARTIFACTS / f"okr_{period}"
+
+
+def _load(period: str):
+    base = _period_dir(period)
+    objs = utils.load_json_list(base / "objectives.json")
+    krs = utils.load_json_list(base / "key_results.json")
+    return objs, krs
+
+
+def _find_period_for_obj(obj_id: str) -> str:
+    for path in utils.ARTIFACTS.glob("okr_*"):
+        objs = utils.load_json_list(path / "objectives.json")
+        if any(o["id"] == obj_id for o in objs):
+            return path.name.split("_")[1]
+    raise ValueError("objective not found")
+
+
+def new_objective(level: str, owner: str, period: str, text: str) -> Objective:
+    objs, _ = _load(period)
+    obj_id = utils.next_id("O", objs)
+    obj = Objective(id=obj_id, level=level, owner=owner, period=period, text=text, links=[])
+    objs.append(asdict(obj))
+    utils.write_json_list(_period_dir(period) / "objectives.json", objs)
+    metrics.emit("okr_objs_created")
+    utils.validate_and_write("okrs", asdict(obj))
+    return obj
+
+
+def new_key_result(objective_id: str, metric: str, target: float, unit: str, scoring: str) -> KeyResult:
+    period = _find_period_for_obj(objective_id)
+    _, krs = _load(period)
+    kr_id = utils.next_id("K", krs)
+    kr = KeyResult(
+        id=kr_id,
+        objective_id=objective_id,
+        metric=metric,
+        target=target,
+        current=0,
+        unit=unit,
+        confidence=1.0,
+        scoring=scoring,
+    )
+    krs.append(asdict(kr))
+    utils.write_json_list(_period_dir(period) / "key_results.json", krs)
+    metrics.emit("okr_krs_created")
+    utils.validate_and_write("okrs", asdict(kr))
+    return kr
+
+
+def link(child_id: str, parent_id: str) -> None:
+    period = _find_period_for_obj(child_id)
+    objs, _ = _load(period)
+    for obj in objs:
+        if obj["id"] == child_id:
+            if parent_id not in obj["links"]:
+                obj["links"].append(parent_id)
+    utils.write_json_list(_period_dir(period) / "objectives.json", objs)
+    metrics.emit("okr_links_valid")
+    utils.validate_and_write("okr_links", {"child": child_id, "parent": parent_id, "period": period})
+
+
+def validate(period: str) -> bool:
+    objs, _ = _load(period)
+    ok = True
+    for obj in objs:
+        if obj["level"] != "company" and not obj["links"]:
+            ok = False
+    if ok:
+        metrics.emit("okr_links_valid")
+    return ok

--- a/strategy/reviews.py
+++ b/strategy/reviews.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+import yaml
+
+from tools import storage, metrics
+from . import utils
+
+
+@dataclass
+class Review:
+    date: str
+    agenda: List[str]
+
+
+CFG_PATH = Path("configs/strategy/rhythm.yaml")
+
+
+def _load_cfg() -> dict:
+    if CFG_PATH.exists():
+        return yaml.safe_load(storage.read(str(CFG_PATH)))
+    return {}
+
+
+def prepare(date: str) -> Review:
+    cfg = _load_cfg()
+    agenda = cfg.get("weekly", [])
+    out_dir = utils.ARTIFACTS / f"review_{date}"
+    utils._ensure_dir(out_dir / "tmp")
+    storage.write(str(out_dir / "agenda.md"), "\n".join(["# Agenda"] + [f"- {a}" for a in agenda]))
+    metrics.emit("reviews_prepared")
+    utils.validate_and_write("reviews", {"date": date, "agenda": agenda})
+    return Review(date=date, agenda=agenda)
+
+
+def packet(date: str) -> Path:
+    out_dir = utils.ARTIFACTS / f"review_{date}"
+    # approvals
+    if not (out_dir / "CFO.approved").exists() or not (out_dir / "COO.approved").exists():
+        raise RuntimeError("approvals missing")
+    storage.write(str(out_dir / "packet.md"), "# Review Packet\n")
+    metrics.emit("reviews_prepared")
+    return out_dir / "packet.md"

--- a/strategy/scorecard.py
+++ b/strategy/scorecard.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+from tools import storage, metrics
+from . import utils, okr
+
+
+@dataclass
+class Scorecard:
+    period: str
+    level: str
+    owner: str
+    objectives: List[dict]
+
+
+def build(period: str, level: str, owner: str) -> Scorecard:
+    objs, krs = okr._load(period)  # type: ignore
+    objs_sel = [o for o in objs if o["level"] == level and o["owner"] == owner]
+    for obj in objs_sel:
+        obj["krs"] = [kr for kr in krs if kr["objective_id"] == obj["id"]]
+    sc = Scorecard(period=period, level=level, owner=owner, objectives=objs_sel)
+    out_dir = utils.ARTIFACTS / "scorecards" / period
+    utils._ensure_dir(out_dir / "tmp")
+    md_lines = [f"# {level.title()} Scorecard - {owner}", ""]
+    for o in objs_sel:
+        md_lines.append(f"## {o['text']}")
+        for kr in o["krs"]:
+            md_lines.append(f"- {kr['metric']}: {kr['current']}/{kr['target']} {kr['unit']}")
+    storage.write(str(out_dir / f"{level}_{owner}.md"), "\n".join(md_lines))
+    html = "<br>".join(md_lines)
+    storage.write(str(out_dir / f"{level}_{owner}.html"), html)
+    metrics.emit("scorecards_built")
+    utils.validate_and_write("scorecards", {
+        "period": period,
+        "level": level,
+        "owner": owner,
+    })
+    return sc

--- a/strategy/tradeoffs.py
+++ b/strategy/tradeoffs.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+import yaml
+
+from tools import storage, metrics
+from . import utils
+
+
+@dataclass
+class Item:
+    id: str
+    impact: float
+    cost: float
+    time: int
+    risk: str
+    strategic_fit: float
+
+
+PERIOD_DIR = lambda period: utils.ARTIFACTS / f"tradeoffs_{period}"
+
+
+def _load_bets(period: str) -> List[dict]:
+    path = utils.ARTIFACTS / f"bets_{period}" / "bets.json"
+    return utils.load_json_list(path)
+
+
+def select(period: str, budget: float) -> List[dict]:
+    bets = _load_bets(period)
+    items = sorted(bets, key=lambda b: b["est_impact_score"] / b["est_cost_credits"], reverse=True)
+    chosen = []
+    total = 0.0
+    for b in items:
+        if total + b["est_cost_credits"] <= budget:
+            chosen.append(b)
+            total += b["est_cost_credits"]
+    out_dir = PERIOD_DIR(period)
+    utils.write_json_list(out_dir / "selected.json", chosen)
+    metrics.emit("tradeoffs_selected")
+    utils.validate_and_write("tradeoffs", {"period": period, "selected": [c["id"] for c in chosen]})
+    # policy check
+    pol = yaml.safe_load(storage.read("configs/strategy/policies.yaml")) if Path("configs/strategy/policies.yaml").exists() else {}
+    mins = pol.get("min_invest", {})
+    for theme, amt in mins.items():
+        spent = sum(c["est_cost_credits"] for c in chosen if c.get("theme") == theme)
+        if spent < amt:
+            raise RuntimeError("POLICY_MIN_INVEST_BREACH")
+    return chosen
+
+
+def frontier(period: str) -> List[tuple]:
+    bets = _load_bets(period)
+    frontier = []
+    for b in bets:
+        dominated = False
+        for f in bets:
+            if f is b:
+                continue
+            if f["est_cost_credits"] <= b["est_cost_credits"] and f["est_impact_score"] >= b["est_impact_score"]:
+                dominated = True
+                break
+        if not dominated:
+            frontier.append((b["est_cost_credits"], b["est_impact_score"]))
+    out_dir = PERIOD_DIR(period)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with open(out_dir / "frontier.csv", "w", newline="", encoding="utf-8") as fh:
+        w = csv.writer(fh)
+        w.writerow(["cost", "impact"])
+        for c, i in frontier:
+            w.writerow([c, i])
+    storage.write(str(out_dir / "summary.md"), "# Trade-off Summary\n")
+    return frontier

--- a/strategy/utils.py
+++ b/strategy/utils.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, List
+
+from tools import storage, metrics
+
+ROOT = Path(__file__).resolve().parents[1]
+ARTIFACTS = ROOT / "artifacts" / "strategy"
+LAKE = ARTIFACTS / "lake"
+SCHEMAS = ROOT / "contracts" / "schemas"
+
+
+def _ensure_dir(p: Path) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+
+
+def load_json_list(path: Path) -> List[dict]:
+    if not path.exists():
+        return []
+    data = json.loads(storage.read(str(path)) or "[]")
+    return data
+
+
+def write_json_list(path: Path, data: List[dict]) -> None:
+    _ensure_dir(path)
+    storage.write(str(path), json.dumps(data, indent=2))
+
+
+def next_id(prefix: str, existing: List[dict]) -> str:
+    idx = len(existing) + 1
+    return f"{prefix}{idx:03d}"
+
+
+def validate_and_write(table: str, record: dict) -> None:
+    schema_path = SCHEMAS / f"{table}.json"
+    if schema_path.exists():
+        schema = json.loads(storage.read(str(schema_path)))
+        required = set(schema.get("required", []))
+        if not required.issubset(record.keys()):
+            missing = required - set(record.keys())
+            raise ValueError(f"schema violation for {table}: missing {missing}")
+    _ensure_dir(LAKE / f"{table}.jsonl")
+    storage.write(str(LAKE / f"{table}.jsonl"), record)

--- a/tests/strategy/test_bet_scoring.py
+++ b/tests/strategy/test_bet_scoring.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+from strategy import bets, utils
+
+
+def setup_tmp(tmp_path):
+    utils.ARTIFACTS = tmp_path
+    utils.LAKE = tmp_path / "lake"
+
+
+def test_bet_ranking(tmp_path, monkeypatch):
+    setup_tmp(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    baseline = Path("fixtures/strategy/okrs_2025Q4.json")
+    baseline.parent.mkdir(parents=True, exist_ok=True)
+    baseline.write_text("[]")
+    cfg = Path("cfg.yaml")
+    cfg.write_text("weights:\n  impact: 1\n  cost: 1\n  risk:\n    med: 0\n  speed: 0\n")
+    bet = bets.new_bet("prog", "CRO", "2025Q4", 10, 20, "med", 8)
+    ranked = bets.rank("2025Q4", cfg)
+    assert ranked[0].id == bet.id

--- a/tests/strategy/test_contracts.py
+++ b/tests/strategy/test_contracts.py
@@ -1,0 +1,14 @@
+import pytest
+from strategy import utils
+
+
+def setup_tmp(tmp_path):
+    utils.ARTIFACTS = tmp_path
+    utils.LAKE = tmp_path / "lake"
+
+
+def test_contracts(tmp_path):
+    setup_tmp(tmp_path)
+    utils.validate_and_write("bets", {"id": "B1", "period": "p"})
+    with pytest.raises(ValueError):
+        utils.validate_and_write("bets", {"id": "B1"})

--- a/tests/strategy/test_memos.py
+++ b/tests/strategy/test_memos.py
@@ -1,0 +1,12 @@
+from strategy import memos, utils
+
+
+def setup_tmp(tmp_path):
+    utils.ARTIFACTS = tmp_path
+    utils.LAKE = tmp_path / "lake"
+
+
+def test_memo(tmp_path):
+    setup_tmp(tmp_path)
+    m = memos.build("2025Q4", "APAC")
+    assert "Context" in m.body

--- a/tests/strategy/test_okr_cascade.py
+++ b/tests/strategy/test_okr_cascade.py
@@ -1,0 +1,17 @@
+import json
+from pathlib import Path
+
+from strategy import okr, utils
+
+
+def setup_tmp(tmp_path):
+    utils.ARTIFACTS = tmp_path
+    utils.LAKE = tmp_path / "lake"
+
+
+def test_okr_flow(tmp_path):
+    setup_tmp(tmp_path)
+    obj = okr.new_objective("company", "CEO", "2025Q4", "Win")
+    kr = okr.new_key_result(obj.id, "GM%", 36, "pct", "linear")
+    okr.link(obj.id, obj.id)
+    assert okr.validate("2025Q4")

--- a/tests/strategy/test_reviews.py
+++ b/tests/strategy/test_reviews.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from strategy import reviews, utils
+
+
+def setup_tmp(tmp_path):
+    utils.ARTIFACTS = tmp_path
+    utils.LAKE = tmp_path / "lake"
+
+
+def test_review(tmp_path, monkeypatch):
+    setup_tmp(tmp_path)
+    cfg = tmp_path / "rhythm.yaml"
+    cfg.write_text("weekly:\n  - test\n")
+    monkeypatch.setattr(reviews, "CFG_PATH", cfg)
+    reviews.prepare("2025-10-03")
+    (tmp_path / "review_2025-10-03" / "CFO.approved").write_text("ok")
+    (tmp_path / "review_2025-10-03" / "COO.approved").write_text("ok")
+    reviews.packet("2025-10-03")

--- a/tests/strategy/test_scorecard.py
+++ b/tests/strategy/test_scorecard.py
@@ -1,0 +1,14 @@
+from strategy import scorecard, okr, utils
+
+
+def setup_tmp(tmp_path):
+    utils.ARTIFACTS = tmp_path
+    utils.LAKE = tmp_path / "lake"
+
+
+def test_scorecard(tmp_path):
+    setup_tmp(tmp_path)
+    obj = okr.new_objective("org", "Product", "2025Q4", "Ship")
+    okr.new_key_result(obj.id, "Ship", 1, "count", "binary")
+    sc = scorecard.build("2025Q4", "org", "Product")
+    assert sc.objectives

--- a/tests/strategy/test_tradeoffs.py
+++ b/tests/strategy/test_tradeoffs.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from strategy import tradeoffs, bets, utils
+
+
+def setup_tmp(tmp_path):
+    utils.ARTIFACTS = tmp_path
+    utils.LAKE = tmp_path / "lake"
+
+
+def test_tradeoff(tmp_path, monkeypatch):
+    setup_tmp(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    baseline = Path("fixtures/strategy/okrs_2025Q4.json")
+    baseline.parent.mkdir(parents=True, exist_ok=True)
+    baseline.write_text("[]")
+    bets.new_bet("b1", "CRO", "2025Q4", 50, 100, "low", 4, theme="security")
+    bets.new_bet("b2", "CRO", "2025Q4", 60, 80, "low", 4, theme="growth")
+    tradeoffs.select("2025Q4", 100)
+    tradeoffs.frontier("2025Q4")


### PR DESCRIPTION
## Summary
- add strategy modules for OKRs, bets, scorecards, reviews, tradeoffs, and memos
- wire new strategy commands into CLI
- provide sample configs, fixtures, and docs with basic schemas

## Testing
- `pytest tests/strategy -q`


------
https://chatgpt.com/codex/tasks/task_e_68c51b8fa9688329ba97dff9e0f05ed4