### PR TITLE
Add blueprint blog post for curiosity-driven platform

### DIFF
--- a/sites/blackroad/content/blog/curiosity-driven-community-platform.md
+++ b/sites/blackroad/content/blog/curiosity-driven-community-platform.md
@@ -1,0 +1,73 @@
+---
+title: "Blackroad: A Blueprint for a Curiosity-Driven Community Platform"
+date: "2025-02-14"
+tags: [blueprint, community, rewards]
+description: "How Blackroad shares value across curious users, creators, and local communities while keeping privacy and sustainability front and center."
+---
+
+## Earn by Being Curious
+
+Blackroad rewards curiosity with multiple opt-in earning loops:
+
+- **Ad Lounge opt-in** pays micro-payouts for intentionally watching non-tracking ads, with proof-of-watch checks and transparent revenue splits.
+- **Learn & Log** streaks celebrate completed micro-lessons, quizzes, or documented exploration rabbit holes.
+- **Green compute contributions** donate idle processing only during verifiably renewable energy windows, powering civic data tasks while paying credits.
+- **Local good acts** such as verified reports, wiki updates, or moderation build reputation badges and occasional bonus credits.
+
+Rewards mix cashable credits, visible badges, and community perks like higher rate limits or feature access.
+
+## Value Sharing & Wallet Flows
+
+Revenue is split three ways: creators whose work powers engagement, a community treasury for local projects, and the users who watch ads or run compute. The wallet module automates these splits, keeps append-only transaction logs, and enables cash-out or in-community spend with transparent fees.
+
+## Modular System Architecture
+
+Blackroad’s services are loosely coupled:
+
+- **Gateway** enforces fair-use rate limits.
+- **Identity** issues portable DIDs that tie into wallets without revealing personal data.
+- **Wallet** orchestrates payouts, creator shares, and treasury flows on a transparent ledger.
+- **Opt-in Ads** queue sponsor-submitted spots, verify attention, and publish daily Merkle proofs.
+- **Green Compute Scheduler** dispatches sandboxed tasks only when devices run on renewables and are idle.
+- **Local Nodes** cache content per community and publish integrity hashes for auditability.
+- **Resonance Search** boosts quality, recent, and vouched content while diversifying results.
+- **Community Notes** crowdsources sourced context and fact checks similar to Twitter’s notes system.
+- **Learning Tracks** surface micro-lessons, flashcards, and rabbit-hole maps tied to user curiosity paths.
+
+## Privacy-First Opt-In Ads
+
+Ads live in a dedicated lounge with pre-view summaries of sponsor, payout, and community pool contributions. Delivery is randomized within user-selected categories, never behaviorally targeted. Lightweight attention quizzes unlock payouts, and all impressions land in a public ledger so advertisers and the community can audit spend. The design mirrors Brave’s opt-in model without tracking, manipulation, or dark patterns.
+
+## Carbon-Aware Green Compute
+
+Local nodes or trusted energy feeds expose a `renewables_now` signal. Only when true—and when devices are plugged in, cool, and idle—does Blackroad assign tasks like open data transcription or accessibility captioning. Workloads run in sandboxed WASM, never crypto mining, and users can pause instantly. Credits scale with task value and renewable intensity, channeling inspiration from Google’s carbon-intelligent scheduling.
+
+## Local News & Wiki with Receipts
+
+Each community hosts a structured wiki/news hub featuring typed posts (reports, events, PSAs, questions, corrections) that prompt sources or “receipts.” Community Notes attach neutral, cited context to claims, while reputation favors well-sourced contributions over volume. Geography-aware pages, map pins, and weekly digests maintain institutional memory and highlight unresolved questions.
+
+## Anti-Propaganda Safeguards
+
+Propagation leans on “resonance” instead of raw reach. Coordinated boosts trigger throttling, while diverse, independent confirmations raise rankings. Interfaces demand citations for factual posts, require affiliation disclosures, and offer transparent rate limits that expand with trusted behavior. Moderation decisions arrive with human-readable explanations and appeals.
+
+## Learning Rewards & Positive Reinforcement
+
+Daily curiosity packs deliver facts, local highlights, and suggested rabbit holes. Variety-driven acknowledgments replace punitive streaks, weekly unplug quests nudge offline exploration, and friendly feedback celebrates sourced posts or completed lessons. A kid mode emphasizes learning, shields from ads, and respects guardian controls.
+
+## MVP Roadmap (10 Weeks)
+
+1. **Weeks 1–2:** Ship identity, wallet, and fair-use gateway scaffolding.
+2. **Weeks 3–4:** Launch local wiki, community notes, basic moderation, and digest generation.
+3. **Weeks 5–6:** Build the Ad Lounge with proof-of-watch payouts and public logging.
+4. **Week 7:** Prototype green compute with manual renewable toggles and compute receipts.
+5. **Weeks 8–10:** Deliver resonance search with early ranking signals and feedback loops.
+
+## Data Schemas & Safety Guardrails
+
+JSON schemas outline ad impressions, green compute receipts, and wiki posts to jump-start implementation. Safety principles mandate opt-in everything, clear user control, no dark patterns, youth protections, and frequent transparency reporting.
+
+## Picking the First Quick Win
+
+Three launch options stand out: the Ad Lounge MVP, the local wiki with community notes, or a green compute pilot with renewable partners. The Ad Lounge offers the fastest user value by proving the privacy-first reward loop, after which community and compute modules can onboard engaged early adopters.
+
+Blackroad’s blueprint centers curiosity, trust, and sustainability—turning user participation into shared economic and civic value.


### PR DESCRIPTION
## Summary
- add a new blog post detailing the Blackroad curiosity-driven community platform blueprint, covering reward loops, privacy-preserving ads, green compute, local news systems, and roadmap guidance

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d8ad5d937c8329a3f0b55e28b85c1e