### PR TITLE
Add BlackRoad ops integration master plan

### DIFF
--- a/README_PR_AUTOMATION.md
+++ b/README_PR_AUTOMATION.md
@@ -141,3 +141,17 @@ autopr.sh already invokes this if present. To use an external dump directory:
 OWNER=BlackRoad REPO=masterpack GH_TOKEN=*** \
   ./scripts/autopr.sh && ./scripts/sync_artifacts.sh --from ./generated
 ```
+
+---
+
+## 6) Integration checklist
+
+Track the Slack, Asana Auth Bot, and GitLab mirroring setup in
+[`docs/PR_BUNDLE_INTEGRATIONS.md`](docs/PR_BUNDLE_INTEGRATIONS.md). Update the integration status
+matrix in this file once each service is configured in the target environment.
+
+For the broader operations rollout—including the `blackroad.io` product surface, the
+`blackroadinc.us` operations hub, and the multi-system integration backlog—work from the
+[`docs/BLACKROAD_OPS_INTEGRATION_PLAN.md`](docs/BLACKROAD_OPS_INTEGRATION_PLAN.md) playbook. It
+describes how to generate batches of Codex prompts (10–20 at a time), assign owners across the tool
+stack, and record evidence in the shared ops hub.

--- a/docs/BLACKROAD_OPS_INTEGRATION_PLAN.md
+++ b/docs/BLACKROAD_OPS_INTEGRATION_PLAN.md
@@ -1,0 +1,135 @@
+# BlackRoad Ops & Integration Master Plan
+
+This playbook aligns the BlackRoad ecosystem across `blackroad.io` (public product surface) and
+`blackroadinc.us` (operations and business hub). It synthesizes the integration touchpoints across
+project management, communications, development infrastructure, marketing, design, finance, HR, and
+security so we can fan out simultaneous Codex prompt workstreams (10–20 at a time) with a unified
+source of truth.
+
+## 1. Domain Strategy
+- **blackroad.io**: Front-facing product experiences, documentation, and launch funnels. House all
+  product demos, consoles (e.g., [blackroad-prism-console](https://github.com/blackboxprogramming/blackroad-prism-console)),
+  and Lucidia activations.
+- **blackroadinc.us**: Operational heartbeat for business enablement, compliance, finance, and
+  partner integrations. Acts as the control plane for credentials, workflow orchestration, and
+  shared services (Slack, Asana, Jira, Airtable, etc.).
+
+## 2. Integration Backbone
+For each category below, anchor a Codex prompt template that enumerates configuration steps,
+security controls, evidence capture, and owner handoffs. Store rendered prompts in
+`prompts/integrations/` and index them via the operations hub on `blackroadinc.us`.
+
+| Category | BlackRoad System | Purpose | Primary Owner | Notes |
+| --- | --- | --- | --- | --- |
+| Project Management | **BlackRoad Tasks** (Asana) | Task/workflow management | Alexa Amundson | Link [Asana project](https://app.asana.com/0/1211130261655445/1211130261655445) for PR automation approvals. |
+| Project Management | **BlackRoad Issues** (Jira) | Agile tracking | Alexa Amundson | Join via Jira app invite; mirror sprint cadence with Asana. |
+| Project Management | **BlackRoad Boards** (Monday) | Visual workflow | Ops Team | Map intake swimlanes to Slack channels. |
+| Project Management | **BlackRoad Cards** (Trello) | Kanban boards | Ops Team | Sync with Trello profile <https://trello.com/u/alexaamundson>. |
+| Project Management | **BlackRoad Hub** (ClickUp) | Productivity suite | Ops Team | Use for documentation handoffs. |
+| Project Management | **BlackRoad Notes** (Notion) | Knowledge base | Ops/PM | Invite via <https://www.notion.so/invite/9a5094be3f272ab2e4c02e4a439f2c57288d3403>. |
+| Project Management | **BlackRoad Sheets** (Smartsheet) | Spreadsheet ops | Finance Ops | Map to finance ledger prompts. |
+| CRM & Biz Ops | **BlackRoad CRM** (Salesforce) | Customer management | BizOps | Create API auth prompts. |
+| CRM & Biz Ops | **BlackRoad Leads** (HubSpot) | Inbound marketing | Growth | Sync landing forms from `blackroad.io`. |
+| CRM & Biz Ops | **BlackRoad Tables** (Airtable) | Operations DB | Alexa Amundson | Align with Airtable workspace (amundsonalexa@gmail.com). |
+| CRM & Biz Ops | **BlackRoad Roadmap** (Linear) | Product roadmap | Product | Mirror GitHub milestones. |
+| Communications | **BlackRoad Chat** (Slack) | Messaging hub | Alexa Amundson | Invite link <https://join.slack.com/t/blackroadinc/shared_invite/zt-3e5fcftzn-geIhI9q4RIrBgEy0cnmjdA>. |
+| Communications | **BlackRoad Voice** (Discord) | Community voice | Community | Document moderation guardrails. |
+| Communications | **BlackRoad Meet** (Microsoft Teams) | Video collaboration | Ops | Align with `amundsonalexa@gmail.com`. |
+| Communications | **BlackRoad Mail** (Outlook) | Email/calendar | Ops | Configure SPF/DKIM for `blackroadinc.us`. |
+| Communications | **BlackRoad Secure** (Telegram) | Encrypted messaging | Security | Define incident response channel. |
+| Communications | **BlackRoad Video** (Zoom) | Meetings | Ops | Add meeting retention policy. |
+| Dev & Infra | **BlackRoad Code** (GitHub) | Source control | Engineering | Primary repo hub: <https://github.com/blackboxprogramming>. |
+| Dev & Infra | **BlackRoad Lab** (GitLab) | CI/CD pipelines | DevOps | Ensure mirroring per PR bundle checklist. |
+| Dev & Infra | **BlackRoad Containers** (Docker) | Containerization | Platform | Harden base images. |
+| Dev & Infra | **BlackRoad IDE** (Replit) | Online coding | Education | Build onboarding prompt. |
+| Dev & Infra | **BlackRoad API** (Postman) | API testing | Platform | Sync collections. |
+| Dev & Infra | **BlackRoad Betai** (TestFlight) | iOS beta | Mobile | Document distribution. |
+| Dev & Infra | **BlackRoad iDev** (Apple Developer) | Apple tools | Mobile | Ensure org enrollment. |
+| Dev & Infra | **BlackRoad Store** (App Store Connect) | Publishing | Mobile | Align with releases. |
+| Dev & Infra | **BlackRoad CodeX** (VS Code) | IDE standard | Engineering | Ship extension pack. |
+| Cloud & Hosting | **BlackRoad Storage** (Dropbox) | File sharing | Ops | Classify folders by domain. |
+| Cloud & Hosting | **BlackRoad Droplets** (DigitalOcean) | VPS hosting | Infra | Track in CMDB. |
+| Cloud & Hosting | **BlackRoad Domains** (GoDaddy) | Domain management | IT | Ensure DNS for both domains. |
+| Cloud & Hosting | **BlackRoad Cloud** (AWS) | Cloud services | Platform | Centralize IAM guardrails. |
+| Cloud & Hosting | **BlackRoad Platform** (GCP) | Cloud infra | Platform | Document org policies. |
+| Cloud & Hosting | **BlackRoad Azure** (Azure) | Cloud infra | Platform | Link to AD. |
+| Cloud & Hosting | **BlackRoad Orchestrate** (Kubernetes) | Orchestration | SRE | Map cluster prompts. |
+| Cloud & Hosting | **BlackRoad IaC** (Terraform) | IaC | Platform | Standardize module registry. |
+| Marketing | **BlackRoad Ads** (Google Ads) | Paid marketing | Growth | Tie UTMs to `blackroad.io`. |
+| Marketing | **BlackRoad Social** (Instagram) | Social media | Growth | Integrate the following profiles: `blackroadinc`, `blackroad.io`, `lucidia_ai`, `blackroad_ai`, `blackroad_inc`. |
+| Marketing | **BlackRoad Pulse** (X/Twitter) | Real-time feed | Growth | Curate content calendar. |
+| Design | **BlackRoad Design** (Canva) | Creative templates | Design | Define brand kit. |
+| Design | **BlackRoad Proto** (Figma) | UI/UX prototyping | Design | Connect to VS Code tokens. |
+| Design | **BlackRoad Jam** (FigJam) | Whiteboarding | Product | Capture workshop notes. |
+| Design | **BlackRoad Creative** (Adobe) | Creative tools | Design | Manage licenses via `blackroadinc.us`. |
+| Design | **BlackRoad Affinity** (Affinity) | Vector/raster design | Design | Establish asset repo. |
+| Design | **BlackRoad Sketch** (Sketch) | MacOS design | Design | Ensure share drives. |
+| Data & AI | **BlackRoad Data** (Kaggle) | ML datasets | AI Team | Manage dataset approvals. |
+| Data & AI | **BlackRoad Notebooks** (JupyterHub) | Interactive notebooks | AI Team | Host on `blackroad.io` subdomain. |
+| Data & AI | **BlackRoad Warehouse** (Snowflake) | Data warehousing | Data | Link to finance metrics. |
+| Data & AI | **BlackRoad Query** (BigQuery) | Big data analytics | Data | Mirror to GCP project. |
+| Finance | **BlackRoad Pay** (Stripe) | Payments | Finance | Document webhook secrets. |
+| Finance | **BlackRoad Wallet** (PayPal) | Payments | Finance | Align reconciliation flows. |
+| Finance | **BlackRoad Books** (QuickBooks) | Accounting | Finance | Map chart of accounts. |
+| Finance | **BlackRoad ERP** (NetSuite) | ERP | Finance | Align contract mgmt. |
+| Finance | **BlackRoad Cards** (Brex) | Corporate cards | Finance | Set spend limits. |
+| Finance | **BlackRoad Spend** (Ramp) | Expense mgmt | Finance | Configure approvals. |
+| Finance | **BlackRoad Global** (Wise) | Cross-border payments | Finance | Document currency hedging. |
+| HR | **BlackRoad HR** (Workday) | Payroll/HR | People Ops | Sync onboarding prompts. |
+| HR | **BlackRoad Payroll** (Gusto) | Payroll | People Ops | Manage contractor payouts. |
+| HR | **BlackRoad People** (BambooHR) | HR system | People Ops | Sync docs to Notion. |
+| HR | **BlackRoad Recruit** (Greenhouse) | Applicant tracking | Talent | Align Slack channel updates. |
+| HR | **BlackRoad Talent** (Lever) | Recruiting | Talent | Connect to Gmail alias. |
+| HR | **BlackRoad Source** (LinkedIn Recruiter) | Talent sourcing | Talent | Template outreach prompts. |
+| Security | **BlackRoad Identity** (Okta) | SSO | Security | Centralize SAML for both domains. |
+| Security | **BlackRoad Auth** (Auth0) | Auth | Security | Manage B2C flows for `blackroad.io`. |
+| Security | **BlackRoad Logs** (Splunk) | Log analysis | Security | Stream from GitLab, AWS. |
+| Security | **BlackRoad Monitor** (Datadog) | Observability | SRE | Track integration health. |
+| Security | **BlackRoad SecureCode** (Snyk) | Vulnerability mgmt | Security | Align with GitHub checks. |
+| Security | **BlackRoad Vault** (1Password) | Password mgmt | Security | Share vault with `amundsonalexa@gmail.com`. |
+| Knowledge | **BlackRoad Wiki** (Confluence) | Knowledge mgmt | Ops | Mirror docs from Notion. |
+| Knowledge | **BlackRoad Learn** (Coursera) | Courses | L&D | Assign curricula. |
+| Knowledge | **BlackRoad Academy** (edX) | MOOCs | L&D | Track completions. |
+| Knowledge | **BlackRoad Courses** (Udemy) | Skills | L&D | Manage licenses. |
+| Knowledge | **BlackRoad Basics** (Khan Academy) | STEM training | L&D | Use for intern ramp. |
+| Hardware | **BlackRoad AI** (Nvidia Jetson/Orin) | Edge AI hardware | Hardware | Document provisioning. |
+| Hardware | **BlackRoad Pi** (Raspberry Pi) | Prototyping | Hardware | Maintain inventory. |
+| Hardware | **BlackRoad Maker** (Arduino) | IoT dev kits | Hardware | Capture firmware prompts. |
+| Hardware | **BlackRoad Robotics** (ROS) | Robotics framework | Hardware | Align with GitHub actions. |
+
+## 3. Codex Prompt Factory
+1. **Prompt Templates**: Define YAML prompt descriptors (`prompts/integrations/*.yml`) with fields for
+   objective, systems touched, secrets required, validation steps, and evidence deliverables.
+2. **Batch Generation**: Use `codex_pipeline.py` to fan out 10–20 prompts simultaneously. Each prompt
+   should target a row in the integration table and reference whether execution happens on
+   `blackroad.io` or `blackroadinc.us`.
+3. **Approval Loop**: Pipe generated prompts to Asana (BlackRoad Tasks) via the Auth Bot for manual
+   review before execution.
+4. **Evidence Binding**: Store artifacts (screenshots, exports) under `evidence/integrations/<system>/`
+   and reference them in the prompt metadata.
+
+## 4. Ops Execution Roadmap
+- **Week 0 (Today)**: Finalize this master plan, align domain messaging, and inventory all invites
+  (Slack, Asana, Jira, Airtable, Notion). Document owner confirmations in `ops/invite-tracker.csv`.
+- **Week 1**: Stand up Slack side-channel protections and Asana Auth Bot per the PR bundle
+  checklist. Begin GitLab mirroring with deploy keys and Gitleaks integration.
+- **Week 2**: Complete CRM & marketing integrations, connect Instagram profiles, and align analytics
+  for `blackroad.io` funnels.
+- **Week 3**: Roll out finance and HR systems, ensuring `blackroadinc.us` hosts the compliance
+  dashboards.
+- **Week 4**: Harden security stack (Okta, Auth0, Splunk, Datadog, Snyk) and formalize incident
+  response using Telegram secure channels.
+
+## 5. Coordination & Communication
+- Primary coordinator: **Alexa Amundson** (`amundsonalexa@gmail.com`).
+- Daily sync via Slack (#ops-integration) with summaries mirrored to Notion and Asana.
+- Escalations route through the Jira service desk project and notify via Teams/Outlook.
+- Social alignment handled through Instagram profiles and the marketing prompt backlog.
+
+## 6. Next Steps Checklist
+- [ ] Publish this plan to `blackroadinc.us` ops hub.
+- [ ] Generate initial 10 Codex prompts using the integration table as the backlog.
+- [ ] Update `README_PR_AUTOMATION.md` with a pointer to this master plan and the PR bundle checklist.
+- [ ] Confirm Slack, Asana, GitLab credentials stored in 1Password vault.
+- [ ] Kick off invite acceptance audit across Slack, Asana, Jira, Airtable, Notion.
+

--- a/docs/PR_BUNDLE_INTEGRATIONS.md
+++ b/docs/PR_BUNDLE_INTEGRATIONS.md
@@ -1,0 +1,47 @@
+# PR Bundle Integration Checklist
+
+The PR bundle unlocks integration testing with external systems. Use this checklist to wire up the
+mandatory services before enabling automated sync jobs or approvals.
+
+## Slack
+- **Incoming webhook**: Create an app-scoped webhook in the target workspace and store the URL in
+  the `SLACK_WEBHOOK_URL` secret. Limit the webhook to the `#pr-bundle` (or equivalent) channel and
+  disable posting elsewhere.
+- **Side-channel protection**: Require signed requests using Slack's signing secret and verify the
+  timestamp and signature inside relay functions (`scripts/notifications/*`). Rotate the signing
+  secret quarterly.
+- **Secrets handling**: Mount the webhook URL in CI via the secrets manager (e.g., Vault path
+  `kv/team-pr/slack`). Never commit the URL to the repository. Use runtime templating to inject it
+  into deployment manifests.
+- **Monitoring**: Configure Slack app-level audit logs and subscribe to the webhook error events so
+  failures surface in the observability stack.
+
+## Asana (Auth Bot)
+- **GitHub App**: Register a GitHub App (Probot-compatible) dedicated to PR approvals. Grant it
+  `pull_request`, `checks`, and `metadata` read/write scopes. Install the app on repositories that
+  participate in the PR bundle flow.
+- **Bot authentication**: Generate an Asana Personal Access Token scoped to the integration project
+  and store it as `ASANA_AUTH_BOT_TOKEN`. Map GitHub App installations to Asana workspace/team IDs.
+- **Approval workflow**: Implement a Probot handler that listens for review requests tagged with the
+  `asana-approval` label. When triggered, the bot opens/updates an Asana task, assigns the
+  approver, and posts back the approval decision to the PR conversation.
+- **Manual override**: Allow a `/asana approve` slash command in PR comments that the bot validates
+  against Asana task status before merging. All actions should be logged to `logs/asana-auth-bot/`.
+
+## GitLab Mirroring
+- **Deploy key**: Provision an SSH deploy key with read/write privileges on the GitLab project and
+  add the corresponding public key under the GitHub repository's deploy keys. Use it for mirroring
+  rather than personal tokens.
+- **Gitleaks in CI**: When using Gitleaks, inject the deploy key via an SSH agent step before the
+  scan runs. Configure the pipeline to fetch from the mirrored repository and push leak reports
+  back to GitHub as PR comments.
+- **Alternate CI/CD tooling**: For runners orchestrated via Grunt or Ansible, template the mirroring
+  configuration (remote URL, refspecs, schedules) inside the respective playbooks. Ensure inventory
+  vars store the SSH key path and that the tasks include a `known_hosts` entry for `gitlab.com`.
+- **Sync cadence**: Run the mirror job at least hourly and after every protected-branch merge. Track
+  mirror status in the deployment dashboard and alert if lag exceeds two sync cycles.
+
+## Evidence & Auditing
+- Record integration setup evidence (screenshots, config exports) under `evidence/pr-bundle/`.
+- Update `README_PR_AUTOMATION.md` with the integration status matrix once each service is live.
+- Link the evidence bundle in the PR description when requesting security review.


### PR DESCRIPTION
## Summary
- document the end-to-end BlackRoad ops and integration plan covering blackroad.io and blackroadinc.us domains
- map ownership, tooling categories, and codex prompt batching workflow in a dedicated playbook
- link the PR automation README to the new plan so ops teams can find both the checklist and rollout roadmap

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d833d487788329ae36f15f1ad20382