### PR TITLE
Add blog covering Cloudflare's Content Signals policy

### DIFF
--- a/sites/blackroad/content/blog/cloudflare-content-signals-policy.md
+++ b/sites/blackroad/content/blog/cloudflare-content-signals-policy.md
@@ -1,0 +1,42 @@
+---
+title: "Cloudflare Gives Publishers an AI-Specific Robots Signal"
+date: "2025-09-25"
+tags: [ai, web, policy]
+description: "Breaking down Cloudflare's new Content Signals Policy and what it means for search, AI summaries, and model training."
+---
+
+Cloudflare is adding a new layer of control on top of good old `robots.txt`. Rolling out across September 24–25, the company introduced a **Content Signals Policy** that lets site owners state different preferences for three buckets of automated access:
+
+1. Traditional search indexing (`search=`)
+2. AI usage for generating snippets or answers (`ai-input=`)
+3. AI model training (`ai-train=`)
+
+For the 3.8 million domains that lean on Cloudflare's managed `robots.txt`, the platform will automatically prepend the new comments with a default posture of `search=yes` and `ai-train=no`. The `ai-input` field is optional—leaving it out signals "no preference."
+
+```text
+# Content-Signal: search=yes, ai-train=no
+# (ai-input omitted = no preference)
+```
+
+There is a big caveat: the signals are **advisory, not enforcement**. Respecting them is voluntary, just like conventional `robots.txt`. Cloudflare is telling customers to back up the guidance with tangible defenses—firewall rules, bot management, and traffic analytics—if they want to block aggressive crawlers or scrape-heavy AI agents.
+
+### Why this matters now
+
+Separating search from AI usage is a rare concession from a major infrastructure player. Publishers can stay visible in search results while still telling AI systems to keep their content out of answer overviews or training corpora. That distinction arrives precisely as Google and others are shipping AI-generated summaries that risk bypassing the source site entirely—and with it, advertising and subscription revenue.
+
+### Open questions for AI platforms
+
+The move now puts pressure on downstream consumers of web content:
+
+- **Search giants**: Google currently blends search indexing and AI experiences behind the same crawlers. Honoring an `ai-train=no` directive could force architectural changes or new user-agent splits.
+- **AI startups**: Compliance will be a reputation test. Ignoring the signals could spur lawsuits or invite more aggressive blocking at the network layer.
+- **Auditing and enforcement**: Publishers still lack visibility into which bots obey or defy the guidance, so expect calls for reporting, legal guardrails, and better telemetry.
+
+### What builders should do
+
+1. **Adopt the signals**: Even though they are advisory, they provide a standardized, machine-readable declaration of your stance on AI reuse.
+2. **Layer defenses**: Pair the signals with Cloudflare's firewall, rate limiting, or custom bot rules to intercept unwanted crawlers.
+3. **Monitor traffic**: Track unusual agents or surges in scraping so you can adjust policies quickly.
+4. **Coordinate with partners**: Ask search and AI vendors how they plan to respect the signals and whether they'll publish compliance reports.
+
+The tug-of-war between publishers and AI platforms is far from settled. Cloudflare's move doesn't settle the debate, but it gives the open web a new piece of leverage—and a rallying point for demanding better behavior from the next generation of crawlers.


### PR DESCRIPTION
## Summary
- add a new blog post detailing Cloudflare's Content Signals Policy and the default signals applied to managed robots.txt customers
- outline why the change matters for publishers, the open questions for AI platforms, and recommended next steps for builders

## Testing
- not run (content-only change)


------
https://chatgpt.com/codex/tasks/task_e_68da97031aac8329800860b78306f8a1