### PR TITLE
Add September 26 crypto market landscape brief

### DIFF
--- a/docs/updates/2025-09-26-crypto-landscape.md
+++ b/docs/updates/2025-09-26-crypto-landscape.md
@@ -1,0 +1,36 @@
+# Crypto Market Landscape — September 26, 2025
+
+## Solana Throughput Debate: Firedancer's SIMD-0370
+- **Proposal overview:** Jump Crypto's Firedancer client introduced SIMD-0370 to remove the fixed compute unit cap per Solana block, allowing throughput to scale with validator hardware.
+- **Potential upside:** High-performance validators could push block capacity upward and accelerate the "performance flywheel" initiated by Alpenglow's faster finality targets.
+- **Decentralization concerns:** Critics caution that dynamically scaling block sizes may reward only well-capitalized validators, raising barriers for smaller operators and concentrating influence.
+
+### Key Questions
+1. Can hardware-driven scaling raise network throughput without hollowing out Solana's validator set?
+2. What guardrails might be needed so that validator performance gains do not erode decentralization guarantees?
+
+## Spot Ethereum ETF Flows Reverse Course
+- **Data point:** U.S. spot ETH ETFs recorded roughly **$795.6 million** in net outflows for the week ending September 26, 2025—their sharpest single-week withdrawal since launch.
+- **Interpretation:** The reversal suggests investors are either taking profits after prior inflows or reassessing Ethereum's near-term catalysts.
+
+### Key Questions
+1. Do upcoming macro events or network upgrades offer catalysts to stem redemptions?
+2. How sensitive are ETF flows to staking yields, ETH price volatility, and broader risk sentiment?
+
+## SEC Accelerates Crypto ETF Listings
+- **Regulatory shift:** The SEC's late-September adoption of generic listing standards shrinks the approval window for qualifying crypto ETFs from up to 270 days to as few as 75.
+- **Market impact:** Products tracking assets with established regulated futures markets—or other qualifying references—can now list with less bespoke review, opening the door to spot ETFs beyond Bitcoin and Ethereum.
+
+### Key Questions
+1. Which assets (e.g., Solana, XRP) meet the criteria soonest, and how quickly will issuers file?
+2. Will faster approvals spur exchange competition on fees, liquidity incentives, or product innovation?
+
+## Threads to Monitor
+- Whether Solana's SIMD-0370 ushers in internet-scale throughput or pressures decentralization.
+- If Ethereum ETF outflows stabilize or signal waning institutional conviction.
+- How many new crypto ETF filings emerge under the 75-day regime and which tokens lead the next wave.
+
+## Next Steps
+- Track Firedancer benchmarking data and validator participation metrics as SIMD-0370 progresses.
+- Watch for weekly ETF flow reports and options positioning to gauge institutional ETH sentiment.
+- Monitor SEC filings, comment periods, and exchange rule change notices for the next slate of spot crypto ETF proposals.


### PR DESCRIPTION
## Summary
- add a September 26, 2025 crypto market landscape brief covering Solana SIMD-0370, spot ETH ETF outflows, and faster SEC approvals

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68da967696348329bed0bb7252bef288