### PR TITLE
Add automation around br-seed-events seeding

### DIFF
--- a/.github/workflows/seed-nightly.yml
+++ b/.github/workflows/seed-nightly.yml
@@ -1,0 +1,25 @@
+name: seed-nightly
+on:
+  schedule:
+    - cron: "12 6 * * *"   # 06:12 UTC daily (~12:12am America/Chicago)
+  workflow_dispatch: {}
+jobs:
+  seed:
+    runs-on: ubuntu-latest
+    env:
+      PG_URL: ${{ secrets.PG_URL_DEV }}
+      DAYS: "14"
+      USERS: "500"
+      EVENTS: "15000"
+      PURCHASE_RATE: "0.04"
+      SIGNUP_RATE: "0.15"
+      SESSIONS_PER_USER: "3"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: "20", cache: "npm" }
+      - run: npm ci
+      - name: Apply schema (idempotent)
+        run: npm run schema
+      - name: Seed dev data
+        run: npm run seed

--- a/br-seed-events/.devcontainer/devcontainer.json
+++ b/br-seed-events/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+  "name": "br-seed-events",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": { "version": "20" },
+    "ghcr.io/devcontainers/features/aws-cli:1": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:2": { "moby": true }
+  },
+  "postCreateCommand": "npm ci",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode"
+      ]
+    }
+  },
+  "remoteEnv": {
+    "PG_URL": "${localEnv:PG_URL}"
+  }
+}

--- a/br-seed-events/Makefile
+++ b/br-seed-events/Makefile
@@ -1,0 +1,19 @@
+SHELL := /bin/bash
+ENV ?= .env
+
+.PHONY: install schema seed clean
+
+install:
+	@[ -f package-lock.json ] || npm i --package-lock-only
+	npm ci
+
+schema:
+	@[ -f $(ENV) ] || (echo "Missing $(ENV)"; exit 1)
+	source $(ENV); npm run schema
+
+seed:
+	@[ -f $(ENV) ] || (echo "Missing $(ENV)"; exit 1)
+	source $(ENV); npm run seed
+
+clean:
+	rm -rf node_modules


### PR DESCRIPTION
## Summary
- add a Makefile so the seeder can install deps, apply the schema, and seed via simple make targets
- provide a devcontainer definition with Node 20, AWS CLI, and Docker-in-Docker for consistent local setup
- schedule a nightly GitHub Action workflow to run the schema and seed commands against the dev database secret

## Testing
- not run (config-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d8569e7f588329affd2b13d878a008