### PR TITLE
Add BlackRoad Pi OS builder and first boot helpers

### DIFF
--- a/docs/blackroad-os.md
+++ b/docs/blackroad-os.md
@@ -1,0 +1,56 @@
+# BlackRoad OS Image Builder
+
+This repository includes helper scripts for preparing a Raspberry Pi OS Lite image
+with BlackRoad defaults and a first-boot helper for finalizing EEPROM settings on
+the Raspberry Pi itself.
+
+## Prerequisites
+
+- A Linux workstation (e.g., the Jetson) with `curl`, `xzcat`, `dd`, `partprobe`,
+  and standard GNU core utilities available.
+- Root access (`sudo`) to write directly to the target block device.
+- An SD card or USB drive visible under `/dev/`.
+
+## Flashing the Image
+
+```bash
+cd scripts
+chmod +x blackroad-build.sh
+sudo ./blackroad-build.sh /dev/sdX
+```
+
+Replace `/dev/sdX` with the block device that maps to your removable media. The
+script will download the latest Raspberry Pi OS Lite image, flash it to the
+specified device, and apply the following customizations:
+
+- Enable USB high-current mode and conservative HDMI defaults in `config.txt`.
+- Enable the SSH service by default.
+- Set the hostname to `blackroad` and configure `/etc/hosts` accordingly.
+- Install a custom login banner (MOTD).
+- Drop `blackroad-firstboot.sh` on the boot partition for later use.
+
+The operation is destructive and will wipe the target device.
+
+## First-Boot Finalization
+
+After the Raspberry Pi boots from the prepared media:
+
+1. Log in via console or SSH.
+2. Run the bundled helper (already copied to `/boot/blackroad-firstboot.sh`):
+
+   ```bash
+   sudo /boot/blackroad-firstboot.sh
+   ```
+
+   The script removes the temporary HDMI safe-mode overrides and programs the
+   EEPROM boot order to `0xf14` (USB → SD). A reboot is recommended once it
+   completes.
+
+3. Optionally delete the helper script after use:
+
+   ```bash
+   sudo rm /boot/blackroad-firstboot.sh
+   ```
+
+The EEPROM update step must be executed directly on the Raspberry Pi because the
+EEPROM is not accessible when the storage is attached to another machine.

--- a/scripts/blackroad-build.sh
+++ b/scripts/blackroad-build.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMG_URL="https://downloads.raspberrypi.com/raspios_lite_arm64_latest"
+DEVICE="${1:-}"
+HOSTNAME="blackroad"
+BOOT_ORDER="0xf14"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+usage() {
+  cat <<'USAGE'
+Usage: sudo ./blackroad-build.sh /dev/sdX
+
+This script downloads the latest Raspberry Pi OS Lite image and flashes it to the
+specified block device with BlackRoad defaults applied.
+USAGE
+  exit 1
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Error: required command '$1' not found." >&2
+    exit 1
+  fi
+}
+
+ensure_root() {
+  if [[ "${EUID:-$(id -u)}" -ne 0 ]]; then
+    echo "Error: this script must be run as root." >&2
+    exit 1
+  fi
+}
+
+confirm_device() {
+  local dev=$1
+  if [[ ! -b "$dev" ]]; then
+    echo "Error: '$dev' is not a valid block device." >&2
+    usage
+  fi
+  if lsblk -nr -o MOUNTPOINT "$dev" | grep -qE '\S'; then
+    echo "Error: device $dev has mounted partitions. Unmount them and retry." >&2
+    exit 1
+  fi
+}
+
+append_if_missing() {
+  local pattern=$1
+  local line=$2
+  local file=$3
+  if ! grep -qE "^${pattern}(=|$)" "$file"; then
+    printf '%s\n' "$line" >>"$file"
+  fi
+}
+
+cleanup() {
+  local status=$?
+  set +e
+  if [[ -n "${BOOT_MNT:-}" ]] && mountpoint -q "$BOOT_MNT"; then
+    umount "$BOOT_MNT"
+  fi
+  if [[ -n "${ROOT_MNT:-}" ]] && mountpoint -q "$ROOT_MNT"; then
+    umount "$ROOT_MNT"
+  fi
+  [[ -n "${BOOT_MNT:-}" ]] && rm -rf "$BOOT_MNT"
+  [[ -n "${ROOT_MNT:-}" ]] && rm -rf "$ROOT_MNT"
+  [[ -n "${WORKDIR:-}" ]] && rm -rf "$WORKDIR"
+  exit $status
+}
+
+main() {
+  ensure_root
+
+  if [[ -z "$DEVICE" ]]; then
+    usage
+  fi
+
+  require_cmd curl
+  require_cmd xzcat
+  require_cmd dd
+  require_cmd partprobe
+  require_cmd lsblk
+  require_cmd mount
+  require_cmd umount
+  require_cmd sed
+  require_cmd install
+
+  confirm_device "$DEVICE"
+
+  echo "== BlackRoad OS build on $DEVICE =="
+
+  WORKDIR=$(mktemp -d)
+  trap cleanup EXIT
+  cd "$WORKDIR"
+
+  echo "Downloading base Raspberry Pi OS…"
+  curl -L "$IMG_URL" -o raspios.img.xz
+
+  echo "Writing image… (this wipes $DEVICE)"
+  xzcat raspios.img.xz | dd of="$DEVICE" bs=8M status=progress conv=fsync
+  sync
+  partprobe "$DEVICE"
+
+  local suffix=""
+  case "$DEVICE" in
+    *[0-9]) suffix="p" ;;
+  esac
+  local bootpart="${DEVICE}${suffix}1"
+  local rootpart="${DEVICE}${suffix}2"
+
+  if [[ ! -b "$bootpart" || ! -b "$rootpart" ]]; then
+    echo "Error: expected partitions $bootpart and $rootpart not found." >&2
+    exit 1
+  fi
+
+  BOOT_MNT=$(mktemp -d)
+  ROOT_MNT=$(mktemp -d)
+
+  echo "Mounting boot partition $bootpart"
+  mount "$bootpart" "$BOOT_MNT"
+
+  local config_txt
+  if [[ -f "$BOOT_MNT/config.txt" ]]; then
+    config_txt="$BOOT_MNT/config.txt"
+  elif [[ -f "$BOOT_MNT/firmware/config.txt" ]]; then
+    config_txt="$BOOT_MNT/firmware/config.txt"
+  else
+    echo "Error: unable to locate config.txt on boot partition." >&2
+    exit 1
+  fi
+
+  echo "Patching config.txt…"
+  append_if_missing "usb_max_current_enable" "usb_max_current_enable=1" "$config_txt"
+  append_if_missing "hdmi_safe" "hdmi_safe=1" "$config_txt"
+  append_if_missing "hdmi_force_hotplug" "hdmi_force_hotplug=1" "$config_txt"
+
+  echo "Enabling SSH…"
+  touch "$BOOT_MNT/ssh"
+
+  if [[ -f "$SCRIPT_DIR/blackroad-firstboot.sh" ]]; then
+    echo "Copying first-boot helper script…"
+    install -m 0755 "$SCRIPT_DIR/blackroad-firstboot.sh" "$BOOT_MNT/blackroad-firstboot.sh"
+  fi
+
+  umount "$BOOT_MNT"
+
+  echo "Mounting root partition $rootpart"
+  mount "$rootpart" "$ROOT_MNT"
+
+  echo "Setting hostname to $HOSTNAME…"
+  printf '%s\n' "$HOSTNAME" >"$ROOT_MNT/etc/hostname"
+  if grep -q "^127\.0\.1\.1" "$ROOT_MNT/etc/hosts"; then
+    sed -i "s/^127\.0\.1\.1\s\+.*/127.0.1.1\t$HOSTNAME/" "$ROOT_MNT/etc/hosts"
+  else
+    printf '127.0.1.1\t%s\n' "$HOSTNAME" >>"$ROOT_MNT/etc/hosts"
+  fi
+
+  echo "Installing custom MOTD…"
+  cat <<'MOTD' >"$ROOT_MNT/etc/motd"
+##################################
+   Welcome to BlackRoad OS
+   (built on Raspberry Pi OS)
+##################################
+MOTD
+
+  umount "$ROOT_MNT"
+
+  echo "Boot order will be set to $BOOT_ORDER on first boot."
+  echo "Run blackroad-firstboot.sh on the Pi to apply EEPROM changes."
+  echo "Done."
+}
+
+main "$@"

--- a/scripts/blackroad-firstboot.sh
+++ b/scripts/blackroad-firstboot.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BOOT_ORDER="${1:-0xf14}"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Error: required command '$1' not found." >&2
+    exit 1
+  fi
+}
+
+ensure_root() {
+  if [[ "${EUID:-$(id -u)}" -ne 0 ]]; then
+    echo "Error: this script must be run with sudo/root privileges." >&2
+    exit 1
+  fi
+}
+
+update_boot_config() {
+  local config_path="/boot/config.txt"
+  if [[ -f /boot/firmware/config.txt ]]; then
+    config_path="/boot/firmware/config.txt"
+  fi
+
+  if [[ ! -f "$config_path" ]]; then
+    echo "Warning: could not locate config.txt; skipping HDMI cleanup." >&2
+    return
+  fi
+
+  echo "Cleaning up HDMI safe-mode overrides in $config_path"
+  cp "$config_path" "${config_path}.blackroad.bak"
+  sed -i -E '/^hdmi_safe=1$/d' "$config_path"
+  sed -i -E '/^hdmi_force_hotplug=1$/d' "$config_path"
+}
+
+apply_boot_order() {
+  local tmp_cfg
+  tmp_cfg=$(mktemp)
+
+  echo "Applying EEPROM boot order BOOT_ORDER=$BOOT_ORDER"
+  rpi-eeprom-config --out "$tmp_cfg"
+  if grep -q '^BOOT_ORDER=' "$tmp_cfg"; then
+    sed -i "s/^BOOT_ORDER=.*/BOOT_ORDER=${BOOT_ORDER}/" "$tmp_cfg"
+  else
+    printf 'BOOT_ORDER=%s\n' "$BOOT_ORDER" >>"$tmp_cfg"
+  fi
+  rpi-eeprom-config --apply "$tmp_cfg"
+  rm -f "$tmp_cfg"
+}
+
+main() {
+  ensure_root
+  require_cmd rpi-eeprom-config
+
+  update_boot_config
+  apply_boot_order
+
+  cat <<'MSG'
+BlackRoad first-boot customization complete.
+- HDMI safe-mode entries removed from config.txt
+- EEPROM boot order updated
+A reboot is recommended to apply EEPROM settings.
+MSG
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add a Jetson-friendly `blackroad-build.sh` helper to flash Raspberry Pi OS Lite with BlackRoad defaults
- provide a first-boot script that programs the EEPROM boot order and removes temporary HDMI overrides
- document the build and first-boot workflow for preparing "BlackRoad OS"

## Testing
- not run (automation not applicable for hardware flashing scripts)


------
https://chatgpt.com/codex/tasks/task_e_68daf2ae6cc88329a348b2e80bb30818