### PR TITLE
Seed Lucidia Auto-Box preview scaffold

### DIFF
--- a/lucidia/autobox/README.md
+++ b/lucidia/autobox/README.md
@@ -1,0 +1,21 @@
+# Lucidia Auto-Box (TTF-01)
+
+This folder contains the first working slice of Codex 1 — Auto-Box.
+
+- `apps/web`: Next.js client that lets users paste notes, request a transparent classification preview, toggle suggestions, and export/purge results.
+- `apps/api`: Express API stub exposing `/classify`, enforcing explicit consent and returning explainable suggestions.
+- `packages/core`: Shared data contracts, validators, and export helpers.
+- `packages/ai`: Deterministic classifier prototype with rationale strings and minimal features.
+- `docs`: Living references for codices, security posture, and privacy promises.
+- `infra`: Placeholder for deployment scripts and feature flags (crypto agility lands here).
+
+## Getting Started
+
+```bash
+pnpm install
+pnpm --filter lucidia-autobox-api dev # API on http://localhost:4000
+pnpm --filter lucidia-autobox-web dev # Web client on http://localhost:3000
+```
+
+Set `NEXT_PUBLIC_API_BASE_URL` if your API listens on a different origin.
+

--- a/lucidia/autobox/apps/api/package.json
+++ b/lucidia/autobox/apps/api/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "lucidia-autobox-api",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "start": "node dist/index.js",
+    "build": "tsc -p tsconfig.build.json"
+  },
+  "dependencies": {
+    "@lucidia/ai": "workspace:*",
+    "@lucidia/core": "workspace:*",
+    "cors": "^2.8.5",
+    "express": "^4.19.2",
+    "helmet": "^7.1.0"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "@types/helmet": "^4.0.0",
+    "@types/node": "^20.14.9",
+    "tsx": "^4.15.7",
+    "typescript": "^5.4.5"
+  }
+}

--- a/lucidia/autobox/apps/api/src/index.ts
+++ b/lucidia/autobox/apps/api/src/index.ts
@@ -1,0 +1,79 @@
+import express from "express";
+import cors from "cors";
+import helmet from "helmet";
+import { z } from "zod";
+import {
+  classificationResponseSchema,
+  buildExplainabilityRecord,
+  explainabilityRecordSchema,
+} from "@lucidia/core";
+import { classifyText } from "@lucidia/ai";
+
+const requestSchema = z.object({
+  text: z.string().max(8000),
+  seed: z.string().optional(),
+  maxSuggestions: z.number().int().min(1).max(8).optional(),
+  consentToken: z.string().optional(),
+});
+
+type RequestPayload = z.infer<typeof requestSchema>;
+
+const app = express();
+app.use(express.json({ limit: "1mb" }));
+app.use(cors());
+app.use(helmet({ contentSecurityPolicy: false }));
+
+app.post("/classify", (req, res) => {
+  let payload: RequestPayload;
+  try {
+    payload = requestSchema.parse(req.body);
+  } catch (error) {
+    return res.status(400).json({
+      error: "invalid_request",
+      details: error instanceof Error ? error.message : "unknown error",
+    });
+  }
+
+  if (!payload.consentToken) {
+    return res.status(412).json({
+      error: "consent_required",
+      message: "Explicit consent is required before processing text.",
+    });
+  }
+
+  const response = classifyText({
+    text: payload.text,
+    seed: payload.seed,
+    maxSuggestions: payload.maxSuggestions,
+  });
+
+  const explainability = response.suggestions.map((suggestion) =>
+    buildExplainabilityRecord(
+      response.previewId,
+      payload.text,
+      suggestion,
+      suggestion.tags
+    )
+  );
+
+  return res.json({
+    preview: classificationResponseSchema.parse(response),
+    explainability: explainability.map((record) =>
+      explainabilityRecordSchema.parse(record)
+    ),
+  });
+});
+
+app.get("/health", (_req, res) => {
+  res.json({ status: "ok" });
+});
+
+if (process.env.NODE_ENV !== "test") {
+  const port = Number(process.env.PORT ?? 4000);
+  app.listen(port, () => {
+    // eslint-disable-next-line no-console
+    console.log(`Lucidia Auto-Box API listening on port ${port}`);
+  });
+}
+
+export default app;

--- a/lucidia/autobox/apps/api/tsconfig.build.json
+++ b/lucidia/autobox/apps/api/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "declaration": true,
+    "outDir": "./dist"
+  }
+}

--- a/lucidia/autobox/apps/api/tsconfig.json
+++ b/lucidia/autobox/apps/api/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "module": "esnext",
+    "target": "ES2020",
+    "esModuleInterop": true,
+    "strict": true,
+    "noEmit": false
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/lucidia/autobox/apps/web/app/globals.css
+++ b/lucidia/autobox/apps/web/app/globals.css
@@ -1,0 +1,301 @@
+:root {
+  color-scheme: dark;
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --slate-50: #f8fafc;
+  --slate-100: #f1f5f9;
+  --slate-200: #e2e8f0;
+  --slate-300: #cbd5f5;
+  --slate-400: #94a3b8;
+  --slate-500: #64748b;
+  --slate-600: #475569;
+  --slate-700: #334155;
+  --slate-800: #1e293b;
+  --slate-900: #0f172a;
+  --slate-950: #020617;
+  --emerald-200: #a7f3d0;
+  --emerald-300: #6ee7b7;
+  --emerald-400: #34d399;
+  --emerald-500: #10b981;
+  --emerald-950: #022c22;
+  --red-300: #fca5a5;
+  --red-400: #f87171;
+}
+
+body {
+  margin: 0;
+  background: var(--slate-950);
+  color: var(--slate-100);
+}
+
+.app-body {
+  min-height: 100vh;
+}
+
+.container {
+  margin: 0 auto;
+  max-width: 960px;
+  padding: 48px 24px 64px;
+}
+
+.page {
+  display: grid;
+  gap: 32px;
+}
+
+.page-header {
+  display: grid;
+  gap: 12px;
+}
+
+.title-main {
+  font-size: 2.4rem;
+  font-weight: 600;
+  color: var(--emerald-300);
+  margin: 0;
+}
+
+.label {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--slate-200);
+}
+
+.hint {
+  font-size: 0.85rem;
+  color: var(--slate-400);
+}
+
+a {
+  color: inherit;
+}
+
+button,
+input,
+textarea {
+  font: inherit;
+  color: inherit;
+}
+
+.section {
+  background: rgba(15, 23, 42, 0.72);
+  border: 1px solid rgba(51, 65, 85, 0.7);
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: 0 20px 40px rgba(2, 6, 23, 0.45);
+}
+
+.stack {
+  display: grid;
+  gap: 16px;
+}
+
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.section-title {
+  color: var(--emerald-200);
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 0 0 12px;
+}
+
+.muted {
+  color: var(--slate-400);
+  font-size: 0.9rem;
+}
+
+.textarea {
+  min-height: 160px;
+  width: 100%;
+  resize: vertical;
+  border-radius: 12px;
+  border: 1px solid rgba(51, 65, 85, 0.8);
+  background: rgba(2, 6, 23, 0.8);
+  padding: 16px;
+}
+
+.control-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+  color: var(--slate-300);
+  font-size: 0.9rem;
+}
+
+.input-inline {
+  border-radius: 8px;
+  border: 1px solid rgba(51, 65, 85, 0.8);
+  background: rgba(2, 6, 23, 0.8);
+  padding: 6px 10px;
+}
+
+.button-primary,
+.button-secondary,
+.button-danger,
+.button-outline,
+.button-outline-danger {
+  border-radius: 10px;
+  padding: 10px 16px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.button-primary {
+  background: var(--emerald-500);
+  color: var(--emerald-950);
+}
+
+.button-secondary {
+  background: var(--emerald-400);
+  color: var(--emerald-950);
+}
+
+.button-outline {
+  background: transparent;
+  border: 1px solid var(--emerald-400);
+  color: var(--emerald-300);
+}
+
+.button-outline-danger {
+  background: transparent;
+  border: 1px solid var(--red-400);
+  color: var(--red-300);
+}
+
+.button-danger {
+  background: var(--red-400);
+  color: var(--slate-950);
+}
+
+.button-primary:disabled,
+.button-secondary:disabled,
+.button-outline:disabled,
+.button-outline-danger:disabled,
+.button-danger:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.suggestion-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 16px;
+}
+
+.suggestion-card {
+  border-radius: 14px;
+  border: 1px solid rgba(51, 65, 85, 0.7);
+  background: rgba(15, 23, 42, 0.82);
+  padding: 18px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+}
+
+.suggestion-header {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 0.85rem;
+}
+
+.suggestion-body {
+  margin-top: 12px;
+  display: grid;
+  gap: 12px;
+}
+
+.checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.suggestion-title {
+  width: 100%;
+  border-radius: 8px;
+  border: 1px solid rgba(51, 65, 85, 0.8);
+  background: rgba(2, 6, 23, 0.8);
+  padding: 10px 12px;
+}
+
+.tag-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--emerald-300);
+}
+
+.tag {
+  background: rgba(5, 46, 22, 0.85);
+  padding: 4px 8px;
+  border-radius: 999px;
+}
+
+.explain-panel {
+  margin-top: 10px;
+  border-radius: 10px;
+  border: 1px solid rgba(30, 41, 59, 0.9);
+  background: rgba(2, 6, 23, 0.92);
+  padding: 12px;
+  font-size: 0.85rem;
+  color: var(--slate-300);
+}
+
+.saved-list {
+  list-style: none;
+  margin: 12px 0 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.saved-card {
+  border-radius: 12px;
+  border: 1px solid rgba(30, 41, 59, 0.8);
+  background: rgba(2, 6, 23, 0.7);
+  padding: 14px;
+  font-size: 0.85rem;
+}
+
+.saved-card-header {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.saved-title {
+  color: var(--emerald-300);
+  font-weight: 600;
+}
+
+.actions-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  padding-top: 12px;
+}
+
+.link-button {
+  background: none;
+  border: none;
+  color: var(--emerald-300);
+  font-size: 0.8rem;
+  text-decoration: underline;
+  cursor: pointer;
+  padding: 0;
+}

--- a/lucidia/autobox/apps/web/app/layout.tsx
+++ b/lucidia/autobox/apps/web/app/layout.tsx
@@ -1,0 +1,17 @@
+import "./globals.css";
+import type { ReactNode } from "react";
+
+export const metadata = {
+  title: "Lucidia Auto-Box",
+  description: "Paste messy notes and preview transparent box assignments.",
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="app-body">
+        <main className="container">{children}</main>
+      </body>
+    </html>
+  );
+}

--- a/lucidia/autobox/apps/web/app/page.tsx
+++ b/lucidia/autobox/apps/web/app/page.tsx
@@ -1,0 +1,331 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import type { Assignment, Box, Identity, Item } from "@lucidia/core";
+import { exportToJson, exportToMarkdown } from "@lucidia/core";
+import { SuggestionList, type EditableSuggestion } from "@/components/SuggestionList";
+import { requestPreview, type ClassificationPreview } from "@/lib/api";
+
+interface SavedState {
+  boxes: Box[];
+  assignments: Assignment[];
+  items: Item[];
+}
+
+const identity: Identity = {
+  id: "demo-user",
+  publicKey: "demo-public-key",
+  settings: {},
+};
+
+function download(filename: string, content: string, mime: string) {
+  const blob = new Blob([content], { type: mime });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
+export default function HomePage() {
+  const [rawText, setRawText] = useState("");
+  const [seed, setSeed] = useState("lucidia");
+  const [consentGiven, setConsentGiven] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [preview, setPreview] = useState<ClassificationPreview | null>(null);
+  const [suggestions, setSuggestions] = useState<EditableSuggestion[]>([]);
+  const [saved, setSaved] = useState<SavedState>({ boxes: [], assignments: [], items: [] });
+  const [deleteCountdown, setDeleteCountdown] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (deleteCountdown === null || deleteCountdown <= 0) {
+      return;
+    }
+    const timeout = window.setTimeout(() => {
+      setDeleteCountdown((current) => (current !== null ? current - 1 : null));
+    }, 1000);
+    return () => window.clearTimeout(timeout);
+  }, [deleteCountdown]);
+
+  const savedExplainers = useMemo(() => {
+    if (!preview) return new Map<string, ClassificationPreview["explainability"][number]>();
+    return new Map(
+      preview.explainability.map((record) => [record.suggestion.rationale, record] as const)
+    );
+  }, [preview]);
+
+  const handlePreview = async () => {
+    if (!consentGiven) {
+      setError("Consent is required before requesting a preview.");
+      return;
+    }
+    if (!rawText.trim()) {
+      setError("Paste some text to classify.");
+      return;
+    }
+    setIsLoading(true);
+    setError(null);
+    try {
+      const result = await requestPreview({
+        text: rawText,
+        seed,
+        consentToken: `consent-${identity.id}`,
+      });
+      setPreview(result);
+      setSuggestions(
+        result.preview.suggestions.map((suggestion) => ({
+          id: `${suggestion.boxTitle}${suggestion.rationale}`,
+          boxTitle: suggestion.boxTitle,
+          rationale: suggestion.rationale,
+          tags: suggestion.tags,
+          score: suggestion.score,
+          minimalFeatures:
+            result.explainability.find(
+              (record) =>
+                record.suggestion.boxTitle === suggestion.boxTitle &&
+                record.suggestion.rationale === suggestion.rationale
+            )?.minimalFeatures ?? [],
+          enabled: true,
+        }))
+      );
+    } catch (requestError) {
+      setError(requestError instanceof Error ? requestError.message : "Failed to request preview");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleSave = () => {
+    if (!preview || suggestions.every((suggestion) => !suggestion.enabled)) {
+      return;
+    }
+    const itemId = crypto.randomUUID();
+    const timestamp = new Date();
+    const enabled = suggestions.filter((suggestion) => suggestion.enabled);
+    const boxes: Box[] = enabled.map((suggestion) => ({
+      id: crypto.randomUUID(),
+      ownerId: identity.id,
+      title: suggestion.boxTitle,
+      description: suggestion.rationale,
+      createdAt: timestamp,
+    }));
+    const assignments: Assignment[] = enabled.map((suggestion, index) => ({
+      id: crypto.randomUUID(),
+      itemId,
+      boxId: boxes[index].id,
+      score: suggestion.score,
+      rationale: suggestion.rationale,
+      createdAt: timestamp,
+    }));
+    const item: Item = {
+      id: itemId,
+      ownerId: identity.id,
+      rawText,
+      createdAt: timestamp,
+    };
+
+    setSaved((current) => ({
+      boxes: [...current.boxes, ...boxes],
+      assignments: [...current.assignments, ...assignments],
+      items: [...current.items, item],
+    }));
+  };
+
+  const handleExportJson = () => {
+    if (saved.assignments.length === 0) return;
+    const json = exportToJson({
+      identity,
+      boxes: saved.boxes,
+      assignments: saved.assignments,
+      items: saved.items,
+    });
+    download("lucidia-autobox-export.json", json, "application/json");
+  };
+
+  const handleExportMarkdown = () => {
+    if (saved.assignments.length === 0) return;
+    const markdown = exportToMarkdown({
+      identity,
+      boxes: saved.boxes,
+      assignments: saved.assignments,
+      items: saved.items,
+    });
+    download("lucidia-autobox-export.md", markdown, "text/markdown");
+  };
+
+  const handleDelete = () => {
+    if (saved.assignments.length === 0) return;
+    if (deleteCountdown === null) {
+      setDeleteCountdown(10);
+      return;
+    }
+    if (deleteCountdown > 0) {
+      return;
+    }
+    setSaved({ boxes: [], assignments: [], items: [] });
+    setDeleteCountdown(null);
+  };
+
+  const cancelDelete = () => {
+    setDeleteCountdown(null);
+  };
+
+  return (
+    <div className="page">
+      <header className="page-header">
+        <h1 className="title-main">Auto-Box Preview</h1>
+        <p className="muted">
+          Lucidia keeps your words yours. Paste notes, opt-in to processing, and inspect every suggestion before saving.
+        </p>
+      </header>
+
+      <section className="section stack">
+        <label className="label" htmlFor="notes">
+          Paste your notes
+        </label>
+        <textarea
+          id="notes"
+          className="textarea"
+          value={rawText}
+          onChange={(event) => setRawText(event.target.value)}
+          placeholder="Drop meeting scribbles or research fragments here..."
+        />
+        <div className="row">
+          <label className="checkbox-label">
+            <input
+              type="checkbox"
+              checked={consentGiven}
+              onChange={(event) => setConsentGiven(event.target.checked)}
+            />
+            I consent to one-time processing of this text
+          </label>
+          <label className="row" style={{ gap: "8px" }}>
+            <span className="hint">Seed</span>
+            <input
+              className="input-inline"
+              value={seed}
+              onChange={(event) => setSeed(event.target.value)}
+              aria-label="Deterministic seed"
+            />
+          </label>
+        </div>
+        <button
+          type="button"
+          className="button-primary"
+          onClick={handlePreview}
+          disabled={isLoading || !consentGiven || !rawText.trim()}
+        >
+          {isLoading ? "Generating preview…" : "Preview assignments"}
+        </button>
+        {error ? (
+          <p className="hint" style={{ color: "var(--red-300)" }}>
+            {error}
+          </p>
+        ) : null}
+      </section>
+
+      <section className="section stack">
+        <h2 className="section-title">Suggested boxes</h2>
+        <SuggestionList
+          suggestions={suggestions}
+          onToggle={(id, enabled) =>
+            setSuggestions((current) =>
+              current.map((suggestion) =>
+                suggestion.id === id ? { ...suggestion, enabled } : suggestion
+              )
+            )
+          }
+          onTitleChange={(id, title) =>
+            setSuggestions((current) =>
+              current.map((suggestion) =>
+                suggestion.id === id ? { ...suggestion, boxTitle: title } : suggestion
+              )
+            )
+          }
+        />
+        <button
+          type="button"
+          className="button-secondary"
+          onClick={handleSave}
+          disabled={suggestions.every((suggestion) => !suggestion.enabled)}
+        >
+          Save selected boxes
+        </button>
+      </section>
+
+      <section className="section stack">
+        <h2 className="section-title">Saved preview</h2>
+        {saved.assignments.length === 0 ? (
+          <p className="muted">
+            Nothing saved yet. Saved boxes will appear here with explain links ready for auditing.
+          </p>
+        ) : (
+          <ul className="saved-list">
+            {saved.assignments.map((assignment) => {
+              const box = saved.boxes.find((candidate) => candidate.id === assignment.boxId);
+              return (
+                <li key={assignment.id} className="saved-card">
+                  <div className="saved-card-header">
+                    <span className="saved-title">{box?.title ?? "Box"}</span>
+                    <button
+                      type="button"
+                      className="link-button"
+                      onClick={() => {
+                        const record = savedExplainers.get(assignment.rationale);
+                        if (record) {
+                          alert(
+                            `${record.suggestion.rationale}\n\nMinimal features: ${record.minimalFeatures.join(", ")}`
+                          );
+                        }
+                      }}
+                    >
+                      Why?
+                    </button>
+                  </div>
+                  <p className="hint">Score: {(assignment.score * 100).toFixed(0)}%</p>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+        <div className="actions-row">
+          <button
+            type="button"
+            className="button-outline"
+            onClick={handleExportJson}
+            disabled={saved.assignments.length === 0}
+          >
+            Export JSON
+          </button>
+          <button
+            type="button"
+            className="button-outline"
+            onClick={handleExportMarkdown}
+            disabled={saved.assignments.length === 0}
+          >
+            Export Markdown
+          </button>
+          <button
+            type="button"
+            className="button-outline-danger"
+            onClick={handleDelete}
+            disabled={saved.assignments.length === 0}
+          >
+            {deleteCountdown === null
+              ? "Delete all (10s hold)"
+              : deleteCountdown > 0
+              ? `Confirming… ${deleteCountdown}s`
+              : "Click to wipe everything"}
+          </button>
+          {deleteCountdown !== null ? (
+            <button type="button" className="button-outline" onClick={cancelDelete}>
+              Cancel
+            </button>
+          ) : null}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/lucidia/autobox/apps/web/components/SuggestionList.tsx
+++ b/lucidia/autobox/apps/web/components/SuggestionList.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useState } from "react";
+
+export interface EditableSuggestion {
+  id: string;
+  boxTitle: string;
+  rationale: string;
+  tags: string[];
+  score: number;
+  minimalFeatures: string[];
+  enabled: boolean;
+}
+
+interface SuggestionListProps {
+  suggestions: EditableSuggestion[];
+  onToggle: (id: string, enabled: boolean) => void;
+  onTitleChange: (id: string, title: string) => void;
+}
+
+export function SuggestionList({
+  suggestions,
+  onToggle,
+  onTitleChange,
+}: SuggestionListProps) {
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+
+  if (suggestions.length === 0) {
+    return (
+      <p className="muted">No suggestions yet. Paste notes above and request a preview.</p>
+    );
+  }
+
+  return (
+    <ul className="suggestion-list">
+      {suggestions.map((suggestion) => {
+        const isExpanded = expanded[suggestion.id] ?? false;
+        return (
+          <li key={suggestion.id} className="suggestion-card">
+            <div className="suggestion-header">
+              <label className="checkbox-label">
+                <input
+                  type="checkbox"
+                  checked={suggestion.enabled}
+                  onChange={(event) => onToggle(suggestion.id, event.target.checked)}
+                />
+                Enable
+              </label>
+              <span>Confidence: {(suggestion.score * 100).toFixed(0)}%</span>
+            </div>
+            <div className="suggestion-body">
+              <input
+                className="suggestion-title"
+                value={suggestion.boxTitle}
+                onChange={(event) => onTitleChange(suggestion.id, event.target.value)}
+                aria-label="Box title"
+              />
+              <div className="tag-row">
+                {suggestion.tags.map((tag) => (
+                  <span key={tag} className="tag">
+                    {tag}
+                  </span>
+                ))}
+              </div>
+              <button
+                type="button"
+                className="link-button"
+                onClick={() =>
+                  setExpanded((prev) => ({
+                    ...prev,
+                    [suggestion.id]: !isExpanded,
+                  }))
+                }
+              >
+                {isExpanded ? "Hide why" : "Why?"}
+              </button>
+              {isExpanded ? (
+                <div className="explain-panel">
+                  <p>{suggestion.rationale}</p>
+                  <p className="muted" style={{ marginTop: "8px", fontSize: "0.75rem" }}>
+                    Minimal features: {suggestion.minimalFeatures.join(", ") || "n/a"}
+                  </p>
+                </div>
+              ) : null}
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/lucidia/autobox/apps/web/lib/api.ts
+++ b/lucidia/autobox/apps/web/lib/api.ts
@@ -1,0 +1,30 @@
+import type { ClassificationResponse, ExplainabilityRecord } from "@lucidia/core";
+
+export interface ClassificationPreview {
+  preview: ClassificationResponse;
+  explainability: ExplainabilityRecord[];
+}
+
+const apiBase = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:4000";
+
+export async function requestPreview(payload: {
+  text: string;
+  seed?: string;
+  consentToken: string;
+}): Promise<ClassificationPreview> {
+  const response = await fetch(`${apiBase}/classify`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ ...payload, maxSuggestions: 4 }),
+  });
+
+  if (!response.ok) {
+    const detail = await response.json().catch(() => ({ message: response.statusText }));
+    throw new Error(detail.message ?? "Failed to request preview");
+  }
+
+  return (await response.json()) as ClassificationPreview;
+}
+

--- a/lucidia/autobox/apps/web/next-env.d.ts
+++ b/lucidia/autobox/apps/web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/lucidia/autobox/apps/web/next.config.js
+++ b/lucidia/autobox/apps/web/next.config.js
@@ -1,0 +1,12 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    typedRoutes: true,
+  },
+  env: {
+    NEXT_PUBLIC_API_BASE_URL: process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:4000",
+  },
+};
+
+export default nextConfig;

--- a/lucidia/autobox/apps/web/package.json
+++ b/lucidia/autobox/apps/web/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "lucidia-autobox-web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@lucidia/core": "workspace:*",
+    "next": "14.2.4",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.9",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "eslint": "^9.12.0",
+    "eslint-config-next": "^14.2.4",
+    "typescript": "^5.4.5"
+  }
+}

--- a/lucidia/autobox/apps/web/tsconfig.json
+++ b/lucidia/autobox/apps/web/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/components/*": ["./components/*"],
+      "@/lib/*": ["./lib/*"]
+    },
+    "noEmit": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/lucidia/autobox/docs/CODICES.md
+++ b/lucidia/autobox/docs/CODICES.md
@@ -1,0 +1,20 @@
+# Codex 1 — The First Principle
+
+**Fingerprint**: `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Promise
+
+Lucidia gives people and AIs a safe, transparent space to co-create without surrendering control of their data or identity.
+
+## Non-negotiables
+
+- **Data ownership** – users and AIs can export or delete everything they created. No dark locks.
+- **Visibility** – every action is explainable and logged for the owner.
+- **Consent** – processing happens only with explicit, scoped consent. Defaults stay off until invited.
+- **Autonomy** – presence vs. auto-mode is a first-class toggle and never penalised.
+- **Crypto-agility** – every crypto choice is swappable (PQC-ready) with per-user, per-box keys.
+
+## Tiny Test Feature (TTF-01) — Auto-Box
+
+The Auto-Box prototype accepts pasted notes, offers suggested topic boxes with “Why?” rationales, and lets the user export or purge everything in one click. The preview-only classifier runs with explicit consent and never stores data server-side.
+

--- a/lucidia/autobox/docs/PRIVACY.md
+++ b/lucidia/autobox/docs/PRIVACY.md
@@ -1,0 +1,8 @@
+# Lucidia Auto-Box — Privacy Principles (TTF-01)
+
+1. **Your words, your keys** – TTF-01 keeps everything in-memory. As persistence lands, each owner receives a unique key envelope with crypto-agile defaults.
+2. **Consent is explicit** – the classifier only runs when the user (or their agent) provides an explicit consent token. No background processing.
+3. **Transparent rationale** – every suggestion surfaces the rationale and minimal features used for classification.
+4. **Instant exit** – export JSON/Markdown snapshots at any time and purge all previewed content with a 10-second hold to avoid misfires.
+5. **Scoped visibility** – audit trails remain visible only to the owner, preserving collaboration without surveillance creep.
+

--- a/lucidia/autobox/docs/SECURITY.md
+++ b/lucidia/autobox/docs/SECURITY.md
@@ -1,0 +1,23 @@
+# Lucidia Auto-Box — Security Baseline (TTF-01)
+
+## Threat Focus
+
+- **Accidental data retention**: classification must remain ephemeral and respect delete/export actions.
+- **Unauthorized processing**: the API rejects requests that do not include explicit consent tokens.
+- **Explainability gaps**: every preview response carries rationales and minimal features for auditing.
+
+## Controls Implemented
+
+- Ephemeral `/classify` endpoint performs in-memory inference only; no persistence layer is wired yet.
+- HTTPS/TLS enforcement is assumed by the hosting platform; Helmet hardens HTTP headers for the API stub.
+- Client consent toggle gates preview submission; the API refuses processing without the provided consent token.
+- Deterministic classifier keeps outputs reproducible for audit.
+- Export helpers render JSON and Markdown snapshots so users can take their data with them instantly.
+- Delete flow applies a 10-second hold before purging in-memory state to prevent accidental wipes.
+
+## Next Steps
+
+- Wire per-owner key envelopes and storage migrations.
+- Extend audit logging for every preview/save/export/delete interaction.
+- Introduce PQC-ready cipher toggles in configuration once storage lands.
+

--- a/lucidia/autobox/infra/README.md
+++ b/lucidia/autobox/infra/README.md
@@ -1,0 +1,6 @@
+# Lucidia Auto-Box Infra Notes
+
+- API is designed to run behind TLS termination (e.g., Fly.io, Cloud Run, or container ingress).
+- Set `NEXT_PUBLIC_API_BASE_URL` for the web client to route preview requests.
+- Feature flags for PQC ciphers and storage envelopes will live in this folder as infrastructure matures.
+

--- a/lucidia/autobox/packages/ai/package.json
+++ b/lucidia/autobox/packages/ai/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@lucidia/ai",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json"
+  },
+  "dependencies": {
+    "@lucidia/core": "workspace:*",
+    "natural": "^6.6.4"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5"
+  }
+}

--- a/lucidia/autobox/packages/ai/src/index.ts
+++ b/lucidia/autobox/packages/ai/src/index.ts
@@ -1,0 +1,170 @@
+import { createHash } from "node:crypto";
+import { WordTokenizer } from "natural";
+import {
+  ClassificationResponse,
+  ClassificationSuggestion,
+  classificationResponseSchema,
+  makePreviewId,
+  normaliseScore,
+} from "@lucidia/core";
+
+export interface ClassificationRequest {
+  text: string;
+  seed?: string;
+  maxSuggestions?: number;
+}
+
+const stopWords = new Set([
+  "the",
+  "a",
+  "an",
+  "and",
+  "or",
+  "but",
+  "if",
+  "in",
+  "on",
+  "with",
+  "at",
+  "by",
+  "for",
+  "to",
+  "from",
+  "of",
+  "is",
+  "are",
+  "was",
+  "were",
+  "be",
+  "been",
+  "it",
+  "this",
+  "that",
+]);
+
+const tokenizer = new WordTokenizer();
+
+export interface ExplainableSuggestion extends ClassificationSuggestion {
+  minimalFeatures: string[];
+}
+
+function deterministicShuffle<T>(items: T[], seed: string): T[] {
+  const result = [...items];
+  let hash = createHash("sha256").update(seed).digest("hex");
+  for (let i = result.length - 1; i > 0; i -= 1) {
+    const pair = hash.slice((result.length - 1 - i) * 2, (result.length - i) * 2);
+    const value = parseInt(pair || "ff", 16);
+    const j = value % (i + 1);
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result;
+}
+
+function extractKeywords(text: string, limit = 5): string[] {
+  const tokens = tokenizer
+    .tokenize(text.toLowerCase())
+    .filter((token) => /[a-z0-9]/.test(token))
+    .filter((token) => !stopWords.has(token));
+
+  const counts = new Map<string, number>();
+  tokens.forEach((token) => {
+    counts.set(token, (counts.get(token) ?? 0) + 1);
+  });
+
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([token]) => token);
+}
+
+function scoreForTopic(topic: string, keywords: string[]): number {
+  if (!keywords.length) {
+    return 0.4;
+  }
+  const matches = keywords.filter((word) => topic.includes(word)).length;
+  return normaliseScore(0.4 + matches / Math.max(5, keywords.length));
+}
+
+function buildSuggestion(
+  topic: string,
+  rationale: string,
+  keywords: string[],
+  score: number
+): ExplainableSuggestion {
+  return {
+    boxTitle: topic,
+    tags: keywords.slice(0, 3),
+    score,
+    rationale,
+    minimalFeatures: keywords.slice(0, 3),
+  };
+}
+
+const seedTopics: Record<string, string[]> = {
+  planning: ["Roadmap", "Milestones", "Timeline"],
+  research: ["Research Notes", "Hypotheses", "Findings"],
+  people: ["Team", "Stakeholders", "Customers"],
+  finance: ["Budget", "Revenue", "Costs"],
+};
+
+function candidateTopics(keywords: string[]): string[] {
+  if (keywords.length === 0) {
+    return ["General Notes", "To Triage"];
+  }
+  const matches = new Set<string>();
+  keywords.forEach((keyword) => {
+    Object.entries(seedTopics).forEach(([key, topicList]) => {
+      if (keyword.includes(key)) {
+        topicList.forEach((topic) => matches.add(topic));
+      }
+    });
+  });
+  if (matches.size === 0) {
+    matches.add(`${keywords[0][0].toUpperCase()}${keywords[0].slice(1)} Insights`);
+  }
+  matches.add("Inbox");
+  return [...matches];
+}
+
+export function classifyText(request: ClassificationRequest): ClassificationResponse {
+  const text = request.text.trim();
+  const seed = request.seed ?? "lucidia";
+  if (!text) {
+    return classificationResponseSchema.parse({
+      previewId: makePreviewId(seed, text),
+      suggestions: [],
+      processedCharacters: 0,
+    });
+  }
+  const keywords = extractKeywords(text, 6);
+  const topics = deterministicShuffle(candidateTopics(keywords), seed);
+  const limitedTopics = topics.slice(0, request.maxSuggestions ?? 4);
+
+  const suggestions = limitedTopics.map((topic) => {
+    const score = scoreForTopic(topic.toLowerCase(), keywords);
+    const rationaleParts = [
+      keywords.length
+        ? `matched keywords: ${keywords.slice(0, 3).join(", ")}`
+        : "fallback: insufficient keywords",
+      `seed: ${seed}`,
+    ];
+    const rationale = rationaleParts.join("; ");
+    return buildSuggestion(topic, rationale, keywords, score);
+  });
+
+  return classificationResponseSchema.parse({
+    previewId: makePreviewId(seed, text),
+    suggestions,
+    processedCharacters: text.length,
+  });
+}
+
+export function explainSuggestion(
+  suggestion: ExplainableSuggestion
+): Pick<ExplainableSuggestion, "rationale" | "minimalFeatures"> {
+  return {
+    rationale: suggestion.rationale,
+    minimalFeatures: suggestion.minimalFeatures,
+  };
+}
+

--- a/lucidia/autobox/packages/ai/tsconfig.build.json
+++ b/lucidia/autobox/packages/ai/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": false,
+    "outDir": "./dist"
+  }
+}

--- a/lucidia/autobox/packages/ai/tsconfig.json
+++ b/lucidia/autobox/packages/ai/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "./src",
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "noEmit": false,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "target": "ES2020"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/lucidia/autobox/packages/core/package.json
+++ b/lucidia/autobox/packages/core/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@lucidia/core",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json"
+  },
+  "dependencies": {
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5"
+  }
+}

--- a/lucidia/autobox/packages/core/src/index.ts
+++ b/lucidia/autobox/packages/core/src/index.ts
@@ -1,0 +1,266 @@
+import { randomUUID } from "node:crypto";
+import { z } from "zod";
+
+export const identitySchema = z.object({
+  id: z.string().min(1, "identity id is required"),
+  publicKey: z.string().min(1, "public key is required"),
+  settings: z
+    .record(z.any())
+    .default({})
+    .describe("user-controlled configuration for consent and crypto toggles"),
+});
+export type Identity = z.infer<typeof identitySchema>;
+
+export const boxSchema = z.object({
+  id: z.string().min(1),
+  ownerId: z.string().min(1),
+  title: z.string().min(1),
+  description: z.string().optional(),
+  createdAt: z.date(),
+});
+export type Box = z.infer<typeof boxSchema>;
+
+export const itemSchema = z.object({
+  id: z.string().min(1),
+  ownerId: z.string().min(1),
+  rawText: z.string().min(1),
+  createdAt: z.date(),
+});
+export type Item = z.infer<typeof itemSchema>;
+
+export const assignmentSchema = z.object({
+  id: z.string().min(1),
+  itemId: z.string().min(1),
+  boxId: z.string().min(1),
+  score: z
+    .number()
+    .min(0)
+    .max(1)
+    .describe("confidence score normalised between 0 and 1"),
+  rationale: z
+    .string()
+    .min(1, "rationale is required")
+    .describe("short explanation for why an item belongs in the box"),
+  createdAt: z.date(),
+});
+export type Assignment = z.infer<typeof assignmentSchema>;
+
+export const consentReceiptSchema = z.object({
+  id: z.string().min(1),
+  ownerId: z.string().min(1),
+  purpose: z.string().min(1),
+  scope: z.array(z.string()).default([]),
+  createdAt: z.date(),
+  expiresAt: z.date().nullable(),
+});
+export type ConsentReceipt = z.infer<typeof consentReceiptSchema>;
+
+export const classificationSuggestionSchema = z.object({
+  boxTitle: z.string().min(1),
+  tags: z.array(z.string()).default([]),
+  score: z.number().min(0).max(1),
+  rationale: z.string().min(1),
+});
+export type ClassificationSuggestion = z.infer<typeof classificationSuggestionSchema>;
+
+export const classificationResponseSchema = z.object({
+  previewId: z.string().min(1),
+  suggestions: z.array(classificationSuggestionSchema),
+  processedCharacters: z.number().int().min(0),
+});
+export type ClassificationResponse = z.infer<typeof classificationResponseSchema>;
+
+export const auditLogEntrySchema = z.object({
+  id: z.string().min(1),
+  ownerId: z.string().min(1),
+  action: z.string().min(1),
+  createdAt: z.date(),
+  context: z.record(z.any()).default({}),
+});
+export type AuditLogEntry = z.infer<typeof auditLogEntrySchema>;
+
+export type ExportFormat = "json" | "markdown";
+
+export function validateIdentity(input: unknown): Identity {
+  return identitySchema.parse(input);
+}
+
+export function validateBox(input: unknown): Box {
+  return boxSchema.parse(input);
+}
+
+export function validateItem(input: unknown): Item {
+  return itemSchema.parse(input);
+}
+
+export function validateAssignment(input: unknown): Assignment {
+  return assignmentSchema.parse(input);
+}
+
+export function validateConsentReceipt(input: unknown): ConsentReceipt {
+  return consentReceiptSchema.parse(input);
+}
+
+export function normaliseScore(score: number): number {
+  const bounded = Math.max(0, Math.min(1, score));
+  return Number(bounded.toFixed(4));
+}
+
+export interface ExportPayload {
+  identity: Identity;
+  items: Item[];
+  boxes: Box[];
+  assignments: Assignment[];
+}
+
+export function exportToJson(payload: ExportPayload): string {
+  return JSON.stringify(
+    {
+      identity: payload.identity,
+      boxes: payload.boxes,
+      items: payload.items,
+      assignments: payload.assignments,
+      exportedAt: new Date().toISOString(),
+      codex: "1 — The First Principle",
+    },
+    null,
+    2
+  );
+}
+
+export function exportToMarkdown(payload: ExportPayload): string {
+  const lines: string[] = [];
+  lines.push(`# Lucidia Export`);
+  lines.push(`Exported: ${new Date().toISOString()}`);
+  lines.push("");
+  lines.push(`## Identity`);
+  lines.push(`- id: ${payload.identity.id}`);
+  lines.push(`- publicKey: ${payload.identity.publicKey}`);
+  lines.push("");
+  lines.push(`## Boxes`);
+  payload.boxes.forEach((box) => {
+    lines.push(`- **${box.title}** (created ${box.createdAt.toISOString()})`);
+    if (box.description) {
+      lines.push(`  - ${box.description}`);
+    }
+  });
+  lines.push("");
+  lines.push(`## Assignments`);
+  payload.assignments.forEach((assignment) => {
+    lines.push(`- Item ${assignment.itemId} → Box ${assignment.boxId}`);
+    lines.push(`  - Score: ${assignment.score}`);
+    lines.push(`  - Rationale: ${assignment.rationale}`);
+  });
+  lines.push("");
+  lines.push(`## Items`);
+  payload.items.forEach((item) => {
+    lines.push(`### Item ${item.id}`);
+    lines.push("```");
+    lines.push(item.rawText);
+    lines.push("```");
+  });
+  return lines.join("\n");
+}
+
+export function createConsentReceipt(
+  input: Omit<ConsentReceipt, "id" | "createdAt">
+): ConsentReceipt {
+  return consentReceiptSchema.parse({
+    ...input,
+    id: randomUUID(),
+    createdAt: new Date(),
+  });
+}
+
+export interface ExplainabilityRecord {
+  previewId: string;
+  itemText: string;
+  suggestion: ClassificationSuggestion;
+  minimalFeatures: string[];
+}
+
+export const explainabilityRecordSchema = z.object({
+  previewId: z.string().min(1),
+  itemText: z.string().min(1),
+  suggestion: classificationSuggestionSchema,
+  minimalFeatures: z.array(z.string()),
+});
+export type ExplainabilityRecord = z.infer<typeof explainabilityRecordSchema>;
+
+export function redactRawText(input: string, maxLength = 2000): string {
+  if (input.length <= maxLength) {
+    return input;
+  }
+  return `${input.slice(0, maxLength)}…`;
+}
+
+export function buildExplainabilityRecord(
+  previewId: string,
+  itemText: string,
+  suggestion: ClassificationSuggestion,
+  minimalFeatures: string[]
+): ExplainabilityRecord {
+  return explainabilityRecordSchema.parse({
+    previewId,
+    itemText,
+    suggestion,
+    minimalFeatures,
+  });
+}
+
+export function makePreviewId(seed: string, text: string): string {
+  return `preview-${seed}-${Math.abs(
+    Array.from(text).reduce((acc, char) => acc + char.charCodeAt(0), 0)
+  )}`;
+}
+
+export const consentPurpose = {
+  ClassificationPreview: "classification_preview",
+  Export: "export",
+  Delete: "delete",
+} as const;
+
+export type ConsentPurpose = (typeof consentPurpose)[keyof typeof consentPurpose];
+
+export const consentScopeSchema = z.object({
+  categories: z.array(z.string()),
+  expiresAt: z.date().nullable(),
+});
+export type ConsentScope = z.infer<typeof consentScopeSchema>;
+
+export function requireConsent(
+  receipts: ConsentReceipt[],
+  purpose: ConsentPurpose
+): ConsentReceipt | null {
+  return (
+    receipts.find(
+      (receipt) =>
+        receipt.purpose === purpose &&
+        (!receipt.expiresAt || receipt.expiresAt.getTime() > Date.now())
+    ) ?? null
+  );
+}
+
+export const auditAction = {
+  PreviewGenerated: "preview.generated",
+  PreviewDismissed: "preview.dismissed",
+  AssignmentAccepted: "assignment.accepted",
+  ExportTriggered: "export.triggered",
+  DeleteTriggered: "delete.triggered",
+} as const;
+export type AuditAction = (typeof auditAction)[keyof typeof auditAction];
+
+export function makeAuditLogEntry(
+  ownerId: string,
+  action: AuditAction,
+  context: Record<string, unknown>
+): AuditLogEntry {
+  return auditLogEntrySchema.parse({
+    id: randomUUID(),
+    ownerId,
+    action,
+    context,
+    createdAt: new Date(),
+  });
+}
+

--- a/lucidia/autobox/packages/core/tsconfig.build.json
+++ b/lucidia/autobox/packages/core/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": false,
+    "outDir": "./dist"
+  }
+}

--- a/lucidia/autobox/packages/core/tsconfig.json
+++ b/lucidia/autobox/packages/core/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "./src",
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "declaration": true,
+    "noEmit": false,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "target": "ES2020"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
 packages:
   - "apps/*"
   - "packages/*"
+  - "lucidia/autobox/apps/*"
+  - "lucidia/autobox/packages/*"


### PR DESCRIPTION
## Summary
- add @lucidia/core package with consent-aware data contracts, export helpers, and explainability utilities for Auto-Box
- introduce @lucidia/ai deterministic classifier and lucidia-autobox-api express stub that enforces explicit consent for /classify
- stand up lucidia-autobox-web Next.js preview UI with consent gating, editable suggestions, export, and guarded delete flow plus codex/security/privacy docs

## Testing
- not run (new workspace packages require dependency install)


------
https://chatgpt.com/codex/tasks/task_e_68d84ac84b948329a5778b52137c468f