### PR TITLE
Add governance and compliance control plane

### DIFF
--- a/compliance/legal_ops.py
+++ b/compliance/legal_ops.py
@@ -1,0 +1,37 @@
+"""Legal operations helpers for automated governance.
+
+The ``LegalOps`` class provides tiny helpers to generate simple
+contracts and run placeholder regulatory checks.  The real platform
+would integrate with dedicated compliance engines for SEC/FINRA/GAAP etc.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass
+class Contract:
+    parties: Dict[str, str]
+    terms: str
+
+    def render(self) -> str:
+        party_lines = "\n".join(f"{role}: {name}" for role, name in self.parties.items())
+        return f"Contract\n{party_lines}\n\nTerms:\n{self.terms}\n"
+
+
+class LegalOps:
+    """Very small contract and compliance utilities."""
+
+    def generate_contract(self, parties: Dict[str, str], terms: str) -> Contract:
+        return Contract(parties=parties, terms=terms)
+
+    def sec_compliance_check(self, document: str) -> bool:
+        """Placeholder check for SEC wording.
+
+        The function simply ensures some basic disclosures are present.
+        """
+
+        required = ["risk", "forward-looking", "liability"]
+        return all(word in document.lower() for word in required)

--- a/ethics/ai_guardian.py
+++ b/ethics/ai_guardian.py
@@ -1,0 +1,42 @@
+"""Simple AI compliance and ethics monitor.
+
+The :class:`AIGuardian` class offers a minimal interface that other
+agents can call to record decisions and validate that outcomes respect
+fiduciary duties and fairness guidelines.  Real deployments would hook
+into bias detection libraries and maintain an auditable trail.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class DecisionRecord:
+    agent: str
+    action: str
+    notes: str = ""
+
+
+class AIGuardian:
+    """Monitor actions taken by AI agents."""
+
+    def __init__(self) -> None:
+        self.records: List[DecisionRecord] = []
+
+    def record(self, agent: str, action: str, notes: str = "") -> None:
+        self.records.append(DecisionRecord(agent=agent, action=action, notes=notes))
+
+    def detect_conflict(self, record: DecisionRecord) -> bool:
+        """Naive conflict-of-interest check.
+
+        For demonstration purposes we only flag actions that mention
+        keywords such as ``"kickback"`` or ``"inside"``.
+        """
+
+        lowered = record.action.lower() + record.notes.lower()
+        return any(keyword in lowered for keyword in ["kickback", "inside"])
+
+    def recent_issues(self) -> List[DecisionRecord]:
+        return [r for r in self.records if self.detect_conflict(r)]

--- a/finance/auto_plan_generator.ipynb
+++ b/finance/auto_plan_generator.ipynb
@@ -1,0 +1,45 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Auto Plan Generator\n",
+    "Generates rolling 5-year business plans, cashflow and valuation models."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "\n",
+    "def rolling_plan(revenue, growth=0.05, years=5):\n",
+    "    data=[]\n",
+    "    for y in range(years):\n",
+    "        data.append({'year': y+1, 'revenue': revenue})\n",
+    "        revenue *= (1 + growth)\n",
+    "    return pd.DataFrame(data)\n",
+    "\n",
+    "plan = rolling_plan(1_000_000)\n",
+    "plan"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/governance/strategy_engine.py
+++ b/governance/strategy_engine.py
@@ -1,0 +1,76 @@
+"""Strategic fit evaluation utilities.
+
+This module provides a small ``StrategyEngine`` that captures
+Michael Porter's view that strategy is about choosing a unique
+position, making trade-offs and creating fit across a company's
+activities.  The engine exposes a :class:`CorporateStrategy`
+configuration and a :meth:`StrategyEngine.check_fit` helper that can be
+used by other Codex agents to validate that new initiatives reinforce
+the overall positioning rather than drift into operational effectiveness only.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List
+
+
+@dataclass
+class CorporateStrategy:
+    """High level description of the company's chosen strategy.
+
+    Attributes
+    ----------
+    positioning:
+        The unique value proposition (e.g. ``"low cost fintech"``).
+    tradeoffs:
+        Activities the firm *will not* perform in order to protect the
+        strategic position.
+    activities:
+        Core reinforcing activities that should remain aligned.
+    mode:
+        One of ``"cost_leadership"``, ``"differentiation"`` or ``"focus"``.
+    """
+
+    positioning: str
+    tradeoffs: List[str] = field(default_factory=list)
+    activities: List[str] = field(default_factory=list)
+    mode: str = "differentiation"
+
+
+class StrategyEngine:
+    """Check projects and modules for strategic fit."""
+
+    def __init__(self, strategy: CorporateStrategy) -> None:
+        self.strategy = strategy
+
+    def check_fit(self, activity: Dict[str, Iterable[str]]) -> List[str]:
+        """Return a list of issues for the provided activity description.
+
+        Parameters
+        ----------
+        activity:
+            Mapping with keys ``positioning``, ``mode`` and ``activities``
+            describing a proposed initiative.
+        """
+
+        issues: List[str] = []
+
+        if activity.get("mode") and activity["mode"] != self.strategy.mode:
+            issues.append(
+                f"Mode mismatch: {activity['mode']} vs expected {self.strategy.mode}"
+            )
+
+        if activity.get("positioning") and activity["positioning"] != self.strategy.positioning:
+            issues.append("Positioning deviates from corporate strategy")
+
+        for act in activity.get("activities", []):
+            if act in self.strategy.tradeoffs:
+                issues.append(f"Activity '{act}' conflicts with strategic trade-offs")
+            elif act not in self.strategy.activities:
+                issues.append(f"Activity '{act}' is outside core fit")
+
+        if not issues:
+            issues.append("fit")
+
+        return issues

--- a/pm/portfolio_controller.py
+++ b/pm/portfolio_controller.py
@@ -1,0 +1,46 @@
+"""Hybrid project portfolio controller.
+
+This module introduces a lightweight ``PortfolioController`` that can
+collect project proposals, score them and prioritise execution while
+keeping a link to the strategic objectives defined elsewhere in the
+platform.  The implementation is intentionally small but provides hooks
+for predictive, agile and design-thinking approaches as required by the
+Handbook of Project Management.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class Project:
+    name: str
+    strategic_value: float
+    risk: float
+    sustainable: bool = True
+
+
+class PortfolioController:
+    """Manage a portfolio of projects and provide simple prioritisation."""
+
+    def __init__(self) -> None:
+        self.projects: List[Project] = []
+
+    def add_project(self, project: Project) -> None:
+        self.projects.append(project)
+
+    def prioritise(self) -> List[Project]:
+        """Return projects sorted by a naive risk-adjusted value.
+
+        A real implementation would incorporate machine learning and a
+        full portfolio optimisation model.  Here we simply rank by
+        ``strategic_value / (1 + risk)``.
+        """
+
+        return sorted(
+            self.projects,
+            key=lambda p: p.strategic_value / (1.0 + p.risk),
+            reverse=True,
+        )

--- a/strategic_console.py
+++ b/strategic_console.py
@@ -1,0 +1,38 @@
+"""BlackRoad Strategic Console.
+
+A very small command line dashboard that stitches together the
+specialised governance modules.  It is not interactive but illustrates
+how board members could obtain a high level overview of strategic fit,
+financial plans and ethical alerts.
+"""
+
+from __future__ import annotations
+
+from governance.strategy_engine import CorporateStrategy, StrategyEngine
+from pm.portfolio_controller import PortfolioController, Project
+from ethics.ai_guardian import AIGuardian
+
+
+def sample_dashboard() -> None:
+    strategy = CorporateStrategy(
+        positioning="AI-first fintech",
+        tradeoffs=["on-premise"],
+        activities=["cloud", "ml"],
+        mode="differentiation",
+    )
+    engine = StrategyEngine(strategy)
+    controller = PortfolioController()
+    guardian = AIGuardian()
+
+    controller.add_project(Project("ML risk model", strategic_value=10, risk=2))
+    controller.add_project(Project("Legacy cleanup", strategic_value=3, risk=1))
+
+    guardian.record("agent1", "recommended insider trade", notes="inside tip")
+
+    print("Strategic check:", engine.check_fit({"mode": "differentiation", "positioning": "AI-first fintech", "activities": ["cloud"]}))
+    print("Portfolio order:", [p.name for p in controller.prioritise()])
+    print("AI issues:", [r.action for r in guardian.recent_issues()])
+
+
+if __name__ == "__main__":
+    sample_dashboard()


### PR DESCRIPTION
## Summary
- add strategy engine to evaluate project fit against corporate positioning
- scaffold auto plan generator notebook for rolling financial models
- introduce portfolio controller, legal ops, AI guardian and a simple strategic console

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'torchquantum')*
- `python strategic_console.py`

------
https://chatgpt.com/codex/tasks/task_e_68c60e72b4308329a6313c0e70bec805