### PR TITLE
feat: add okta sso and warehouse sync

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,5 @@
 *.{js,jsx,ts,tsx} linguist-language=JavaScript
 *.py text eol=lf
 *.db binary
+# Treat unencrypted env files as binary so Git won’t diff them
+.env* -text

--- a/.github/environments/production.yml
+++ b/.github/environments/production.yml
@@ -1,0 +1,1 @@
+url: https://blackroad.io

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,10 @@ env:
 jobs:
   build-test-push:
     runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://blackroad.io
+      reviewers: ['blackboxprogramming']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/warehouse.yml
+++ b/.github/workflows/warehouse.yml
@@ -1,0 +1,18 @@
+name: Warehouse Sync
+on:
+  schedule:
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - run: npm ci --prefix apps/api
+      - run: node scripts/warehouse_sync.ts
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          WAREHOUSE_URL: ${{ secrets.WAREHOUSE_URL }}
+          WAREHOUSE_TOKEN: ${{ secrets.WAREHOUSE_TOKEN }}

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,5 @@
+creation_rules:
+  - path_regex: \.env\.enc$
+    encrypted_regex: ^(.*)$
+    age: # Insert your age recipient(s)
+      - <REPLACE_ME_PUBLIC_KEY>

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,2 +1,10 @@
 PORT=4000
 GITHUB_WEBHOOK_SECRET=<REPLACE_ME>
+# Okta SSO
+OKTA_ISSUER=https://{yourOktaDomain}
+OKTA_CLIENT_ID={yourClientId}
+OKTA_CLIENT_SECRET={clientSecret}
+OKTA_REDIRECT_URI=https://blackroad.io/api/auth/okta/callback
+# Warehouse
+WAREHOUSE_URL=<REPLACE_ME>
+WAREHOUSE_TOKEN=<REPLACE_ME>

--- a/apps/api/package-lock.json
+++ b/apps/api/package-lock.json
@@ -11,7 +11,9 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.0",
         "express": "^4.19.2",
-        "morgan": "^1.10.0"
+        "morgan": "^1.10.0",
+        "node-fetch": "^3.3.0",
+        "openid-client": "^6.6.0"
       },
       "devDependencies": {
         "@semantic-release/changelog": "^6.0.3",
@@ -2214,6 +2216,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2938,6 +2949,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/figures": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
@@ -3080,6 +3114,18 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -3724,6 +3770,15 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/jose": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.0.tgz",
+      "integrity": "sha512-TTQJyoEoKcC1lscpVDCSsVgYzUDg/0Bt3WE//WiTPK6uOCQC2KZS4MpugbMWt/zyjkopgZoXhZuCi00gLudfUA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4239,6 +4294,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-emoji": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
@@ -4253,6 +4328,24 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/normalize-package-data": {
@@ -6992,6 +7085,15 @@
       "inBundle": true,
       "license": "ISC"
     },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.1.tgz",
+      "integrity": "sha512-olkZDELNycOWQf9LrsELFq8n05LwJgV8UkrS0cburk6FOwf8GvLam+YB+Uj5Qvryee+vwWOfQVeI5Vm0MVg7SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -7048,6 +7150,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openid-client": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.0.tgz",
+      "integrity": "sha512-oG1d1nAVhIIE+JSjLS+7E9wY1QOJpZltkzlJdbZ7kEn7Hp3hqur2TEeQ8gLOHoHkhbRAGZJKoOnEQcLOQJuIyg==",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^6.1.0",
+        "oauth4webapi": "^3.8.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/optionator": {
@@ -8934,6 +9049,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/which": {

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,7 +17,9 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.0",
     "express": "^4.19.2",
-    "morgan": "^1.10.0"
+    "morgan": "^1.10.0",
+    "openid-client": "^6.6.0",
+    "node-fetch": "^3.3.0"
   },
   "devDependencies": {
     "semantic-release": "^24.0.0",

--- a/apps/api/src/routes/okta.ts
+++ b/apps/api/src/routes/okta.ts
@@ -1,0 +1,45 @@
+import { Router } from 'express';
+import { Issuer, generators } from 'openid-client';
+import { setSessionCookie } from '../middleware/session.js';
+
+const router = Router();
+const oktaIssuer = process.env.OKTA_ISSUER || '';
+const clientId = process.env.OKTA_CLIENT_ID || '';
+const clientSecret = process.env.OKTA_CLIENT_SECRET || '';
+const redirectUri = process.env.OKTA_REDIRECT_URI || '';
+const clientPromise = (async () => {
+  const issuer = await Issuer.discover(oktaIssuer);
+  return new issuer.Client({
+    client_id: clientId,
+    client_secret: clientSecret,
+    redirect_uris: [redirectUri],
+    response_types: ['code']
+  });
+})();
+
+router.get('/login', async (_req, res) => {
+  const client = await clientPromise;
+  const codeVerifier = generators.codeVerifier();
+  const codeChallenge = generators.codeChallenge(codeVerifier);
+  // Save verifier in a temporary cookie
+  res.cookie('okta_cv', codeVerifier, { httpOnly: true });
+  const authUrl = client.authorizationUrl({
+    scope: 'openid profile email',
+    code_challenge: codeChallenge,
+    code_challenge_method: 'S256'
+  });
+  res.redirect(authUrl);
+});
+
+router.get('/callback', async (req, res) => {
+  const client = await clientPromise;
+  const codeVerifier = req.cookies.okta_cv || '';
+  const params = client.callbackParams(req);
+  const tokenSet = await client.callback(redirectUri, params, { code_verifier: codeVerifier });
+  const { email, sub } = tokenSet.claims();
+  // Create or find user and issue your own session cookie
+  setSessionCookie(res, { uid: sub, email }, process.env.SESSION_SECRET || '', 60 * 60 * 24 * 7);
+  res.redirect('/');
+});
+
+export default router;

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -13,8 +13,10 @@ app.get('/api/health', (_req, res) => res.json({ ok: true }));
 
 import hooks from './routes/hooks.js';
 import metrics from './routes/metrics.js';
+import okta from './routes/okta.js';
 app.use('/api/hooks', hooks);
 app.use('/api/metrics', metrics);
+app.use('/api/auth/okta', okta);
 
 const port = process.env.PORT || 4000;
 

--- a/docs/DATA_WAREHOUSE.md
+++ b/docs/DATA_WAREHOUSE.md
@@ -1,0 +1,3 @@
+# Data Warehouse Sync
+
+The nightly `warehouse.yml` workflow runs `scripts/warehouse_sync.ts`, which posts API metrics to a data warehouse.  Configure `WAREHOUSE_URL` and `WAREHOUSE_TOKEN` as GitHub Secrets.  The script reads a JSON metrics file and sends it as a POST request.  Adjust `scripts/warehouse_sync.ts` to match your warehouse’s API.

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -1,0 +1,7 @@
+# Managing Secrets with SOPS & age
+
+We use [sops](https://github.com/getsops/sops) and [age](https://github.com/FiloSottile/age) to encrypt our secret files.  Generate a keypair with `age-keygen` [oai_citation:9‡msound.net](https://msound.net/blog/2023/05/managing-secrets/#:~:text=Keys) and store it in `~/.config/sops/age/keys.txt`.  Encrypt a `.env` file with:
+
+sops -e -a  .env > .env.enc 
+
+Do **not** commit unencrypted files.  The `.sops.yaml` config ensures files ending with `.env.enc` are encrypted via age.  Use `scripts/encrypt_secret.sh` to simplify encryption.

--- a/scripts/encrypt_secret.sh
+++ b/scripts/encrypt_secret.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Encrypt a .env file using sops and age. Generates a key if none exists.
+set -euo pipefail
+ENV_FILE="${1:-.env}"
+AGE_KEY_FILE="${HOME}/.config/sops/age/keys.txt"
+if [ ! -f "${AGE_KEY_FILE}" ]; then
+  mkdir -p "$(dirname "${AGE_KEY_FILE}")"
+  age-keygen -o "${AGE_KEY_FILE}"
+  echo "Generated new age key at ${AGE_KEY_FILE}"
+fi
+PUB=$(grep "^# public key:" "${AGE_KEY_FILE}" | awk '{print $4}')
+sops -e -a "${PUB}" "${ENV_FILE}" > "${ENV_FILE}.enc"
+echo "Encrypted ${ENV_FILE} to ${ENV_FILE}.enc"

--- a/scripts/warehouse_sync.ts
+++ b/scripts/warehouse_sync.ts
@@ -1,0 +1,17 @@
+import fetch from 'node-fetch';
+import fs from 'fs';
+
+// Example: read API metrics from local file or endpoint
+const metrics = JSON.parse(fs.readFileSync('apps/api/dist/metrics.json', 'utf-8') || '{}');
+
+const url = process.env.WAREHOUSE_URL || '';
+const token = process.env.WAREHOUSE_TOKEN || '';
+async function send() {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ timestamp: Date.now(), metrics })
+  });
+  console.log(`Warehouse sync status: ${res.status}`);
+}
+send().catch(e => console.error(e));


### PR DESCRIPTION
## Summary
- add Okta OpenID Connect login and callback routes with env vars
- encrypt secrets via sops/age and helper script
- nightly metrics sync to warehouse with GitHub environment reviewers

## Testing
- `npm test --prefix apps/api` (fails: connect ECONNREFUSED 127.0.0.1:4000)


------
https://chatgpt.com/codex/tasks/task_e_68c5e0e427188329a2ce9052cc3c48f6