### PR TITLE
Add FastAPI dashboard and service unit

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,1 @@
+"""Utility modules for the BlackRoad dashboard service."""

--- a/agent/dashboard.py
+++ b/agent/dashboard.py
@@ -1,0 +1,33 @@
+"""FastAPI application serving the BlackRoad dashboard."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+import uvicorn
+
+from agent import telemetry
+
+app = FastAPI(title="BlackRoad Dashboard")
+_templates_dir = Path(__file__).parent / "templates"
+templates = Jinja2Templates(directory=str(_templates_dir))
+
+JETSON_HOST = "jetson.local"
+JETSON_USER = "jetson"
+
+
+@app.get("/", response_class=HTMLResponse)
+def home(request: Request):
+    pi = telemetry.collect_local()
+    jetson = telemetry.collect_remote(JETSON_HOST, user=JETSON_USER)
+    return templates.TemplateResponse(
+        "dashboard.html",
+        {"request": request, "pi": pi, "jetson": jetson},
+    )
+
+
+def main():
+    uvicorn.run(app, host="0.0.0.0", port=8081)

--- a/agent/telemetry.py
+++ b/agent/telemetry.py
@@ -1,0 +1,77 @@
+"""Helpers for collecting system telemetry for the dashboard."""
+
+from __future__ import annotations
+
+import platform
+import shutil
+import subprocess
+from typing import Any, Dict, Iterable, Mapping, Sequence
+
+DEFAULT_COMMANDS: Mapping[str, Sequence[str]] = {
+    "uname": ["uname", "-a"],
+    "uptime": ["uptime"],
+    "disk": ["df", "-h"],
+}
+
+
+def collect_local(commands: Mapping[str, Sequence[str]] | None = None) -> Dict[str, Any]:
+    """Collect telemetry information from the local machine."""
+
+    return _collect(commands or DEFAULT_COMMANDS)
+
+
+def collect_remote(
+    host: str,
+    *,
+    user: str | None = None,
+    commands: Mapping[str, Sequence[str]] | None = None,
+) -> Dict[str, Any]:
+    """Collect telemetry from a remote host via SSH."""
+
+    if not host:
+        raise ValueError("host must be provided")
+
+    return _collect(commands or DEFAULT_COMMANDS, ssh_target=_format_ssh_target(host, user))
+
+
+def _format_ssh_target(host: str, user: str | None) -> str:
+    return f"{user}@{host}" if user else host
+
+
+def _collect(
+    commands: Mapping[str, Sequence[str]],
+    *,
+    ssh_target: str | None = None,
+) -> Dict[str, Any]:
+    telemetry: Dict[str, Any] = {
+        "hostname": platform.node() if ssh_target is None else ssh_target,
+    }
+
+    for label, command in commands.items():
+        telemetry[label] = _run_command(command, ssh_target=ssh_target)
+
+    return telemetry
+
+
+def _run_command(command: Sequence[str], *, ssh_target: str | None = None) -> Dict[str, Any]:
+    if ssh_target:
+        if shutil.which("ssh") is None:
+            return {"error": "ssh executable not found"}
+        full_command: Iterable[str] = ("ssh", ssh_target, *command)
+    else:
+        full_command = command
+
+    try:
+        completed = subprocess.run(
+            list(full_command),
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except subprocess.CalledProcessError as exc:
+        return {"error": exc.stderr.strip() or str(exc)}
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        return {"error": str(exc)}
+
+    return {"stdout": completed.stdout.strip()}

--- a/agent/templates/dashboard.html
+++ b/agent/templates/dashboard.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>BlackRoad Dashboard</title>
+  <style>
+    body { font-family: sans-serif; margin: 2em; background: #111; color: #eee; }
+    h1 { color: #0f0; }
+    .card { background: #222; padding: 1em; margin-bottom: 1em; border-radius: 8px; }
+    .title { font-weight: bold; margin-bottom: 0.5em; }
+  </style>
+</head>
+<body>
+  <h1>BlackRoad Dashboard</h1>
+
+  <div class="card">
+    <div class="title">Pi</div>
+    <pre>{{ pi | tojson(indent=2) }}</pre>
+  </div>
+
+  <div class="card">
+    <div class="title">Jetson</div>
+    <pre>{{ jetson | tojson(indent=2) }}</pre>
+  </div>
+
+</body>
+</html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = ["typer"]
 
 [project.scripts]
 brc = "cli.console:main"
+blackroad-dashboard = "agent.dashboard:main"
 
 [tool.pytest.ini_options]
 pythonpath = ["."]

--- a/services/systemd/blackroad-dashboard.service
+++ b/services/systemd/blackroad-dashboard.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=BlackRoad Web Dashboard
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart=/usr/local/bin/blackroad-dashboard
+Restart=always
+User=pi
+WorkingDirectory=/home/pi
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add a FastAPI-powered dashboard application and HTML template that surfaces Pi and Jetson telemetry
- implement telemetry helpers for local and remote data collection and register a blackroad-dashboard entry point
- add a systemd unit to run the dashboard service on boot

## Testing
- python -m py_compile agent/*.py


------
https://chatgpt.com/codex/tasks/task_e_68daf6f86f008329a69d50468d85d3b5