### PR TITLE
Add Pi console connectivity checks for offline/online usage

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -157,4 +157,9 @@ export async function infer(x, y){
   return data
 }
 
+export async function fetchPiStatus(){
+  const { data } = await axios.get(`${API_BASE}/api/pi/status`)
+  return data
+}
+
 export { API_BASE }

--- a/frontend/src/components/AgentStack.jsx
+++ b/frontend/src/components/AgentStack.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Cpu, Activity, Wallet as WalletIcon } from 'lucide-react'
 import { LineChart, Line, XAxis, YAxis, ResponsiveContainer } from 'recharts'
+import PiConsole from './PiConsole.jsx'
 
 function MiniChart({ data, dataKey }){
   return (
@@ -90,6 +91,7 @@ export default function AgentStack({ stream, setStream, system, wallet, contradi
         <div className="font-semibold mb-2">Session Notes</div>
         <textarea className="input w-full h-28 resize-none" value={notes} onChange={e=>setNotes(e.target.value)} />
       </div>
+      <PiConsole />
     </div>
   )
 }

--- a/frontend/src/components/PiConsole.jsx
+++ b/frontend/src/components/PiConsole.jsx
@@ -1,0 +1,122 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import { fetchPiStatus } from '../api'
+
+const DEFAULT_POLL_MS = 15000
+
+function useBrowserOnline() {
+  const [online, setOnline] = useState(
+    typeof navigator === 'undefined' ? true : navigator.onLine
+  )
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const on = () => setOnline(true)
+    const off = () => setOnline(false)
+    window.addEventListener('online', on)
+    window.addEventListener('offline', off)
+    return () => {
+      window.removeEventListener('online', on)
+      window.removeEventListener('offline', off)
+    }
+  }, [])
+
+  return online
+}
+
+export default function PiConsole({ pollMs = DEFAULT_POLL_MS }) {
+  const [status, setStatus] = useState(null)
+  const [error, setError] = useState(null)
+  const browserOnline = useBrowserOnline()
+
+  useEffect(() => {
+    let ignore = false
+    let timer
+
+    async function load() {
+      try {
+        const data = await fetchPiStatus()
+        if (!ignore) {
+          setStatus(data)
+          setError(null)
+        }
+      } catch (err) {
+        if (!ignore) {
+          setError(err)
+        }
+      }
+    }
+
+    load()
+    timer = setInterval(load, pollMs)
+    return () => {
+      ignore = true
+      clearInterval(timer)
+    }
+  }, [pollMs])
+
+  const reachable = useMemo(() => {
+    if (!browserOnline) return false
+    if (!status) return false
+    if (error) return false
+    return Boolean(status.reachable)
+  }, [browserOnline, status, error])
+
+  const command = status?.command || 'ssh pi@192.168.4.23 -p 22'
+  const url = status?.url
+  const lastTs = status?.ts ? new Date(status.ts) : null
+
+  function handleOpen() {
+    if (!reachable) return
+    if (!url) return
+    if (typeof window === 'undefined') return
+    window.open(url, '_blank', 'noopener,noreferrer')
+  }
+
+  let helperText = 'Checking connectivity…'
+  if (!browserOnline) {
+    helperText = 'Browser offline. Use the SSH command below to connect locally.'
+  } else if (reachable) {
+    helperText = 'Online — the Pi console can be opened in a new tab.'
+  } else if (error) {
+    helperText = 'Unable to reach the Pi status endpoint. Retrying automatically.'
+  } else if (status) {
+    helperText = 'Pi appears offline. Ensure the device is powered on or reachable from this network.'
+  }
+
+  return (
+    <div className="card p-4 space-y-3">
+      <div>
+        <div className="font-semibold">Pi Console</div>
+        <div className="text-xs text-slate-400 mt-1">
+          Target: {status ? `${status.host}:${status.port}` : 'Detecting…'}
+        </div>
+      </div>
+      <div className={`text-sm font-semibold ${reachable ? 'text-green-400' : 'text-red-400'}`}>
+        {browserOnline ? (reachable ? 'Online' : 'Offline') : 'Offline'}
+      </div>
+      <div className="text-xs text-slate-400">{helperText}</div>
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+        <button
+          className="btn"
+          type="button"
+          onClick={handleOpen}
+          disabled={!reachable}
+          style={{
+            backgroundColor: 'var(--accent-2)',
+            color: '#000',
+            opacity: reachable ? 1 : 0.5,
+          }}
+        >
+          Open Pi Console
+        </button>
+        <code className="text-xs bg-slate-900 px-3 py-2 rounded select-all">
+          {command}
+        </code>
+      </div>
+      <div className="text-xs text-slate-500">
+        {lastTs ? `Last checked ${lastTs.toLocaleTimeString()}` : 'Awaiting status…'}
+      </div>
+    </div>
+  )
+}
+

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -18,6 +18,7 @@ router.use('/commits', require('./commits'));
 router.use('/metrics', require('./metrics'));
 router.use('/llm', require('./llm'));
 router.use('/lucidia', require('./lucidia'));
+router.use('/pi', require('./pi'));
 router.use('/roadbook', require('./roadbook'));
 router.use('/deploy', require('./deploy'));
 router.use('/json', require('./json'));

--- a/src/routes/pi.js
+++ b/src/routes/pi.js
@@ -1,0 +1,73 @@
+'use strict';
+
+let express;
+try {
+  express = require('express');
+} catch (_err) {
+  express = null;
+}
+const net = require('net');
+
+const router = express ? express.Router() : { get: () => {} };
+
+function parseNumber(value, fallback) {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isNaN(parsed) ? fallback : parsed;
+}
+
+function checkTcp(host, port, timeout) {
+  return new Promise((resolve) => {
+    const socket = new net.Socket();
+    let finished = false;
+
+    const finalize = (result) => {
+      if (finished) return;
+      finished = true;
+      socket.destroy();
+      resolve(result);
+    };
+
+    socket.setTimeout(timeout);
+    socket.once('connect', () => finalize(true));
+    socket.once('timeout', () => finalize(false));
+    socket.once('error', () => finalize(false));
+
+    try {
+      socket.connect(port, host);
+    } catch (_err) {
+      finalize(false);
+    }
+  });
+}
+
+async function buildStatusPayload() {
+  const host = process.env.PI_HOST || '192.168.4.23';
+  const port = parseNumber(process.env.PI_PORT, 22);
+  const user = process.env.PI_USER || 'pi';
+  const timeout = parseNumber(process.env.PI_TIMEOUT_MS, 2000);
+  const targetUrl =
+    process.env.PI_TARGET_URL || `http://${user}@${host}:${port}/`;
+
+  const reachable = await checkTcp(host, port, timeout);
+
+  return {
+    ok: true,
+    host,
+    port,
+    user,
+    reachable,
+    url: targetUrl,
+    command: `ssh ${user}@${host} -p ${port}`,
+    timeout_ms: timeout,
+    ts: new Date().toISOString(),
+  };
+}
+
+router.get('/status', async (_req, res) => {
+  const payload = await buildStatusPayload();
+  res.json(payload);
+});
+
+module.exports = router;
+module.exports.buildStatusPayload = buildStatusPayload;
+

--- a/tests/test_pi_status.js
+++ b/tests/test_pi_status.js
@@ -1,0 +1,19 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+process.env.PI_HOST = '127.0.0.1'
+process.env.PI_PORT = '1'
+process.env.PI_TARGET_URL = 'http://pi.local/'
+
+const { buildStatusPayload } = require('../src/routes/pi')
+
+test('pi status endpoint returns structured payload', async () => {
+  const body = await buildStatusPayload()
+  assert.equal(body.ok, true)
+  assert.equal(body.host, '127.0.0.1')
+  assert.equal(body.port, 1)
+  assert.equal(body.url, 'http://pi.local/')
+  assert.equal(body.command, 'ssh pi@127.0.0.1 -p 1')
+  assert.ok(Object.prototype.hasOwnProperty.call(body, 'reachable'))
+  assert.ok(Object.prototype.hasOwnProperty.call(body, 'ts'))
+})
+


### PR DESCRIPTION
## Summary
- add backend endpoint that reports Raspberry Pi reachability with configurable host, port, and timeout defaults
- expose a frontend Pi console card that polls the status API, disables the launch button when offline, and shows the SSH command fallback
- cover the status payload helper with a node:test to keep the route logic reliable

## Testing
- node --test tests/test_pi_status.js

------
https://chatgpt.com/codex/tasks/task_e_68d86555055483299232094e62e9cfff