### PR TITLE
Add Codex 22 Security Spine

### DIFF
--- a/codex/README.md
+++ b/codex/README.md
@@ -14,6 +14,7 @@ integrations.
 | 001 | The First Principle    | Lucidia exists to protect and empower everyone. |
 | 003 | The Workflow Circle    | Work runs in visible capture → adjust loops.    |
 | 004 | The Autonomy Manifest  | Data autonomy through consent, export, and wipe. |
+| 022 | The Security Spine     | Security backbone with layered zero-trust defenses. |
 
 ## BlackRoad Pipeline
 

--- a/codex/entries/022-security-spine.md
+++ b/codex/entries/022-security-spine.md
@@ -1,0 +1,28 @@
+# Codex 22 — The Security Spine
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Principle
+Security is not a bolt-on feature; it is the vertebrae of Lucidia. Every motion, connection, and memory stands on this spine.
+
+## Non-Negotiables
+1. **Defense in Depth:** Layer infrastructure, application, identity, and data controls so a single breach never collapses the system.
+2. **Zero Trust Default:** Verify every request — no implicit trust, even inside the network perimeter.
+3. **Crypto-Agility:** Stay PQC-ready, rotate keys continuously, and swap algorithms without downtime.
+4. **Tamper-Evidence:** Hash-chain logs and ledgers so anomalies raise immediate alarms.
+5. **Secure Defaults:** Ship every service locked down with least privilege and minimal exposure.
+6. **Regular Drills:** Run red-team, chaos, and threat-model exercises every release cycle.
+
+## Implementation Hooks (v0)
+- Wire static analysis and dependency scanning into the CI/CD pipeline.
+- Persist hash-chained audit logs in an append-only database.
+- Enforce default Kubernetes network policies that microsegment services.
+- Schedule key rotation jobs and document the PQC toggle path.
+- Automate chaos tests alongside the security regression suite.
+
+## Policy Stub (`SECURITY-SPINE.md`)
+- Lucidia commits to continuous security, not one-off audits.
+- Lucidia publishes its security posture transparently — vulnerability reports and drill outcomes.
+- Lucidia treats security as inseparable from functionality.
+
+**Tagline:** Without the spine, nothing stands.


### PR DESCRIPTION
## Summary
- add Codex 22 entry describing the Security Spine principles, safeguards, and implementation hooks
- list the new codex entry in the Codex automation README table for discoverability

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d8530294bc8329bd2f3fc02ba00722