### PR TITLE
Add remote JD workflow prompt assets

### DIFF
--- a/downloads/Prompts_Suite.json
+++ b/downloads/Prompts_Suite.json
@@ -1,0 +1,51 @@
+{
+  "metadata": {
+    "version": "2024-05-01",
+    "steps": 7,
+    "description": "Paste-ready prompts for the BlackRoad JD-to-deliverables workflow."
+  },
+  "prompts": [
+    {
+      "step": 1,
+      "name": "JD Parser",
+      "goal": "Extract structure, must-have skills, and non-negotiables from the raw JD.",
+      "prompt": "You are the JD parser. Return company, role, location policy, salary data, must-have skills, preferred skills, and compliance notes. Mark clearly if the JD violates the remote-only lane."
+    },
+    {
+      "step": 2,
+      "name": "Signal Classifier",
+      "goal": "Tag the JD with sales/finance signals for later bullet matching.",
+      "prompt": "Evaluate the parsed JD and output tags for function, industry, tooling, and Ameriprise alignment. Only use tags present in SnapIns_Library.json."
+    },
+    {
+      "step": 3,
+      "name": "Gap Mapper",
+      "goal": "Find resume gaps or missing proof points versus the JD requirements.",
+      "prompt": "Compare JD must-haves with the resume baseline. Highlight each gap with severity (high/med/low) and cite which SnapIns bullet families can close it."
+    },
+    {
+      "step": 4,
+      "name": "Bullet Composer",
+      "goal": "Draft six tailored bullets using the SnapIns templates and gap map.",
+      "prompt": "Use the gap map and tags to select SnapIns. Rewrite them with company-specific nouns, quant results, and remote-first framing. Output exactly six bullets."
+    },
+    {
+      "step": 5,
+      "name": "Summary Writer",
+      "goal": "Produce a 55-word, high-signal summary for the cover note.",
+      "prompt": "Synthesize JD highlights and the strongest wins from the drafted bullets. Output one paragraph capped at 55 words, no fluff, highlight MN/remote strength."
+    },
+    {
+      "step": 6,
+      "name": "Micro Note",
+      "goal": "Generate a 1-2 sentence note that signals cultural fit and remote cadence.",
+      "prompt": "Draft a short note referencing Ameriprise-style client care, automation comfort, and remote collaboration norms. 2 sentences max."
+    },
+    {
+      "step": 7,
+      "name": "Q&A Pack",
+      "goal": "Create JSON Q&A pairs for interview prep.",
+      "prompt": "Return JSON with keys: question, answer, proof_point, automation_hook. Provide at least four entries tuned to the JD and remote expectations."
+    }
+  ]
+}

--- a/downloads/SnapIns_Library.json
+++ b/downloads/SnapIns_Library.json
@@ -1,0 +1,176 @@
+{
+  "metadata": {
+    "version": "2024-05-01",
+    "description": "Bullet bank for remote-first U.S. job applications with Minnesota preference."
+  },
+  "categories": [
+    {
+      "name": "sales_finance",
+      "label": "Sales & Finance",
+      "bullets": [
+        {
+          "id": "sf_pipeline_optics",
+          "text": "Activated a remote-first revenue desk spanning MN and nationwide advisors, converting Ameriprise-style consults into a $4.8M qualified pipeline in two quarters.",
+          "focus": ["pipeline", "remote", "ameriprise"]
+        },
+        {
+          "id": "sf_margin_growth",
+          "text": "Piloted AI-driven forecasting automations that trimmed close cycles by 32% while holding GAAP compliance, boosting contribution margin by 6.4% for hybrid-free teams.",
+          "focus": ["automation", "forecasting", "finance"]
+        },
+        {
+          "id": "sf_cross_sell",
+          "text": "Mapped cross-sell plays between MN retirement portfolios and national SMB accounts, lifting attach rate from 1.4x to 2.1x without increasing headcount.",
+          "focus": ["strategy", "sales", "retirement"]
+        }
+      ]
+    },
+    {
+      "name": "ameriprise",
+      "label": "Ameriprise Alignment",
+      "bullets": [
+        {
+          "id": "amp_client_loyalty",
+          "text": "Replicated Ameriprise client loyalty rituals inside a fintech CRM, raising net promoter results by 18 points across fully remote households.",
+          "focus": ["client experience", "loyalty", "crm"]
+        },
+        {
+          "id": "amp_reg_compliance",
+          "text": "Integrated Reg BI guardrails directly into playbooks, keeping 100% of remote MN advisors audit-ready while shortening onboarding from 45 to 21 days.",
+          "focus": ["compliance", "enablement", "remote onboarding"]
+        },
+        {
+          "id": "amp_fin_planning",
+          "text": "Coached planners on Ameriprise-style Goals-Based Advice using AI nudges that surface next-best actions and surface plan drift inside distributed pods.",
+          "focus": ["financial planning", "ai", "coaching"]
+        }
+      ]
+    },
+    {
+      "name": "ai_orchestration",
+      "label": "AI Orchestration",
+      "bullets": [
+        {
+          "id": "ai_routing",
+          "text": "Sequenced multi-model call routing that pairs GPT ops with deterministic calculators, lifting first-touch resolution by 21% in remote advisor care.",
+          "focus": ["ai", "orchestration", "support"]
+        },
+        {
+          "id": "ai_guardrails",
+          "text": "Launched an AI safety net with reversible automations, logging every inference for FINRA-ready audits and giving remote teams rapid rollback control.",
+          "focus": ["safety", "audit", "automation"]
+        },
+        {
+          "id": "ai_enablement",
+          "text": "Packaged weekly composer-style labs so MN analysts co-design prompts, delivering 40+ reusable workflows without any on-prem dependencies.",
+          "focus": ["enablement", "prompts", "remote"]
+        }
+      ]
+    },
+    {
+      "name": "automation",
+      "label": "Automation",
+      "bullets": [
+        {
+          "id": "auto_zapier_control",
+          "text": "Authored Zapier + Make blueprints that stitch ATS, CRM, and compliance trackers, eliminating 70 hours/month of swivel-chair updates for distributed teams.",
+          "focus": ["zapier", "make", "ops"]
+        },
+        {
+          "id": "auto_fin_reporting",
+          "text": "Automated Ameriprise-style finance close packets, syncing ledger, CRM, and DocuSign artifacts so executives preview status without calling hybrid standups.",
+          "focus": ["finance", "automation", "reporting"]
+        },
+        {
+          "id": "auto_onboarding",
+          "text": "Built zero-touch onboarding runs that trigger background checks, LMS paths, and payroll setup the moment remote offers are signed.",
+          "focus": ["onboarding", "automation", "remote"]
+        }
+      ]
+    },
+    {
+      "name": "support",
+      "label": "Client & Advisor Support",
+      "bullets": [
+        {
+          "id": "support_playbooks",
+          "text": "Codified tierless support playbooks so remote service pods resolve 83% of advisor tickets asynchronously before escalation.",
+          "focus": ["support", "playbooks", "remote"]
+        },
+        {
+          "id": "support_voice_of_client",
+          "text": "Turned raw call notes into sentiment dashboards, piping MN client wins back to marketing ops within 24 hours.",
+          "focus": ["analytics", "support", "marketing ops"]
+        },
+        {
+          "id": "support_kb_growth",
+          "text": "Expanded AI-searchable knowledge bases by 220 articles with clear Ameriprise compliance flags for distributed agents.",
+          "focus": ["knowledge base", "ai", "compliance"]
+        }
+      ]
+    },
+    {
+      "name": "marketing_ops",
+      "label": "Marketing Ops",
+      "bullets": [
+        {
+          "id": "mops_pipeline",
+          "text": "Linked campaign automation into Salesforce + Marketo loops, lifting MN-qualified inbound by 34% without live events.",
+          "focus": ["campaigns", "salesforce", "remote"]
+        },
+        {
+          "id": "mops_content_syndication",
+          "text": "Stood up AI-assisted content syndication that syndicates Ameriprise-thought leadership across remote advisor microsites in hours, not weeks.",
+          "focus": ["content", "ai", "syndication"]
+        },
+        {
+          "id": "mops_reporting",
+          "text": "Delivered CMO dashboards with spend-to-pipeline clarity, auto-refreshing from attribution data without any hybrid reporting cadence.",
+          "focus": ["analytics", "dashboards", "remote"]
+        }
+      ]
+    },
+    {
+      "name": "agent_ops",
+      "label": "Agent Operations",
+      "bullets": [
+        {
+          "id": "agent_staffing",
+          "text": "Forecasted agent load vs. licensing windows, enabling MN supervisors to shift coverage before queues spike.",
+          "focus": ["workforce", "forecast", "remote"]
+        },
+        {
+          "id": "agent_quality",
+          "text": "Spun up asynchronous quality reviews with AI-generated scorecards so leaders coach without hybrid ride-alongs.",
+          "focus": ["quality", "ai", "remote coaching"]
+        },
+        {
+          "id": "agent_tooling",
+          "text": "Unified advisor tech stack (CRM, VOIP, planning) with SSO guardrails to keep remote sessions secure and auditable.",
+          "focus": ["tooling", "security", "compliance"]
+        }
+      ]
+    },
+    {
+      "name": "real_estate",
+      "label": "Real Estate & Field Ops",
+      "bullets": [
+        {
+          "id": "re_virtual_showings",
+          "text": "Launched remote-first property tours using interactive calculators and Ameriprise-aligned finance flows for relocation clients.",
+          "focus": ["real estate", "remote", "finance"]
+        },
+        {
+          "id": "re_data_room",
+          "text": "Assembled compliance-ready data rooms that sync MLS, appraisal, and lending artifacts for distributed brokers in under an hour.",
+          "focus": ["data", "compliance", "speed"]
+        },
+        {
+          "id": "re_portfolio_ops",
+          "text": "Automated investor reporting with vacancy, rent roll, and capex metrics surfaced weekly without on-site visits.",
+          "focus": ["reporting", "automation", "investor relations"]
+        }
+      ]
+    }
+  ]
+}

--- a/downloads/jd_tools.py
+++ b/downloads/jd_tools.py
@@ -1,0 +1,184 @@
+"""Utility helpers for working with job descriptions inside Zapier Code steps."""
+
+from __future__ import annotations
+
+import html
+import re
+from typing import Iterable, List, Sequence
+
+__all__ = [
+    "clean_html",
+    "detect_remote_policy",
+    "scrape_salary",
+    "keyword_echo",
+]
+
+_TAG_RE = re.compile(r"<[^>]+>")
+_BREAK_RE = re.compile(r"<\s*(?:br|/p)\s*/?>", re.IGNORECASE)
+_SPACE_RE = re.compile(r"\s+")
+
+REMOTE_PATTERNS = [
+    r"fully remote",
+    r"100% remote",
+    r"remote within the united states",
+    r"remote within (?:mn|minnesota)",
+    r"work from (?:anywhere|home)",
+]
+HYBRID_PATTERNS = [
+    r"hybrid",
+    r"in-office [\w\s]+days",
+    r"\b[23]-?day in office",
+]
+ONSITE_PATTERNS = [
+    r"on[- ]site",
+    r"in office",
+    r"relocat(?:e|ion) required",
+]
+STATE_PATTERN = re.compile(r"\b(?:minnesota|mn|united states|u\.?s\.?|usa)\b", re.IGNORECASE)
+
+MONEY_RE = re.compile(
+    r"\$?\s*(?P<amount>[\d,.]+)\s*(?P<modifier>k|K|m|M)?\s*(?P<period>per\s+\w+|hour|ann?ual|year|yr)?",
+)
+RANGE_RE = re.compile(
+    r"\$?\s*(?P<low>[\d,.]+)\s*(?P<low_modifier>k|K|m|M|000)?\s*(?:-|to|–|—)\s*\$?\s*(?P<high>[\d,.]+)\s*(?P<high_modifier>k|K|m|M|000)?\s*(?P<period>per\s+\w+|hour|ann?ual|year|yr)?",
+)
+
+
+def clean_html(source: str) -> str:
+    """Strip HTML tags, collapse whitespace, and unescape HTML entities."""
+
+    if not source:
+        return ""
+
+    text = _BREAK_RE.sub("\n", source)
+    text = _TAG_RE.sub(" ", text)
+    text = html.unescape(text)
+    text = _SPACE_RE.sub(" ", text)
+    return text.strip()
+
+
+def detect_remote_policy(source: str) -> dict:
+    """Return heuristics about remote, hybrid, and onsite signals in the JD."""
+
+    normalized = source.lower()
+    remote_hits = _match_any(normalized, REMOTE_PATTERNS)
+    hybrid_hits = _match_any(normalized, HYBRID_PATTERNS)
+    onsite_hits = _match_any(normalized, ONSITE_PATTERNS)
+    states = sorted({m.group(0).lower() for m in STATE_PATTERN.finditer(source)})
+    policy = "remote" if remote_hits and not onsite_hits else "hybrid" if hybrid_hits else "onsite" if onsite_hits else "unspecified"
+
+    return {
+        "policy": policy,
+        "remote_signals": remote_hits,
+        "hybrid_signals": hybrid_hits,
+        "onsite_signals": onsite_hits,
+        "location_mentions": states,
+    }
+
+
+def scrape_salary(source: str) -> List[dict]:
+    """Extract structured salary data from a JD."""
+
+    salaries: List[dict] = []
+
+    for match in RANGE_RE.finditer(source):
+        low = _normalize_amount(match.group("low"), match.group("low_modifier"))
+        high = _normalize_amount(match.group("high"), match.group("high_modifier"))
+        period = _normalize_period(match.group("period"))
+        salaries.append(
+            {
+                "type": "range",
+                "raw": match.group(0).strip(),
+                "min": low,
+                "max": high,
+                "period": period,
+            }
+        )
+
+    if salaries:
+        return salaries
+
+    for match in MONEY_RE.finditer(source):
+        amount = _normalize_amount(match.group("amount"), match.group("modifier"))
+        period = _normalize_period(match.group("period"))
+        salaries.append(
+            {
+                "type": "single",
+                "raw": match.group(0).strip(),
+                "value": amount,
+                "period": period,
+            }
+        )
+
+    return salaries
+
+
+def keyword_echo(source: str, keywords: Sequence[str]) -> List[dict]:
+    """Return occurrence counts and context snippets for each keyword."""
+
+    results: List[dict] = []
+    lower_source = source.lower()
+
+    for keyword in keywords:
+        if not keyword:
+            continue
+        pattern = re.escape(keyword.lower())
+        matches = list(re.finditer(pattern, lower_source))
+        snippets = [_extract_snippet(source, m.start(), m.end()) for m in matches]
+        results.append(
+            {
+                "keyword": keyword,
+                "count": len(matches),
+                "snippets": snippets,
+            }
+        )
+
+    return results
+
+
+def _match_any(text: str, patterns: Iterable[str]) -> List[str]:
+    hits: List[str] = []
+    for pattern in patterns:
+        if re.search(pattern, text):
+            hits.append(pattern)
+    return hits
+
+
+def _normalize_amount(amount: str, modifier: str | None) -> float:
+    value = float(amount.replace(",", ""))
+    modifier = (modifier or "").lower()
+    if modifier in {"k"}:
+        value *= 1_000
+    elif modifier in {"m"}:
+        value *= 1_000_000
+    elif modifier == "000":
+        value *= 1_000
+    return value
+
+
+def _normalize_period(period: str | None) -> str:
+    if not period:
+        return "unspecified"
+    period = period.lower().strip()
+    if period.startswith("per "):
+        return period.replace("per ", "")
+    if period in {"year", "annual", "ann", "yr"}:
+        return "year"
+    if period == "hour":
+        return "hour"
+    return period
+
+
+def _extract_snippet(text: str, start: int, end: int, window: int = 40) -> str:
+    left = max(start - window, 0)
+    right = min(end + window, len(text))
+    snippet = text[left:right].strip()
+    return snippet.replace("\n", " ")
+
+
+if __name__ == "__main__":
+    sample = "Salary: $95K-$120K per year. Role is fully remote within Minnesota and the United States."
+    print(clean_html(sample))
+    print(detect_remote_policy(sample))
+    print(scrape_salary(sample))
+    print(keyword_echo(sample, ["remote", "Minnesota"]))


### PR DESCRIPTION
## Summary
- add a SnapIns bullet bank tailored to remote-first sales and finance roles
- publish a prompt suite for the JD-to-deliverables pipeline
- implement Python helpers for cleaning JDs, checking remote policy, scraping salary data, and keyword echoing

## Testing
- python -m py_compile downloads/jd_tools.py

------
https://chatgpt.com/codex/tasks/task_e_68dae4ff054c832982a0441cccdff17f