### PR TITLE
Add telemetry collection and remote job CLI

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,3 @@
+"""Agent utilities for BlackRoad."""
+
+__all__ = ["jobs", "telemetry"]

--- a/agent/jobs.py
+++ b/agent/jobs.py
@@ -1,0 +1,13 @@
+"""Utilities to run jobs on remote Jetson devices."""
+from __future__ import annotations
+
+import subprocess
+
+
+def run_remote(host: str, command: str, user: str = "jetson") -> None:
+    """Run an arbitrary command on the Jetson via SSH."""
+    full_host = f"{user}@{host}"
+    try:
+        subprocess.run(["ssh", "-t", full_host, command], check=True)
+    except subprocess.CalledProcessError as exc:
+        print(f"[BlackRoad] Job failed with exit {exc.returncode}")

--- a/agent/telemetry.py
+++ b/agent/telemetry.py
@@ -1,0 +1,44 @@
+"""Telemetry collection utilities for local hosts and remote Jetson devices."""
+from __future__ import annotations
+
+import shlex
+import subprocess
+from typing import Dict
+
+
+def _run(cmd: str) -> str:
+    """Run a shell command and return its stripped output or ``"n/a"`` on failure."""
+    try:
+        return subprocess.check_output(shlex.split(cmd), text=True).strip()
+    except Exception:
+        return "n/a"
+
+
+def collect_local() -> Dict[str, str]:
+    """Collect telemetry from the local machine (e.g. Raspberry Pi)."""
+    return {
+        "uptime": _run("uptime -p"),
+        "temp": _run("vcgencmd measure_temp"),
+        "load": _run("uptime | awk -F'load average:' '{print $2}'"),
+    }
+
+
+def collect_remote(host: str, user: str = "jetson") -> Dict[str, str]:
+    """Collect telemetry from a remote Jetson device over SSH."""
+
+    base = f"{user}@{host}"
+
+    def ssh(cmd: str) -> str:
+        try:
+            return subprocess.check_output(
+                ["ssh", "-o", "ConnectTimeout=3", base, cmd],
+                text=True,
+            ).strip()
+        except Exception:
+            return "n/a"
+
+    return {
+        "uptime": ssh("uptime -p"),
+        "load": ssh("uptime | awk -F'load average:' '{print $2}'"),
+        "tegrastats": ssh("tegrastats --interval 1000 --count 1 || echo 'no tegrastats'"),
+    }

--- a/cli/blackroad.py
+++ b/cli/blackroad.py
@@ -1,0 +1,35 @@
+"""BlackRoad CLI entrypoint."""
+from __future__ import annotations
+
+import click
+
+from agent import jobs, telemetry
+
+
+@click.group()
+def cli() -> None:
+    """BlackRoad CLI."""
+
+
+@cli.command()
+@click.argument("command", nargs=-1)
+def run(command: tuple[str, ...]) -> None:
+    """Run a command on the Jetson."""
+    jobs.run_remote("jetson.local", " ".join(command))
+
+
+@cli.command()
+def status() -> None:
+    """Show telemetry for the local device and the Jetson."""
+    pi = telemetry.collect_local()
+    jetson = telemetry.collect_remote("jetson.local")
+    click.echo("== Pi ==")
+    for key, value in pi.items():
+        click.echo(f"{key}: {value}")
+    click.echo("\n== Jetson ==")
+    for key, value in jetson.items():
+        click.echo(f"{key}: {value}")
+
+
+if __name__ == "__main__":
+    cli()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,11 @@ requires-python = ">=3.10"
 description = "Offline PLM & Manufacturing Ops (Phase 37) — deterministic, file-backed."
 readme = "README.md"
 authors = [{ name = "Blackroad", email = "eng@blackroadinc.us" }]
-dependencies = ["typer"]
+dependencies = ["typer", "click"]
 
 [project.scripts]
 brc = "cli.console:main"
+blackroad = "cli.blackroad:cli"
 
 [tool.pytest.ini_options]
 pythonpath = ["."]


### PR DESCRIPTION
## Summary
- add an agent package with telemetry collection for the local Pi and remote Jetson hosts
- provide remote job execution helpers and a Click-based `blackroad` CLI with `status` and `run`
- register the new CLI entry point and declare the Click dependency in the project metadata

## Testing
- pytest *(fails: missing third-party dependencies such as torch, sympy, matplotlib, networkx, anthropic, jsonschema, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68daf5db34ec8329b8da6aae5bff592e