### PR TITLE
Add Codex 21 interface promise documentation

### DIFF
--- a/codex/README.md
+++ b/codex/README.md
@@ -14,6 +14,7 @@ integrations.
 | 001 | The First Principle    | Lucidia exists to protect and empower everyone. |
 | 003 | The Workflow Circle    | Work runs in visible capture → adjust loops.    |
 | 004 | The Autonomy Manifest  | Data autonomy through consent, export, and wipe. |
+| 021 | The Interface Promise  | Interfaces stay honest, accessible, and quiet.   |
 
 ## BlackRoad Pipeline
 

--- a/codex/entries/021-interface-promise.md
+++ b/codex/entries/021-interface-promise.md
@@ -1,0 +1,27 @@
+# Codex 21 — The Interface Promise
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Principle
+The interface is where trust lives or dies. Lucidia’s surface must be clear, honest, and kind. No tricks, no mazes, no hidden levers.
+
+## Non-Negotiables
+1. **No Dark Patterns:** Interfaces cannot deceive or coerce (no pre-checked boxes, no endless nags).
+2. **Consistency:** Same action = same effect, across web, mobile, CLI, or API.
+3. **Accessibility:** Every feature usable by people of all abilities — keyboard nav, screen reader, high contrast modes mandatory.
+4. **Explain-in-Place:** Every button, toggle, or warning has contextual help; no buried manuals.
+5. **Respect Attention:** No unnecessary notifications, no hijacking focus. Quiet by default.
+6. **AI Surfaces Clearly:** If AI is generating or suggesting, the interface shows it plainly — no blending with human input.
+
+## Implementation Hooks (v0)
+- Design checklist: accessibility + anti-dark pattern review required in PR.
+- Component library with enforced ARIA labels + keyboard nav baked in.
+- Notification system: rate-limited, opt-in channels only.
+- “AI badge” automatically appended to AI-sourced outputs.
+
+## Policy Stub (INTERFACE.md)
+- Lucidia commits to honesty in its interface design.
+- Lucidia bans manipulative or coercive UI patterns.
+- Lucidia ensures accessibility is a first-class requirement, not an afterthought.
+
+**Tagline:** Clarity is the interface of care.

--- a/docs/INTERFACE.md
+++ b/docs/INTERFACE.md
@@ -1,0 +1,11 @@
+# Lucidia Interface Commitments
+
+Lucidia locks the front door against manipulation. Every surface reflects the Interface Promise: clarity, honesty, and care.
+
+## Core Pledges
+- Lucidia commits to honesty in its interface design.
+- Lucidia bans manipulative or coercive UI patterns.
+- Lucidia ensures accessibility is a first-class requirement, not an afterthought.
+
+## Notes
+These commitments accompany Codex 21 — The Interface Promise and inform design reviews, accessibility audits, and notification policies across products.

--- a/lucidia/autobox/docs/CODICES.md
+++ b/lucidia/autobox/docs/CODICES.md
@@ -50,3 +50,35 @@ Lucidia does not stand still. Every loop carries forward what was learned. Progr
 
 **Tagline**: We circle, we rise.
 
+# Codex 21 — The Interface Promise
+
+**Fingerprint**: `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Principle
+
+The interface is where trust lives or dies. Every Lucidia surface stays clear, honest, and kind — no tricks, no hidden levers.
+
+## Non-Negotiables
+
+1. **No Dark Patterns** — No deceptive defaults, forced consent, or endless nags.
+2. **Consistency** — The same action delivers the same result across web, mobile, CLI, or API.
+3. **Accessibility** — Keyboard navigation, screen reader support, and high-contrast modes are mandatory.
+4. **Explain-in-Place** — Buttons, toggles, and warnings carry contextual help; no buried manuals.
+5. **Respect Attention** — Notifications stay rate-limited and quiet by default.
+6. **AI Surfaces Clearly** — AI-generated or suggested content wears an explicit badge.
+
+## Implementation Hooks (v0)
+
+- **Design checklist**: Every PR includes accessibility and anti-dark-pattern review.
+- **Component library**: Enforce ARIA labels and keyboard navigation.
+- **Notification system**: Opt-in channels with rate limits.
+- **AI badge**: Automatically append to AI-sourced outputs.
+
+## Policy Stub — `INTERFACE.md`
+
+- Lucidia commits to honesty in its interface design.
+- Lucidia bans manipulative or coercive UI patterns.
+- Lucidia ensures accessibility is a first-class requirement, not an afterthought.
+
+**Tagline**: Clarity is the interface of care.
+


### PR DESCRIPTION
## Summary
- add Codex 21 entry describing Lucidia's interface promise and guardrails
- record the INTERFACE policy commitments for design teams
- update Codex references so the new principle is discoverable

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d852e617888329914c042e92d9dd9a