### PR TITLE
Add low-power miner bundle for optional services

### DIFF
--- a/miners/README.md
+++ b/miners/README.md
@@ -1,0 +1,40 @@
+# Miners (learn-mode, low power)
+
+**Important:** These are for education, not profit. We hard-cap CPU, add temp
+watchers, and recommend duty cycles so average watts are tiny (and “solar-offsetable”).
+
+## Services included
+- **Monero (xmrig)** – CPU PoW; best fit for a Pi in learn-mode
+- **Verus (verusminer)** – efficient CPU algo; still tiny on a Pi
+- **Chia (farmer/harvester only)** – ultra-low energy, needs pre-plotted drives
+
+## Turn on (only what you want)
+```bash
+# Monero xmrig (Docker):
+docker compose -f miners/miners-compose.yml up -d xmrig
+
+# Verus (Docker):
+docker compose -f miners/miners-compose.yml up -d verusminer
+
+# Chia farmer (you must mount /mnt/plots with your plots):
+docker compose -f miners/miners-compose.yml up -d chia
+
+Turn off
+
+docker compose -f miners/miners-compose.yml stop xmrig
+
+Native systemd (Monero) instead of Docker
+
+sudo cp miners/xmrig/xmrig.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now xmrig.service
+sudo systemctl status xmrig --no-pager
+
+Duty-cycle (crontab) to get near-zero average watts
+
+Run 15 minutes per hour:
+
+0 * * * *   systemctl start xmrig.service
+15 * * * *  systemctl stop xmrig.service
+
+---

--- a/miners/chia/chia-notes.md
+++ b/miners/chia/chia-notes.md
@@ -1,0 +1,15 @@
+# Chia farming on a Pi (low power)
+- Farming/harvesting is low energy; **plotting is not**. Create plots elsewhere.
+- Mount plots at `/mnt/plots` and enable the service in `miners-compose.yml`.
+
+Example:
+```bash
+sudo mkdir -p /mnt/plots
+sudo mount /dev/sdX1 /mnt/plots   # your HDD
+sudo nano /etc/fstab               # add a persistent mount entry
+docker compose -f miners/miners-compose.yml up -d chia
+docker compose -f miners/miners-compose.yml logs -f chia
+
+```
+
+---

--- a/miners/common/power-math.mjs
+++ b/miners/common/power-math.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+// Usage:
+// node power-math.mjs --watts=2 --kwh=0.15 --hrs=24 --solar=30 --sun=4 --eta=0.75
+// watts: miner average watts when ON
+// hrs: hours/day actually ON (duty-cycle)
+// solar: Wh/day your panel produces (or panelWatts*sunHours*eta)
+
+const a = Object.fromEntries(process.argv.slice(2).map(x => x.split('=').map(s=>s.replace(/^--/,''))));
+const watts = +a.watts || 2;
+const kwh = +a.kwh || 0.15;
+const hrs = +a.hrs || 24;
+const solarWhDay = +a.solar || 0;   // e.g. 10W * 4h * 0.75 = 30 Wh/day
+const kwhDay = (watts/1000) * hrs;
+const costDay = kwhDay * kwh;
+const costMonth = costDay * 30;
+const gridWhDay = Math.max((watts*hrs) - solarWhDay, 0);
+const gridKwhMonth = (gridWhDay/1000) * 30;
+const gridCostMonth = gridKwhMonth * kwh;
+
+console.log({
+  watts, hrs, kwhDay, costDay, costMonth,
+  solarWhDay,
+  gridWhDay, gridKwhMonth, gridCostMonth,
+  note: "Lower watts via CPUQuota/duty-cycling; increase solarWhDay to offset."
+});

--- a/miners/miners-compose.yml
+++ b/miners/miners-compose.yml
@@ -1,0 +1,59 @@
+services:
+  # --- Monero (xmrig) • CPU miner (learn-mode, throttled) ---
+  xmrig:
+    image: ghcr.io/xmrig/xmrig:latest
+    container_name: xmrig
+    command: >
+      -o POOL_HOST:PORT
+      -u YOUR_XMR_ADDRESS
+      --donate-level=0
+      --cpu-max-threads-hint=1
+    environment:
+      # cap internal throttling further if desired:
+      - XMRIG_ALGO=rx/0
+    cpus: 0.25              # Docker-level CPU cap
+    mem_limit: 256m
+    restart: unless-stopped
+    security_opt: [no-new-privileges:true]
+    read_only: true
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
+    # Enable manually:
+    # docker compose -f miners/miners-compose.yml up -d xmrig
+
+  # --- Verus (VRSC) • CPU miner (efficient but still tiny on a Pi) ---
+  verusminer:
+    image: krypt0nn/verus-miner:latest
+    container_name: verusminer
+    environment:
+      - POOL=POOL_HOST:PORT
+      - WALLET=YOUR_VRSC_ADDRESS
+      - PASSWORD=x
+      - THREADS=1
+    cpus: 0.25
+    mem_limit: 256m
+    restart: unless-stopped
+    security_opt: [no-new-privileges:true]
+    read_only: true
+    # Enable:
+    # docker compose -f miners/miners-compose.yml up -d verusminer
+
+  # --- Chia farmer (ultra-low energy; pre-plotted drives needed) ---
+  chia:
+    image: ghcr.io/chia-network/chia:latest
+    container_name: chia
+    environment:
+      - keys=none            # no private keys loaded on Pi
+      - service=farm
+      - log_level=INFO
+      - TZ=UTC
+    volumes:
+      - ./chia:/root/.chia
+      - /mnt/plots:/plots:ro  # mount your plots read-only
+    cpus: 0.2
+    mem_limit: 512m
+    restart: unless-stopped
+    security_opt: [no-new-privileges:true]
+    read_only: false
+    # Enable:
+    # docker compose -f miners/miners-compose.yml up -d chia

--- a/miners/verus/verusminer.service
+++ b/miners/verus/verusminer.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Verus Miner (docker) throttled
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=pi
+ExecStart=/usr/bin/docker run --rm --name verusminer \
+  --cpus=0.25 --memory=256m --read-only --security-opt no-new-privileges:true \
+  -e POOL=POOL_HOST:PORT -e WALLET=YOUR_VRSC_ADDRESS -e PASSWORD=x -e THREADS=1 \
+  krypt0nn/verus-miner:latest
+ExecStop=/usr/bin/docker stop verusminer
+Restart=on-failure
+RestartSec=10
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=strict
+ProtectHome=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/miners/xmrig/run-throttled.sh
+++ b/miners/xmrig/run-throttled.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Wrapper that runs xmrig in short bursts and cools off if temp is high.
+# Requires: xmrig binary available (for native), or you can just use the Docker service.
+
+POOL="${POOL_HOST_PORT:-POOL_HOST:PORT}"
+ADDR="${XMR_ADDR:-YOUR_XMR_ADDRESS}"
+THREADS="${THREADS:-1}"
+MAX_TEMP_C="${MAX_TEMP_C:-70}"     # Pi CPU max temp before cooldown
+BURST_SEC="${BURST_SEC:-90}"       # mine for N seconds
+COOL_SEC="${COOL_SEC:-60}"         # then rest M seconds
+
+xmrig_cmd=(/home/pi/xmrig/build/xmrig -o "$POOL" -u "$ADDR" --donate-level=0 --cpu-max-threads-hint="$THREADS")
+
+read_temp() {
+  if command -v vcgencmd >/dev/null 2>&1; then
+    # vcgencmd measure_temp -> temp=49.0'C
+    vcgencmd measure_temp | sed "s/[^0-9.]//g"
+  elif [ -f /sys/class/thermal/thermal_zone0/temp ]; then
+    awk '{printf "%.1f\n",$1/1000}' /sys/class/thermal/thermal_zone0/temp
+  else
+    echo 0
+  fi
+}
+
+while true; do
+  T="$(read_temp)"
+  if [ "${T%.*}" -ge "$MAX_TEMP_C" ]; then
+    # too hot, wait
+    sleep "$COOL_SEC"
+    continue
+  fi
+  # run a burst at lowest priority
+  timeout "$BURST_SEC" nice -n 19 "${xmrig_cmd[@]}" || true
+  sleep "$COOL_SEC"
+done

--- a/miners/xmrig/watch-temp.mjs
+++ b/miners/xmrig/watch-temp.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+// Optional watcher: if temp > MAX, send SIGTERM to xmrig and exit.
+// Use with Docker xmrig by 'docker stop xmrig' on trip (preferred).
+
+import { readFileSync, existsSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+
+const MAX = Number(process.env.MAX_TEMP_C || 70);
+function readTemp() {
+  try {
+    const out = execSync('vcgencmd measure_temp', { stdio: ['ignore','pipe','ignore'] }).toString();
+    const v = parseFloat(out.replace(/[^0-9.]/g,''));
+    if (!isNaN(v)) return v;
+  } catch {}
+  if (existsSync('/sys/class/thermal/thermal_zone0/temp')) {
+    const raw = readFileSync('/sys/class/thermal/thermal_zone0/temp','utf8').trim();
+    const v = Number(raw)/1000;
+    if (!isNaN(v)) return v;
+  }
+  return 0;
+}
+
+const t = readTemp();
+if (t >= MAX) {
+  try {
+    execSync('docker stop xmrig', { stdio: 'ignore' });
+  } catch {}
+  console.log(JSON.stringify({ ok:false, temp:t, action:'stopped xmrig' }));
+  process.exit(1);
+}
+console.log(JSON.stringify({ ok:true, temp:t }));

--- a/miners/xmrig/xmrig.service
+++ b/miners/xmrig/xmrig.service
@@ -1,0 +1,31 @@
+[Unit]
+Description=XMRig (learn-mode, throttled)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=pi
+WorkingDirectory=/home/pi/miners/xmrig
+ExecStart=/usr/bin/bash /home/pi/miners/xmrig/run-throttled.sh
+Restart=always
+RestartSec=10
+
+# caps: roughly 25% of a core and 256 MB
+CPUQuota=25%
+MemoryMax=256M
+IOSchedulingClass=idle
+IOSchedulingPriority=7
+
+# sandboxing
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=strict
+ProtectHome=read-only
+CapabilityBoundingSet=
+LockPersonality=yes
+RestrictRealtime=yes
+SystemCallFilter=@system-service
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add a miners bundle with documentation for enabling optional xmrig, verus, and chia services
- provide docker compose and systemd unit files with conservative CPU and memory limits for each miner
- include helper scripts for throttled xmrig operation, temperature monitoring, and power cost math

## Testing
- Not run (documentation and configuration changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d8570e1cd88329af46f3f254f7c0ac