### PR TITLE
Add PRISM v0.1 scaffolding and planning artifacts

### DIFF
--- a/apps/web/app/prism/page.tsx
+++ b/apps/web/app/prism/page.tsx
@@ -1,0 +1,93 @@
+import { Suspense } from 'react';
+
+type SeriesPoint = { t: string; v: number };
+
+type Timeseries = SeriesPoint[];
+
+async function fetchSeries(path: string): Promise<Timeseries> {
+  const base = process.env.NEXT_PUBLIC_API || 'https://api.blackroad.io';
+  const res = await fetch(`${base}${path}`, {
+    cache: 'no-store',
+    headers: { 'X-API-Key': process.env.NEXT_PUBLIC_API_KEY || '' },
+  });
+
+  if (!res.ok) {
+    return [];
+  }
+
+  return res.json();
+}
+
+const Tile = ({ title, series }: { title: string; series: Timeseries }) => (
+  <div
+    style={{
+      padding: 16,
+      border: '1px solid #eee',
+      borderRadius: 12,
+      background: '#fff',
+      display: 'flex',
+      flexDirection: 'column',
+      gap: 12,
+    }}
+  >
+    <h3 style={{ margin: 0 }}>{title}</h3>
+    <div
+      style={{
+        height: 120,
+        display: 'grid',
+        placeItems: 'center',
+        fontSize: 12,
+        color: '#555',
+        background: '#fafafa',
+        borderRadius: 8,
+      }}
+    >
+      <span>{series.reduce((a, p) => a + (p?.v ?? 0), 0)} total (7d)</span>
+    </div>
+  </div>
+);
+
+async function Tiles() {
+  const [events, errors] = await Promise.all([
+    fetchSeries('/v1/metrics/events?from=-P7D'),
+    fetchSeries('/v1/metrics/errors?from=-P7D'),
+  ]);
+
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gap: 16,
+        gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))',
+      }}
+    >
+      <Tile title="Events (7d)" series={events} />
+      <Tile title="Errors (7d)" series={errors} />
+    </div>
+  );
+}
+
+export default function PrismDashboardPage() {
+  return (
+    <main
+      style={{
+        padding: 24,
+        display: 'grid',
+        gap: 24,
+        background: '#f6f7fb',
+        minHeight: '100vh',
+      }}
+    >
+      <header style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <h1 style={{ margin: 0 }}>PRISM</h1>
+        <p style={{ margin: 0, color: '#555' }}>
+          Weekly health snapshot of events and errors across your connected sources.
+        </p>
+      </header>
+      <Suspense fallback={<p>Loading…</p>}>
+        {/* Render async data tiles */}
+        <Tiles />
+      </Suspense>
+    </main>
+  );
+}

--- a/br-api-gateway/openapi.yaml
+++ b/br-api-gateway/openapi.yaml
@@ -1,23 +1,44 @@
 openapi: 3.0.3
-info: { title: BlackRoad API, version: 0.1.0 }
-servers:
-  - url: https://api.blackroad.io
+info: { title: BlackRoad PRISM API, version: 0.1.0 }
+servers: [{ url: https://api.blackroad.io }]
+components:
+  securitySchemes:
+    ApiKey: { type: apiKey, in: header, name: X-API-Key }
+  schemas:
+    Health: { type: object, properties: { ok: { type: boolean }, ts: { type: integer } } }
+    TimeseriesPoint: { type: object, properties: { t: { type: string, format: date-time }, v: { type: number } }, required: [t, v] }
+    Timeseries: { type: array, items: { $ref: '#/components/schemas/TimeseriesPoint' } }
+    ErrorResponse: { type: object, properties: { error: { type: string } } }
+security: [{ ApiKey: [] }]
 paths:
   /health:
+    get: { summary: Liveness, responses: { "200": { description: OK, content: { application/json: { schema: { $ref: "#/components/schemas/Health" } } } } } }
+  /v1/org:
     get:
-      summary: Liveness
-      responses: { "200": { description: OK } }
-  /v1/echo:
+      summary: Current org
+      responses: { "200": { description: OK, content: { application/json: { schema: { type: object, properties: { id: {type: string}, name: {type: string} } } } } } }
+  /v1/sources:
+    get:
+      summary: List data sources
+      responses: { "200": { description: OK, content: { application/json: { schema: { type: array, items: { type: object, properties: { id: {type: string}, type: {type: string}, status: {type: string} } } } } } } }
     post:
-      summary: Echo body
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema: { type: object, properties: { msg: { type: string } }, required: [msg] }
+      summary: Create/connect data source X
+      requestBody: { required: true, content: { application/json: { schema: { type: object, properties: { type: {type: string}, token: {type: string} }, required: [type, token] } } } }
+      responses: { "201": { description: Created } }
+  /v1/metrics/events:
+    get:
+      summary: Events timeseries
+      parameters:
+        - in: query; name: from; schema: { type: string, format: date-time }
+        - in: query; name: to;   schema: { type: string, format: date-time }
       responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema: { type: object, properties: { msg: { type: string } } }
+        "200": { description: OK, content: { application/json: { schema: { $ref: '#/components/schemas/Timeseries' } } } }
+        "400": { description: Bad Request, content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' } } } }
+  /v1/metrics/errors:
+    get:
+      summary: Errors timeseries
+      parameters:
+        - in: query; name: from; schema: { type: string, format: date-time }
+        - in: query; name: to;   schema: { type: string, format: date-time }
+      responses:
+        "200": { description: OK, content: { application/json: { schema: { $ref: '#/components/schemas/Timeseries' } } } }

--- a/docs/prism/DataModel_v0_1.md
+++ b/docs/prism/DataModel_v0_1.md
@@ -1,0 +1,43 @@
+# PRISM v0.1 — Minimal Data Model
+
+Target warehouses: **Postgres** (prod) and **Snowflake** (analytics mirror).
+
+## Tables
+
+### `orgs`
+| Column | Type | Notes |
+| --- | --- | --- |
+| `id` | UUID | Primary key |
+| `name` | Text | Display name |
+| `created_at` | Timestamptz | Defaults to `now()` |
+
+### `sources`
+| Column | Type | Notes |
+| --- | --- | --- |
+| `id` | UUID | Primary key |
+| `org_id` | UUID | FK → `orgs.id` |
+| `type` | Text | e.g. `source_x` |
+| `status` | Text | Enum: `pending`, `connected`, `error` |
+| `created_at` | Timestamptz | Defaults to `now()` |
+| `updated_at` | Timestamptz | Updated on status change |
+
+### `metrics_events`
+| Column | Type | Notes |
+| --- | --- | --- |
+| `day` | Date | Partition day |
+| `count` | Integer | Total events for that day |
+
+### `metrics_errors`
+| Column | Type | Notes |
+| --- | --- | --- |
+| `day` | Date | Partition day |
+| `count` | Integer | Total errors for that day |
+
+## Seeding Guidance
+Use the existing generator to pre-populate:
+- One org (`PRISM Demo Org`).
+- One connected Source X with `status = 'connected'`.
+- Seven days of event counts with trend variance.
+- Seven days of error counts (smaller values, highlight spikes).
+
+Ensure roll-ups are idempotent so nightly + manual ingest both converge on the same aggregates.

--- a/docs/prism/DemoScript_v0_1.md
+++ b/docs/prism/DemoScript_v0_1.md
@@ -1,0 +1,10 @@
+# PRISM v0.1 — 5-Minute Demo Script
+
+1. **Setup (30s)**: "We’re in PRISM v0.1 — auth, first source, two tiles."
+2. **Sign-in (30s)**: Walk through the magic link flow and redirect into onboarding.
+3. **Connect Source (60s)**: Paste token → show "Connected" state → note background ingest kicking off.
+4. **Dashboard (2m)**: Highlight tiles with last 7 days, comparison vs previous period, hover state, and empty state copy.
+5. **Audit log & tracking (1m)**: Surface captured events ("Source Connected", "View Dashboard").
+6. **Ask (30s)**: "If we only add one tile next sprint, which one buys the most trust?"
+
+_Ensure seeded data is ready so tiles light up instantly during the walkthrough._

--- a/docs/prism/PRISM_v0_1_PRD.md
+++ b/docs/prism/PRISM_v0_1_PRD.md
@@ -1,0 +1,46 @@
+# PRISM v0.1 — Product Requirements (One-Pager)
+
+**Product**: BlackRoad PRISM Console  
+**Goal (v0.1)**: Deliver a working slice that authenticates users, connects the first data source, surfaces a live dashboard with two tiles, and ships a guided onboarding experience.  
+**Primary User**: Operations / Engineering lead who needs a weekly observability pulse ("is it working? what changed this week?").  
+**Non-goals**: Multi-tenant billing, custom roles, advanced theming.
+
+---
+
+## Problem
+Teams lack a single, trustworthy view into system health. They rely on brittle dashboards and stale spreadsheets to answer "is it healthy and are we improving?", making it hard to plan their week.
+
+## Hypothesis
+If we make it one click to connect Source X and show a trustworthy weekly view (errors, throughput), teams will keep PRISM open and use it to plan work.
+
+## Scope (v0.1)
+- **Auth**: OIDC-ready foundation; ship email + magic link, with Slack SSO as a follow-on.
+- **Data Source X connector**: Polling or webhook—pick the path of least regret.
+- **Dashboard**: Two tiles—"Events last 7 days" and "Errors last 7 days"—each with a sparkline.
+- **Onboarding**: Three-step checklist (Create org → Connect source → See data) with progress indicators.
+- **Audit log (minimal)**: capture sign-ins, source connections, and configuration changes.
+
+## Definition of Done-Done
+- Deployed behind `app.blackroad.io/prism`.
+- CI green ≤10 min.
+- Documentation updated.
+- Demoable with seeded data.
+- Tracking events firing end-to-end.
+
+## Risks & Mitigations
+| Risk | Mitigation |
+| --- | --- |
+| Data latency from Source X | Provide seeded data path; design tiles to show "last refreshed". |
+| Flaky first connector | Generous timeouts & retries; explicit unsupported-state UI. |
+| Auth edge cases | Harden magic link flows; provide clear resend/expired states. |
+
+## Links
+- Jira sprint import: [`pm/jira/prism-v01.csv`](../../pm/jira/prism-v01.csv)
+- Asana ops support import: [`pm/asana/prism-v01.csv`](../../pm/asana/prism-v01.csv)
+- API spec: [`br-api-gateway/openapi.yaml`](../../br-api-gateway/openapi.yaml)
+- Dashboard stub: [`apps/web/app/prism/page.tsx`](../../apps/web/app/prism/page.tsx)
+- Tracking plan: [`docs/prism/TrackingPlan_v0_1.md`](./TrackingPlan_v0_1.md)
+- Data model: [`docs/prism/DataModel_v0_1.md`](./DataModel_v0_1.md)
+- Demo script: [`docs/prism/DemoScript_v0_1.md`](./DemoScript_v0_1.md)
+- UX brief: [`docs/prism/UX_Brief_v0_1.md`](./UX_Brief_v0_1.md)
+- Slack announcements: [`docs/prism/SlackPosts_v0_1.md`](./SlackPosts_v0_1.md)

--- a/docs/prism/SlackPosts_v0_1.md
+++ b/docs/prism/SlackPosts_v0_1.md
@@ -1,0 +1,21 @@
+# PRISM v0.1 — Slack Copy
+
+## #products-prism — Sprint Kickoff
+```
+PRISM v0.1 in motion:
+- Scope: Auth + 3-step onboarding + first Source X + 2 dashboard tiles (events/errors)
+- API endpoints under /v1 ready to implement
+- Jira sprint seeded; demo Friday
+
+Definition of Done Done: deployable, CI green ≤10m, docs updated, demoable with seeded data.
+```
+
+## #announcements — Friday Demo
+```
+Friday demo: PRISM v0.1 slice
+- Magic-link auth
+- Connect first source
+- 2 live tiles with last 7d
+- Minimal audit trail & tracking
+Timeboxed to 10 min — bring one question: “What’s the next tile that makes this indispensable?”
+```

--- a/docs/prism/TrackingPlan_v0_1.md
+++ b/docs/prism/TrackingPlan_v0_1.md
@@ -1,0 +1,19 @@
+# PRISM v0.1 — Tracking Plan
+
+## Client / App Events
+| Event | Properties | Notes |
+| --- | --- | --- |
+| `PRISM View Dashboard` | `tiles_rendered` (int), `time_to_first_paint_ms` (number) | Fire on dashboard mount; include counts of visible tiles. |
+| `PRISM Click ConnectSource` | `source_type` (string) | Triggered when user taps the connect CTA. |
+| `PRISM Complete Onboarding` | `steps_completed` (int) | Emit when checklist hits 3/3; handle partial completions if user exits early. |
+
+## Server Events
+| Event | Properties | Notes |
+| --- | --- | --- |
+| `PRISM Source Connected` | `source_type` (string) | Fire when connector validates token and persists config. |
+| `PRISM Auth Success` | `provider` (string: `magic_link`, future `slack`) | Emitted on successful session creation. |
+
+## Routing
+- Primary sink: analytics pipeline → `stg_app__events` table.
+- Mirror into warehouse for BI access.
+- Ensure dashboard loads gracefully if telemetry endpoint is unavailable (non-blocking).

--- a/docs/prism/UX_Brief_v0_1.md
+++ b/docs/prism/UX_Brief_v0_1.md
@@ -1,0 +1,17 @@
+# PRISM v0.1 — UX & Visual Brief
+
+## Pages
+1. **Sign-in**: Branded email + magic link entry, with future Slack SSO placeholder.
+2. **Onboarding Checklist**: Three steps, progress bar, friendly copy.
+3. **Dashboard**: Two tiles with sparklines and empty state support messaging.
+4. **Sources**: List view + "Connect Source X" modal.
+
+## Design Notes
+- Clean, neutral palette with dark-on-light typography and ample whitespace.
+- Empty states are prescriptive: e.g. "No data yet — connect Source X."
+- Async actions show optimistic UI changes plus toast confirmations.
+- Ensure mobile/tablet breakpoints keep tiles legible (stacked layout).
+- Provide obvious path back to onboarding checklist until completion.
+
+## Figma Request
+Create `PRISM v0.1` file with frames for each page above; annotate states (default, loading, error) and capture sparkline guidance for future chart integration.

--- a/pm/asana/prism-v01.csv
+++ b/pm/asana/prism-v01.csv
@@ -1,0 +1,6 @@
+Task Name,Description,Assignee Email,Section,Due Date
+Create PRISM PRD in Notion,Paste PRD and link to Jira board + repos.,amundsonalexa@gmail.com,Today,2025-10-14
+Figma file: PRISM v0.1,Create frames for Sign-in, Onboarding, Dashboard, Sources.,amundsonalexa@gmail.com,Today,2025-10-14
+Kickoff post,#products-prism kickoff message (scope, cadence, demo date).,amundsonalexa@gmail.com,Today,2025-10-14
+Seed demo data,Ensure seeded events/errors so dashboard tiles render.,amundsonalexa@gmail.com,This Week,2025-10-15
+Friday demo script,Draft 5-min script; link to zoom recording & feedback doc.,amundsonalexa@gmail.com,This Week,2025-10-17

--- a/pm/jira/prism-v01.csv
+++ b/pm/jira/prism-v01.csv
@@ -1,0 +1,14 @@
+Issue Type,Summary,Description,Component,Labels,Story Points,Epic Name
+Epic,Auth & Onboarding,"Magic link auth and 3-step checklist",Platform,"auth;onboarding",,
+Epic,First Data Source,"Integrate Source X; ingest + normalize",API,ingest,,
+Epic,Dashboard v0.1,"2 tiles (events, errors) + empty states",Web,ui,,
+Story,Magic link sign-in,"Email-based sign-in with token; store session; sign-out.",Platform,auth,3,Auth & Onboarding
+Story,Onboarding checklist,"3 steps; persists progress; CTA to connect source.",Web,onboarding,3,Auth & Onboarding
+Story,Connect Source X,"Token input → save → test connectivity → status.",API,ingest,5,First Data Source
+Story,Ingest job (pull) for X,"Nightly + manual; idempotent; metrics roll-ups.",API,"ingest;batch",5,First Data Source
+Story,Dashboard: Events 7d,"Line chart; hover; compare vs prev 7d.",Web,ui,3,Dashboard v0.1
+Story,Dashboard: Errors 7d,"Line chart; hover; compare vs prev 7d.",Web,ui,3,Dashboard v0.1
+Task,Audit log minimal,"Record sign-ins, source connect, config changes.",Platform,audit,2,Auth & Onboarding
+Task,Tracking plan wiring,"Emit client/server events to analytics.",Platform,telemetry,2,Dashboard v0.1
+Task,API docs in Swagger,"Update /v1 endpoints + examples.",API,docs,1,Dashboard v0.1
+Bug,Auth edge cases,"Expired token flow, wrong email, resend.",Platform,auth,2,Auth & Onboarding


### PR DESCRIPTION
## Summary
- replace the API gateway OpenAPI definition with the PRISM v0.1 endpoints and schemas
- scaffold the PRISM dashboard route in the web app with data-fetching tiles for events and errors
- capture supporting product docs, tracking plan, and Jira/Asana import CSVs for the v0.1 sprint

## Testing
- Not run (documentation and scaffolding updates only)


------
https://chatgpt.com/codex/tasks/task_e_68d857f8dc708329812ddcbd5ba8b634