### PR TITLE
feat: add codex index page

### DIFF
--- a/apps/portals/app/codex/page.tsx
+++ b/apps/portals/app/codex/page.tsx
@@ -1,9 +1,94 @@
-import { Card } from "../../components/ui/card";
+"use client";
 
-export default function CodexPage() {
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import CodexSearch from "../../components/CodexSearch";
+import CodexTag from "../../components/CodexTag";
+
+interface Item {
+  id: string;
+  slug: string;
+  title: string;
+  tags?: string[];
+  updated?: string;
+}
+
+export default function CodexIndex() {
+  const [items, setItems] = useState<Item[]>([]);
+  const [q, setQ] = useState("");
+  const [tag, setTag] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch("/codex-index.json")
+      .then((r) => r.json())
+      .then(setItems)
+      .catch(() => setItems([]));
+  }, []);
+
+  const allTags = useMemo(() => {
+    const t = new Set<string>();
+    items.forEach((i) => (i.tags || []).forEach(t.add, t));
+    return Array.from(t).sort();
+  }, [items]);
+
+  const filtered = useMemo(() => {
+    const qn = q.trim().toLowerCase();
+    return items
+      .filter((i) => {
+        const okQ =
+          !qn ||
+          i.title.toLowerCase().includes(qn) ||
+          (i.tags || []).some((t) => t.toLowerCase().includes(qn));
+        const okT = !tag || (i.tags || []).includes(tag);
+        return okQ && okT;
+      })
+      .sort((a, b) => (b.updated || "").localeCompare(a.updated || ""));
+  }, [items, q, tag]);
+
   return (
-    <div className="flex min-h-screen items-center justify-center">
-      <Card className="p-8">Codex coming soon.</Card>
-    </div>
+    <main className="mx-auto max-w-4xl p-6">
+      <header className="mb-6 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <h1 className="text-2xl font-semibold">Codex Prompts</h1>
+        <CodexSearch value={q} onChange={setQ} />
+      </header>
+
+      <section className="mb-5 flex flex-wrap gap-2">
+        <CodexTag label="all" active={!tag} onClick={() => setTag(null)} />
+        {allTags.map((t) => (
+          <CodexTag key={t} label={t} active={tag === t} onClick={() => setTag(t)} />
+        ))}
+      </section>
+
+      <ul className="grid gap-3">
+        {filtered.map((i) => (
+          <li key={i.slug} className="rounded-2xl border p-4 hover:shadow-sm transition">
+            <Link href={`/codex/${i.slug}`} className="block">
+              <div className="flex items-center justify-between gap-3">
+                <h2 className="text-lg font-medium">{i.title}</h2>
+                <div className="flex items-center gap-2">
+                  {i.updated && <time className="text-sm opacity-70">{i.updated}</time>}
+                  {i.updated &&
+                    Date.now() - new Date(i.updated).getTime() < 1000 * 60 * 60 * 24 * 30 && (
+                      <span className="ml-2 text-xs rounded bg-black text-white px-2 py-0.5">new</span>
+                    )}
+                </div>
+              </div>
+              {i.tags && (
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {i.tags.map((t) => (
+                    <span key={t} className="text-xs rounded-xl border px-2 py-0.5">
+                      #{t}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </Link>
+          </li>
+        ))}
+        {filtered.length === 0 && (
+          <li className="opacity-70">No prompts match your search.</li>
+        )}
+      </ul>
+    </main>
   );
 }

--- a/apps/portals/components/CodexSearch.tsx
+++ b/apps/portals/components/CodexSearch.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+type Props = { value: string; onChange: (v: string) => void };
+export default function CodexSearch({ value, onChange }: Props) {
+  return (
+    <input
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder="Search by title or tag…"
+      className="w-full md:w-96 rounded-xl border px-3 py-2"
+      aria-label="Search codex prompts"
+    />
+  );
+}

--- a/apps/portals/components/CodexTag.tsx
+++ b/apps/portals/components/CodexTag.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+type Props = { label: string; active?: boolean; onClick?: () => void };
+export default function CodexTag({ label, active = false, onClick }: Props) {
+  return (
+    <button
+      onClick={onClick}
+      className={`px-3 py-1 rounded-2xl border text-sm ${active ? "bg-black text-white" : ""}`}
+      aria-pressed={active}
+    >
+      #{label}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- add CodexTag and CodexSearch components
- build codex index page listing prompts with search and tag filters

## Testing
- `npm --prefix apps/portals run build` *(fails: Module not found: Can't resolve '@radix-ui/react-tabs')*
- `npm --prefix apps/portals run lint` *(fails: Invalid options)*
- `npm --prefix apps/portals run dev` *(fails: fetch failed during startup)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a8ca37108329b5ed575a3081628b