### PR TITLE
Add GitHub Action to auto-mention teams based on changed paths

### DIFF
--- a/.github/mention-routes.yml
+++ b/.github/mention-routes.yml
@@ -1,0 +1,15 @@
+# Globs → who to @
+routes:
+  - patterns: ["frontend/**", "apps/web/**"]
+    mention: "@your-org/frontend-team"
+  - patterns: ["api/**", "services/**"]
+    mention: "@your-org/api-team"
+  - patterns: ["infra/**", ".github/workflows/**"]
+    mention: "@your-org/platform-team"
+  - patterns: ["db/migrations/**"]
+    mention: "@your-org/data-team"
+  - patterns: ["docs/**"]
+    mention: "@your-handle"   # swap with your GH username
+
+# Always mention these on every PR (optional)
+always: []

--- a/.github/workflows/auto-mention.yml
+++ b/.github/workflows/auto-mention.yml
@@ -1,0 +1,83 @@
+name: Auto mention on PRs
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  mention:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Load mention routes
+        id: cfg
+        run: |
+          FILE=".github/mention-routes.yml"
+          if [ ! -f "$FILE" ]; then
+            echo "cfg=" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          echo "cfg<<EOF" >> $GITHUB_OUTPUT
+          cat "$FILE" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Get changed files (JSON)
+        id: changed
+        uses: tj-actions/changed-files@v45
+        with:
+          json: "true"
+
+      - name: Install PyYAML
+        run: python3 -m pip install --quiet PyYAML
+
+      - name: Compute mentions from routes
+        id: calc
+        shell: bash
+        run: |
+          mentions=$(python - <<'PY'
+import json, os, fnmatch, yaml
+cfg_text = os.environ.get('CFG_TEXT', '')
+changed_text = os.environ.get('CHANGED_FILES', '[]')
+if not cfg_text:
+    raise SystemExit(0)
+
+cfg = yaml.safe_load(cfg_text) or {}
+routes = cfg.get('routes', []) or []
+always = cfg.get('always', []) or []
+files = json.loads(changed_text)
+
+hits = set(always)
+for route in routes:
+    pats = route.get('patterns', []) or []
+    who = route.get('mention')
+    if not who:
+        continue
+    if any(any(fnmatch.fnmatch(f, p) for p in pats) for f in files):
+        hits.add(who)
+
+print(" ".join(sorted(hits)))
+PY
+)
+          echo "MENTIONS=$mentions" >> $GITHUB_OUTPUT
+        env:
+          CFG_TEXT: ${{ steps.cfg.outputs.cfg }}
+          CHANGED_FILES: ${{ steps.changed.outputs.all_changed_files }}
+
+      - name: Comment with mentions
+        if: ${{ steps.calc.outputs.MENTIONS != '' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = `Routing to: ${process.env.MENTIONS}\n\n(Automated based on changed paths.)`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body
+            })
+        env:
+          MENTIONS: ${{ steps.calc.outputs.MENTIONS }}


### PR DESCRIPTION
## Summary
- add a mention routing configuration for key repository paths
- add a GitHub Action workflow to comment on pull requests with the computed mentions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d89bbf8fac8329b3edd2c9ad2c63d4