### PR TITLE
Add Appen AI data annotation application pack

### DIFF
--- a/portfolio/reports/job_applications/appen-ai-data-annotation-pack.md
+++ b/portfolio/reports/job_applications/appen-ai-data-annotation-pack.md
@@ -1,0 +1,42 @@
+# Appen — AI Data Annotation / Contributor (Remote U.S.)
+
+## 55-Word Summary (ATS-Friendly)
+AI workflow orchestrator focused on guideline-based evaluation and clean documentation. Ships prompt and rubric iterations fast, tracks failure modes, and keeps reviewers aligned with tight runbooks. Delivered $23M revenue impact and 33.3% MoM lift; surfaced $18.4M AUM and cut $3.1M at-risk through disciplined processes. Ready for Remote U.S./MN consistent contributor throughput with dependable, audit-friendly output.
+
+## Tailored Bullet Points
+- Label and evaluate data against detailed guidelines; capture concise rationale for auditability and re-triage.
+- Calibrate decisions with sample sets; maintain a lightweight failure taxonomy to standardize edge-case handling.
+- Keep versioned notes and simple regression checks so quality doesn’t drift over time.
+- Hit consistent throughput without sacrificing accuracy; flag ambiguous items with context and suggested clarifications.
+- Ran enablement at scale (200+ trainings) and drove outcomes ($23M impact; 33.3% MoM lift) by enforcing simple, repeatable workflows.
+- Write tight SOPs/runbooks so other annotators reproduce decisions reliably.
+
+## Cover Micro-Note
+Hi Appen Team,
+
+I’m built for dependable, guideline-driven annotation—tight rubrics, disciplined iterations, and documentation others can trust. Recent outcomes: $23M revenue impact while lifting advisor case growth 33.3% MoM; at Ameriprise I surfaced $18.4M AUM and reduced $3.1M at-risk assets by enforcing simple, repeatable workflows and clear communication.
+
+In the first 30 days I would: (1) internalize your project guidelines and help calibrate with a small sample set; (2) maintain versioned notes plus a lightweight failure taxonomy so decisions stay consistent; (3) publish a short runbook and QA checklist to keep accuracy steady while meeting throughput targets. I keep feedback crisp, reproducible, and audit-friendly.
+
+Portfolio + short Looms: blackroad.io
+Happy to share a 2-minute walkthrough.
+
+— Alexa Louise
+
+## Application Q&A JSON
+```json
+{
+  "eligibility": "Yes",
+  "sponsorship": "No",
+  "notice_period": "Immediate",
+  "salary_min": "N/A",
+  "salary_pref": "N/A",
+  "timezone": "America/Chicago",
+  "locations_ok": ["Remote (U.S.)", "Remote (Minnesota)"],
+  "linkedin": "https://www.linkedin.com/in/<handle>",
+  "portfolio": "https://blackroad.io/#proof",
+  "certs": ["SIE", "7", "63", "65", "Life & Health", "MN Real Estate"],
+  "eeo_optional": {"gender": "Decline to answer", "race": "Decline to answer", "veteran_status": "Decline to answer"},
+  "disability_optional": {"status": "Decline to answer"}
+}
+```


### PR DESCRIPTION
## Summary
- add an application pack for the Appen AI Data Annotation / Contributor role with summary, bullets, cover note, and Q&A JSON.

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68daf4722870832991c49c9760362e40