### PR TITLE
Add agentic payment vision scenarios

### DIFF
--- a/docs/agentic-payments-vision.md
+++ b/docs/agentic-payments-vision.md
@@ -1,0 +1,39 @@
+# Agentic Payments Vision Scenarios
+
+## Overview
+
+The convergence of Google\'s Agent Payments Protocol (AP2), Anthropic\'s Model Context Protocol (MCP), and Cloudflare\'s NET Dollar stablecoin provides a composable stack for autonomous agents to transact on behalf of people and organizations. AP2 standardizes the mandate-driven authorization flow, MCP enables context-rich tool access, and NET Dollar adds always-on settlement designed for automated interactions.
+
+The following scenarios outline how this stack could deliver practical value while highlighting operational and governance guardrails teams should prepare to manage.
+
+## Travel Booking Concierge
+
+1. **Context assembly (MCP)**: A traveler authorizes a personal itinerary agent to retrieve loyalty balances, company travel policy, and prior preferences through MCP connections to airline, hotel, and corporate booking APIs. The agent receives scoped tokens that expire after the trip window.
+2. **Offer negotiation (agent-to-agent)**: The concierge agent chats directly with airline and hotel agents, exchanging availability, fare rules, and ancillary upsell options. MCP-standardized context ensures each agent sees consistent policy constraints and user intent metadata.
+3. **Mandated payment (AP2)**: Once the traveler approves an itinerary summary, the concierge submits an AP2 payment request signed with the traveler\'s mandate. The mandate caps spend per vendor and requires multi-factor confirmation for charges above $3,000.
+4. **Settlement (NET Dollar and traditional rails)**: Airlines accepting NET Dollar receive funds instantly, enabling ticket issuance within seconds. Hotels preferring card settlement receive an AP2-routed authorization through existing processors. A unified ledger tracks both flows, supporting automated expense reporting.
+5. **Risk controls**: AP2 mandates embed cancellation windows, MCP connectors log every data fetch, and all agent messages feed a compliance review dashboard. If an agent deviates from policy, revocation of the signed mandate immediately halts further spend.
+
+## API Monetization Marketplace
+
+1. **Publisher onboarding**: A developer exposes a data enrichment API and publishes an MCP tool schema plus AP2-compatible pricing tiers (per-call, per-bundle, or subscription). Mandates specify throttle limits and usage analytics required for auditing.
+2. **Subscriber agent workflow**: A downstream analytics agent subscribes using a corporate mandate that sets monthly spend ceilings and requires periodic human approval. MCP brokering allows the analytics agent to discover the API, fetch documentation, and negotiate discounts with the publisher agent.
+3. **Granular payments**: Each API call logs usage events. Micro-invoices are bundled hourly and settled via NET Dollar for sub-cent fees, while larger enterprise invoices route through ACH via AP2. Mandate scopes ensure rate limits and termination rights remain enforceable.
+4. **Governance and compliance**: Tool poisoning defenses include mutual attestation: MCP connectors require signed manifests, and AP2 mandates reference checksum hashes. Marketplace operators monitor for anomalous call patterns and can freeze mandates if compromised.
+
+## Content Micropayments Network
+
+1. **Creator agent setup**: Writers and musicians deploy storefront agents that expose catalogs via MCP. They define AP2 mandates allowing pay-per-view, timed rentals, and subscription bundles, each with specific refund and redistribution rules.
+2. **Consumer wallet agent**: Users authorize a media wallet agent with a discretionary budget denominated partly in NET Dollar for instant settlements and partly in a traditional bank account for higher-value purchases. Spending caps and parental controls live in the signed mandate.
+3. **Streaming transaction flow**: When a user starts a stream, the wallet agent pings the creator agent to retrieve licensing terms. Per-second micropayments stream in NET Dollar using x402 extensions, while the AP2 ledger aggregates activity for dispute resolution.
+4. **Cross-platform portability**: Because AP2 is payment-agnostic and MCP abstracts tool access, users can port their wallet agent across platforms without re-entering payment credentials. NET Dollar settlements finalize instantly, but if regulators restrict stablecoin use in a region, AP2 falls back to local bank rails without changing the agent workflows.
+5. **Trust and identity**: Creators leverage decentralized identity proofs attached to their MCP manifests. Consumer agents verify these before releasing funds, reducing phishing risk. Revocation registries let creators or consumers halt compromised agents immediately.
+
+## Strategic Considerations
+
+- **Regulatory readiness**: Stablecoin adoption requires jurisdiction-specific compliance. Maintain region-aware mandate policies and automated reporting hooks for regulators.
+- **Liability frameworks**: Define clear accountability if an agent misinterprets a mandate. Insurance products or bonded guarantees could backstop large transactions.
+- **Security posture**: Invest in MCP connector hardening, mandate signing infrastructure, and runtime monitoring to detect anomalous behaviors.
+- **Ecosystem governance**: Participate in standards bodies shaping AP2, MCP, and x402 to influence interoperability decisions that affect your roadmap.
+
+By prototyping against these scenarios, teams can pressure-test mandate designs, risk thresholds, and observability requirements before agentic payments reach mainstream volume.


### PR DESCRIPTION
## Summary
- add a vision document outlining how AP2, MCP, and NET Dollar could power agentic travel booking, API marketplaces, and content micropayments
- capture security, governance, and compliance guardrails teams should track while experimenting with the stack

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d846e5dd808329ba4a54d6d5352c93