### PR TITLE
feat: add prompt site and routing schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2025-09-30
+
+### Features
+
+- wire up where-used CLI
+- scaffold Next.js site for Codex prompts with page, component, API, and sitemap
+- add deterministic artifact hashing with optional tag-based release workflow
+- document quickstart commands in README
+- allow optional strict schema validation for routing
+
 ## 1.0.0 (2025-09-12)
 
 

--- a/README.md
+++ b/README.md
@@ -498,4 +498,21 @@ python -m cli.console close:sign --period 2025-09 --role CFO --as-user U_CFO
 python -m cli.console plm:items:load --dir fixtures/plm/items
 python -m cli.console plm:bom:load --dir fixtures/plm/boms
 python -m cli.console plm:bom:explode --item PROD-100 --rev A --level 2
+python -m cli.console plm:bom:where-used --component COMP-1
 ```
+
+## Codex Prompt Site Quickstart
+
+```
+npm --prefix sites/codex-prompts run dev
+```
+
+Serves the markdown prompts directory as a Next.js site with plain-text API and sitemap.
+
+## Artifact Release
+
+```
+python -m tools.artifacts artifacts/data.json --schema schemas/routing.schema.json --tag
+```
+
+Generates a deterministic hash for the artifact and optionally tags the current commit.

--- a/cli/console.py
+++ b/cli/console.py
@@ -374,6 +374,13 @@ def plm_bom_explode(item: str = typer.Option(..., "--item"), rev: str = typer.Op
         typer.echo(f"{lvl}\t{comp}\t{qty}")
 
 
+@app.command("plm:bom:where-used")
+def plm_bom_where_used(component: str = typer.Option(..., "--component")):
+    used = plm_bom.where_used(component)
+    for item_id, rev in used:
+        typer.echo(f"{item_id}\t{rev}")
+
+
 @app.command("plm:eco:new")
 def plm_eco_new(item: str = typer.Option(..., "--item"), from_rev: str = typer.Option(..., "--from"), to_rev: str = typer.Option(..., "--to"), reason: str = typer.Option(..., "--reason")):
     ch = plm_eco.new_change(item, from_rev, to_rev, reason)
@@ -405,8 +412,11 @@ def mfg_wc_load(file: Path = typer.Option(..., "--file", exists=True, dir_okay=F
 
 
 @app.command("mfg:routing:load")
-def mfg_routing_load(dir: Path = typer.Option(..., "--dir", exists=True, file_okay=False)):
-    mfg_routing.load_routings(str(dir))
+def mfg_routing_load(
+    dir: Path = typer.Option(..., "--dir", exists=True, file_okay=False),
+    strict: bool = typer.Option(False, "--strict"),
+):
+    mfg_routing.load_routings(str(dir), strict)
     typer.echo("ok")
 
 

--- a/schemas/routing.schema.json
+++ b/schemas/routing.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "item_rev": {"type": "string"},
+    "steps": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "wc": {"type": "string"},
+          "op": {"type": "string"},
+          "std_time_min": {"type": "number"},
+          "yield_pct": {"type": "number"},
+          "instructions_path": {"type": "string"}
+        },
+        "required": ["wc", "op", "std_time_min", "yield_pct"]
+      }
+    }
+  },
+  "required": ["item_rev", "steps"]
+}

--- a/sites/codex-prompts/components/PromptList.tsx
+++ b/sites/codex-prompts/components/PromptList.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link'
+
+export default function PromptList({ prompts }: { prompts: { slug: string }[] }) {
+  return (
+    <ul>
+      {prompts.map(p => (
+        <li key={p.slug}>
+          <Link href={`/${p.slug}`}>{p.slug}</Link> | <Link href={`/api/${p.slug}`}>plain</Link>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/sites/codex-prompts/next-env.d.ts
+++ b/sites/codex-prompts/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+export {}

--- a/sites/codex-prompts/next.config.mjs
+++ b/sites/codex-prompts/next.config.mjs
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {}
+
+export default nextConfig

--- a/sites/codex-prompts/package.json
+++ b/sites/codex-prompts/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "codex-prompts",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/sites/codex-prompts/pages/[slug].tsx
+++ b/sites/codex-prompts/pages/[slug].tsx
@@ -1,0 +1,20 @@
+import fs from 'fs'
+import path from 'path'
+import { GetStaticPaths, GetStaticProps } from 'next'
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const dir = path.join(process.cwd(), '../../prompts')
+  const files = fs.readdirSync(dir).filter(f => f.endsWith('.md'))
+  const paths = files.map(f => ({ params: { slug: f.replace(/\.md$/, '') } }))
+  return { paths, fallback: false }
+}
+
+export const getStaticProps: GetStaticProps = async ({ params }) => {
+  const file = path.join(process.cwd(), '../../prompts', `${params!.slug}.md`)
+  const content = fs.readFileSync(file, 'utf-8')
+  return { props: { content } }
+}
+
+export default function PromptPage({ content }: { content: string }) {
+  return <pre>{content}</pre>
+}

--- a/sites/codex-prompts/pages/api/[slug].ts
+++ b/sites/codex-prompts/pages/api/[slug].ts
@@ -1,0 +1,11 @@
+import fs from 'fs'
+import path from 'path'
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { slug } = req.query
+  const file = path.join(process.cwd(), '../../prompts', `${slug}.md`)
+  const content = fs.readFileSync(file, 'utf-8')
+  res.setHeader('Content-Type', 'text/plain')
+  res.send(content)
+}

--- a/sites/codex-prompts/pages/index.tsx
+++ b/sites/codex-prompts/pages/index.tsx
@@ -1,0 +1,19 @@
+import fs from 'fs'
+import path from 'path'
+import PromptList from '../components/PromptList'
+
+export async function getStaticProps() {
+  const dir = path.join(process.cwd(), '../../prompts')
+  const files = fs.readdirSync(dir).filter(f => f.endsWith('.md'))
+  const prompts = files.map(f => ({ slug: f.replace(/\.md$/, '') }))
+  return { props: { prompts } }
+}
+
+export default function Home({ prompts }: { prompts: { slug: string }[] }) {
+  return (
+    <div>
+      <h1>Codex Prompts</h1>
+      <PromptList prompts={prompts} />
+    </div>
+  )
+}

--- a/sites/codex-prompts/pages/sitemap.xml.ts
+++ b/sites/codex-prompts/pages/sitemap.xml.ts
@@ -1,0 +1,16 @@
+import fs from 'fs'
+import path from 'path'
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export default function handler(_req: NextApiRequest, res: NextApiResponse) {
+  const dir = path.join(process.cwd(), '../../prompts')
+  const files = fs.readdirSync(dir).filter(f => f.endsWith('.md'))
+  const urls = files
+    .map(f => f.replace(/\.md$/, ''))
+    .map(slug => `<url><loc>/${slug}</loc></url>`)
+    .join('')
+  const xml = `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${urls}</urlset>`
+  res.setHeader('Content-Type', 'text/xml')
+  res.write(xml)
+  res.end()
+}

--- a/sites/codex-prompts/tsconfig.json
+++ b/sites/codex-prompts/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/tools/artifacts.py
+++ b/tools/artifacts.py
@@ -1,5 +1,7 @@
+import argparse
 import hashlib
 import json
+import subprocess
 from typing import Any
 
 from . import storage
@@ -18,3 +20,25 @@ def validate_and_write(path: str, data: Any, schema_path: str | None = None) -> 
     storage.write(path, content)
     sig = hashlib.sha256(content.encode("utf-8")).hexdigest()
     storage.write(path + ".sig", sig)
+
+
+def hash_and_release(path: str, schema_path: str | None = None, tag: bool = False) -> str:
+    data = json.loads(storage.read(path))
+    validate_and_write(path, data, schema_path)
+    sig = storage.read(path + ".sig")
+    if tag:
+        subprocess.run(["git", "tag", f"rel-{sig[:12]}"])
+    return sig
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("path")
+    parser.add_argument("--schema", dest="schema", default=None)
+    parser.add_argument("--tag", action="store_true")
+    args = parser.parse_args()
+    hash_and_release(args.path, args.schema, args.tag)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- wire up `plm:bom:where-used` CLI command
- scaffold Next.js site to publish Codex prompts with HTML pages, API, and sitemap
- add deterministic artifact hashing helper with optional tag release
- document quickstart commands in README
- support optional strict schema validation when loading routings

## Testing
- `npm test` *(fails: 503 Service Unavailable - GET http://verdaccio.internal:4873/jest)*

------
https://chatgpt.com/codex/tasks/task_e_68c51d054dc083299af249327f23a8fb