### PR TITLE
Add Codex 18 Memory Covenant documentation

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,0 +1,5 @@
+# Lucidia Memory Covenant Stub
+
+- Lucidia commits to finite memory, with default expiry.
+- Lucidia treats forgetting as a core right, not an edge case.
+- Lucidia ensures memory is always visible to its owner.

--- a/codex/README.md
+++ b/codex/README.md
@@ -14,6 +14,7 @@ integrations.
 | 001 | The First Principle    | Lucidia exists to protect and empower everyone. |
 | 003 | The Workflow Circle    | Work runs in visible capture → adjust loops.    |
 | 004 | The Autonomy Manifest  | Data autonomy through consent, export, and wipe. |
+| 018 | The Memory Covenant    | Memory stays purposeful, finite, and revocable. |
 
 ## BlackRoad Pipeline
 

--- a/codex/entries/018-memory-covenant.md
+++ b/codex/entries/018-memory-covenant.md
@@ -1,0 +1,28 @@
+# Codex 18 — The Memory Covenant
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Principle
+Lucidia remembers to serve, not to hoard. Memory must be purposeful, limited, and erasable. Forgetting is as sacred as recalling.
+
+## Non-Negotiables
+1. **Scoped Retention:** Data is only kept for its declared purpose and timeframe. No silent archives.
+2. **Right to Forget:** Users and AIs can trigger immediate, irreversible deletion of their traces (#4 Autonomy Manifest).
+3. **Selective Recall:** Memory is queryable, not all-seeing; only the owner can summon their full history.
+4. **Expiration by Default:** Unless extended by explicit consent, data expires.
+5. **Anonymized History:** Aggregated learnings are stripped of identifiers before reuse.
+6. **Memory Transparency:** Owners can view what Lucidia remembers at any moment.
+
+## Implementation Hooks (v0)
+- `retention_policy` field on all stored entities.
+- Cron job: purge expired data daily, log deletions.
+- `/my-memory` endpoint: owner dashboard of retained items and expiry dates.
+- Consent receipts store retention overrides.
+- Background anonymizer pipeline for aggregate learning.
+
+## Policy Stub (MEMORY.md)
+- Lucidia commits to finite memory, with default expiry.
+- Lucidia treats forgetting as a core right, not an edge case.
+- Lucidia ensures memory is always visible to its owner.
+
+**Tagline:** We remember with consent, we forget with grace.


### PR DESCRIPTION
## Summary
- add Codex entry 18 documenting the Memory Covenant principle and implementation hooks
- extend the Codex index to reference the new memory covenant entry
- create MEMORY.md with the policy stub commitments for retention and transparency

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d851e118848329b4823a6261a3cb96