### PR TITLE
feat: add CLN Tor sidecar and gitleaks guardrails

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,9 @@
-/infra/            @platform-team
-/flows/            @integration-team
-/monitors/         @sre-team
-/runbooks/         @platform-team
-/apps/api/       @platform-team
-/apps/web-public/ @platform-team
-/ops/            @sre-team
-/scripts/        @platform-team
+# CODEOWNERS ensures reviews from the right people.
+# Adjust teams/users as needed for BlackRoad.
+*       @blackboxprogramming/maintainers
+
+# Example: require core reviewers for security-sensitive areas
+docs/** @blackboxprogramming/maintainers
+.github/** @blackboxprogramming/maintainers
+miners/** @blackboxprogramming/maintainers
+lightning/** @blackboxprogramming/maintainers

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,18 @@
+name: Security • gitleaks
+on:
+  pull_request:
+  push:
+    branches: [ main, release/* ]
+permissions:
+  contents: read
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: gitleaks scan (redacted)
+        uses: zricethezav/gitleaks-action@v2
+        with:
+          args: --no-banner --redact

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,12 @@ repos:
       - id: eslint
         args: ['--fix']
         files: "\\.(js|jsx|ts|tsx)$"
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.18.4
+    hooks:
+      - id: gitleaks
+        name: gitleaks (prevent secrets)
+        entry: gitleaks detect --source . --no-banner --redact --exit-code 1
+        language: golang
+        pass_filenames: false
+        stages: [commit, push]

--- a/docs/policies/branch-protection.md
+++ b/docs/policies/branch-protection.md
@@ -1,0 +1,24 @@
+# Branch Protection — BlackRoad (template)
+
+Apply these in **GitHub → Settings → Branches → Branch protection rules** for `main`:
+
+1. **Require a pull request before merging**
+   - Require approvals: **2**
+   - Dismiss stale approvals on new commits: **on**
+   - Require review from Code Owners: **on**
+   - Block force pushes: **on**
+   - Block deletions: **on**
+2. **Require status checks to pass before merging**
+   - Required checks (examples):
+     - CI • Node 20 (lint/typecheck/test)
+     - Miners • Validate
+     - Security • gitleaks
+3. **Require conversation resolution before merging:** **on**
+4. **Require linear history:** optional but recommended
+5. **Require signed commits:** recommended (if your team can support it)
+6. **Enforce for administrators:** **on** (recommended)
+
+Org-level:
+- Enforce **2FA** for all members.
+- Use SSO/SCIM if available.
+- Rotate team permissions quarterly.

--- a/lightning/tor/README.md
+++ b/lightning/tor/README.md
@@ -1,0 +1,22 @@
+# Tor sidecar for CLN (optional, safe)
+
+This exposes your Core Lightning (CLN) node over a Tor onion service **without** exposing it on clearnet. Keys remain local in CLN.
+
+## Files
+- `lightning/tor/torrc` – Tor config with a HiddenService for CLN port 9735.
+- `lightning/tor/compose.tor.yml` – compose fragment to run Tor next to CLN.
+
+## Usage
+1) Ensure your main Bitcoin/CLN compose is running (bitcoind + cln).
+2) Start Tor sidecar (add `-f` to your main compose command if needed):
+```bash
+docker compose -f btc-compose.yml -f lightning/tor/compose.tor.yml up -d tor
+```
+3) Get your onion:
+```bash
+docker compose -f lightning/tor/compose.tor.yml exec tor \
+  sh -lc 'cat /var/lib/tor/lightning/hostname || cat /var/lib/tor/hidden_service/lightning/hostname'
+```
+4) Share your onion with peers who connect via Tor. You do **not** need to expose port 9735 on the internet.
+
+> NOTE: This is a sidecar; CLN must be reachable as `cln:9735` on the Docker network (the default if CLN’s service name is `cln`).

--- a/lightning/tor/compose.tor.yml
+++ b/lightning/tor/compose.tor.yml
@@ -1,0 +1,17 @@
+services:
+  tor:
+    image: alpine/tor:latest
+    container_name: tor
+    restart: unless-stopped
+    volumes:
+      - ./lightning/tor/torrc:/etc/tor/torrc:ro
+      - tor-state:/var/lib/tor
+    command: ["-f", "/etc/tor/torrc"]
+    healthcheck:
+      test: ["CMD", "sh", "-lc", "test -f /var/lib/tor/lightning/hostname"]
+      interval: 30s
+      timeout: 5s
+      retries: 10
+volumes:
+  tor-state:
+    name: tor-state

--- a/lightning/tor/torrc
+++ b/lightning/tor/torrc
@@ -1,0 +1,12 @@
+# Minimal Tor config for a CLN hidden service
+# Tor stores keys under /var/lib/tor/lightning/
+DataDirectory /var/lib/tor
+ClientOnly 1
+SocksPort 0
+Log notice stdout
+
+# Hidden service for CLN
+HiddenServiceDir /var/lib/tor/lightning/
+HiddenServiceVersion 3
+# expose 9735 to internal CLN service on same Docker network
+HiddenServicePort 9735 cln:9735


### PR DESCRIPTION
## Summary
- add optional Tor sidecar compose fragment and docs for exposing CLN over onion service
- configure gitleaks in pre-commit and CI plus establish CODEOWNERS defaults
- document recommended branch protection policy for main branch

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d85b5e7e1083298d8e7866f772b956