### PR TITLE
Add GitHub Action to auto-mention teams on PRs

### DIFF
--- a/.github/mention-routes.yml
+++ b/.github/mention-routes.yml
@@ -1,0 +1,12 @@
+routes:
+  - patterns: ["frontend/**", "apps/web/**"]
+    mention: "@your-org/frontend-team"
+  - patterns: ["api/**", "services/**"]
+    mention: "@your-org/api-team"
+  - patterns: ["infra/**", ".github/workflows/**"]
+    mention: "@your-org/platform-team"
+  - patterns: ["db/migrations/**"]
+    mention: "@your-org/data-team"
+  - patterns: ["docs/**"]
+    mention: "@your-handle"
+always: []

--- a/.github/workflows/auto-mention.yml
+++ b/.github/workflows/auto-mention.yml
@@ -1,0 +1,83 @@
+name: Auto mention on PRs
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  mention:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Load mention routes
+        id: cfg
+        run: |
+          FILE=".github/mention-routes.yml"
+          if [ ! -f "$FILE" ]; then echo "cfg=" >> $GITHUB_OUTPUT; exit 0; fi
+          echo "cfg<<EOF" >> $GITHUB_OUTPUT
+          cat "$FILE" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Get changed files (JSON)
+        id: changed
+        uses: tj-actions/changed-files@v45
+        with:
+          json: "true"
+
+      - name: Install dependencies
+        run: python -m pip install --quiet pyyaml
+
+      - name: Compute mentions
+        id: calc
+        shell: bash
+        run: |
+          python - << 'PY'
+import json, os, fnmatch, yaml
+cfg_text = os.environ.get('CFG_TEXT','')
+if not cfg_text:
+    print("MENTIONS="); raise SystemExit(0)
+cfg = yaml.safe_load(cfg_text) or {}
+routes = cfg.get('routes', []) or []
+always = cfg.get('always', []) or []
+changed = json.loads(os.environ['CHANGED_JSON'])
+files = changed.get('all_changed_files', [])
+hits = set(always)
+for r in routes:
+  pats = r.get('patterns', []) or []
+  who = r.get('mention')
+  if who and any(any(fnmatch.fnmatch(f, p) for p in pats) for f in files):
+    hits.add(who)
+print("MENTIONS=" + " ".join(sorted(hits)))
+PY
+        env:
+          CFG_TEXT: ${{ steps.cfg.outputs.cfg }}
+          CHANGED_JSON: ${{ steps.changed.outputs.all_changed_files }}
+
+      - name: Create or update a single comment
+        if: ${{ steps.calc.outputs.MENTIONS != '' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const {owner, repo} = context.repo
+            const number = context.payload.pull_request.number
+            const body = `Routing to: ${process.env.MENTIONS}\n\n(Automated based on changed paths.)`
+
+            // find existing bot comment
+            const {data: comments} = await github.rest.issues.listComments({owner, repo, issue_number: number, per_page: 100})
+            const mine = comments.find(c =>
+              c.user.type === "Bot" &&
+              c.user.login.endsWith("[bot]") &&
+              c.body?.includes("(Automated based on changed paths.)")
+            )
+
+            if (mine) {
+              await github.rest.issues.updateComment({owner, repo, comment_id: mine.id, body})
+            } else {
+              await github.rest.issues.createComment({owner, repo, issue_number: number, body})
+            }
+        env:
+          MENTIONS: ${{ steps.calc.outputs.MENTIONS }}


### PR DESCRIPTION
## Summary
- add an auto-mention workflow that updates a single bot comment with routed mentions
- provide a mention routing configuration file covering core path groups

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d89ced7dc8832993016ed52793c8d7