### PR TITLE
docs: add blackroad a-to-z framework

### DIFF
--- a/docs/BLACKROAD_A_TO_Z_FRAMEWORK.md
+++ b/docs/BLACKROAD_A_TO_Z_FRAMEWORK.md
@@ -1,0 +1,258 @@
+# BlackRoad A→Z Framework
+
+A single, universal, scale-aware framework that blends scientific method, Lean/Six Sigma, classic program management, and agile operating rhythms. Each letter is a modular toolbox that can scale from "build a universe" programs down to "1+1" tasks by relying on a FAST-PATH option.
+
+## Choosing the Right Track
+
+| Track | When to Use | Guidance |
+| --- | --- | --- |
+| **T1 — Tiny** | Effort under a day, low risk | Use the FAST-PATH note for each letter only. |
+| **T2 — Standard** | Multi-week efforts, cross-team coordination | Apply FAST-PATH + 2–3 key items per letter. Include a lightweight governance gate. |
+| **T3 — Complex / Critical** | Multi-month, regulated, or high-risk initiatives | Run the full A→Z toolbox. Layer in formal governance gates (e.g., SRR/PDR/CDR/ORR/LRR). |
+
+> **Mapping to familiar systems**: The framework aligns to PMBOK (Initiate/Plan/Execute/Monitor–Control/Close), DMAIC/PDCA, Scrum/Kanban cadences, and big-system design reviews.
+
+## Letter-by-Letter Toolbox
+
+Each letter captures the purpose, core actions, expected artifacts, and a FAST-PATH compression for small or low-risk work.
+
+### A — Aim & Alignment *(Initiate)*
+
+- **Purpose**: State the mission, outcomes, and boundaries.
+- **Do**: Articulate the vision → set OKRs or a North Star → define success criteria.
+- **Artifacts**: 1-page vision and product goal.
+- **FAST-PATH**: Write a single sentence: “We will ___ so that ___ by ___.”
+
+### B — Business Case & Baseline *(Initiate / Plan)*
+
+- **Purpose**: Explain why now, the value at stake, and the current state.
+- **Do**: Outline costs/benefits, constraints, and baseline performance (time/quality/cost).
+- **Artifacts**: Business case and baseline dashboard.
+- **FAST-PATH**: List three benefits and a go/no-go threshold.
+
+### C — Charter & Customers *(Initiate)*
+
+- **Purpose**: Authorize the work and identify who cares.
+- **Do**: Draft the charter; map stakeholders; define primary customers.
+- **Artifacts**: RACI and stakeholder map.
+- **FAST-PATH**: Name the sponsor, the decider, and the user.
+
+### D — Define *(DMAIC / Plan)*
+
+- **Purpose**: Clearly define the problem/goal and scope boundaries.
+- **Do**: Build a SIPOC + A3 header; mark in/out scope fences.
+- **Artifacts**: Problem statement and Definition of Done v1.
+- **FAST-PATH**: One-line problem plus three “in” bullets and three “out” bullets.
+
+### E — Evidence & Experiment *(Scientific Method / PDCA)*
+
+- **Purpose**: Form hypotheses and design tests.
+- **Do**: Write hypotheses → design experiments → create a minimal experiment plan.
+- **Artifacts**: PDCA card (Plan–Do–Check–Act).
+- **FAST-PATH**: One experiment with a measurable pass/fail.
+
+### F — Flow & Forecast *(Plan / Execute)*
+
+- **Purpose**: Choose the delivery cadence and make realistic forecasts.
+- **Do**: Select Scrum (timeboxes) or Kanban (WIP), estimate relatively, set WIP limits.
+- **Artifacts**: Sprint plan or Kanban board with WIP caps.
+- **FAST-PATH**: Cap WIP to team size and start.
+
+### G — Governance & Gates *(Monitor / Control)*
+
+- **Purpose**: Balance control with autonomy.
+- **Do**: Pick a gate set—Lite (T1), Standard (T2), or Major (T3 with SRR/PDR/CDR/ORR/LRR).
+- **Artifacts**: Gate checklist and evidence list.
+- **FAST-PATH**: One mid-point “health check.”
+
+### H — Hypotheses & Hoshin *(Plan)*
+
+- **Purpose**: Link experiments to strategy.
+- **Do**: Rank hypotheses by impact/effort and align to OKRs.
+- **Artifacts**: Hypothesis backlog.
+- **FAST-PATH**: Test the riskiest assumption first.
+
+### I — Implementation & Iteration *(Execute)*
+
+- **Purpose**: Deliver increments frequently.
+- **Do**: Run Sprint → Review → Retrospective cycles or continuous Kanban flow.
+- **Artifacts**: Working increment and demo with Definition of Done met.
+- **FAST-PATH**: 1–2-day micro-sprint.
+
+### J — Just-in-Time *(Execute)*
+
+- **Purpose**: Reduce waste by keeping queues short.
+- **Do**: Pull work JIT, keep batches small, apply 5S to digital/physical spaces.
+- **Artifacts**: Visual workflow and batch size policy.
+- **FAST-PATH**: Split any item longer than two days.
+
+### K — Kanban & Key Constraints *(Monitor / Control)*
+
+- **Purpose**: Manage flow systemically.
+- **Do**: Visualize → limit WIP → manage bottlenecks → measure cycle time.
+- **Artifacts**: Board with explicit WIP limits per column.
+- **FAST-PATH**: Set WIP equal to team size and measure cycle time.
+
+### L — Learning & Logs *(Monitor / Control)*
+
+- **Purpose**: Capture decisions and lessons efficiently.
+- **Do**: Maintain A3s; run root-cause (5 Whys); keep decision logs; conduct retros.
+- **Artifacts**: A3 gallery and retro actions.
+- **FAST-PATH**: 15-minute retro with one improvement.
+
+### M — Measure *(DMAIC Measure / Monitor)*
+
+- **Purpose**: Instrument both outcomes and process.
+- **Do**: Pick 3–5 KPIs (value, flow, quality, happiness); baseline and track; run MSA if needed.
+- **Artifacts**: Single-page metrics view.
+- **FAST-PATH**: One value metric plus one flow metric.
+
+### N — Navigate Risk *(Plan / Control)*
+
+- **Purpose**: Surface and manage risk actively.
+- **Do**: Build a RAID log; run pre-mortems; plan responses (avoid/mitigate/transfer/accept).
+- **Artifacts**: Top-10 risks with owners and triggers.
+- **FAST-PATH**: List the top three risks and their triggers.
+
+### O — Operations Link *(Plan / Execute)*
+
+- **Purpose**: Synchronize with operations, finance, marketing, IT, etc.
+- **Do**: Map inter-functional dependencies and handoffs.
+- **Artifacts**: "Ops across the org" information flow map.
+- **FAST-PATH**: Hold one 30-minute sync with Ops and Finance.
+
+### P — People & Portfolio *(Plan)*
+
+- **Purpose**: Align roles, capacity, and priorities.
+- **Do**: Confirm roles (PO, Scrum Master, Developers) and capacity; limit portfolio WIP.
+- **Artifacts**: Capacity plan and portfolio Kanban.
+- **FAST-PATH**: Agree on the decider and the driver.
+
+### Q — Quality System *(Execute / Control)*
+
+- **Purpose**: Build in quality and prove it.
+- **Do**: Define Definition of Done; establish test strategy; set SQC/defect policies; govern tech debt.
+- **Artifacts**: DoD, test matrix, SPC charts if required.
+- **FAST-PATH**: Add acceptance checks to each card.
+
+### R — Release & Readiness *(Execute / Close)*
+
+- **Purpose**: Deploy with confidence.
+- **Do**: Run ORR/LRR; prepare cutover plan, comms, training, and rollback.
+- **Artifacts**: Release notes and go/no-go checklist.
+- **FAST-PATH**: Soft-launch to a small cohort.
+
+### S — Stakeholders & Scope *(Plan / Control)*
+
+- **Purpose**: Keep expectations precise and evolving.
+- **Do**: Build user stories; curate backlog; set scope guardrails; design comms plan.
+- **Artifacts**: Prioritized backlog and change policy.
+- **FAST-PATH**: Weekly 30-minute review with the sponsor.
+
+### T — Tools & Technical Excellence *(Execute)*
+
+- **Purpose**: Enable speed without creating chaos.
+- **Do**: Implement CI, trunk-based development, test automation, coding standards, and ten-minute builds.
+- **Artifacts**: CI pipeline and working agreements.
+- **FAST-PATH**: Add CI coverage and one smoke test immediately.
+
+### U — Unblock & Uplevel *(Execute / Control)*
+
+- **Purpose**: Remove impediments and improve capability.
+- **Do**: Maintain an impediment board; set escalation ladders; coach the team; invest in belts.
+- **Artifacts**: Weekly impediment burn-down.
+- **FAST-PATH**: Name today’s top blocker and assign an owner.
+
+### V — Value & Validation *(Execute / Control)*
+
+- **Purpose**: Prove outcomes, not just activity.
+- **Do**: Define value tests (usability, NPS, cycle-time delta, revenue proxy); run A/B tests where suitable.
+- **Artifacts**: Outcomes review each sprint/release.
+- **FAST-PATH**: Review one value metric during every demo.
+
+### W — Waste & Workflows *(Execute)*
+
+- **Purpose**: Eliminate non-value work and smooth delivery.
+- **Do**: Identify TIMWOODS waste; map the value stream; apply 5S.
+- **Artifacts**: Before/after flow map.
+- **FAST-PATH**: Cancel one recurring meeting that adds no value.
+
+### X — eXplore *(PDCA / Discovery)*
+
+- **Purpose**: Run structured discovery when the unknowns dominate.
+- **Do**: Schedule spikes, design sprints, and prototypes; decide at the last responsible moment.
+- **Artifacts**: Spike report with keep/kill decision.
+- **FAST-PATH**: Execute a one-day spike and demo the results.
+
+### Y — Yardsticks & Yield *(Benefits Realization / Close)*
+
+- **Purpose**: Confirm the effort paid off and decide what to continue.
+- **Do**: Track benefits; monitor operational KPIs; sunset experiments.
+- **Artifacts**: 90-day value check after release.
+- **FAST-PATH**: Write a single after-action note with metric movement.
+
+### Z — Zero-Drift Close *(Close)*
+
+- **Purpose**: Close cleanly to set up the next initiative.
+- **Do**: Conduct post-implementation review; archive assets; celebrate; roll forward open risks/actions.
+- **Artifacts**: Closure pack and one-page lessons.
+- **FAST-PATH**: 30-minute PIR with three “keep/stop/start.”
+
+## Scaling & Skip Rules
+
+- **Pick your lane**: T1 = FAST-PATH only; T2 = FAST-PATH plus governance (G), quality (Q), and risk (N); T3 = full framework with formal reviews for high-blast-radius systems.
+- **Choose delivery style**: Scrum (prescriptive sprints, roles, reviews) or Kanban (evolutionary flow, WIP limits). Both plug into F, I, and K.
+- **Problem-solving backbone**: Use DMAIC across D/M/A/I/C for improvements; apply PDCA/PDSA cycles within E, X, and L during discovery.
+- **Context matters**: Apply Cynefin to calibrate ceremony. Complex work → iterate/experiment; complicated → leverage expert analysis; chaotic → stabilize first.
+- **Ops linkage**: Keep Operations–Marketing–Finance–IT integration visible (O) so projects never become orphans.
+
+## Core Checklists
+
+### Gate (G) Mini-Check *(T2/T3)*
+
+1. Aim clear (A).
+2. Baseline measured (B/M).
+3. Scope & customer defined (C/D/S).
+4. Risks/mitigations owned (N).
+5. Flow plan & WIP caps (F/K).
+6. Quality/DoD agreed (Q).
+7. Value test defined (V).
+8. Ops readiness (O/R).
+9. Metrics wired (M).
+10. Lessons captured (L/Z).
+
+### Definition of Done (Q)
+
+- Meets acceptance criteria.
+- Tests green.
+- Security checks pass.
+- Docs updated sufficiently.
+- Debt logged or resolved.
+- Deployable state achieved.
+
+### Kanban Policy (K/F)
+
+1. Visualize workflow.
+2. Set WIP per column.
+3. Pull, don’t push.
+4. Measure cycle time.
+5. Improve one constraint at a time.
+
+## Example: Universe vs. 1+1
+
+- **Build-a-Universe (T3)**: Run the full A→Z; apply SRR → PDR → CDR → ORR/LRR gates; run DMAIC on subsystems; orchestrate multi-team Scrum or portfolio-level Kanban; reinforce Q with SQC/SPC; coordinate releases and operational handshakes across the supply chain.
+- **1+1 (T1)**: Use the FAST-PATH set only—A (one-line aim), D (one-line define), E (quick experiment), F/K (limit WIP to one and move the card), Q (tiny DoD), L (single retro note), and Z (close). Complete in under an hour.
+
+## Why the Blend Works
+
+- **PMBOK** provides the north–south spine (Initiate → Close).
+- **Lean/Six Sigma** supplies rigor via DMAIC/PDCA and A3-based learning.
+- **Scrum/Kanban** give the daily operating system for delivery.
+- **Big-system reviews** protect high-risk work with SRR/PDR/CDR checkpoints.
+- **Operations thinking** keeps the whole organization in the loop, preventing orphan projects.
+
+## Next Steps
+
+- Convert this framework into a fill-in-the-blanks template (Notion, Sheets, or Kanban) with gate/DoD cards and scale presets.
+- Stress-test the FAST-PATH on a live "1+1" task and iterate based on observed friction.
+


### PR DESCRIPTION
## Summary
- add a comprehensive reference for the BlackRoad A→Z framework with FAST-PATH guidance
- document scaling tracks, governance checkpoints, and supporting checklists

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da0dff92a4832996f8de645b8b1dbb