### PR TITLE
Add one-shot first boot systemd service

### DIFF
--- a/etc/systemd/system/blackroad-firstboot.service
+++ b/etc/systemd/system/blackroad-firstboot.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=BlackRoad OS First Boot Setup
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/blackroad-firstboot.sh
+ExecStartPost=/bin/bash -c 'systemctl disable blackroad-firstboot.service; rm -f /etc/systemd/system/blackroad-firstboot.service'
+
+[Install]
+WantedBy=multi-user.target

--- a/etc/systemd/system/multi-user.target.wants/blackroad-firstboot.service
+++ b/etc/systemd/system/multi-user.target.wants/blackroad-firstboot.service
@@ -1,0 +1,1 @@
+../blackroad-firstboot.service


### PR DESCRIPTION
## Summary
- add a systemd unit that runs `blackroad-firstboot.sh` and removes itself after completion
- enable the unit by linking it into `multi-user.target.wants` so it runs on the first boot

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68daf37dfb8c83299673334c66fa66ab