### PR TITLE
Add TELUS International AI rater application pack

### DIFF
--- a/portfolio/reports/telus_international_ai_rater_us_remote.md
+++ b/portfolio/reports/telus_international_ai_rater_us_remote.md
@@ -54,3 +54,9 @@ Happy to walk through a 2-minute demo.
 ## 6. Next Steps Prompt
 
 Want me to spin the same pack for Outlier AI next, or pull a fresh batch of U.S.-remote, no-code listings and run them through your chain? Say “next with Outlier” or “pull fresh.”
+
+## 7. Operational Checklist
+
+- ✅ **Security sanity:** No credentials, tokens, or proprietary data embedded in this pack.
+- ✅ **Dependencies:** Documentation-only asset; no packages or runtime changes introduced.
+- ✅ **Pipelines:** No CI/CD impacts expected—safe to merge once reviewed.


### PR DESCRIPTION
## Summary
- add a ready-to-use application pack for the TELUS International AI Rater role
- include ATS summary, tailored bullets, cover note, application JSON, and next-step prompt in a single reference document

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daf31da3588329b30d258b27576763