### PR TITLE
feat(devx): add preview env automation and tooling

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,11 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-22.04
+
+RUN apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    python3-pip \
+    jq \
+    unzip \
+    make \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install --no-cache-dir awscli-local

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,26 +1,36 @@
 {
-  "name": "blackroad-prism-console",
+  "name": "BlackRoad DevX",
   "build": {
-    "dockerfile": "../Dockerfile",
-    "context": ".."
+    "dockerfile": "Dockerfile"
   },
-  "workspaceFolder": "/workspace",
   "features": {
-    "ghcr.io/devcontainers/features/git:1": {}
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "20"
+    },
+    "ghcr.io/devcontainers/features/aws-cli:1": {},
+    "ghcr.io/devcontainers/features/terraform:1": {
+      "version": "1.6.6"
+    },
+    "ghcr.io/devcontainers/features/aws-ssm-session-manager:1": {}
   },
+  "postCreateCommand": "npm install -g commitlint @commitlint/config-conventional && pip install --user pre-commit",
   "customizations": {
     "vscode": {
       "settings": {
-        "terminal.integrated.defaultProfile.linux": "bash"
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "terraform.codelens.enabled": true,
+        "editor.formatOnSave": true
       },
       "extensions": [
-        "ms-python.python",
-        "ms-python.vscode-pylance",
+        "HashiCorp.terraform",
         "esbenp.prettier-vscode",
-        "dbaeumer.vscode-eslint"
+        "dbaeumer.vscode-eslint",
+        "ms-python.python"
       ]
     }
   },
-  "forwardPorts": [3000],
-  "postCreateCommand": "pip install -U pip pytest jsonschema && (npm ci || true)"
+  "remoteUser": "vscode",
+  "containerEnv": {
+    "AWS_REGION": "us-east-1"
+  }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: ci
 on: [push, pull_request]
 jobs:
   build:
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -23,6 +24,7 @@ jobs:
         run: bash scripts/hash_artifacts.sh || true
 
   build-test:
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,16 @@
+name: lint-pr
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v5
+        with:
+          configFile: commitlint.config.js

--- a/.github/workflows/preview-env.yml
+++ b/.github/workflows/preview-env.yml
@@ -1,0 +1,193 @@
+name: preview-environment
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+
+env:
+  AWS_REGION: us-east-1
+  TF_WORKING_DIR: infra/preview-env
+  PREVIEW_DOMAIN: dev.blackroad.io
+
+jobs:
+  provision:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Collect pull request metadata
+        id: pr
+        run: |
+          echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          echo "head_sha=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.PREVIEW_ENV_AWS_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        env:
+          ECR_REGISTRY: ${{ secrets.PREVIEW_ENV_ECR_REGISTRY }}
+        run: |
+          aws ecr get-login-password --region "$AWS_REGION" | docker login --username AWS --password-stdin "$ECR_REGISTRY"
+
+      - name: Build preview image
+        env:
+          ECR_REGISTRY: ${{ secrets.PREVIEW_ENV_ECR_REGISTRY }}
+          ECR_REPOSITORY: ${{ secrets.PREVIEW_ENV_ECR_REPOSITORY }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          IMAGE_TAG="pr${PR_NUMBER}"
+          IMAGE_URI="${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}"
+          echo "IMAGE_URI=${IMAGE_URI}" >> "$GITHUB_ENV"
+          docker build --build-arg GIT_SHA=${{ steps.pr.outputs.head_sha }} -t "$IMAGE_URI" .
+          docker push "$IMAGE_URI"
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.6.6
+
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Terraform init
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        env:
+          TF_IN_AUTOMATION: true
+        run: |
+          terraform init \
+            -backend-config="bucket=${{ secrets.PREVIEW_ENV_TF_STATE_BUCKET }}" \
+            -backend-config="dynamodb_table=${{ secrets.PREVIEW_ENV_TF_LOCK_TABLE }}" \
+            -backend-config="key=preview/pr-${{ steps.pr.outputs.number }}.tfstate" \
+            -backend-config="region=${{ env.AWS_REGION }}"
+
+      - name: Terraform apply
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        env:
+          TF_VAR_region: ${{ env.AWS_REGION }}
+          TF_VAR_pr_number: ${{ steps.pr.outputs.number }}
+          TF_VAR_container_image: ${{ env.IMAGE_URI }}
+          TF_VAR_cluster_arn: ${{ secrets.PREVIEW_ENV_CLUSTER_ARN }}
+          TF_VAR_execution_role_arn: ${{ secrets.PREVIEW_ENV_EXECUTION_ROLE_ARN }}
+          TF_VAR_task_role_arn: ${{ secrets.PREVIEW_ENV_TASK_ROLE_ARN }}
+          TF_VAR_subnet_ids: ${{ secrets.PREVIEW_ENV_PRIVATE_SUBNET_IDS }}
+          TF_VAR_alb_subnet_ids: ${{ secrets.PREVIEW_ENV_PUBLIC_SUBNET_IDS }}
+          TF_VAR_vpc_id: ${{ secrets.PREVIEW_ENV_VPC_ID }}
+          TF_VAR_hosted_zone_id: ${{ secrets.PREVIEW_ENV_HOSTED_ZONE_ID }}
+          TF_VAR_hosted_zone_name: ${{ env.PREVIEW_DOMAIN }}
+          TF_VAR_env_vars: ${{ secrets.PREVIEW_ENV_VARS_JSON }}
+          TF_VAR_secrets: ${{ secrets.PREVIEW_ENV_SECRETS_JSON }}
+        run: |
+          terraform apply -auto-approve
+
+      - name: Capture outputs
+        id: tf
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        run: |
+          terraform output -json > tf-outputs.json
+          cat tf-outputs.json
+          URL=$(jq -r '.preview_url.value // .preview_url' tf-outputs.json)
+          echo "preview_url=${URL}" >> "$GITHUB_OUTPUT"
+
+      - name: Comment with preview URL
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const url = process.env.PREVIEW_URL;
+            if (!url) {
+              console.log('Preview URL missing, skipping PR comment.');
+              return;
+            }
+            const body = `🚀 Preview environment ready: [${url}](${url})`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body
+            });
+        env:
+          PREVIEW_URL: ${{ steps.tf.outputs.preview_url }}
+
+      - name: Notify Slack
+        if: ${{ steps.tf.outputs.preview_url }}
+        uses: slackapi/slack-github-action@v1.27.0
+        with:
+          payload: |
+            {
+              "channel": "${{ secrets.SLACK_PREVIEW_CHANNEL }}",
+              "text": "PR #${{ steps.pr.outputs.number }} preview: ${{ steps.tf.outputs.preview_url }}"
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+  destroy:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.PREVIEW_ENV_AWS_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.6.6
+
+      - name: Terraform init
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        env:
+          TF_IN_AUTOMATION: true
+        run: |
+          terraform init \
+            -backend-config="bucket=${{ secrets.PREVIEW_ENV_TF_STATE_BUCKET }}" \
+            -backend-config="dynamodb_table=${{ secrets.PREVIEW_ENV_TF_LOCK_TABLE }}" \
+            -backend-config="key=preview/pr-${{ github.event.pull_request.number }}.tfstate" \
+            -backend-config="region=${{ env.AWS_REGION }}"
+
+      - name: Terraform destroy
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        env:
+          TF_VAR_region: ${{ env.AWS_REGION }}
+          TF_VAR_pr_number: ${{ github.event.pull_request.number }}
+          TF_VAR_container_image: "${{ secrets.PREVIEW_ENV_ECR_REGISTRY }}/${{ secrets.PREVIEW_ENV_ECR_REPOSITORY }}:pr${{ github.event.pull_request.number }}"
+          TF_VAR_cluster_arn: ${{ secrets.PREVIEW_ENV_CLUSTER_ARN }}
+          TF_VAR_execution_role_arn: ${{ secrets.PREVIEW_ENV_EXECUTION_ROLE_ARN }}
+          TF_VAR_task_role_arn: ${{ secrets.PREVIEW_ENV_TASK_ROLE_ARN }}
+          TF_VAR_subnet_ids: ${{ secrets.PREVIEW_ENV_PRIVATE_SUBNET_IDS }}
+          TF_VAR_alb_subnet_ids: ${{ secrets.PREVIEW_ENV_PUBLIC_SUBNET_IDS }}
+          TF_VAR_vpc_id: ${{ secrets.PREVIEW_ENV_VPC_ID }}
+          TF_VAR_hosted_zone_id: ${{ secrets.PREVIEW_ENV_HOSTED_ZONE_ID }}
+          TF_VAR_hosted_zone_name: ${{ env.PREVIEW_DOMAIN }}
+          TF_VAR_env_vars: ${{ secrets.PREVIEW_ENV_VARS_JSON }}
+          TF_VAR_secrets: ${{ secrets.PREVIEW_ENV_SECRETS_JSON }}
+        run: |
+          terraform destroy -auto-approve
+
+      - name: Notify Slack teardown
+        uses: slackapi/slack-github-action@v1.27.0
+        with:
+          payload: |
+            {
+              "channel": "${{ secrets.SLACK_PREVIEW_CHANNEL }}",
+              "text": "Preview for PR #${{ github.event.pull_request.number }} destroyed"
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .RECIPEPREFIX = >
-.PHONY: setup test lint demo validate dc-up dc-test dc-shell
+.PHONY: setup test lint demo validate dc-up dc-test dc-shell build run deploy preview-destroy
 
 setup:
 >python -m venv .venv && . .venv/bin/activate && pip install -U pip pytest jsonschema ruff
@@ -25,6 +25,20 @@ demo:
 >brc mfg:yield --period 2025-09 && \
 >brc mfg:mrp --demand artifacts/sop/allocations.csv --inventory fixtures/mfg/inventory.csv --pos fixtures/mfg/open_pos.csv && \
 >brc mfg:coq --period 2025-Q3
+
+build:
+>docker build -t blackroad/prism-console:dev -f Dockerfile .
+
+run:
+>docker compose up --build app
+
+deploy:
+>@test -n "$(PR)" || (echo "PR=<number> is required" >&2 && exit 1)
+>PR_NUMBER=$(PR) PROJECT_NAME=prism-console scripts/devx/deploy_preview.sh apply
+
+preview-destroy:
+>@test -n "$(PR)" || (echo "PR=<number> is required" >&2 && exit 1)
+>PR_NUMBER=$(PR) PROJECT_NAME=prism-console scripts/devx/deploy_preview.sh destroy
 
 dc-up:
 >docker compose up --build app

--- a/asana-devx-epic.csv
+++ b/asana-devx-epic.csv
@@ -1,0 +1,7 @@
+Task Name,Description,Assignee Email,Section,Due Date
+Repo template,Create br-repo-template with Next.js/Fastify + CI + security.,amundsonalexa@gmail.com,Today,2025-10-10
+PR previews,Terraform module + GH Action to spin ECS Fargate per PR under pr-###.dev.blackroad.io.,amundsonalexa@gmail.com,This Week,2025-10-11
+Commit linting,Add commitlint + PR template to all repos.,amundsonalexa@gmail.com,Today,2025-10-10
+Pre-commit hooks,Add Husky/lefthook for lint/test/secret-scan.,amundsonalexa@gmail.com,This Week,2025-10-11
+Dev containers,Standardize .devcontainer for Node/Terraform/AWS.,amundsonalexa@gmail.com,This Week,2025-10-11
+Makefile baseline,Add build/test/lint/run/deploy targets across repos.,amundsonalexa@gmail.com,Today,2025-10-10

--- a/docs/devx/preview-environments.md
+++ b/docs/devx/preview-environments.md
@@ -1,0 +1,43 @@
+# Pull Request Preview Environments
+
+Preview environments are provisioned per pull request using ECS Fargate. The Terraform module under `modules/preview-env` creates an application load balancer, task definition, ECS service, and Route53 alias record (`pr-###.dev.blackroad.io`).
+
+## GitHub Action flow
+
+1. `preview-environment` workflow triggers on PR open/reopen/update.
+2. Docker image is built and pushed to the preview ECR repository with tag `pr<NUMBER>`.
+3. Terraform runs from `infra/preview-env` using the pull request number to namespace resources and state.
+4. A PR comment and Slack notification share the preview URL.
+5. When the PR closes, Terraform destroys the resources and posts a teardown message to Slack.
+
+### Required secrets
+
+| Secret | Description |
+| ------ | ----------- |
+| `PREVIEW_ENV_AWS_ROLE` | IAM role ARN assumed by the workflow. |
+| `PREVIEW_ENV_ECR_REGISTRY` | ECR registry URI (e.g. `123456789012.dkr.ecr.us-east-1.amazonaws.com`). |
+| `PREVIEW_ENV_ECR_REPOSITORY` | ECR repository name storing preview images. |
+| `PREVIEW_ENV_TF_STATE_BUCKET` | S3 bucket used for Terraform state. |
+| `PREVIEW_ENV_TF_LOCK_TABLE` | DynamoDB table for Terraform state locking. |
+| `PREVIEW_ENV_CLUSTER_ARN` | ECS cluster ARN used for previews. |
+| `PREVIEW_ENV_EXECUTION_ROLE_ARN` | ECS task execution role ARN. |
+| `PREVIEW_ENV_TASK_ROLE_ARN` | ECS task role ARN. |
+| `PREVIEW_ENV_PRIVATE_SUBNET_IDS` | JSON array of private subnet IDs. |
+| `PREVIEW_ENV_PUBLIC_SUBNET_IDS` | JSON array of public subnet IDs for the ALB. |
+| `PREVIEW_ENV_VPC_ID` | VPC identifier. |
+| `PREVIEW_ENV_HOSTED_ZONE_ID` | Route53 hosted zone ID for `dev.blackroad.io`. |
+| `PREVIEW_ENV_VARS_JSON` | JSON object of environment variables. |
+| `PREVIEW_ENV_SECRETS_JSON` | JSON array of secret mappings. |
+| `SLACK_BOT_TOKEN` | Slack bot token with permission to post to `#eng`. |
+| `SLACK_PREVIEW_CHANNEL` | Channel ID (e.g. `C1234567890`) for preview announcements. |
+
+### Local operations
+
+Use the helper script to apply or destroy previews from your workstation:
+
+```bash
+PR=128 make deploy
+PR=128 make preview-destroy
+```
+
+Set the appropriate environment variables (cluster, VPC, hosted zone, etc.) before running the commands so Terraform can connect to AWS.

--- a/docs/devx/repo-template.md
+++ b/docs/devx/repo-template.md
@@ -1,0 +1,50 @@
+# `br-repo-template`
+
+The `br-repo-template` repository bootstraps new BlackRoad services with batteries included developer experience. It ships two application skeletons (Next.js frontend and Fastify backend) and shared operational scaffolding so that new teams can focus on product code instead of wiring.
+
+## Contents
+
+- `apps/web`: Next.js 14 baseline with Tailwind, ESLint/Prettier, Cypress smoke test, and Vercel-ready configuration.
+- `apps/api`: Fastify service with TypeScript, Prisma example, Jest unit tests, and OpenAPI contract stub.
+- Shared GitHub Actions workflows:
+  - Continuous Integration matrix that runs linting, unit tests, type checking, and secret scanning in under ten minutes.
+  - Docker image build and publishing job for API artefacts.
+  - Deploy hooks for main branch.
+- Security defaults:
+  - Dependabot configuration for npm, Docker, and GitHub Actions.
+  - Snyk workflow triggered daily and on pull requests.
+  - CODEOWNERS, PR template, and Definition-of-Done checklist.
+- Repository hygiene: Conventional Commit linting, Husky-managed pre-commit hooks, issue templates, LICENSE, CONTRIBUTING, README.
+
+## Creating the template repository
+
+1. Authenticate with GitHub CLI using an account that has access to the `blackboxprogramming` organisation.
+2. Create the repository from this codebase:
+   ```bash
+   gh repo create blackboxprogramming/br-repo-template --private --description "BlackRoad full-stack service template"
+   git push git@github.com:blackboxprogramming/br-repo-template.git main
+   ```
+3. Enable required settings:
+   - Default branch protections for `main` (require PR, passing status checks, and linear history).
+   - Snyk app installed with automated testing enabled.
+   - Dependabot alerts and security updates activated.
+4. Share the repository URL with the platform team so they can subscribe `br-platform` CODEOWNERS.
+
+## Spinning up a new service
+
+Once the template repository exists, new services can be generated via GitHub's template flow or CLI:
+
+```bash
+gh repo create blackboxprogramming/new-service --template blackboxprogramming/br-repo-template --private --description "New BlackRoad service"
+```
+
+After creation:
+
+1. Update `package.json` metadata (`name`, `description`, `repository`).
+2. Configure environment secrets (Vercel, AWS, databases) in the new repository settings.
+3. Wire the preview environment GitHub Action to the correct cluster and DNS using repository-level secrets.
+4. Announce the new service in `#eng` with the preview URL once the first PR lands.
+
+## Definition of Done checklist
+
+Each repository created from the template should keep the included `.github/pull_request_template.md` checklist. Items cover testing, security review, documentation, and observability hooks to ensure consistent quality across teams.

--- a/docs/devx/slack-announcement.md
+++ b/docs/devx/slack-announcement.md
@@ -1,0 +1,11 @@
+# Slack Announcement — #eng
+
+```
+DevX Cadillac drop:
+- Preview envs per PR (pr-###.dev.blackroad.io)
+- Repo template with CI + security baked in
+- Commit linting + PR template
+- Pre-commit hooks, dev containers, Makefiles
+
+Goal: cut feedback loops to minutes. Ten-minute build rule enforced.
+```

--- a/docs/devx/tooling.md
+++ b/docs/devx/tooling.md
@@ -1,0 +1,30 @@
+# Developer Tooling Baseline
+
+## Pre-commit automation
+
+- Managed by `lefthook.yml`.
+- Runs lint (`npm run lint --if-present` and `make lint`), targeted tests, and `scripts/devx/secret_scan.sh` (Dockerised gitleaks) on each commit.
+- Invoking `lefthook install` will wire the Git hooks after cloning.
+
+## PR hygiene
+
+- `commitlint` enforced through `.github/workflows/lint-pr.yml` with the conventional commits preset.
+- Preview environments post URLs back to the pull request for manual QA.
+- Definition-of-Done checklist ships in the repository template (`docs/devx/repo-template.md`).
+
+## Dev containers
+
+- `.devcontainer` builds from Ubuntu 22.04 with Node 20, AWS CLI, Terraform 1.6, and the SSM Session Manager plugin.
+- Installs commitlint globally and Python pre-commit dependencies in the container.
+- VS Code recommendations include Terraform, ESLint, Prettier, and Python extensions.
+
+## Makefile contract
+
+- `make build` → Docker build using the repository `Dockerfile`.
+- `make test` / `make lint` → Python virtualenv harness plus npm fallbacks via Lefthook.
+- `make run` → Brings up the application container using Docker Compose.
+- `make deploy` / `make preview-destroy` → Wrapper around Terraform preview stack (requires `PR=<number>` and AWS credentials).
+
+## Ten-minute CI guarantee
+
+`.github/workflows/ci.yml` enforces a ten-minute timeout for the Python and Node build jobs so that excessively long feedback loops fail fast.

--- a/infra/preview-env/README.md
+++ b/infra/preview-env/README.md
@@ -1,0 +1,23 @@
+# Preview Environment Stack
+
+This Terraform configuration wraps the reusable `modules/preview-env` module to provision ephemeral review environments per pull request. The stack is parameterised entirely by variables so that automation (for example GitHub Actions) can `terraform apply` with the pull request number and destroy the stack on merge or close.
+
+## Usage
+
+```bash
+terraform init
+terraform apply \
+  -var="pr_number=128" \
+  -var="cluster_arn=arn:aws:ecs:us-east-1:123456789012:cluster/prism-preview" \
+  -var="execution_role_arn=arn:aws:iam::123456789012:role/ecsExecutionRole" \
+  -var="subnet_ids=[\"subnet-123\",\"subnet-456\"]" \
+  -var="alb_subnet_ids=[\"subnet-abc\",\"subnet-def\"]" \
+  -var="vpc_id=vpc-123456" \
+  -var="hosted_zone_id=Z0123456789" \
+  -var="hosted_zone_name=dev.blackroad.io" \
+  -var="container_image=123456789012.dkr.ecr.us-east-1.amazonaws.com/prism-console:pr128"
+```
+
+Running `terraform destroy` with the same arguments cleans up the preview environment.
+
+See the module README for the full list of variables and defaults.

--- a/infra/preview-env/main.tf
+++ b/infra/preview-env/main.tf
@@ -1,0 +1,43 @@
+locals {
+  project_name = var.project != "" ? var.project : "prism-console"
+}
+
+module "preview_environment" {
+  source = "../../modules/preview-env"
+
+  project             = local.project_name
+  pr_number           = var.pr_number
+  cluster_arn         = var.cluster_arn
+  execution_role_arn  = var.execution_role_arn
+  task_role_arn       = var.task_role_arn
+  subnet_ids          = var.subnet_ids
+  alb_subnet_ids      = var.alb_subnet_ids
+  vpc_id              = var.vpc_id
+  hosted_zone_id      = var.hosted_zone_id
+  hosted_zone_name    = var.hosted_zone_name
+  container_image     = var.container_image
+  container_name      = var.container_name
+  container_port      = var.container_port
+  desired_count       = var.desired_count
+  cpu                 = var.cpu
+  memory              = var.memory
+  assign_public_ip    = var.assign_public_ip
+  env_vars            = var.env_vars
+  secrets             = var.secrets
+  health_check_path   = var.health_check_path
+  protocol            = var.protocol
+  listener_certificate_arn = var.listener_certificate_arn
+  ingress_cidrs            = var.ingress_cidrs
+  log_retention_in_days    = var.log_retention_in_days
+  tags                     = var.tags
+}
+
+output "preview_url" {
+  description = "Preview URL generated for the pull request."
+  value       = module.preview_environment.url
+}
+
+output "service_name" {
+  description = "Name of the ECS service deployed for the preview."
+  value       = module.preview_environment.service_name
+}

--- a/infra/preview-env/providers.tf
+++ b/infra/preview-env/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = var.region
+}

--- a/infra/preview-env/variables.tf
+++ b/infra/preview-env/variables.tf
@@ -1,0 +1,149 @@
+variable "region" {
+  type        = string
+  description = "AWS region hosting preview environments."
+  default     = "us-east-1"
+}
+
+variable "project" {
+  type        = string
+  description = "Name of the service being deployed."
+  default     = ""
+}
+
+variable "pr_number" {
+  type        = number
+  description = "Pull request number used to namespace the preview environment."
+}
+
+variable "cluster_arn" {
+  type        = string
+  description = "ARN of the ECS cluster running previews."
+}
+
+variable "execution_role_arn" {
+  type        = string
+  description = "IAM execution role used by ECS."
+}
+
+variable "task_role_arn" {
+  type        = string
+  description = "IAM task role assumed by the preview container."
+  default     = ""
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = "Private subnet IDs for ECS tasks."
+}
+
+variable "alb_subnet_ids" {
+  type        = list(string)
+  description = "Public subnet IDs for the preview load balancer."
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "VPC identifier hosting the preview infrastructure."
+}
+
+variable "hosted_zone_id" {
+  type        = string
+  description = "Route53 hosted zone ID for preview DNS records."
+}
+
+variable "hosted_zone_name" {
+  type        = string
+  description = "Root domain serving preview URLs (e.g. dev.blackroad.io)."
+}
+
+variable "container_image" {
+  type        = string
+  description = "Image URI to deploy for the preview."
+}
+
+variable "container_name" {
+  type        = string
+  description = "Optional override for the ECS container name."
+  default     = ""
+}
+
+variable "container_port" {
+  type        = number
+  description = "Port exposed by the preview container."
+  default     = 3000
+}
+
+variable "desired_count" {
+  type        = number
+  description = "Number of tasks to run for the preview environment."
+  default     = 1
+}
+
+variable "cpu" {
+  type        = number
+  description = "CPU units allocated to the task."
+  default     = 512
+}
+
+variable "memory" {
+  type        = number
+  description = "Memory (MiB) allocated to the task."
+  default     = 1024
+}
+
+variable "assign_public_ip" {
+  type        = bool
+  description = "Assign a public IP to the ECS task ENI."
+  default     = false
+}
+
+variable "env_vars" {
+  type        = map(string)
+  description = "Plain environment variables added to the task definition."
+  default     = {}
+}
+
+variable "secrets" {
+  type = list(object({
+    name      = string
+    valueFrom = string
+  }))
+  description = "Secret references forwarded to the container."
+  default     = []
+}
+
+variable "health_check_path" {
+  type        = string
+  description = "HTTP path used for load balancer health checks."
+  default     = "/"
+}
+
+variable "protocol" {
+  type        = string
+  description = "Load balancer protocol (HTTP or HTTPS)."
+  default     = "HTTP"
+}
+
+variable "listener_certificate_arn" {
+  type        = string
+  description = "ACM certificate ARN required for HTTPS listeners."
+  default     = ""
+}
+
+variable "ingress_cidrs" {
+  type        = list(string)
+  description = "CIDR blocks that can reach the preview load balancer."
+  default     = ["0.0.0.0/0"]
+}
+
+variable "log_retention_in_days" {
+  type        = number
+  description = "CloudWatch log retention for preview workloads."
+  default     = 14
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags added to all preview resources."
+  default     = {}
+}

--- a/infra/preview-env/versions.tf
+++ b/infra/preview-env/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,17 @@
+pre-commit:
+  parallel: false
+  commands:
+    lint:
+      run: |
+        npm run lint --if-present
+        make lint
+    test:
+      run: |
+        npm test --if-present -- --watch=false
+        make test
+    secret-scan:
+      run: scripts/devx/secret_scan.sh
+pre-push:
+  commands:
+    full-test-suite:
+      run: make test

--- a/modules/preview-env/README.md
+++ b/modules/preview-env/README.md
@@ -1,0 +1,79 @@
+# Preview Environment Terraform Module
+
+This module provisions an ephemeral preview environment for a pull request. It creates an ECS service running on Fargate behind an application load balancer and publishes the environment under a predictable `pr-<number>.dev.blackroad.io` hostname.
+
+## Features
+
+- Builds a dedicated task definition and ECS service per pull request.
+- Creates an application load balancer with a security group locked down to HTTP/HTTPS traffic.
+- Publishes an alias record in Route53 pointing to the preview load balancer.
+- Allows callers to inject environment variables and secrets into the container definition.
+- Supports automatic teardown by reusing the same configuration with `terraform destroy`.
+
+## Usage
+
+```hcl
+module "preview" {
+  source = "../../modules/preview-env"
+
+  project             = "prism-console"
+  pr_number           = 128
+  cluster_arn         = var.cluster_arn
+  execution_role_arn  = var.execution_role_arn
+  task_role_arn       = var.task_role_arn
+  subnet_ids          = var.private_subnet_ids
+  alb_subnet_ids      = var.public_subnet_ids
+  vpc_id              = var.vpc_id
+  hosted_zone_id      = var.hosted_zone_id
+  hosted_zone_name    = "dev.blackroad.io"
+  container_image     = "123456789012.dkr.ecr.us-east-1.amazonaws.com/prism-console:pr128"
+  container_port      = 3000
+  env_vars            = {
+    NODE_ENV = "production"
+  }
+  secrets = [
+    {
+      name      = "DATABASE_URL"
+      valueFrom = aws_secretsmanager_secret.example.arn
+    }
+  ]
+}
+```
+
+Destroy the preview environment by running the same configuration with `terraform destroy` (the module name and arguments must remain unchanged between apply/destroy runs).
+
+## Inputs
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `project` | `string` | Human-friendly name of the service the preview belongs to. |
+| `pr_number` | `number` | Pull request identifier used to compose names and DNS entries. |
+| `cluster_arn` | `string` | ARN of the ECS cluster hosting preview services. |
+| `execution_role_arn` | `string` | IAM role assumed by the ECS task for pulling images and sending logs. |
+| `task_role_arn` | `string` | IAM role assumed by the application container. Optional. |
+| `subnet_ids` | `list(string)` | Private subnet IDs for running the tasks. |
+| `alb_subnet_ids` | `list(string)` | Public subnet IDs used by the load balancer. |
+| `vpc_id` | `string` | VPC identifier for security group associations. |
+| `hosted_zone_id` | `string` | Route53 hosted zone ID for the preview DNS record. |
+| `hosted_zone_name` | `string` | Root domain used for preview URLs (e.g. `dev.blackroad.io`). |
+| `container_image` | `string` | Fully qualified image URI tagged with the PR number. |
+| `container_port` | `number` | Application port exposed by the container. Defaults to `3000`. |
+| `desired_count` | `number` | Number of tasks to run. Defaults to `1`. |
+| `cpu` | `number` | CPU units for the task definition. Defaults to `512`. |
+| `memory` | `number` | Memory (MiB) for the task definition. Defaults to `1024`. |
+| `assign_public_ip` | `bool` | Whether to assign a public IP to the tasks. Defaults to `false`. |
+| `env_vars` | `map(string)` | Plain environment variables injected into the container. Defaults to `{}`. |
+| `secrets` | `list(object)` | Secret references passed directly to the container definition. Defaults to `[]`. |
+| `health_check_path` | `string` | HTTP path used by the ALB health check. Defaults to `/`. |
+| `protocol` | `string` | Listener protocol (`HTTP` or `HTTPS`). Defaults to `"HTTP"`. |
+| `listener_certificate_arn` | `string` | ACM certificate ARN required when protocol is `HTTPS`. Optional. |
+| `ingress_cidrs` | `list(string)` | CIDR ranges allowed to reach the ALB. Defaults to `["0.0.0.0/0"]`. |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| `service_name` | Name of the ECS service powering the preview. |
+| `task_definition_arn` | ARN of the task definition created for the preview. |
+| `url` | Fully qualified preview URL (e.g. `https://pr-128.dev.blackroad.io`). |
+```

--- a/modules/preview-env/main.tf
+++ b/modules/preview-env/main.tf
@@ -1,0 +1,238 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+locals {
+  pr_suffix       = "pr-${var.pr_number}"
+  resource_prefix = lower(replace(var.project, " ", "-"))
+  service_name    = "${local.resource_prefix}-${local.pr_suffix}"
+  container_name  = var.container_name != "" ? var.container_name : local.resource_prefix
+}
+
+resource "aws_security_group" "alb" {
+  name        = "${local.service_name}-alb"
+  description = "Preview ALB security group"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = var.ingress_cidrs
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = var.ingress_cidrs
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(var.tags, {
+    "Name"        = "${local.service_name}-alb"
+    "Preview"     = local.pr_suffix
+    "Environment" = "preview"
+  })
+}
+
+resource "aws_security_group" "tasks" {
+  name        = "${local.service_name}-tasks"
+  description = "Preview task security group"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description      = "Allow traffic from the ALB"
+    from_port        = var.container_port
+    to_port          = var.container_port
+    protocol         = "tcp"
+    security_groups  = [aws_security_group.alb.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(var.tags, {
+    "Name"        = "${local.service_name}-tasks"
+    "Preview"     = local.pr_suffix
+    "Environment" = "preview"
+  })
+}
+
+resource "aws_lb" "this" {
+  name               = substr("${local.service_name}-alb", 0, 32)
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = var.alb_subnet_ids
+
+  tags = merge(var.tags, {
+    "Name"        = "${local.service_name}-alb"
+    "Preview"     = local.pr_suffix
+    "Environment" = "preview"
+  })
+}
+
+resource "aws_lb_target_group" "this" {
+  name        = substr("${local.service_name}-tg", 0, 32)
+  port        = var.container_port
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "ip"
+
+  health_check {
+    enabled             = true
+    interval            = 30
+    healthy_threshold   = 2
+    unhealthy_threshold = 5
+    timeout             = 5
+    path                = var.health_check_path
+    matcher             = "200-399"
+  }
+
+  tags = merge(var.tags, {
+    "Name"        = "${local.service_name}-tg"
+    "Preview"     = local.pr_suffix
+    "Environment" = "preview"
+  })
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.this.arn
+  }
+}
+
+resource "aws_lb_listener" "https" {
+  count             = var.protocol == "HTTPS" ? 1 : 0
+  load_balancer_arn = aws_lb.this.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  certificate_arn   = var.listener_certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.this.arn
+  }
+}
+
+resource "aws_cloudwatch_log_group" "this" {
+  name              = "/aws/ecs/${local.service_name}"
+  retention_in_days = var.log_retention_in_days
+
+  tags = merge(var.tags, {
+    "Preview"     = local.pr_suffix
+    "Environment" = "preview"
+  })
+}
+
+resource "aws_ecs_task_definition" "this" {
+  family                   = local.service_name
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = tostring(var.cpu)
+  memory                   = tostring(var.memory)
+  execution_role_arn       = var.execution_role_arn
+  task_role_arn            = var.task_role_arn != "" ? var.task_role_arn : null
+
+  container_definitions = jsonencode([
+    {
+      name      = local.container_name
+      image     = var.container_image
+      essential = true
+      portMappings = [
+        {
+          containerPort = var.container_port
+          protocol      = "tcp"
+        }
+      ]
+      environment = [
+        for key, value in var.env_vars : {
+          name  = key
+          value = value
+        }
+      ]
+      secrets = var.secrets
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.this.name
+          awslogs-region        = data.aws_region.current.name
+          awslogs-stream-prefix = local.container_name
+        }
+      }
+    }
+  ])
+
+  tags = merge(var.tags, {
+    "Preview"     = local.pr_suffix
+    "Environment" = "preview"
+  })
+}
+
+data "aws_region" "current" {}
+
+resource "aws_ecs_service" "this" {
+  name            = local.service_name
+  cluster         = var.cluster_arn
+  task_definition = aws_ecs_task_definition.this.arn
+  desired_count   = var.desired_count
+  launch_type     = "FARGATE"
+  propagate_tags  = "SERVICE"
+
+  network_configuration {
+    subnets         = var.subnet_ids
+    security_groups = [aws_security_group.tasks.id]
+    assign_public_ip = var.assign_public_ip
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.this.arn
+    container_name   = local.container_name
+    container_port   = var.container_port
+  }
+
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
+
+  tags = merge(var.tags, {
+    "Preview"     = local.pr_suffix
+    "Environment" = "preview"
+  })
+}
+
+resource "aws_route53_record" "this" {
+  zone_id = var.hosted_zone_id
+  name    = "${local.pr_suffix}.${var.hosted_zone_name}"
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.this.dns_name
+    zone_id                = aws_lb.this.zone_id
+    evaluate_target_health = true
+  }
+
+  depends_on = [aws_lb_listener.http]
+}

--- a/modules/preview-env/outputs.tf
+++ b/modules/preview-env/outputs.tf
@@ -1,0 +1,14 @@
+output "service_name" {
+  description = "Name of the ECS service powering the preview."
+  value       = aws_ecs_service.this.name
+}
+
+output "task_definition_arn" {
+  description = "ARN of the preview task definition."
+  value       = aws_ecs_task_definition.this.arn
+}
+
+output "url" {
+  description = "Preview URL served via Route53."
+  value       = "${var.protocol == "HTTPS" ? "https" : "http"}://${aws_route53_record.this.name}"
+}

--- a/modules/preview-env/variables.tf
+++ b/modules/preview-env/variables.tf
@@ -1,0 +1,142 @@
+variable "project" {
+  type        = string
+  description = "Human-friendly name of the service the preview belongs to."
+}
+
+variable "pr_number" {
+  type        = number
+  description = "Pull request identifier used to compose resource names."
+}
+
+variable "cluster_arn" {
+  type        = string
+  description = "ARN of the ECS cluster hosting preview services."
+}
+
+variable "execution_role_arn" {
+  type        = string
+  description = "IAM role assumed by ECS to pull images and emit logs."
+}
+
+variable "task_role_arn" {
+  type        = string
+  default     = ""
+  description = "IAM role assumed by the preview task. Optional."
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = "Private subnet IDs for the ECS tasks."
+}
+
+variable "alb_subnet_ids" {
+  type        = list(string)
+  description = "Public subnet IDs used by the application load balancer."
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "Identifier of the VPC hosting the preview infrastructure."
+}
+
+variable "hosted_zone_id" {
+  type        = string
+  description = "Route53 hosted zone ID serving the preview DNS records."
+}
+
+variable "hosted_zone_name" {
+  type        = string
+  description = "Root DNS name for preview environments (e.g. dev.blackroad.io)."
+}
+
+variable "container_image" {
+  type        = string
+  description = "Container image URI tagged with the PR number."
+}
+
+variable "container_name" {
+  type        = string
+  default     = ""
+  description = "Override for the ECS container name. Defaults to the project name."
+}
+
+variable "container_port" {
+  type        = number
+  default     = 3000
+  description = "Application port exposed by the container."
+}
+
+variable "desired_count" {
+  type        = number
+  default     = 1
+  description = "Number of tasks to run for the preview environment."
+}
+
+variable "cpu" {
+  type        = number
+  default     = 512
+  description = "CPU units allocated to the ECS task."
+}
+
+variable "memory" {
+  type        = number
+  default     = 1024
+  description = "Memory (MiB) allocated to the ECS task."
+}
+
+variable "assign_public_ip" {
+  type        = bool
+  default     = false
+  description = "Assign a public IP to the ECS tasks."
+}
+
+variable "env_vars" {
+  type        = map(string)
+  default     = {}
+  description = "Plain environment variables injected into the preview container."
+}
+
+variable "secrets" {
+  type = list(object({
+    name      = string
+    valueFrom = string
+  }))
+  default     = []
+  description = "List of secret references passed directly to the container definition."
+}
+
+variable "health_check_path" {
+  type        = string
+  default     = "/"
+  description = "HTTP path used by the load balancer health check."
+}
+
+variable "protocol" {
+  type        = string
+  default     = "HTTP"
+  description = "Listener protocol for the preview load balancer (HTTP or HTTPS)."
+}
+
+variable "listener_certificate_arn" {
+  type        = string
+  default     = ""
+  description = "ACM certificate ARN used when protocol is HTTPS."
+}
+
+variable "ingress_cidrs" {
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+  description = "CIDR ranges allowed to access the preview load balancer."
+}
+
+variable "log_retention_in_days" {
+  type        = number
+  default     = 14
+  description = "CloudWatch log retention for preview task logs."
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Common tags applied to all preview resources."
+}

--- a/scripts/devx/deploy_preview.sh
+++ b/scripts/devx/deploy_preview.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ACTION=${1:-}
+if [[ "$ACTION" != "apply" && "$ACTION" != "destroy" ]]; then
+  echo "usage: $0 <apply|destroy>" >&2
+  exit 1
+fi
+
+: "${PR_NUMBER:?Set PR_NUMBER to the pull request identifier}"
+
+AWS_REGION=${AWS_REGION:-us-east-1}
+PROJECT_NAME=${PROJECT_NAME:-prism-console}
+IMAGE_URI=${IMAGE_URI:-"${PROJECT_NAME}:pr${PR_NUMBER}"}
+TF_DIR="infra/preview-env"
+
+if ! command -v terraform >/dev/null 2>&1; then
+  echo "terraform CLI is required on PATH" >&2
+  exit 1
+fi
+
+export TF_VAR_region="$AWS_REGION"
+export TF_VAR_pr_number="$PR_NUMBER"
+export TF_VAR_container_image="$IMAGE_URI"
+
+if [[ -n "${CLUSTER_ARN:-}" ]]; then export TF_VAR_cluster_arn="$CLUSTER_ARN"; fi
+if [[ -n "${EXECUTION_ROLE_ARN:-}" ]]; then export TF_VAR_execution_role_arn="$EXECUTION_ROLE_ARN"; fi
+if [[ -n "${TASK_ROLE_ARN:-}" ]]; then export TF_VAR_task_role_arn="$TASK_ROLE_ARN"; fi
+if [[ -n "${SUBNET_IDS:-}" ]]; then export TF_VAR_subnet_ids="$SUBNET_IDS"; fi
+if [[ -n "${ALB_SUBNET_IDS:-}" ]]; then export TF_VAR_alb_subnet_ids="$ALB_SUBNET_IDS"; fi
+if [[ -n "${VPC_ID:-}" ]]; then export TF_VAR_vpc_id="$VPC_ID"; fi
+if [[ -n "${HOSTED_ZONE_ID:-}" ]]; then export TF_VAR_hosted_zone_id="$HOSTED_ZONE_ID"; fi
+if [[ -n "${HOSTED_ZONE_NAME:-}" ]]; then export TF_VAR_hosted_zone_name="$HOSTED_ZONE_NAME"; fi
+if [[ -n "${ENV_VARS_JSON:-}" ]]; then export TF_VAR_env_vars="$ENV_VARS_JSON"; fi
+if [[ -n "${SECRETS_JSON:-}" ]]; then export TF_VAR_secrets="$SECRETS_JSON"; fi
+
+pushd "$TF_DIR" >/dev/null
+
+if [[ -n "${TF_STATE_BUCKET:-}" ]]; then
+  backend_args=(
+    "-backend-config=bucket=${TF_STATE_BUCKET}"
+    "-backend-config=key=preview/pr-${PR_NUMBER}.tfstate"
+    "-backend-config=region=${AWS_REGION}"
+  )
+  if [[ -n "${TF_LOCK_TABLE:-}" ]]; then
+    backend_args+=("-backend-config=dynamodb_table=${TF_LOCK_TABLE}")
+  fi
+  terraform init "${backend_args[@]}"
+else
+  terraform init
+fi
+
+if [[ "$ACTION" == "apply" ]]; then
+  terraform apply -auto-approve
+else
+  terraform destroy -auto-approve
+fi
+
+popd >/dev/null

--- a/scripts/devx/secret_scan.sh
+++ b/scripts/devx/secret_scan.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker is required for secret scanning" >&2
+  exit 0
+fi
+
+docker run --rm \
+  -v "${PWD}:/repo" \
+  --workdir /repo \
+  zricethezav/gitleaks:latest detect \
+  --no-banner \
+  --redact \
+  --source=/repo


### PR DESCRIPTION
## Summary
- add Terraform module and stack for ECS-based preview environments plus GitHub Action automation and Slack notifications
- enforce conventional commits via commitlint workflow and document the repo template, preview flow, and Slack messaging
- ship developer tooling baseline (devcontainer, lefthook hooks, Makefile targets, secret-scan script, and Asana planning CSV)

## Testing
- not run (infrastructure/terraform tooling unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d852b58228832997e05dc028fb9bbd