### PR TITLE
Add policy rule engine fixtures and tests

### DIFF
--- a/docs/runbooks/mirror_class_limit.md
+++ b/docs/runbooks/mirror_class_limit.md
@@ -1,0 +1,23 @@
+# MIRROR_CLASS_LIMIT Runbook
+
+**Owner:** SecOps Eng Duty <secops@corp>
+
+## Summary
+
+Blocks mirror actions that target repositories classified as `restricted` or `secret`. Mirrors to those repositories risk copying sensitive IP to uncontrolled destinations.
+
+## Triage
+
+1. Confirm the target repository's classification in the registry.
+2. Reach out to the requestor listed in the violation payload.
+3. If the mirror is required, coordinate an exception review with data governance.
+
+## Remediation
+
+- If the classification is incorrect, update the metadata and re-run the action.
+- If the mirror is legitimate, file an exception ticket and add it to the allowlist rotation job.
+- Otherwise, document the deny event and notify the product security list.
+
+## Related Dashboards
+
+- `dashboards/grafana-rule-board.json` — Mirror Guard panel.

--- a/fixtures/consent/low_rate.series.json
+++ b/fixtures/consent/low_rate.series.json
@@ -1,0 +1,8 @@
+{
+  "window": "15m",
+  "series": [
+    { "deny_reason": "consent_required" },
+    { "deny_reason": "insufficient_role" },
+    {}, {}, {}, {}, {}, {}, {}, {}
+  ]
+}

--- a/fixtures/consent/spike_trips.series.json
+++ b/fixtures/consent/spike_trips.series.json
@@ -1,0 +1,8 @@
+{
+  "window": "15m",
+  "series": [
+    { "deny_reason": "consent_required", "ticket": "INC-901" },
+    { "deny_reason": "consent_required", "ticket": "INC-902" },
+    {}, {}, {}, {}, {}, {}, {}, {}
+  ]
+}

--- a/fixtures/mirror/deny_secret.json
+++ b/fixtures/mirror/deny_secret.json
@@ -1,0 +1,6 @@
+{
+  "action": "mirror",
+  "resource_class": "secret",
+  "repo": "payments/api",
+  "owners": ["secops@corp"]
+}

--- a/fixtures/multi/multi_provider_window.series.json
+++ b/fixtures/multi/multi_provider_window.series.json
@@ -1,0 +1,7 @@
+{
+  "window": "5m",
+  "series": [
+    { "action": "mirror", "resource_provider": "github", "user_role": "viewer", "event_id": "evt-1" },
+    { "action": "mirror", "resource_provider": "gitlab", "user_role": "viewer", "event_id": "evt-2" }
+  ]
+}

--- a/fixtures/policy/drift_spike.series.json
+++ b/fixtures/policy/drift_spike.series.json
@@ -1,0 +1,19 @@
+{
+  "window": "30m",
+  "series": [
+    { "outcome": "deny", "policy_version": "2024.03.01" },
+    { "outcome": "deny", "policy_version": "2024.03.01" },
+    { "outcome": "deny", "policy_version": "2024.03.01" },
+    { "outcome": "deny", "policy_version": "2024.03.01" },
+    { "outcome": "deny", "policy_version": "2024.03.01" },
+    { "outcome": "deny", "policy_version": "2024.03.01" },
+    { "outcome": "allow" },
+    { "outcome": "allow" },
+    { "outcome": "allow" },
+    { "outcome": "allow" }
+  ],
+  "metadata": {
+    "last_policy_change": "2024-03-01T11:40:00Z",
+    "diff_url": "https://prism/ruleset/changeset/784"
+  }
+}

--- a/fixtures/secret/burst.series.json
+++ b/fixtures/secret/burst.series.json
@@ -1,0 +1,10 @@
+{
+  "window": "10m",
+  "series": [
+    { "tool": "sync-service", "error_kind": "secret_expired", "secret_id": "hash_2f9c", "observed_at": "2024-03-05T09:00:00Z" },
+    { "tool": "sync-service", "error_kind": "secret_expired", "secret_id": "hash_2f9c", "observed_at": "2024-03-05T09:01:30Z" },
+    { "tool": "sync-service", "error_kind": "secret_expired", "secret_id": "hash_2f9c", "observed_at": "2024-03-05T09:02:10Z" },
+    { "tool": "sync-service", "error_kind": "timeout" },
+    { "tool": "sync-service", "error_kind": "secret_expired", "secret_id": "hash_9a", "observed_at": "2024-03-05T09:04:00Z" }
+  ]
+}

--- a/fixtures/secret/ok.series.json
+++ b/fixtures/secret/ok.series.json
@@ -1,0 +1,12 @@
+{
+  "window": "10m",
+  "series": [
+    { "tool": "mirror", "error_kind": "secret_expired", "secret_id": "hash_a1" },
+    { "tool": "mirror", "error_kind": "timeout" },
+    { "tool": "mirror", "error_kind": "secret_refreshed" },
+    { "tool": "mirror", "error_kind": "timeout" },
+    { "tool": "mirror", "error_kind": "ok" },
+    { "tool": "mirror", "error_kind": "ok" },
+    { "tool": "mirror", "error_kind": "ok" }
+  ]
+}

--- a/policy/rules_engine/__init__.py
+++ b/policy/rules_engine/__init__.py
@@ -1,0 +1,18 @@
+"""Policy rule evaluation engine utilities."""
+
+from .rule import Rule, RuleMode, RuleEvaluationResult, RuleRuntime
+from .context import EvaluationContext, duration_from_text
+from .loader import RuleTestCase, load_rule_file, load_fixture, build_context
+
+__all__ = [
+    "Rule",
+    "RuleMode",
+    "RuleEvaluationResult",
+    "RuleRuntime",
+    "EvaluationContext",
+    "duration_from_text",
+    "RuleTestCase",
+    "load_rule_file",
+    "load_fixture",
+    "build_context",
+]

--- a/policy/rules_engine/context.py
+++ b/policy/rules_engine/context.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence
+
+
+class MissingFieldError(KeyError):
+    """Raised when a field lookup fails during rule evaluation."""
+
+
+_DURATION_UNITS = {
+    "s": 1,
+    "m": 60,
+    "h": 60 * 60,
+    "d": 60 * 60 * 24,
+}
+
+
+def duration_from_text(text: str) -> timedelta:
+    """Parse compact duration strings such as ``"15m"`` or ``"2h"``."""
+
+    if not text:
+        raise ValueError("duration string must be non-empty")
+    unit = text[-1]
+    if unit not in _DURATION_UNITS:
+        raise ValueError(f"unsupported duration unit: {unit!r}")
+    try:
+        value = float(text[:-1])
+    except ValueError as exc:
+        raise ValueError(f"invalid duration value: {text}") from exc
+    return timedelta(seconds=value * _DURATION_UNITS[unit])
+
+
+def _ensure_datetime(value: Any) -> datetime:
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value
+    if isinstance(value, (int, float)):
+        return datetime.fromtimestamp(value, tz=timezone.utc)
+    if isinstance(value, str):
+        # Accept RFC3339/ISO-8601 strings including trailing Z
+        if value.endswith("Z"):
+            value = value[:-1] + "+00:00"
+        return datetime.fromisoformat(value)
+    raise TypeError(f"Unsupported datetime representation: {type(value)!r}")
+
+
+@dataclass
+class EvaluationContext:
+    """Context shared across rule evaluations and helper functions."""
+
+    series: Sequence[Mapping[str, Any]] = field(default_factory=list)
+    baseline: Mapping[str, float] | None = None
+    metadata: Mapping[str, Any] | None = None
+    now_value: datetime | None = None
+    extras: Mapping[str, Any] | None = None
+
+    captures: Dict[str, List[Dict[str, Any]]] = field(default_factory=dict)
+    missing_fields: List[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self.baseline = dict(self.baseline or {})
+        self.metadata = dict(self.metadata or {})
+        self.extras = dict(self.extras or {})
+        if self.now_value is None:
+            self.now_value = datetime.now(timezone.utc)
+        elif self.now_value.tzinfo is None:
+            self.now_value = self.now_value.replace(tzinfo=timezone.utc)
+
+    # -- value helpers -------------------------------------------------
+    def resolve(self, name: str, event: Mapping[str, Any]) -> Any:
+        if isinstance(event, Mapping) and name in event:
+            return event[name]
+        if name in self.metadata:
+            return self.metadata[name]
+        if name in self.extras:
+            return self.extras[name]
+        if name in self.baseline:
+            return self.baseline[name]
+        self.missing_fields.append(name)
+        return None
+
+    def has(self, name: str, event: Mapping[str, Any]) -> bool:
+        if isinstance(event, Mapping) and name in event:
+            return True
+        return name in self.metadata or name in self.extras or name in self.baseline
+
+    def record(self, key: str, payload: Dict[str, Any]) -> None:
+        self.captures.setdefault(key, []).append(payload)
+
+    # -- builtins exposed to expressions -------------------------------
+    def now(self) -> datetime:
+        return self.now_value  # type: ignore[return-value]
+
+    def duration(self, text: str) -> timedelta:
+        return duration_from_text(text)
+
+    def ingest_lag(self, stream: str) -> timedelta:
+        lag = self.metadata.get("ingest_lag", {}).get(stream)
+        if lag is None:
+            return timedelta(0)
+        if isinstance(lag, timedelta):
+            return lag
+        return duration_from_text(str(lag)) if isinstance(lag, str) else timedelta(seconds=float(lag))
+
+    def baseline_rate(self, metric: str) -> float:
+        return float(self.baseline.get(metric, 0.0))
+
+    def last_policy_change_within(self, text: str) -> bool:
+        window = duration_from_text(text)
+        stamp = self.metadata.get("last_policy_change")
+        if stamp is None:
+            return False
+        ts = _ensure_datetime(stamp)
+        delta = self.now() - ts
+        return delta <= window
+
+    # -- aggregation helpers ------------------------------------------
+    def rate(
+        self,
+        predicate: Callable[[Mapping[str, Any]], bool],
+        window: str,
+        include_series: Optional[Sequence[Mapping[str, Any]]] = None,
+    ) -> float:
+        events = list(include_series or self.series)
+        total = len(events)
+        if total == 0:
+            value = 0.0
+            matches: List[Mapping[str, Any]] = []
+        else:
+            matches = [event for event in events if predicate(event)]
+            value = len(matches) / total
+        secret_ids = [event.get("secret_id") for event in matches if isinstance(event, Mapping) and "secret_id" in event]
+        deduped_secret_ids = sorted({sid for sid in secret_ids if sid is not None})
+        self.record(
+            "rate",
+            {
+                "window": window,
+                "value": value,
+                "matches": len(matches),
+                "total": total,
+                "matching_events": matches,
+                "secret_ids": deduped_secret_ids,
+            },
+        )
+        return value
+
+    def distinct_over(
+        self,
+        field_name: str,
+        window: str,
+        include_series: Optional[Sequence[Mapping[str, Any]]] = None,
+    ) -> int:
+        events = include_series or self.series
+        values = []
+        for event in events:
+            if isinstance(event, Mapping) and field_name in event:
+                values.append(event[field_name])
+        result = len(set(values))
+        self.record(
+            "distinct_over",
+            {
+                "window": window,
+                "field": field_name,
+                "value": result,
+                "total": len(events),
+            },
+        )
+        return result
+
+    # -- context assembly ---------------------------------------------
+    def with_series(self, series: Sequence[Mapping[str, Any]]) -> "EvaluationContext":
+        clone = EvaluationContext(
+            series=series,
+            baseline=self.baseline,
+            metadata=self.metadata,
+            now_value=self.now_value,
+            extras=self.extras,
+        )
+        clone.captures = self.captures
+        clone.missing_fields = self.missing_fields
+        return clone
+
+    def to_details(self) -> Dict[str, Any]:
+        details: Dict[str, Any] = {}
+        if self.captures:
+            details["captures"] = self.captures
+        if self.missing_fields:
+            details["missing_fields"] = self.missing_fields
+        return details
+

--- a/policy/rules_engine/evaluator.py
+++ b/policy/rules_engine/evaluator.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import ast
+import operator
+import re
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Mapping
+
+from .context import EvaluationContext
+
+
+_OPERATORS: Dict[type, Callable[[Any, Any], Any]] = {
+    ast.Add: operator.add,
+    ast.Sub: operator.sub,
+    ast.Mult: operator.mul,
+    ast.Div: operator.truediv,
+    ast.Mod: operator.mod,
+    ast.Pow: operator.pow,
+    ast.BitAnd: operator.and_,
+    ast.BitOr: operator.or_,
+    ast.BitXor: operator.xor,
+}
+
+_COMPARATORS: Dict[type, Callable[[Any, Any], bool]] = {
+    ast.Eq: operator.eq,
+    ast.NotEq: operator.ne,
+    ast.Lt: operator.lt,
+    ast.LtE: operator.le,
+    ast.Gt: operator.gt,
+    ast.GtE: operator.ge,
+    ast.In: lambda left, right: left in right,
+    ast.NotIn: lambda left, right: left not in right,
+    ast.Is: operator.is_,
+    ast.IsNot: operator.is_not,
+}
+
+_BOOL_OPS: Dict[type, Callable[[Any, Any], bool]] = {
+    ast.And: lambda a, b: bool(a) and bool(b),
+    ast.Or: lambda a, b: bool(a) or bool(b),
+}
+
+_UNARY_OPS: Dict[type, Callable[[Any], Any]] = {
+    ast.Not: operator.not_,
+    ast.USub: operator.neg,
+    ast.UAdd: operator.pos,
+}
+
+_BUILTINS: Dict[str, Callable[..., Any]] = {
+    "abs": abs,
+    "len": len,
+    "min": min,
+    "max": max,
+    "sum": sum,
+    "any": any,
+    "all": all,
+}
+
+
+def _prepare_expression(expr: str) -> str:
+    prepared = expr.replace("&&", " and ").replace("||", " or ")
+    # Replace standalone ! with not
+    out = []
+    i = 0
+    while i < len(prepared):
+        ch = prepared[i]
+        if ch == "!":
+            nxt = prepared[i + 1] if i + 1 < len(prepared) else ""
+            prev = prepared[i - 1] if i > 0 else ""
+            if nxt == "=" or prev in ("=", "!", "<", ">"):
+                out.append("!")
+            else:
+                out.append(" not ")
+            i += 1
+            continue
+        out.append(ch)
+        i += 1
+    prepared = "".join(out)
+    prepared = re.sub(r"\btrue\b", "True", prepared)
+    prepared = re.sub(r"\bfalse\b", "False", prepared)
+    prepared = re.sub(r"\bnull\b", "None", prepared)
+    return prepared
+
+
+@dataclass
+class ExpressionEvaluator:
+    """Evaluate policy expressions against an event."""
+
+    source: str
+
+    def __post_init__(self) -> None:
+        prepared = _prepare_expression(self.source)
+        tree = ast.parse(prepared, mode="eval")
+        self._expr = tree.body
+
+    # -----------------------------------------------------------------
+    def evaluate(self, event: Mapping[str, Any], ctx: EvaluationContext) -> Any:
+        return self._eval_node(self._expr, event, ctx)
+
+    # -----------------------------------------------------------------
+    def _eval_node(self, node: ast.AST, event: Mapping[str, Any], ctx: EvaluationContext) -> Any:
+        if isinstance(node, ast.BoolOp):
+            return self._eval_boolop(node, event, ctx)
+        if isinstance(node, ast.BinOp):
+            left = self._eval_node(node.left, event, ctx)
+            right = self._eval_node(node.right, event, ctx)
+            op = _OPERATORS.get(type(node.op))
+            if op is None:
+                raise ValueError(f"unsupported binary operator: {ast.dump(node.op)}")
+            return op(left, right)
+        if isinstance(node, ast.UnaryOp):
+            operand = self._eval_node(node.operand, event, ctx)
+            op = _UNARY_OPS.get(type(node.op))
+            if op is None:
+                raise ValueError(f"unsupported unary operator: {ast.dump(node.op)}")
+            return op(operand)
+        if isinstance(node, ast.Compare):
+            return self._eval_compare(node, event, ctx)
+        if isinstance(node, ast.Call):
+            return self._eval_call(node, event, ctx)
+        if isinstance(node, ast.IfExp):
+            cond = self._eval_node(node.test, event, ctx)
+            branch = node.body if cond else node.orelse
+            return self._eval_node(branch, event, ctx)
+        if isinstance(node, ast.Name):
+            if node.id in ("True", "False", "None"):
+                return eval(node.id)
+            if node.id in _BUILTINS:
+                return _BUILTINS[node.id]
+            return ctx.resolve(node.id, event)
+        if isinstance(node, ast.Constant):
+            return node.value
+        if isinstance(node, ast.List):
+            return [self._eval_node(elt, event, ctx) for elt in node.elts]
+        if isinstance(node, ast.Tuple):
+            return tuple(self._eval_node(elt, event, ctx) for elt in node.elts)
+        if isinstance(node, ast.Set):
+            return {self._eval_node(elt, event, ctx) for elt in node.elts}
+        if isinstance(node, ast.Dict):
+            return {
+                self._eval_node(key, event, ctx): self._eval_node(value, event, ctx)
+                for key, value in zip(node.keys, node.values)
+            }
+        if isinstance(node, ast.Subscript):
+            container = self._eval_node(node.value, event, ctx)
+            index = self._eval_node(node.slice, event, ctx)  # type: ignore[arg-type]
+            return container[index]
+        if isinstance(node, ast.Attribute):
+            target = self._eval_node(node.value, event, ctx)
+            return getattr(target, node.attr)
+        raise ValueError(f"unsupported expression node: {ast.dump(node)}")
+
+    # -----------------------------------------------------------------
+    def _eval_boolop(self, node: ast.BoolOp, event: Mapping[str, Any], ctx: EvaluationContext) -> Any:
+        op = _BOOL_OPS.get(type(node.op))
+        if op is None:
+            raise ValueError(f"unsupported bool operator: {ast.dump(node.op)}")
+        result = self._eval_node(node.values[0], event, ctx)
+        for value in node.values[1:]:
+            result = op(result, self._eval_node(value, event, ctx))
+        return result
+
+    def _eval_compare(self, node: ast.Compare, event: Mapping[str, Any], ctx: EvaluationContext) -> bool:
+        left = self._eval_node(node.left, event, ctx)
+        for op, comparator in zip(node.ops, node.comparators):
+            right = self._eval_node(comparator, event, ctx)
+            operator_fn = _COMPARATORS.get(type(op))
+            if operator_fn is None:
+                raise ValueError(f"unsupported comparator: {ast.dump(op)}")
+            if not operator_fn(left, right):
+                return False
+            left = right
+        return True
+
+    def _eval_call(self, node: ast.Call, event: Mapping[str, Any], ctx: EvaluationContext) -> Any:
+        if isinstance(node.func, ast.Name):
+            func_name = node.func.id
+            if func_name == "rate":
+                predicate_node = node.args[0]
+                window = self._eval_node(node.args[1], event, ctx) if len(node.args) > 1 else ""
+                series = ctx.series
+                predicate = lambda item: bool(self._eval_node(predicate_node, item, ctx))
+                return ctx.rate(predicate, window, series)
+            if func_name == "distinct_over":
+                field = self._eval_node(node.args[0], event, ctx)
+                window = self._eval_node(node.args[1], event, ctx) if len(node.args) > 1 else ""
+                series = ctx.series
+                return ctx.distinct_over(field, window, series)
+            if func_name == "baseline_rate":
+                metric = self._eval_node(node.args[0], event, ctx)
+                return ctx.baseline_rate(metric)
+            if func_name == "last_policy_change_within":
+                duration = self._eval_node(node.args[0], event, ctx)
+                return ctx.last_policy_change_within(duration)
+            if func_name == "duration":
+                text = self._eval_node(node.args[0], event, ctx)
+                return ctx.duration(text)
+            if func_name == "now":
+                return ctx.now()
+            if func_name == "ingest_lag":
+                stream = self._eval_node(node.args[0], event, ctx)
+                return ctx.ingest_lag(stream)
+            if func_name == "has":
+                field_name = self._eval_node(node.args[0], event, ctx)
+                return ctx.has(field_name, event)
+        func = self._eval_node(node.func, event, ctx)
+        args = [self._eval_node(arg, event, ctx) for arg in node.args]
+        kwargs = {kw.arg: self._eval_node(kw.value, event, ctx) for kw in node.keywords}
+        return func(*args, **kwargs)

--- a/policy/rules_engine/loader.py
+++ b/policy/rules_engine/loader.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional
+
+import yaml
+
+from datetime import datetime
+from .context import EvaluationContext
+from .rule import Rule
+
+
+@dataclass
+class RuleTestCase:
+    name: str
+    want: bool
+    input: Optional[Dict[str, Any]] = None
+    series: Optional[List[Dict[str, Any]]] = None
+    window: Optional[str] = None
+    baseline: Optional[Dict[str, Any]] = None
+    metadata: Optional[Dict[str, Any]] = None
+    now: Optional[str] = None
+    fixture: Optional[str] = None
+    expect_details: Optional[Dict[str, Any]] = None
+    expect_error: Optional[str] = None
+
+
+def _expand_series(series: List[Any]) -> List[Dict[str, Any]]:
+    events: List[Dict[str, Any]] = []
+    for item in series:
+        if isinstance(item, Mapping) and "repeat" in item:
+            count = int(item["repeat"])
+            template = item.get("each", {}) if isinstance(item.get("each"), Mapping) else {}
+            for _ in range(count):
+                events.append(dict(template))
+        else:
+            events.append(dict(item))
+    return events
+
+
+def load_fixture(path: Path) -> Dict[str, Any]:
+    data = json.loads(path.read_text())
+    if isinstance(data, list):
+        return {"series": data}
+    if not isinstance(data, Mapping):
+        raise TypeError(f"Fixture must be an object or array: {path}")
+    return dict(data)
+
+
+def load_rule_file(path: str | Path) -> tuple[Rule, List[RuleTestCase]]:
+    rule_path = Path(path)
+    payload = yaml.safe_load(rule_path.read_text())
+    rule = Rule.from_dict(payload)
+
+    tests: List[RuleTestCase] = []
+    for entry in payload.get("tests", []):
+        tc = RuleTestCase(
+            name=entry["name"],
+            want=bool(entry.get("want")),
+            input=dict(entry.get("input", {})),
+            window=entry.get("window"),
+            baseline=dict(entry.get("baseline", {})),
+            metadata=dict(entry.get("metadata", {})),
+            now=entry.get("now"),
+            fixture=entry.get("fixture"),
+            expect_details=entry.get("expect_details"),
+            expect_error=entry.get("expect_error"),
+        )
+        if "series" in entry:
+            tc.series = _expand_series(entry["series"])
+        tests.append(tc)
+    return rule, tests
+
+
+def build_context(test_case: RuleTestCase) -> EvaluationContext:
+    series = test_case.series or []
+    now_value = None
+    if test_case.now:
+        text = test_case.now
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        now_value = datetime.fromisoformat(text)
+    return EvaluationContext(
+        series=series,
+        baseline=test_case.baseline,
+        metadata=test_case.metadata,
+        extras={},
+        now_value=now_value,
+    )
+

--- a/policy/rules_engine/rule.py
+++ b/policy/rules_engine/rule.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, Mapping, Optional, Tuple
+
+from .context import EvaluationContext
+from .evaluator import ExpressionEvaluator
+
+
+class RuleMode(str, Enum):
+    OBSERVE = "observe"
+    ENFORCE = "enforce"
+
+
+@dataclass
+class RuleEvaluationResult:
+    triggered: bool
+    details: Dict[str, Any]
+    error: Optional[Exception] = None
+
+
+@dataclass
+class Rule:
+    """A declarative policy rule backed by CEL-like expressions."""
+
+    rule_id: str
+    expr: str
+    mode: RuleMode = RuleMode.OBSERVE
+    severity: str = "low"
+    block_on_error: bool = False
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self._evaluator = ExpressionEvaluator(self.expr)
+
+    @property
+    def id(self) -> str:
+        return self.rule_id
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "Rule":
+        rule_id = payload["id"]
+        expr = payload["expr"]
+        mode = RuleMode(payload.get("mode", RuleMode.OBSERVE.value))
+        severity = payload.get("severity", "low")
+        block_on_error = bool(payload.get("block_on_error", False))
+        metadata = dict(payload.get("metadata", {}))
+        return cls(rule_id, expr, mode=mode, severity=severity, block_on_error=block_on_error, metadata=metadata)
+
+    def evaluate(self, event: Mapping[str, Any], ctx: EvaluationContext) -> RuleEvaluationResult:
+        ctx.captures = {}
+        ctx.missing_fields = []
+        try:
+            outcome = bool(self._evaluator.evaluate(event, ctx))
+        except Exception as exc:
+            details = ctx.to_details()
+            details.setdefault("rule", {"id": self.id, "mode": self.mode.value, "severity": self.severity})
+            return RuleEvaluationResult(False, details, error=exc)
+        details = ctx.to_details()
+        details.setdefault("rule", {"id": self.id, "mode": self.mode.value, "severity": self.severity})
+        return RuleEvaluationResult(outcome, details)
+
+
+@dataclass
+class RuleRuntimeResult:
+    rule_id: str
+    triggered: bool
+    blocked: bool
+    code: Optional[str]
+    violation_id: Optional[str]
+    details: Dict[str, Any]
+    error: Optional[Exception] = None
+    created_violation: bool = False
+    message_override: Optional[str] = None
+
+    @property
+    def message(self) -> str:
+        if self.message_override:
+            return self.message_override
+        if self.blocked and self.code == "policy_violation":
+            return f"Blocked by policy {self.rule_id}."
+        if self.blocked and self.code == "policy_eval_error":
+            return f"Evaluation error for policy {self.rule_id}."
+        return ""
+
+
+class RuleRuntime:
+    """Manage evaluation bookkeeping, violations, and notifications."""
+
+    def __init__(self) -> None:
+        self.metrics: Dict[str, Dict[str, int]] = {}
+        self.violations: Dict[str, Dict[str, Any]] = {}
+        self.notifications: list[Dict[str, Any]] = []
+
+    # -----------------------------------------------------------------
+    def _metric(self, name: str, rule_id: str) -> None:
+        bucket = self.metrics.setdefault(name, {})
+        bucket[rule_id] = bucket.get(rule_id, 0) + 1
+
+    def _fingerprint(self, rule: Rule, event: Mapping[str, Any]) -> str:
+        data = json.dumps({"rule": rule.id, "event": event}, sort_keys=True, default=str)
+        return hashlib.sha1(data.encode("utf-8")).hexdigest()
+
+    def upsert_violation(self, rule: Rule, event: Mapping[str, Any], details: Dict[str, Any]) -> Tuple[str, bool]:
+        fingerprint = self._fingerprint(rule, event)
+        existing = self.violations.get(fingerprint)
+        if existing:
+            existing["count"] = existing.get("count", 1) + 1
+            existing["last_event"] = event
+            existing.setdefault("details", {}).update(details)
+            existing.setdefault("events", []).append(event)
+            created = False
+        else:
+            violation_id = uuid.uuid4().hex
+            self.violations[fingerprint] = {
+                "id": violation_id,
+                "rule_id": rule.id,
+                "count": 1,
+                "details": dict(details),
+                "events": [event],
+            }
+            existing = self.violations[fingerprint]
+            created = True
+        self.notifications.append({"rule_id": rule.id, "violation_id": existing["id"], "created": created})
+        return existing["id"], created
+
+    def apply(self, rule: Rule, event: Mapping[str, Any], ctx: EvaluationContext) -> RuleRuntimeResult:
+        result = rule.evaluate(event, ctx)
+        details = dict(result.details)
+        if result.error:
+            self._metric("rule_eval_error", rule.id)
+            details.setdefault("error", str(result.error))
+            blocked = rule.mode is RuleMode.ENFORCE and rule.block_on_error
+            code = "policy_eval_error" if blocked else None
+            message_override = None
+            if blocked:
+                template = rule.metadata.get("error_message") if isinstance(rule.metadata, dict) else None
+                if isinstance(template, str):
+                    try:
+                        message_override = template.format(**event)
+                    except Exception:
+                        message_override = template
+            return RuleRuntimeResult(
+                rule.id,
+                False,
+                blocked,
+                code,
+                None,
+                details,
+                error=result.error,
+                message_override=message_override,
+            )
+        if not result.triggered:
+            return RuleRuntimeResult(rule.id, False, False, None, None, details)
+        violation_id, created = self.upsert_violation(rule, event, details)
+        code = "policy_violation" if rule.mode is RuleMode.ENFORCE else None
+        blocked = rule.mode is RuleMode.ENFORCE
+        message_override = None
+        if blocked and isinstance(rule.metadata, dict):
+            template = rule.metadata.get("block_message")
+            if isinstance(template, str):
+                try:
+                    message_override = template.format(**event)
+                except Exception:
+                    message_override = template
+        return RuleRuntimeResult(
+            rule.id,
+            True,
+            blocked,
+            code,
+            violation_id,
+            details,
+            created_violation=created,
+            message_override=message_override,
+        )
+

--- a/rules/consent_friction_spike.yaml
+++ b/rules/consent_friction_spike.yaml
@@ -1,0 +1,27 @@
+id: CONSENT_FRICTION_SPIKE
+mode: observe
+severity: medium
+metadata:
+  description: Detect consent-required deny spikes to reduce operator load.
+expr: rate(deny_reason == "consent_required", "15m") > 0.15
+tests:
+  - name: low_rate_ok
+    window: "15m"
+    series:
+      - { deny_reason: "consent_required" }
+      - { deny_reason: "insufficient_role" }
+      - repeat: 8
+    want: false
+  - name: spike_trips
+    window: "15m"
+    series:
+      - repeat: 2
+        each: { deny_reason: "consent_required" }
+      - repeat: 8
+    want: true
+  - name: missing_field_no_panic
+    window: "15m"
+    series:
+      - { outcome: "deny" }
+      - repeat: 9
+    want: false

--- a/rules/mirror_class_limit.yaml
+++ b/rules/mirror_class_limit.yaml
@@ -1,0 +1,22 @@
+id: MIRROR_CLASS_LIMIT
+mode: enforce
+severity: high
+block_on_error: true
+metadata:
+  runbook: docs/runbooks/mirror_class_limit.md
+  summary: Block mirrors on restricted or secret repositories.
+  block_message: "Blocked by policy MIRROR_CLASS_LIMIT. Reason: repo classified '{resource_class}'. See runbook for exception steps."
+expr: action == "mirror" && (resource_class == "restricted" || resource_class == "secret")
+tests:
+  - name: deny_secret
+    input: { action: "mirror", resource_class: "secret", repo: "api/core" }
+    want: true
+  - name: deny_restricted
+    input: { action: "mirror", resource_class: "restricted", repo: "ml/labs" }
+    want: true
+  - name: allow_internal
+    input: { action: "mirror", resource_class: "internal" }
+    want: false
+  - name: allow_other_action
+    input: { action: "deploy", resource_class: "secret" }
+    want: false

--- a/rules/multi_provider_single_role.yaml
+++ b/rules/multi_provider_single_role.yaml
@@ -1,0 +1,25 @@
+id: MULTI_PROVIDER_SINGLE_ROLE
+mode: enforce
+severity: medium
+block_on_error: true
+metadata:
+  product: Mirror Guard
+  description: Block low-privilege users from fanning out mirrors across providers.
+  block_message: "Blocked by policy MULTI_PROVIDER_SINGLE_ROLE. Reason: low-role user touched multiple providers in 5m window."
+expr: action in ["mirror", "pr.create"] && user_role in ["viewer", "contributor"] && distinct_over("resource_provider", "5m") >= 2
+tests:
+  - name: viewer_multi_provider_blocks
+    fixture: multi/multi_provider_window.series.json
+    want: true
+  - name: contributor_single_provider_allows
+    window: "5m"
+    series:
+      - { action: "mirror", resource_provider: "github", user_role: "contributor" }
+      - { action: "mirror", resource_provider: "github", user_role: "contributor" }
+    want: false
+  - name: admin_multi_provider_allows
+    window: "5m"
+    series:
+      - { action: "mirror", resource_provider: "github", user_role: "admin" }
+      - { action: "mirror", resource_provider: "gitlab", user_role: "admin" }
+    want: false

--- a/rules/policy_drift_regression.yaml
+++ b/rules/policy_drift_regression.yaml
@@ -1,0 +1,38 @@
+id: POLICY_DRIFT_REGRESSION
+mode: observe
+severity: medium
+metadata:
+  product: Mirror Guard
+  description: Compare deny rate to baseline after recent policy change.
+expr: rate(outcome == "deny", "30m") > baseline_rate("deny") * 2 && last_policy_change_within("1h") == True
+tests:
+  - name: baseline_ok
+    window: "30m"
+    baseline: { deny: 0.25 }
+    metadata:
+      last_policy_change: "2024-03-01T06:00:00Z"
+    now: "2024-03-01T10:00:00Z"
+    series:
+      - { outcome: "deny" }
+      - { outcome: "allow" }
+      - repeat: 8
+    want: false
+  - name: spike_after_change
+    fixture: policy/drift_spike.series.json
+    baseline: { deny: 0.25 }
+    want: true
+    metadata:
+      last_policy_change: "2024-03-01T11:40:00Z"
+      diff_url: "https://prism/ruleset/changeset/784"
+    now: "2024-03-01T12:00:00Z"
+  - name: spike_without_change
+    window: "30m"
+    baseline: { deny: 0.25 }
+    metadata:
+      last_policy_change: "2024-02-20T09:00:00Z"
+    now: "2024-03-01T12:00:00Z"
+    series:
+      - repeat: 6
+        each: { outcome: "deny" }
+      - repeat: 4
+    want: false

--- a/rules/secret_expiry_cluster.yaml
+++ b/rules/secret_expiry_cluster.yaml
@@ -1,0 +1,24 @@
+id: SECRET_EXPIRY_CLUSTER
+mode: observe
+severity: high
+metadata:
+  product: Secret Hygiene
+  description: Cluster secret-expired errors to trigger automated rotation.
+expr: rate(error_kind == "secret_expired", "10m") >= 0.3
+tests:
+  - name: ok_fixture
+    fixture: secret/ok.series.json
+    want: false
+  - name: burst_fixture
+    fixture: secret/burst.series.json
+    want: true
+    expect_details:
+      captures:
+        rate:
+          - secret_ids: ["hash_2f9c", "hash_9a"]
+  - name: inline_single
+    window: "10m"
+    series:
+      - { error_kind: "secret_expired", secret_id: "hash_x" }
+      - repeat: 5
+    want: false

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+from policy.rules_engine import EvaluationContext, Rule, RuleMode, RuleRuntime, load_fixture, load_rule_file
+
+
+RULE_DIR = Path("rules")
+FIXTURE_DIR = Path("fixtures")
+
+
+def _materialize_case(raw_case) -> tuple[Dict[str, Any], EvaluationContext]:
+    fixture_payload: Dict[str, Any] = {}
+    if raw_case.fixture:
+        fixture_payload = load_fixture(FIXTURE_DIR / raw_case.fixture)
+    series = raw_case.series if raw_case.series is not None else fixture_payload.get("series", [])
+    series = [dict(event) for event in series]
+    window = raw_case.window or fixture_payload.get("window")
+
+    baseline = dict(fixture_payload.get("baseline", {}))
+    baseline.update(raw_case.baseline or {})
+
+    metadata = dict(fixture_payload.get("metadata", {}))
+    metadata.update(raw_case.metadata or {})
+    extras = dict(fixture_payload.get("extras", {}))
+
+    event: Dict[str, Any] = {}
+    if isinstance(fixture_payload.get("input"), dict):
+        event.update(fixture_payload["input"])
+    if raw_case.input:
+        event.update(raw_case.input)
+    if not event and series:
+        event = dict(series[-1])
+
+    now_value = raw_case.now or fixture_payload.get("now")
+    parsed_now = None
+    if now_value:
+        text = now_value
+        if isinstance(text, str) and text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        parsed_now = datetime.fromisoformat(text)
+    ctx = EvaluationContext(
+        series=series or [event],
+        baseline=baseline,
+        metadata=metadata,
+        extras={**extras, **({"window": window} if window else {})},
+        now_value=parsed_now,
+    )
+    return event, ctx
+
+
+def _dict_contains(actual: Any, expected: Any) -> bool:
+    if isinstance(expected, dict):
+        if not isinstance(actual, dict):
+            return False
+        for key, value in expected.items():
+            if key not in actual:
+                return False
+            if not _dict_contains(actual[key], value):
+                return False
+        return True
+    if isinstance(expected, list):
+        if not isinstance(actual, list):
+            return False
+        for item in expected:
+            if isinstance(item, dict):
+                if not any(_dict_contains(candidate, item) for candidate in actual):
+                    return False
+            else:
+                if item not in actual:
+                    return False
+        return True
+    return actual == expected
+
+
+def _rule_cases():
+    for path in sorted(RULE_DIR.glob("*.yaml")):
+        rule, cases = load_rule_file(path)
+        for case in cases:
+            yield path, rule, case
+
+
+@pytest.mark.parametrize("_rule_path, rule, case", list(_rule_cases()))
+def test_rule_definitions(_rule_path: Path, rule: Rule, case) -> None:
+    event, ctx = _materialize_case(case)
+    runtime = RuleRuntime()
+    result = runtime.apply(rule, event, ctx)
+
+    assert result.triggered is case.want, f"{rule.id}/{case.name} expected {case.want}, got {result.triggered}"
+
+    if rule.mode is RuleMode.ENFORCE:
+        assert result.blocked == case.want
+        if case.want:
+            expected_message = rule.metadata.get("block_message") if isinstance(rule.metadata, dict) else None
+            if expected_message:
+                expected_message = expected_message.format(**event)
+                assert result.message == expected_message
+    else:
+        assert result.blocked is False
+
+    if case.expect_details:
+        assert _dict_contains(result.details, case.expect_details)
+
+    if case.want:
+        assert result.violation_id
+        assert runtime.notifications, "violation should enqueue notification"
+    else:
+        assert result.violation_id is None
+
+
+def test_runtime_fail_open_on_error() -> None:
+    rule = Rule(
+        rule_id="TEST_OBSERVE_ERROR",
+        expr="missing_field.some_method()",
+        mode=RuleMode.OBSERVE,
+        severity="low",
+    )
+    event = {}
+    ctx = EvaluationContext(series=[event])
+    runtime = RuleRuntime()
+    result = runtime.apply(rule, event, ctx)
+    assert result.blocked is False
+    assert result.code is None
+    assert runtime.metrics["rule_eval_error"][rule.id] == 1
+
+
+def test_runtime_fail_closed_when_marked() -> None:
+    rule = Rule(
+        rule_id="TEST_ENFORCE_ERROR",
+        expr="unknown.value > 1",
+        mode=RuleMode.ENFORCE,
+        severity="high",
+        block_on_error=True,
+        metadata={"error_message": "Blocked by policy TEST_ENFORCE_ERROR due to evaluation failure."},
+    )
+    ctx = EvaluationContext(series=[{}])
+    runtime = RuleRuntime()
+    result = runtime.apply(rule, {}, ctx)
+    assert result.blocked is True
+    assert result.code == "policy_eval_error"
+    assert "Blocked by policy" in result.message
+
+
+def test_violation_upsert_creates_stable_id() -> None:
+    rule = Rule(rule_id="TEST_VIOLATION", expr="true", mode=RuleMode.ENFORCE, severity="high")
+    ctx = EvaluationContext(series=[{"foo": "bar"}])
+    runtime = RuleRuntime()
+    event = {"foo": "bar"}
+    first = runtime.apply(rule, event, ctx)
+    assert first.violation_id is not None
+    again = runtime.apply(rule, event, ctx)
+    assert again.violation_id == first.violation_id
+    assert runtime.violations
+    assert len(runtime.notifications) == 2


### PR DESCRIPTION
## Summary
- add a reusable rules_engine package that evaluates CEL-like policy expressions, tracks violations, and formats enforcement messages
- define mirror, consent, secret-expiry, policy-drift, and multi-provider rules in YAML with supporting JSON fixtures and runbook documentation
- add pytest coverage that exercises the rule definitions plus runtime fail-open/fail-closed paths

## Testing
- `pytest tests/test_rule_engine.py`
- `pytest policy/kernel/tests/test_kernel.py`


------
https://chatgpt.com/codex/tasks/task_e_68da088e003c8329bb89db6acfbf7e03