### PR TITLE
feat: add artifacts browser and hash verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,3 +19,5 @@ jobs:
           test "$A1" = "$A2"
       - name: Contract validation
         run: python scripts/validate_contracts.py
+      - name: Artifacts hash
+        run: bash scripts/hash_artifacts.sh || true

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ publicssh.sh
 dist/
 .cache/
 .env
+artifacts.sha256
+public/artifacts.sha256
 
 # Local data
 srv/blackroad-api/blackroad.db

--- a/scripts/hash_artifacts.sh
+++ b/scripts/hash_artifacts.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+find artifacts -type f -print0 | sort -z | xargs -0 sha256sum > artifacts.sha256
+mkdir -p public
+cp artifacts.sha256 public/artifacts.sha256 || true
+echo "Artifacts hash -> public/artifacts.sha256"

--- a/sites/blackroad-next/lib/hash.ts
+++ b/sites/blackroad-next/lib/hash.ts
@@ -1,0 +1,6 @@
+export async function hashFileSHA256(file: File): Promise<string> {
+  const buf = await file.arrayBuffer();
+  const digest = await crypto.subtle.digest('SHA-256', buf);
+  const hashArray = Array.from(new Uint8Array(digest));
+  return hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+}

--- a/sites/blackroad-next/next-env.d.ts
+++ b/sites/blackroad-next/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/sites/blackroad-next/pages/api/artifacts/index.ts
+++ b/sites/blackroad-next/pages/api/artifacts/index.ts
@@ -1,0 +1,21 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import fs from 'node:fs';
+import path from 'node:path';
+
+function readShaFile(p: string){
+  if(!fs.existsSync(p)) return [] as { hash: string; file: string }[];
+  const raw = fs.readFileSync(p,'utf8').trim().split('\n');
+  return raw.map(line => {
+    // Format: <sha>  <path>
+    const [hash, ...rest] = line.split(/\s+/);
+    const file = rest.join(' ').trim();
+    return { hash, file };
+  }).filter(x=>x.hash && x.file);
+}
+
+export default function handler(req: NextApiRequest, res: NextApiResponse){
+  const shaPath = path.join(process.cwd(), 'public', 'artifacts.sha256');
+  const rows = readShaFile(shaPath);
+  res.setHeader('Cache-Control','s-maxage=60, stale-while-revalidate=600');
+  res.status(200).json({ generated: new Date().toISOString(), count: rows.length, entries: rows });
+}

--- a/sites/blackroad-next/pages/artifacts.tsx
+++ b/sites/blackroad-next/pages/artifacts.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useMemo, useState } from 'react';
+import { hashFileSHA256 } from '@/lib/hash';
+
+type Entry = { hash: string; file: string };
+
+export default function ArtifactsPage(){
+  const [entries, setEntries] = useState<Entry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [sel, setSel] = useState<Entry | null>(null);
+  const [verifyResult, setVerifyResult] = useState<null | 'ok' | 'mismatch'>(null);
+
+  useEffect(()=>{
+    fetch('/api/artifacts/index').then(r=>r.json()).then(d=>{
+      setEntries(d.entries || []);
+      setLoading(false);
+    }).catch(()=>setLoading(false));
+  },[]);
+
+  async function onPickFile(ev: React.ChangeEvent<HTMLInputElement>){
+    const file = ev.target.files?.[0];
+    if(!file || !sel) return;
+    setVerifyResult(null);
+    const h = await hashFileSHA256(file);
+    setVerifyResult(h === sel.hash ? 'ok' : 'mismatch');
+  }
+
+  const groups = useMemo(()=>{
+    // group by top-level dir under artifacts/
+    const g = new Map<string, Entry[]>();
+    for(const e of entries){
+      const m = e.file.match(/^artifacts\/(\w+)/);
+      const key = m ? m[1] : 'misc';
+      g.set(key, [...(g.get(key)||[]), e]);
+    }
+    return Array.from(g.entries()).sort((a,b)=>a[0].localeCompare(b[0]));
+  },[entries]);
+
+  return (
+    <main className="mx-auto max-w-5xl p-6">
+      <h1 className="text-2xl font-semibold mb-4">Build Artifacts</h1>
+      {loading && <p>Loading…</p>}
+      {!loading && entries.length===0 && <p>No artifacts yet. Run the Phase 37 demo or check CI.</p>}
+
+      {groups.map(([bucket, list]) => (
+        <section key={bucket} className="mb-8">
+          <h2 className="text-lg font-medium mb-2">{bucket}</h2>
+          <div className="overflow-auto rounded-xl border">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="bg-gray-50">
+                  <th className="text-left p-2">File</th>
+                  <th className="text-left p-2">SHA-256</th>
+                  <th className="p-2">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {list.map(e => (
+                  <tr key={e.file} className="border-t">
+                    <td className="p-2 font-mono text-xs">{e.file}</td>
+                    <td className="p-2 font-mono text-xs break-all">{e.hash}</td>
+                    <td className="p-2 flex gap-2 justify-center">
+                      <button
+                        className="rounded-2xl border px-3 py-1"
+                        onClick={()=>{ navigator.clipboard.writeText(e.hash); }}
+                      >Copy hash</button>
+                      <a
+                        className="rounded-2xl border px-3 py-1"
+                        href={'/'+e.file}
+                        download
+                      >Download</a>
+                      <button
+                        className="rounded-2xl border px-3 py-1"
+                        onClick={()=>{ setSel(e); setVerifyResult(null); (document.getElementById('filepick') as HTMLInputElement)?.click(); }}
+                      >Verify…</button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      ))}
+
+      <input id="filepick" type="file" className="hidden" onChange={onPickFile} />
+
+      {sel && (
+        <div className="mt-4 rounded-2xl border p-4">
+          <div className="mb-2">Verify against <span className="font-mono text-xs">{sel.file}</span></div>
+          {verifyResult === 'ok' && <div className="text-green-600">Hash match ✔</div>}
+          {verifyResult === 'mismatch' && <div className="text-red-600">Hash mismatch ✖</div>}
+          {!verifyResult && <div className="opacity-70">Choose a file to verify.</div>}
+        </div>
+      )}
+    </main>
+  );
+}

--- a/sites/blackroad-next/tsconfig.json
+++ b/sites/blackroad-next/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
@@ -13,8 +17,26 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/sites/blackroad/src/ui/CodexPrompt.tsx
+++ b/sites/blackroad/src/ui/CodexPrompt.tsx
@@ -5,5 +5,10 @@ export default function CodexPrompt({ id }: { id: string }) {
   useEffect(() => {
     fetch(`/api/codex/${id}`).then(r => r.text()).then(setText);
   }, [id]);
-  return <pre>{text}</pre>;
+  return (
+    <div>
+      <pre>{text}</pre>
+      <p className="mt-8 text-sm opacity-70">Need outputs? See <a className="underline" href="/artifacts">Artifacts</a> for downloads + verification.</p>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- add script and workflow step to generate artifacts SHA256 index
- expose artifacts JSON API and browser-based verifier page
- link Codex prompts to new artifacts page

## Testing
- `npm test` *(fails: npx jest hung due to missing dependencies)*
- `npm --prefix sites/blackroad-next run lint` *(fails: interactive ESLint prompt)*
- `npm --prefix sites/blackroad run lint`
- `bash scripts/hash_artifacts.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c5a92c0b208329b8f31cebf83dd511