### PR TITLE
Add guide for no-code remote AI evaluation roles

### DIFF
--- a/docs/no-code-remote-roles.md
+++ b/docs/no-code-remote-roles.md
@@ -1,0 +1,43 @@
+# No-Code Remote AI Evaluation Roles (U.S.)
+
+This guide consolidates active, U.S.-eligible, no-code roles focused on AI prompt engineering, evaluation, and orchestration support. Each listing includes engagement details and quick-apply notes to keep application prep under a minute per role.
+
+## 1. DataAnnotation Tech — AI Prompt Engineering & Evaluation (Will Train)
+- **Engagement**: Fully remote contractor; project-based with asynchronous scheduling.
+- **Requirements**: No prior AI experience necessary per FAQ; U.S. applicants accepted.
+- **Compensation**: Commonly reported range of $20–$30/hour.
+- **Apply**: Submit both the role-specific application and the generalist intake form to access the project pool.
+
+## 2. Invisible Technologies — AI QA Trainer (LLM Evaluation) & Entry-Level Specialist (U.S.)
+- **Engagement**: Remote contractor positions through their marketplace (LLM evaluation) and entry-level specialist track.
+- **Requirements**: U.S. eligibility for the entry-level specialist posting; AI QA trainer is open worldwide.
+- **Compensation**: Task-based; rates vary by evaluation project.
+- **Apply**: Use the marketplace listings for “AI QA Trainer – LLM Evaluation (Worldwide)” and “Entry Level Specialist (US) – AI Trainer.”
+
+## 3. TELUS International AI — U.S. Rater / Online Data Research
+- **Engagement**: Part-time contractor with ~10 hours/week minimum commitment.
+- **Requirements**: Must reside in the United States; platform-specific qualification tests.
+- **Compensation**: Approximately $12–$15/hour depending on project.
+- **Apply**: Complete the U.S. rater application and any associated language or platform assessments.
+
+## 4. Outlier AI — Prompt Writer / LLM Evaluator (Freelance)
+- **Engagement**: Freelance evaluation and prompt-authoring assignments with variable volume by project.
+- **Requirements**: U.S. applicants supported; follow project-specific style guides.
+- **Compensation**: Paid per assignment; rates vary with prompt complexity and evaluation depth.
+- **Apply**: Register on the opportunities board and opt in to relevant prompt-writing or evaluation briefs.
+
+## 5. Appen — CrowdGen (Get Paid to Train AI)
+- **Engagement**: Task marketplace delivering crowd-sourced model training and evaluation work.
+- **Requirements**: U.S. residency supported; project availability fluctuates.
+- **Compensation**: Task-based, dependent on the active CrowdGen projects.
+- **Apply**: Create an Appen account, enroll in CrowdGen, and monitor for U.S.-eligible tasks.
+
+## Fast-Track Application Strategy
+1. **Immediate submissions**: Prioritize DataAnnotation Tech, Invisible Technologies (U.S. entry-level track), and TELUS International AI to establish a short-term pipeline.
+2. **Queue onboarding**: Complete registrations for Outlier AI and Appen CrowdGen, as activation can take longer but provides additional earning channels.
+3. **Application pack**: Reuse a templated “one-shot” prompt plus your resume and cover letter files to generate tailored submissions in under a minute for each role.
+4. **Tracking**: Maintain a simple spreadsheet logging submission dates, follow-up reminders, and onboarding status for each platform.
+
+## Next Steps
+- Decide which role to target first and prepare the application pack (summary, six bullet highlights, micro note, and Q&A JSON) before opening the apply page.
+- If support is needed, provide the target company name so an application pack can be drafted rapidly.


### PR DESCRIPTION
## Summary
- add documentation covering five U.S.-eligible, no-code AI evaluation roles with application notes
- outline a fast-track application strategy to prioritize submissions and onboarding

## Testing
- not run (docs-only change)

------
https://chatgpt.com/codex/tasks/task_e_68daf115049483299a0666ba8eeb5e87