### PR TITLE
Add BlackRoad agent bootstrap script and remote flash roadmap

### DIFF
--- a/docs/blackroad_native_ai_stack.md
+++ b/docs/blackroad_native_ai_stack.md
@@ -1,0 +1,43 @@
+# BlackRoad Native AI Stack Roadmap
+
+## Vision Recap
+
+BlackRoad is evolving from "Pi with helper scripts" into a unified edge stack that ships with:
+
+- **Local intelligence**: Pi + Jetson hosts run inference without external calls by default.
+- **Hardware awareness**: Agents inspect temps, power, GPIO, storage and can coordinate Jetson/Pi hand-offs.
+- **Remote flashing**: Devices accept new OS images or config bundles over the air.
+- **Git-style sync**: Configs, weights, jobs flow like repos between remotes.
+
+The bootstrap script at `scripts/blackroad/bootstrap_agent.sh` lays down the first pillar: a resilient telemetry agent with a slot for the local AI runtime.
+
+## Remote Flash Pipeline First
+
+The next build sequence should focus on remote flashing before bundling model runtimes.
+
+1. **Reasoning**
+   - Remote flashing unblocks every other iteration loop: once devices can re-image themselves, we can safely ship heavier model builds later without SD card swaps.
+   - OTA upgrades reduce the risk of bricking: the agent can snapshot health and roll back if a flashing job fails.
+   - Packaging llama.cpp or Whisper later becomes a pure software update pushed via the same pipeline.
+
+2. **Milestones**
+   - [ ] Author `blackroad-flasher` service: exposes `flash <image>` and `apply-update <bundle>` endpoints guarded by signed manifests.
+   - [ ] Extend the agent loop with a flashing job queue plus health gates (temps, power, storage headroom).
+   - [ ] Build a `blackroad push` CLI that wraps `git bundle` and image artifact upload.
+   - [ ] Implement staged boot: download → verify SHA/signature → write to spare partition or drive → flip boot variables.
+   - [ ] Record flash telemetry to `/var/log/blackroad-flasher.log` and stream summaries back to the control plane.
+
+3. **Prereq Tasks**
+   - Document partition layout and PARTUUID strategy for Pi SD plus Jetson NVMe.
+   - Reserve a recovery channel (USB gadget, UART, or watchdog) for last-resort rollback.
+   - Harden SSH mutual auth so that only signed control-plane pushes can request a flash.
+
+## Follow-On: Bundled Model Runtime
+
+With the flashing lane ready:
+
+- Build a `blackroad-ai` bundle containing llama.cpp binaries plus curated GGUF models.
+- Teach the agent to hot-reload models after verifying quantization and checksum.
+- Provide upgrade hooks for quick retraining on-device (Jetson GPU path, Pi CPU-only fallback).
+
+This order keeps the platform resilient while we layer richer AI capabilities.

--- a/scripts/blackroad/bootstrap_agent.sh
+++ b/scripts/blackroad/bootstrap_agent.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bootstrap script for installing the BlackRoad agent skeleton on a Raspberry Pi.
+# The script lays down an always-on telemetry watcher with a Jetson peer check.
+
+LOG_PATH="/var/log/blackroad-agent.log"
+JETSON_HOST="jetson.local"
+AGENT_BIN="/usr/local/bin/blackroad-agent.sh"
+
+sudo tee "$AGENT_BIN" >/dev/null <<'AGENT'
+#!/usr/bin/env bash
+set -euo pipefail
+
+LOG=/var/log/blackroad-agent.log
+JETSON="${JETSON_OVERRIDE:-jetson.local}"
+
+log() { echo "[$(date +%F %T)] $*" | tee -a "$LOG"; }
+
+while true; do
+  # Collect telemetry from the Pi
+  pi_temp=$(vcgencmd measure_temp 2>/dev/null || echo "n/a")
+
+  # Probe the Jetson companion if reachable
+  jetson_temp=$(ssh -o ConnectTimeout=2 jetson@"$JETSON" "vcgencmd measure_temp" 2>/dev/null || echo "n/a")
+
+  log "Pi temp=$pi_temp | Jetson temp=$jetson_temp"
+
+  # Placeholder health check for the embedded AI runtime
+  if [ -x /usr/local/bin/blackroad-ai ]; then
+    /usr/local/bin/blackroad-ai --health >>"$LOG" 2>&1 || true
+  fi
+
+  sleep 60
+done
+AGENT
+
+sudo chmod +x "$AGENT_BIN"
+
+# Provision the systemd unit so the agent runs on boot.
+sudo tee /etc/systemd/system/blackroad-agent.service >/dev/null <<'UNIT'
+[Unit]
+Description=BlackRoad Telemetry Agent
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/blackroad-agent.sh
+Restart=always
+RestartSec=5
+User=root
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+sudo systemctl daemon-reload
+sudo systemctl enable blackroad-agent.service
+sudo systemctl restart blackroad-agent.service
+
+cat <<INFO
+BlackRoad agent installed.
+- Log file: $LOG_PATH
+- Service: blackroad-agent.service
+INFO


### PR DESCRIPTION
## Summary
- add a bootstrap script that installs the BlackRoad telemetry agent with a systemd unit
- document the native AI stack roadmap and prioritize building the remote flash pipeline before bundling models

## Testing
- bash -n scripts/blackroad/bootstrap_agent.sh

------
https://chatgpt.com/codex/tasks/task_e_68daf4c2b9d08329a035f34681278b1c