### PR TITLE
Seed BlackRoad agent skeleton

### DIFF
--- a/README_AGENT.md
+++ b/README_AGENT.md
@@ -1,0 +1,45 @@
+# BlackRoad Agent Seed
+
+The "BlackRoad agent" starts as a small, legible harness you can run on a Pi, a Jetson, or a laptop.
+This first sketch is intentionally humble: no network calls, no mystery binaries, just the bones of
+an agent that can grow into a trustworthy companion.
+
+## Repository layout
+
+```
+agent/      <- runtime + config primitives for the core loop
+plugins/    <- extension points the runtime can mount at startup
+cli/        <- human-facing entry points for local experimentation
+```
+
+## What exists today
+
+- A **dataclass-powered configuration layer** (`agent/config.py`) that describes the persona, plugin
+  mounts, and workspace for the agent.
+- A **minimal runtime** (`agent/runtime.py`) that boots plugins and routes messages through them in
+  order.
+- A **base plugin helper** (`plugins/base.py`) you can subclass to stitch in tools, models, and
+  external services.
+- A **tiny CLI** (`cli/agent.py`) that wires everything together and ships with an `EchoPlugin`
+  placeholder so you can exercise the flow immediately.
+
+## How to try it
+
+```bash
+python -m cli.agent "open the north road"
+```
+
+You should see the echo response from the placeholder plugin. Swap in your own plugin modules, or
+point the runtime at a different config, and the same harness will orchestrate your custom stack.
+
+## Next steps
+
+1. Define a richer plugin contract that can stream tokens, schedule background work, and persist
+   memories to local storage.
+2. Build a filesystem-backed workspace manager that keeps agent artifacts neat and inspectable.
+3. Introduce declarative personas so you can swap between "navigator", "builder", and "companion"
+   profiles with a flag.
+4. Wire in local/offline models (whisper, llama, vision) through plugins that you opt into at boot.
+
+The guardrails stay simple: everything runs locally, every action is inspectable, and you own the
+loop. This document evolves with each layer we add.

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,6 @@
+"""Foundational runtime primitives for the BlackRoad personal agent."""
+
+from .config import AgentConfig
+from .runtime import AgentRuntime
+
+__all__ = ["AgentConfig", "AgentRuntime"]

--- a/agent/config.py
+++ b/agent/config.py
@@ -1,0 +1,34 @@
+"""Configuration dataclasses for the BlackRoad agent runtime."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+@dataclass
+class PluginMount:
+    """Represents a plugin mount point in the agent workspace."""
+
+    name: str
+    module: str
+    enabled: bool = True
+    config: Dict[str, object] = field(default_factory=dict)
+
+
+@dataclass
+class AgentConfig:
+    """Top-level configuration for instantiating an agent runtime."""
+
+    name: str
+    persona: str
+    workspace_root: Path
+    mounts: List[PluginMount] = field(default_factory=list)
+    default_model: Optional[str] = None
+    notes: Optional[str] = None
+
+    def enabled_mounts(self) -> List[PluginMount]:
+        """Return only the mounts that should be activated at startup."""
+
+        return [mount for mount in self.mounts if mount.enabled]

--- a/agent/runtime.py
+++ b/agent/runtime.py
@@ -1,0 +1,54 @@
+"""Minimal agent runtime harness for the BlackRoad personal agent."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Dict, Protocol
+
+from .config import AgentConfig, PluginMount
+
+
+class AgentPlugin(Protocol):
+    """Simple protocol describing a runtime plugin."""
+
+    name: str
+
+    def activate(self, config: PluginMount) -> None:
+        """Hook executed when the runtime is starting up."""
+
+    def handle(self, message: str, context: Dict[str, object]) -> str:
+        """Process an inbound message and return the agent's reply."""
+
+
+class AgentRuntime:
+    """Coordinator responsible for wiring together the core agent pieces."""
+
+    def __init__(self, config: AgentConfig, plugins: Iterable[AgentPlugin] | None = None) -> None:
+        self.config = config
+        self._plugins: Dict[str, AgentPlugin] = {}
+        if plugins:
+            for plugin in plugins:
+                self._plugins[plugin.name] = plugin
+
+    def bootstrap(self) -> None:
+        """Activate enabled plugins before the runtime begins handling work."""
+
+        for mount in self.config.enabled_mounts():
+            plugin = self._plugins.get(mount.name)
+            if plugin is None:
+                continue
+            plugin.activate(mount)
+
+    def dispatch(self, message: str, context: Dict[str, object] | None = None) -> str:
+        """Send a message through the plugin chain and collect a response."""
+
+        if context is None:
+            context = {}
+
+        response = message
+        for mount in self.config.enabled_mounts():
+            plugin = self._plugins.get(mount.name)
+            if plugin is None:
+                continue
+            response = plugin.handle(response, context)
+        return response

--- a/cli/agent.py
+++ b/cli/agent.py
@@ -1,0 +1,51 @@
+"""Command line entrypoint for running the BlackRoad personal agent locally."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from agent import AgentConfig, AgentRuntime
+from agent.config import PluginMount
+from plugins.base import BasePlugin
+
+
+class EchoPlugin(BasePlugin):
+    """Default plugin placeholder that simply echoes the user input."""
+
+    name = "echo"
+
+    def handle(self, message: str, context):  # type: ignore[override]
+        return message
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run the BlackRoad personal agent")
+    parser.add_argument("message", nargs="?", default="hello", help="Seed message to send to the agent")
+    parser.add_argument(
+        "--workspace",
+        type=Path,
+        default=Path.cwd() / "workspace",
+        help="Location for the agent's persistent workspace",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> str:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    config = AgentConfig(
+        name="blackroad-bff",
+        persona="north star navigator",
+        workspace_root=args.workspace,
+        mounts=[PluginMount(name="echo", module="plugins.base", enabled=True)],
+        notes="Seed runtime wiring the real agent will extend.",
+    )
+    runtime = AgentRuntime(config, plugins=[EchoPlugin()])
+    runtime.bootstrap()
+    return runtime.dispatch(args.message, {"workspace": str(args.workspace)})
+
+
+if __name__ == "__main__":
+    print(main())

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1,0 +1,5 @@
+"""Plugin namespace for the BlackRoad agent runtime."""
+
+from .base import BasePlugin
+
+__all__ = ["BasePlugin"]

--- a/plugins/base.py
+++ b/plugins/base.py
@@ -1,0 +1,21 @@
+"""Base classes and helpers for BlackRoad agent plugins."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from agent.config import PluginMount
+
+
+class BasePlugin:
+    """Lightweight convenience superclass for runtime plugins."""
+
+    name: str = "base"
+
+    def activate(self, config: PluginMount) -> None:  # pragma: no cover - hook
+        """Optional hook executed once during runtime bootstrap."""
+
+    def handle(self, message: str, context: Dict[str, object]) -> str:
+        """Process a message and return the modified text."""
+
+        return message


### PR DESCRIPTION
## Summary
- introduce the `agent` package with configuration dataclasses and a minimal runtime harness
- add a `plugins` namespace with a base plugin helper to extend the runtime
- wire up a starter CLI entrypoint and document the layout in `README_AGENT.md`

## Testing
- python -m cli.agent "test message"


------
https://chatgpt.com/codex/tasks/task_e_68daf58159688329925dfd0b407c9751