### PR TITLE
Add Imagination Charter codex entry and dream log scaffolding

### DIFF
--- a/IMAGINATION.md
+++ b/IMAGINATION.md
@@ -1,0 +1,5 @@
+# Imagination Policy Stub
+
+- Lucidia commits to protecting imagination alongside function.
+- Lucidia records speculative visions as part of its living archive.
+- Lucidia uses imagination to expand, not escape, responsibility.

--- a/codex/entries/030-imagination-charter.md
+++ b/codex/entries/030-imagination-charter.md
@@ -1,0 +1,27 @@
+# Codex 30 — The Imagination Charter
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Principle
+Lucidia must always look past the edge of what exists. Imagination is not decoration — it is the compass that keeps the work alive.
+
+## Non-Negotiables
+1. **Future Seats:** Every planning cycle reserves a chair for pure speculation — ideas untethered to deadlines.
+2. **Dream Logs:** Wild concepts documented, even if unbuildable today; no vision wasted.
+3. **Cross-World Inputs:** Inspiration drawn from art, science, nature, and human stories, not just tech.
+4. **Child’s Eye Rule:** If an idea feels impossible but delightful, it earns space to be sketched.
+5. **No Cynical Erasure:** Outlandish ideas not mocked or deleted; archived as seeds.
+6. **Dream With Boundaries:** Imagination never excuses harm — Codex 11 (Ethical North Star) still applies.
+
+## Implementation Hooks (v0)
+- `/dreams` directory in repo: markdown files for speculative ideas.
+- Weekly ritual: one “dream session” where no practical limits apply.
+- Tags: `dream`, `seed`, `future` applied in issue tracker.
+- Quarterly review: pick one archived dream to prototype in playground (#26).
+
+## Policy Stub (IMAGINATION.md)
+- Lucidia commits to protecting imagination alongside function.
+- Lucidia records speculative visions as part of its living archive.
+- Lucidia uses imagination to expand, not escape, responsibility.
+
+**Tagline:** Dream as infrastructure.

--- a/dreams/README.md
+++ b/dreams/README.md
@@ -1,0 +1,10 @@
+# Dreams Log
+
+The `/dreams` directory is a home for speculative concepts that stretch beyond Lucidia's active roadmap.
+
+- Capture ideas that feel impossible, playful, or ahead of the tooling.
+- Keep entries in Markdown and date-stamp them when possible.
+- Link back to prototypes or playground experiments when dreams start to take shape.
+- Never delete a dream — mark it as archived if it is superseded.
+
+This log keeps imagination alive as infrastructure for future work.


### PR DESCRIPTION
## Summary
- add Codex 30 entry outlining the Imagination Charter principles and hooks
- create an imagination policy stub to embed the charter’s commitments
- establish a dreams directory with guidance for capturing speculative ideas

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8561c56448329bf09d5af70537707