### PR TITLE
docs: add risk assessment for cloudflare service issues and LON1 maintenance

### DIFF
--- a/docs/incidents/2025-09-28-cloudflare-digitalocean-risk-assessment.md
+++ b/docs/incidents/2025-09-28-cloudflare-digitalocean-risk-assessment.md
@@ -1,0 +1,66 @@
+# Risk Assessment — Cloudflare Service Issues & DigitalOcean LON1 Maintenance
+
+This report evaluates two provider events relevant to BlackRoad's infrastructure footprint:
+
+1. Cloudflare's resolved service issues on 28 Sep 2025, including a short-lived spike in 5xx errors for the Atlanta load balancing region.
+2. DigitalOcean's scheduled network maintenance for the LON1 region on 29 Sep 2025.
+
+Our objectives are to quantify the operational risk exposure, summarize potential customer impact, and recommend mitigations or readiness steps.
+
+## Executive Summary
+
+| Event | Current Status | Risk Level | Primary Concerns |
+| --- | --- | --- | --- |
+| Cloudflare service incident (28 Sep 2025) | Resolved as of 21:25 UTC | **Medium** — latent customer-facing impact if failover, health-check, or retry policies underperformed during the 500-error spike. | Verify regional failover, revalidate monitoring fidelity, and confirm no residual latency across edge services. |
+| DigitalOcean LON1 network maintenance (29 Sep 2025) | Scheduled 17:00–20:00 UTC | **Medium** — potential for transient packet loss, Droplet reboots, or database control plane hiccups if maintenance windows extend or rollbacks occur. | Ensure redundancy across other regions, rehearse connection retries, and pause sensitive deployments during the window. |
+
+## Cloudflare — 28 Sep 2025 Service Issues
+
+- **Timeline**: 17:45–21:25 UTC active incident. Elevated 500 responses in the Atlanta (ATL) region for load balancing between ~20:02 and 20:07 UTC.
+- **Service surface**: Traffic steering, health checks, Workers Durable Objects, KV metadata APIs, and load balancing were impacted according to Cloudflare's status stream. The Atlanta spike implies possible regional failover churn for US East traffic.
+- **Observed outcome**: Cloudflare applied an effective fix and reported full recovery. However, any services pinned to the ATL pool may have seen user-facing errors or failover events.
+
+### Risk Considerations
+
+1. **Health check reliability** — If BlackRoad origins rely on Cloudflare load balancing with active health checks, false positives could have temporarily drained healthy pool members or triggered unnecessary traffic shifts.
+2. **Failover sensitivity** — A short error burst may expose slow-to-drain connection pools or sticky sessions that assume regional stability.
+3. **Customer experience** — Five minutes of 5xx errors is enough to trip SLO burn alerts; any user cohorts concentrated near ATL might have experienced retries or timeouts.
+
+### Mitigations & Action Items
+
+- **Confirm observability**: Audit logs and analytics for Cloudflare load balancing pools to detect any abnormal failover or error spikes during the 20:02–20:07 UTC window.
+- **Regression checks**: Validate that Synthetic probes and external monitors captured the incident. If not, raise detection thresholds or add Atlanta-specific vantage points.
+- **Retry posture**: Review client and edge retry logic for idempotent requests. Ensure exponential backoff and jitter handled the spike gracefully.
+- **Capacity buffer**: If emergency rerouting pushed traffic to secondary regions, verify those origins remained within CPU/memory budgets.
+- **Stakeholder communication**: Share a brief note with customer support and account teams summarizing observed impact (even if none) to preempt inbound questions.
+
+## DigitalOcean — 29 Sep 2025 LON1 Network Maintenance
+
+- **Schedule**: Planned for 29 Sep 2025 from 17:00 to 20:00 UTC.
+- **Scope**: Core network upgrades in LON1 affecting Droplets, Managed Databases, Load Balancers, Kubernetes clusters, Spaces, and Marketplace appliances.
+- **Provider expectation**: DigitalOcean anticipates a seamless change but cautions about possible transient connectivity interruptions.
+
+### Risk Considerations
+
+1. **Session disruption** — Even brief packet loss can disconnect long-lived TCP sessions, leading to retry storms or partial writes for workloads without transaction-level safeguards.
+2. **Control plane blips** — Managed database failovers or load balancer re-provisioning could introduce minute-long brownouts.
+3. **Maintenance overruns** — Historical maintenances occasionally overrun or require rollback, extending risk exposure beyond the published window.
+
+### Mitigations & Readiness Steps
+
+- **Freeze windows**: Avoid planned deploys, schema changes, or infrastructure modifications involving LON1 resources for the duration of the maintenance.
+- **Failover readiness**: Confirm that cross-region replicas (e.g., in AMS or FRA) are healthy and can absorb traffic if LON1 destabilizes.
+- **Backup posture**: Ensure recent backups/snapshots exist for critical LON1 workloads before the maintenance begins.
+- **Connection resilience**: Review application-level retry and timeout settings; ensure clients tolerate transient resets without cascading failures.
+- **On-call staffing**: Schedule an on-call with provider console access and escalate paths to DigitalOcean support in case the maintenance degrades services.
+- **Customer messaging**: Prepare a proactive status note for affected customers highlighting the maintenance window and expected behavior.
+
+## Next Steps
+
+- Track Cloudflare's incident postmortem (if published) for root-cause details that might prompt architecture changes.
+- Subscribe to DigitalOcean maintenance RSS/email alerts to catch any last-minute scope changes or postponements.
+- Reassess risk levels post-maintenance and document any anomalies in the incident log.
+
+---
+*Prepared by: Autonomous Agent*
+*Date: 28 Sep 2025*


### PR DESCRIPTION
## Summary
- add a 28 Sep 2025 risk assessment covering Cloudflare's service incident and DigitalOcean's planned LON1 maintenance
- capture risk considerations and mitigation steps for both providers

## Testing
- not run (documentation change only)

------
https://chatgpt.com/codex/tasks/task_e_68da9640366c83299b00c962d16070ce