### PR TITLE
Add feasibility map for custom OS initiative

### DIFF
--- a/docs/CUSTOM_OS_FEASIBILITY.md
+++ b/docs/CUSTOM_OS_FEASIBILITY.md
@@ -1,0 +1,103 @@
+# Custom OS Feasibility Map for Raspberry Pi, Jetson, and Advanced Interfaces
+
+## Objectives
+- Deliver a vertically integrated operating system that can span Raspberry Pi class devices, NVIDIA Jetson modules, and mixed-display environments (LCD, projection, holographic simulators).
+- Support distributed input/output orchestration across peripherals (touch, sensors, robotic controllers) while offering an extensible GUI layer.
+- Provide a runway from rapid prototyping on existing Linux derivatives to a bespoke, minimized stack if required for certification or security.
+
+## Hardware Portfolio & Support Tiers
+| Platform | Notes | Recommended Base | Toolchain Support | Risk Level |
+| --- | --- | --- | --- | --- |
+| Raspberry Pi 4/5 Compute Modules | Broad community support, plentiful carrier boards | Raspberry Pi OS or Buildroot-derived image | GCC/Linaro aarch64-linux-gnu, LLVM/Clang, Rust via rustup target `aarch64-unknown-linux-gnu` | Low |
+| Raspberry Pi Zero 2 W | Lower RAM/CPU, beneficial for IoT nodes | Buildroot minimal image with BusyBox | GCC cross toolchain tuned for `arm-linux-gnueabihf` | Medium (resource constraints) |
+| NVIDIA Jetson Orin/Nano | CUDA acceleration, richer peripheral buses | NVIDIA JetPack SDK (Ubuntu LTS base) or custom Yocto BSP | NVIDIA CUDA toolkit, NVCC, Nsight suite | Medium (binary blobs, kernel pinning) |
+| Auxiliary MCUs (Teensy, STM32) | For deterministic IO & coprocessing | Zephyr RTOS or FreeRTOS | Zephyr SDK, PlatformIO | Medium |
+| Display/Holographic Interfaces | May rely on HDMI/DisplayPort, depth sensors | Linux DRM/KMS + Wayland/Qt 3D stack; holographic via Looking Glass SDK or custom OpenXR | Mesa, Vulkan SDK, OpenXR | High (proprietary hardware, custom drivers) |
+
+## System Layer Breakdown
+### Bootloaders
+- **Raspberry Pi**: Leverage vendor EEPROM boot then U-Boot for consistent boot scripts; supports netboot for distributed updates.
+- **Jetson**: NVIDIA cboot → U-Boot chain; JetPack tooling manages flashing. Customization via L4T BSP to integrate secure boot.
+- **Unified Strategy**: Maintain U-Boot configuration repository with device-tree overlays. Automate via `Yocto` or `Buildroot` recipes.
+
+### Kernel
+- Start with Linux LTS (6.6+) configured per target using defconfig overlays.
+- Enable PREEMPT_RT patches on nodes that must handle tight IO latencies.
+- Track vendor-specific drivers (Broadcom for Pi, NVIDIA kernel modules). Wrap binary components in containerized build steps for reproducibility.
+
+### Init & System Services
+- **Stage 1**: systemd for ease of integration (networking, journaling).
+- **Stage 2 (minimal)**: Transition to `OpenRC` or custom init when footprint must shrink.
+- Distributed IO can be coordinated with `gRPC` or `ROS 2`, with a supervisor service orchestrating device discovery.
+
+### GUI / UX Stack
+- **Wayland compositor**: `Sway` or `Weston` as reference; custom shell via `wlr` or `QtWayland` for kiosk-style deployments.
+- **3D/Holographic**: Build on `Qt 6 3D`, `Godot`, or `Unity` (for Jetson) interfacing with `OpenXR`. Depth-camera integration through `librealsense` or ZED SDK.
+- Provide fallback `fbdev` UI for headless or low-resource nodes.
+
+### Input/Output Fabric
+- Abstract devices using a message bus (`MQTT`, `ROS 2 DDS`) to allow remote peripherals.
+- Implement a capability registry so screens, sensors, and controllers announce features; orchestrator assigns tasks dynamically.
+- For deterministic robotic IO, pair Jetson main control with MCU running Zephyr over CAN-FD or EtherCAT.
+
+## Existing OS Baselines & Modification Paths
+1. **Yocto Project**
+   - Pros: Layered architecture, reproducible builds, fine-grained control.
+   - Cons: Steep learning curve, heavy CI requirements.
+   - Usage: Create `meta-prism` layer defining common recipes, then machine layers for Pi (`raspberrypi`) and Jetson (`tegra`).
+2. **Buildroot**
+   - Pros: Faster builds, simpler configuration, ideal for Pi Zero/edge nodes.
+   - Cons: Less package management, patch management manual.
+   - Usage: Generate rootfs + kernel, integrate `weston`/`qt` packages, embed systemd or BusyBox init depending on target.
+3. **Ubuntu Core / Raspberry Pi OS**
+   - Pros: Rapid prototyping, snap ecosystem.
+   - Cons: Larger footprint, slower to customize kernel.
+   - Usage: Short-term dev platform; gradually replace packages with custom builds.
+4. **NVIDIA JetPack (L4T)**
+   - Pros: Hardware-accelerated libraries included.
+   - Cons: Vendor lock-in, must align with JetPack version matrix.
+   - Usage: Use as reference rootfs; port critical packages into Yocto layer to unify stack.
+
+## Toolchains & Build Infrastructure
+- **Cross-compilation**: Use `crosstool-ng` or containerized build images to produce deterministic GCC toolchains for ARMv7/ARMv8.
+- **Container Strategy**: Maintain Dockerfiles per target (Pi, Jetson) embedding toolchains, Yocto dependencies, and binary blobs.
+- **CI/CD**: GitHub Actions or GitLab runners with artifact caching; integrate QA tests with QEMU + hardware-in-the-loop benches.
+- **Testing Frameworks**: `pytest` for services, `GTest` for C/C++; adopt `LAVA` or `LabGrid` for remote flashing and regression tests.
+
+## Holographic Interface Considerations
+- Evaluate hardware like Looking Glass Portrait or Holovect; most require proprietary SDKs but expose standard GPU APIs.
+- Prototype rendering with `OpenXR` on Jetson (supports Vulkan) and Raspberry Pi (limited; rely on `Monado` runtime with Mesa).
+- Need high-bandwidth data paths (USB 3.0, DisplayPort); confirm carrier boards expose necessary connectors.
+- For gesture/input, integrate depth sensors (Intel RealSense, Azure Kinect) via USB 3.0 hubs; process data with `OpenCV`/`PCL` on Jetson.
+
+## Distributed IO Control Strategy
+- **Control Plane**: Kubernetes is heavy; prefer lightweight orchestrator using `NATS` or `ROS 2` for message routing.
+- **Edge Nodes**: Deploy micro-agents that subscribe to capability topics and expose gRPC endpoints.
+- **Security**: mTLS between nodes, TPM-backed keys where available (Jetson supports). Use OSTree/RAUC for signed updates.
+
+## Roadmap & Next Steps
+1. **Feasibility Validation (0-4 weeks)**
+   - Stand up Buildroot image for Pi 4 with Wayland kiosk demo.
+   - Flash Jetson with JetPack, run sample OpenXR/holographic rendering pipeline.
+   - Document driver gaps (e.g., specific display panels, holographic hardware).
+2. **Unified Build System (4-12 weeks)**
+   - Create Yocto meta-layer with shared recipes, integrate OSTree updates.
+   - Develop distributed IO service prototypes with ROS 2 on both platforms.
+3. **Custom Kernel & Security Hardening (12-20 weeks)**
+   - Apply PREEMPT_RT patches, enable SELinux/AppArmor profiles.
+   - Implement secure boot chain (U-Boot + dm-verity + signed rootfs).
+4. **Holographic & Advanced UX (20+ weeks)**
+   - Build dedicated compositor plugin supporting holographic display APIs.
+   - Integrate gesture recognition + remote IO orchestration into GUI layer.
+
+## Open Questions / Risks
+- Availability of open drivers for chosen holographic hardware; may require NDA or binary SDK.
+- Jetson kernel update cadence tied to NVIDIA release cycle—plan for long-term support path.
+- Power/thermal constraints when running intensive graphics on Pi; may need external GPU via USB/PCIe on Compute Module carrier.
+- Distributed IO security posture: need threat modeling for remote peripherals.
+
+## Recommended References
+- Yocto Project Mega-Manual, Buildroot Reference Manual.
+- Raspberry Pi and NVIDIA Jetson hardware design guides for carrier board integration.
+- OpenXR + Monado documentation for cross-platform XR runtimes.
+- ROS 2 design docs for distributed robotics communication.


### PR DESCRIPTION
## Summary
- document a feasibility roadmap for building a custom OS across Raspberry Pi, Jetson, and advanced display hardware
- outline recommended tooling, build strategies, and risks for holographic interface and distributed IO support

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d97dd0137c832981fbb1bfcef5b99f