### PR TITLE
Add monitoring dashboard and alarm modules

### DIFF
--- a/asana-security-baseline.csv
+++ b/asana-security-baseline.csv
@@ -8,3 +8,7 @@ Integrate Notion SSO,Enable SSO; test deprovision.,amundsonalexa@gmail.com,This 
 Create 1Password vaults + policy,Team vaults; sharing; break-glass account.,amundsonalexa@gmail.com,Today,2025-10-03
 Enable Snyk + Dependabot org-wide,Block on high severity; add PR checks.,amundsonalexa@gmail.com,This Week,2025-10-04
 Document “SSO & Access” in Notion,Screenshots, SOP, rollback, break-glass.,amundsonalexa@gmail.com,This Week,2025-10-04
+Create CloudWatch dashboard,Add ALB requests/5xx + WAF allowed/blocked widgets.,amundsonalexa@gmail.com,Today,2025-10-07
+Wire Slack to AWS Chatbot,Connect Slack workspace, add #security channel, get SNS topic ARN.,amundsonalexa@gmail.com,Today,2025-10-07
+Deploy alarms to SNS,Apply Terraform for alb_5xx and waf_blocks alarms with Slack SNS.,amundsonalexa@gmail.com,This Week,2025-10-08
+Tune thresholds,Review 1 week data, adjust 5xx threshold and block rate.,amundsonalexa@gmail.com,Next Week,2025-10-14

--- a/br-infra-iac/modules/monitoring-alarms/main.tf
+++ b/br-infra-iac/modules/monitoring-alarms/main.tf
@@ -1,0 +1,31 @@
+resource "aws_cloudwatch_metric_alarm" "alb_5xx" {
+  alarm_name          = "${var.name}-alb-5xx"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  period              = 300
+  threshold           = 20
+  statistic           = "Sum"
+  namespace           = "AWS/ApplicationELB"
+  metric_name         = "HTTPCode_ELB_5XX_Count"
+  dimensions = {
+    LoadBalancer = var.alb_arn_suffix
+  }
+  alarm_actions = [var.sns_topic_arn]
+  tags          = var.tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "waf_blocks" {
+  alarm_name          = "${var.name}-waf-blocks"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  period              = 300
+  threshold           = 50
+  statistic           = "Sum"
+  namespace           = "AWS/WAFV2"
+  metric_name         = "BlockedRequests"
+  dimensions = {
+    WebACL = var.web_acl_arn
+  }
+  alarm_actions = [var.sns_topic_arn]
+  tags          = var.tags
+}

--- a/br-infra-iac/modules/monitoring-alarms/variables.tf
+++ b/br-infra-iac/modules/monitoring-alarms/variables.tf
@@ -1,0 +1,24 @@
+variable "name" {
+  type = string
+}
+
+variable "alb_arn_suffix" {
+  type = string
+}
+
+variable "web_acl_arn" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "sns_topic_arn" {
+  type = string
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}

--- a/br-infra-iac/modules/monitoring-dashboard/main.tf
+++ b/br-infra-iac/modules/monitoring-dashboard/main.tf
@@ -1,0 +1,46 @@
+resource "aws_cloudwatch_dashboard" "this" {
+  dashboard_name = "${var.name}-dash"
+  dashboard_body = jsonencode({
+    widgets = [
+      {
+        type   = "metric"
+        x      = 0
+        y      = 0
+        width  = 12
+        height = 6
+        properties = {
+          title  = "ALB Requests / 5xx"
+          metrics = [
+            ["AWS/ApplicationELB", "RequestCount", "LoadBalancer", var.alb_arn_suffix],
+            ["AWS/ApplicationELB", "HTTPCode_ELB_5XX_Count", "LoadBalancer", var.alb_arn_suffix]
+          ]
+          view    = "timeSeries"
+          stacked = false
+          region  = var.region
+          period  = 60
+          stat    = "Sum"
+        }
+      },
+      {
+        type   = "metric"
+        x      = 12
+        y      = 0
+        width  = 12
+        height = 6
+        properties = {
+          title = "WAF Allowed vs Blocked"
+          metrics = [
+            ["AWS/WAFV2", "AllowedRequests", "WebACL", var.web_acl_arn],
+            ["AWS/WAFV2", "BlockedRequests", "WebACL", var.web_acl_arn]
+          ]
+          view   = "timeSeries"
+          region = var.region
+          period = 300
+          stat   = "Sum"
+        }
+      }
+    ]
+  })
+
+  tags = var.tags
+}

--- a/br-infra-iac/modules/monitoring-dashboard/variables.tf
+++ b/br-infra-iac/modules/monitoring-dashboard/variables.tf
@@ -1,0 +1,21 @@
+variable "name" {
+  type = string
+}
+
+variable "alb_arn_suffix" {
+  type = string
+  # Example: app/my-alb/1234567890abcdef
+}
+
+variable "web_acl_arn" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}

--- a/ops/next_push/slack_posts.md
+++ b/ops/next_push/slack_posts.md
@@ -30,3 +30,12 @@ PRISM v0.1 starts now. Sprint 0 focus:
 
 Friday demo: working auth stub + CI green + first endpoint.
 Cadillac cutover: api.blackroad.io now has ACM cert + ALB + ECS Fargate + autoscaling + SSM secrets + GitHub OIDC deploys. Merge to main in br-api-gateway → auto rollout with zero downtime.
+
+## #security — Monitoring stack go-live
+
+Monitoring stack added:
+- CloudWatch dashboard: ALB 5xx + WAF blocks
+- Alarms: >20 5xx in 5m, >50 blocked in 5m
+- Slack alerts via Chatbot to this channel
+
+Next: tune thresholds after baseline week.


### PR DESCRIPTION
## Summary
- add a CloudWatch dashboard module to visualize ALB traffic and WAF decisions
- add CloudWatch alarm module wiring ALB 5xx and WAF block thresholds to SNS
- log companion Asana tasks and Slack comms for the monitoring rollout

## Testing
- not run (terraform CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d8515a7fcc8329ae55d13174fbe243