### PR TITLE
Add application pack for Teemwork.ai search evaluator role

### DIFF
--- a/portfolio/reports/teemwork_ai_search_evaluator.md
+++ b/portfolio/reports/teemwork_ai_search_evaluator.md
@@ -1,0 +1,40 @@
+# Teemwork.ai — Search Evaluator Application Pack
+
+## 1. 55-Word Summary (ATS-Clean)
+Guideline-driven evaluator who keeps decisions consistent and auditable: crisp rubrics, failure taxonomies, and versioned notes. Built human-in-the-loop gates; trained 200+ colleagues. Prior roles delivered $23M impact and a 33.3% MoM lift by standardizing workflows. Ready for Remote U.S./MN search evaluation with steady throughput and clean documentation. Brings fintech compliance rigor and cross-team calibration habits daily.
+
+## 2. Tailored Bullets
+- Rate search results against detailed criteria; capture concise, audit-ready rationales.
+- Maintain a lightweight failure taxonomy; propose rubric clarifications and edge-case exemplars.
+- Keep versioned notes and quick regression checks to prevent drift across raters/time.
+- Escalate ambiguous items with context; help calibrate judgments across the pool.
+- Ran enablement at scale (200+ trainings); delivered outcomes ($23M impact; 33.3% MoM lift) via disciplined workflows.
+- Write tight SOPs/runbooks so decisions are reproducible without hand-holding.
+
+## 3. Cover Micro-Note (Application Box)
+Hi Teemwork.ai Team,
+
+I’m built for dependable, guideline-driven evaluation—tight rubrics, disciplined iterations, and documentation others can trust. Recent outcomes: $23M revenue impact while lifting advisor case growth 33.3% MoM; at Ameriprise I surfaced $18.4M AUM and reduced $3.1M at-risk assets by enforcing simple, repeatable workflows and clear communication.
+
+In the first 30 days I would: (1) internalize your rating guidelines and seed a small failure taxonomy; (2) keep versioned notes with small regression checks to hold consistency; (3) publish a short runbook to align raters while meeting throughput targets. Feedback stays concise, reproducible, and audit-friendly.
+
+Portfolio + short Looms: blackroad.io
+— Alexa Louise
+
+## 4. Application Q&A JSON
+```json
+{
+  "eligibility": "Yes",
+  "sponsorship": "No",
+  "notice_period": "Immediate",
+  "salary_min": "N/A",
+  "salary_pref": "N/A",
+  "timezone": "America/Chicago",
+  "locations_ok": ["Remote (U.S.)", "Remote (Minnesota)"],
+  "linkedin": "https://www.linkedin.com/in/<handle>",
+  "portfolio": "https://blackroad.io/#proof",
+  "certs": ["SIE", "7", "63", "65", "Life & Health", "MN Real Estate"],
+  "eeo_optional": {"gender": "Decline to answer", "race": "Decline to answer", "veteran_status": "Decline to answer"},
+  "disability_optional": {"status": "Decline to answer"}
+}
+```


### PR DESCRIPTION
## Summary
- add a paste-ready application pack for the Teemwork.ai Search Evaluator role
- include summary, tailored bullets, cover micro-note, and structured application Q&A JSON

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daf8a32b508329b47af92f53e9474e