### PR TITLE
Add security automation workflows and docs

### DIFF
--- a/.bots/app.js
+++ b/.bots/app.js
@@ -1,0 +1,47 @@
+// Probot GitHub App scaffold
+// Permissions: Issues (RW), Pull Requests (RW), Commit statuses (W), Checks (R)
+export default (app) => {
+  // Greet issues
+  app.on("issues.opened", async (context) => {
+    await context.octokit.issues.createComment(context.issue({
+      body: "Thanks! A maintainer will review shortly. 🤖"
+    }));
+  });
+
+  // Manual approval label gate
+  app.on(["pull_request.labeled","pull_request.opened","pull_request.synchronize"], async (context) => {
+    const pr = context.payload.pull_request;
+    const labels = (pr.labels || []).map((l) => l.name);
+    const required = "manual-approval";
+    const owner = context.payload.repository.owner.login;
+    const repo = context.payload.repository.name;
+    const sha = pr.head.sha;
+
+    const hasApproval = labels.includes(required);
+    const state = hasApproval ? "success" : "failure";
+    const description = hasApproval
+      ? "Manual approval present"
+      : `Label '${required}' required by authorized reviewer`;
+
+    await context.octokit.repos.createCommitStatus({
+      owner,
+      repo,
+      sha,
+      state,
+      context: "probot/manual-approval",
+      description
+    });
+  });
+
+  // Escalate critical issues (example log hook for Slack relay)
+  app.on("issues.labeled", async (context) => {
+    const label = context.payload.label.name;
+    if (label === "severity:critical") {
+      context.log.info({
+        msg: "Critical issue escalation",
+        title: context.payload.issue.title,
+        url: context.payload.issue.html_url
+      });
+    }
+  });
+};

--- a/.bots/probot.config.yml
+++ b/.bots/probot.config.yml
@@ -1,0 +1,2 @@
+greeting: true
+requiredApprovalLabel: "manual-approval"

--- a/.editorconfig
+++ b/.editorconfig
@@ -17,3 +17,7 @@ indent_size = 4
 [*.md]
 trim_trailing_whitespace = false
 
+[*.yml]
+indent_style = space
+indent_size = 2
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,16 @@
-/infra/            @platform-team
-/flows/            @integration-team
-/monitors/         @sre-team
-/runbooks/         @platform-team
-/apps/api/       @platform-team
-/apps/web-public/ @platform-team
-/ops/            @sre-team
-/scripts/        @platform-team
+# Default maintainers review
+*                       @blackboxprogramming/maintainers
+
+# Security-sensitive paths require sec-review
+.github/workflows/**    @blackboxprogramming/maintainers @blackboxprogramming/sec-review
+/infra/**               @platform-team @blackboxprogramming/maintainers @blackboxprogramming/sec-review
+/scripts/**             @platform-team @blackboxprogramming/maintainers @blackboxprogramming/sec-review
+
+# Domain ownership
+/infra/                 @platform-team
+/flows/                 @integration-team
+/monitors/              @sre-team
+/runbooks/              @platform-team
+/apps/api/              @platform-team
+/apps/web-public/       @platform-team
+/ops/                   @sre-team

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,8 @@
-## Problem
-Describe bug or feature.
+## Description
+-
 
-## Solution
-Planned fix.
+## Acceptance Criteria
+- [ ]
 
-## Notes
+## Additional Context
+-

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,16 @@
 
-## What
-- Summary
+## Summary
+-
 
 ## Why
 - Business / reliability impact
 
-## Checks
+## Checklist
+- [ ] Tests added/updated (if applicable)
+- [ ] No secrets/keys in diff (Gitleaks will run)
 - [ ] CI green
-- [ ] API /api/health returns 200
-- [ ] Updated docs/tests as needed
+- [ ] API `/api/health` returns 200 (if relevant)
+- [ ] If touching workflows/scripts/infra: security reviewer added
 
 > Comment `@codex fix comments` to trigger bot autofix.
 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,14 @@
+# Security Policy
+
+- Report vulnerabilities privately to: security@blackroad.io
+- Do not open public issues for security matters.
+- Protected branches require reviews and passing checks (CI build, CodeQL, Gitleaks).
+- We rotate secrets every 90 days (see `docs/SECRET_ROTATION.md`).
+- Enable Org-level 2FA, Secret Scanning, and Push Protection.
+
+## Scope
+This applies to this repository (code, workflows, and the Probot app scaffold under `/.bots`).
+
+## Incident Handling
+- Limit blast radius; revoke tokens; rotate secrets; add temporary branch restrictions.
+- Document postmortem under `docs/incidents/` (private repo recommended).

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,12 @@
 version: 2
 updates:
   - package-ecosystem: npm
+    directory: "/"
+    schedule: { interval: weekly }
+  - package-ecosystem: pip
+    directory: "/"
+    schedule: { interval: weekly }
+  - package-ecosystem: npm
     directory: "/apps/api"
     schedule: { interval: weekly }
   - package-ecosystem: github-actions

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -19,3 +19,12 @@
 - name: status/help-wanted
   color: "5319e7"
   description: Needs attention
+- name: priority: high
+  color: "b60205"
+  description: Critical priority for triage
+- name: manual-approval
+  color: "ededed"
+  description: Authorized reviewer validated manually
+- name: severity:critical
+  color: "000000"
+  description: Requires immediate security response

--- a/.github/workflows/asana-close-on-merge.yml
+++ b/.github/workflows/asana-close-on-merge.yml
@@ -1,0 +1,29 @@
+name: Asana: Close Task on Merge
+on:
+  pull_request:
+    types: [closed]
+jobs:
+  close:
+    if: ${{ github.event.pull_request.merged == true }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find and close Asana task (by PR URL in notes)
+        env:
+          ASANA_PAT: ${{ secrets.ASANA_PAT }}
+          ASANA_PROJECT_ID: ${{ secrets.ASANA_PROJECT_ID }}
+        run: |
+          PR_URL="${{ github.event.pull_request.html_url }}"
+          TASK_ID=$(curl -s -G "https://app.asana.com/api/1.0/projects/${ASANA_PROJECT_ID}/tasks" \
+              -H "Authorization: Bearer ${ASANA_PAT}" \
+              --data-urlencode "opt_fields=gid,name,notes" | jq -r \
+              --arg pr "${PR_URL}" '.data[] | select(.notes|contains($pr)) | .gid' | head -n1)
+
+          if [ -n "$TASK_ID" ]; then
+            curl -s -X PUT "https://app.asana.com/api/1.0/tasks/${TASK_ID}" \
+              -H "Authorization: Bearer ${ASANA_PAT}" \
+              -H "Content-Type: application/json" \
+              -d '{"data": {"completed": true}}' >/dev/null
+            echo "Closed Asana task ${TASK_ID}"
+          else
+            echo "No matching Asana task found."
+          fi

--- a/.github/workflows/asana-pr-task.yml
+++ b/.github/workflows/asana-pr-task.yml
@@ -1,0 +1,20 @@
+name: Asana: Create PR Task
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+jobs:
+  asana:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create Asana task
+        env:
+          ASANA_PAT: ${{ secrets.ASANA_PAT }}
+          ASANA_PROJECT_ID: ${{ secrets.ASANA_PROJECT_ID }}
+        run: |
+          PR_URL="${{ github.event.pull_request.html_url }}"
+          TITLE="PR: ${{ github.event.pull_request.title }}"
+          BODY="Repo: ${{ github.repository }} | Author: ${{ github.actor }} | URL: ${PR_URL}"
+          curl -s -X POST "https://app.asana.com/api/1.0/tasks" \
+            -H "Authorization: Bearer ${ASANA_PAT}" \
+            -H "Content-Type: application/json" \
+            -d "{\"data\": {\"projects\": [\"${ASANA_PROJECT_ID}\"], \"name\": \"${TITLE}\", \"notes\": \"${BODY}\"}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,7 +1,10 @@
 name: CodeQL
 on:
-  push: { branches: [main] }
-  pull_request: { branches: [main] }
+  push:
+    branches: [main, develop]
+  pull_request:
+  schedule:
+    - cron: '22 4 * * 2'
 jobs:
   analyze:
     runs-on: ubuntu-latest
@@ -9,8 +12,12 @@ jobs:
       security-events: write
       actions: read
       contents: read
+    strategy:
+      matrix:
+        language: [javascript, python]
     steps:
       - uses: actions/checkout@v4
       - uses: github/codeql-action/init@v3
-        with: { languages: javascript }
+        with:
+          languages: ${{ matrix.language }}
       - uses: github/codeql-action/analyze@v3

--- a/.github/workflows/dispatch-listener.yml
+++ b/.github/workflows/dispatch-listener.yml
@@ -1,0 +1,10 @@
+name: Dispatch Listener
+on:
+  repository_dispatch:
+    types: [sync_airtable, rerun_ci]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Dispatch received: ${{ github.event.action }} :: ${{ github.event.client_payload }}"

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,13 @@
+name: Gitleaks
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gitleaks/gitleaks-action@v2
+        with:
+          args: detect --source . --redact

--- a/.github/workflows/labels-sync.yml
+++ b/.github/workflows/labels-sync.yml
@@ -1,0 +1,14 @@
+name: Sync Labels
+on:
+  push:
+    paths: [".github/labels.yml"]
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: EndBug/label-sync@v2
+        with:
+          config-file: .github/labels.yml
+          delete-other-labels: false

--- a/.github/workflows/mirror-to-gitlab.yml
+++ b/.github/workflows/mirror-to-gitlab.yml
@@ -1,0 +1,32 @@
+name: Mirror to GitLab (SSH)
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up SSH for GitLab
+        if: ${{ secrets.GITLAB_SSH_PRIVATE_KEY && secrets.GITLAB_REPO_SSH }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.GITLAB_SSH_PRIVATE_KEY }}" > ~/.ssh/gitlab_key
+          chmod 600 ~/.ssh/gitlab_key
+          cat >> ~/.ssh/config <<EOF
+          Host gitlab-mirror
+            HostName $(echo "${{ secrets.GITLAB_REPO_SSH }}" | sed -E 's#git@(.*):.*#\1#')
+            User git
+            IdentityFile ~/.ssh/gitlab_key
+            StrictHostKeyChecking accept-new
+          EOF
+
+      - name: Push mirror
+        if: ${{ secrets.GITLAB_SSH_PRIVATE_KEY && secrets.GITLAB_REPO_SSH }}
+        run: |
+          git remote add gitlab "${{ secrets.GITLAB_REPO_SSH }}"
+          git push --mirror gitlab

--- a/.github/workflows/notify-discord.yml
+++ b/.github/workflows/notify-discord.yml
@@ -1,0 +1,14 @@
+name: Notify Discord (Releases)
+on:
+  release:
+    types: [published]
+jobs:
+  discord:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Discord
+        run: |
+          MSG="**Release** `${{ github.event.release.tag_name }}` in `${{ github.repository }}`"
+          curl -H "Content-Type: application/json" \
+               -d "{\"content\": \"$MSG\"}" \
+               "${{ secrets.DISCORD_WEBHOOK_URL }}"

--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -1,0 +1,28 @@
+name: Notify Slack
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, closed]
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+jobs:
+  slack:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack
+        if: ${{ always() }}
+        uses: slackapi/slack-github-action@v1.27.0
+        with:
+          payload: |
+            {
+              "text": "*${{ github.event_name }}* in `${{ github.repository }}` by ${{ github.actor }}",
+              "blocks": [
+                { "type": "section",
+                  "text": { "type": "mrkdwn", "text": "Ref: `${{ github.ref }}`\nAction: `${{ github.event.action || 'n/a' }}`" }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,14 @@
 repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.18.0
+    hooks:
+      - id: gitleaks
+        args: ["detect", "--no-banner", "--redact"]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
     hooks:
+      - id: check-added-large-files
+      - id: check-case-conflict
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml

--- a/docs/BRANCH_PROTECTIONS.md
+++ b/docs/BRANCH_PROTECTIONS.md
@@ -1,0 +1,13 @@
+# Branch Protections
+
+Protect `main` (and `develop` if used):
+- Require PR reviews (minimum 1; suggest 2 on `main`)
+- Require status checks: CI/build, CodeQL, Gitleaks
+- Dismiss stale approvals on new commits
+- Restrict who can push: maintainers only
+- (Optional) Require signed commits
+
+Org-level:
+- Enforce 2FA
+- Enable Secret Scanning + Push Protection
+- Enable Dependabot alerts

--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -1,0 +1,17 @@
+# Integration Tests
+
+## PR Flow
+- Open PR → Slack posts to `#dev-prs`
+- Probot status `probot/manual-approval` fails until label added
+- Add `manual-approval` by authorized reviewer → status success
+- Merge PR → Asana task completed
+
+## Releases
+- Tag `v*` + publish release → Discord release message
+
+## Mirroring
+- Push to `main` → GitLab mirror receives commits; verify SHA
+
+## Security
+- Gitleaks blocks leaked secrets in PRs
+- CodeQL scans PRs + scheduled weekly

--- a/docs/SECRET_ROTATION.md
+++ b/docs/SECRET_ROTATION.md
@@ -1,0 +1,12 @@
+# Secret Rotation
+
+- Rotate all integration secrets every 90 days.
+- Maintain inventory: name, owner, scope, last/next rotation.
+- Prefer GitHub App tokens over PATs; least privileges.
+- Use Environment secrets for deploy/production with required reviewers.
+
+## Suggested cadence
+- Slack webhook URLs
+- Asana PAT
+- Airtable token
+- GitLab deploy key (SSH)


### PR DESCRIPTION
## Summary
- add a Probot scaffold to enforce the manual-approval label and log critical issue escalations
- expand security posture with CODEOWNERS updates, Dependabot coverage, label definitions, and project templates/docs
- wire up CodeQL matrix scanning, Gitleaks, label sync, chat notifications, Asana automation, GitLab mirroring, and dispatch listener workflows

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d84ead48f48329be41957ed4517026