### PR TITLE
feat: add iterative auto fixes to PR autopilot

### DIFF
--- a/agents/pr_autopilot.py
+++ b/agents/pr_autopilot.py
@@ -8,7 +8,7 @@ import subprocess
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Sequence
 
 import requests
 
@@ -23,6 +23,10 @@ class AutomatedPullRequestManager:
     codex_trigger: str = "@codex"
     log_file: str = "pr_autopilot.log"
     token: Optional[str] = None
+    auto_fix_commands: tuple[Sequence[str] | str, ...] = (
+        ("bash", "fix-everything.sh"),
+    )
+    max_fix_iterations: int = 3
 
     def __post_init__(self) -> None:
         if self.token is None:
@@ -31,10 +35,7 @@ class AutomatedPullRequestManager:
 
     def monitor_repo(self) -> bool:
         """Check whether the repository has uncommitted changes."""
-        result = subprocess.run(
-            ["git", "status", "--porcelain"], capture_output=True, text=True, check=False
-        )
-        return bool(result.stdout.strip())
+        return self._has_uncommitted_changes(Path.cwd())
 
     def prepare_draft_pr(self) -> None:
         """Create a draft pull request from the latest commit."""
@@ -51,6 +52,7 @@ class AutomatedPullRequestManager:
         body = f"### Diff Summary\n```\n{diff[:1000]}\n```\n"
         pr = self._create_pr(commit_msg, branch_name, "main", body)
         self._assign_reviewer(pr["number"])
+        self.auto_enhance_pull_request(pr["number"], branch_name)
         logging.info("Opened draft PR #%s", pr["number"])
 
     def _create_pr(self, title: str, head: str, base: str, body: str) -> dict:
@@ -99,6 +101,104 @@ class AutomatedPullRequestManager:
     def log(self, message: str) -> None:
         """Write a message to the log file."""
         logging.info(message)
+
+    def auto_enhance_pull_request(self, pr_number: int, branch_name: str) -> None:
+        """Apply configured fixers to iteratively improve an open pull request."""
+        if not self.auto_fix_commands:
+            self.log("No auto-fix commands configured; skipping enhancements.")
+            return
+
+        repo_root = Path(__file__).resolve().parents[1]
+        try:
+            subprocess.run(["git", "checkout", branch_name], cwd=repo_root, check=True)
+        except (OSError, subprocess.CalledProcessError) as exc:
+            self.log(f"Unable to checkout branch {branch_name!r}: {exc}")
+            return
+
+        for iteration in range(1, self.max_fix_iterations + 1):
+            self.log(f"Running auto-fix iteration {iteration} for PR #{pr_number}")
+
+            for command in self.auto_fix_commands:
+                self._run_auto_fix_command(command, repo_root)
+
+            if not self._has_uncommitted_changes(repo_root):
+                self.log(f"No changes detected after auto-fix iteration {iteration}; stopping.")
+                break
+
+            if not self._commit_and_push(branch_name, repo_root, iteration):
+                break
+
+            self._comment_on_pr(
+                pr_number,
+                f"Auto-fix pass {iteration} applied :sparkles:",
+            )
+
+    def _has_uncommitted_changes(self, cwd: Path) -> bool:
+        result = subprocess.run(
+            ["git", "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=cwd,
+        )
+        return bool(result.stdout.strip())
+
+    def _run_auto_fix_command(
+        self, command: Sequence[str] | str, repo_root: Path
+    ) -> bool:
+        shell = isinstance(command, str)
+        cmd = command if shell else list(command)
+        try:
+            subprocess.run(
+                cmd,
+                cwd=repo_root,
+                check=True,
+                shell=shell,
+            )
+            return True
+        except (OSError, subprocess.CalledProcessError) as exc:
+            self.log(f"Auto-fix command {command!r} failed: {exc}")
+            return False
+
+    def _commit_and_push(self, branch_name: str, repo_root: Path, iteration: int) -> bool:
+        try:
+            subprocess.run(["git", "add", "-A"], cwd=repo_root, check=True)
+            commit_message = f"chore: auto improvements (pass {iteration})"
+            subprocess.run(
+                ["git", "commit", "-m", commit_message],
+                cwd=repo_root,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "push", "origin", branch_name],
+                cwd=repo_root,
+                check=True,
+            )
+            return True
+        except subprocess.CalledProcessError as exc:
+            self.log(f"Failed to commit/push auto-fix iteration {iteration}: {exc}")
+            return False
+
+    def _comment_on_pr(self, pr_number: int, message: str) -> None:
+        if not self.token:
+            self.log("Skipping PR comment because no token is configured.")
+            return
+
+        url = f"https://api.github.com/repos/{self.repo}/issues/{pr_number}/comments"
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"token {self.token}",
+        }
+        try:
+            response = requests.post(
+                url,
+                json={"body": message},
+                headers=headers,
+                timeout=10,
+            )
+            response.raise_for_status()
+        except requests.RequestException as exc:
+            self.log(f"Failed to post auto-fix comment to PR #{pr_number}: {exc}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend the PR autopilot manager with configurable auto-fix commands that run after a branch is created
- iterate through fix passes that commit, push, and comment on improvements while stopping when no changes occur or failures happen
- add helpers for checking repository status and running fix commands to support the automated loop

## Testing
- python -m py_compile *.py
- python auto_novel_agent.py

------
https://chatgpt.com/codex/tasks/task_e_68d864d970448329a61dfd58656fcde7