### PR TITLE
feat: add miners pack and validation workflow

### DIFF
--- a/.github/workflows/miners-ci.yml
+++ b/.github/workflows/miners-ci.yml
@@ -1,0 +1,30 @@
+name: Miners • Validate
+
+on:
+  pull_request:
+  push:
+    branches: [ main, release/* ]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+      - name: Check miners compose parses (no run)
+        run: |
+          docker --version
+          docker compose version || true
+          test -f miners/miners-compose.yml
+          docker compose -f miners/miners-compose.yml config >/dev/null
+      - name: Lint helper scripts exist
+        run: |
+          test -f miners/xmrig/run-throttled.sh
+          test -f miners/xmrig/watch-temp.mjs
+          test -f miners/common/power-math.mjs

--- a/miners/README.md
+++ b/miners/README.md
@@ -1,0 +1,36 @@
+# Miners (learn-mode, low power)
+
+> Education & telemetry only — not profit. Everything is **off by default**, throttled, and easy to duty-cycle so average watts ≈ “rounding error”.
+
+## Services included
+- **Monero (xmrig)** – CPU PoW, best for demos
+- **Verus (verusminer)** – efficient CPU algo (still tiny on a Pi)
+- **Litecoin (scrypt CPU demo)** – educational; real LTC needs Scrypt ASICs
+- **Chia farmer** – ultra-low energy **farming** of pre-plotted drives
+
+## Compose (don’t start until you’re ready)
+```bash
+docker compose -f miners/miners-compose.yml config   # validate only
+docker compose -f miners/miners-compose.yml up -d xmrig          # enable xmrig (example)
+docker compose -f miners/miners-compose.yml stop xmrig           # stop
+```
+
+## Native systemd (xmrig, throttled, hardened)
+```bash
+sudo cp miners/xmrig/xmrig.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now xmrig.service
+sudo systemctl status xmrig --no-pager
+```
+
+## Duty-cycle to hit “near-zero” average watts
+Run 15 min per hour:
+```
+0 * * * *   systemctl start xmrig.service
+15 * * * *  systemctl stop xmrig.service
+```
+
+## Safety
+- CPU caps (`cpus: 0.25` / `CPUQuota=25%`)
+- Temp watcher for Docker xmrig (`watch-temp.mjs`)
+- No keys or secrets here. Addresses (if used elsewhere) are always masked/digested in logs.

--- a/miners/chia/chia-notes.md
+++ b/miners/chia/chia-notes.md
@@ -1,0 +1,12 @@
+# Chia farming on a Pi (low power)
+- Farming/harvesting is low energy; **plotting is not**. Create plots elsewhere.
+- Mount plots at `/mnt/plots` and enable the service in `miners-compose.yml`.
+
+Example:
+```bash
+sudo mkdir -p /mnt/plots
+sudo mount /dev/sdX1 /mnt/plots   # your HDD
+sudo nano /etc/fstab               # add a persistent mount entry
+docker compose -f miners/miners-compose.yml up -d chia
+docker compose -f miners/miners-compose.yml logs -f chia
+```

--- a/miners/common/power-math.mjs
+++ b/miners/common/power-math.mjs
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+// node miners/common/power-math.mjs --watts=2 --kwh=0.15 --hrs=6 --solar=30
+const args = Object.fromEntries(process.argv.slice(2).map(x=>x.split('=').map(s=>s.replace(/^--/,''))));
+const watts = +args.watts || 2;
+const kwh   = +args.kwh   || 0.15;
+const hrs   = +args.hrs   || 24;
+const solarWhDay = +args.solar || 0;
+const kwhDay = (watts/1000)*hrs;
+const costDay = kwhDay*kwh, costMonth = costDay*30;
+const gridWhDay = Math.max((watts*hrs)-solarWhDay,0);
+const gridKwhMonth = (gridWhDay/1000)*30, gridCostMonth = gridKwhMonth*kwh;
+console.log({watts,hrs,kwhDay,costDay,costMonth,solarWhDay,gridWhDay,gridKwhMonth,gridCostMonth});

--- a/miners/miners-compose.yml
+++ b/miners/miners-compose.yml
@@ -1,0 +1,74 @@
+services:
+  # --- Monero (xmrig) • CPU miner (learn-mode, throttled) ---
+  xmrig:
+    image: ghcr.io/xmrig/xmrig:latest
+    container_name: xmrig
+    command: >
+      -o POOL_HOST:PORT
+      -u YOUR_XMR_ADDRESS
+      --donate-level=0
+      --cpu-max-threads-hint=1
+    cpus: 0.25
+    mem_limit: 256m
+    restart: unless-stopped
+    security_opt: [no-new-privileges:true]
+    read_only: true
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
+    # enable manually:
+    # docker compose -f miners/miners-compose.yml up -d xmrig
+
+  # --- Verus (VRSC) • CPU miner (learn-mode) ---
+  verusminer:
+    image: krypt0nn/verus-miner:latest
+    container_name: verusminer
+    environment:
+      - POOL=POOL_HOST:PORT
+      - WALLET=YOUR_VRSC_ADDRESS
+      - PASSWORD=x
+      - THREADS=1
+    cpus: 0.25
+    mem_limit: 256m
+    restart: unless-stopped
+    security_opt: [no-new-privileges:true]
+    read_only: true
+    # enable:
+    # docker compose -f miners/miners-compose.yml up -d verusminer
+
+  # --- Litecoin (LTC) • scrypt CPU demo (educational only) ---
+  ltc-cpuminer:
+    image: registry.gitlab.com/foss/cpuminer-multi:latest
+    container_name: ltc-cpuminer
+    command: >
+      -a scrypt
+      -o stratum+tcp://POOL_HOST:PORT
+      -u YOUR_LTC_ADDRESS
+      -p x
+      -t 1
+    cpus: 0.25
+    mem_limit: 256m
+    restart: unless-stopped
+    security_opt: [no-new-privileges:true]
+    read_only: true
+    # enable:
+    # docker compose -f miners/miners-compose.yml up -d ltc-cpuminer
+
+  # --- Chia farmer (ULTRA low energy; pre-plotted drives needed) ---
+  chia:
+    image: ghcr.io/chia-network/chia:latest
+    container_name: chia
+    environment:
+      - keys=none
+      - service=farm
+      - log_level=INFO
+      - TZ=UTC
+    volumes:
+      - ./chia:/root/.chia
+      - /mnt/plots:/plots:ro
+    cpus: 0.2
+    mem_limit: 512m
+    restart: unless-stopped
+    security_opt: [no-new-privileges:true]
+    read_only: false
+    # enable:
+    # docker compose -f miners/miners-compose.yml up -d chia

--- a/miners/verus/verusminer.service
+++ b/miners/verus/verusminer.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Verus Miner (docker) throttled
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=pi
+ExecStart=/usr/bin/docker run --rm --name verusminer \
+  --cpus=0.25 --memory=256m --read-only --security-opt no-new-privileges:true \
+  -e POOL=POOL_HOST:PORT -e WALLET=YOUR_VRSC_ADDRESS -e PASSWORD=x -e THREADS=1 \
+  krypt0nn/verus-miner:latest
+ExecStop=/usr/bin/docker stop verusminer
+Restart=on-failure
+RestartSec=10
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=strict
+ProtectHome=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/miners/xmrig/run-throttled.sh
+++ b/miners/xmrig/run-throttled.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Low-power burst runner for xmrig. Caps CPU via short bursts + cooloffs.
+# env: POOL_HOST_PORT, XMR_ADDR, THREADS, MAX_TEMP_C, BURST_SEC, COOL_SEC
+
+POOL="${POOL_HOST_PORT:-POOL_HOST:PORT}"
+ADDR="${XMR_ADDR:-YOUR_XMR_ADDRESS}"
+THREADS="${THREADS:-1}"
+MAX_TEMP_C="${MAX_TEMP_C:-70}"
+BURST_SEC="${BURST_SEC:-90}"
+COOL_SEC="${COOL_SEC:-60}"
+CMD=(/home/pi/xmrig/build/xmrig -o "$POOL" -u "$ADDR" --donate-level=0 --cpu-max-threads-hint="$THREADS")
+
+read_temp() {
+  if command -v vcgencmd >/dev/null 2>&1; then
+    vcgencmd measure_temp | sed 's/[^0-9.]//g'
+  elif [ -f /sys/class/thermal/thermal_zone0/temp ]; then
+    awk '{printf "%.1f\n",$1/1000}' /sys/class/thermal/thermal_zone0/temp
+  else
+    echo 0
+  fi
+}
+
+while true; do
+  T="$(read_temp)"
+  if [ "${T%.*}" -ge "$MAX_TEMP_C" ]; then
+    sleep "$COOL_SEC"
+    continue
+  fi
+  timeout "$BURST_SEC" nice -n 19 "${CMD[@]}" || true
+  sleep "$COOL_SEC"
+done

--- a/miners/xmrig/watch-temp.mjs
+++ b/miners/xmrig/watch-temp.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+import { readFileSync, existsSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+const MAX = Number(process.env.MAX_TEMP_C || 70);
+function temp() {
+  try {
+    const out = execSync('vcgencmd measure_temp',{stdio:['ignore','pipe','ignore']}).toString();
+    const v = parseFloat(out.replace(/[^0-9.]/g,''));
+    if (!isNaN(v)) return v;
+  } catch {}
+  if (existsSync('/sys/class/thermal/thermal_zone0/temp')) {
+    const raw = readFileSync('/sys/class/thermal/thermal_zone0/temp','utf8').trim();
+    const v = Number(raw)/1000; if (!isNaN(v)) return v;
+  }
+  return 0;
+}
+const t = temp();
+if (t >= MAX) {
+  try { execSync('docker stop xmrig',{stdio:'ignore'}); } catch {}
+  console.log(JSON.stringify({ok:false,temp:t,action:'stopped xmrig'})); process.exit(1);
+}
+console.log(JSON.stringify({ok:true,temp:t}));

--- a/miners/xmrig/xmrig.service
+++ b/miners/xmrig/xmrig.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=XMRig (learn-mode, throttled)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=pi
+WorkingDirectory=/home/pi/miners/xmrig
+ExecStart=/usr/bin/bash /home/pi/miners/xmrig/run-throttled.sh
+Restart=always
+RestartSec=10
+CPUQuota=25%
+MemoryMax=256M
+IOSchedulingClass=idle
+IOSchedulingPriority=7
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=strict
+ProtectHome=read-only
+CapabilityBoundingSet=
+LockPersonality=yes
+RestrictRealtime=yes
+SystemCallFilter=@system-service
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add a miners/ pack with compose configs, services, and helper scripts for low-power demo mining setups
- document usage and safety controls for xmrig, verus, litecoin cpu miner, and chia farming
- add a GitHub Actions workflow that validates the compose file and required helper scripts without running miners

## Testing
- not run (configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d858354b6883298e8f25504f7a626b