### PR TITLE
Add streaming Jetson command output to dashboard

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,3 @@
+"""Agent package for BlackRoad dashboard utilities."""
+
+__all__ = ["dashboard", "jobs", "telemetry"]

--- a/agent/dashboard.py
+++ b/agent/dashboard.py
@@ -1,0 +1,41 @@
+"""FastAPI application providing the BlackRoad device dashboard."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+
+from agent import jobs, telemetry
+
+app = FastAPI(title="BlackRoad Dashboard")
+templates = Jinja2Templates(directory="agent/templates")
+
+JETSON_HOST = "jetson.local"
+JETSON_USER = "jetson"
+
+
+@app.get("/", response_class=HTMLResponse)
+def home(request: Request) -> HTMLResponse:
+    """Render the dashboard page with telemetry from the Pi and Jetson."""
+    pi = telemetry.collect_local()
+    jetson = telemetry.collect_remote(JETSON_HOST, user=JETSON_USER)
+    return templates.TemplateResponse(
+        "dashboard.html",
+        {"request": request, "pi": pi, "jetson": jetson},
+    )
+
+
+@app.websocket("/ws/run")
+async def ws_run(websocket: WebSocket) -> None:
+    """WebSocket endpoint streaming command output from the Jetson."""
+    await websocket.accept()
+    try:
+        cmd = await websocket.receive_text()
+        for line in jobs.run_remote_stream(JETSON_HOST, cmd, user=JETSON_USER):
+            await websocket.send_text(line)
+        await websocket.send_text("[[BLACKROAD_DONE]]")
+    except WebSocketDisconnect:
+        pass
+    finally:
+        await websocket.close()

--- a/agent/jobs.py
+++ b/agent/jobs.py
@@ -1,0 +1,33 @@
+"""Utilities for running remote jobs on Jetson hosts."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Iterator
+
+
+def run_remote(host: str, command: str, user: str = "jetson") -> None:
+    """Execute a remote command over SSH and wait for completion."""
+    full = ["ssh", "-t", f"{user}@{host}", command]
+    subprocess.run(full, check=True)
+
+
+def run_remote_stream(host: str, command: str, user: str = "jetson") -> Iterator[str]:
+    """Yield stdout lines live from a remote command over SSH."""
+    full = ["ssh", f"{user}@{host}", command]
+    proc = subprocess.Popen(
+        full,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+    try:
+        if proc.stdout is None:
+            return
+        for line in proc.stdout:
+            yield line.rstrip("\n")
+    finally:
+        if proc.stdout is not None:
+            proc.stdout.close()
+        proc.wait()

--- a/agent/telemetry.py
+++ b/agent/telemetry.py
@@ -1,0 +1,24 @@
+"""Telemetry helpers for the BlackRoad dashboard."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def collect_local() -> Dict[str, Any]:
+    """Collect telemetry for the local device.
+
+    Placeholder implementation returning an empty payload when telemetry
+    commands are unavailable in the development environment.
+    """
+
+    return {}
+
+
+def collect_remote(host: str, user: str = "jetson") -> Dict[str, Any]:
+    """Collect telemetry for a remote device via SSH.
+
+    Placeholder implementation returning an empty payload.
+    """
+
+    return {}

--- a/agent/templates/dashboard.html
+++ b/agent/templates/dashboard.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>BlackRoad Dashboard</title>
+  <style>
+    body { font-family: sans-serif; margin: 2em; background: #111; color: #eee; }
+    h1 { color: #0f0; }
+    .card { background: #222; padding: 1em; margin-bottom: 1em; border-radius: 8px; }
+    .title { font-weight: bold; margin-bottom: 0.5em; }
+    input[type=text] { width: 70%; padding: 0.5em; }
+    button { padding: 0.5em 1em; margin-left: .5em; cursor: pointer; }
+    #log { background:#000; color:#0f0; padding:1em; height:280px; overflow:auto; border-radius:6px; font-family:ui-monospace, SFMono-Regular, Menlo, monospace; }
+  </style>
+</head>
+<body>
+  <h1>BlackRoad Dashboard</h1>
+
+  <div class="card">
+    <div class="title">Pi</div>
+    <pre>{{ pi | tojson(indent=2) }}</pre>
+  </div>
+
+  <div class="card">
+    <div class="title">Jetson</div>
+    <pre>{{ jetson | tojson(indent=2) }}</pre>
+
+    <form id="runForm" onsubmit="return false;">
+      <input type="text" id="cmd" placeholder="Enter command (e.g. nvidia-smi)" />
+      <button id="runBtn">Run (stream)</button>
+      <button id="stopBtn" type="button">Stop</button>
+    </form>
+
+    <div id="log"></div>
+  </div>
+
+<script>
+let ws = null;
+const logEl = document.getElementById('log');
+const cmdEl = document.getElementById('cmd');
+const runBtn = document.getElementById('runBtn');
+const stopBtn = document.getElementById('stopBtn');
+
+function append(line){
+  logEl.textContent += line + "\n";
+  logEl.scrollTop = logEl.scrollHeight;
+}
+
+runBtn.addEventListener('click', () => {
+  if (ws) { ws.close(); ws = null; }
+  logEl.textContent = "";
+  const cmd = cmdEl.value.trim() || "nvidia-smi";
+  const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+  ws = new WebSocket(`${proto}://${location.host}/ws/run`);
+  ws.onopen = () => ws.send(cmd);
+  ws.onmessage = (ev) => {
+    if (ev.data === "[[BLACKROAD_DONE]]") { ws.close(); ws = null; append("--- done ---"); }
+    else { append(ev.data); }
+  };
+  ws.onerror = () => append("[error]");
+  ws.onclose = () => { /* noop */ };
+});
+
+stopBtn.addEventListener('click', () => {
+  if (ws) { ws.close(); ws = null; append("--- stopped ---"); }
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a FastAPI dashboard that renders device telemetry and exposes a WebSocket for streaming Jetson commands
- add SSH job helpers including a streaming runner to feed command output back to the client
- provide a dashboard template with a live log pane and controls for starting/stopping remote commands

## Testing
- python -m py_compile agent/*.py

------
https://chatgpt.com/codex/tasks/task_e_68daf82291108329a31f85c7ff79658d