### PR TITLE
Add Welocalize search quality rater job pack

### DIFF
--- a/portfolio/reports/README.md
+++ b/portfolio/reports/README.md
@@ -1,0 +1,18 @@
+# Portfolio Reports
+
+This directory collects paste-ready, presentation-friendly artifacts that support outbound applications and update packs.
+
+## Job Packs
+
+Each job pack bundles the following blocks so a hiring manager or recruiter can get a complete snapshot quickly:
+
+- A 55-word ATS-safe summary of the candidate and value proposition.
+- Six tailored bullets that map directly to core responsibilities.
+- A short cover micro-note designed to fit application text boxes.
+- An application Q&A JSON file for quick upload into job portals.
+
+| Pack | Role | Link |
+| --- | --- | --- |
+| #5 | Welocalize — Search Quality Rater (US) | [Markdown](./job-packs/pack-05-welocalize-search-quality-rater-us.md) · [JSON](./job-packs/pack-05-welocalize-search-quality-rater-us.json) |
+
+Add future packs by dropping a Markdown narrative and companion JSON file in `portfolio/reports/job-packs/` and listing them in the table above.

--- a/portfolio/reports/job-packs/pack-05-welocalize-search-quality-rater-us.json
+++ b/portfolio/reports/job-packs/pack-05-welocalize-search-quality-rater-us.json
@@ -1,0 +1,30 @@
+{
+  "eligibility": "Yes",
+  "sponsorship": "No",
+  "notice_period": "Immediate",
+  "salary_min": "N/A",
+  "salary_pref": "N/A",
+  "timezone": "America/Chicago",
+  "locations_ok": [
+    "Remote (U.S.)",
+    "Remote (Minnesota)"
+  ],
+  "linkedin": "https://www.linkedin.com/in/<handle>",
+  "portfolio": "https://blackroad.io/#proof",
+  "certs": [
+    "SIE",
+    "7",
+    "63",
+    "65",
+    "Life & Health",
+    "MN Real Estate"
+  ],
+  "eeo_optional": {
+    "gender": "Decline to answer",
+    "race": "Decline to answer",
+    "veteran_status": "Decline to answer"
+  },
+  "disability_optional": {
+    "status": "Decline to answer"
+  }
+}

--- a/portfolio/reports/job-packs/pack-05-welocalize-search-quality-rater-us.md
+++ b/portfolio/reports/job-packs/pack-05-welocalize-search-quality-rater-us.md
@@ -23,7 +23,7 @@ Portfolio + short Looms: blackroad.io
 
 ## Application Q&A JSON
 ```json
-{
+{ 
   "eligibility": "Yes",
   "sponsorship": "No",
   "notice_period": "Immediate",
@@ -38,6 +38,8 @@ Portfolio + short Looms: blackroad.io
   "disability_optional": {"status": "Decline to answer"}
 }
 ```
+
+You can also download the structured responses directly as [`pack-05-welocalize-search-quality-rater-us.json`](./pack-05-welocalize-search-quality-rater-us.json) for quick uploads into applicant tracking systems.
 
 ## Apply Link
 Remote U.S., 10–29 hrs/week (W-2) via Lever.


### PR DESCRIPTION
## Summary
- add a paste-ready application pack for the Welocalize Search Quality Rater (US) role, including summary, tailored bullets, cover note, and application Q&A JSON

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68daf55f30a08329a43d418dbdb257c5