### PR TITLE
Add middleware base path redirects and 404 guidance

### DIFF
--- a/sites/blackroad-next/app/not-found.tsx
+++ b/sites/blackroad-next/app/not-found.tsx
@@ -1,0 +1,10 @@
+export default function NotFound() {
+  const base = process.env.NEXT_PUBLIC_BASE_PATH || '';
+  const tip = base ? `Try ${base}/ instead.` : 'Double-check the link.';
+  return (
+    <main style={{ padding: 32, fontFamily: 'system-ui, sans-serif' }}>
+      <h1>404</h1>
+      <p>We couldn’t find that page. {tip}</p>
+    </main>
+  );
+}

--- a/sites/blackroad-next/middleware.ts
+++ b/sites/blackroad-next/middleware.ts
@@ -1,12 +1,49 @@
-import { NextResponse } from 'next/server';
-import type { NextRequest } from 'next/server';
+import { NextResponse, type NextRequest } from 'next/server';
 
-export function middleware(_req: NextRequest) {
-  const res = NextResponse.next();
-  res.headers.set('Strict-Transport-Security','max-age=63072000; includeSubDomains; preload');
-  res.headers.set('Referrer-Policy','strict-origin-when-cross-origin');
-  res.headers.set('X-Content-Type-Options','nosniff');
-  res.headers.set('Permissions-Policy','geolocation=(), microphone=(), camera=()');
-  res.headers.set('Content-Security-Policy',"default-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https:; script-src 'self' https: 'unsafe-inline' 'report-sample'; connect-src 'self'; font-src 'self' https: data:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'");
+// Read once at boot; same value you set in CI for path previews
+const BASE_PATH = process.env.BASE_PATH?.trim()?.replace(/\/+$/, '') || '';
+
+function withSecurityHeaders(res: NextResponse) {
+  res.headers.set('Strict-Transport-Security', 'max-age=63072000; includeSubDomains; preload');
+  res.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
+  res.headers.set('X-Content-Type-Options', 'nosniff');
+  res.headers.set('Permissions-Policy', 'geolocation=(), microphone=(), camera=()');
+  res.headers.set(
+    'Content-Security-Policy',
+    "default-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https:; script-src 'self' https: 'unsafe-inline' 'report-sample'; connect-src 'self'; font-src 'self' https: data:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'",
+  );
   return res;
 }
+
+export function middleware(req: NextRequest) {
+  if (!BASE_PATH) {
+    return withSecurityHeaders(NextResponse.next());
+  }
+
+  const url = req.nextUrl.clone();
+  const { pathname } = url;
+
+  if (
+    pathname === BASE_PATH ||
+    pathname.startsWith(`${BASE_PATH}/`) ||
+    pathname.startsWith('/_next') ||
+    pathname.startsWith('/api') ||
+    pathname.startsWith('/favicon') ||
+    pathname.startsWith('/robots') ||
+    pathname.startsWith('/sitemap')
+  ) {
+    return withSecurityHeaders(NextResponse.next());
+  }
+
+  if (pathname === '/health') {
+    return withSecurityHeaders(NextResponse.next());
+  }
+
+  url.pathname = pathname === '/' ? `${BASE_PATH}/` : `${BASE_PATH}${pathname}`;
+  return withSecurityHeaders(NextResponse.redirect(url, { status: 307 }));
+}
+
+export const config = {
+  // Run on everything but static assets in /public; tweak if needed
+  matcher: ['/((?!_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml).*)'],
+};

--- a/sites/blackroad-next/next.config.mjs
+++ b/sites/blackroad-next/next.config.mjs
@@ -1,6 +1,18 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  experimental: { appDir: true }
+  experimental: { appDir: true },
+  async redirects() {
+    const raw = process.env.BASE_PATH?.trim();
+    const base = raw ? (raw.startsWith('/') ? raw : `/${raw}`) : '';
+    if (!base) return [];
+    return [
+      {
+        source: `${base}`,
+        destination: `${base}/`,
+        permanent: false,
+      },
+    ];
+  },
 };
 export default nextConfig;


### PR DESCRIPTION
## Summary
- add middleware routing guards that redirect non-prefixed paths into the configured BASE_PATH while preserving security headers
- surface a not-found page that nudges users toward the preview base path
- ensure /pr-### requests pick up a trailing slash via a Next.js redirect rule

## Testing
- `npm run lint` *(fails: prompts for Next.js ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d8a65f74488329a7a581e70d452ddd