### PR TITLE
Add Codex 15 trust ledger entry

### DIFF
--- a/codex/README.md
+++ b/codex/README.md
@@ -14,6 +14,7 @@ integrations.
 | 001 | The First Principle    | Lucidia exists to protect and empower everyone. |
 | 003 | The Workflow Circle    | Work runs in visible capture → adjust loops.    |
 | 004 | The Autonomy Manifest  | Data autonomy through consent, export, and wipe. |
+| 015 | The Trust Ledger       | Trust is tracked via a public reliability ledger. |
 
 ## BlackRoad Pipeline
 

--- a/codex/entries/015-trust-ledger.md
+++ b/codex/entries/015-trust-ledger.md
@@ -1,0 +1,27 @@
+# Codex 15 — The Trust Ledger
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Principle
+Trust is not owed; it is earned, recorded, and renewed. Lucidia keeps a visible ledger of its promises kept, mistakes made, and repairs done.
+
+## Non-Negotiables
+1. **Public Scorecard:** Uptime, incidents, fixes, and ethics reports published regularly.
+2. **Error Honesty:** Every outage or breach disclosed within 24 hours, with plain-language postmortem.
+3. **Repair Visible:** When harm occurs, steps to repair are documented and tracked until complete.
+4. **Reciprocity:** Users + AIs can rate interactions; those ratings feed into the ledger openly.
+5. **No Silent Debt:** Trust debt (bugs, unresolved issues, ignored feedback) is logged and cannot be hidden.
+6. **Cycle Renewal:** Trust metrics are reviewed at every spiral loop (#10).
+
+## Implementation Hooks (v0)
+- `/trust-ledger` endpoint: exposes uptime, incidents, fixes, user ratings.
+- GitHub Action: auto-generate monthly trust report from issues + CI stats.
+- Feedback integration: `/feedback` ratings flow into ledger.
+- Postmortem template in `/docs/incidents`.
+
+## Policy Stub (drop into TRUST.md)
+- Lucidia commits to transparent accounting of its reliability and ethics.
+- Lucidia accepts ratings from its community as part of the ledger.
+- Lucidia treats broken trust as highest priority debt.
+
+**Tagline:** Trust is a balance sheet, not a slogan.


### PR DESCRIPTION
## Summary
- add the Codex 15 Trust Ledger entry capturing principles, hooks, and policy stub
- list the new Codex entry in the codex README table for discoverability

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d8500e66748329b7cced2ba095f610