### PR TITLE
Add RWS TrainAI search quality rater pack

### DIFF
--- a/portfolio/reports/rws-trainai-search-quality-rater.md
+++ b/portfolio/reports/rws-trainai-search-quality-rater.md
@@ -1,0 +1,40 @@
+# RWS TrainAI — Search Quality Rater (English-US, Remote)
+
+## 1. 55-word summary (ATS-clean)
+Guideline-driven evaluator who keeps decisions consistent and auditable: crisp rubrics, versioned notes, and light regression checks. Built failure taxonomies and human-in-the-loop gates; trained 200+ colleagues. Prior roles delivered $23M impact and a 33.3% MoM lift by standardizing workflows. Ready for Remote U.S./MN rater work with steady throughput and clean documentation.
+
+## 2. Six tailored bullets
+- Rate search results against detailed criteria; capture concise rationales suitable for audit and re-triage.
+- Maintain a lightweight failure taxonomy; propose rubric clarifications and edge-case exemplars.
+- Keep versioned notes and quick regression checks to prevent drift across raters and time.
+- Escalate ambiguous cases with context; help calibrate judgments across the pool.
+- Ran enablement at scale (200+ trainings) and drove outcomes ($23M impact; 33.3% MoM lift) via disciplined workflows.
+- Write tight SOPs/runbooks so decisions are reproducible without hand-holding.
+
+## 3. Cover micro-note (application box)
+Hi RWS TrainAI Team,
+
+I’m built for dependable, guideline-driven evaluation—tight rubrics, disciplined iterations, and documentation others can trust. Recent outcomes: $23M revenue impact while lifting advisor case growth 33.3% MoM; at Ameriprise I surfaced $18.4M AUM and reduced $3.1M at-risk assets by enforcing clear workflows and communication.
+
+In the first 30 days I would: (1) internalize your rater guidelines and seed a lightweight failure taxonomy; (2) keep versioned notes plus small regression checks so decisions stay consistent; (3) publish a short runbook to align reviewers while meeting throughput targets. Feedback stays concise, reproducible, and audit-friendly.
+
+Portfolio + short Looms: blackroad.io
+— Alexa Louise
+
+## 4. Application Q&A JSON
+```json
+{
+  "eligibility": "Yes",
+  "sponsorship": "No",
+  "notice_period": "Immediate",
+  "salary_min": "N/A",
+  "salary_pref": "N/A",
+  "timezone": "America/Chicago",
+  "locations_ok": ["Remote (U.S.)", "Remote (Minnesota)"],
+  "linkedin": "https://www.linkedin.com/in/<handle>",
+  "portfolio": "https://blackroad.io/#proof",
+  "certs": ["SIE","7","63","65","Life & Health","MN Real Estate"],
+  "eeo_optional": {"gender":"Decline to answer","race":"Decline to answer","veteran_status":"Decline to answer"},
+  "disability_optional": {"status":"Decline to answer"}
+}
+```


### PR DESCRIPTION
## Summary
- add a paste-ready application pack for the RWS TrainAI search quality rater role under `portfolio/reports`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daf5969f5883298cc106d0028b1b93