### PR TITLE
Add Jetson offload helpers and telemetry bridge

### DIFF
--- a/usr/local/bin/blackroad-run
+++ b/usr/local/bin/blackroad-run
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+JETSON_USER="jetson"
+JETSON_HOST="jetson.local"
+
+if [ $# -lt 1 ]; then
+  echo "Usage: blackroad-run <script.py|cmd>"
+  exit 1
+fi
+
+CMD="$*"
+echo "== Offloading to $JETSON_HOST =="
+ssh -t ${JETSON_USER}@${JETSON_HOST} "$CMD"

--- a/usr/local/bin/blackroad-telemetry
+++ b/usr/local/bin/blackroad-telemetry
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Pi will call this over SSH to grab Jetson stats
+echo "## Jetson Telemetry"
+echo "Uptime: $(uptime -p)"
+echo "Load: $(uptime | awk -F'load average:' '{print $2}')"
+command -v tegrastats >/dev/null && sudo tegrastats --interval 1000 --count 1 || echo "tegrastats not available"

--- a/usr/local/bin/blackroad-telemetry-pull
+++ b/usr/local/bin/blackroad-telemetry-pull
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+JETSON_USER="jetson"
+JETSON_HOST="jetson.local"
+
+ssh ${JETSON_USER}@${JETSON_HOST} blackroad-telemetry


### PR DESCRIPTION
## Summary
- add blackroad-run helper to offload Pi commands to the Jetson over SSH
- expose Jetson telemetry via blackroad-telemetry and pull it from the Pi with blackroad-telemetry-pull
- document the new Jetson integration workflow in the Raspberry Pi day-one setup guide

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68daf440b65c8329b3120de80903e031