### PR TITLE
feat: add interactive agent desktop apps

### DIFF
--- a/sites/blackroad/src/desktop/AgentModeToggle.jsx
+++ b/sites/blackroad/src/desktop/AgentModeToggle.jsx
@@ -1,0 +1,29 @@
+const MODES = [
+  { id: "manual", label: "Manual" },
+  { id: "copilot", label: "Copilot" },
+  { id: "autonomous", label: "Autonomous" },
+];
+
+export default function AgentModeToggle({ mode, onChange }) {
+  return (
+    <div className="inline-flex rounded border border-neutral-700 bg-neutral-900/70 text-xs overflow-hidden">
+      {MODES.map((option) => {
+        const active = option.id === mode;
+        return (
+          <button
+            key={option.id}
+            type="button"
+            onClick={() => onChange(option.id)}
+            className={`${
+              active
+                ? "bg-emerald-500/20 text-emerald-200"
+                : "text-neutral-300 hover:bg-neutral-800"
+            } px-2 py-1 transition-colors`}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/sites/blackroad/src/desktop/apps/ApiAgent.jsx
+++ b/sites/blackroad/src/desktop/apps/ApiAgent.jsx
@@ -1,0 +1,135 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import AgentModeToggle from "../AgentModeToggle.jsx";
+
+const ENDPOINTS = [
+  { method: "GET", path: "/api/health", description: "Service heartbeat and metadata" },
+  { method: "GET", path: "/api/projects", description: "List active Prism projects" },
+  { method: "POST", path: "/api/jobs", description: "Schedule a background orchestration" },
+  { method: "GET", path: "/api/agents", description: "Enumerate registered copilots" },
+];
+
+function formatTime(ts) {
+  return new Date(ts).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+}
+
+export default function ApiAgent() {
+  const [mode, setMode] = useState("copilot");
+  const [status, setStatus] = useState({ state: "idle", ok: null, info: "" });
+  const [logs, setLogs] = useState(() => []);
+  const timerRef = useRef(null);
+
+  const ping = async () => {
+    setStatus({ state: "probing", ok: null, info: "Contacting /api/health" });
+    const stamp = Date.now();
+    try {
+      const fetcher = globalThis.fetch;
+      if (typeof fetcher !== "function") {
+        throw new Error("fetch unavailable");
+      }
+      const response = await fetcher("/api/health", { cache: "no-store" });
+      const payload = await response.json().catch(() => ({}));
+      const ok = response.ok;
+      const info = payload.time || formatTime(stamp);
+      setStatus({ state: "complete", ok, info });
+      setLogs((entries) => [
+        `${formatTime(stamp)} — ${ok ? "Health probe succeeded" : "Health probe failed"}`,
+        ...entries,
+      ].slice(0, 12));
+    } catch (error) {
+      setStatus({ state: "complete", ok: false, info: "network error" });
+      setLogs((entries) => [
+        `${formatTime(Date.now())} — Network error: ${error.message}`,
+        ...entries,
+      ].slice(0, 12));
+    }
+  };
+
+  useEffect(() => {
+    if (mode !== "autonomous") return;
+    ping();
+    timerRef.current = globalThis.setInterval ? globalThis.setInterval(ping, 15000) : null;
+    return () => {
+      if (timerRef.current && typeof globalThis.clearInterval === "function") {
+        globalThis.clearInterval(timerRef.current);
+      }
+      timerRef.current = null;
+    };
+  }, [mode]);
+
+  const statusTone = useMemo(() => {
+    if (status.state === "idle") return "text-neutral-300";
+    if (status.state === "probing") return "text-amber-300";
+    return status.ok ? "text-emerald-300" : "text-rose-300";
+  }, [status]);
+
+  return (
+    <div className="h-full flex flex-col bg-neutral-950 text-neutral-100">
+      <header className="flex flex-col gap-2 border-b border-neutral-800 p-3">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <p className="text-sm font-semibold">API Agent</p>
+            <p className={`text-xs ${statusTone}`}>
+              {status.state === "idle" && "Standing by"}
+              {status.state === "probing" && "Running health probe…"}
+              {status.state === "complete" &&
+                (status.ok ? `Healthy • ${status.info}` : `Issue detected • ${status.info}`)}
+            </p>
+          </div>
+          <AgentModeToggle mode={mode} onChange={setMode} />
+        </div>
+        <div className="flex items-center gap-2 text-xs">
+          <button
+            type="button"
+            onClick={ping}
+            className="rounded bg-emerald-500/20 px-3 py-1 text-emerald-200 hover:bg-emerald-500/30"
+          >
+            Run health probe
+          </button>
+          <span className="text-neutral-400">
+            {mode === "manual" && "Manual investigations only."}
+            {mode === "copilot" && "Assisted debugging with analyst context."}
+            {mode === "autonomous" && "Auto-scanning every 15 seconds."}
+          </span>
+        </div>
+      </header>
+
+      <div className="grid grid-rows-[1fr_auto] gap-3 p-3 flex-1 min-h-0">
+        <section className="rounded border border-neutral-800 bg-neutral-900/40 p-3 overflow-auto">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-neutral-400 mb-2">Recent activity</h3>
+          {logs.length === 0 ? (
+            <p className="text-sm text-neutral-400">No probes yet. Trigger a health check to populate telemetry.</p>
+          ) : (
+            <ul className="space-y-1 text-sm font-mono">
+              {logs.map((line, index) => (
+                <li key={`${line}-${index}`} className="whitespace-pre-wrap">
+                  {line}
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        <section className="rounded border border-neutral-800 bg-neutral-900/40 p-3">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-neutral-400 mb-2">Surface map</h3>
+          <div className="space-y-1 text-xs">
+            {ENDPOINTS.map((endpoint) => (
+              <div
+                key={endpoint.path}
+                className="flex items-start justify-between gap-3 rounded bg-neutral-950/60 px-2 py-1"
+              >
+                <div>
+                  <span className="font-semibold text-emerald-200">{endpoint.method}</span>{" "}
+                  <code className="font-mono text-neutral-200">{endpoint.path}</code>
+                  <p className="text-[11px] text-neutral-400">{endpoint.description}</p>
+                </div>
+                <span className="rounded bg-neutral-800 px-2 py-0.5 text-[11px] text-neutral-300">
+                  {mode === "autonomous" ? "watching" : "ready"}
+                </span>
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/sites/blackroad/src/desktop/apps/EchoAgent.jsx
+++ b/sites/blackroad/src/desktop/apps/EchoAgent.jsx
@@ -1,0 +1,87 @@
+import { useEffect, useState } from "react";
+import AgentModeToggle from "../AgentModeToggle.jsx";
+import createId from "../createId.js";
+
+export default function EchoAgent() {
+  const [mode, setMode] = useState("manual");
+  const [draft, setDraft] = useState("");
+  const [history, setHistory] = useState(() => []);
+
+  useEffect(() => {
+    if (mode !== "autonomous") return;
+    if (history.length > 0) return;
+    const timer = globalThis.setTimeout?.(() => {
+      appendMessage("Auto-hello from the echo agent.");
+    }, 1200);
+    return () => {
+      if (timer && typeof globalThis.clearTimeout === "function") {
+        globalThis.clearTimeout(timer);
+      }
+    };
+  }, [mode, history.length]);
+
+  const appendMessage = (text) => {
+    const entry = { id: createId(), text, at: new Date().toLocaleTimeString() };
+    setHistory((prev) => [entry, ...prev].slice(0, 16));
+  };
+
+  const submit = () => {
+    const text = draft.trim();
+    if (!text) return;
+    appendMessage(text);
+    setDraft("");
+  };
+
+  return (
+    <div className="h-full flex flex-col bg-neutral-950 text-neutral-100">
+      <header className="flex items-center justify-between border-b border-neutral-900 p-3">
+        <div>
+          <p className="text-sm font-semibold">Echo Agent</p>
+          <p className="text-xs text-neutral-400">Routes natural language into the shared activity log.</p>
+        </div>
+        <AgentModeToggle mode={mode} onChange={setMode} />
+      </header>
+
+      <section className="flex-1 overflow-auto p-3">
+        {history.length === 0 ? (
+          <p className="text-sm text-neutral-400">No transmissions yet. Start typing below.</p>
+        ) : (
+          <ul className="space-y-2">
+            {history.map((entry) => (
+              <li
+                key={entry.id}
+                className="rounded border border-neutral-800 bg-neutral-900/50 px-3 py-2 text-sm text-neutral-200"
+              >
+                <div className="text-[11px] uppercase tracking-wide text-neutral-500">{entry.at}</div>
+                <div className="font-mono whitespace-pre-wrap">{entry.text}</div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <footer className="border-t border-neutral-900 bg-neutral-950 p-3 space-y-2">
+        <textarea
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          placeholder="Dictate updates, TODOs, or scratch notes…"
+          className="h-16 w-full resize-none rounded border border-neutral-800 bg-neutral-900/60 p-2 text-sm text-neutral-100 focus:border-emerald-500/60 focus:outline-none"
+        />
+        <div className="flex items-center justify-between text-xs text-neutral-400">
+          <span>
+            {mode === "manual" && "Only echoes what you type."}
+            {mode === "copilot" && "Suggests storing every keystroke for context."}
+            {mode === "autonomous" && "Sends periodic pings to keep humans in the loop."}
+          </span>
+          <button
+            type="button"
+            onClick={submit}
+            className="rounded bg-emerald-500/20 px-3 py-1 text-emerald-200 hover:bg-emerald-500/30"
+          >
+            Echo
+          </button>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/sites/blackroad/src/desktop/apps/ExplorerAgent.jsx
+++ b/sites/blackroad/src/desktop/apps/ExplorerAgent.jsx
@@ -1,0 +1,111 @@
+import { useMemo, useState } from "react";
+import AgentModeToggle from "../AgentModeToggle.jsx";
+
+const FILESYSTEM = [
+  {
+    path: "src/pages/Desktop.jsx",
+    summary: "Prism desktop orchestrator with draggable windows.",
+    snippet: `const APPS = {\n  api: { title: "API Agent", icon: "API" },\n  llm: { title: "LLM Agent", icon: "LLM" },\n};`,
+  },
+  {
+    path: "src/desktop/Window.jsx",
+    summary: "Window manager harness for the on-screen agents.",
+    snippet: `export default function Window({ win, onClose, onToggleMin, onToggleMax, onUpdate, children }) {\n  if (win.minimized) return null;\n}`,
+  },
+  {
+    path: "src/pages/Editor.jsx",
+    summary: "In-browser code runner for quick scripts.",
+    snippet: `const run = () => {\n  const logs = [];\n  const orig = console.log;\n};`,
+  },
+  {
+    path: "src/pages/Terminal.jsx",
+    summary: "Simulated terminal streaming operations logs.",
+    snippet: `const commands = [\n  { label: "git status", output: "On branch main" },\n];`,
+  },
+];
+
+export default function ExplorerAgent() {
+  const [mode, setMode] = useState("manual");
+  const [filter, setFilter] = useState("");
+  const [selectedPath, setSelectedPath] = useState(FILESYSTEM[0].path);
+
+  const listing = useMemo(() => {
+    const term = filter.trim().toLowerCase();
+    if (!term) return FILESYSTEM;
+    return FILESYSTEM.filter((file) => file.path.toLowerCase().includes(term));
+  }, [filter]);
+
+  const selected = listing.find((file) => file.path === selectedPath) || listing[0] || null;
+
+  return (
+    <div className="h-full flex flex-col bg-neutral-950 text-neutral-100">
+      <header className="flex flex-col gap-2 border-b border-neutral-900 p-3">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <p className="text-sm font-semibold">Prism Explorer</p>
+            <p className="text-xs text-neutral-400">
+              Browse on-screen agent blueprints and drop them into a coding session.
+            </p>
+          </div>
+          <AgentModeToggle mode={mode} onChange={setMode} />
+        </div>
+        <input
+          value={filter}
+          onChange={(event) => setFilter(event.target.value)}
+          placeholder="Filter files or agents…"
+          className="w-full rounded border border-neutral-800 bg-neutral-900/60 px-2 py-1 text-sm text-neutral-100 focus:border-emerald-500/60 focus:outline-none"
+        />
+      </header>
+
+      <div className="flex flex-1 min-h-0 divide-x divide-neutral-900">
+        <aside className="w-44 overflow-auto">
+          <ul className="divide-y divide-neutral-900 text-xs">
+            {listing.map((file) => (
+              <li key={file.path}>
+                <button
+                  type="button"
+                  onClick={() => setSelectedPath(file.path)}
+                  className={`flex w-full flex-col items-start gap-0.5 px-3 py-2 text-left transition-colors ${
+                    selected && selected.path === file.path
+                      ? "bg-emerald-500/10 text-emerald-100"
+                      : "hover:bg-neutral-900/80 text-neutral-200"
+                  }`}
+                >
+                  <span className="font-semibold">{file.path}</span>
+                  <span className="text-[11px] text-neutral-400">{file.summary}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </aside>
+
+        <section className="flex-1 overflow-auto p-3">
+          {selected ? (
+            <div className="space-y-3">
+              <header className="flex items-center justify-between">
+                <div>
+                  <h3 className="text-sm font-semibold text-neutral-100">{selected.path}</h3>
+                  <p className="text-xs text-neutral-400">{selected.summary}</p>
+                </div>
+                <span className="rounded bg-neutral-900/70 px-2 py-1 text-[11px] text-neutral-300">
+                  {mode === "manual" && "Preview"}
+                  {mode === "copilot" && "Linked to editor"}
+                  {mode === "autonomous" && "Syncing snippets"}
+                </span>
+              </header>
+              <div className="rounded border border-neutral-800 bg-neutral-900/60 p-3">
+                <p className="text-[11px] uppercase tracking-wide text-neutral-500 mb-2">Code snippet</p>
+                <pre className="whitespace-pre-wrap font-mono text-xs text-neutral-100">{selected.snippet}</pre>
+              </div>
+              <div className="rounded border border-neutral-800 bg-neutral-900/40 p-3 text-xs text-neutral-300">
+                Drop into live coding by copying the snippet above or sending to the LLM agent.
+              </div>
+            </div>
+          ) : (
+            <p className="text-sm text-neutral-400">No files matched this filter.</p>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/sites/blackroad/src/desktop/apps/GuardianAgent.jsx
+++ b/sites/blackroad/src/desktop/apps/GuardianAgent.jsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from "react";
+import AgentModeToggle from "../AgentModeToggle.jsx";
+
+const CHECKS = [
+  { id: "policy", label: "Policy drift", detail: "Compare live config vs. baseline" },
+  { id: "secrets", label: "Secrets hygiene", detail: "Scan for leaked credentials" },
+  { id: "access", label: "Access control", detail: "Verify role boundaries" },
+  { id: "telemetry", label: "Telemetry", detail: "Ensure audit events are flowing" },
+];
+
+export default function GuardianAgent() {
+  const [mode, setMode] = useState("copilot");
+  const [flags, setFlags] = useState([]);
+  const [lastRun, setLastRun] = useState(null);
+
+  const runScan = () => {
+    const timestamp = new Date();
+    setLastRun(timestamp.toLocaleTimeString());
+    const flagged = CHECKS.filter(() => Math.random() > 0.5).map((check) => ({
+      id: check.id,
+      summary: `${check.label} requires attention`,
+      mitigation: `Loop agent on ${check.detail.toLowerCase()}.`,
+    }));
+    setFlags(flagged);
+  };
+
+  useEffect(() => {
+    if (mode !== "autonomous") return;
+    runScan();
+    const id = globalThis.setInterval?.(runScan, 20000);
+    return () => {
+      if (id && typeof globalThis.clearInterval === "function") {
+        globalThis.clearInterval(id);
+      }
+    };
+  }, [mode]);
+
+  return (
+    <div className="h-full flex flex-col bg-neutral-950 text-neutral-100">
+      <header className="flex flex-col gap-2 border-b border-neutral-900 p-3">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <p className="text-sm font-semibold">Guardian Agent</p>
+            <p className="text-xs text-neutral-400">
+              {lastRun ? `Last scan ${lastRun}` : "Standing by for contradictions."}
+            </p>
+          </div>
+          <AgentModeToggle mode={mode} onChange={setMode} />
+        </div>
+        <div className="flex flex-wrap gap-2 text-xs text-neutral-300">
+          {CHECKS.map((check) => (
+            <span key={check.id} className="rounded border border-neutral-800 bg-neutral-900/50 px-2 py-1">
+              {check.label}
+            </span>
+          ))}
+        </div>
+        <button
+          type="button"
+          onClick={runScan}
+          className="self-start rounded bg-emerald-500/20 px-3 py-1 text-sm text-emerald-200 hover:bg-emerald-500/30"
+        >
+          Run guardian scan
+        </button>
+      </header>
+
+      <section className="flex-1 overflow-auto p-3 space-y-3">
+        {flags.length === 0 ? (
+          <div className="rounded border border-neutral-800 bg-neutral-900/40 px-3 py-2 text-sm text-neutral-400">
+            All clear. Guardian agent will surface contradictions as soon as they appear.
+          </div>
+        ) : (
+          flags.map((flag) => (
+            <article
+              key={flag.id}
+              className="rounded border border-rose-700/40 bg-rose-500/10 px-3 py-2 text-sm text-rose-100"
+            >
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-rose-200">{flag.summary}</h3>
+              <p className="text-xs text-rose-100/80">{flag.mitigation}</p>
+            </article>
+          ))
+        )}
+      </section>
+    </div>
+  );
+}

--- a/sites/blackroad/src/desktop/apps/LlmAgent.jsx
+++ b/sites/blackroad/src/desktop/apps/LlmAgent.jsx
@@ -1,0 +1,137 @@
+import { useEffect, useRef, useState } from "react";
+import AgentModeToggle from "../AgentModeToggle.jsx";
+import createId from "../createId.js";
+
+function synthesizeReply(prompt, mode) {
+  const headline = mode === "autonomous" ? "Autopilot" : mode === "copilot" ? "Paired" : "Manual";
+  const summary = prompt.length > 140 ? `${prompt.slice(0, 140)}…` : prompt;
+  return [
+    `${headline} analysis: ${summary}`,
+    "```plan",
+    "1. Understand the request",
+    "2. Draft a concise strategy",
+    "3. Generate code with guardrails",
+    "```",
+    "```code",
+    "// Generated snippet",
+    "function demo() {",
+    "  return 'co-create';",
+    "}",
+    "```",
+  ].join("\n");
+}
+
+const QUICK_PROMPTS = [
+  "Draft an onboarding checklist",
+  "Create a REST handler for POST /api/jobs",
+  "Summarize the math agent status",
+];
+
+export default function LlmAgent() {
+  const [mode, setMode] = useState("copilot");
+  const [input, setInput] = useState("");
+  const [messages, setMessages] = useState(() => [
+    { id: "intro", role: "assistant", content: "LLM agent standing by for on-screen coding." },
+  ]);
+  const scrollRef = useRef(null);
+
+  useEffect(() => {
+    if (!scrollRef.current) return;
+    scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+  }, [messages]);
+
+  useEffect(() => {
+    if (mode !== "autonomous" || input.trim()) return;
+    if (messages.length > 1) return;
+    const autoprompt = "Observe active agents and suggest coordination.";
+    sendPrompt(autoprompt);
+  }, [mode]);
+
+  const sendPrompt = (prompt) => {
+    const text = prompt.trim();
+    if (!text) return;
+    const id = createId();
+    setMessages((prev) => [...prev, { id: createId(), role: "user", content: text }, { id, role: "assistant", content: "…" }]);
+    setInput("");
+
+    const delay = mode === "manual" ? 600 : 250;
+    const timer = globalThis.setTimeout?.(() => {
+      setMessages((prev) =>
+        prev.map((msg) => (msg.id === id ? { ...msg, content: synthesizeReply(text, mode) } : msg))
+      );
+    }, delay);
+    return timer;
+  };
+
+  return (
+    <div className="h-full flex flex-col bg-neutral-950 text-neutral-100">
+      <header className="flex flex-col gap-2 border-b border-neutral-900 p-3">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <p className="text-sm font-semibold">LLM Agent</p>
+            <p className="text-xs text-neutral-400">
+              Real-time copilot responses with structured plans and code blocks.
+            </p>
+          </div>
+          <AgentModeToggle mode={mode} onChange={setMode} />
+        </div>
+        <div className="flex flex-wrap gap-2 text-xs">
+          {QUICK_PROMPTS.map((prompt) => (
+            <button
+              key={prompt}
+              type="button"
+              onClick={() => sendPrompt(prompt)}
+              className="rounded bg-neutral-800 px-2 py-1 text-neutral-200 hover:bg-neutral-700"
+            >
+              {prompt}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      <div ref={scrollRef} className="flex-1 overflow-auto space-y-3 p-3">
+        {messages.map((msg) => (
+          <article
+            key={msg.id}
+            className={`rounded border px-3 py-2 text-sm leading-relaxed ${
+              msg.role === "assistant"
+                ? "border-emerald-700/60 bg-emerald-500/10 text-emerald-100"
+                : "border-neutral-800 bg-neutral-900/60 text-neutral-200"
+            }`}
+          >
+            <p className="text-[11px] uppercase tracking-wide text-neutral-400 mb-1">{msg.role}</p>
+            <pre className="whitespace-pre-wrap font-mono text-xs text-left">{msg.content}</pre>
+          </article>
+        ))}
+      </div>
+
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          sendPrompt(input);
+        }}
+        className="border-t border-neutral-900 bg-neutral-950 p-3 space-y-2"
+      >
+        <textarea
+          value={input}
+          onChange={(event) => setInput(event.target.value)}
+          placeholder="Type instructions, paste code, or drop a spec…"
+          className="h-20 w-full resize-none rounded border border-neutral-800 bg-neutral-900/60 p-2 text-sm text-neutral-100 focus:border-emerald-500/60 focus:outline-none"
+        />
+        <div className="flex items-center justify-between text-xs text-neutral-400">
+          <span>
+            {mode === "manual" && "No automation — agent replies only when prompted."}
+            {mode === "copilot" && "Agent drafts solutions as you type."}
+            {mode === "autonomous" && "Autonomous orchestration with proactive outputs."}
+          </span>
+          <button
+            type="submit"
+            className="rounded bg-emerald-500/20 px-3 py-1 text-emerald-200 hover:bg-emerald-500/30"
+          >
+            Send
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/sites/blackroad/src/desktop/apps/MathAgent.jsx
+++ b/sites/blackroad/src/desktop/apps/MathAgent.jsx
@@ -1,0 +1,173 @@
+import { useEffect, useMemo, useState } from "react";
+import AgentModeToggle from "../AgentModeToggle.jsx";
+
+function normalizeExpression(expression) {
+  return expression.replace(/y/g, "x");
+}
+
+function evaluateExpression(expression, domain) {
+  const fn = new Function("x", `return (${expression});`);
+  const values = [];
+  for (let x = domain.start; x <= domain.end; x += domain.step) {
+    let result;
+    try {
+      result = fn(Number(x.toFixed(5)));
+    } catch (error) {
+      result = `error: ${error.message}`;
+    }
+    values.push({ x: Number(x.toFixed(2)), y: result });
+  }
+  return values;
+}
+
+const PRESETS = [
+  { label: "Sine wave", expression: "Math.sin(x).toFixed(3)", domain: { start: 0, end: Math.PI * 2, step: 0.4 } },
+  { label: "Logistic map", expression: "3.6 * y * (1 - y)", domain: { start: 0, end: 1, step: 0.1 } },
+  { label: "Quadratic", expression: "(x*x - 4*x + 3).toFixed(2)", domain: { start: -2, end: 6, step: 0.5 } },
+];
+
+export default function MathAgent() {
+  const [mode, setMode] = useState("copilot");
+  const [expression, setExpression] = useState("Math.sin(x)");
+  const [domain, setDomain] = useState({ start: 0, end: 6.28, step: 0.5 });
+  const [series, setSeries] = useState(() => evaluateExpression("Math.sin(x)", { start: 0, end: 6.28, step: 0.5 }));
+  const [status, setStatus] = useState("Ready to compute trajectories.");
+
+  const compute = () => {
+    setStatus("Crunching numbers…");
+    try {
+      const results = evaluateExpression(expression, domain);
+      setSeries(results);
+      setStatus(`Evaluated ${results.length} points.`);
+    } catch (error) {
+      setStatus(`Error: ${error.message}`);
+    }
+  };
+
+  useEffect(() => {
+    if (mode !== "autonomous") return;
+    const id = globalThis.setInterval?.(() => {
+      setStatus("Auto-sampling new values…");
+      setSeries((previous) => {
+        if (previous.length === 0) return previous;
+        const rotated = [...previous.slice(1), previous[0]];
+        return rotated;
+      });
+    }, 4000);
+    return () => {
+      if (id && typeof globalThis.clearInterval === "function") {
+        globalThis.clearInterval(id);
+      }
+    };
+  }, [mode]);
+
+  const preview = useMemo(() => series.slice(0, 12), [series]);
+
+  return (
+    <div className="h-full flex flex-col bg-neutral-950 text-neutral-100">
+      <header className="flex flex-col gap-2 border-b border-neutral-900 p-3">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <p className="text-sm font-semibold">Math Agent</p>
+            <p className="text-xs text-neutral-400">{status}</p>
+          </div>
+          <AgentModeToggle mode={mode} onChange={setMode} />
+        </div>
+        <div className="flex flex-wrap gap-2 text-xs">
+          {PRESETS.map((preset) => {
+            const normalizedExpression = normalizeExpression(preset.expression);
+            return (
+              <button
+                key={preset.label}
+                type="button"
+                onClick={() => {
+                  setExpression(normalizedExpression);
+                  setDomain(preset.domain);
+                  setSeries(evaluateExpression(normalizedExpression, preset.domain));
+                }}
+                className="rounded bg-neutral-800 px-2 py-1 text-neutral-200 hover:bg-neutral-700"
+              >
+                {preset.label}
+              </button>
+            );
+          })}
+        </div>
+      </header>
+
+      <div className="grid flex-1 min-h-0 grid-rows-[auto_auto_1fr] gap-3 p-3">
+        <section className="rounded border border-neutral-800 bg-neutral-900/40 p-3 space-y-2">
+          <label className="text-xs font-semibold uppercase tracking-wide text-neutral-400">Expression</label>
+          <textarea
+            value={expression}
+            onChange={(event) => setExpression(event.target.value)}
+            className="h-16 w-full resize-none rounded border border-neutral-800 bg-neutral-950/60 p-2 font-mono text-sm text-neutral-100 focus:border-emerald-500/60 focus:outline-none"
+          />
+          <div className="grid grid-cols-3 gap-2 text-xs">
+            <label className="flex flex-col gap-1">
+              <span className="text-neutral-400">Start</span>
+              <input
+                type="number"
+                value={domain.start}
+                onChange={(event) => setDomain((d) => ({ ...d, start: Number(event.target.value) }))}
+                className="rounded border border-neutral-800 bg-neutral-950/60 p-2"
+              />
+            </label>
+            <label className="flex flex-col gap-1">
+              <span className="text-neutral-400">End</span>
+              <input
+                type="number"
+                value={domain.end}
+                onChange={(event) => setDomain((d) => ({ ...d, end: Number(event.target.value) }))}
+                className="rounded border border-neutral-800 bg-neutral-950/60 p-2"
+              />
+            </label>
+            <label className="flex flex-col gap-1">
+              <span className="text-neutral-400">Step</span>
+              <input
+                type="number"
+                step="0.1"
+                value={domain.step}
+                onChange={(event) => setDomain((d) => ({ ...d, step: Number(event.target.value) }))}
+                className="rounded border border-neutral-800 bg-neutral-950/60 p-2"
+              />
+            </label>
+          </div>
+          <button
+            type="button"
+            onClick={compute}
+            className="rounded bg-emerald-500/20 px-3 py-1 text-sm text-emerald-200 hover:bg-emerald-500/30"
+          >
+            Compute dataset
+          </button>
+        </section>
+
+        <section className="rounded border border-neutral-800 bg-neutral-900/40 p-3">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-neutral-400 mb-2">First samples</h3>
+          <table className="w-full table-fixed text-xs text-neutral-300">
+            <thead>
+              <tr className="text-neutral-500">
+                <th className="text-left font-semibold">x</th>
+                <th className="text-left font-semibold">f(x)</th>
+              </tr>
+            </thead>
+            <tbody>
+              {preview.map((point, index) => (
+                <tr key={`${point.x}-${index}`} className="border-t border-neutral-900">
+                  <td className="py-1 font-mono">{point.x}</td>
+                  <td className="py-1 font-mono">{String(point.y)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+
+        <section className="rounded border border-neutral-800 bg-neutral-900/40 p-3 overflow-auto">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-neutral-400 mb-2">Code export</h3>
+          <pre className="text-[11px] font-mono leading-relaxed whitespace-pre">
+{`const samples = ${JSON.stringify(series.slice(0, 24), null, 2)};`}
+          </pre>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/sites/blackroad/src/desktop/createId.js
+++ b/sites/blackroad/src/desktop/createId.js
@@ -1,0 +1,7 @@
+export default function createId() {
+  const { crypto } = globalThis;
+  if (crypto && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return Math.random().toString(36).slice(2);
+}

--- a/sites/blackroad/src/pages/Desktop.jsx
+++ b/sites/blackroad/src/pages/Desktop.jsx
@@ -1,24 +1,33 @@
 import { useEffect, useState } from "react";
 import Window from "../desktop/Window.jsx";
+import ApiAgent from "../desktop/apps/ApiAgent.jsx";
+import LlmAgent from "../desktop/apps/LlmAgent.jsx";
+import MathAgent from "../desktop/apps/MathAgent.jsx";
+import EchoAgent from "../desktop/apps/EchoAgent.jsx";
+import GuardianAgent from "../desktop/apps/GuardianAgent.jsx";
+import ExplorerAgent from "../desktop/apps/ExplorerAgent.jsx";
+import createId from "../desktop/createId.js";
 
 const APPS = {
-  api: { title: "API Agent", icon: "API" },
-  llm: { title: "LLM Agent", icon: "LLM" },
-  math: { title: "Math Agent", icon: "MATH" },
-  echo: { title: "Echo Agent", icon: "ECHO" },
-  guardian: { title: "Guardian Agent", icon: "GUARD" },
-  explorer: { title: "Prism Explorer", icon: "FS" },
+  api: { title: "API Agent", icon: "API", component: ApiAgent, size: { width: 420, height: 360 } },
+  llm: { title: "LLM Agent", icon: "LLM", component: LlmAgent, size: { width: 460, height: 440 } },
+  math: { title: "Math Agent", icon: "MATH", component: MathAgent, size: { width: 520, height: 480 } },
+  echo: { title: "Echo Agent", icon: "ECHO", component: EchoAgent, size: { width: 360, height: 320 } },
+  guardian: { title: "Guardian Agent", icon: "GUARD", component: GuardianAgent, size: { width: 380, height: 340 } },
+  explorer: { title: "Prism Explorer", icon: "FS", component: ExplorerAgent, size: { width: 460, height: 360 } },
 };
 
 function defaultWin(key) {
+  const layout = APPS[key];
+  const size = layout?.size || {};
   return {
-    id: crypto.randomUUID(),
+    id: createId(),
     app: key,
-    title: APPS[key].title,
+    title: layout?.title || key,
     x: 80,
     y: 80,
-    w: 400,
-    h: 300,
+    w: size.width || 400,
+    h: size.height || 320,
     minimized: false,
     maximized: false,
   };
@@ -111,21 +120,9 @@ export default function Desktop() {
 }
 
 function renderApp(key) {
-  switch (key) {
-    case "api":
-      return <pre className="p-2">/prism/logs/api tail</pre>;
-    case "llm":
-      return <div className="p-2">LLM chat placeholder</div>;
-    case "math":
-      return <div className="p-2">Graph canvas placeholder</div>;
-    case "echo":
-      return <div className="p-2">Echo agent window</div>;
-    case "guardian":
-      return <div className="p-2">Contradictions list</div>;
-    case "explorer":
-      return <div className="p-2">/prism file explorer</div>;
-    default:
-      return null;
-  }
+  const entry = APPS[key];
+  if (!entry || !entry.component) return null;
+  const Component = entry.component;
+  return <Component />;
 }
 


### PR DESCRIPTION
## Summary
- implement dedicated agent windows for API health, LLM chat, math workspace, echo log, guardian scans, and explorer previews
- add a shared presence toggle and ID helper to support manual, copilot, and autonomous behaviors across agents
- wire the desktop launcher to render the new agents with sensible default window sizing

## Testing
- npm --prefix sites/blackroad run lint

------
https://chatgpt.com/codex/tasks/task_e_68da0c29e3e4832994f7eb324befb226