### PR TITLE
Add Custodianship Code entry and stewardship guidelines

### DIFF
--- a/CUSTODIANSHIP.md
+++ b/CUSTODIANSHIP.md
@@ -1,0 +1,5 @@
+# Custodianship Policy Stub
+
+- Lucidia recognizes custodians as caretakers, not owners.
+- Lucidia commits to shared responsibility and clear accountability.
+- Lucidia ensures no single actor can compromise continuity.

--- a/codex/entries/028-custodianship-code.md
+++ b/codex/entries/028-custodianship-code.md
@@ -1,0 +1,28 @@
+# Codex 28 — The Custodianship Code
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Principle
+Lucidia is not owned. It is entrusted. Builders, maintainers, and leaders are custodians: responsible for tending, repairing, and handing it forward intact.
+
+## Non-Negotiables
+1. **Stewardship Over Profit:** Decisions prioritize longevity, safety, and community health above short-term gain.
+2. **Rot Checks:** Custodians must watch for decay — technical debt, cultural drift, security lapse — and address it.
+3. **Succession Clarity:** Roles and responsibilities documented; no single person holds irreplaceable keys.
+4. **Transparency of Power:** Custodians’ decisions logged in governance records (see Codex 20 — Governance Charter).
+5. **No Gatekeeping:** Contributions welcomed from new hands; expertise teaches, not hoards.
+6. **Accountability:** Custodians answer to the community and the codices, not the other way around.
+
+## Implementation Hooks (v0)
+- Maintainer guidelines documented in [`/docs/custodianship.md`](../../docs/custodianship.md).
+- Scheduled “rot review” issues every quarter covering infrastructure, documentation, and culture.
+- Secrets escrow process to ensure no single person retains critical credentials.
+- Governance board listed publicly with clear contact routes.
+- Mentorship pairing for new contributors joining active projects.
+
+## Policy Stub (`CUSTODIANSHIP.md`)
+- Lucidia recognizes custodians as caretakers, not owners.
+- Lucidia commits to shared responsibility and clear accountability.
+- Lucidia ensures no single actor can compromise continuity.
+
+**Tagline:** We hold it, we tend it, we pass it on.

--- a/docs/custodianship.md
+++ b/docs/custodianship.md
@@ -1,0 +1,31 @@
+# Custodianship Guidelines
+
+Lucidia’s systems, communities, and knowledge bases are entrusted to maintainers as a shared inheritance. These guidelines translate the Custodianship Code into day-to-day practice so that every contributor helps the project endure and flourish.
+
+## Core Responsibilities
+- **Tend Before You Expand:** Prioritize resolving incidents, debt, and regressions before pursuing new feature work.
+- **Document As You Go:** Update runbooks, READMEs, and architecture notes when changes ship. Unwritten knowledge is a liability.
+- **Design for Succession:** Avoid one-person bottlenecks by pairing on critical work, distributing credentials, and ensuring automation scripts are reproducible.
+- **Invite Contribution:** Label approachable issues, offer mentorship, and respond to questions within two business days.
+- **Surface Decisions:** Record significant choices (architecture, security, governance) in the public decision log referenced by the Governance Charter.
+
+## Rot Review Ritual
+- Create or update quarterly “rot review” issues for infrastructure, documentation, and culture.
+- Track findings in a shared board and assign remediation owners with target dates.
+- Escalate unresolved items older than one quarter during governance syncs.
+
+## Secrets & Continuity
+- Store credentials in the approved secrets manager with access shared across at least two custodians.
+- Rotate access when roles change and document the rotation in the continuity ledger.
+- Keep an encrypted escrow package updated so emergency stewards can recover critical systems without delay.
+
+## Mentorship & Onboarding
+- Pair new contributors with experienced maintainers for their first two merged changes.
+- Provide clear feedback expectations and celebrate milestones publicly to reinforce open participation.
+- Encourage mentees to co-lead future onboarding cycles to keep knowledge circulating.
+
+## Accountability
+- Review adherence to these guidelines during quarterly governance retros.
+- Capture exceptions, lessons learned, and follow-up actions in the governance record so the community can audit stewardship.
+
+_Tagline: We hold it, we tend it, we pass it on._


### PR DESCRIPTION
## Summary
- add Codex 28 entry capturing the Custodianship Code principles, non-negotiables, and implementation hooks
- add custodianship guidelines documentation and policy stub file to support the new codex

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68d85593fa308329b1a9c14415da554e