### PR TITLE
Add WAFv2 module and Route53 failover maintenance path

### DIFF
--- a/br-infra-iac/envs/dev/main.tf
+++ b/br-infra-iac/envs/dev/main.tf
@@ -36,6 +36,38 @@ module "rds" {
   tags                      = local.tags
 }
 
+# WAF on ALB
+module "api_waf" {
+  source                     = "../../modules/wafv2-alb"
+  name                       = "br-dev-api"
+  alb_arn                    = module.api_service.alb_arn
+  ip_allowlist_cidrs         = []
+  ip_blocklist_cidrs         = []
+  rate_limit                 = 1000
+  enable_common_rules        = true
+  enable_ip_reputation_rules = true
+  enable_known_bad_inputs    = true
+  tags                       = local.tags
+}
+
+# Route53 failover to CloudFront maintenance
+module "api_failover" {
+  source = "../../modules/route53-failover"
+
+  providers = {
+    aws           = aws
+    aws.us_east_1 = aws.us_east_1
+  }
+
+  name             = "br-dev-api"
+  hosted_zone_name = "blackroad.io."
+  domain_name      = "api.blackroad.io"
+  alb_dns_name     = module.api_service.alb_dns_name
+  alb_zone_id      = module.api_service.alb_zone_id
+  health_check_path = "/health"
+  tags             = local.tags
+}
+
 output "vpc_id"          { value = module.network.vpc_id }
 output "private_subnets" { value = module.network.private_subnet_ids }
 output "ecs_cluster"     { value = module.ecs.cluster_name }

--- a/br-infra-iac/envs/dev/providers.tf
+++ b/br-infra-iac/envs/dev/providers.tf
@@ -9,4 +9,11 @@ terraform {
     encrypt        = true
   }
 }
-provider "aws" { region = var.region }
+provider "aws" {
+  region = var.region
+}
+
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+}

--- a/br-infra-iac/modules/ecs-service-alb/outputs.tf
+++ b/br-infra-iac/modules/ecs-service-alb/outputs.tf
@@ -1,0 +1,8 @@
+output "alb_arn" {
+  value = aws_lb.this.arn
+}
+
+output "alb_zone_id" {
+  value = aws_lb.this.zone_id
+}
+

--- a/br-infra-iac/modules/route53-failover/main.tf
+++ b/br-infra-iac/modules/route53-failover/main.tf
@@ -1,0 +1,212 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+data "aws_route53_zone" "zone" {
+  name         = var.hosted_zone_name
+  private_zone = false
+}
+
+resource "aws_route53_health_check" "api" {
+  type            = "HTTPS"
+  fqdn            = var.alb_dns_name
+  port            = 443
+  resource_path   = var.health_check_path
+  measure_latency = true
+  regions         = ["us-east-1", "us-west-1", "us-west-2"]
+  inverted        = false
+  tags            = var.tags
+}
+
+resource "aws_s3_bucket" "maintenance" {
+  bucket        = "${var.name}-maintenance"
+  force_destroy = true
+  tags          = var.tags
+}
+
+resource "aws_s3_bucket_public_access_block" "pab" {
+  bucket = aws_s3_bucket.maintenance.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_cloudfront_origin_access_control" "oac" {
+  name                              = "${var.name}-oac"
+  description                       = "OAC for maintenance bucket"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+resource "aws_acm_certificate" "cf_cert" {
+  provider          = aws.us_east_1
+  domain_name       = var.domain_name
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = var.tags
+}
+
+resource "aws_route53_record" "cf_cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.cf_cert.domain_validation_options :
+    dvo.domain_name => {
+      name   = dvo.resource_record_name
+      type   = dvo.resource_record_type
+      record = dvo.resource_record_value
+    }
+  }
+
+  zone_id = data.aws_route53_zone.zone.zone_id
+  name    = each.value.name
+  type    = each.value.type
+  ttl     = 60
+  records = [each.value.record]
+}
+
+resource "aws_acm_certificate_validation" "cf_cert" {
+  provider                 = aws.us_east_1
+  certificate_arn          = aws_acm_certificate.cf_cert.arn
+  validation_record_fqdns  = [for r in aws_route53_record.cf_cert_validation : r.fqdn]
+}
+
+resource "aws_cloudfront_distribution" "maintenance" {
+  enabled         = true
+  is_ipv6_enabled = true
+  comment         = "Maintenance page for ${var.domain_name}"
+  aliases         = [var.domain_name]
+
+  origin {
+    domain_name              = aws_s3_bucket.maintenance.bucket_regional_domain_name
+    origin_id                = "s3-maintenance"
+    origin_access_control_id = aws_cloudfront_origin_access_control.oac.id
+  }
+
+  default_cache_behavior {
+    target_origin_id       = "s3-maintenance"
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+  }
+
+  default_root_object = "index.html"
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate_validation.cf_cert.certificate_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  tags = var.tags
+
+  depends_on = [aws_acm_certificate_validation.cf_cert]
+}
+
+data "aws_iam_policy_document" "bucket" {
+  statement {
+    sid    = "AllowCloudFrontServiceRead"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.maintenance.arn}/*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = [aws_cloudfront_distribution.maintenance.arn]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "maintenance" {
+  bucket = aws_s3_bucket.maintenance.id
+  policy = data.aws_iam_policy_document.bucket.json
+}
+
+resource "aws_s3_object" "index" {
+  bucket       = aws_s3_bucket.maintenance.id
+  key          = "index.html"
+  content_type = "text/html"
+  content      = <<HTML
+<!doctype html><html lang="en"><meta charset="utf-8">
+<title>BlackRoad – Maintenance</title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<body style="margin:0;font-family:system-ui,sans-serif;display:grid;place-items:center;height:100vh;background:#0b0b0b;color:#fff">
+  <main style="text-align:center">
+    <h1>We’ll be right back</h1>
+    <p>api.blackroad.io is temporarily unavailable. Check <a href="https://status.blackroad.io" style="color:#9cf">status</a> for updates.</p>
+  </main>
+</body></html>
+HTML
+}
+
+resource "aws_route53_record" "api_primary" {
+  zone_id        = data.aws_route53_zone.zone.zone_id
+  name           = var.domain_name
+  type           = "A"
+  set_identifier = "primary-alb"
+
+  alias {
+    name                   = var.alb_dns_name
+    zone_id                = var.alb_zone_id
+    evaluate_target_health = true
+  }
+
+  failover_routing_policy {
+    type = "PRIMARY"
+  }
+
+  health_check_id = aws_route53_health_check.api.id
+}
+
+resource "aws_route53_record" "api_secondary" {
+  zone_id        = data.aws_route53_zone.zone.zone_id
+  name           = var.domain_name
+  type           = "A"
+  set_identifier = "secondary-cf"
+
+  alias {
+    name                   = aws_cloudfront_distribution.maintenance.domain_name
+    zone_id                = aws_cloudfront_distribution.maintenance.hosted_zone_id
+    evaluate_target_health = false
+  }
+
+  failover_routing_policy {
+    type = "SECONDARY"
+  }
+}
+
+output "maintenance_distribution" {
+  value = aws_cloudfront_distribution.maintenance.domain_name
+}

--- a/br-infra-iac/modules/route53-failover/variables.tf
+++ b/br-infra-iac/modules/route53-failover/variables.tf
@@ -1,0 +1,29 @@
+variable "name" {
+  type = string
+}
+
+variable "hosted_zone_name" {
+  type = string
+}
+
+variable "domain_name" {
+  type = string
+}
+
+variable "alb_dns_name" {
+  type = string
+}
+
+variable "alb_zone_id" {
+  type = string
+}
+
+variable "health_check_path" {
+  type    = string
+  default = "/health"
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}

--- a/br-infra-iac/modules/wafv2-alb/main.tf
+++ b/br-infra-iac/modules/wafv2-alb/main.tf
@@ -1,0 +1,205 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+resource "aws_wafv2_ip_set" "allow" {
+  count              = length(var.ip_allowlist_cidrs) > 0 ? 1 : 0
+  name               = "${var.name}-allow"
+  description        = "Allowlist"
+  scope              = var.scope
+  ip_address_version = "IPV4"
+  addresses          = var.ip_allowlist_cidrs
+  tags               = var.tags
+}
+
+resource "aws_wafv2_ip_set" "block" {
+  count              = length(var.ip_blocklist_cidrs) > 0 ? 1 : 0
+  name               = "${var.name}-block"
+  description        = "Blocklist"
+  scope              = var.scope
+  ip_address_version = "IPV4"
+  addresses          = var.ip_blocklist_cidrs
+  tags               = var.tags
+}
+
+resource "aws_wafv2_web_acl" "this" {
+  name        = "${var.name}-waf"
+  description = "WAF for ${var.name} ALB"
+  scope       = var.scope
+
+  default_action {
+    allow {}
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${var.name}-waf"
+    sampled_requests_enabled   = true
+  }
+
+  dynamic "rule" {
+    for_each = length(var.ip_allowlist_cidrs) > 0 ? [1] : []
+
+    content {
+      name     = "AllowList"
+      priority = 1
+
+      action {
+        allow {}
+      }
+
+      statement {
+        ip_set_reference_statement {
+          arn = aws_wafv2_ip_set.allow[0].arn
+        }
+      }
+
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        metric_name                = "AllowList"
+        sampled_requests_enabled   = true
+      }
+    }
+  }
+
+  dynamic "rule" {
+    for_each = length(var.ip_blocklist_cidrs) > 0 ? [1] : []
+
+    content {
+      name     = "BlockList"
+      priority = 2
+
+      action {
+        block {}
+      }
+
+      statement {
+        ip_set_reference_statement {
+          arn = aws_wafv2_ip_set.block[0].arn
+        }
+      }
+
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        metric_name                = "BlockList"
+        sampled_requests_enabled   = true
+      }
+    }
+  }
+
+  dynamic "rule" {
+    for_each = var.enable_common_rules ? [1] : []
+
+    content {
+      name     = "AWS-AWSManagedRulesCommonRuleSet"
+      priority = 10
+
+      override_action {
+        none {}
+      }
+
+      statement {
+        managed_rule_group_statement {
+          vendor_name = "AWS"
+          name        = "AWSManagedRulesCommonRuleSet"
+        }
+      }
+
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        metric_name                = "CommonRuleSet"
+        sampled_requests_enabled   = true
+      }
+    }
+  }
+
+  dynamic "rule" {
+    for_each = var.enable_ip_reputation_rules ? [1] : []
+
+    content {
+      name     = "AWS-AmazonIpReputationList"
+      priority = 11
+
+      override_action {
+        none {}
+      }
+
+      statement {
+        managed_rule_group_statement {
+          vendor_name = "AWS"
+          name        = "AWSManagedRulesAmazonIpReputationList"
+        }
+      }
+
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        metric_name                = "IpReputation"
+        sampled_requests_enabled   = true
+      }
+    }
+  }
+
+  dynamic "rule" {
+    for_each = var.enable_known_bad_inputs ? [1] : []
+
+    content {
+      name     = "AWS-KnownBadInputs"
+      priority = 12
+
+      override_action {
+        none {}
+      }
+
+      statement {
+        managed_rule_group_statement {
+          vendor_name = "AWS"
+          name        = "AWSManagedRulesKnownBadInputsRuleSet"
+        }
+      }
+
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        metric_name                = "KnownBadInputs"
+        sampled_requests_enabled   = true
+      }
+    }
+  }
+
+  rule {
+    name     = "RateLimitPerIP"
+    priority = 90
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        aggregate_key_type = "IP"
+        limit              = var.rate_limit
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "RateLimit"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  tags = var.tags
+}
+
+resource "aws_wafv2_web_acl_association" "assoc" {
+  resource_arn = var.alb_arn
+  web_acl_arn  = aws_wafv2_web_acl.this.arn
+}
+
+output "web_acl_arn" {
+  value = aws_wafv2_web_acl.this.arn
+}

--- a/br-infra-iac/modules/wafv2-alb/variables.tf
+++ b/br-infra-iac/modules/wafv2-alb/variables.tf
@@ -1,0 +1,47 @@
+variable "name" {
+  type = string
+}
+
+variable "alb_arn" {
+  type = string
+}
+
+variable "scope" {
+  type    = string
+  default = "REGIONAL"
+}
+
+variable "rate_limit" {
+  type    = number
+  default = 1000
+}
+
+variable "ip_allowlist_cidrs" {
+  type    = list(string)
+  default = []
+}
+
+variable "ip_blocklist_cidrs" {
+  type    = list(string)
+  default = []
+}
+
+variable "enable_common_rules" {
+  type    = bool
+  default = true
+}
+
+variable "enable_ip_reputation_rules" {
+  type    = bool
+  default = true
+}
+
+variable "enable_known_bad_inputs" {
+  type    = bool
+  default = true
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}

--- a/ops/next_push/asana_blackroad_ops_next_push.csv
+++ b/ops/next_push/asana_blackroad_ops_next_push.csv
@@ -11,3 +11,7 @@ Airtable Growth Calendar,Create base with views Editorial/Social/Launches; 6-wee
 Notion: Content pipeline,Create “Content” page with brief template + asset checklist; link to Airtable.,amundsonalexa@gmail.com,This Week,2025-10-04
 Social account wiring,Confirm access: blackroadinc, blackroad.io, lucidia_ai, blackroad_ai, blackroad_inc; store creds in 1Password.,amundsonalexa@gmail.com,This Week,2025-10-04
 Friday Demo #2,Demo: Okta SSO, repo guardrails, PRISM auth stub + CI, Growth calendar live.,amundsonalexa@gmail.com,Today,2025-10-03
+Enable WAFv2 on ALB,Apply wafv2-alb module with managed rules + rate limit.,amundsonalexa@gmail.com,Today,2025-10-05
+Add Route53 failover,Provision CF maintenance + dual A-alias records with health check.,amundsonalexa@gmail.com,Today,2025-10-05
+Test failover,Simulate unhealthy ALB target; verify CF page; restore health.,amundsonalexa@gmail.com,This Week,2025-10-06
+Tune WAF rules,Review logs; add allowlist/blocks if needed; set final rate.,amundsonalexa@gmail.com,This Week,2025-10-07

--- a/ops/next_push/slack_posts.md
+++ b/ops/next_push/slack_posts.md
@@ -29,3 +29,7 @@ PRISM v0.1 starts now. Sprint 0 focus:
 - /health, logs, OpenAPI
 
 Friday demo: working auth stub + CI green + first endpoint.
+
+## #products-prism — WAF + failover hardening
+
+Hardening pass shipped: WAFv2 (managed rules + per-IP rate-limit) on ALB + Route53 failover to CloudFront “maintenance” page for api.blackroad.io. If ALB health dips, traffic flips automatically; flip back is automatic when healthy. We’ll tune WAF after a day of real traffic.


### PR DESCRIPTION
## Summary
- expose the ALB ARN and hosted zone ID from the ecs-service-alb module
- add reusable modules for ALB-focused AWS WAFv2 configuration and Route53 failover with a CloudFront-backed maintenance page
- wire the new modules into the dev environment and record the related Asana tasks and Slack update

## Testing
- not run (terraform binary not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d84da5598c8329b87ebed16c8b2247