### PR TITLE
Add Raspberry Pi 4 mini tower integration guide

### DIFF
--- a/docs/raspberry-pi-4-mini-tower-case-integration-guide.md
+++ b/docs/raspberry-pi-4-mini-tower-case-integration-guide.md
@@ -1,0 +1,105 @@
+# Raspberry Pi 4 Mini Tower Case Integration Guide
+
+## Introduction
+Set up the Raspberry Pi 4 mini tower to act as a compact workstation, server, or automation hub. This guide walks through hardware assembly, storage and cooling integration, initial operating system setup, and optional enhancements.
+
+## Parts in the Kit
+| Component | Quantity | Purpose |
+| --- | --- | --- |
+| Raspberry Pi 4 Model B board | 1 | Core compute module for the build. |
+| Mini tower enclosure with acrylic panels | 1 | Protects components while providing airflow. |
+| ICE Tower cooler with 40 mm fan and RGB lighting | 1 | Keeps the CPU temperature stable during sustained workloads. |
+| M.2 SATA SSD expansion board (NGFF 2280/2260/2242) | 1 | Adds high-speed SATA storage through USB 3. |
+| USB 3.0 bridge cable (expansion board to Pi) | 1 | Links the SSD board to the Pi’s blue USB 3 port. |
+| GPIO fan power cable (5V and GND) | 1 | Powers the tower fan from the Pi. |
+| OLED display and ribbon cable | 1 | Displays system telemetry or status text. |
+| Standoffs, screws, and thermal pads | Assorted | Mounts the boards securely and ensures thermal contact. |
+
+## Tools Required
+- Small Phillips-head screwdriver
+- Tweezers or needle-nose pliers (helpful for jumpers and small screws)
+- Antistatic wrist strap (recommended)
+
+## Pre-Assembly Checklist
+1. Power off the Raspberry Pi and disconnect every cable.
+2. Remove protective film from the acrylic panels.
+3. Confirm you have a 5 V / 3 A USB-C power supply ready.
+4. Back up any data on the Pi’s existing storage media.
+
+## Hardware Assembly Steps
+1. **Install motherboard standoffs.** Thread the four brass standoffs into the base plate of the mini tower.
+2. **Mount the expansion board.** Align the M.2 SATA expansion board with its standoffs and secure it with the provided screws.
+3. **Insert the Raspberry Pi 4.** Slide the Pi’s ports into the case cutouts and fasten the board to the standoffs.
+4. **Attach the SSD.** Insert the M.2 SATA SSD into the expansion board at a 30° angle, push it flat, and secure it with the single retaining screw. Only SATA drives are supported; NVMe drives will not work.
+5. **Connect the USB bridge.** Plug the USB 3.0 bridge cable into the expansion board and the Raspberry Pi’s blue USB 3 port to enable SSD communication.
+6. **Place thermal pads.** Position pads on the CPU, RAM, and USB controller as indicated by the kit diagram so they contact the cooler.
+7. **Mount the ICE Tower cooler.** Lower the heatsink onto the pads, align the holes with the Pi mounting points, and tighten the screws evenly.
+8. **Connect the cooling fan.** Plug the fan cable onto the Pi’s GPIO header (5V on pin 4, GND on pin 6). Confirm the connector seats firmly.
+9. **Install the OLED display.** Route the ribbon cable carefully, insert it into the display header, and lock the latch. Secure the display panel to the case bracket.
+10. **Attach side panels.** Fit each acrylic panel and fasten it with the supplied screws without overtightening.
+11. **Verify cabling.** Confirm that the USB bridge, fan connector, and ribbon cable are all firmly seated and clear of the fan blades.
+
+## Initial Power-On Checklist
+1. Connect the monitor (HDMI), keyboard, and mouse or prepare for headless access.
+2. Plug in the power supply and turn on the Pi.
+3. Confirm that the fan spins and the OLED backlight turns on.
+4. If the Pi fails to boot, disconnect power, recheck cable orientation, and ensure the SSD is fully seated.
+
+## Operating System Preparation
+1. Download the latest Raspberry Pi OS or preferred distribution.
+2. Flash a microSD card with Raspberry Pi Imager. Use the advanced options to configure hostname, SSH, and Wi-Fi credentials when needed.
+3. Insert the microSD card before powering on. If you plan to boot directly from the SSD, update the bootloader EEPROM using `sudo raspi-config` (Advanced Options → Boot Order) after the first boot from microSD.
+4. Optional: Clone the microSD image to the SSD using SD Card Copier (Desktop) or `rpi-clone` / `dd` on the command line.
+
+## Network Configuration
+### Ethernet Setup
+1. Connect an Ethernet cable from the Pi to your router or switch.
+2. Boot the Pi and confirm it obtains an IP address via DHCP (`ip addr show eth0`).
+
+### Wi-Fi Setup
+1. On Raspberry Pi OS Desktop, click the network icon and select your SSID, entering the passphrase when prompted.
+2. For headless setups, add a `wpa_supplicant.conf` file to the `/boot` partition before the first boot or configure Wi-Fi via Raspberry Pi Imager’s advanced options.
+3. Verify connectivity with `ping -c 4 raspberrypi.org`.
+
+## SSD Partitioning and Mounting
+1. Run `lsblk` to identify the SSD (usually `sda`).
+2. Partition the drive with `sudo fdisk /dev/sda`, creating a new primary partition.
+3. Format the partition: `sudo mkfs.ext4 /dev/sda1`.
+4. Create a mount point (`sudo mkdir /mnt/ssd`) and mount the drive (`sudo mount /dev/sda1 /mnt/ssd`).
+5. Add an `/etc/fstab` entry to mount the drive automatically on boot.
+
+## Enabling the OLED Display and Fan Lighting
+1. Enable I²C via `sudo raspi-config` (Interface Options → I2C → Enable).
+2. Install utilities: `sudo apt update && sudo apt install -y git python3-pip i2c-tools`.
+3. Detect the display with `sudo i2cdetect -y 1`. A result around `0x3C` confirms communication.
+4. Install Python libraries for the OLED: `pip install pillow luma.oled`.
+5. Clone the vendor scripts if provided (for example, `git clone https://github.com/geeekpi/absminitowerkit.git`) and run the setup script to configure systemd services for the OLED and RGB fan.
+6. Customize the OLED content by editing the Python script to display CPU temperature, IP address, or uptime. Restart the service after changes.
+7. Adjust RGB fan effects with the provided script or libraries such as `rpi_ws281x` to signal temperature thresholds.
+
+## Usage Ideas
+- **Media center:** Install LibreELEC or OSMC for a Kodi-based HTPC experience.
+- **Network-attached storage:** Configure Samba or OpenMediaVault to share the SSD across your network.
+- **Home automation hub:** Install Home Assistant or Node-RED and connect Zigbee, Z-Wave, or GPIO sensors.
+- **Development server:** Deploy a Docker environment or a LAMP stack for web prototypes and CI agents.
+- **Status display:** Program the OLED to show resource usage while using RGB lighting to signal system state.
+
+## Troubleshooting
+| Symptom | Possible Cause | Resolution |
+| --- | --- | --- |
+| Pi does not power on | Insufficient power supply | Use a 5 V / 3 A USB-C adapter and avoid drawing power from weak USB hubs. |
+| SSD not detected | USB bridge cable loose or NVMe drive installed | Reseat the cable and confirm the drive is SATA. Replace the cable if damage is visible. |
+| OLED remains blank | Ribbon reversed or I²C disabled | Reinsert the ribbon with correct orientation and re-enable I²C in `raspi-config`. |
+| Fan does not spin | GPIO connector misaligned | Ensure the fan’s red wire sits on 5 V (pin 4) and the black wire on GND (pin 6). |
+| High temperatures | Thermal pads misaligned or cooler loose | Reapply thermal pads, retighten the heatsink evenly, and confirm unobstructed airflow. |
+
+## Maintenance Tips
+- Inspect cable connections quarterly and clean dust from the heatsink and fan blades.
+- Update Raspberry Pi OS regularly with `sudo apt update && sudo apt full-upgrade`.
+- Monitor disk health via `sudo smartctl -a /dev/sda` if the SSD supports SMART.
+- Keep backups of critical data stored on the SSD by syncing to another drive or cloud service.
+
+## Further Resources
+- Official Raspberry Pi documentation for bootloader and storage configuration
+- Vendor repositories for OLED and fan lighting scripts
+- Raspberry Pi forums for community troubleshooting and project inspiration


### PR DESCRIPTION
## Summary
- add a comprehensive Raspberry Pi 4 mini tower case integration guide with hardware, software, and troubleshooting steps
- document SSD setup, network configuration, OLED/fan enablement, and usage ideas for the mini tower build

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d89b196d9c8329b1934443b1167e06