### PR TITLE
Add AI remix rights sheet template

### DIFF
--- a/docs/AI_REMIX_RIGHTS_SHEET_TEMPLATE.md
+++ b/docs/AI_REMIX_RIGHTS_SHEET_TEMPLATE.md
@@ -1,0 +1,63 @@
+# AI Remix Rights Sheet
+
+Use this one-page template to document rights, licenses, and human contributions when multiple collaborators use AI to build remix projects. Update it for each release and store it with your production assets.
+
+---
+
+## 1. Project Overview
+- **Project title:**
+- **Version / release date:**
+- **Project lead / rights manager:**
+- **Intended distribution (commercial, internal, non-commercial):**
+- **Summary of AI involvement (models, services, automation layers):**
+
+## 2. Source Material Inventory
+List every third-party or legacy asset incorporated into the remix.
+
+| ID | Asset description | Owner / licensor | License or permission (attach docs) | Usage scope (clips, duration, territory) | Notes on approvals or restrictions |
+|----|-------------------|------------------|-------------------------------------|------------------------------------------|------------------------------------|
+
+## 3. AI-Generated Elements
+Catalog machine-generated material and note whether any human authorship may be claimed.
+
+| ID | Model / tool used | Prompt contributor(s) | Generation date | Human curation (edits, selections, arrangement) | Copyright status (claimable human portion?) | Usage notes |
+|----|-------------------|-----------------------|-----------------|-----------------------------------------------|---------------------------------------------|------------|
+
+- **Disclosure statement for public release:**
+
+## 4. Human Creative Contributions
+Capture the work of editors, mixers, colorists, captioners, and other human collaborators.
+
+| Contributor | Role / contribution | Source layers involved | Rights granted to project (license/assignment) | Registration planned? |
+|-------------|---------------------|------------------------|-----------------------------------------------|------------------------|
+
+- **Contributor agreement on file?** ☐ Yes ☐ No (attach or link)
+
+## 5. Voice, Likeness, and Personality Rights
+- **Synthetic voices or faces used?** List performers or training references and attach releases.
+- **Jurisdictions of exploitation:** Note states/countries with publicity or privacy requirements.
+- **Mitigation steps:** e.g., disclaimers, consent notices, platform policy compliance.
+
+## 6. Compliance & Risk Notes
+- **Fair-use / fair-dealing analysis (if any):** Provide rationale, especially post *Warhol v. Goldsmith*.
+- **Training-data considerations:** Document transparency notices or obligations (e.g., EU AI Act, TDM exceptions).
+- **Open issues / follow-ups:**
+  - [ ] Item / owner / deadline
+  - [ ] Item / owner / deadline
+
+## 7. Distribution & Licensing Plan
+- **Planned platforms / channels:**
+- **Licenses to publish (sync, mechanical, performance, etc.):**
+- **Third-party claim monitoring strategy:**
+- **Archive location for proof of rights:**
+
+## 8. Approvals & Sign-Offs
+| Name / role | Date | Scope of approval |
+|-------------|------|-------------------|
+
+- **Next review date:**
+- **Revision history:** Keep a short log of updates to this sheet.
+
+---
+
+**Reminder:** Register only the human-authored portions when filing copyright applications. Keep AI disclosures transparent and credit source creators, AI contributors, and human editors separately.


### PR DESCRIPTION
## Summary
- add a one-page AI remix rights sheet template for documenting sources, AI outputs, and human contributions
- include sections for licensing, compliance, and approvals to support collaborative remix tracking

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da96c646c88329ac058f5dbd3e85b1