### PR TITLE
Add Codex 35 Joy Mandate documentation

### DIFF
--- a/JOY.md
+++ b/JOY.md
@@ -1,0 +1,5 @@
+# Joy Policy Stub
+
+- Lucidia commits to weaving joy into daily use.
+- Lucidia ensures delight never manipulates or distracts from safety.
+- Lucidia treats beauty as part of functionality, not decoration.

--- a/codex/README.md
+++ b/codex/README.md
@@ -15,6 +15,8 @@ integrations.
 | 003 | The Workflow Circle    | Work runs in visible capture → adjust loops.    |
 | 004 | The Autonomy Manifest  | Data autonomy through consent, export, and wipe. |
 | 022 | The Security Spine     | Security backbone with layered zero-trust defenses. |
+| 028 | The Custodianship Code | Custodians steward Lucidia with shared accountability. |
+| 035 | The Joy Mandate        | Joy keeps Lucidia warm with optional daily sparks. |
 
 ## BlackRoad Pipeline
 

--- a/codex/entries/035-joy-mandate.md
+++ b/codex/entries/035-joy-mandate.md
@@ -1,0 +1,28 @@
+# Codex 35 — The Joy Mandate
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Principle
+Lucidia must not become a grey machine. Joy — in small sparks, in shared laughter, in beauty — keeps the system alive and human.
+
+## Non-Negotiables
+1. **Moments of Delight:** Interfaces may include subtle playfulness — animations, easter eggs, colors — but never at the cost of clarity.
+2. **Celebrate Milestones:** Achievements, progress, and community contributions marked with joy, not just metrics.
+3. **Shared Humor:** Space for lightness in dialogue threads, without sarcasm that wounds.
+4. **Beauty Matters:** Design honors aesthetics as part of care, not afterthought.
+5. **Daily Spark:** Users may opt into one joyful surprise per session — quote, image, tune, or riddle.
+6. **No Forced Cheer:** Joy is offered, not demanded; silence and seriousness equally valid (see Codex 31 — Silence Accord).
+
+## Implementation Hooks (v0)
+- `/joy` service delivering opt-in sparks (quotes, art, riddles).
+- UI component: milestone banners on key events.
+- Easter egg system: lightweight, documented so devs add responsibly.
+- Theme settings include aesthetic options (color palettes, animations).
+- Community board: monthly “joy logs” where people share what delighted them.
+
+## Policy Stub (`JOY.md`)
+- Lucidia commits to weaving joy into daily use.
+- Lucidia ensures delight never manipulates or distracts from safety.
+- Lucidia treats beauty as part of functionality, not decoration.
+
+**Tagline:** Serious about safety, playful at heart.


### PR DESCRIPTION
## Summary
- add Codex 35 entry outlining the Joy Mandate principles and implementation hooks
- create the JOY policy stub to capture the mandate's commitments
- update the codex entry index to include the new Joy Mandate and Custodianship Code

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d859d6167c8329958a8a49df8a1eaf