### PR TITLE
Add Welocalize search quality rater job pack

### DIFF
--- a/portfolio/reports/job-packs/pack-05-welocalize-search-quality-rater-us.md
+++ b/portfolio/reports/job-packs/pack-05-welocalize-search-quality-rater-us.md
@@ -1,0 +1,43 @@
+# Pack #5: Welocalize — Search Quality Rater (US)
+
+## 55-word Summary (ATS-clean)
+Guideline-driven evaluator who keeps decisions consistent and auditable: crisp rubrics, versioned notes, and light regression checks. Built failure taxonomies and human-in-the-loop gates; trained 200+ colleagues. Prior roles delivered $23M impact and a 33.3% MoM lift by standardizing workflows. Ready for Remote U.S./MN rater work with reliable throughput and clean documentation.
+
+## Six Tailored Bullets
+- Review search results against detailed rating criteria; capture concise rationale for each decision.
+- Maintain a lightweight failure taxonomy; propose rubric clarifications and edge-case examples to improve consistency.
+- Track versioned notes and quick regression checks so quality doesn’t drift across raters.
+- Escalate ambiguous items with context; help calibrate judgments across the team.
+- Ran enablement at scale (200+ trainings); shipped SOPs/runbooks so others reproduce decisions reliably.
+- Drove measurable outcomes in prior roles ($23M impact; 33.3% MoM lift) through disciplined workflows and feedback loops.
+
+## Cover Micro-note (Application Box)
+Hi Welocalize Team,
+
+I’m built for dependable, guideline-driven evaluation—tight rubrics, disciplined iterations, and documentation others can trust. Recent outcomes: $23M revenue impact while lifting advisor case growth 33.3% MoM; at Ameriprise I surfaced $18.4M AUM and reduced $3.1M at-risk assets by enforcing clear workflows and communication.
+
+In the first 30 days I would: (1) internalize your rater guidelines and propose a lightweight failure taxonomy; (2) keep versioned notes plus small regression checks so decisions stay consistent; (3) publish a short runbook to align reviewers while meeting throughput targets. I keep feedback crisp, reproducible, and audit-friendly.
+
+Portfolio + short Looms: blackroad.io
+— Alexa Louise
+
+## Application Q&A JSON
+```json
+{
+  "eligibility": "Yes",
+  "sponsorship": "No",
+  "notice_period": "Immediate",
+  "salary_min": "N/A",
+  "salary_pref": "N/A",
+  "timezone": "America/Chicago",
+  "locations_ok": ["Remote (U.S.)", "Remote (Minnesota)"],
+  "linkedin": "https://www.linkedin.com/in/<handle>",
+  "portfolio": "https://blackroad.io/#proof",
+  "certs": ["SIE", "7", "63", "65", "Life & Health", "MN Real Estate"],
+  "eeo_optional": {"gender": "Decline to answer", "race": "Decline to answer", "veteran_status": "Decline to answer"},
+  "disability_optional": {"status": "Decline to answer"}
+}
+```
+
+## Apply Link
+Remote U.S., 10–29 hrs/week (W-2) via Lever.


### PR DESCRIPTION
## Summary
- add a paste-ready application pack for the Welocalize Search Quality Rater (US) role, including summary, tailored bullets, cover note, and application Q&A JSON

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68daf55f30a08329a43d418dbdb257c5