### PR TITLE
Add risk & compliance fabric skeleton

### DIFF
--- a/bin/riskctl
+++ b/bin/riskctl
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+"""Entry point for riskctl CLI."""
+
+import pathlib
+import sys
+
+# Ensure repository root on path
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+from risk.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/risk/api.py
+++ b/risk/api.py
@@ -1,0 +1,155 @@
+"""Minimal risk and compliance API using FastAPI."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import List
+
+import yaml
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+app = FastAPI(title="Compliance Fabric")
+
+REGISTER_FILE = Path(__file__).with_name("register.yaml")
+COMPLIANCE_FILE = Path(__file__).with_name("compliance_mapping.yaml")
+EVIDENCE_FILE = Path(__file__).with_name("evidence.yaml")
+
+
+# ---------------------------------------------------------------------------
+# Utilities
+
+
+def _load(path: Path) -> list:
+    if path.exists():
+        with path.open("r", encoding="utf-8") as f:
+            return yaml.safe_load(f) or []
+    return []
+
+
+def _save(path: Path, data: list) -> None:
+    with path.open("w", encoding="utf-8") as f:
+        yaml.safe_dump(data, f, sort_keys=False)
+
+
+# ---------------------------------------------------------------------------
+# Models
+
+
+class Risk(BaseModel):
+    id: str
+    description: str
+    owner: str
+    mitigation: str
+    impact: float
+    likelihood: float
+    residual_risk: float | None = None
+
+
+class ControlMapping(BaseModel):
+    framework: str
+    control: str
+    internal_policy: str
+    evidence: List[str]
+
+
+class Evidence(BaseModel):
+    id: str
+    source_system: str
+    timestamp: datetime
+    hash: str
+    reviewer: str
+
+
+# ---------------------------------------------------------------------------
+# Risk registry endpoints
+
+
+@app.get("/risk/registry", response_model=List[Risk])
+def list_risks() -> List[Risk]:
+    return _load(REGISTER_FILE)
+
+
+@app.post("/risk/registry", response_model=Risk)
+def create_risk(risk: Risk) -> Risk:
+    data = _load(REGISTER_FILE)
+    if any(item["id"] == risk.id for item in data):
+        raise HTTPException(status_code=400, detail="Risk id already exists")
+    data.append(risk.dict())
+    _save(REGISTER_FILE, data)
+    return risk
+
+
+@app.get("/risk/registry/{risk_id}", response_model=Risk)
+def get_risk(risk_id: str) -> Risk:
+    data = _load(REGISTER_FILE)
+    for item in data:
+        if item["id"] == risk_id:
+            return item
+    raise HTTPException(status_code=404, detail="Risk not found")
+
+
+@app.put("/risk/registry/{risk_id}", response_model=Risk)
+def update_risk(risk_id: str, risk: Risk) -> Risk:
+    data = _load(REGISTER_FILE)
+    for i, item in enumerate(data):
+        if item["id"] == risk_id:
+            data[i] = risk.dict()
+            _save(REGISTER_FILE, data)
+            return risk
+    raise HTTPException(status_code=404, detail="Risk not found")
+
+
+@app.delete("/risk/registry/{risk_id}")
+def delete_risk(risk_id: str) -> None:
+    data = _load(REGISTER_FILE)
+    new_data = [item for item in data if item["id"] != risk_id]
+    if len(new_data) == len(data):
+        raise HTTPException(status_code=404, detail="Risk not found")
+    _save(REGISTER_FILE, new_data)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Compliance mapping endpoints
+
+
+@app.get("/compliance/mapping", response_model=List[ControlMapping])
+def list_mappings() -> List[ControlMapping]:
+    return _load(COMPLIANCE_FILE)
+
+
+@app.post("/compliance/mapping", response_model=ControlMapping)
+def create_mapping(mapping: ControlMapping) -> ControlMapping:
+    data = _load(COMPLIANCE_FILE)
+    data.append(mapping.dict())
+    _save(COMPLIANCE_FILE, data)
+    return mapping
+
+
+# ---------------------------------------------------------------------------
+# Audit evidence endpoints
+
+
+@app.get("/audit/evidence", response_model=List[Evidence])
+def list_evidence() -> List[Evidence]:
+    return _load(EVIDENCE_FILE)
+
+
+@app.post("/audit/evidence", response_model=Evidence)
+def add_evidence(evidence: Evidence) -> Evidence:
+    data = _load(EVIDENCE_FILE)
+    data.append(evidence.dict())
+    _save(EVIDENCE_FILE, data)
+    return evidence
+
+
+# ---------------------------------------------------------------------------
+# Placeholder hook for remediation actions
+
+
+@app.post("/compliance/remediate/{framework}")
+def trigger_remediation(framework: str) -> dict:
+    """Stub endpoint for Codex agent remediation hooks."""
+    return {"framework": framework, "status": "remediation triggered"}

--- a/risk/cli.py
+++ b/risk/cli.py
@@ -1,0 +1,53 @@
+"""Simple CLI for risk simulations."""
+
+from __future__ import annotations
+
+import argparse
+import random
+import statistics
+from pathlib import Path
+from typing import List
+
+import yaml
+
+REGISTER_FILE = Path(__file__).with_name("register.yaml")
+
+
+def _load() -> List[dict]:
+    with REGISTER_FILE.open("r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def simulate(monte_carlo: int) -> None:
+    data = _load()
+    results = []
+    for _ in range(monte_carlo):
+        total = 0.0
+        for item in data:
+            lik = random.betavariate(
+                max(item["likelihood"] * 10, 1), max((1 - item["likelihood"]) * 10, 1)
+            )
+            imp = random.betavariate(max(item["impact"] * 10, 1), max((1 - item["impact"]) * 10, 1))
+            total += lik * imp
+        results.append(total)
+    mean = statistics.mean(results)
+    p95 = statistics.quantiles(results, n=100)[94]
+    print(f"mean={mean:.4f} p95={p95:.4f}")
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(prog="riskctl")
+    sub = parser.add_subparsers(dest="cmd")
+
+    sim = sub.add_parser("simulate", help="run risk Monte Carlo")
+    sim.add_argument("--monte-carlo", type=int, default=1000, help="number of simulations")
+
+    args = parser.parse_args(argv)
+    if args.cmd == "simulate":
+        simulate(args.monte_carlo)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/risk/compliance_dashboard.html
+++ b/risk/compliance_dashboard.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Compliance Fabric Dashboard</title>
+    <style>
+      .green {
+        background-color: #2ecc71;
+        color: #fff;
+      }
+      .amber {
+        background-color: #f39c12;
+        color: #fff;
+      }
+      .red {
+        background-color: #e74c3c;
+        color: #fff;
+      }
+      td,
+      th {
+        padding: 4px 8px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Compliance Fabric Dashboard</h1>
+    <table>
+      <tr>
+        <th>Framework</th>
+        <th>Status</th>
+      </tr>
+      <tr class="green">
+        <td>SOC2</td>
+        <td>passing</td>
+      </tr>
+      <tr class="amber">
+        <td>ISO27001</td>
+        <td>needs review</td>
+      </tr>
+      <tr class="red">
+        <td>PCI DSS</td>
+        <td>failing</td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/risk/compliance_mapping.yaml
+++ b/risk/compliance_mapping.yaml
@@ -1,0 +1,10 @@
+- framework: SOC2
+  control: CC6.1
+  internal_policy: 'Access control policy'
+  evidence:
+    - ev1
+- framework: ISO27001
+  control: A.9.2.6
+  internal_policy: 'User access review'
+  evidence:
+    - ev2

--- a/risk/evidence.yaml
+++ b/risk/evidence.yaml
@@ -1,0 +1,10 @@
+- id: ev1
+  source_system: GitHub
+  timestamp: '2024-06-01T12:00:00Z'
+  hash: 'sha256:abc123'
+  reviewer: alice
+- id: ev2
+  source_system: Jira
+  timestamp: '2024-06-15T09:30:00Z'
+  hash: 'sha256:def456'
+  reviewer: bob

--- a/risk/register.yaml
+++ b/risk/register.yaml
@@ -1,15 +1,21 @@
 - id: R1
-  description: "Data breach"
+  description: 'Data breach'
+  owner: security
   likelihood: 0.3
   impact: 0.8
-  mitigation: "Encrypt data and monitor access"
+  mitigation: 'Encrypt data and monitor access'
+  residual_risk: 0.24
 - id: R2
-  description: "Service outage"
+  description: 'Service outage'
+  owner: operations
   likelihood: 0.2
   impact: 0.9
-  mitigation: "Multi-region deployment"
+  mitigation: 'Multi-region deployment'
+  residual_risk: 0.18
 - id: R3
-  description: "Compliance violation"
+  description: 'Compliance violation'
+  owner: legal
   likelihood: 0.1
   impact: 0.7
-  mitigation: "Regular training and audits"
+  mitigation: 'Regular training and audits'
+  residual_risk: 0.07


### PR DESCRIPTION
## Summary
- extend risk register with owner and residual risk fields
- implement FastAPI service exposing risk registry, compliance mapping, and audit evidence endpoints
- add `riskctl` CLI for Monte Carlo simulations and a simple compliance dashboard

## Testing
- `pre-commit run --files risk/__init__.py risk/api.py risk/cli.py risk/register.yaml risk/compliance_mapping.yaml risk/evidence.yaml risk/compliance_dashboard.html bin/riskctl`
- `pytest risk` (no tests found)
- `bin/riskctl simulate --monte-carlo 10`


------
https://chatgpt.com/codex/tasks/task_e_68c60640b57c8329a39fae40466ec5c0