### PR TITLE
Add principal AI platform engineer job description

### DIFF
--- a/docs/principal_ai_platform_engineer_jd.md
+++ b/docs/principal_ai_platform_engineer_jd.md
@@ -1,0 +1,38 @@
+# Principal AI Platform Engineer — Job Description
+
+## Overview
+BlackRoad is expanding the Prism Console to power autonomous operations across finance, risk, and product lines. We are hiring a Principal AI Platform Engineer to design and harden the systems that orchestrate our multi-model intelligence stack, accelerate feature delivery, and ensure enterprise-grade reliability for Fortune 500 deployments.
+
+## Responsibilities
+- Lead end-to-end architecture for the AI platform, including model lifecycle management, vector search, orchestration runtimes, and observability.
+- Partner with product, applied research, and security teams to translate ambiguous enterprise requirements into resilient technical roadmaps.
+- Own roadmap execution for data pipelines, feature stores, experiment tracking, and evaluation harnesses across multiple domains.
+- Establish best practices for model governance, prompt security, and red-teaming in regulated industries.
+- Design APIs and SDKs that enable product teams to build AI-native workflows on top of Prism Console services.
+- Stand up automated testing, canarying, and rollback mechanisms for model and agent deployments.
+- Mentor senior engineers through design reviews, pair programming, and cross-functional initiatives.
+- Interface with strategic customers to gather feedback, align on SLAs, and guide co-development pilots.
+
+## Qualifications
+- 10+ years of experience in large-scale distributed systems, data infrastructure, or machine learning platform engineering.
+- Expert proficiency in Python or Go, with hands-on experience shipping production services in Kubernetes environments.
+- Proven track record building or operating model management systems (MLflow, Vertex AI, SageMaker, custom platforms) with strict reliability targets.
+- Deep knowledge of embeddings, retrieval-augmented generation, and agentic orchestration patterns.
+- Strong grasp of security and compliance frameworks (SOC 2, ISO 27001, FedRAMP, GDPR) as applied to AI systems.
+- Demonstrated ability to lead cross-functional programs and influence stakeholders without direct authority.
+- Familiarity with vector databases, feature stores, event-driven architectures, and streaming analytics.
+- Excellent written and verbal communication skills for technical and executive audiences.
+
+## Nice to Have
+- Experience with reinforcement learning, autonomous agents, or safety evaluation frameworks.
+- Background integrating AI platforms with ERP, CRM, or risk management systems.
+- Contributions to open-source AI infrastructure projects.
+- Prior work in high-compliance sectors such as financial services, healthcare, or critical infrastructure.
+
+## Location & Compensation
+- Location: Remote within North America, with quarterly onsite collaboration weeks in New York City.
+- Compensation: $250k–$300k base salary, 30% target bonus, and meaningful equity.
+- Benefits: 100% covered medical/dental/vision, 401(k) with 5% match, 20 PTO days, 12 company holidays, wellness stipend, and continuous learning budget.
+
+## How to Apply
+Interested candidates should email recruiting@blackroad.io with a resume, portfolio of platform-scale projects, and a brief description of the most challenging AI system they have delivered in production.


### PR DESCRIPTION
## Summary
- add a copy-ready job description for a Principal AI Platform Engineer supporting the Prism Console rollout

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68dae20496a083298bbc3d0826f986c4