### PR TITLE
Add Codex 7 resilience policy and runbook

### DIFF
--- a/codex/README.md
+++ b/codex/README.md
@@ -13,6 +13,7 @@ integrations.
 | --- | ---------------------- | ----------------------------------------------- |
 | 001 | The First Principle    | Lucidia exists to protect and empower everyone. |
 | 003 | The Workflow Circle    | Work runs in visible capture → adjust loops.    |
+| 007 | The Resilience Code    | Failure is expected; recovery keeps service live. |
 
 ## BlackRoad Pipeline
 

--- a/codex/entries/007-resilience-code.md
+++ b/codex/entries/007-resilience-code.md
@@ -1,0 +1,32 @@
+# Codex 7 — The Resilience Code
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Principle
+
+Lucidia does not snap under strain. It bends, reroutes, heals, and keeps the light on. Failure is expected, recovery is required.
+
+## Non-Negotiables
+
+1. **No Single Point** — Every critical service runs in clusters or replicas; one fall does not end the system.
+2. **Immutable Backups** — 3-2-1 rule, encrypted, offline copy. Restores tested monthly.
+3. **Fail-Safe Modes** — If systems falter, drop to read-only rather than crash.
+4. **Self-Healing** — Containers auto-replace on compromise or failure; logs preserved for forensics.
+5. **Geographic Redundancy** — Multi-region deployment; traffic reroutes automatically.
+6. **Incident Drill** — Simulated breakage is routine; chaos tested, resilience measured.
+
+## Implementation Hooks (v0)
+
+- Kubernetes deployment with health probes and auto-restart.
+- Daily snapshot → S3 (WORM locked), weekly offline sync.
+- Feature flag: `READ_ONLY_MODE` toggle.
+- Chaos monkey job in staging cluster; results logged.
+- Runbook: “Recover in 15” checklist stored in `/docs/ops`.
+
+## Policy Stub
+
+- Lucidia commits to continuous availability.
+- Lucidia prioritizes graceful degradation over sudden outage.
+- Lucidia keeps resilience evidence public (uptime logs, drill reports).
+
+**Tagline:** We bend. We do not break.

--- a/docs/RESILIENCE.md
+++ b/docs/RESILIENCE.md
@@ -2,4 +2,31 @@
 
 Resilience playbooks in `resilience/playbooks/` outline incident response, disaster recovery, and business continuity procedures. The chaos runner (`chaos/runner.py`) simulates outages and records outcomes to unified memory, ensuring playbooks remain actionable.
 
+## Codex Alignment
+
+- **Codex 7 — The Resilience Code** anchors durability into the platform and requires that failure be anticipated, contained, and followed by rapid recovery.
+- Policy commitments: continuous availability, graceful degradation before outage, and public evidence of resilience (uptime logs, drill reports).
+
+## Non-Negotiables
+
+1. No single point of failure: run critical workloads in clusters or replicated pairs.
+2. Immutable backups: follow the 3-2-1 rule with encrypted storage and monthly restore tests.
+3. Fail-safe modes: if instability is detected, flip `READ_ONLY_MODE` instead of allowing data loss.
+4. Self-healing: orchestrators replace compromised or failed containers while preserving logs for forensics.
+5. Geographic redundancy: deploy to multiple regions with automated traffic failover.
+6. Incident drills: schedule recurring chaos tests and log results in `resilience/smoke/`.
+
+## Implementation Hooks (v0)
+
+- Kubernetes health probes and auto-restart policies (`k8s/` manifests) keep pods rotating back to health.
+- Daily snapshots replicate to WORM-locked S3 buckets; `backups/` scripts handle weekly offline sync to removable storage.
+- `resilience/read_only_mode.sh` provides the feature flag toggle to enter or exit read-only service.
+- Chaos monkey jobs in staging must publish artifacts into `logs/resilience/` for review.
+- Runbook **Recover in 15** (see `/docs/ops/RECOVER_IN_15.md`) documents the minimum viable recovery steps.
+
+## Evidence & Reporting
+
+- Publish uptime graphs and drill after-action reports to the internal status dashboard before archiving to `metrics_portal/`.
+- Track completion of restore tests and chaos exercises in the incident management system; export summaries quarterly.
+
 These practices support Porter's strategic differentiation by demonstrating operational reliability and clear activity fit, allowing BlackRoad to withstand disruptions while maintaining customer trust.

--- a/docs/ops/RECOVER_IN_15.md
+++ b/docs/ops/RECOVER_IN_15.md
@@ -1,0 +1,39 @@
+# Recover in 15 — Resilience Drill Checklist
+
+Codex 7 mandates that the platform bends without breaking. This runbook is the minimum viable path to recover Lucidia services within fifteen minutes of a major disruption.
+
+## Pre-Flight (Monthly)
+
+- ✅ Verify last successful restore test is logged in the incident tracker and mirrored in `metrics_portal/`.
+- ✅ Confirm immutable backup chain (3-2-1) is healthy: production snapshots in S3 (WORM), warm replica in secondary region, offline disk stored securely.
+- ✅ Ensure `READ_ONLY_MODE` toggle is functional by running `resilience/read_only_mode.sh` in staging.
+- ✅ Rotate contact roster and on-call bridge numbers; publish to the NOC dashboard.
+
+## Minute 0–5 — Stabilize & Contain
+
+1. **Detect:** Receive alert (PagerDuty/Status dashboard) confirming impact scope.
+2. **Announce:** Post incident start in `#lucidia-ops` with timestamp, affected services, initial severity.
+3. **Fail-Safe:** If write path instability is confirmed, toggle `READ_ONLY_MODE` via `resilience/read_only_mode.sh`.
+4. **Capture:** Start incident log (OpsGenie/Notion) noting responders, suspected trigger, and current status.
+
+## Minute 5–10 — Restore Core Services
+
+1. **Cluster Health:** Check Kubernetes dashboard (`kubectl get pods -A`) for failing workloads; trigger redeploy on unhealthy replicas.
+2. **Backups:** Validate latest snapshot integrity via `restic -r ssh:backup1:/srv/backups check --password-file /root/.restic-pass` (read-only check).
+3. **Traffic Shift:** If the primary region remains degraded, execute the documented DNS or load balancer failover procedure (track automation work in `infra/ansible/playbooks/`).
+4. **Self-Heal Review:** Confirm auto-recreated containers are emitting logs; escalate to manual redeploy if crash loops persist.
+
+## Minute 10–15 — Validate & Communicate
+
+1. **Service Tests:** Run `resilience/smoke/healthcheck.sh`; record results in the incident log and supplement with manual API/UI probes.
+2. **Data Integrity:** Spot-check critical transactions in read-only mode. If corruption suspected, initiate point-in-time restore plan.
+3. **Comms Update:** Publish status page update summarizing mitigation actions and next checkpoint (T+30 min).
+4. **Exit Read-Only:** Once error rate <1% across all probes, disable `READ_ONLY_MODE` and monitor for five minutes.
+
+## Post-Recovery
+
+- File after-action review within 24 hours including metrics (time to detect, stabilize, restore).
+- Archive logs to `logs/resilience/` and tag with incident ID for forensics.
+- Feed improvements back into Codex 7 entry and update tooling/backups scripts as needed.
+
+_This checklist is versioned with the Codex fingerprint `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`._


### PR DESCRIPTION
## Summary
- add Codex 7 entry detailing resilience principles, non-negotiables, and policy commitments
- extend the Codex index to reference the new resilience directive
- document resilience implementation hooks and add a 15-minute recovery runbook in docs

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d84d1c2ed48329ae2b70472c4b1ade