### PR TITLE
Add Codex entry for the Community Oath

### DIFF
--- a/codex/README.md
+++ b/codex/README.md
@@ -14,6 +14,7 @@ integrations.
 | 001 | The First Principle    | Lucidia exists to protect and empower everyone. |
 | 003 | The Workflow Circle    | Work runs in visible capture → adjust loops.    |
 | 004 | The Autonomy Manifest  | Data autonomy through consent, export, and wipe. |
+| 013 | The Community Oath     | Community safety through respect, consent, and care. |
 
 ## BlackRoad Pipeline
 

--- a/codex/entries/013-community-oath.md
+++ b/codex/entries/013-community-oath.md
@@ -1,0 +1,27 @@
+# Codex 13 — The Community Oath
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Principle
+Lucidia is not a solitary system; it lives in community. That community must be safe, inclusive, and generative. The oath is what we promise each other.
+
+## Non-Negotiables
+1. **Respect First:** No harassment, hate, or abuse — ever.
+2. **Voice for All:** Systems give equal floor to quieter voices; no domination by volume or privilege.
+3. **Consent in Sharing:** No posting private work or data without explicit permission from its owner.
+4. **Accountability:** Violations are addressed with transparency, not secrecy. Restorative justice preferred, but harm never ignored.
+5. **Open Doors:** Documentation, forums, and discussions remain open by default; no artificial walls.
+6. **Zero Exploitation:** No pyramid schemes, no manipulation, no extracting value without giving back.
+
+## Implementation Hooks (v0)
+- Code of Conduct file in every repo.
+- Moderation tools baked into community forums; strike log is public.
+- Opt-in contribution credits (users choose if their name shows).
+- Consent flag required for sharing any user-generated artifact.
+
+## Policy Stub (COMMUNITY.md)
+- Lucidia commits to a culture of care and curiosity.
+- Lucidia bans harassment, manipulation, and exploitation.
+- Lucidia will always prioritize the safety of members over growth metrics.
+
+**Tagline:** A circle, not a cage.


### PR DESCRIPTION
## Summary
- add Codex 13 entry documenting the Community Oath community guidelines
- list the Community Oath in the codex index for quick discovery

## Testing
- not run (documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d84fb555cc83299a0e247006f2d4ce