### PR TITLE
Add app events staging and daily fact models

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,26 @@
+name: dbt-docs
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install dbt-snowflake
+      - run: dbt deps
+      - run: dbt docs generate --profiles-dir .
+        env:
+          SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
+          SNOWFLAKE_USER: ${{ secrets.SNOWFLAKE_USER }}
+          SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
+      - name: Publish
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: target

--- a/srv/blackroads/elt/dbt/docs/metabase_ops_overview.sql
+++ b/srv/blackroads/elt/dbt/docs/metabase_ops_overview.sql
@@ -1,0 +1,61 @@
+-- Metabase dashboard: Ops Overview
+-- Card 1 — Events (7/28/90 days)
+select
+  date_trunc('day', occurred_at) as day,
+  count(*) as events
+from BR_ANALYTICS.STG.STG_APP__EVENTS
+where occurred_at >= dateadd(day, -90, current_timestamp())
+group by 1
+order by 1 asc;
+
+-- Card 2 — DAU (last 30 days)
+select
+  date_trunc('day', occurred_at) as day,
+  approx_count_distinct(user_id) as dau
+from BR_ANALYTICS.STG.STG_APP__EVENTS
+where occurred_at >= dateadd(day, -30, current_timestamp())
+group by 1
+order by 1 asc;
+
+-- Card 3 — Events by name (last 7 days)
+select
+  upper(event_name) as event_name,
+  count(*) as events
+from BR_ANALYTICS.STG.STG_APP__EVENTS
+where occurred_at >= dateadd(day, -7, current_timestamp())
+group by 1
+order by events desc
+limit 20;
+
+-- Card 4 — Purchases by day (trend)
+select
+  date_trunc('day', occurred_at) as day,
+  count(*) as purchases
+from BR_ANALYTICS.STG.STG_APP__EVENTS
+where upper(event_name) = 'PURCHASE'
+  and occurred_at >= dateadd(day, -60, current_timestamp())
+group by 1
+order by 1 asc;
+
+-- Card 5 — Funnel snapshot (Signup → Purchase, last 14 days)
+with base as (
+  select user_id, min(occurred_at) as first_seen
+  from BR_ANALYTICS.STG.STG_APP__EVENTS
+  where occurred_at >= dateadd(day,-14,current_timestamp())
+  group by 1
+),
+signup as (
+  select distinct user_id from BR_ANALYTICS.STG.STG_APP__EVENTS
+  where upper(event_name)='SIGNUP'
+    and occurred_at >= dateadd(day,-14,current_timestamp())
+),
+purchase as (
+  select distinct user_id from BR_ANALYTICS.STG.STG_APP__EVENTS
+  where upper(event_name)='PURCHASE'
+    and occurred_at >= dateadd(day,-14,current_timestamp())
+)
+select
+  (select count(*) from signup)   as signups,
+  (select count(*) from purchase) as purchases,
+  (select 100.0 * count(*) / nullif((select count(*) from signup),0)
+     from purchase)               as signup_to_purchase_pct;

--- a/srv/blackroads/elt/dbt/metrics.yml
+++ b/srv/blackroads/elt/dbt/metrics.yml
@@ -1,0 +1,21 @@
+version: 2
+metrics:
+  - name: dau
+    label: Daily Active Users
+    model: ref('stg_app__events')
+    type: count_distinct
+    sql: user_id
+    timestamp: occurred_at
+    time_grains: [day, week, month]
+
+  - name: purchases
+    label: Purchases
+    model: ref('stg_app__events')
+    type: count
+    sql: event_id
+    filters:
+      - field: event_name
+        operator: '='
+        value: 'PURCHASE'
+    timestamp: occurred_at
+    time_grains: [day, week, month]

--- a/srv/blackroads/elt/dbt/models/marts/ops/fct_events_daily.sql
+++ b/srv/blackroads/elt/dbt/models/marts/ops/fct_events_daily.sql
@@ -1,0 +1,13 @@
+with e as (
+  select * from {{ ref('stg_app__events') }}
+)
+select
+  date_trunc('day', occurred_at) as day,
+  count(*)                        as events_total,
+  count_if(event_name = 'LOGIN')  as events_login,
+  count_if(event_name = 'SIGNUP') as events_signup,
+  count_if(event_name = 'PURCHASE') as events_purchase,
+  approx_count_distinct(user_id)  as dau
+from e
+group by 1
+order by 1 desc;

--- a/srv/blackroads/elt/dbt/models/marts/ops/ops.yml
+++ b/srv/blackroads/elt/dbt/models/marts/ops/ops.yml
@@ -1,0 +1,11 @@
+version: 2
+models:
+  - name: fct_events_daily
+    description: "Daily event rollups with DAU and key event counts"
+    columns:
+      - name: day
+        tests: [not_null, unique]
+      - name: events_total
+        tests: [not_null]
+      - name: dau
+        tests: [not_null]

--- a/srv/blackroads/elt/dbt/models/sources.yml
+++ b/srv/blackroads/elt/dbt/models/sources.yml
@@ -1,0 +1,11 @@
+version: 2
+sources:
+  - name: app
+    database: BR_RAW
+    schema: APP
+    tables:
+      - name: events
+        loaded_at_field: occurred_at
+        freshness:
+          warn_after: { count: 6, period: hour }
+          error_after: { count: 24, period: hour }

--- a/srv/blackroads/elt/dbt/models/staging/staging.yml
+++ b/srv/blackroads/elt/dbt/models/staging/staging.yml
@@ -1,0 +1,16 @@
+version: 2
+models:
+  - name: stg_app__events
+    description: "Normalized application events from BR_RAW.APP.EVENTS"
+    columns:
+      - name: event_id
+        tests: [not_null, unique]
+      - name: occurred_at
+        tests: [not_null]
+      - name: event_name
+        tests:
+          - accepted_values:
+              values: ['LOGIN','LOGOUT','SIGNUP','PAGEVIEW','CLICK','PURCHASE']
+              quote: true
+              config:
+                severity: warn

--- a/srv/blackroads/elt/dbt/models/staging/stg_app__events.sql
+++ b/srv/blackroads/elt/dbt/models/staging/stg_app__events.sql
@@ -1,0 +1,21 @@
+with base as (
+  select
+    id::string                as event_id,
+    occurred_at::timestamp_ntz as occurred_at,
+    user_id::string           as user_id,
+    event_name::string        as event_name,
+    try_parse_json(payload)   as payload
+  from {{ source('app','events') }}
+),
+clean as (
+  select
+    event_id,
+    occurred_at,
+    user_id,
+    upper(trim(event_name)) as event_name,
+    payload
+  from base
+  where event_id is not null
+    and occurred_at is not null
+)
+select * from clean;


### PR DESCRIPTION
## Summary
- register BR_RAW.APP.EVENTS as an app source with freshness checks and stage it into a normalized stg_app__events model
- build daily fact and metrics definitions for event rollups, including DAU, purchases, and supporting tests
- add Metabase starter SQL and a GitHub workflow to publish dbt docs on main pushes

## Testing
- No automated tests were run (dbt is not installed in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d8552e866c8329ad198aa2694b16ba