### PR TITLE
feat: add FastAPI API server for telemetry and jobs

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,1 @@
+"""BlackRoad agent package."""

--- a/agent/api.py
+++ b/agent/api.py
@@ -1,0 +1,36 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+import uvicorn
+from agent import telemetry, jobs
+
+app = FastAPI(title="BlackRoad API")
+
+JETSON_HOST = "jetson.local"
+JETSON_USER = "jetson"
+
+
+class JobRequest(BaseModel):
+    command: str
+
+
+@app.get("/status")
+def status():
+    """Return telemetry for Pi and Jetson."""
+    pi = telemetry.collect_local()
+    jetson = telemetry.collect_remote(JETSON_HOST, user=JETSON_USER)
+    return {"pi": pi, "jetson": jetson}
+
+
+@app.post("/run")
+def run_job(req: JobRequest):
+    """Run a command on the Jetson."""
+    jobs.run_remote(JETSON_HOST, req.command, user=JETSON_USER)
+    return {"status": "ok", "command": req.command}
+
+
+def main():
+    uvicorn.run(app, host="0.0.0.0", port=8080)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = ["typer"]
 
 [project.scripts]
 brc = "cli.console:main"
+blackroad-api = "agent.api:main"
 
 [tool.pytest.ini_options]
 pythonpath = ["."]

--- a/services/systemd/blackroad-api.service
+++ b/services/systemd/blackroad-api.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=BlackRoad API Service
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart=/usr/local/bin/blackroad-api
+Restart=always
+User=pi
+WorkingDirectory=/home/pi
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add a FastAPI application exposing status and job endpoints for the Pi and Jetson
- register a `blackroad-api` console script entry point to launch the server
- provide a systemd unit file to run the API service on boot

## Testing
- python -m py_compile agent/__init__.py agent/api.py

------
https://chatgpt.com/codex/tasks/task_e_68daf696eb3c832987b0db4aef87dc51