### PR TITLE
Add Lightning compose, XMRig unit, and address health reporter

### DIFF
--- a/compose/btc-lightning.yml
+++ b/compose/btc-lightning.yml
@@ -1,0 +1,66 @@
+version: "3.8"
+
+# Private Bitcoin Core + Core Lightning bundle for low-power hosts.
+# The services share Docker's internal network. No ports are published by default.
+services:
+  bitcoind:
+    image: ruimarinho/bitcoin-core:26.0
+    container_name: bitcoind
+    restart: unless-stopped
+    stop_grace_period: 1m
+    environment:
+      BITCOIN_RPCUSER: ${BITCOIN_RPCUSER:-bitcoin}
+      BITCOIN_RPCPASSWORD: ${BITCOIN_RPCPASSWORD:-please_change_me}
+    command:
+      - -server
+      - -daemon=0
+      - -txindex=0
+      - -prune=550
+      - -dbcache=300
+      - -rpcuser=${BITCOIN_RPCUSER:-bitcoin}
+      - -rpcpassword=${BITCOIN_RPCPASSWORD:-please_change_me}
+      - -rpcbind=0.0.0.0
+      - -rpcallowip=127.0.0.1/32
+      - -rpcallowip=172.0.0.0/8
+      - -zmqpubrawblock=tcp://0.0.0.0:28332
+      - -zmqpubrawtx=tcp://0.0.0.0:28333
+    volumes:
+      - bitcoin:/home/bitcoin/.bitcoin
+    healthcheck:
+      test: ["CMD", "bitcoin-cli", "-rpcconnect=127.0.0.1", "-rpcuser=${BITCOIN_RPCUSER:-bitcoin}", "-rpcpassword=${BITCOIN_RPCPASSWORD:-please_change_me}", "getblockchaininfo"]
+      interval: 1m
+      timeout: 30s
+      retries: 10
+      start_period: 5m
+
+  cln:
+    image: elementsproject/lightningd:v24.08
+    container_name: cln
+    restart: unless-stopped
+    depends_on:
+      bitcoind:
+        condition: service_healthy
+    command: >-
+      --network=bitcoin
+      --alias=BlackRoad-Pi
+      --bitcoin-rpcuser=${BITCOIN_RPCUSER:-bitcoin}
+      --bitcoin-rpcpassword=${BITCOIN_RPCPASSWORD:-please_change_me}
+      --bitcoin-rpcconnect=bitcoind
+      --bitcoin-rpcport=8332
+      --log-level=info
+      --disable-plugin=bcli
+      --rgb=off
+    volumes:
+      - lightning:/root/.lightning
+    environment:
+      LIGHTNINGD_NETWORK: bitcoin
+    healthcheck:
+      test: ["CMD", "lightning-cli", "--network=bitcoin", "getinfo"]
+      interval: 1m
+      timeout: 30s
+      retries: 10
+      start_period: 5m
+
+volumes:
+  bitcoin:
+  lightning:

--- a/docs/pi-safety-modules.md
+++ b/docs/pi-safety-modules.md
@@ -1,0 +1,136 @@
+# Raspberry Pi Safety Modules
+
+The repository now includes artefacts to deploy three "learn-mode" services on a
+low-power Raspberry Pi that already runs a Bitcoin Core node. Each component is
+opt-in and designed to stay private by default.
+
+## 1. Core Lightning sidecar
+
+* File: [`compose/btc-lightning.yml`](../compose/btc-lightning.yml)
+* Adds a Core Lightning daemon (`cln`) next to `bitcoind` without exposing
+  public ports.
+* Requires the existing Core container to share the Docker network.
+* Provide `BITCOIN_RPCUSER` and `BITCOIN_RPCPASSWORD` via an `.env` file or
+  shell environment before launching.
+
+```bash
+# bootstrap from the repository root on the Pi
+cp compose/btc-lightning.yml ~/btc-compose.yml
+cat <<'ENV' > ~/btc.env
+BITCOIN_RPCUSER=bitcoin
+BITCOIN_RPCPASSWORD=change_this_long_random_pw
+ENV
+
+docker compose -f ~/btc-compose.yml --env-file ~/btc.env up -d bitcoind cln
+```
+
+* Check the node status when Core is synced:
+
+```bash
+docker compose -f ~/btc-compose.yml --env-file ~/btc.env exec cln lightning-cli getinfo
+```
+
+## 2. XMRig learn-mode miner
+
+* File: [`systemd/xmrig-learn.service`](../systemd/xmrig-learn.service)
+* Runs XMRig with `nice`, CPU quotas, and strict systemd sandboxing.
+* Install XMRig once (throttled build flags keep dependencies minimal):
+
+```bash
+sudo apt update
+sudo apt install -y build-essential cmake git libuv1-dev libssl-dev libhwloc-dev
+cd ~ && git clone https://github.com/xmrig/xmrig.git
+cd xmrig && mkdir build && cd build
+cmake .. -DWITH_HWLOC=OFF -DWITH_HTTPD=OFF
+make -j2
+```
+
+* Configure `/etc/default/xmrig` (owned by root) so the unit never stores pool
+  secrets directly:
+
+```bash
+sudo install -m 600 /dev/null /etc/default/xmrig
+sudo tee /etc/default/xmrig >/dev/null <<'ENV'
+XMRIG_POOL_HOST=POOL_HOST:PORT
+XMRIG_ADDRESS=YOUR_XMR_ADDRESS
+XMRIG_THREADS_HINT=1
+XMRIG_CPU_QUOTA=25%
+XMRIG_EXTRA_ARGS=--randomx-mode=light
+ENV
+```
+
+* Enable the unit:
+
+```bash
+sudo cp systemd/xmrig-learn.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now xmrig-learn.service
+sudo systemctl status xmrig-learn --no-pager
+```
+
+Lower `XMRIG_CPU_QUOTA` or `XMRIG_THREADS_HINT` for quieter operation.
+
+## 3. Masked address health reporter
+
+* File: [`scripts/addr-health.mjs`](../scripts/addr-health.mjs)
+* Emits a masked + digested view of configured addresses and appends the
+  results to a local log.
+* Configure `/etc/default/addr-health` with the variable names and values you
+  want the script to read:
+
+```bash
+sudo install -m 600 /dev/null /etc/default/addr-health
+sudo tee /etc/default/addr-health >/dev/null <<'ENV'
+ADDRESS_NAMES=ROBINHOOD_ETHEREUM,ROBINHOOD_BITCOIN,COINBASE_BITCOIN,VENMO_LITECOIN
+ROBINHOOD_ETHEREUM=0x...
+ROBINHOOD_BITCOIN=bc1...
+COINBASE_BITCOIN=3...
+VENMO_LITECOIN=ltc1...
+ADDR_HEALTH_LOG=/home/pi/addr-health.log
+ENV
+```
+
+* Add a cron entry that loads the environment file and runs nightly:
+
+```bash
+( crontab -l 2>/dev/null ; \
+  echo "17 2 * * * . /etc/default/addr-health; /usr/bin/env -i bash -lc 'node ~/repo/scripts/addr-health.mjs' >/dev/null 2>&1" \
+) | crontab -
+```
+
+  * Adjust the repository path (`~/repo`) to match where this project lives on
+    the Pi.
+
+* View the latest log entry:
+
+```bash
+tail -n 50 /home/pi/addr-health.log
+```
+
+### Optional agent endpoint
+
+If you run the Node 20 agent included in this repository, expose the latest log
+via HTTP so remote operators can fetch it safely:
+
+```ts
+if (req.url === '/addresses/local-report') {
+  const fs = require('node:fs');
+  const path = process.env.ADDR_HEALTH_LOG || '/home/pi/addr-health.log';
+  let body = '';
+  try {
+    body = fs.readFileSync(path, 'utf8').split('\n').slice(-200).join('\n');
+  } catch (error) {
+    body = `no report yet: ${error.message}\n`;
+  }
+  res.writeHead(200, { 'content-type': 'text/plain' });
+  res.end(body || 'no report yet\n');
+  return;
+}
+```
+
+Restart the agent after adding the snippet, then fetch the report over a trusted
+network (for example through Tailscale):
+
+```bash
+curl http://<tailscale-ip>:8080/addresses/local-report
+```

--- a/scripts/addr-health.mjs
+++ b/scripts/addr-health.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/**
+ * Masked address health reporter.
+ *
+ * Reads the comma separated ADDRESS_NAMES environment variable and for each
+ * corresponding environment entry prints the masked tail and a truncated
+ * SHA-256 digest. Output is appended to ADDR_HEALTH_LOG (defaults to the
+ * invoking user's home directory).
+ */
+
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+
+const parseNames = (value = '') =>
+  value
+    .split(',')
+    .map((token) => token.trim())
+    .filter(Boolean);
+
+const maskValue = (value) => (value ? `****${value.slice(-6)}` : '');
+const digestValue = (value) =>
+  crypto.createHash('sha256').update(value ?? '', 'utf8').digest('hex');
+
+const ADDRESS_NAMES = parseNames(process.env.ADDRESS_NAMES);
+const LOG_FILE =
+  process.env.ADDR_HEALTH_LOG ||
+  `${os.homedir().replace(/\\$/, '')}/addr-health.log`;
+
+const rows = [['NAME', 'LEN', 'MASKED', 'DIGEST8']];
+for (const name of ADDRESS_NAMES) {
+  const value = process.env[name];
+  if (!value) continue;
+  rows.push([
+    name,
+    String(value.length),
+    maskValue(value),
+    digestValue(value).slice(0, 8),
+  ]);
+}
+
+if (rows.length === 1) {
+  rows.push(['(no addresses)', '0', '', '']);
+}
+
+const columnWidth = (index) =>
+  Math.max(...rows.map((row) => (row[index] ?? '').length));
+const widths = rows[0].map((_, index) => columnWidth(index));
+const renderRow = (row) =>
+  row
+    .map((cell, index) =>
+      index === 0 ? cell.padEnd(widths[index]) : cell.padStart(widths[index])
+    )
+    .join('  ');
+
+const header = renderRow(rows[0]);
+const separator = '-'.repeat(widths.reduce((acc, width) => acc + width, 0) + 6);
+const body = rows.slice(1).map(renderRow).join('\n');
+const output = `${header}\n${separator}${body ? `\n${body}` : ''}\n`;
+
+const timestamp = new Date().toISOString();
+const logEntry = `\n# ${timestamp}\n${output}`;
+try {
+  fs.appendFileSync(LOG_FILE, logEntry, 'utf8');
+} catch (error) {
+  console.error(`failed to write to ${LOG_FILE}:`, error.message);
+}
+
+process.stdout.write(output);

--- a/systemd/xmrig-learn.service
+++ b/systemd/xmrig-learn.service
@@ -1,0 +1,32 @@
+[Unit]
+Description=XMRig (learn-mode, throttled)
+After=network.target
+Wants=network.target
+
+[Service]
+Type=simple
+User=pi
+WorkingDirectory=/home/pi/xmrig/build
+EnvironmentFile=-/etc/default/xmrig
+ExecStart=/usr/bin/nice -n 19 /home/pi/xmrig/build/xmrig \
+  -o ${XMRIG_POOL_HOST:?set in /etc/default/xmrig} \
+  -u ${XMRIG_ADDRESS:?set in /etc/default/xmrig} \
+  --cpu-max-threads-hint=${XMRIG_THREADS_HINT:-1} \
+  --donate-level=0 \
+  ${XMRIG_EXTRA_ARGS}
+Restart=always
+RestartSec=10
+CPUQuota=${XMRIG_CPU_QUOTA:-25%%}
+IOSchedulingClass=idle
+IOSchedulingPriority=7
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectHome=yes
+ProtectSystem=strict
+CapabilityBoundingSet=
+LockPersonality=yes
+RestrictRealtime=yes
+SystemCallFilter=@system-service
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add a private bitcoin-core + core lightning compose bundle with health checks and shared volumes
- provide a hardened xmrig learn-mode systemd unit that defers secrets to /etc/default/xmrig
- document the Pi workflow and ship a Node-based address health reporter script

## Testing
- node scripts/addr-health.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d8557cb8208329bf74be054293bdca