### PR TITLE
Add Bitcoin proof-of-work worksheet scaffolding

### DIFF
--- a/codex/prompts/bitcoin_pow_worksheet.prompt.md
+++ b/codex/prompts/bitcoin_pow_worksheet.prompt.md
@@ -1,0 +1,30 @@
+# Bitcoin Proof-of-Work Worksheet
+
+Goal: implement the staged helpers in `codex/worksheets/bitcoin_pow.py` and
+unlock the assertions in `tests/test_bitcoin_pow_worksheet.py`.
+
+## How to use
+1. Work through each step in order—the pytest file skips later sections until
+the corresponding functions stop raising `NotImplementedError`.
+2. After completing a step, run:
+   ```bash
+   pytest tests/test_bitcoin_pow_worksheet.py
+   ```
+   Watch for the next block of tests to activate.
+3. Keep the reference formulas from the worksheet header close by; every step
+highlights a common endianness or rounding pitfall.
+
+## Step breakdown
+1. **Compact difficulty math** — convert between `nBits`, full targets, and
+difficulty values using `Decimal` precision.
+2. **Header hashing** — serialize the 80-byte header correctly and confirm the
+hash against mainnet block 0.
+3. **Merkle trees** — rebuild the root with proper little-endian ordering and
+odd-node duplication.
+4. **Mining probability** — compute share probabilities, expected hashes, and
+run-time estimates.
+5. **Retarget windows** — clamp the observed timespan, derive the new target,
+and produce the compact `nBits` encoding.
+
+SegWit commitments and extranonce handling are outside the scope of this
+worksheet but make great follow-up explorations once the basics are passing.

--- a/codex/worksheets/__init__.py
+++ b/codex/worksheets/__init__.py
@@ -1,0 +1,5 @@
+"""Learning-oriented worksheets for Codex exercises."""
+
+from . import bitcoin_pow
+
+__all__ = ["bitcoin_pow"]

--- a/codex/worksheets/bitcoin_pow.py
+++ b/codex/worksheets/bitcoin_pow.py
@@ -1,0 +1,191 @@
+"""Bitcoin proof-of-work worksheet for Codex agents.
+
+Each step in this module corresponds to a test block in
+``tests/test_bitcoin_pow_worksheet.py``.  Fill in the implementations
+sequentially and run ``pytest tests/test_bitcoin_pow_worksheet.py`` after
+finishing each step to see new assertions unlock.
+
+Steps
+-----
+1. Bits ↔ target ↔ difficulty conversions.
+2. Block header serialization and hashing helpers.
+3. Merkle root construction for block templates.
+4. Mining probability utilities for shares and timing.
+5. Difficulty retarget window math.
+
+Endianness, compact-format rounding, and Decimal precision all matter
+here—pay close attention to the docstrings for required behaviour.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal, getcontext
+
+getcontext().prec = 50
+
+T1 = int("00000000FFFF0000000000000000000000000000000000000000000000000000", 16)
+"""Difficulty-1 target for Bitcoin mainnet."""
+
+TWO_256 = Decimal(2) ** 256
+"""Convenience constant for probability math."""
+
+TARGET_TIMESPAN = 2016 * 600
+"""Retarget interval in seconds (two weeks)."""
+
+__all__ = [
+    "T1",
+    "TWO_256",
+    "TARGET_TIMESPAN",
+    "bits_to_target",
+    "target_to_bits",
+    "target_to_difficulty",
+    "difficulty_to_target",
+    "le_hex_to_bytes",
+    "dsha256",
+    "serialize_header",
+    "header_hash",
+    "is_valid_pow",
+    "merkle_root",
+    "success_prob_per_hash",
+    "expected_hashes",
+    "expected_time_seconds",
+    "is_share_valid",
+    "clamp_retarget_timespan",
+    "compute_retarget",
+]
+
+
+def bits_to_target(nbits: int) -> int:
+    """Step 1A – convert compact ``nBits`` to an integer target.
+
+    * Extract the exponent (most significant byte) and the 3-byte coefficient.
+    * For ``E >= 3`` multiply the coefficient by ``2 ** (8 * (E - 3))``.
+    * For ``E < 3`` right-shift the coefficient by ``8 * (3 - E)`` bits.
+    * Ignore the sign bit—``nBits`` is assumed positive for valid headers.
+    """
+
+    raise NotImplementedError("Step 1A: bits_to_target")
+
+
+def target_to_bits(target: int) -> int:
+    """Step 1B – encode a target back into Bitcoin's compact format.
+
+    Requirements
+    ------------
+    * Strip leading zero bytes from the big-endian representation.
+    * If the most-significant byte is ``>= 0x80``, prepend a zero byte and
+      bump the exponent.
+    * The coefficient must be exactly three bytes, left padded with zeros if
+      needed.
+    * Return ``(exponent << 24) | coefficient``.
+    """
+
+    raise NotImplementedError("Step 1B: target_to_bits")
+
+
+def target_to_difficulty(target: int) -> Decimal:
+    """Step 1C – convert a target into human-readable difficulty."""
+
+    raise NotImplementedError("Step 1C: target_to_difficulty")
+
+
+def difficulty_to_target(difficulty: Decimal) -> int:
+    """Step 1D – invert :func:`target_to_difficulty` using ``Decimal`` math."""
+
+    raise NotImplementedError("Step 1D: difficulty_to_target")
+
+
+def le_hex_to_bytes(hex_string: str) -> bytes:
+    """Step 2A – convert big-endian display hex into little-endian bytes."""
+
+    raise NotImplementedError("Step 2A: le_hex_to_bytes")
+
+
+def dsha256(payload: bytes) -> bytes:
+    """Step 2B – return ``SHA256(SHA256(payload))`` bytes."""
+
+    raise NotImplementedError("Step 2B: dsha256")
+
+
+def serialize_header(
+    version: int,
+    prev_block_hex: str,
+    merkle_root_hex: str,
+    timestamp: int,
+    nbits: int,
+    nonce: int,
+) -> bytes:
+    """Step 2C – serialize a block header into 80 little-endian bytes."""
+
+    raise NotImplementedError("Step 2C: serialize_header")
+
+
+def header_hash(
+    version: int,
+    prev_block_hex: str,
+    merkle_root_hex: str,
+    timestamp: int,
+    nbits: int,
+    nonce: int,
+) -> tuple[int, str]:
+    """Step 2D – compute the double-SHA256 hash and big-endian hex digest."""
+
+    raise NotImplementedError("Step 2D: header_hash")
+
+
+def is_valid_pow(hash_value: int, target: int) -> bool:
+    """Step 2E – return ``True`` when ``hash_value <= target``."""
+
+    raise NotImplementedError("Step 2E: is_valid_pow")
+
+
+def merkle_root(txids_hex: list[str]) -> tuple[str, str]:
+    """Step 3 – build a Merkle root from transaction IDs.
+
+    The first element of the tuple is the big-endian hex string for display.
+    The second element is the little-endian hex string for header insertion.
+    Duplicate the final hash on odd levels.
+    """
+
+    raise NotImplementedError("Step 3: merkle_root")
+
+
+def success_prob_per_hash(target: int) -> Decimal:
+    """Step 4A – approximate ``target / 2**256`` as a :class:`Decimal`."""
+
+    raise NotImplementedError("Step 4A: success_prob_per_hash")
+
+
+def expected_hashes(target: int) -> Decimal:
+    """Step 4B – return the expected number of hashes for success."""
+
+    raise NotImplementedError("Step 4B: expected_hashes")
+
+
+def expected_time_seconds(target: int, hashrate_hs: Decimal) -> Decimal:
+    """Step 4C – expected seconds to solve a block at ``hashrate_hs``."""
+
+    raise NotImplementedError("Step 4C: expected_time_seconds")
+
+
+def is_share_valid(hash_value: int, share_target: int) -> bool:
+    """Step 4D – helper for pool share validation checks."""
+
+    raise NotImplementedError("Step 4D: is_share_valid")
+
+
+def clamp_retarget_timespan(actual_timespan: int, target_timespan: int = TARGET_TIMESPAN) -> int:
+    """Step 5A – clamp the observed timespan by Bitcoin's 4× bounds."""
+
+    raise NotImplementedError("Step 5A: clamp_retarget_timespan")
+
+
+def compute_retarget(
+    old_target: int,
+    first_timestamp: int,
+    last_timestamp: int,
+    target_timespan: int = TARGET_TIMESPAN,
+) -> tuple[int, int]:
+    """Step 5B – compute the next target and compact bits after retarget."""
+
+    raise NotImplementedError("Step 5B: compute_retarget")

--- a/tests/test_bitcoin_pow_worksheet.py
+++ b/tests/test_bitcoin_pow_worksheet.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from codex.worksheets import bitcoin_pow as bp
+
+
+def call_or_skip(func, *args, **kwargs):
+    try:
+        return func(*args, **kwargs)
+    except NotImplementedError as exc:  # pragma: no cover - skip helper
+        pytest.skip(str(exc))
+
+
+class TestStep1DifficultyMath:
+    def test_bits_to_target_genesis(self):
+        target = call_or_skip(bp.bits_to_target, 0x1D00FFFF)
+        assert target == bp.T1
+
+    def test_bits_to_target_small_exponent(self):
+        target = call_or_skip(bp.bits_to_target, 0x01123456)
+        assert target == 0x12
+
+    def test_target_to_bits_round_trip(self):
+        target = call_or_skip(bp.bits_to_target, 0x05009234)
+        bits = call_or_skip(bp.target_to_bits, target)
+        assert bits == 0x05009234
+
+    def test_target_to_bits_handles_high_bit(self):
+        bits = call_or_skip(bp.target_to_bits, 0x12)
+        assert bits == 0x01120000
+
+    def test_difficulty_conversions(self):
+        target = call_or_skip(bp.bits_to_target, 0x1B0404CB)
+        diff = call_or_skip(bp.target_to_difficulty, target)
+        expected = Decimal(bp.T1) / Decimal(target)
+        assert diff == expected
+
+        rebuilt_target = call_or_skip(bp.difficulty_to_target, Decimal("2"))
+        assert rebuilt_target == int(Decimal(bp.T1) / Decimal(2))
+
+
+class TestStep2HeaderHashing:
+    def test_le_hex_to_bytes_roundtrip(self):
+        payload = call_or_skip(bp.le_hex_to_bytes, "aabbccdd")
+        assert payload == bytes.fromhex("ddccbbaa")
+
+    def test_dsha256(self):
+        digest = call_or_skip(bp.dsha256, b"bitcoin")
+        assert digest.hex() == (
+            "f1ef1bf105d788352c052453b15a913403be59b90ddf9f7c1f937edee8938dc5"
+        )
+
+    def test_serialize_and_hash_genesis(self):
+        header = call_or_skip(
+            bp.serialize_header,
+            1,
+            "00" * 32,
+            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b",
+            1231006505,
+            0x1D00FFFF,
+            2083236893,
+        )
+        assert len(header) == 80
+        assert header[:4] == (1).to_bytes(4, "little")
+
+        hash_int, hash_hex = call_or_skip(
+            bp.header_hash,
+            1,
+            "00" * 32,
+            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b",
+            1231006505,
+            0x1D00FFFF,
+            2083236893,
+        )
+        assert hash_hex == "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
+        assert hash_int == 10628944869218562084050143519444549580389464591454674019345556079
+        assert call_or_skip(bp.is_valid_pow, hash_int, bp.T1) is True
+
+
+class TestStep3MerkleRoots:
+    def test_merkle_root_three_transactions(self):
+        txids = [
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        ]
+        root_be, root_le = call_or_skip(bp.merkle_root, txids)
+        assert root_be == "1946e9d4a203723d7d7464f5d158c3f411c7ba5c82014d97342e447f8326f2d6"
+        assert root_le == "d6f226837f442e34974d01825cbac711f4c358d1f564747d3d7203a2d4e94619"
+
+    def test_merkle_root_empty(self):
+        root_be, root_le = call_or_skip(bp.merkle_root, [])
+        assert root_be == "00" * 32
+        assert root_le == "00" * 32
+
+
+class TestStep4Probability:
+    def test_success_probability(self):
+        target = bp.T1 // 2
+        prob = call_or_skip(bp.success_prob_per_hash, target)
+        expected = Decimal(target) / bp.TWO_256
+        assert prob == expected
+
+    def test_expected_hashes_and_time(self):
+        target = bp.T1 // 1024
+        hashes = call_or_skip(bp.expected_hashes, target)
+        expected_hashes = Decimal(1) / (Decimal(target) / bp.TWO_256)
+        assert hashes == expected_hashes
+
+        seconds = call_or_skip(bp.expected_time_seconds, target, Decimal("1e12"))
+        assert seconds == expected_hashes / Decimal("1e12")
+
+    def test_share_validation(self):
+        assert call_or_skip(bp.is_share_valid, 10, 100) is True
+        assert call_or_skip(bp.is_share_valid, 200, 100) is False
+
+
+class TestStep5Retarget:
+    def test_clamp_timespan(self):
+        assert call_or_skip(bp.clamp_retarget_timespan, bp.TARGET_TIMESPAN) == bp.TARGET_TIMESPAN
+        assert call_or_skip(bp.clamp_retarget_timespan, bp.TARGET_TIMESPAN // 10) == (
+            bp.TARGET_TIMESPAN // 4
+        )
+        assert call_or_skip(bp.clamp_retarget_timespan, bp.TARGET_TIMESPAN * 10) == (
+            bp.TARGET_TIMESPAN * 4
+        )
+
+    def test_compute_retarget(self):
+        old_target = bp.T1 // 1024
+        base = 1_000_000
+
+        new_target, new_bits = call_or_skip(
+            bp.compute_retarget,
+            old_target,
+            base,
+            base + bp.TARGET_TIMESPAN // 2,
+        )
+        assert new_target == 13163835591314115963455310715197261394536571649694416057684459520
+        assert new_bits == 0x1B1FFFE0
+
+        slow_target, slow_bits = call_or_skip(
+            bp.compute_retarget,
+            old_target,
+            base,
+            base + bp.TARGET_TIMESPAN * 2,
+        )
+        assert slow_target == 52655342365256463853821242860789045578146286598777664230737838080
+        assert slow_bits == 0x1B7FFF80
+
+        fast_target, fast_bits = call_or_skip(
+            bp.compute_retarget,
+            old_target,
+            base,
+            base + bp.TARGET_TIMESPAN // 10,
+        )
+        assert fast_target == 6581917795657057981727655357598630697268285824847208028842229760
+        assert fast_bits == 0x1B0FFFF0


### PR DESCRIPTION
## Summary
- add a Codex worksheet module that scaffolds Bitcoin proof-of-work helpers across five sequential steps
- document the worksheet instructions in a dedicated prompt for agents to follow
- add a pytest suite that gradually unlocks as each worksheet step is implemented

## Testing
- pytest tests/test_bitcoin_pow_worksheet.py

------
https://chatgpt.com/codex/tasks/task_e_68d85acf0e648329aa09b4e656399cd9