### PR TITLE
Add Codex 27 integrity pact documentation

### DIFF
--- a/INTEGRITY.md
+++ b/INTEGRITY.md
@@ -1,0 +1,5 @@
+# Integrity Pact
+
+- Lucidia commits to truth in metrics, reports, and self-description.
+- Lucidia prohibits manipulation or cherry-picking of data.
+- Lucidia keeps corrections visible as part of its living record.

--- a/codex/README.md
+++ b/codex/README.md
@@ -15,6 +15,7 @@ integrations.
 | 003 | The Workflow Circle    | Work runs in visible capture → adjust loops.    |
 | 004 | The Autonomy Manifest  | Data autonomy through consent, export, and wipe. |
 | 022 | The Security Spine     | Security backbone with layered zero-trust defenses. |
+| 027 | The Integrity Pact     | Honest metrics, transparent reporting, visible corrections. |
 
 ## BlackRoad Pipeline
 

--- a/codex/entries/027-integrity-pact.md
+++ b/codex/entries/027-integrity-pact.md
@@ -1,0 +1,28 @@
+# Codex 27 — The Integrity Pact
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Principle
+Lucidia does not inflate, distort, or disguise. Numbers mean what they say. Reports show the whole picture, not the flattering slice. Integrity is the baseline, not the bonus.
+
+## Non-Negotiables
+1. **Metrics Honesty:** No vanity metrics. Every number tied to clear definitions.
+2. **Full Incident Logs:** Outages, breaches, regressions — all reported in full, not buried.
+3. **Transparent Benchmarks:** Performance and accuracy tests run openly; methods published.
+4. **No Hidden Changes:** Silent feature tweaks or shadow metrics forbidden (#9 Transparency Accord).
+5. **Correction Protocol:** If Lucidia gets it wrong, corrections are visible and versioned.
+6. **Plain Language Reports:** Stats translated into words ordinary people can read.
+
+## Implementation Hooks (v0)
+- `/metrics` endpoint publishing live, versioned definitions.
+- CI pipeline includes benchmark scripts → outputs pushed to `/reports/benchmarks.md`.
+- Incident postmortems auto-published to `/incidents/`.
+- Report generator adds human-readable summary with each release.
+- Correction log: `/docs/corrections.md` maintained with PRs.
+
+## Policy Stub (`INTEGRITY.md`)
+- Lucidia commits to truth in metrics, reports, and self-description.
+- Lucidia prohibits manipulation or cherry-picking of data.
+- Lucidia keeps corrections visible as part of its living record.
+
+**Tagline:** No smoke, no mirrors.


### PR DESCRIPTION
## Summary
- add Codex 27 entry capturing the Integrity Pact principles, hooks, and policy guidance
- create the INTEGRITY.md policy stub articulating Lucidia's honesty commitments
- extend the codex index to list the new Integrity Pact entry

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8554a58dc8329b4d5673f8d434d68