### PR TITLE
Fix GitHub workflows using supported actions

### DIFF
--- a/.github/workflows/prism-ci.yml
+++ b/.github/workflows/prism-ci.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: '3.x'
       - run: pip install -r requirements-dev.txt
       - run: pytest tests/prism
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
         with:
           files: prism/server/coverage/coverage-final.json
       - run: docker build -t ghcr.io/blackroad/prism:${{ github.sha }} prism

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -17,8 +17,10 @@ jobs:
       - run: |
           echo "## v${{ github.event.inputs.version }}" > CHANGELOG.md
           git log --pretty=format:'* %s' $(git describe --tags --abbrev=0)..HEAD >> CHANGELOG.md
-      - uses: actions/create-release@v1
-        with:
-          tag_name: v${{ github.event.inputs.version }}
-          release_name: v${{ github.event.inputs.version }}
-          body_path: CHANGELOG.md
+      - name: Publish GitHub release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${{ github.event.inputs.version }}" \
+            --title "v${{ github.event.inputs.version }}" \
+            --notes-file CHANGELOG.md


### PR DESCRIPTION
## Summary
- upgrade the prism CI workflow to use `codecov/codecov-action@v4`
- replace the deprecated `actions/create-release@v1` step with a `gh release create` invocation in the tag-and-release workflow

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d89d9a3a1483299f22b3a2cf078f8d