### PR TITLE
Add workflow to auto-mention teams based on changed paths

### DIFF
--- a/.github/workflows/auto-mention.yml
+++ b/.github/workflows/auto-mention.yml
@@ -1,7 +1,7 @@
 name: Auto-mention reviewers
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, ready_for_review]
 
 permissions:
@@ -16,7 +16,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Detect changed files
         id: changed


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that scans changed files in pull requests
- automatically mention the appropriate teams based on path patterns and keep a single routed comment per PR

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d8615ea6e48329969e8262f9af437a