### PR TITLE
Add Codex Automation Specialist JD for remote U.S./MN

### DIFF
--- a/docs/job-descriptions/remote-us-mn-codex-automation-specialist.md
+++ b/docs/job-descriptions/remote-us-mn-codex-automation-specialist.md
@@ -1,0 +1,39 @@
+# Codex Automation Specialist (Remote — U.S. / Minnesota Preferred)
+
+## Overview
+BlackRoad is launching the Codex Prompt Kit v1.0 to operationalize AI-assisted automation across our Prism console. We are searching for a Codex Automation Specialist to own the day-to-day orchestration of the prompt chain, Make scenarios, and Airtable schema that power rapid hiring and onboarding loops for Minnesota-based remote roles.
+
+## Responsibilities
+- Partner with People Ops and hiring managers to capture role profiles, craft structured job descriptions, and publish updates to Airtable within same-day SLAs.
+- Operate and continuously tune the Codex Prompt Kit, including maintaining prompt variants, Make automations, and Airtable integrations for reliable end-to-end execution.
+- Design feedback loops that validate generated outreach, interview guides, and candidate packets before release.
+- Monitor automation performance, triage failures, and document playbooks for edge cases or manual overrides.
+- Collaborate with Engineering to expand API coverage, connect new data sources, and surface telemetry inside the Prism console.
+- Champion compliance with BlackRoad security, accessibility, and privacy guardrails while working with candidate and employee data.
+
+## Minimum Qualifications
+- 4+ years of experience in marketing operations, sales/revenue operations, or technical program management with demonstrable automation ownership.
+- Hands-on expertise with Make (Integromat), Airtable scripting/automations, and AI prompt chaining.
+- Ability to translate fuzzy hiring requirements into structured data models and reproducible workflows.
+- Familiarity with employment regulations for remote workers in the United States, with depth in Minnesota labor considerations.
+- Excellent written communication skills with a knack for drafting concise copy, checklists, and runbooks.
+
+## Preferred Qualifications
+- Experience embedding AI copilots or LLM-based assistants into HR/recruiting workflows.
+- Working knowledge of Zapier or similar automation platforms for cross-training and contingency support.
+- Comfort with Git-based collaboration and documenting changes via Markdown within engineering repositories.
+- Exposure to SOC 2, ISO 27001, or similar compliance programs governing sensitive personnel data.
+
+## Success Metrics
+- Time-to-publish job descriptions and hiring campaigns reduced below 24 hours while meeting accuracy KPIs.
+- Automation run success rate sustained above 98% with documented remediation for the remaining edge cases.
+- Continuous delivery of iteration notes that improve prompt quality, candidate experience, and downstream analytics adoption.
+
+## Compensation & Benefits
+- Salary range: $110,000 – $135,000 USD, commensurate with experience and Minnesota market benchmarks.
+- Equity grants aligned with BlackRoad’s standard refresh program for operations leaders.
+- Comprehensive health, dental, and vision coverage with remote-first wellness stipends.
+- 401(k) with company match, flexible PTO, and fully remote work environment with quarterly in-person collaboration weeks in Minneapolis–Saint Paul.
+
+## How to Apply
+Send a resume, a short description of a complex automation you delivered, and your GitHub or workflow portfolio links to **careers@blackroad.io**. Please include “Codex Automation Specialist – Remote U.S./MN” in the subject line.


### PR DESCRIPTION
## Summary
- add a job description for the Codex Automation Specialist focused on operating the prompt kit for remote U.S./Minnesota hiring workflows

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dadcead2388329891ebfdfca683338