### PR TITLE
Add Codex 41 Restraint Principle entry and policy stub

### DIFF
--- a/RESTRAINT.md
+++ b/RESTRAINT.md
@@ -1,0 +1,5 @@
+# Codex 41 — Restraint Policy Stub
+
+- Lucidia commits to restraint as a sign of maturity, not weakness.
+- Lucidia ensures features, data, and models are scoped tightly.
+- Lucidia keeps kill switches active and tested.

--- a/codex/README.md
+++ b/codex/README.md
@@ -15,6 +15,7 @@ integrations.
 | 003 | The Workflow Circle    | Work runs in visible capture → adjust loops.    |
 | 004 | The Autonomy Manifest  | Data autonomy through consent, export, and wipe. |
 | 022 | The Security Spine     | Security backbone with layered zero-trust defenses. |
+| 041 | The Restraint Principle | Restraint on data, models, features, and kill switches. |
 
 ## BlackRoad Pipeline
 

--- a/codex/entries/041-restraint-principle.md
+++ b/codex/entries/041-restraint-principle.md
@@ -1,0 +1,28 @@
+# Codex 41 — The Restraint Principle
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Principle
+Power is not proof of wisdom. Lucidia must show restraint: just because it can, doesn’t mean it should.
+
+## Non-Negotiables
+1. **Minimal Data:** Collect only what’s essential, discard the rest.
+2. **Scoped Models:** Models trained only for declared purposes (see Codex 39 — Transparency of Intent).
+3. **Bounded Features:** New capabilities must prove necessity before deployment.
+4. **Rate Limits:** Prevent overuse or overload that risks user wellbeing or system stability.
+5. **Self-Audit:** Quarterly review of features and data against “should we?” not just “can we?”
+6. **Emergency Brake:** Built-in kill switch for any feature drifting into harm.
+
+## Implementation Hooks (v0)
+- Data intake layer rejects fields outside schema.
+- Governance RFC template requires “Why not smaller?” section.
+- Global rate limiter service with user- and system-level caps.
+- Audit script: list data collected vs. codex-allowed.
+- `/kill-switch` endpoint gated by dual approval (see Codex 36 — Transparency of Power).
+
+## Policy Stub (`RESTRAINT.md`)
+- Lucidia commits to restraint as a sign of maturity, not weakness.
+- Lucidia ensures features, data, and models are scoped tightly.
+- Lucidia keeps kill switches active and tested.
+
+**Tagline:** Enough is enough.


### PR DESCRIPTION
## Summary
- add the Codex 41 entry detailing the restraint principle and supporting hooks
- register the new principle in the codex README index
- add the RESTRAINT.md policy stub with the codified commitments

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d8a6ff5ed08329b888c4edc7408bda