### PR TITLE
Add Jetson learn-mode miner pack and ASIC supervisor

### DIFF
--- a/.github/workflows/miners-ci.yml
+++ b/.github/workflows/miners-ci.yml
@@ -1,0 +1,37 @@
+name: "Miners • Validate"
+
+on:
+  push:
+    paths:
+      - 'miners/**'
+      - '.github/workflows/miners-ci.yml'
+  pull_request:
+    paths:
+      - 'miners/**'
+      - '.github/workflows/miners-ci.yml'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+      - name: Check miners compose parses (no run)
+        run: |
+          docker --version
+          docker compose version || true
+          test -f miners/miners-compose.yml
+          docker compose -f miners/miners-compose.yml config >/dev/null
+      - name: Lint helper scripts exist
+        run: |
+          test -f miners/xmrig/run-throttled.sh
+          test -f miners/xmrig/watch-temp.mjs
+          test -f miners/common/power-math.mjs
+      - name: Validate Jetson pack (no run)
+        run: |
+          test -f miners/jetson/Dockerfile
+          test -f miners/jetson/jetson-compose.yml
+          docker compose -f miners/jetson/jetson-compose.yml config >/dev/null

--- a/miners/README.md
+++ b/miners/README.md
@@ -1,0 +1,38 @@
+# Miners pack (opt-in, throttled)
+
+Educational miners designed for demos and power-budget experiments. Everything defaults to low impact and requires explicit opt-in.
+
+## Services included
+- **Monero (xmrig)** – CPU PoW; best for demos
+- **Verus (verusminer)** – efficient CPU algo; still tiny on a Pi
+- **Chia farmer** – ultra-low energy **farming** of pre-plotted drives
+- **Litecoin (scrypt CPU demo)** – educational only (real LTC needs Scrypt ASICs)
+- **Jetson CUDA (xmrig-cuda)** – GPU learn-mode on NVIDIA Jetson (see `miners/jetson/`)
+
+## Turn on (only what you want)
+```bash
+# Monero xmrig (Docker):
+docker compose -f miners/miners-compose.yml up -d xmrig
+
+# stop anytime:
+docker compose -f miners/miners-compose.yml stop xmrig
+```
+
+### Jetson CUDA (learn-mode)
+```bash
+docker compose -f miners/jetson/jetson-compose.yml config
+docker compose -f miners/jetson/jetson-compose.yml up -d xmrig-cuda
+```
+Stop the Jetson container with:
+```bash
+docker compose -f miners/jetson/jetson-compose.yml stop xmrig-cuda
+```
+
+Native systemd (xmrig, throttled, hardened)
+
+```bash
+sudo cp miners/xmrig/xmrig.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now xmrig.service
+sudo systemctl status xmrig --no-pager
+```

--- a/miners/asic/asic-supervisor.mjs
+++ b/miners/asic/asic-supervisor.mjs
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+// Duty-cycle an external ASIC (Scrypt/SHA) by toggling API/pool settings.
+// Replace stubs with real ASIC API calls.
+const onMin  = Number(process.env.ASIC_ON_MIN  || 10);
+const offMin = Number(process.env.ASIC_OFF_MIN || 50);
+async function asicStart(){ console.log('[asic] start (stub)'); /* call ASIC */ }
+async function asicStop(){  console.log('[asic] stop  (stub)'); /* call ASIC */ }
+(async ()=>{
+  while(true){
+    await asicStart(); await new Promise(r=>setTimeout(r,onMin*60*1000));
+    await asicStop();  await new Promise(r=>setTimeout(r,offMin*60*1000));
+  }
+})();

--- a/miners/jetson/Dockerfile
+++ b/miners/jetson/Dockerfile
@@ -1,0 +1,20 @@
+# Jetson (ARM64) xmrig build with CUDA backend (learn-mode)
+FROM nvcr.io/nvidia/l4t-cuda:12.2.0-runtime
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git build-essential cmake libuv1-dev libssl-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt
+RUN git clone https://github.com/xmrig/xmrig.git && mkdir -p xmrig/build
+WORKDIR /opt/xmrig/build
+RUN cmake .. -DWITH_CUDA=ON -DWITH_HWLOC=OFF -DWITH_HTTPD=OFF && \
+    make -j$(nproc)
+
+WORKDIR /work
+COPY jetson-run.sh /work/jetson-run.sh
+RUN chmod +x /work/jetson-run.sh
+
+ENV NVIDIA_VISIBLE_DEVICES=all
+ENV NVIDIA_DRIVER_CAPABILITIES=utility,compute
+ENTRYPOINT ["/work/jetson-run.sh"]

--- a/miners/jetson/README.md
+++ b/miners/jetson/README.md
@@ -1,0 +1,30 @@
+# Jetson miners (learn-mode, CUDA, low power)
+
+These are for **education**, not profit. Everything is throttled / duty-cycled.
+Works on NVIDIA Jetson devices with JetPack (CUDA + nvidia-container-runtime).
+
+## Build xmrig-cuda (Jetson)
+```bash
+cd miners/jetson
+docker build -t xmrig-cuda-arm64 .
+```
+
+## Run via compose (opt-in)
+```bash
+docker compose -f miners/jetson/jetson-compose.yml config
+docker compose -f miners/jetson/jetson-compose.yml up -d xmrig-cuda
+docker compose -f miners/jetson/jetson-compose.yml stop xmrig-cuda
+```
+
+## Native systemd (opt-in)
+```bash
+sudo cp miners/jetson/xmrig-cuda.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now xmrig-cuda.service
+sudo systemctl status xmrig-cuda --no-pager
+```
+
+## Power / safety knobs
+- `nvpmodel` to select low-power modes (see `nvpmodel.sh`)
+- duty cycle: BURST/COOL seconds (in env)
+- thermal guard via `tegrastats` (stops if too hot)

--- a/miners/jetson/jetson-compose.yml
+++ b/miners/jetson/jetson-compose.yml
@@ -1,0 +1,19 @@
+services:
+  xmrig-cuda:
+    image: xmrig-cuda-arm64
+    container_name: xmrig-cuda
+    runtime: nvidia
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
+      - NVIDIA_DRIVER_CAPABILITIES=utility,compute
+      - POOL=POOL_HOST:PORT
+      - ADDR=YOUR_ADDRESS
+      - THREADS=1
+      - BURST_SEC=90
+      - COOL_SEC=60
+      - MAX_TEMP_C=70
+    cpus: 0.50
+    mem_limit: 512m
+    restart: unless-stopped
+    security_opt: [no-new-privileges:true]
+    read_only: true

--- a/miners/jetson/jetson-run.sh
+++ b/miners/jetson/jetson-run.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# CUDA xmrig wrapper with duty-cycle + temp guard (tegrastats)
+# env: POOL=host:port ADDR=address THREADS=1 BURST_SEC=90 COOL_SEC=60 MAX_TEMP_C=70
+
+POOL="${POOL:-POOL_HOST:PORT}"
+ADDR="${ADDR:-YOUR_ADDRESS}"
+THREADS="${THREADS:-1}"
+BURST_SEC="${BURST_SEC:-90}"
+COOL_SEC="${COOL_SEC:-60}"
+MAX_TEMP_C="${MAX_TEMP_C:-70}"
+
+read_temp() {
+  if command -v tegrastats >/dev/null 2>&1; then
+    local out; out=$(tegrastats --interval 1000 --count 1 2>/dev/null || true)
+    local t; t=$(echo "$out" | sed -n 's/.*\(Tdiode@\|Tboard@\)\([0-9]\{1,3\}\)C.*/\2/p' | sort -nr | head -n1)
+    echo "${t:-0}"
+  else
+    echo 0
+  fi
+}
+
+CMD=(/opt/xmrig/build/xmrig -o "$POOL" -u "$ADDR" --donate-level=0 --cpu-max-threads-hint="$THREADS")
+while true; do
+  T="$(read_temp)"
+  if [ "${T:-0}" -ge "$MAX_TEMP_C" ]; then
+    sleep "$COOL_SEC"; continue
+  fi
+  timeout "$BURST_SEC" nice -n 19 "${CMD[@]}" || true
+  sleep "$COOL_SEC"
+done

--- a/miners/jetson/xmrig-cuda.service
+++ b/miners/jetson/xmrig-cuda.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=XMRig-CUDA (Jetson learn-mode, throttled)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=pi
+WorkingDirectory=/home/pi/miners/jetson
+ExecStart=/usr/bin/docker run --rm --name xmrig-cuda \
+  --runtime nvidia --gpus all \
+  --cpus=0.5 --memory=512m --read-only --security-opt no-new-privileges:true \
+  -e NVIDIA_VISIBLE_DEVICES=all -e NVIDIA_DRIVER_CAPABILITIES=utility,compute \
+  -e POOL=POOL_HOST:PORT -e ADDR=YOUR_ADDRESS -e THREADS=1 \
+  -e BURST_SEC=90 -e COOL_SEC=60 -e MAX_TEMP_C=70 \
+  xmrig-cuda-arm64
+ExecStop=/usr/bin/docker stop xmrig-cuda
+Restart=on-failure
+RestartSec=10
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=strict
+ProtectHome=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add Jetson CUDA learn-mode collateral, including Docker build, compose bundle, systemd unit, and run wrapper
- introduce ASIC duty-cycle supervisor stub for external miners and document the expanded pack
- extend miners documentation and CI workflow to cover the Jetson assets and path validation

## Testing
- `docker compose -f miners/jetson/jetson-compose.yml config` *(fails locally: docker not installed in runner)*

------
https://chatgpt.com/codex/tasks/task_e_68d85a2f942c83299a4800ba39c4d376