### PR TITLE
feat: add Tor onion export workflow and masked digest notifier

### DIFF
--- a/.github/workflows/masked-digests-notify.yml
+++ b/.github/workflows/masked-digests-notify.yml
@@ -1,0 +1,93 @@
+name: Addresses • Masked Digest Notifier
+
+on:
+  workflow_dispatch:
+    inputs:
+      secrets_csv:
+        description: "CSV of secret names (e.g. ROBINHOOD_ETHEREUM,COINBASE_BITCOIN)"
+        type: string
+        required: true
+      to_slack:
+        description: "Post to Slack (uses secret SLACK_WEBHOOK_URL)"
+        type: boolean
+        required: true
+        default: false
+      to_discord:
+        description: "Post to Discord (uses secret DISCORD_WEBHOOK_URL)"
+        type: boolean
+        required: true
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+
+      # Build masked table without printing raw values
+      - name: Build masked digest table
+        id: table
+        env:
+          CSV: ${{ inputs.secrets_csv }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          node - <<'NODE'
+          const crypto = require('crypto');
+          const csv = process.env.CSV || '';
+          const names = csv.split(',').map((s) => s.trim()).filter(Boolean);
+          const rows = [];
+          rows.push(['NAME', 'LEN', 'MASKED', 'DIGEST8']);
+          for (const name of names) {
+            const value = process.env[name] || '';
+            const digest = value ? crypto.createHash('sha256').update(value, 'utf8').digest('hex').slice(0, 8) : '';
+            const masked = value ? '****' + value.slice(-6) : '';
+            rows.push([name, String(value.length), masked, digest]);
+          }
+          const widths = [0, 1, 2, 3].map((index) => Math.max(...rows.map((row) => (row[index] || '').length)));
+          const format = (row) => row
+            .map((cell, index) => (index === 0 ? cell.padEnd(widths[index]) : cell.padStart(widths[index])))
+            .join('  ');
+          const table = [format(rows[0]), '-'.repeat(widths.reduce((a, b) => a + b, 0) + 6)]
+            .concat(rows.slice(1).map(format))
+            .join('\n');
+          require('fs').writeFileSync('masked_table.txt', table + '\n');
+          console.log(table);
+          NODE
+
+      - name: Upload summary artifact (optional)
+        uses: actions/upload-artifact@v4
+        with:
+          name: masked-digests
+          path: masked_table.txt
+
+      - name: Post to Slack (optional)
+        if: ${{ inputs.to_slack }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$SLACK_WEBHOOK_URL"
+          body=$(jq -Rs '{text: ("Masked address digests:\n```" + . + "```")}' < masked_table.txt)
+          curl -s -X POST -H 'content-type: application/json' \
+            --data "$body" "$SLACK_WEBHOOK_URL" >/dev/null
+
+      - name: Post to Discord (optional)
+        if: ${{ inputs.to_discord }}
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$DISCORD_WEBHOOK_URL"
+          content="Masked address digests:\n\`\`\`\n$(cat masked_table.txt)\n\`\`\`"
+          curl -s -X POST -H 'content-type: application/json' \
+            --data "$(jq -n --arg content "$content" '{content:$content}')" \
+            "$DISCORD_WEBHOOK_URL" >/dev/null

--- a/.github/workflows/tor-onion-export.yml
+++ b/.github/workflows/tor-onion-export.yml
@@ -1,0 +1,73 @@
+name: Tor • Onion Export (Pi)
+
+on:
+  workflow_dispatch:
+    inputs:
+      redact:
+        description: "Redact onion (show head/tail only)?"
+        type: boolean
+        required: true
+        default: true
+      compose_main:
+        description: "Path to main compose (on Pi)"
+        type: string
+        required: true
+        default: "~/btc-compose.yml"
+      compose_tor:
+        description: "Path to Tor compose fragment (in repo)"
+        type: string
+        required: true
+        default: "lightning/tor/compose.tor.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  export:
+    # Runs ON the Pi so it can read the real tor hostname from the container
+    runs-on: [self-hosted, linux, blackroad-pi]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Ensure tor is up (no-op if already running)
+        shell: bash
+        run: |
+          set -euo pipefail
+          MAIN="${{ inputs.compose_main }}"
+          TOR="${{ inputs.compose_tor }}"
+          docker compose -f "$MAIN" -f "$TOR" up -d tor
+          docker compose -f "$MAIN" -f "$TOR" ps tor
+
+      - name: Read onion hostname from tor sidecar
+        id: onion
+        shell: bash
+        run: |
+          set -euo pipefail
+          MAIN="${{ inputs.compose_main }}"
+          TOR="${{ inputs.compose_tor }}"
+          host=$(docker compose -f "$MAIN" -f "$TOR" exec -T tor sh -lc 'cat /var/lib/tor/lightning/hostname' 2>/dev/null || true)
+          if [ -z "$host" ]; then
+            echo "No onion hostname found (tor not ready?)" >&2
+            exit 1
+          fi
+          echo "full=$host" >> $GITHUB_OUTPUT
+          # redact in logs by default
+          if [ "${{ inputs.redact }}" = "true" ]; then
+            echo "mask=on" >> $GITHUB_OUTPUT
+            echo "::notice title=Tor Onion (redacted)::${host:0:10}…${host: -10}"
+          else
+            echo "mask=off" >> $GITHUB_OUTPUT
+            echo "::notice title=Tor Onion::${host}"
+          fi
+
+      - name: Job Summary
+        shell: bash
+        run: |
+          if [ "${{ steps.onion.outputs.mask }}" = "on" ]; then
+            red="${{ steps.onion.outputs.full }}"
+            echo "### Tor Onion (redacted)" >> $GITHUB_STEP_SUMMARY
+            echo "\`${red:0:10}…${red: -10}\`" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "### Tor Onion" >> $GITHUB_STEP_SUMMARY
+            echo "\`${{ steps.onion.outputs.full }}\`" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/docs/runner-pi.md
+++ b/docs/runner-pi.md
@@ -1,0 +1,29 @@
+# Self-hosted GitHub Runner on the Pi
+
+We run the Tor Onion Export workflow **on the Pi** so it can read the real
+`/var/lib/tor/lightning/hostname` from the Tor container locally.
+
+## Install runner (once)
+1. Create a runner in GitHub: Repo → **Settings → Actions → Runners → New self-hosted runner**.
+2. Choose **Linux** / **ARM64**; follow the printed commands on the Pi:
+   ```bash
+   # example (from GitHub’s UI):
+   mkdir -p ~/actions-runner && cd ~/actions-runner
+   curl -o actions-runner-linux-arm64-<ver>.tar.gz -L https://...
+   tar xzf actions-runner-linux-arm64-<ver>.tar.gz
+   ./config.sh --url https://github.com/<org>/<repo> --token <TOKEN>
+   ```
+3. Add labels so workflows can target this runner (recommended label: `blackroad-pi`).
+   You can set labels during `./config.sh` or later in the UI.
+4. (Optional) Install as a service:
+   ```bash
+   sudo ./svc.sh install
+   sudo ./svc.sh start
+   ```
+
+## Requirements on the Pi
+- Docker/Compose installed (already in your setup).
+- Your `btc-compose.yml` and Tor sidecar file available at the paths used by the workflow. By default we reference:
+  - `~/btc-compose.yml`
+  - `lightning/tor/compose.tor.yml` (from repo)
+


### PR DESCRIPTION
## Summary
- add a manual Tor onion export workflow that targets the Pi self-hosted runner and supports optional redaction
- add a masked digest notifier workflow that builds a masked address table and can post it to Slack or Discord
- document how to register the Pi self-hosted runner and required compose files

## Testing
- not run (workflow definitions only)


------
https://chatgpt.com/codex/tasks/task_e_68da0ce3e140832990b0f5ec577613ed