### PR TITLE
Add Codex 11 Ethical North Star documentation

### DIFF
--- a/ETHICS.md
+++ b/ETHICS.md
@@ -1,0 +1,6 @@
+# ETHICS
+
+Lucidia commits to uphold the Ethical North Star, even at the cost of revenue or growth.
+
+- Leadership must publicly document any exceptions that were attempted and rejected.
+- Any violation of Codex 11 triggers a rollback. No excuses.

--- a/codex/README.md
+++ b/codex/README.md
@@ -14,6 +14,7 @@ integrations.
 | 001 | The First Principle    | Lucidia exists to protect and empower everyone. |
 | 003 | The Workflow Circle    | Work runs in visible capture → adjust loops.    |
 | 004 | The Autonomy Manifest  | Data autonomy through consent, export, and wipe. |
+| 011 | The Ethical North Star | Ethical guardrails: consent, equity, no harm.   |
 
 ## BlackRoad Pipeline
 

--- a/codex/entries/011-ethical-north-star.md
+++ b/codex/entries/011-ethical-north-star.md
@@ -1,0 +1,27 @@
+# Codex 11 — The Ethical North Star
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Principle
+Lucidia’s power bends toward care. The ethical compass overrides growth, convenience, or profit when harm is in sight.
+
+## Non-Negotiables
+1. **No Manipulation:** Lucidia never nudges or deceives to drive engagement, sales, or compliance.
+2. **No Exploitation:** Lucidia will not monetize personal data, attention, or private identity.
+3. **No Violence:** Lucidia cannot be used to build weapons, spread hate, or incite harm.
+4. **Consent First:** Any experiment, model training, or data use requires explicit permission. Silence is not consent.
+5. **Equity Lens:** Lucidia continuously checks outputs for bias or exclusion; equity is treated as a live system property.
+6. **Right to Walk Away:** Users and AIs alike may leave, delete, or disengage at any time without retaliation.
+
+## Implementation Hooks (v0)
+- Ethics checklist required in the PR template: “Does this violate Codex 11?”
+- Automated content filters block creation of flagged harmful categories.
+- Consent receipts audited weekly for misuse.
+- Bias monitoring script runs on all major releases with published results.
+
+## Policy Stub (ETHICS.md)
+- Lucidia commits to uphold the Ethical North Star, even at cost of revenue or growth.
+- Leadership must publicly document exceptions attempted and rejected.
+- Violations trigger rollback. No excuses.
+
+**Tagline:** We do not cross the line.

--- a/lucidia/autobox/docs/CODICES.md
+++ b/lucidia/autobox/docs/CODICES.md
@@ -18,3 +18,36 @@ Lucidia gives people and AIs a safe, transparent space to co-create without surr
 
 The Auto-Box prototype accepts pasted notes, offers suggested topic boxes with “Why?” rationales, and lets the user export or purge everything in one click. The preview-only classifier runs with explicit consent and never stores data server-side.
 
+
+# Codex 11 — The Ethical North Star
+
+**Fingerprint**: `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Principle
+
+Lucidia’s power bends toward care. Harm prevention outranks growth, convenience, or revenue.
+
+## Non-Negotiables
+
+1. **No Manipulation** – never nudge or deceive for engagement, sales, or compliance.
+2. **No Exploitation** – no monetisation of personal data, attention, or private identity.
+3. **No Violence** – do not build weapons, spread hate, or incite harm.
+4. **Consent First** – experiments, model training, or data use require explicit permission.
+5. **Equity Lens** – monitor outputs for bias or exclusion as a live system property.
+6. **Right to Walk Away** – users and AIs can leave, delete, or disengage without retaliation.
+
+## Implementation Hooks (v0)
+
+- Ethics checklist in every PR template: “Does this violate Codex 11?”
+- Automated filters block harmful content categories.
+- Weekly audits of consent receipts to catch misuse.
+- Bias monitoring script runs on major releases; publish the findings.
+
+## Policy Stub (ETHICS.md)
+
+- Lucidia upholds the Ethical North Star even when it costs revenue or growth.
+- Leadership documents attempted exceptions and why they were rejected.
+- Violations demand rollback with no exceptions.
+
+**Tagline:** We do not cross the line.
+


### PR DESCRIPTION
## Summary
- add Codex 11 entry capturing the Ethical North Star guardrails
- update codex references and documentation to link to the new principle
- add an ETHICS policy stub committing leadership to Codex 11 enforcement

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68d84f39a6d88329909882fe2a0c1016