### PR TITLE
Add ternary contradiction logging for API errors

### DIFF
--- a/srv/blackroad-api/lib/db.js
+++ b/srv/blackroad-api/lib/db.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+const path = require('path');
+const Database = require('better-sqlite3');
+
+const DB_PATH = process.env.DB_PATH || '/srv/blackroad-api/blackroad.db';
+fs.mkdirSync(path.dirname(DB_PATH), { recursive: true });
+
+const db = new Database(DB_PATH);
+
+db.pragma('journal_mode = WAL');
+db.pragma('synchronous = NORMAL');
+
+module.exports = { db, DB_PATH };

--- a/srv/blackroad-api/lib/ternaryError.js
+++ b/srv/blackroad-api/lib/ternaryError.js
@@ -1,0 +1,19 @@
+class TernaryError extends Error {
+  constructor(message, opts) {
+    super(message);
+    if (!opts || typeof opts.state === 'undefined') {
+      throw new Error('TernaryError requires a state (-1, 0, or 1)');
+    }
+    if (![ -1, 0, 1 ].includes(opts.state)) {
+      throw new Error('TernaryError state must be -1, 0, or 1');
+    }
+    this.state = opts.state;
+    this.code = opts.code;
+    this.severity = opts.severity || 'med';
+    this.hint = opts.hint;
+  }
+}
+
+module.exports = {
+  TernaryError,
+};

--- a/srv/blackroad-api/middleware/contradictionLogger.js
+++ b/srv/blackroad-api/middleware/contradictionLogger.js
@@ -1,0 +1,87 @@
+const crypto = require('crypto');
+const { TernaryError } = require('../lib/ternaryError');
+const { db } = require('../lib/db');
+
+function safeStringify(body) {
+  if (typeof body === 'string') return body;
+  try {
+    return JSON.stringify(body ?? {});
+  } catch (_err) {
+    return '[unserializable]';
+  }
+}
+
+function hashPayload(body) {
+  const payload = safeStringify(body);
+  return crypto.createHash('sha256').update(payload).digest('hex').slice(0, 16);
+}
+
+const insertStmt = db.prepare(
+  `INSERT INTO error_contradictions
+    (req_id, user_id, route, method, state, resolved, severity, code, message, stack, payload_hash, contradiction_hint)
+   VALUES (@req_id, @user_id, @route, @method, @state, 0, @severity, @code, @message, @stack, @payload_hash, @contradiction_hint)`
+);
+
+function contradictionLogger(err, req, res, next) {
+  if (res.headersSent) {
+    return next(err);
+  }
+
+  const reqIdSource =
+    req.headers['x-request-id'] ||
+    (typeof crypto.randomUUID === 'function'
+      ? crypto.randomUUID()
+      : crypto.randomBytes(16).toString('hex'));
+  const reqId = String(reqIdSource);
+  const userId = req.user?.id ?? null;
+  const route = req.route?.path || req.originalUrl || 'unknown';
+  const method = req.method || 'UNKNOWN';
+  const isTernary = err instanceof TernaryError;
+  const state = isTernary ? err.state : -1;
+  const code = isTernary ? err.code : err.code || 'E_THROW';
+  const severity = isTernary ? err.severity : 'med';
+  const hint = isTernary ? err.hint : null;
+  const payloadHash = hashPayload(req.body);
+  const stack = (err && err.stack ? String(err.stack) : '').slice(0, 8000);
+
+  try {
+    insertStmt.run({
+      req_id: reqId,
+      user_id: userId || null,
+      route,
+      method,
+      state,
+      severity,
+      code: code || null,
+      message: err && err.message ? String(err.message) : null,
+      stack,
+      payload_hash: payloadHash,
+      contradiction_hint: hint || null,
+    });
+  } catch (logErr) {
+    console.error('[contradictionLogger] failed to insert', logErr);
+  }
+
+  if (process.env.NODE_ENV !== 'production') {
+    console.error(err);
+  }
+
+  const statusCandidate =
+    (err && typeof err.status !== 'undefined' ? err.status : undefined) ??
+    (err && typeof err.statusCode !== 'undefined' ? err.statusCode : undefined);
+  const statusNumber = Number(statusCandidate);
+  const status = Number.isInteger(statusNumber) && statusNumber >= 400 ? statusNumber : 500;
+
+  res.status(status).json({
+    ok: false,
+    req_id: reqId,
+    state,
+    code: code || 'E_THROW',
+    message: 'Internal error',
+  });
+}
+
+module.exports = {
+  contradictionLogger,
+  hashPayload,
+};

--- a/srv/blackroad-api/migrations/007_error_contradictions.sql
+++ b/srv/blackroad-api/migrations/007_error_contradictions.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS error_contradictions (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts DATETIME DEFAULT CURRENT_TIMESTAMP,
+  req_id TEXT,
+  user_id TEXT,
+  route TEXT,
+  method TEXT,
+  state INTEGER CHECK(state IN (-1,0,1)) NOT NULL,
+  resolved INTEGER DEFAULT 0,
+  resolved_ts DATETIME,
+  severity TEXT,
+  code TEXT,
+  message TEXT,
+  stack TEXT,
+  payload_hash TEXT,
+  contradiction_hint TEXT,
+  resolver_note TEXT,
+  resolver_ref TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_err_unresolved ON error_contradictions(resolved, state);
+CREATE INDEX IF NOT EXISTS idx_err_route ON error_contradictions(route, method);

--- a/srv/blackroad-api/routes/contradictions.js
+++ b/srv/blackroad-api/routes/contradictions.js
@@ -1,0 +1,57 @@
+const express = require('express');
+const { db } = require('../lib/db');
+
+const router = express.Router();
+
+router.post('/api/contradictions/:id/resolve', (req, res) => {
+  const id = Number(req.params.id);
+  if (!Number.isInteger(id)) {
+    return res.status(400).json({ ok: false, error: 'invalid_id' });
+  }
+
+  const note = req.body?.note ? String(req.body.note) : '';
+  const ref = req.body?.ref ? String(req.body.ref) : null;
+  const timestamp = new Date().toISOString();
+  const existing = db
+    .prepare('SELECT resolver_note, resolver_ref FROM error_contradictions WHERE id = ?')
+    .get(id);
+  if (!existing) {
+    return res.status(404).json({ ok: false, error: 'not_found' });
+  }
+
+  const entries = [];
+  if (existing.resolver_note) entries.push(existing.resolver_note);
+  if (note || entries.length === 0) {
+    entries.push(`${timestamp} ${note}`.trim());
+  }
+  const nextNote = entries.join('\n');
+
+  const resolverRef = ref ?? existing.resolver_ref ?? null;
+
+  db.prepare(
+    `UPDATE error_contradictions
+     SET resolved = 1,
+         resolved_ts = datetime('now'),
+         resolver_note = ?,
+         resolver_ref = ?
+     WHERE id = ?`
+  ).run(nextNote, resolverRef, id);
+
+  res.json({ ok: true, id });
+});
+
+router.get('/api/contradictions/unresolved', (_req, res) => {
+  const rows = db
+    .prepare(
+      `SELECT id, ts, route, method, state, severity, code, message
+       FROM error_contradictions
+       WHERE resolved = 0
+       ORDER BY datetime(ts) DESC
+       LIMIT 200`
+    )
+    .all();
+
+  res.json({ ok: true, items: rows });
+});
+
+module.exports = router;

--- a/srv/blackroad-api/server_full.js
+++ b/srv/blackroad-api/server_full.js
@@ -11,8 +11,6 @@
 const http = require('http');
 const os = require('os');
 const path = require('path');
-const fs = require('fs');
-
 const express = require('express');
 const compression = require('compression');
 const morgan = require('morgan');
@@ -21,7 +19,6 @@ const rateLimit = require('express-rate-limit');
 const cors = require('cors');
 const cookieSession = require('cookie-session');
 const { body, validationResult } = require('express-validator');
-const Database = require('better-sqlite3');
 const { Server: SocketIOServer } = require('socket.io');
 const { exec } = require('child_process');
 const { randomUUID } = require('crypto');
@@ -29,14 +26,17 @@ const Stripe = require('stripe');
 const verify = require('./lib/verify');
 const notify = require('./lib/notify');
 const logger = require('./lib/log');
+const { db, DB_PATH } = require('./lib/db');
+const { TernaryError } = require('./lib/ternaryError');
 const attachLlmRoutes = require('./routes/admin_llm');
 const gitRouter = require('./routes/git');
 const providersRouter = require('./routes/providers');
+const contradictionRoutes = require('./routes/contradictions');
+const { contradictionLogger } = require('./middleware/contradictionLogger');
 
 // --- Config
 const PORT = parseInt(process.env.PORT || '4000', 10);
 const SESSION_SECRET = process.env.SESSION_SECRET || 'dev-secret-change-me';
-const DB_PATH = process.env.DB_PATH || '/srv/blackroad-api/blackroad.db';
 const LLM_URL = process.env.LLM_URL || 'http://127.0.0.1:8000/chat';
 const ALLOW_SHELL =
   String(process.env.ALLOW_SHELL || 'false').toLowerCase() === 'true';
@@ -146,9 +146,6 @@ const PLAN_ENTITLEMENTS = {
     },
   },
 };
-
-// Ensure DB dir exists
-fs.mkdirSync(path.dirname(DB_PATH), { recursive: true });
 
 // --- App & server
 const app = express();
@@ -331,10 +328,6 @@ app.post('/api/billing/webhook', (req, res) => {
 });
 
 // --- SQLite bootstrap
-const db = new Database(DB_PATH);
-db.pragma('journal_mode = WAL');
-db.pragma('synchronous = NORMAL');
-
 const TABLES = ['projects', 'agents', 'datasets', 'models', 'integrations'];
 for (const t of TABLES) {
   db.prepare(
@@ -495,6 +488,7 @@ for (const row of qSeed) {
 // Git API
 app.use('/api/git', requireAuth, gitRouter);
 app.use('/v1/providers', providersRouter);
+app.use(contradictionRoutes);
 
 // Helpers
 function listRows(t) {
@@ -637,6 +631,40 @@ app.post('/api/subscribe/invoice-intent', (req, res) => {
   res.json({ ok: true, next: '/subscribe/thanks' });
 });
 
+app.post('/api/wallet/credit', (req, res, next) => {
+  try {
+    const amountRaw = req.body?.amount;
+    const amount = Number(amountRaw);
+    if (!Number.isFinite(amount)) {
+      throw new TernaryError('Amount must be a finite number', {
+        state: -1,
+        code: 'AMOUNT_INVALID',
+        severity: 'high',
+        hint: 'Provide a numeric amount to credit',
+      });
+    }
+    if (amount === 0) {
+      throw new TernaryError('Zero amount is neutral no-op', {
+        state: 0,
+        code: 'AMOUNT_ZERO',
+        hint: 'Skip write when amount is 0',
+      });
+    }
+    if (amount < 0) {
+      throw new TernaryError('Negative credit is contradiction', {
+        state: -1,
+        code: 'NEGATIVE_CREDIT',
+        severity: 'high',
+        hint: 'Use /api/wallet/debit for negative amounts',
+      });
+    }
+
+    res.json({ ok: true, state: 1, credited: amount });
+  } catch (err) {
+    next(err);
+  }
+});
+
 app.get('/api/subscribe/status', (req, res) => {
   const { email } = req.query || {};
   if (!email) return res.status(400).json({ error: 'email_required' });
@@ -776,6 +804,8 @@ app.post('/api/actions/mint', requireAuth, (req, res) => {
 require('./modules/yjs_callback')({ app });
 require('./modules/trust_curvature')({ app });
 require('./modules/truth_diff')({ app });
+
+app.use(contradictionLogger);
 
 // --- Socket.IO presence (metrics)
 io.on('connection', (socket) => {


### PR DESCRIPTION
## Summary
- add an `error_contradictions` migration and shared SQLite helper for reuse across the API
- introduce a ternary-aware error class and middleware that logs every failure with request context
- expose resolution/listing routes and a sample wallet endpoint wired through the new logger

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da965b6b0c832992601025e7f95954