### PR TITLE
Add Terraform baseline infrastructure configuration

### DIFF
--- a/br-infra-iac/.github/workflows/terraform.yml
+++ b/br-infra-iac/.github/workflows/terraform.yml
@@ -1,0 +1,41 @@
+name: terraform
+on:
+  pull_request:
+    paths: ['envs/**', 'modules/**', '.github/workflows/terraform.yml']
+  push:
+    branches: [main]
+    paths: ['envs/**', 'modules/**', '.github/workflows/terraform.yml']
+permissions:
+  id-token: write
+  contents: read
+env:
+  AWS_REGION: ${{ vars.AWS_REGION }}
+  TF_IN_AUTOMATION: true
+jobs:
+  plan:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    defaults: { run: { working-directory: envs/dev } }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_REGION }}
+      - run: terraform init
+      - run: terraform plan -var-file=dev.tfvars
+  apply:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment: aws-dev
+    defaults: { run: { working-directory: envs/dev } }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_REGION }}
+      - run: terraform init -upgrade
+      - run: terraform apply -auto-approve -var-file=dev.tfvars

--- a/br-infra-iac/Makefile
+++ b/br-infra-iac/Makefile
@@ -1,0 +1,23 @@
+TF?=terraform
+ENV?=dev
+
+init:
+@(cd envs/$(ENV) && $(TF) init)
+
+plan:
+@(cd envs/$(ENV) && $(TF) plan -var-file=$(ENV).tfvars)
+
+apply:
+@(cd envs/$(ENV) && $(TF) apply -auto-approve -var-file=$(ENV).tfvars)
+
+destroy:
+@(cd envs/$(ENV) && $(TF) destroy -auto-approve -var-file=$(ENV).tfvars)
+
+bootstrap-init:
+@(cd global/bootstrap && $(TF) init)
+
+bootstrap-apply:
+@(cd global/bootstrap && $(TF) apply -auto-approve)
+
+bootstrap-destroy:
+@(cd global/bootstrap && $(TF) destroy -auto-approve)

--- a/br-infra-iac/README.md
+++ b/br-infra-iac/README.md
@@ -1,0 +1,45 @@
+# BlackRoad Terraform Baseline
+
+## What you get
+- Remote state (S3 + DynamoDB)
+- GitHub OIDC role for Terraform (no long-lived AWS keys)
+- VPC (2 AZs, public + private, IGW + single NAT)
+- ECS Cluster (Fargate + Container Insights)
+- ECR repos (scanning on push)
+- RDS Postgres (password managed by AWS; not stored in code)
+
+## One-time bootstrap
+```bash
+make bootstrap-init
+cp global/bootstrap/terraform.tfvars.example global/bootstrap/terraform.tfvars
+# edit values (state bucket, table, org/repo)
+make bootstrap-apply
+
+Copy oidc_role_arn to repo secret AWS_ROLE_TO_ASSUME. Set repo variable AWS_REGION.
+
+Deploy dev
+
+cp envs/dev/terraform.tfvars.example envs/dev/dev.tfvars
+# tweak values
+make init ENV=dev
+make plan ENV=dev
+make apply ENV=dev
+
+CI/CD
+  • PR → terraform plan
+  • Push to main (env: aws-dev) → terraform apply (environment protection recommended)
+
+Notes
+  • NAT gateways cost money; keep one NAT (default here) and monitor.
+  • For app access to DB, prefer SG-to-SG rules (set app_sg_ids).
+  • RDS master password is managed by AWS; fetch when needed via AWS console/Secrets Manager (no plaintext in code).
+```
+
+---
+
+That’s your baseline. Next moves I can tee up fast:
+- **Helm/Ingress** add-on for ECS service or an ALB-backed example service.
+- **Route53** + ACM certificates and ALB for `api.blackroad.io`.
+- **SSM Parameter Store** wiring for app env vars with `task_definition` examples.
+
+Pick one and I’ll drop the files.

--- a/br-infra-iac/envs/dev/main.tf
+++ b/br-infra-iac/envs/dev/main.tf
@@ -1,0 +1,43 @@
+locals {
+  name = "br-dev"
+  tags = merge(var.tags, { env = "dev" })
+}
+
+module "network" {
+  source   = "../../modules/network"
+  name     = local.name
+  vpc_cidr = var.vpc_cidr
+  azs      = var.azs
+  tags     = local.tags
+}
+
+module "ecs" {
+  source = "../../modules/ecs-cluster"
+  name   = local.name
+  tags   = local.tags
+}
+
+module "ecr" {
+  source            = "../../modules/ecr"
+  repository_names  = var.ecr_repositories
+  tags              = local.tags
+}
+
+module "rds" {
+  source                    = "../../modules/rds-postgres"
+  name                      = local.name
+  vpc_id                    = module.network.vpc_id
+  subnet_ids                = module.network.private_subnet_ids
+  app_sg_ids                = [] # put ECS SG here when you add services
+  db_allowed_cidr_blocks    = var.db_allowed_cidr_blocks
+  instance_class            = var.rds_instance_class
+  multi_az                  = false
+  backup_retention_days     = 7
+  tags                      = local.tags
+}
+
+output "vpc_id"          { value = module.network.vpc_id }
+output "private_subnets" { value = module.network.private_subnet_ids }
+output "ecs_cluster"     { value = module.ecs.cluster_name }
+output "ecr_repos"       { value = module.ecr.repo_arns }
+output "db_endpoint"     { value = module.rds.db_endpoint }

--- a/br-infra-iac/envs/dev/providers.tf
+++ b/br-infra-iac/envs/dev/providers.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers { aws = { source = "hashicorp/aws", version = ">= 5.0" } }
+  backend "s3" {
+    bucket         = "br-tfstate-<unique>"      # from bootstrap
+    key            = "dev/terraform.tfstate"
+    region         = "us-west-2"
+    dynamodb_table = "br-terraform-lock"
+    encrypt        = true
+  }
+}
+provider "aws" { region = var.region }

--- a/br-infra-iac/envs/dev/terraform.tfvars.example
+++ b/br-infra-iac/envs/dev/terraform.tfvars.example
@@ -1,0 +1,6 @@
+region   = "us-west-2"
+vpc_cidr = "10.20.0.0/16"
+azs      = ["us-west-2a","us-west-2b"]
+ecr_repositories = ["br-api-gateway", "br-products-site"]
+db_allowed_cidr_blocks = ["10.20.0.0/16"] # or leave empty if using app SGs
+tags = { app = "blackroad", owner = "ops", cost-center = "core" }

--- a/br-infra-iac/envs/dev/variables.tf
+++ b/br-infra-iac/envs/dev/variables.tf
@@ -1,0 +1,7 @@
+variable "region"       { type = string }
+variable "vpc_cidr"     { type = string }
+variable "azs"          { type = list(string) }
+variable "ecr_repositories" { type = list(string) }
+variable "db_allowed_cidr_blocks" { type = list(string) default = [] }
+variable "rds_instance_class" { type = string default = "db.t4g.micro" }
+variable "tags" { type = map(string) default = { app = "blackroad" } }

--- a/br-infra-iac/envs/prod/main.tf
+++ b/br-infra-iac/envs/prod/main.tf
@@ -1,0 +1,44 @@
+locals {
+  name = "br-prod"
+  tags = merge(var.tags, { env = "prod" })
+}
+
+module "network" {
+  source   = "../../modules/network"
+  name     = local.name
+  vpc_cidr = var.vpc_cidr
+  azs      = var.azs
+  tags     = local.tags
+}
+
+module "ecs" {
+  source = "../../modules/ecs-cluster"
+  name   = local.name
+  tags   = local.tags
+}
+
+module "ecr" {
+  source            = "../../modules/ecr"
+  repository_names  = var.ecr_repositories
+  tags              = local.tags
+}
+
+module "rds" {
+  source                    = "../../modules/rds-postgres"
+  name                      = local.name
+  vpc_id                    = module.network.vpc_id
+  subnet_ids                = module.network.private_subnet_ids
+  app_sg_ids                = []
+  db_allowed_cidr_blocks    = var.db_allowed_cidr_blocks
+  instance_class            = var.rds_instance_class
+  multi_az                  = var.rds_multi_az
+  backup_retention_days     = var.rds_backup_retention_days
+  deletion_protection       = true
+  tags                      = local.tags
+}
+
+output "vpc_id"          { value = module.network.vpc_id }
+output "private_subnets" { value = module.network.private_subnet_ids }
+output "ecs_cluster"     { value = module.ecs.cluster_name }
+output "ecr_repos"       { value = module.ecr.repo_arns }
+output "db_endpoint"     { value = module.rds.db_endpoint }

--- a/br-infra-iac/envs/prod/providers.tf
+++ b/br-infra-iac/envs/prod/providers.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers { aws = { source = "hashicorp/aws", version = ">= 5.0" } }
+  backend "s3" {
+    bucket         = "br-tfstate-<unique>"      # from bootstrap
+    key            = "prod/terraform.tfstate"
+    region         = "us-west-2"
+    dynamodb_table = "br-terraform-lock"
+    encrypt        = true
+  }
+}
+provider "aws" { region = var.region }

--- a/br-infra-iac/envs/prod/terraform.tfvars.example
+++ b/br-infra-iac/envs/prod/terraform.tfvars.example
@@ -1,0 +1,9 @@
+region   = "us-west-2"
+vpc_cidr = "10.40.0.0/16"
+azs      = ["us-west-2a","us-west-2b"]
+ecr_repositories = ["br-api-gateway", "br-products-site"]
+db_allowed_cidr_blocks = ["10.40.0.0/16"]
+rds_instance_class = "db.t4g.medium"
+rds_multi_az = true
+rds_backup_retention_days = 30
+tags = { app = "blackroad", owner = "ops", cost-center = "core" }

--- a/br-infra-iac/envs/prod/variables.tf
+++ b/br-infra-iac/envs/prod/variables.tf
@@ -1,0 +1,9 @@
+variable "region"       { type = string }
+variable "vpc_cidr"     { type = string }
+variable "azs"          { type = list(string) }
+variable "ecr_repositories" { type = list(string) }
+variable "db_allowed_cidr_blocks" { type = list(string) default = [] }
+variable "rds_instance_class" { type = string default = "db.t4g.medium" }
+variable "rds_multi_az" { type = bool default = true }
+variable "rds_backup_retention_days" { type = number default = 30 }
+variable "tags" { type = map(string) default = { app = "blackroad" } }

--- a/br-infra-iac/envs/stg/main.tf
+++ b/br-infra-iac/envs/stg/main.tf
@@ -1,0 +1,43 @@
+locals {
+  name = "br-stg"
+  tags = merge(var.tags, { env = "stg" })
+}
+
+module "network" {
+  source   = "../../modules/network"
+  name     = local.name
+  vpc_cidr = var.vpc_cidr
+  azs      = var.azs
+  tags     = local.tags
+}
+
+module "ecs" {
+  source = "../../modules/ecs-cluster"
+  name   = local.name
+  tags   = local.tags
+}
+
+module "ecr" {
+  source            = "../../modules/ecr"
+  repository_names  = var.ecr_repositories
+  tags              = local.tags
+}
+
+module "rds" {
+  source                    = "../../modules/rds-postgres"
+  name                      = local.name
+  vpc_id                    = module.network.vpc_id
+  subnet_ids                = module.network.private_subnet_ids
+  app_sg_ids                = []
+  db_allowed_cidr_blocks    = var.db_allowed_cidr_blocks
+  instance_class            = var.rds_instance_class
+  multi_az                  = var.rds_multi_az
+  backup_retention_days     = var.rds_backup_retention_days
+  tags                      = local.tags
+}
+
+output "vpc_id"          { value = module.network.vpc_id }
+output "private_subnets" { value = module.network.private_subnet_ids }
+output "ecs_cluster"     { value = module.ecs.cluster_name }
+output "ecr_repos"       { value = module.ecr.repo_arns }
+output "db_endpoint"     { value = module.rds.db_endpoint }

--- a/br-infra-iac/envs/stg/providers.tf
+++ b/br-infra-iac/envs/stg/providers.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers { aws = { source = "hashicorp/aws", version = ">= 5.0" } }
+  backend "s3" {
+    bucket         = "br-tfstate-<unique>"      # from bootstrap
+    key            = "stg/terraform.tfstate"
+    region         = "us-west-2"
+    dynamodb_table = "br-terraform-lock"
+    encrypt        = true
+  }
+}
+provider "aws" { region = var.region }

--- a/br-infra-iac/envs/stg/terraform.tfvars.example
+++ b/br-infra-iac/envs/stg/terraform.tfvars.example
@@ -1,0 +1,9 @@
+region   = "us-west-2"
+vpc_cidr = "10.30.0.0/16"
+azs      = ["us-west-2a","us-west-2b"]
+ecr_repositories = ["br-api-gateway", "br-products-site"]
+db_allowed_cidr_blocks = ["10.30.0.0/16"]
+rds_instance_class = "db.t4g.small"
+rds_multi_az = false
+rds_backup_retention_days = 14
+tags = { app = "blackroad", owner = "ops", cost-center = "core" }

--- a/br-infra-iac/envs/stg/variables.tf
+++ b/br-infra-iac/envs/stg/variables.tf
@@ -1,0 +1,9 @@
+variable "region"       { type = string }
+variable "vpc_cidr"     { type = string }
+variable "azs"          { type = list(string) }
+variable "ecr_repositories" { type = list(string) }
+variable "db_allowed_cidr_blocks" { type = list(string) default = [] }
+variable "rds_instance_class" { type = string default = "db.t4g.small" }
+variable "rds_multi_az" { type = bool default = false }
+variable "rds_backup_retention_days" { type = number default = 14 }
+variable "tags" { type = map(string) default = { app = "blackroad" } }

--- a/br-infra-iac/global/bootstrap/main.tf
+++ b/br-infra-iac/global/bootstrap/main.tf
@@ -1,0 +1,73 @@
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers { aws = { source = "hashicorp/aws", version = ">= 5.0" } }
+}
+provider "aws" { region = var.region }
+
+# Remote state backend (S3 + DynamoDB)
+resource "aws_s3_bucket" "tfstate" {
+  bucket        = var.state_bucket_name
+  force_destroy = false
+}
+resource "aws_s3_bucket_versioning" "v" {
+  bucket = aws_s3_bucket.tfstate.id
+  versioning_configuration { status = "Enabled" }
+}
+resource "aws_s3_bucket_encryption" "enc" {
+  bucket = aws_s3_bucket.tfstate.id
+  server_side_encryption_configuration { rule { apply_server_side_encryption_by_default { sse_algorithm = "AES256" } } }
+}
+resource "aws_s3_bucket_public_access_block" "pab" {
+  bucket                  = aws_s3_bucket.tfstate.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+resource "aws_dynamodb_table" "lock" {
+  name         = var.lock_table_name
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
+  attribute { name = "LockID"; type = "S" }
+}
+
+# GitHub OIDC provider + role for Terraform
+resource "aws_iam_openid_connect_provider" "github" {
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"] # GitHub's
+}
+
+data "aws_iam_policy_document" "assume" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    effect  = "Allow"
+    principals { type = "Federated"; identifiers = [aws_iam_openid_connect_provider.github.arn] }
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:${var.github_org}/${var.github_repo}:ref:refs/heads/main"]
+    }
+  }
+}
+
+resource "aws_iam_role" "gh_terraform" {
+  name               = var.github_role_name
+  assume_role_policy = data.aws_iam_policy_document.assume.json
+  tags               = var.tags
+}
+
+# Keep simple first; tighten later (least-privilege by service)
+resource "aws_iam_role_policy_attachment" "poweruser" {
+  role       = aws_iam_role.gh_terraform.name
+  policy_arn = "arn:aws:iam::aws:policy/PowerUserAccess"
+}
+
+output "state_bucket" { value = aws_s3_bucket.tfstate.bucket }
+output "lock_table"   { value = aws_dynamodb_table.lock.name }
+output "oidc_role_arn" { value = aws_iam_role.gh_terraform.arn }

--- a/br-infra-iac/global/bootstrap/terraform.tfvars.example
+++ b/br-infra-iac/global/bootstrap/terraform.tfvars.example
@@ -1,0 +1,6 @@
+region            = "us-west-2"
+state_bucket_name = "br-tfstate-<unique>"
+lock_table_name   = "br-terraform-lock"
+github_org        = "blackboxprogramming"
+github_repo       = "br-infra-iac"
+github_role_name  = "github-terraform"

--- a/br-infra-iac/global/bootstrap/variables.tf
+++ b/br-infra-iac/global/bootstrap/variables.tf
@@ -1,0 +1,7 @@
+variable "region"            { type = string }
+variable "state_bucket_name" { type = string }
+variable "lock_table_name"   { type = string }
+variable "github_org"        { type = string }
+variable "github_repo"       { type = string }
+variable "github_role_name"  { type = string  default = "github-terraform" }
+variable "tags" { type = map(string) default = { app = "blackroad", env = "global" } }

--- a/br-infra-iac/modules/ecr/main.tf
+++ b/br-infra-iac/modules/ecr/main.tf
@@ -1,0 +1,9 @@
+locals { repos = toset(var.repository_names) }
+
+resource "aws_ecr_repository" "repo" {
+  for_each                  = local.repos
+  name                      = each.value
+  image_scanning_configuration { scan_on_push = true }
+  encryption_configuration     { encryption_type = "AES256" }
+  tags = var.tags
+}

--- a/br-infra-iac/modules/ecr/outputs.tf
+++ b/br-infra-iac/modules/ecr/outputs.tf
@@ -1,0 +1,1 @@
+output "repo_arns" { value = { for k, r in aws_ecr_repository.repo : k => r.arn } }

--- a/br-infra-iac/modules/ecr/variables.tf
+++ b/br-infra-iac/modules/ecr/variables.tf
@@ -1,0 +1,2 @@
+variable "repository_names" { type = list(string) }
+variable "tags"             { type = map(string) default = {} }

--- a/br-infra-iac/modules/ecs-cluster/main.tf
+++ b/br-infra-iac/modules/ecs-cluster/main.tf
@@ -1,0 +1,13 @@
+resource "aws_ecs_cluster" "this" {
+  name = "${var.name}-ecs"
+  setting { name = "containerInsights"; value = "enabled" }
+  configuration { execute_command_configuration { logging = "DEFAULT" } }
+  capacity_providers = ["FARGATE", "FARGATE_SPOT"]
+  tags = merge(var.tags, { Name = "${var.name}-ecs" })
+}
+
+resource "aws_cloudwatch_log_group" "ecs" {
+  name              = "/blackroad/${var.name}/ecs"
+  retention_in_days = 30
+  tags              = var.tags
+}

--- a/br-infra-iac/modules/ecs-cluster/outputs.tf
+++ b/br-infra-iac/modules/ecs-cluster/outputs.tf
@@ -1,0 +1,2 @@
+output "cluster_name" { value = aws_ecs_cluster.this.name }
+output "log_group"    { value = aws_cloudwatch_log_group.ecs.name }

--- a/br-infra-iac/modules/ecs-cluster/variables.tf
+++ b/br-infra-iac/modules/ecs-cluster/variables.tf
@@ -1,0 +1,2 @@
+variable "name" { type = string }
+variable "tags" { type = map(string) default = {} }

--- a/br-infra-iac/modules/network/main.tf
+++ b/br-infra-iac/modules/network/main.tf
@@ -1,0 +1,64 @@
+terraform { required_providers { aws = { source = "hashicorp/aws", version = ">= 5.0" } } }
+
+resource "aws_vpc" "this" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+  tags = merge(var.tags, { Name = "${var.name}-vpc" })
+}
+
+resource "aws_internet_gateway" "igw" {
+  vpc_id = aws_vpc.this.id
+  tags   = merge(var.tags, { Name = "${var.name}-igw" })
+}
+
+# Public subnets
+resource "aws_subnet" "public" {
+  for_each                = { for idx, az in var.azs : idx => az }
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = cidrsubnet(var.vpc_cidr, 8, each.key)
+  availability_zone       = each.value
+  map_public_ip_on_launch = true
+  tags = merge(var.tags, { Name = "${var.name}-public-${each.value}", Tier = "public" })
+}
+
+# Private subnets
+resource "aws_subnet" "private" {
+  for_each          = { for idx, az in var.azs : idx => az }
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = cidrsubnet(var.vpc_cidr, 8, each.key + 10)
+  availability_zone = each.value
+  tags = merge(var.tags, { Name = "${var.name}-private-${each.value}", Tier = "private" })
+}
+
+resource "aws_eip" "nat" { vpc = true tags = merge(var.tags, { Name = "${var.name}-nat-eip" }) }
+
+resource "aws_nat_gateway" "nat" {
+  allocation_id = aws_eip.nat.id
+  subnet_id     = values(aws_subnet.public)[0].id
+  tags          = merge(var.tags, { Name = "${var.name}-nat" })
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+  route { cidr_block = "0.0.0.0/0"; gateway_id = aws_internet_gateway.igw.id }
+  tags = merge(var.tags, { Name = "${var.name}-rtb-public" })
+}
+
+resource "aws_route_table_association" "public" {
+  for_each       = aws_subnet.public
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.this.id
+  route { cidr_block = "0.0.0.0/0"; nat_gateway_id = aws_nat_gateway.nat.id }
+  tags = merge(var.tags, { Name = "${var.name}-rtb-private" })
+}
+
+resource "aws_route_table_association" "private" {
+  for_each       = aws_subnet.private
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.private.id
+}

--- a/br-infra-iac/modules/network/outputs.tf
+++ b/br-infra-iac/modules/network/outputs.tf
@@ -1,0 +1,3 @@
+output "vpc_id"              { value = aws_vpc.this.id }
+output "public_subnet_ids"   { value = [for s in aws_subnet.public  : s.id] }
+output "private_subnet_ids"  { value = [for s in aws_subnet.private : s.id] }

--- a/br-infra-iac/modules/network/variables.tf
+++ b/br-infra-iac/modules/network/variables.tf
@@ -1,0 +1,4 @@
+variable "name"     { type = string }
+variable "vpc_cidr" { type = string }
+variable "azs"      { type = list(string) } # e.g., ["us-west-2a","us-west-2b"]
+variable "tags"     { type = map(string) default = {} }

--- a/br-infra-iac/modules/rds-postgres/main.tf
+++ b/br-infra-iac/modules/rds-postgres/main.tf
@@ -1,0 +1,65 @@
+resource "aws_db_subnet_group" "this" {
+  name       = "${var.name}-db-subnets"
+  subnet_ids = var.subnet_ids
+  tags       = var.tags
+}
+
+resource "aws_security_group" "db" {
+  name        = "${var.name}-db-sg"
+  description = "DB access"
+  vpc_id      = var.vpc_id
+  tags        = var.tags
+}
+
+# Allow from app SGs (preferred)
+resource "aws_security_group_rule" "from_app" {
+  for_each                 = toset(var.app_sg_ids)
+  type                     = "ingress"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.db.id
+  source_security_group_id = each.value
+}
+
+# Optional: allow from CIDR (fallback for tooling/bastion)
+resource "aws_security_group_rule" "from_cidr" {
+  count             = length(var.db_allowed_cidr_blocks)
+  type              = "ingress"
+  from_port         = 5432
+  to_port           = 5432
+  protocol          = "tcp"
+  security_group_id = aws_security_group.db.id
+  cidr_blocks       = [element(var.db_allowed_cidr_blocks, count.index)]
+}
+
+resource "aws_security_group_rule" "egress_all" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  security_group_id = aws_security_group.db.id
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_db_instance" "this" {
+  identifier                           = "${var.name}-pg"
+  engine                               = "postgres"
+  engine_version                       = var.engine_version
+  instance_class                       = var.instance_class
+  allocated_storage                    = var.allocated_storage
+  storage_encrypted                    = true
+  db_subnet_group_name                 = aws_db_subnet_group.this.name
+  vpc_security_group_ids               = [aws_security_group.db.id]
+  publicly_accessible                  = false
+  multi_az                             = var.multi_az
+  skip_final_snapshot                  = var.skip_final_snapshot
+  manage_master_user_password          = true
+  username                             = var.master_username
+  deletion_protection                  = var.deletion_protection
+  backup_retention_period              = var.backup_retention_days
+  apply_immediately                    = true
+  auto_minor_version_upgrade           = true
+  performance_insights_enabled         = false
+  tags                                 = var.tags
+}

--- a/br-infra-iac/modules/rds-postgres/outputs.tf
+++ b/br-infra-iac/modules/rds-postgres/outputs.tf
@@ -1,0 +1,2 @@
+output "db_endpoint" { value = aws_db_instance.this.address }
+output "db_sg_id"    { value = aws_security_group.db.id }

--- a/br-infra-iac/modules/rds-postgres/variables.tf
+++ b/br-infra-iac/modules/rds-postgres/variables.tf
@@ -1,0 +1,14 @@
+variable "name"        { type = string }
+variable "vpc_id"      { type = string }
+variable "subnet_ids"  { type = list(string) }
+variable "app_sg_ids"  { type = list(string) default = [] }
+variable "db_allowed_cidr_blocks" { type = list(string) default = [] }
+variable "engine_version"     { type = string  default = "16.3" }
+variable "instance_class"     { type = string  default = "db.t4g.micro" }
+variable "allocated_storage"  { type = number  default = 20 }
+variable "multi_az"           { type = bool    default = false }
+variable "skip_final_snapshot"{ type = bool    default = true }
+variable "deletion_protection"{ type = bool    default = false }
+variable "master_username"    { type = string  default = "master" }
+variable "backup_retention_days" { type = number default = 7 }
+variable "tags"               { type = map(string) default = {} }


### PR DESCRIPTION
## Summary
- add Terraform bootstrap configuration for remote state and GitHub OIDC role
- provide reusable network, ECS, ECR, and RDS modules
- configure dev/stg/prod environments, workflow, and Makefile helpers

## Testing
- not run (tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d84a9c6da083299604e135eb40721f