### PR TITLE
Add droplet disk cleanup runbook and alert script

### DIFF
--- a/ops/do/disk_warn.sh
+++ b/ops/do/disk_warn.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Alert when free space on the root filesystem drops below a threshold.
+set -euo pipefail
+
+thresh=${THRESHOLD:-10}
+mount_point=${MOUNT_POINT:-/}
+
+free=$(df -P "${mount_point}" | awk 'NR==2{print 100-$5}')
+if [ -z "${free}" ]; then
+  echo "[ERROR] Unable to determine free space for ${mount_point} at $(date -u '+%Y-%m-%dT%H:%M:%SZ')" >&2
+  exit 1
+fi
+
+if [ "${free}" -lt "${thresh}" ]; then
+  echo "[WARN] Low disk: ${free}% free on ${mount_point} at $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+fi

--- a/ops/do/droplet_disk_maintenance.md
+++ b/ops/do/droplet_disk_maintenance.md
@@ -1,0 +1,92 @@
+# Droplet Disk Maintenance Runbook
+
+This runbook documents the routine checks and cleanup tasks to prevent DigitalOcean droplets from running out of disk space due to Docker artifacts and system logs.
+
+## Quick Health Checks
+
+Run these commands to inspect filesystem capacity and inode availability:
+
+```bash
+# Overall disk and inode usage
+$ df -hT
+$ df -i
+```
+
+Inspect Docker utilization to understand how space is consumed:
+
+```bash
+# Docker disk usage summary
+$ docker system df
+
+# Largest images, containers, and volumes
+$ docker images --format 'table {{.Size}}\t{{.Repository}}:{{.Tag}}\t{{.ID}}' | sort -hr
+$ docker ps -a --size --format 'table {{.Size}}\t{{.Names}}\t{{.Image}}' | sort -hr
+$ docker volume ls -q | xargs -r -I{} sh -c 'docker system df -v | grep -A2 "{}"'
+```
+
+## Targeted Cleanup Options
+
+Choose the smallest set of commands needed to reclaim space:
+
+```bash
+# 1) Remove unused containers, networks, and build cache (safe default)
+$ docker system prune -f
+
+# 2) Also remove dangling and unused images (ensure no container needs them)
+$ docker image prune -a -f
+
+# 3) Clear the builder cache (can be large)
+$ docker builder prune -a -f
+
+# 4) Remove unused volumes (data loss risk if volumes mattered)
+$ docker volume prune -f
+```
+
+### Non-Docker Sources
+
+Investigate other common space hogs:
+
+```bash
+# Large log directories
+$ sudo du -x -h /var/log | sort -hr | head
+
+# Shrink systemd journal to 200 MB
+$ sudo journalctl --vacuum-size=200M
+
+# Clear apt caches
+$ sudo apt-get clean
+
+# Identify large directories from root
+$ sudo du -x -h -d1 / | sort -hr | head -n 30
+```
+
+### One-Liner Rescue
+
+When you need a fast cleanup without removing in-use images or named volumes:
+
+```bash
+$ sudo journalctl --vacuum-time=7d \
+    && sudo apt-get clean \
+    && docker system prune -f \
+    && docker builder prune -a -f \
+    && docker image prune -f
+```
+
+## Proactive Alerting
+
+Install the `disk_warn.sh` helper script and schedule it via cron to alert before disk space runs out:
+
+```bash
+$ sudo cp ops/do/disk_warn.sh /usr/local/bin/disk_warn.sh
+$ sudo chmod +x /usr/local/bin/disk_warn.sh
+$ ( crontab -l 2>/dev/null; echo "*/30 * * * * /usr/local/bin/disk_warn.sh" ) | crontab -
+```
+
+The script warns when the root filesystem has less than 10% free space, writing a timestamped warning to stdout. Adjust the `thresh` variable or target filesystem inside the script as needed.
+
+## Operational Tips
+
+- Always confirm that critical containers are stopped or can be recreated before removing images or volumes.
+- Capture the output of the health checks in the ticket or incident doc so follow-up actions can be audited.
+- After aggressive pruning, redeploy long-running services to ensure required images are rebuilt and cached.
+- If disk pressure recurs frequently, plan capacity upgrades or move large stateful data into managed services.


### PR DESCRIPTION
## Summary
- document DigitalOcean droplet disk inspection and cleanup steps
- add a reusable disk space warning script for cron-based alerts

## Testing
- ./ops/do/disk_warn.sh

------
https://chatgpt.com/codex/tasks/task_e_68da0a6e4e2c8329943378ad7e610d48