### PR TITLE
Add status site Terraform module and launch runbook

### DIFF
--- a/infra/status-site/README.md
+++ b/infra/status-site/README.md
@@ -1,0 +1,68 @@
+# Status Site Deployment Plan
+
+BlackRoad's public status page (`status.blackroad.io`) runs on a static site delivered through Amazon S3 and CloudFront with an ACM certificate anchored in `us-east-1`. The Terraform module at `modules/status-site` provisions the certificate, DNS, and delivery pipeline so the team only needs to supply the hosted zone name, vanity domain, and shared tags.
+
+## Terraform Module
+
+```hcl
+module "status_site" {
+  source           = "../../modules/status-site"
+  name             = "status"
+  hosted_zone_name = "blackroad.io."
+  domain_name      = "status.blackroad.io"
+  tags = {
+    Project = "Reliability"
+    Owner   = "Alexa Amundson"
+  }
+}
+```
+
+The module creates:
+
+- ACM certificate in `us-east-1` with DNS validation records.
+- Private S3 bucket (no public ACLs) for the static app.
+- CloudFront distribution with Origin Access Control and TLS 1.2 2021 policy.
+- Route53 alias record pointing `status.blackroad.io` at CloudFront.
+
+Outputs expose the bucket name for deploy jobs and the CloudFront hostname for health monitoring.
+
+## Status Application Options
+
+Choose either approach for the static site artifacts that land in the provisioned bucket:
+
+1. **Hugo / cstate fork** – fastest path; edit incidents via Markdown and push rendered HTML.
+2. **Next.js status app** – hosts richer UI components and direct API polling; build to static output and sync the `out/` (or `public/`) directory to S3.
+
+Both flows should invalidate CloudFront after uploads to avoid stale assets.
+
+## Health Check Feeds
+
+Use Route53 health checks to watch production surfaces and supply JSON to the status app.
+
+```hcl
+resource "aws_route53_health_check" "api" {
+  type            = "HTTPS"
+  fqdn            = "api.blackroad.io"
+  resource_path   = "/health"
+  port            = 443
+  measure_latency = true
+  regions         = ["us-east-1", "us-west-1", "us-west-2"]
+  tags            = local.tags
+}
+```
+
+Export health check status nightly to S3 (e.g., via Lambda) or query live endpoints client-side. Start with `/api/health` and `/products` and expand coverage as new services launch.
+
+## Deployment Workflow
+
+1. Create repository `br-status-site` with selected app scaffold.
+2. GitHub Actions builds the site and runs `aws s3 sync ./public s3://$STATUS_BUCKET --delete` with the module output bucket.
+3. Invalidate CloudFront (`aws cloudfront create-invalidation --distribution-id $DIST_ID --paths "/*"`).
+4. DNS already points `status.blackroad.io` at CloudFront; certificate covers the alias.
+5. Incidents publish via content commits (Markdown/JSON) or automation from Asana/Notion.
+
+## Operational Runway
+
+- **Asana Tasks** – `ops/next_push/status_site_asana_tasks.csv` seeds the operations board with provisioning, repo, health check, alerting, and launch validation work.
+- **Slack Comms** – `ops/next_push/slack_posts.md` includes an announcement template for #announcements once the page is live.
+- **Next Iteration Decision** – After launch, decide whether to prioritize a Cost & Spend reporting board or developer experience automation (CI templates, PR linting, preview environments).

--- a/modules/status-site/main.tf
+++ b/modules/status-site/main.tf
@@ -1,0 +1,129 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+data "aws_route53_zone" "zone" {
+  name         = var.hosted_zone_name
+  private_zone = false
+}
+
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+}
+
+resource "aws_acm_certificate" "cert" {
+  provider          = aws.us_east_1
+  domain_name       = var.domain_name
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = var.tags
+}
+
+resource "aws_route53_record" "cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.cert.domain_validation_options :
+    dvo.domain_name => {
+      name   = dvo.resource_record_name
+      type   = dvo.resource_record_type
+      record = dvo.resource_record_value
+    }
+  }
+
+  zone_id = data.aws_route53_zone.zone.zone_id
+  name    = each.value.name
+  type    = each.value.type
+  ttl     = 60
+  records = [each.value.record]
+}
+
+resource "aws_acm_certificate_validation" "cert" {
+  provider                = aws.us_east_1
+  certificate_arn         = aws_acm_certificate.cert.arn
+  validation_record_fqdns = [for r in aws_route53_record.cert_validation : r.fqdn]
+}
+
+resource "aws_s3_bucket" "site" {
+  bucket        = replace(var.domain_name, ".", "-")
+  force_destroy = true
+  tags          = var.tags
+}
+
+resource "aws_s3_bucket_public_access_block" "pab" {
+  bucket = aws_s3_bucket.site.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_cloudfront_origin_access_control" "oac" {
+  name                              = "${var.name}-oac"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+resource "aws_cloudfront_distribution" "dist" {
+  enabled             = true
+  aliases             = [var.domain_name]
+  default_root_object = "index.html"
+
+  origin {
+    domain_name              = aws_s3_bucket.site.bucket_regional_domain_name
+    origin_id                = "s3-origin"
+    origin_access_control_id = aws_cloudfront_origin_access_control.oac.id
+  }
+
+  default_cache_behavior {
+    target_origin_id       = "s3-origin"
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate_validation.cert.certificate_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+
+  tags = var.tags
+}
+
+resource "aws_route53_record" "alias" {
+  zone_id = data.aws_route53_zone.zone.zone_id
+  name    = var.domain_name
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.dist.domain_name
+    zone_id                = aws_cloudfront_distribution.dist.hosted_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/modules/status-site/outputs.tf
+++ b/modules/status-site/outputs.tf
@@ -1,0 +1,9 @@
+output "site_bucket" {
+  description = "Name of the S3 bucket hosting the status site."
+  value       = aws_s3_bucket.site.bucket
+}
+
+output "cf_domain" {
+  description = "CloudFront distribution domain name."
+  value       = aws_cloudfront_distribution.dist.domain_name
+}

--- a/modules/status-site/variables.tf
+++ b/modules/status-site/variables.tf
@@ -1,0 +1,20 @@
+variable "name" {
+  description = "Friendly name used for tagging and resource prefixes."
+  type        = string
+}
+
+variable "hosted_zone_name" {
+  description = "Route53 public hosted zone name (e.g., blackroad.io.)."
+  type        = string
+}
+
+variable "domain_name" {
+  description = "Fully qualified domain name for the status site (e.g., status.blackroad.io)."
+  type        = string
+}
+
+variable "tags" {
+  description = "Common tags applied to all resources."
+  type        = map(string)
+  default     = {}
+}

--- a/ops/next_push/slack_posts.md
+++ b/ops/next_push/slack_posts.md
@@ -30,3 +30,11 @@ PRISM v0.1 starts now. Sprint 0 focus:
 
 Friday demo: working auth stub + CI green + first endpoint.
 Cadillac cutover: api.blackroad.io now has ACM cert + ALB + ECS Fargate + autoscaling + SSM secrets + GitHub OIDC deploys. Merge to main in br-api-gateway → auto rollout with zero downtime.
+
+## #announcements — Status page launch
+
+status.blackroad.io is live 🎉
+- Hosted on S3+CloudFront with ACM cert
+- Health checks wired to API
+- Incidents flow via repo PRs or Asana
+- Customers + team can see uptime and history in one place

--- a/ops/next_push/status_site_asana_tasks.csv
+++ b/ops/next_push/status_site_asana_tasks.csv
@@ -1,0 +1,6 @@
+Task Name,Description,Assignee Email,Section,Due Date
+Provision status site infra,Apply status-site module; cert + CloudFront + S3 + DNS.,amundsonalexa@gmail.com,Today,2025-10-08
+Repo br-status-site,Fork cstate or scaffold Next.js; add CI to sync to S3.,amundsonalexa@gmail.com,Today,2025-10-08
+Route53 health checks,Create health checks for api.blackroad.io and products; expose JSON feed.,amundsonalexa@gmail.com,This Week,2025-10-09
+Slack alerts for incidents,Wire CloudWatch alarms → SNS → Slack (#status) for major outages.,amundsonalexa@gmail.com,This Week,2025-10-09
+Publish first status note,Demo a “planned maintenance” post to validate flow.,amundsonalexa@gmail.com,This Week,2025-10-10


### PR DESCRIPTION
## Summary
- add a Terraform module that provisions the status.blackroad.io certificate, S3 bucket, CloudFront distribution, and Route53 alias
- document the end-to-end status site workflow including app options, health checks, and deployment pipeline
- seed launch operations artifacts with an Asana CSV and Slack announcement template

## Testing
- not run (infrastructure-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d852014bd883299e18e1f4e09b4e36