### PR TITLE
Add Outlier AI prompt writer application pack

### DIFF
--- a/docs/application_packs/outlier_ai_prompt_writer_pack.md
+++ b/docs/application_packs/outlier_ai_prompt_writer_pack.md
@@ -1,0 +1,45 @@
+# Outlier AI — Prompt Writer / LLM Evaluator Application Pack
+
+## 1. 55-word Summary (ATS-clean)
+AI workflow orchestrator focused on clear prompt writing and rubric-driven LLM evaluation. Ships tight iterations, version notes, and guardrails with human-in-the-loop review. Delivered $23M revenue impact and 33.3% MoM lift previously; surfaced $18.4M AUM and reduced $3.1M at-risk via disciplined workflows. Ready for Remote U.S./MN freelance evaluation with dependable throughput.
+
+## 2. Tailored Bullets
+- Write concise prompts with unambiguous instructions, constraints, and examples; document rationale and expected failure modes.
+- Evaluate model outputs against style/tone/policy rubrics; tag issues (factuality, safety, formatting) and propose targeted revisions.
+- Maintain versioned prompt libraries and regression checks to prevent quality drift across tasks.
+- Add lightweight failure taxonomy + escalation notes so reviewers align decisions quickly.
+- Drove measurable outcomes in prior roles ($23M impact; 33.3% MoM lift) by standardizing playbooks and feedback loops.
+- Translate findings for non-technical teammates; produce SOPs/runbooks others can follow without hand-holding.
+
+## 3. Cover Micro-note
+Hi Outlier Team,
+
+I’m built for prompt clarity and reliable evaluation—tight instructions, crisp rubrics, and iteration that sticks. Recent outcomes: $23M revenue impact while lifting advisor case growth 33.3% MoM; at Ameriprise I surfaced $18.4M AUM and reduced $3.1M at-risk assets by enforcing simple, repeatable workflows and documentation.
+
+In the first 30 days I’d (1) align on your style and policy guides; (2) introduce version notes + small regression checks to keep prompts stable; (3) publish a short runbook and failure taxonomy so reviewers make consistent calls. Feedback stays concise, reproducible, and audit-friendly.
+
+Portfolio + short Looms: blackroad.io
+Happy to share a 2-minute walkthrough.
+
+— Alexa Louise
+
+## 4. Application Q&A JSON
+```json
+{
+  "eligibility": "Yes",
+  "sponsorship": "No",
+  "notice_period": "Immediate",
+  "salary_min": "N/A",
+  "salary_pref": "N/A",
+  "timezone": "America/Chicago",
+  "locations_ok": ["Remote (U.S.)", "Remote (Minnesota)"],
+  "linkedin": "https://www.linkedin.com/in/<handle>",
+  "portfolio": "https://blackroad.io/#proof",
+  "certs": ["SIE","7","63","65","Life & Health","MN Real Estate"],
+  "eeo_optional": {"gender":"Decline to answer","race":"Decline to answer","veteran_status":"Decline to answer"},
+  "disability_optional": {"status":"Decline to answer"}
+}
+```
+
+## Next Step Prompt
+Reply “next with Appen” to queue the Appen application, or say “pull fresh” for a new batch of U.S.-remote, no-code roles through this workflow.


### PR DESCRIPTION
## Summary
- add a ready-to-use application pack for the Outlier AI Prompt Writer / LLM Evaluator role
- include ATS summary, tailored bullets, cover micro-note, and JSON Q&A response
- provide guidance for the next workflow step to queue additional applications

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daf34ff3808329bddd271c65421ed3