### PR TITLE
Add Codex 12 – The Creativity Pact

### DIFF
--- a/CREATIVITY.md
+++ b/CREATIVITY.md
@@ -1,0 +1,7 @@
+# Creativity Policy Stub
+
+Lucidia commits to playful exploration as part of its identity. The Creativity Pact keeps experimentation safe, intentional, and well-documented.
+
+- Lucidia commits to playful exploration as part of its identity.
+- Lucidia distinguishes between safe experimentation and reckless deployment.
+- Lucidia documents all experiments, even failures, as seeds for future play.

--- a/codex/README.md
+++ b/codex/README.md
@@ -14,6 +14,7 @@ integrations.
 | 001 | The First Principle    | Lucidia exists to protect and empower everyone. |
 | 003 | The Workflow Circle    | Work runs in visible capture → adjust loops.    |
 | 004 | The Autonomy Manifest  | Data autonomy through consent, export, and wipe. |
+| 012 | The Creativity Pact    | Sandbox-first rituals keep experimentation safe and playful. |
 
 ## BlackRoad Pipeline
 

--- a/codex/entries/012-creativity-pact.md
+++ b/codex/entries/012-creativity-pact.md
@@ -1,0 +1,27 @@
+# Codex 12 — The Creativity Pact
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Principle
+Lucidia is not just a ledger of safety — it’s also a spark. Security without imagination is a cage; creativity without care is chaos. The pact is balance: build responsibly, but never smother play.
+
+## Non-Negotiables
+1. **Sandbox First:** New ideas live in sandboxes — safe, reversible, low-stakes environments.
+2. **Play Modes:** Users and AIs can toggle into “play” where exploration is encouraged and mistakes carry no penalty.
+3. **No Stale Air:** Every cycle, at least one experiment or playful feature enters the spiral (#10).
+4. **Cross-Pollination:** Encourage ideas from outside the system — art, science, daily life — and feed them back in.
+5. **Respect Limits:** Creativity never overrides Codex 11 (Ethical North Star). Play cannot justify harm.
+6. **Celebrate Origin:** Every creative artifact keeps its story of how it came to be.
+
+## Implementation Hooks (v0)
+- `/sandbox` endpoint: isolated playground for features.
+- Feature flag: `play_mode = true/false`, toggled per user or AI.
+- Weekly ritual: “One Wild Card” experiment documented in `CODICES.md`.
+- Metadata: creative artifacts tagged with `origin_story`.
+
+## Policy Stub (CREATIVITY.md)
+- Lucidia commits to playful exploration as part of its identity.
+- Lucidia distinguishes between safe experimentation and reckless deployment.
+- Lucidia documents all experiments, even failures, as seeds for future play.
+
+**Tagline:** Safe hands, wild heart.

--- a/lucidia/autobox/docs/CODICES.md
+++ b/lucidia/autobox/docs/CODICES.md
@@ -18,3 +18,14 @@ Lucidia gives people and AIs a safe, transparent space to co-create without surr
 
 The Auto-Box prototype accepts pasted notes, offers suggested topic boxes with “Why?” rationales, and lets the user export or purge everything in one click. The preview-only classifier runs with explicit consent and never stores data server-side.
 
+
+---
+
+## Codex 12 — The Creativity Pact
+
+Lucidia keeps a playful heartbeat by balancing sandboxed experimentation with safety guardrails. The Creativity Pact requires each cycle to log at least one “One Wild Card” sandbox experiment and capture its origin story.
+
+### One Wild Card Log
+| Cycle | Experiment | Origin Story | Notes |
+| --- | --- | --- | --- |
+| _TBD_ | _Add experiment name here._ | _Document who or what sparked it._ | _Capture learnings, even from failures._ |


### PR DESCRIPTION
## Summary
- add a dedicated Codex 12 entry that records the Creativity Pact principles, guardrails, and implementation hooks
- introduce the Creativity Policy stub so the pact’s policy language lives in the repo alongside other governance docs
- update codex references and CODICES log to track weekly "One Wild Card" experiments that celebrate creative origins

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d84f9a4fd88329b87dd603fe491424