### PR TITLE
Add cost visibility infrastructure plan and collateral

### DIFF
--- a/finops/cost_spend_board.md
+++ b/finops/cost_spend_board.md
@@ -1,0 +1,105 @@
+# Cost & Spend Visibility Board
+
+This playbook captures the initial infrastructure, tooling, and communications needed to get AWS and SaaS spend under control as BlackRoad scales.
+
+## 1. AWS Cost & Usage Pipeline
+
+### Architecture Overview
+- **Cost & Usage Report (CUR)** delivers hourly cost data in Parquet format to an encrypted S3 bucket.
+- **AWS Glue** catalogs the CUR data.
+- **Athena** queries the cataloged data for ad-hoc spend analysis.
+- **QuickSight (optional)** provides lightweight dashboards over Athena datasets.
+
+### Terraform Module
+Use the new module at `modules/cost-usage` to provision the CUR pipeline.
+
+```hcl
+module "cost_usage" {
+  source          = "./modules/cost-usage"
+  name            = "blackroad"
+  s3_bucket_name  = "blackroad-cost-usage"
+  region          = "us-east-1"
+  report_name     = "blackroad-cur"
+  tags = {
+    CostCenter = "finops"
+    Owner      = "platform"
+  }
+}
+```
+
+Outputs:
+- `cur_bucket` – S3 bucket receiving CUR data
+- `athena_db` – Glue database backing Athena
+- `athena_table` – Glue table for querying CUR data
+
+## 2. AWS Budget Alerts
+
+Deploy an 80% threshold alert on a $5K monthly budget. Subscribe the notification to the FinOps SNS → Slack integration.
+
+```hcl
+resource "aws_budgets_budget" "monthly" {
+  name         = "blackroad-monthly"
+  budget_type  = "COST"
+  limit_amount = "5000"
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  cost_types {
+    use_amortized = false
+    use_blended   = false
+  }
+
+  time_period_start = "2025-01-01_00:00"
+
+  notification {
+    comparison_operator = "GREATER_THAN"
+    threshold           = 80
+    threshold_type      = "PERCENTAGE"
+    notification_type   = "ACTUAL"
+
+    subscriber {
+      subscription_type = "SNS"
+      address            = module.mon_alarms.sns_topic_arn
+    }
+  }
+}
+```
+
+## 3. SaaS Spend Tracking (Airtable)
+
+Create an Airtable base named **BlackRoad Spend** with table **SaaS Vendors** containing these fields:
+- Vendor (single line text)
+- Category (single select; e.g., Comms, PM, Design, Security)
+- Monthly Cost (currency)
+- Owner (collaborator or text)
+- Renewal Date (date)
+- Notes (long text)
+
+Views to configure:
+1. **By Owner** – group by Owner to review accountable teams.
+2. **By Renewal Date** – sorted ascending to surface upcoming renewals.
+3. **Total by Category** – summary bar chart or pivot to show category totals.
+
+Seed with the top vendors: Slack, Asana, Figma, Notion, Datadog, Snyk.
+
+Automation idea: Connect billing inbox to Airtable via Zapier/Make to append line items; manual updates are acceptable until volumes grow.
+
+## 4. Notion Spend Dashboard
+
+Create a Notion page with sections:
+- **AWS Spend** – embed an Athena visualization (QuickSight dashboard or static query screenshot). Include quick metrics for the latest month.
+- **SaaS Spend** – embed the Airtable "BlackRoad Spend" view.
+- **Budget vs Actual** – summarize the $5K budget, current month forecast, and highlight any budget alerts.
+
+## 5. Communication Artifacts
+
+- Asana CSV tasks for Ops-Finance handoff: see `ops/finance/cost_spend_tasks.csv` for import.
+- Slack announcement for `#finance`: see `ops/slack/spend_visibility_baseline.md`.
+
+## 6. Next Decision Point
+
+Once this baseline lands, choose the next track:
+- **Developer Experience** – preview environments, PR linting, repo templates.
+- **Data/AI** – warehouse (Snowflake/BigQuery) plus dbt skeleton.
+
+Document the choice and feed it into the roadmap once leadership aligns.

--- a/modules/cost-usage/main.tf
+++ b/modules/cost-usage/main.tf
@@ -1,0 +1,113 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+resource "aws_s3_bucket" "cur" {
+  bucket        = var.s3_bucket_name
+  force_destroy = true
+  tags          = var.tags
+}
+
+resource "aws_s3_bucket_encryption" "enc" {
+  bucket = aws_s3_bucket.cur.id
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "pab" {
+  bucket                  = aws_s3_bucket.cur.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_cur_report_definition" "this" {
+  report_name              = var.report_name
+  time_unit                = "HOURLY"
+  format                   = "Parquet"
+  compression              = "Parquet"
+  additional_schema_elements = ["RESOURCES"]
+  s3_bucket                = aws_s3_bucket.cur.bucket
+  s3_prefix                = "cur"
+  s3_region                = var.region
+  refresh_closed_reports   = true
+  report_versioning        = "CREATE_NEW_REPORT"
+}
+
+resource "aws_glue_catalog_database" "cur" {
+  name = "${var.name}_cur"
+}
+
+resource "aws_glue_catalog_table" "cur" {
+  name          = "aws_cur"
+  database_name = aws_glue_catalog_database.cur.name
+  table_type    = "EXTERNAL_TABLE"
+  parameters = {
+    classification = "parquet"
+  }
+
+  storage_descriptor {
+    location     = "s3://${aws_s3_bucket.cur.bucket}/cur/"
+    input_format = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat"
+
+    serde_info {
+      serialization_library = "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe"
+    }
+
+    columns = [
+      {
+        name = "line_item_usage_start_date"
+        type = "string"
+      },
+      {
+        name = "line_item_usage_end_date"
+        type = "string"
+      },
+      {
+        name = "line_item_usage_account_id"
+        type = "string"
+      },
+      {
+        name = "product_product_name"
+        type = "string"
+      },
+      {
+        name = "line_item_unblended_cost"
+        type = "double"
+      },
+      {
+        name = "line_item_usage_amount"
+        type = "double"
+      },
+      {
+        name = "line_item_resource_id"
+        type = "string"
+      }
+    ]
+  }
+}
+
+output "cur_bucket" {
+  value = aws_s3_bucket.cur.bucket
+}
+
+output "athena_db" {
+  value = aws_glue_catalog_database.cur.name
+}
+
+output "athena_table" {
+  value = aws_glue_catalog_table.cur.name
+}

--- a/modules/cost-usage/variables.tf
+++ b/modules/cost-usage/variables.tf
@@ -1,0 +1,21 @@
+variable "name" {
+  type = string
+}
+
+variable "s3_bucket_name" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "report_name" {
+  type    = string
+  default = "blackroad-cur"
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}

--- a/ops/finance/cost_spend_tasks.csv
+++ b/ops/finance/cost_spend_tasks.csv
@@ -1,0 +1,6 @@
+Task Name,Description,Assignee Email,Section,Due Date
+Provision CUR to S3,"Deploy cost-usage module; verify reports land.",amundsonalexa@gmail.com,Today,2025-10-09
+Glue/Athena query,"Confirm table loads; run test SELECT SUM(line_item_unblended_cost).",amundsonalexa@gmail.com,Today,2025-10-09
+Set AWS budget alert,"Monthly budget $5k; SNS → Slack #finance.",amundsonalexa@gmail.com,Today,2025-10-09
+Create Airtable Spend base,"Table Vendors with cost/owner/renewal; seed top 5 SaaS.",amundsonalexa@gmail.com,This Week,2025-10-10
+Notion Spend dashboard,"Embed Airtable + Athena results; add summary.",amundsonalexa@gmail.com,This Week,2025-10-10

--- a/ops/slack/spend_visibility_baseline.md
+++ b/ops/slack/spend_visibility_baseline.md
@@ -1,0 +1,9 @@
+#finance update – Spend visibility baseline
+
+Spend visibility baseline:
+- AWS CUR flowing to S3, queryable in Athena
+- Monthly budget $5k, 80% alert goes to #finance
+- Airtable base tracking SaaS costs (Slack, Asana, Figma, Notion, Datadog, Snyk)
+- Notion dashboard embedding both
+
+This is our early warning before surprises.


### PR DESCRIPTION
## Summary
- add a Terraform module for provisioning AWS CUR data into S3 with Glue and Athena cataloging
- document the cost and spend visibility rollout, including budget alert configuration and dashboards
- provide ready-to-import Asana tasks and a Slack announcement for the finance channel

## Testing
- not run (documentation and infrastructure definitions only)

------
https://chatgpt.com/codex/tasks/task_e_68d85298f6488329bc81adc534cc3a43