### PR TITLE
Add Codex 9 Transparency Accord entry

### DIFF
--- a/codex/README.md
+++ b/codex/README.md
@@ -13,6 +13,7 @@ integrations.
 | --- | ---------------------- | ----------------------------------------------- |
 | 001 | The First Principle    | Lucidia exists to protect and empower everyone. |
 | 003 | The Workflow Circle    | Work runs in visible capture → adjust loops.    |
+| 009 | The Transparency Accord | Every operation is logged, explainable, visible. |
 
 ## BlackRoad Pipeline
 

--- a/codex/entries/009-transparency-accord.md
+++ b/codex/entries/009-transparency-accord.md
@@ -1,0 +1,26 @@
+# Codex 9 — The Transparency Accord
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Principle
+Nothing hides in Lucidia. What it does, it shows. What it knows, it declares. What it changes, it records. Transparency is not decoration; it’s survival.
+
+## Non-Negotiables
+1. **Open Logs** — Every system action (user, AI, infra) creates an immutable log entry visible to its owner.
+2. **Change Visibility** — Model updates, schema changes, and policy edits are all announced with version tags.
+3. **Consent Ledger** — All receipts (purpose, scope, duration) are stored in an append-only chain.
+4. **Ops Sunlight** — System status, uptime, and incidents are published; no silent failures.
+5. **Explainability Coupled** — Transparency always tied to rationale (#5). No bare numbers without meaning.
+6. **No Shadow Ops** — No feature may run in production without user-visible documentation.
+
+## Implementation Hooks (v0)
+- Append-only log backed by hash-chaining (tamper-evident).
+- `/status` endpoint + public dashboard with uptime, incidents.
+- Changelog file auto-generated from PR merges → surfaced in UI.
+- Consent receipts displayed in owner dashboard.
+
+## Policy Stub (drop into TRANSPARENCY.md)
+- Lucidia commits to radical transparency: all operations are visible, reversible, documented.
+- Lucidia prohibits hidden data collection, shadow features, or unannounced changes.
+
+**Tagline:** Every corner lit, every move seen.


### PR DESCRIPTION
## Summary
- add Codex 9 entry detailing the Transparency Accord principles and implementation hooks
- list the new codex in the automation README table for discoverability

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d84d75d76483299e951d2a3e164fa9