### PR TITLE
Add Codex 38 connection creed

### DIFF
--- a/CONNECTION.md
+++ b/CONNECTION.md
@@ -1,0 +1,5 @@
+# Connection Policy Stub
+
+- Lucidia commits to open, respectful connection across systems and cultures.
+- Lucidia resists silos and lock-ins.
+- Lucidia documents and maintains its bridges transparently.

--- a/codex/README.md
+++ b/codex/README.md
@@ -15,6 +15,8 @@ integrations.
 | 003 | The Workflow Circle    | Work runs in visible capture → adjust loops.    |
 | 004 | The Autonomy Manifest  | Data autonomy through consent, export, and wipe. |
 | 022 | The Security Spine     | Security backbone with layered zero-trust defenses. |
+| 028 | The Custodianship Code | Custodians steward Lucidia as a shared trust.   |
+| 038 | The Connection Creed   | Bridges Lucidia with open, respectful interoperability. |
 
 ## BlackRoad Pipeline
 

--- a/codex/entries/038-connection-creed.md
+++ b/codex/entries/038-connection-creed.md
@@ -1,0 +1,28 @@
+# Codex 38 — The Connection Creed
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Principle
+Lucidia thrives not in isolation but in connection. Systems, cultures, and people are bridges, not borders.
+
+## Non-Negotiables
+1. **Open Standards:** APIs, formats, and protocols follow open specs wherever possible.
+2. **Interoperability First:** Features designed to work across ecosystems, not trap users.
+3. **Cross-Cultural Respect:** Interfaces and docs localized thoughtfully; no one culture is the silent default.
+4. **Mutual Bridges:** Lucidia integrates outward but also welcomes integrations inward.
+5. **Federation Support:** Decentralized links (federated IDs, data sharing) favored over centralization.
+6. **Resilient Links:** Connections degrade gracefully — no lockouts if one bridge fails.
+
+## Implementation Hooks (v0)
+- `/api/openapi.json` published with every release.
+- Export/import tested against at least two external tools.
+- Translation framework with community-driven language packs.
+- Federation endpoints for identity + data sync.
+- Health checks on external dependencies; graceful fallback when offline.
+
+## Policy Stub (`CONNECTION.md`)
+- Lucidia commits to open, respectful connection across systems and cultures.
+- Lucidia resists silos and lock-ins.
+- Lucidia documents and maintains its bridges transparently.
+
+**Tagline:** Bridges, not walls.


### PR DESCRIPTION
## Summary
- document Codex 38 — The Connection Creed with principles, non-negotiables, and implementation hooks
- add the connection policy stub for inclusion in CONNECTION.md
- update the codex catalog to list the custodianship and connection entries

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d88b5e9a948329bead83474453b830