### PR TITLE
Document runtime controller dev-mode probes

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -162,14 +162,14 @@ Use the following steps to confirm the runtime controller is actually running wi
    ```
 3. **Confirm the service is serving developer-mode responses**
    ```bash
-   if [ -n "${PORT:-}" ]; then
-     curl -fsS "http://localhost:${PORT}/health" && echo
-     curl -fsS "http://localhost:${PORT}/version" && echo
+   port="${PORT:-${CONTROLLER_PORT:-8080}}"
+   if [ -z "${PORT:-}" ] && [ -z "${CONTROLLER_PORT:-}" ]; then
+     echo "PORT not exported; probing fallback ${port} (adjust if the service binds elsewhere)"
    else
-     echo "PORT not exported; probing default 8080"
-     curl -fsS "http://localhost:8080/health" && echo
-     curl -fsS "http://localhost:8080/version" && echo
+     echo "Probing controller on ${port}"
    fi
+   curl -fsS "http://localhost:${port}/health" && echo
+   curl -fsS "http://localhost:${port}/version" && echo
    ss -tulpn | awk '/LISTEN/ && /controller|python|gunicorn|uvicorn/ {print}'
    journalctl -u controller.service -n 80 --no-pager | sed -n '1,40p'
    ```
@@ -187,7 +187,7 @@ kubectl port-forward -n <ns> deploy/controller 8080:PORT &
 curl -fsS localhost:8080/version
 ```
 
-> **Tip:** In `btop`, press `f` to filter on the controller process; a healthy developer loop emits small CPU blips roughly every 60 seconds.
+> **Tip:** In `btop`, press `f` to filter on the controller process; a healthy developer loop emits small CPU blips roughly every 60 seconds. Watch for flatlines (stalled loop) or sustained spikes (runaway retries).
 
 **Success criteria**
 


### PR DESCRIPTION
## Summary
- clarify the runtime controller developer-mode checklist to handle unset ports
- add a reminder to use btop for observing the controller loop pulses

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da0cf95de083299600df9c0bf2f982