### PR TITLE
feat(ci): add Pi onion export and masked digest notifier workflows

### DIFF
--- a/.github/workflows/masked-digests-notify.yml
+++ b/.github/workflows/masked-digests-notify.yml
@@ -1,0 +1,106 @@
+name: Addresses • Masked Digest Notifier
+
+on:
+  workflow_dispatch:
+    inputs:
+      secrets_csv:
+        description: "CSV of secret names (e.g. ROBINHOOD_ETHEREUM,COINBASE_BITCOIN)"
+        type: string
+        required: true
+      to_slack:
+        description: "Post to Slack (uses secret SLACK_WEBHOOK_URL)"
+        type: boolean
+        required: true
+        default: false
+      to_discord:
+        description: "Post to Discord (uses secret DISCORD_WEBHOOK_URL)"
+        type: boolean
+        required: true
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+
+      # Build masked table without printing raw values
+      - name: Build masked digest table
+        id: table
+        env:
+          CSV: ${{ inputs.secrets_csv }}
+          # Inject each secret into env using built-in context
+          # We'll load values step-by-step and never echo them.
+        shell: bash
+        run: |
+          set -euo pipefail
+          CSV="$CSV"
+          IFS=',' read -ra NAMES <<< "$CSV"
+          # export env vars:
+          for n in "${NAMES[@]}"; do
+            key="$(echo "$n" | xargs)"
+            # write to temp file to avoid echoing in logs
+            {
+              echo "$key<<EOF"
+              echo "${{ secrets[key] }}"
+              echo "EOF"
+            } >> $GITHUB_ENV
+          done
+
+          node - <<'NODE'
+          const crypto = require('crypto');
+          const csv = process.env.CSV || '';
+          const names = csv.split(',').map(s=>s.trim()).filter(Boolean);
+          const rows = [];
+          rows.push(['NAME','LEN','MASKED','DIGEST8']);
+          for (const name of names) {
+            const v = process.env[name] || '';
+            const dg = crypto.createHash('sha256').update(v,'utf8').digest('hex').slice(0,8);
+            const masked = v ? '****' + v.slice(-6) : '';
+            rows.push([name, String(v.length), masked, dg]);
+          }
+          const w = i => Math.max(...rows.map(r => (r[i]||'').length));
+          const W = [0,1,2,3].map(w);
+          const line = r => r.map((c,i)=> (i===0? c.padEnd(W[i]) : c.padStart(W[i])) ).join('  ');
+          const out = [line(rows[0]), '-'.repeat(W.reduce((a,b)=>a+b,0)+6)]
+                      .concat(rows.slice(1).map(line)).join('\n');
+          // set outputs
+          const core = require('fs');
+          core.writeFileSync('masked_table.txt', out+'\n');
+          console.log(out); // safe: masked + digests only
+          NODE
+
+      - name: Upload summary artifact (optional)
+        uses: actions/upload-artifact@v4
+        with:
+          name: masked-digests
+          path: masked_table.txt
+
+      - name: Post to Slack (optional)
+        if: ${{ inputs.to_slack }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        shell: bash
+        run: |
+          test -n "$SLACK_WEBHOOK_URL"
+          body=$(jq -Rs '{text: ("Masked address digests:\n```" + . + "```")}' < masked_table.txt)
+          curl -s -X POST -H 'content-type: application/json' \
+            --data "$body" "$SLACK_WEBHOOK_URL" >/dev/null
+
+      - name: Post to Discord (optional)
+        if: ${{ inputs.to_discord }}
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        shell: bash
+        run: |
+          test -n "$DISCORD_WEBHOOK_URL"
+          content="Masked address digests:\n\`\`\`\n$(cat masked_table.txt)\n\`\`\`"
+          curl -s -X POST -H 'content-type: application/json' \
+            --data "$(jq -n --arg content "$content" '{content:$content}')" \
+            "$DISCORD_WEBHOOK_URL" >/dev/null

--- a/.github/workflows/tor-onion-export.yml
+++ b/.github/workflows/tor-onion-export.yml
@@ -1,0 +1,73 @@
+name: Tor • Onion Export (Pi)
+
+on:
+  workflow_dispatch:
+    inputs:
+      redact:
+        description: "Redact onion (show head/tail only)?"
+        type: boolean
+        required: true
+        default: true
+      compose_main:
+        description: "Path to main compose (on Pi)"
+        type: string
+        required: true
+        default: "~/btc-compose.yml"
+      compose_tor:
+        description: "Path to Tor compose fragment (in repo)"
+        type: string
+        required: true
+        default: "lightning/tor/compose.tor.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  export:
+    # Runs ON the Pi so it can read the real tor hostname from the container
+    runs-on: [self-hosted, linux, blackroad-pi]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Ensure tor is up (no-op if already running)
+        shell: bash
+        run: |
+          set -euo pipefail
+          MAIN="${{ inputs.compose_main }}"
+          TOR="${{ inputs.compose_tor }}"
+          docker compose -f "$MAIN" -f "$TOR" up -d tor
+          docker compose -f "$MAIN" -f "$TOR" ps tor
+
+      - name: Read onion hostname from tor sidecar
+        id: onion
+        shell: bash
+        run: |
+          set -euo pipefail
+          MAIN="${{ inputs.compose_main }}"
+          TOR="${{ inputs.compose_tor }}"
+          host=$(docker compose -f "$MAIN" -f "$TOR" exec -T tor sh -lc 'cat /var/lib/tor/lightning/hostname' 2>/dev/null || true)
+          if [ -z "$host" ]; then
+            echo "No onion hostname found (tor not ready?)" >&2
+            exit 1
+          fi
+          echo "full=$host" >> $GITHUB_OUTPUT
+          # redact in logs by default
+          if [ "${{ inputs.redact }}" = "true" ]; then
+            echo "mask=on" >> $GITHUB_OUTPUT
+            echo "::notice title=Tor Onion (redacted)::${host:0:10}…${host: -10}"
+          else
+            echo "mask=off" >> $GITHUB_OUTPUT
+            echo "::notice title=Tor Onion::${host}"
+          fi
+
+      - name: Job Summary
+        shell: bash
+        run: |
+          if [ "${{ steps.onion.outputs.mask }}" = "on" ]; then
+            red="${{ steps.onion.outputs.full }}"
+            echo "### Tor Onion (redacted)" >> $GITHUB_STEP_SUMMARY
+            echo "\`${red:0:10}…${red: -10}\`" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "### Tor Onion" >> $GITHUB_STEP_SUMMARY
+            echo "\`${{ steps.onion.outputs.full }}\`" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/docs/runner-pi.md
+++ b/docs/runner-pi.md
@@ -1,0 +1,28 @@
+# Self-hosted GitHub Runner on the Pi
+
+We run the Tor Onion Export workflow **on the Pi** so it can read the real
+`/var/lib/tor/lightning/hostname` from the Tor container locally.
+
+## Install runner (once)
+1. Create a runner in GitHub: Repo → **Settings → Actions → Runners → New self-hosted runner**.
+2. Choose **Linux** / **ARM64**; follow the printed commands on the Pi:
+   ```bash
+   # example (from GitHub’s UI):
+   mkdir -p ~/actions-runner && cd ~/actions-runner
+   curl -o actions-runner-linux-arm64-<ver>.tar.gz -L https://...
+   tar xzf actions-runner-linux-arm64-<ver>.tar.gz
+   ./config.sh --url https://github.com/<org>/<repo> --token <TOKEN>
+   ```
+3. Add labels so workflows can target this runner (recommended label: `blackroad-pi`).
+   You can set labels during `./config.sh` or later in the UI.
+4. (Optional) Install as a service:
+   ```bash
+   sudo ./svc.sh install
+   sudo ./svc.sh start
+   ```
+
+## Requirements on the Pi
+- Docker/Compose installed (already in your setup).
+- Your `btc-compose.yml` and Tor sidecar file available at the paths used by the workflow. By default we reference:
+  - `~/btc-compose.yml`
+  - `lightning/tor/compose.tor.yml` (from repo)


### PR DESCRIPTION
## Summary
- add setup guide for configuring the Pi self-hosted runner used by Tor exports
- add a Tor Onion Export workflow that runs on the labeled Pi runner and reads the hostname from the Tor container
- add a masked digest notifier workflow that builds a redacted address table and can post to Slack or Discord

## Testing
- not run (workflows only)


------
https://chatgpt.com/codex/tasks/task_e_68d861441db8832994e634409d718bb0