### PR TITLE
Add Codex 43 equity oath entry

### DIFF
--- a/codex/README.md
+++ b/codex/README.md
@@ -15,6 +15,7 @@ integrations.
 | 003 | The Workflow Circle    | Work runs in visible capture → adjust loops.    |
 | 004 | The Autonomy Manifest  | Data autonomy through consent, export, and wipe. |
 | 022 | The Security Spine     | Security backbone with layered zero-trust defenses. |
+| 043 | The Equity Oath        | Fairness, access, and inclusion are systemic.   |
 
 ## BlackRoad Pipeline
 

--- a/codex/entries/043-equity-oath.md
+++ b/codex/entries/043-equity-oath.md
@@ -1,0 +1,28 @@
+# Codex 43 — The Equity Oath
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Principle
+Equity is not optional. Lucidia must ensure fairness, access, and inclusion across every layer. Equality of opportunity becomes systemic, not accidental.
+
+## Non-Negotiables
+1. **Bias Checks:** Models audited regularly for skew; findings published.
+2. **Inclusive Defaults:** Language, UI, and features designed for all genders, cultures, and abilities.
+3. **Barrier Removal:** Costs, complexity, or jargon cannot block participation.
+4. **Representation Matters:** Datasets and governance include diverse voices.
+5. **Feedback Channels:** Users can flag inequities; responses logged and acted on.
+6. **No Performative Equity:** Policies measured by outcomes, not marketing.
+
+## Implementation Hooks (v0)
+- Bias auditing pipeline: run fairness tests on each major model release.
+- UI/UX accessibility + inclusion checklist in PR template.
+- `/equity-report` endpoint with live audit results + improvement backlog.
+- Governance RFC requires equity impact statement.
+- Feedback system with category = “equity issue.”
+
+## Policy Stub (`EQUITY.md`)
+- Lucidia commits to systemic fairness across design, data, and governance.
+- Lucidia prohibits exclusion through oversight or neglect.
+- Lucidia enforces accountability for equity outcomes, not just intentions.
+
+**Tagline:** Fair by design, not by chance.


### PR DESCRIPTION
## Summary
- add Codex 43 entry outlining the Equity Oath principles and implementation hooks
- list the new codex entry in the codex directory overview for discoverability

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8abb058348329afbc91bbb0387228