### PR TITLE
Add workflow to expose crypto secrets to Pi agent

### DIFF
--- a/.github/workflows/pi-agent-crypto-secrets.yml
+++ b/.github/workflows/pi-agent-crypto-secrets.yml
@@ -1,0 +1,115 @@
+name: Pi Agent Crypto Secrets
+
+on:
+  workflow_call:
+    inputs:
+      run:
+        description: >-
+          Optional shell command to execute after the secrets are loaded.
+          Example: "node apps/pi-agent/index.js".
+        required: false
+        type: string
+  workflow_dispatch:
+    inputs:
+      run:
+        description: >-
+          Optional shell command to execute after the secrets are loaded.
+          Example: "node apps/pi-agent/index.js".
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+env:
+  NODE_VERSION: "20"
+
+jobs:
+  load-secrets:
+    name: Load crypto wallet secrets
+    runs-on: ubuntu-latest
+    env:
+      CRYPTO_SECRET_MAP: |
+        # Map each wallet secret to an environment variable. Add or remove
+        # entries as your wallet inventory changes.
+        ROBINHOOD_ETHEREUM=${{ secrets.ROBINHOOD_ETHEREUM }}
+        COINBASE_BITCOIN=${{ secrets.COINBASE_BITCOIN }}
+        VENMO_LITECOIN=${{ secrets.VENMO_LITECOIN }}
+        # Example placeholder – delete if unused.
+        GEMINI_SOLANA=${{ secrets.GEMINI_SOLANA }}
+
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Export crypto secrets to environment
+        id: export
+        shell: bash
+        run: |
+          python - <<'PY'
+          import os
+
+          secrets_block = os.environ.get("CRYPTO_SECRET_MAP", "")
+          env_path = os.environ["GITHUB_ENV"]
+
+          with open(env_path, "a", encoding="utf-8") as env_file:
+              for line in secrets_block.splitlines():
+                  line = line.strip()
+                  if not line or line.startswith("#") or "=" not in line:
+                      continue
+                  key, value = line.split("=", 1)
+                  key = key.strip()
+                  value = value.strip()
+                  if not key or not value:
+                      # Skip secrets that are not configured in the repo.
+                      continue
+                  env_file.write(f"{key}={value}\n")
+          PY
+
+      - name: Summarize exported variables
+        shell: bash
+        run: |
+          python - <<'PY'
+          import os
+          import textwrap
+
+          secrets_block = os.environ.get("CRYPTO_SECRET_MAP", "")
+          names = []
+          for line in secrets_block.splitlines():
+              line = line.strip()
+              if not line or line.startswith("#") or "=" not in line:
+                  continue
+              key, value = line.split("=", 1)
+              key = key.strip()
+              value = value.strip()
+              if key and value:
+                  names.append(f"- `{key}`")
+
+          if not names:
+              names.append("- _No wallet secrets are configured yet._")
+
+          summary = textwrap.dedent("""\
+          ## Crypto wallet secrets available to this job
+          The following environment variables are now populated from encrypted GitHub secrets:
+          {items}
+
+          Update the `CRYPTO_SECRET_MAP` list in `.github/workflows/pi-agent-crypto-secrets.yml` whenever
+          you add, rotate, or remove wallet addresses.
+          """).format(items="\n".join(names))
+
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary_file:
+              summary_file.write(summary)
+          PY
+
+      - name: Run Pi agent command (caller input)
+        if: ${{ github.event_name == 'workflow_call' && inputs.run != '' }}
+        shell: bash
+        run: ${{ inputs.run }}
+
+      - name: Run Pi agent command (manual input)
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.run != '' }}
+        shell: bash
+        run: ${{ github.event.inputs.run }}
+


### PR DESCRIPTION
## Summary
- add a reusable `pi-agent-crypto-secrets` workflow that sets up Node 20 and exports wallet secrets into environment variables
- surface the exported variable names via the step summary and provide optional hooks to run a Pi agent command

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d83e6bc7188329b86f51dada85ebc7