### PR TITLE
Add no-code AI gig roundup blog post

### DIFF
--- a/sites/blackroad/content/blog/no-code-ai-gigs-sep-2025.md
+++ b/sites/blackroad/content/blog/no-code-ai-gigs-sep-2025.md
@@ -1,0 +1,33 @@
+---
+title: "No-Code AI Gigs You Can Apply to Today"
+date: "2025-09-29"
+tags: [ai, jobs, remote-work, no-code]
+description: "A vetted shortlist of U.S.-eligible, no-code AI evaluation gigs plus a fast plan to start earning this week."
+---
+
+Dialed in for orchestration pros who want immediate cashflow without touching code. These remote contractor roles prioritize U.S.-eligible talent, move quickly, and pay for the operational instincts you already have.
+
+## No-code, remote (U.S.) roles to target
+
+1. **DataAnnotation.tech — AI Prompt Engineering & Evaluation (Will Train)**  
+   Flexible contractor cohorts appear regularly, pay starts around $20/hr, and they emphasize "no AI experience required." Stay ready for U.S.-only intakes.
+2. **Invisible Technologies — AI Trainer / LLM Evaluation (Expert Marketplace)**  
+   Ongoing QA and evaluation projects, including Entry-Level Specialist (US) and global AI QA Trainer shifts. Expect zero scripting—pure judgment, labeling, and process ops.
+3. **TELUS International AI — Rater (United States)**  
+   Part-time online relevance and quality reviews. Typical requirements: U.S. residency, smartphone, active Gmail, and 10+ hours/week. Listings usually cite $12–$15/hr ranges.
+4. **Outlier AI — AI Prompt Writer / LLM Evaluator**  
+   Freelance prompt writing, rewrites, and output ranking. Built for fast iterations and async availability; fully remote for U.S. contributors.
+5. **Appen USA — Work From Home | English Speakers + LLM Evaluator Gigs**  
+   Stackable projects that blend model training and evaluation. Availability varies by language/domain, but many tracks onboard U.S. workers.
+
+### Reality check
+
+These platforms are excellent cash bridges, but volume can spike or stall with little warning. Reviews highlight inconsistent task queues, so treat them as flexible revenue while we pursue steadier orchestration seats.
+
+## Quick attack plan
+
+- **Hit DataAnnotation, Invisible (Entry-Level US AI Trainer), and TELUS Rater first.** They post the most frequent U.S.-only cohorts with "will train" signals. Submit today to land in the next screening batch.
+- **Reuse your one-shot prompt, resume, and cover templates.** Personalize each submission manually to stay inside every platform's Terms of Service while keeping prep under a minute.
+- **Queue Outlier AI and Appen signups next.** They onboard in waves—get verified now so you're ready when fresh tasks release.
+
+Want live, currently open links tagged "U.S.-only / no coding / will train"? Ping me with **"pull live roles"** and I'll fetch the freshest postings with application notes in one sweep.


### PR DESCRIPTION
## Summary
- add a new blog post outlining five U.S.-eligible, no-code AI evaluation gigs and an application plan

## Testing
- not run (content-only change)


------
https://chatgpt.com/codex/tasks/task_e_68daf0453a94832989a0cd7705f56e78