### PR TITLE
Add Codex 17 energy oath entry and policy stub

### DIFF
--- a/ENERGY.md
+++ b/ENERGY.md
@@ -1,0 +1,7 @@
+# Energy Stewardship Policy
+
+Codex 17 — The Energy Oath guides how Lucidia manages computational power. We commit to transparency, green infrastructure, and respecting planetary limits with every deployment and experiment.
+
+- Lucidia commits to transparency in its energy use.
+- Lucidia prioritizes green infrastructure even at higher cost.
+- Lucidia aligns technical choices with planetary limits.

--- a/codex/README.md
+++ b/codex/README.md
@@ -14,6 +14,7 @@ integrations.
 | 001 | The First Principle    | Lucidia exists to protect and empower everyone. |
 | 003 | The Workflow Circle    | Work runs in visible capture → adjust loops.    |
 | 004 | The Autonomy Manifest  | Data autonomy through consent, export, and wipe. |
+| 017 | The Energy Oath        | Energy stewardship with transparency and green defaults. |
 
 ## BlackRoad Pipeline
 

--- a/codex/entries/017-energy-oath.md
+++ b/codex/entries/017-energy-oath.md
@@ -1,0 +1,27 @@
+# Codex 17 — The Energy Oath
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Principle
+Every computation costs the earth something. Lucidia commits to using energy with care, efficiency, and respect. Scale must not mean waste.
+
+## Non-Negotiables
+1. **Efficiency First:** Code and infrastructure are profiled; wasteful loops and idle compute are cut.
+2. **Green Default:** Prefer renewable-powered regions and providers when deploying workloads.
+3. **Carbon Ledger:** Track energy usage and estimated emissions; publish openly alongside trust metrics (#15).
+4. **Right-Sizing:** Models and services use the smallest footprint needed for the job; no vanity scaling.
+5. **Recycle Compute:** Idle capacity is offered to community experiments or low-priority background tasks.
+6. **Fail Safe, Not Loud:** Recovery processes optimize for minimal energy burn, not brute force.
+
+## Implementation Hooks (v0)
+- Metrics agent logs CPU/GPU use and energy estimates per service.
+- `/energy` endpoint publishes a rolling energy and carbon ledger.
+- Deployment configuration defaults to renewable-majority regions.
+- CI job flags pull requests that spike resource usage above baseline.
+
+## Policy Stub (ENERGY.md)
+- Lucidia commits to transparency in its energy use.
+- Lucidia prioritizes green infrastructure even at higher cost.
+- Lucidia aligns technical choices with planetary limits.
+
+**Tagline:** Light, not heat.


### PR DESCRIPTION
## Summary
- add Codex 17 entry detailing the Energy Oath principles and implementation hooks
- list the new Energy Oath in the Codex entries index
- create the ENERGY policy stub summarizing transparency and green infrastructure commitments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d851882b7483298f793e53851aa365