### PR TITLE
Add initial BlackRoad agent skeleton

### DIFF
--- a/blackroad-agent/README.md
+++ b/blackroad-agent/README.md
@@ -1,0 +1,10 @@
+# BlackRoad OS Agent
+
+BlackRoad turns low-cost boards (Raspberry Pi, Jetson, etc.) into a coordinated, local-first compute network.
+
+- **Telemetry:** Monitor temps, power, usage of each node.
+- **Job Offload:** Run heavy tasks on Jetson from a Pi CLI.
+- **Flash & Config:** Re-image drives, tweak boot order, patch configs remotely.
+- **Local AI:** Run open-source models directly on your hardware.
+
+Everything is open, inspectable, and runs without cloud dependencies by default. This repo holds the agent, plugins, and CLI tools.

--- a/blackroad-agent/agent/ai.py
+++ b/blackroad-agent/agent/ai.py
@@ -1,0 +1,11 @@
+"""Local model runtime adapters for BlackRoad agents."""
+
+
+def load_model(model_path: str):
+    """Load a local AI model for inference."""
+    raise NotImplementedError("Model loading not yet implemented")
+
+
+def infer(prompt: str):
+    """Run inference against the loaded model."""
+    raise NotImplementedError("Inference not yet implemented")

--- a/blackroad-agent/agent/flash.py
+++ b/blackroad-agent/agent/flash.py
@@ -1,0 +1,20 @@
+"""Imaging and configuration helpers for BlackRoad agents."""
+
+
+def flash_device(target: str):
+    """Flash an operating system image to the target device.
+
+    Args:
+        target: Identifier for the device to flash.
+    """
+    raise NotImplementedError("Flashing workflow not yet implemented")
+
+
+def patch_config(target: str, config: dict):
+    """Apply configuration updates to a device.
+
+    Args:
+        target: Identifier for the device receiving the configuration.
+        config: Mapping of configuration values to apply.
+    """
+    raise NotImplementedError("Configuration patching not yet implemented")

--- a/blackroad-agent/agent/jobs.py
+++ b/blackroad-agent/agent/jobs.py
@@ -1,0 +1,11 @@
+"""Remote job orchestration for BlackRoad agents."""
+
+
+def run_remote(hostname: str, command: str):
+    """Execute a command on a remote host.
+
+    Args:
+        hostname: Hostname of the remote agent to run against.
+        command: Command string to execute remotely.
+    """
+    raise NotImplementedError("Remote job execution not yet implemented")

--- a/blackroad-agent/agent/main.py
+++ b/blackroad-agent/agent/main.py
@@ -1,0 +1,17 @@
+import asyncio
+from . import telemetry, jobs
+
+
+async def main():
+    while True:
+        pi_stats = telemetry.collect_local()
+        try:
+            jetson_stats = telemetry.collect_remote("jetson.local")
+        except Exception:
+            jetson_stats = {}
+        print("Pi:", pi_stats, "Jetson:", jetson_stats)
+        await asyncio.sleep(60)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/blackroad-agent/agent/telemetry.py
+++ b/blackroad-agent/agent/telemetry.py
@@ -1,0 +1,21 @@
+"""Telemetry collection utilities for BlackRoad agents."""
+
+
+def collect_local():
+    """Collect metrics from the local device.
+
+    This is a stub implementation for the initial scaffold.
+    """
+    return {}
+
+
+def collect_remote(hostname: str):
+    """Collect metrics from a remote host.
+
+    Args:
+        hostname: Hostname of the remote agent.
+
+    Returns:
+        Mapping of telemetry values retrieved from the remote device.
+    """
+    raise NotImplementedError("Remote telemetry collection not yet implemented")

--- a/blackroad-agent/cli/blackroad.py
+++ b/blackroad-agent/cli/blackroad.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+import click
+from agent import jobs
+
+
+@click.group()
+def cli():
+    """BlackRoad CLI"""
+    pass
+
+
+@cli.command()
+@click.argument("command", nargs=-1)
+def run(command):
+    """Run a command on the Jetson"""
+    jobs.run_remote("jetson.local", " ".join(command))
+
+
+if __name__ == "__main__":
+    cli()

--- a/blackroad-agent/plugins/example_plugin.py
+++ b/blackroad-agent/plugins/example_plugin.py
@@ -1,0 +1,6 @@
+"""Example plugin showcasing the BlackRoad plugin interface."""
+
+
+def register(plugin_manager):
+    """Register plugin components with the plugin manager."""
+    plugin_manager.register("example", lambda: None)

--- a/blackroad-agent/services/systemd/blackroad-agent.path
+++ b/blackroad-agent/services/systemd/blackroad-agent.path
@@ -1,0 +1,9 @@
+[Unit]
+Description=Watch for BlackRoad Agent updates
+
+[Path]
+PathChanged=/opt/blackroad-agent
+Unit=blackroad-agent.service
+
+[Install]
+WantedBy=multi-user.target

--- a/blackroad-agent/services/systemd/blackroad-agent.service
+++ b/blackroad-agent/services/systemd/blackroad-agent.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=BlackRoad Agent
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/env python3 -m agent.main
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/blackroad-agent/setup.py
+++ b/blackroad-agent/setup.py
@@ -1,0 +1,16 @@
+from setuptools import setup, find_packages
+
+
+setup(
+    name="blackroad-agent",
+    version="0.1.0",
+    packages=find_packages(),
+    install_requires=[
+        "click>=8.0",
+    ],
+    entry_points={
+        "console_scripts": [
+            "blackroad=cli.blackroad:cli",
+        ]
+    },
+)


### PR DESCRIPTION
## Summary
- add a new blackroad-agent package scaffold with agent, CLI, and plugin placeholders
- provide systemd unit templates and packaging configuration for editable installs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daf5aa092083299a6a92a29dd61ab0