### PR TITLE
Add WAF bot control and logging pipeline

### DIFF
--- a/br-infra-iac/envs/dev/main.tf
+++ b/br-infra-iac/envs/dev/main.tf
@@ -36,8 +36,31 @@ module "rds" {
   tags                      = local.tags
 }
 
+module "api_waf" {
+  source                   = "../../modules/wafv2-alb"
+  name                     = "${local.name}-api"
+  scope                    = "REGIONAL"
+  association_resource_arn = null
+  enable_bot_control       = true
+  enable_anomaly_rules     = false
+  tags                     = local.tags
+}
+
+module "waf_logging" {
+  source         = "../../modules/waf-logging"
+  name           = "br-dev-api"
+  region         = var.region
+  web_acl_arn    = module.api_waf.web_acl_arn
+  s3_bucket_name = "br-dev-waf-logs-${var.region}"
+  s3_prefix      = "waf_logs/"
+  retention_days = 30
+  tags           = local.tags
+}
+
 output "vpc_id"          { value = module.network.vpc_id }
 output "private_subnets" { value = module.network.private_subnet_ids }
 output "ecs_cluster"     { value = module.ecs.cluster_name }
 output "ecr_repos"       { value = module.ecr.repo_arns }
 output "db_endpoint"     { value = module.rds.db_endpoint }
+output "api_waf_arn"     { value = module.api_waf.web_acl_arn }
+output "waf_logs_s3"     { value = module.waf_logging.s3_log_path_hint }

--- a/br-infra-iac/modules/waf-logging/main.tf
+++ b/br-infra-iac/modules/waf-logging/main.tf
@@ -1,0 +1,229 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+# S3 bucket for logs
+locals {
+  merged_tags = merge(var.tags, { region = var.region })
+}
+
+resource "aws_s3_bucket" "logs" {
+  bucket        = var.s3_bucket_name
+  force_destroy = false
+  tags          = local.merged_tags
+}
+
+resource "aws_s3_bucket_versioning" "v" {
+  bucket = aws_s3_bucket.logs.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_encryption" "enc" {
+  bucket = aws_s3_bucket.logs.id
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "pab" {
+  bucket = aws_s3_bucket.logs.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "lc" {
+  bucket = aws_s3_bucket.logs.id
+
+  rule {
+    id     = "expire"
+    status = "Enabled"
+
+    expiration {
+      days = var.retention_days
+    }
+
+    filter {}
+  }
+}
+
+# Firehose role + policy
+data "aws_iam_policy_document" "assume_firehose" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["firehose.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "firehose" {
+  name               = "${var.name}-waf-firehose"
+  assume_role_policy = data.aws_iam_policy_document.assume_firehose.json
+  tags               = local.merged_tags
+}
+
+data "aws_iam_policy_document" "firehose_s3" {
+  statement {
+    actions = [
+      "s3:PutObject",
+      "s3:AbortMultipartUpload",
+      "s3:ListBucket",
+      "s3:GetBucketLocation",
+      "s3:ListBucketMultipartUploads"
+    ]
+    resources = [aws_s3_bucket.logs.arn, "${aws_s3_bucket.logs.arn}/*"]
+  }
+
+  statement {
+    actions = [
+      "logs:PutLogEvents",
+      "logs:CreateLogStream",
+      "logs:CreateLogGroup",
+      "logs:DescribeLogStreams"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "firehose_s3" {
+  name   = "${var.name}-waf-firehose-s3"
+  policy = data.aws_iam_policy_document.firehose_s3.json
+}
+
+resource "aws_iam_role_policy_attachment" "attach" {
+  role       = aws_iam_role.firehose.name
+  policy_arn = aws_iam_policy.firehose_s3.arn
+}
+
+# Firehose delivery stream (direct put)
+resource "aws_kinesis_firehose_delivery_stream" "waf" {
+  name        = "${var.name}-waf-logs"
+  destination = "s3"
+
+  s3_configuration {
+    role_arn           = aws_iam_role.firehose.arn
+    bucket_arn         = aws_s3_bucket.logs.arn
+    prefix             = "${var.s3_prefix}!{timestamp:yyyy/MM/dd}/"
+    buffering_size     = 5
+    buffering_interval = 60
+    compression_format = "GZIP"
+  }
+
+  tags = local.merged_tags
+}
+
+# Wire WAF logging to Firehose
+resource "aws_wafv2_web_acl_logging_configuration" "this" {
+  resource_arn            = var.web_acl_arn
+  log_destination_configs = [aws_kinesis_firehose_delivery_stream.waf.arn]
+
+  redacted_fields {
+    method {}
+    uri_path {}
+  }
+}
+
+resource "aws_glue_catalog_database" "waf_db" {
+  name = replace("${var.name}-waf", "-", "_")
+}
+
+resource "aws_glue_catalog_table" "waf_table" {
+  name          = "logs"
+  database_name = aws_glue_catalog_database.waf_db.name
+  table_type    = "EXTERNAL_TABLE"
+  parameters    = {
+    classification = "json"
+  }
+
+  storage_descriptor {
+    location      = "s3://${aws_s3_bucket.logs.bucket}/${var.s3_prefix}"
+    input_format  = "org.apache.hadoop.mapred.TextInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+
+    serde_info {
+      serialization_library = "org.openx.data.jsonserde.JsonSerDe"
+    }
+
+    columns = [
+      {
+        name = "timestamp"
+        type = "string"
+      },
+      {
+        name = "formatversion"
+        type = "int"
+      },
+      {
+        name = "webaclid"
+        type = "string"
+      },
+      {
+        name = "terminatingruleid"
+        type = "string"
+      },
+      {
+        name = "action"
+        type = "string"
+      },
+      {
+        name = "httpsourcename"
+        type = "string"
+      },
+      {
+        name = "httpsourceid"
+        type = "string"
+      },
+      {
+        name = "httprequest"
+        type = "string"
+      }
+    ]
+  }
+}
+
+resource "aws_athena_named_query" "top_actions" {
+  name     = "waf_top_actions"
+  database = aws_glue_catalog_database.waf_db.name
+  query    = <<SQL
+SELECT action, count(*) AS n
+FROM ${aws_glue_catalog_database.waf_db.name}.logs
+WHERE from_iso8601_timestamp(json_extract_scalar($path, '$.timestamp')) > now() - interval '1' day
+GROUP BY action
+ORDER BY n DESC
+LIMIT 20;
+SQL
+}
+
+output "logs_bucket" {
+  value = aws_s3_bucket.logs.bucket
+}
+
+output "logs_prefix" {
+  value = var.s3_prefix
+}
+
+output "firehose_name" {
+  value = aws_kinesis_firehose_delivery_stream.waf.name
+}
+
+output "s3_log_path_hint" {
+  value = "s3://${aws_s3_bucket.logs.bucket}/${var.s3_prefix}"
+}

--- a/br-infra-iac/modules/waf-logging/variables.tf
+++ b/br-infra-iac/modules/waf-logging/variables.tf
@@ -1,0 +1,37 @@
+variable "name" {
+  description = "Prefix name for resources (e.g., br-dev-api)."
+  type        = string
+}
+
+variable "region" {
+  description = "AWS region for the resources."
+  type        = string
+}
+
+variable "web_acl_arn" {
+  description = "ARN of the Web ACL to enable logging for."
+  type        = string
+}
+
+variable "s3_bucket_name" {
+  description = "Name of the S3 bucket to store WAF logs. Must be globally unique."
+  type        = string
+}
+
+variable "s3_prefix" {
+  description = "Prefix (folder) for WAF logs inside the bucket."
+  type        = string
+  default     = "waf_logs/"
+}
+
+variable "retention_days" {
+  description = "Number of days to retain WAF logs before expiration."
+  type        = number
+  default     = 30
+}
+
+variable "tags" {
+  description = "Tags to apply to created resources."
+  type        = map(string)
+  default     = {}
+}

--- a/br-infra-iac/modules/wafv2-alb/main.tf
+++ b/br-infra-iac/modules/wafv2-alb/main.tf
@@ -1,0 +1,132 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+locals {
+  metric_name = length(regexall("[A-Za-z0-9]", var.name)) > 0 ?
+    regexreplace(var.name, "[^A-Za-z0-9]", "") :
+    "WebACL"
+}
+
+resource "aws_wafv2_web_acl" "this" {
+  name  = var.name
+  scope = var.scope
+
+  default_action {
+    allow {}
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = local.metric_name
+    sampled_requests_enabled   = true
+  }
+
+  rule {
+    name     = "AWS-CommonRuleSet"
+    priority = 10
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        vendor_name = "AWS"
+        name        = "AWSManagedRulesCommonRuleSet"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "CommonRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWS-KnownBadInputs"
+    priority = 12
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        vendor_name = "AWS"
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "KnownBadInputs"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  dynamic "rule" {
+    for_each = var.enable_bot_control ? [1] : []
+    content {
+      name     = "AWS-BotControl"
+      priority = 13
+
+      override_action {
+        none {}
+      }
+
+      statement {
+        managed_rule_group_statement {
+          vendor_name = "AWS"
+          name        = "AWSManagedRulesBotControlRuleSet"
+        }
+      }
+
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        metric_name                = "BotControl"
+        sampled_requests_enabled   = true
+      }
+    }
+  }
+
+  dynamic "rule" {
+    for_each = var.enable_anomaly_rules ? [1] : []
+    content {
+      name     = "AWS-AnomalyRuleSet"
+      priority = 14
+
+      override_action {
+        none {}
+      }
+
+      statement {
+        managed_rule_group_statement {
+          vendor_name = "AWS"
+          name        = "AWSManagedRulesAnomalyRuleSet"
+        }
+      }
+
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        metric_name                = "Anomaly"
+        sampled_requests_enabled   = true
+      }
+    }
+  }
+
+  tags = var.tags
+}
+
+resource "aws_wafv2_web_acl_association" "this" {
+  count = var.association_resource_arn == null || var.association_resource_arn == "" ? 0 : 1
+
+  resource_arn = var.association_resource_arn
+  web_acl_arn  = aws_wafv2_web_acl.this.arn
+}

--- a/br-infra-iac/modules/wafv2-alb/outputs.tf
+++ b/br-infra-iac/modules/wafv2-alb/outputs.tf
@@ -1,0 +1,4 @@
+output "web_acl_arn" {
+  description = "ARN of the created WAFv2 Web ACL."
+  value       = aws_wafv2_web_acl.this.arn
+}

--- a/br-infra-iac/modules/wafv2-alb/variables.tf
+++ b/br-infra-iac/modules/wafv2-alb/variables.tf
@@ -1,0 +1,34 @@
+variable "name" {
+  description = "Name for the WAFv2 Web ACL."
+  type        = string
+}
+
+variable "scope" {
+  description = "Scope of the Web ACL (REGIONAL for ALB)."
+  type        = string
+  default     = "REGIONAL"
+}
+
+variable "association_resource_arn" {
+  description = "ARN of the resource (e.g., ALB) to associate with the Web ACL."
+  type        = string
+  default     = null
+}
+
+variable "tags" {
+  description = "Tags to apply to supported resources."
+  type        = map(string)
+  default     = {}
+}
+
+variable "enable_bot_control" {
+  description = "Enable the AWS Bot Control managed rule group."
+  type        = bool
+  default     = true
+}
+
+variable "enable_anomaly_rules" {
+  description = "Enable the AWS Anomaly managed rule group."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Summary
- add a reusable WAFv2 module with Bot Control and optional anomaly managed rule toggles
- provision a WAF logging pipeline module that delivers to S3 via Firehose and bootstraps Glue/Athena analytics
- wire the dev environment to the new modules and surface helpful outputs for downstream consumers

## Testing
- not run (terraform CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d84f0db7888329abba238860311ef6