### PR TITLE
feat: add blackroad agent daemon service

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,5 @@
+"""BlackRoad device agent package."""
+
+from . import telemetry as telemetry
+
+__all__ = ["telemetry"]

--- a/agent/daemon.py
+++ b/agent/daemon.py
@@ -1,0 +1,62 @@
+"""System service entrypoint for the BlackRoad agent."""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+import logging
+import os
+from pathlib import Path
+from typing import Any, Callable
+
+from agent import telemetry
+
+LOGFILE = Path(os.environ.get("BLACKROAD_AGENT_LOG", "/var/log/blackroad-agent.log"))
+JETSON_HOST = os.environ.get("BLACKROAD_JETSON_HOST", "jetson.local")
+JETSON_USER = os.environ.get("BLACKROAD_JETSON_USER", "jetson")
+
+
+def _safe_call(func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+    try:
+        return func(*args, **kwargs)
+    except Exception as exc:  # pragma: no cover - defensive guard
+        logging.exception("Telemetry probe failed: %s", func.__name__)
+        return {"error": str(exc), "probe": func.__name__}
+
+
+def _write_line(line: str) -> None:
+    try:
+        LOGFILE.parent.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        # Parent may already exist or be protected; ignore creation failure.
+        pass
+
+    try:
+        with LOGFILE.open("a", encoding="utf-8") as handle:
+            handle.write(line)
+    except PermissionError:
+        logging.error("Insufficient permissions to write telemetry log: %s", LOGFILE)
+    except OSError:
+        logging.exception("Failed to append telemetry line to %s", LOGFILE)
+
+
+async def loop(interval: int = 60) -> None:
+    logging.info("Starting telemetry loop with interval=%ss", interval)
+    while True:
+        timestamp = dt.datetime.now(dt.timezone.utc).isoformat()
+        pi_stats = _safe_call(telemetry.collect_local)
+        jetson_stats = _safe_call(telemetry.collect_remote, JETSON_HOST, user=JETSON_USER)
+
+        line = f"[{timestamp}] PI: {pi_stats} | JETSON: {jetson_stats}\n"
+        _write_line(line)
+
+        await asyncio.sleep(interval)
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    asyncio.run(loop())
+
+
+if __name__ == "__main__":
+    main()

--- a/agent/telemetry.py
+++ b/agent/telemetry.py
@@ -1,0 +1,267 @@
+"""Telemetry helpers for the BlackRoad device agent."""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import shutil
+import socket
+import subprocess
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+DEFAULT_DISK_PATH = "/"
+THERMAL_PATHS = (
+    "/sys/class/thermal/thermal_zone0/temp",
+    "/sys/class/thermal/thermal_zone1/temp",
+)
+
+
+@dataclass(frozen=True)
+class TelemetrySnapshot:
+    """Structured telemetry metrics."""
+
+    hostname: str
+    load_1m: Optional[float]
+    load_5m: Optional[float]
+    load_15m: Optional[float]
+    uptime_seconds: Optional[float]
+    mem_total_kb: Optional[int]
+    mem_available_kb: Optional[int]
+    disk_total_gb: Optional[float]
+    disk_free_gb: Optional[float]
+    cpu_temp_c: Optional[float]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "hostname": self.hostname,
+            "load_1m": self.load_1m,
+            "load_5m": self.load_5m,
+            "load_15m": self.load_15m,
+            "uptime_seconds": self.uptime_seconds,
+            "mem_total_kb": self.mem_total_kb,
+            "mem_available_kb": self.mem_available_kb,
+            "disk_total_gb": self.disk_total_gb,
+            "disk_free_gb": self.disk_free_gb,
+            "cpu_temp_c": self.cpu_temp_c,
+        }
+
+
+def _read_loadavg() -> tuple[Optional[float], Optional[float], Optional[float]]:
+    try:
+        return os.getloadavg()
+    except OSError:
+        return (None, None, None)
+
+
+def _read_uptime() -> Optional[float]:
+    try:
+        with open("/proc/uptime", "r", encoding="utf-8") as fh:
+            return float(fh.read().split()[0])
+    except (OSError, ValueError, IndexError):
+        return None
+
+
+def _read_meminfo() -> Mapping[str, int]:
+    info: dict[str, int] = {}
+    try:
+        with open("/proc/meminfo", "r", encoding="utf-8") as fh:
+            for line in fh:
+                parts = line.split()
+                if len(parts) >= 2:
+                    key = parts[0].rstrip(":")
+                    try:
+                        info[key] = int(parts[1])
+                    except ValueError:
+                        continue
+    except OSError:
+        return {}
+    return info
+
+
+def _read_disk_usage(path: str = DEFAULT_DISK_PATH) -> tuple[Optional[float], Optional[float]]:
+    try:
+        usage = shutil.disk_usage(path)
+    except OSError:
+        return (None, None)
+    total_gb = round(usage.total / (1024**3), 2)
+    free_gb = round(usage.free / (1024**3), 2)
+    return (total_gb, free_gb)
+
+
+def _read_temperature() -> Optional[float]:
+    for candidate in THERMAL_PATHS:
+        try:
+            with open(candidate, "r", encoding="utf-8") as fh:
+                raw = fh.read().strip()
+        except OSError:
+            continue
+        try:
+            value = float(raw) / 1000.0 if len(raw) > 3 else float(raw)
+        except ValueError:
+            continue
+        return round(value, 2)
+    return None
+
+
+def collect_local() -> dict[str, Any]:
+    hostname = platform.node() or socket.gethostname()
+    load_1m, load_5m, load_15m = _read_loadavg()
+    uptime_seconds = _read_uptime()
+    meminfo = _read_meminfo()
+    disk_total_gb, disk_free_gb = _read_disk_usage()
+    cpu_temp_c = _read_temperature()
+
+    snapshot = TelemetrySnapshot(
+        hostname=hostname,
+        load_1m=load_1m,
+        load_5m=load_5m,
+        load_15m=load_15m,
+        uptime_seconds=uptime_seconds,
+        mem_total_kb=meminfo.get("MemTotal"),
+        mem_available_kb=meminfo.get("MemAvailable"),
+        disk_total_gb=disk_total_gb,
+        disk_free_gb=disk_free_gb,
+        cpu_temp_c=cpu_temp_c,
+    )
+    return snapshot.as_dict()
+
+
+REMOTE_COLLECT_SCRIPT = """python3 - <<'PY'
+import json
+import os
+import platform
+import shutil
+import socket
+
+THERMAL_PATHS = (
+    "/sys/class/thermal/thermal_zone0/temp",
+    "/sys/class/thermal/thermal_zone1/temp",
+)
+
+
+def read_loadavg():
+    try:
+        return os.getloadavg()
+    except OSError:
+        return (None, None, None)
+
+
+def read_uptime():
+    try:
+        with open("/proc/uptime", "r", encoding="utf-8") as fh:
+            return float(fh.read().split()[0])
+    except (OSError, ValueError, IndexError):
+        return None
+
+
+def read_meminfo():
+    info = {}
+    try:
+        with open("/proc/meminfo", "r", encoding="utf-8") as fh:
+            for line in fh:
+                parts = line.split()
+                if len(parts) >= 2:
+                    key = parts[0].rstrip(":")
+                    try:
+                        info[key] = int(parts[1])
+                    except ValueError:
+                        continue
+    except OSError:
+        return {}
+    return info
+
+
+def read_disk_usage(path="/"):
+    try:
+        usage = shutil.disk_usage(path)
+    except OSError:
+        return (None, None)
+    total_gb = round(usage.total / (1024**3), 2)
+    free_gb = round(usage.free / (1024**3), 2)
+    return (total_gb, free_gb)
+
+
+def read_temperature():
+    for candidate in THERMAL_PATHS:
+        try:
+            with open(candidate, "r", encoding="utf-8") as fh:
+                raw = fh.read().strip()
+        except OSError:
+            continue
+        try:
+            value = float(raw) / 1000.0 if len(raw) > 3 else float(raw)
+        except ValueError:
+            continue
+        return round(value, 2)
+    return None
+
+
+def collect():
+    load_1m, load_5m, load_15m = read_loadavg()
+    meminfo = read_meminfo()
+    disk_total_gb, disk_free_gb = read_disk_usage()
+    payload = {
+        "hostname": platform.node() or socket.gethostname(),
+        "load_1m": load_1m,
+        "load_5m": load_5m,
+        "load_15m": load_15m,
+        "uptime_seconds": read_uptime(),
+        "mem_total_kb": meminfo.get("MemTotal"),
+        "mem_available_kb": meminfo.get("MemAvailable"),
+        "disk_total_gb": disk_total_gb,
+        "disk_free_gb": disk_free_gb,
+        "cpu_temp_c": read_temperature(),
+    }
+    print(json.dumps(payload))
+
+
+collect()
+PY"""
+
+
+def collect_remote(host: str, *, user: Optional[str] = None, timeout: int = 15) -> dict[str, Any]:
+    target = f"{user}@{host}" if user else host
+    try:
+        result = subprocess.run(
+            [
+                "ssh",
+                "-o",
+                "BatchMode=yes",
+                "-o",
+                "ConnectTimeout=5",
+                target,
+                REMOTE_COLLECT_SCRIPT,
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError:
+        return {"error": "ssh_not_found", "host": host, "user": user}
+    except subprocess.TimeoutExpired:
+        return {"error": "ssh_timeout", "host": host, "user": user}
+
+    if result.returncode != 0:
+        return {
+            "error": "ssh_failed",
+            "host": host,
+            "user": user,
+            "stderr": result.stderr.strip(),
+        }
+
+    stdout = result.stdout.strip()
+    if not stdout:
+        return {"error": "no_data", "host": host, "user": user}
+
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError:
+        return {
+            "error": "invalid_json",
+            "host": host,
+            "user": user,
+            "raw": stdout,
+        }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,8 @@ dependencies = ["typer"]
 
 [project.scripts]
 brc = "cli.console:main"
+blackroad = "cli.console:main"
+blackroad-agent = "agent.daemon:main"
 
 [tool.pytest.ini_options]
 pythonpath = ["."]

--- a/services/systemd/blackroad-agent.service
+++ b/services/systemd/blackroad-agent.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=BlackRoad Agent Daemon
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart=/usr/local/bin/blackroad-agent
+Restart=always
+User=pi
+WorkingDirectory=/home/pi
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add an asyncio-based daemon that records Pi and Jetson telemetry to the agent log
- implement shared telemetry helpers and expose the package for reuse
- wire up console scripts and provide a systemd unit for running the agent on boot

## Testing
- python -m py_compile agent/__init__.py agent/daemon.py agent/telemetry.py

------
https://chatgpt.com/codex/tasks/task_e_68daf620ac808329b916eed8fbc47096