### PR TITLE
feat: add Jetson bridge modules with env-configurable host

### DIFF
--- a/services/jetson_bridge/__init__.py
+++ b/services/jetson_bridge/__init__.py
@@ -1,0 +1,5 @@
+"""Jetson bridge utilities for the BlackRoad Pi dashboard."""
+
+from .config import resolve_target
+
+__all__ = ["resolve_target"]

--- a/services/jetson_bridge/config.py
+++ b/services/jetson_bridge/config.py
@@ -1,0 +1,39 @@
+"""Shared configuration helpers for Jetson bridge modules."""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from typing import Tuple
+
+DEFAULT_HOST = "jetson.local"
+DEFAULT_USER = "jetson"
+
+
+@lru_cache(maxsize=1)
+def resolve_target(host: str | None = None, user: str | None = None) -> Tuple[str, str]:
+    """Return the SSH target for the Jetson device.
+
+    Parameters
+    ----------
+    host:
+        Optional override for the Jetson hostname or IP. When ``None`` the
+        ``JETSON_HOST`` environment variable is used. If the variable is not
+        defined the function falls back to ``"jetson.local"`` so existing
+        behavior remains unchanged on networks with working mDNS.
+    user:
+        Optional override for the SSH username. Defaults to the
+        ``JETSON_USER`` environment variable or ``"jetson"`` when unset.
+
+    The result is cached to avoid repeated environment lookups when modules
+    build frequent telemetry snapshots.
+    """
+
+    env_host = os.getenv("JETSON_HOST", DEFAULT_HOST).strip() or DEFAULT_HOST
+    env_user = os.getenv("JETSON_USER", DEFAULT_USER).strip() or DEFAULT_USER
+    resolved_host = host or env_host
+    resolved_user = user or env_user
+    return resolved_host, resolved_user
+
+
+__all__ = ["DEFAULT_HOST", "DEFAULT_USER", "resolve_target"]

--- a/services/jetson_bridge/dashboard.py
+++ b/services/jetson_bridge/dashboard.py
@@ -1,0 +1,71 @@
+"""Generate a textual dashboard for the Jetson bridge."""
+
+from __future__ import annotations
+
+from typing import Mapping, Sequence
+
+from .config import resolve_target
+from . import jobs, telemetry
+
+
+def build(host: str | None = None, user: str | None = None) -> Mapping[str, object]:
+    """Return a consolidated snapshot for the dashboard service."""
+
+    resolved_host, resolved_user = resolve_target(host, user)
+    telemetry_snapshot = telemetry.collect(resolved_host, resolved_user)
+    job_snapshot = jobs.list_jobs(resolved_host, resolved_user)
+
+    return {
+        "host": resolved_host,
+        "user": resolved_user,
+        "telemetry": telemetry_snapshot,
+        "jobs": job_snapshot,
+    }
+
+
+def _fmt_metric(key: str, value: object) -> str:
+    return f"{key}: {value}"
+
+
+def _format_metrics(metrics: Mapping[str, object]) -> Sequence[str]:
+    lines: list[str] = []
+    for key, value in metrics.items():
+        lines.append(_fmt_metric(key, value))
+    return lines
+
+
+def render_text(snapshot: Mapping[str, object]) -> str:
+    """Render the dashboard snapshot as human friendly text."""
+
+    lines = [f"Jetson target: {snapshot['user']}@{snapshot['host']}"]
+
+    telem = snapshot.get("telemetry", {}) or {}
+    if telem:
+        lines.append("Telemetry:")
+        metrics = telem.get("metrics") or {}
+        if isinstance(metrics, Mapping) and metrics:
+            for line in _format_metrics(metrics):
+                lines.append(f"  {line}")
+        else:
+            lines.append(f"  raw: {telem.get('raw', 'no data')}")
+        if error := telem.get("error"):
+            lines.append(f"  error: {error}")
+
+    job_info = snapshot.get("jobs", {}) or {}
+    if job_info:
+        lines.append("Jobs:")
+        jobs_payload = job_info.get("jobs")
+        if isinstance(jobs_payload, Sequence) and jobs_payload:
+            for job in jobs_payload:
+                if isinstance(job, Mapping):
+                    unit = job.get("unit", "unknown")
+                    state = job.get("state", "?")
+                    job_id = job.get("id", "-")
+                    lines.append(f"  #{job_id} {unit} ({state})")
+        if error := job_info.get("error"):
+            lines.append(f"  error: {error}")
+
+    return "\n".join(lines)
+
+
+__all__ = ["build", "render_text"]

--- a/services/jetson_bridge/jobs.py
+++ b/services/jetson_bridge/jobs.py
@@ -1,0 +1,99 @@
+"""Utilities to list and trigger jobs on the Jetson host."""
+
+from __future__ import annotations
+
+import shlex
+import subprocess
+from typing import Callable, Mapping, MutableSequence, Sequence
+
+from .config import resolve_target
+
+SSHRunner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
+
+
+def _default_runner(cmd: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # type: ignore[arg-type]
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+
+
+def _parse_jobs(output: str) -> MutableSequence[Mapping[str, str]]:
+    jobs: MutableSequence[Mapping[str, str]] = []
+    for line in output.splitlines():
+        parts = line.split()
+        if len(parts) < 4:
+            continue
+        job_id, job_type, state = parts[:3]
+        unit = " ".join(parts[3:])
+        jobs.append({
+            "id": job_id,
+            "type": job_type,
+            "state": state,
+            "unit": unit,
+        })
+    return jobs
+
+
+def list_jobs(host: str | None = None, user: str | None = None, runner: SSHRunner | None = None) -> Mapping[str, object]:
+    """Return active ``systemd`` jobs on the Jetson.
+
+    The function respects ``JETSON_HOST`` / ``JETSON_USER`` and can be supplied
+    with a custom ``runner`` to facilitate testing.
+    """
+
+    resolved_host, resolved_user = resolve_target(host, user)
+    runner = runner or _default_runner
+    cmd = [
+        "ssh",
+        f"{resolved_user}@{resolved_host}",
+        "systemctl list-jobs --all --no-legend",
+    ]
+    result = runner(cmd)
+    output = result.stdout.strip()
+
+    if result.returncode != 0:
+        return {
+            "ok": False,
+            "host": resolved_host,
+            "user": resolved_user,
+            "error": result.stderr.strip() or "systemctl list-jobs failed",
+        }
+
+    return {
+        "ok": True,
+        "host": resolved_host,
+        "user": resolved_user,
+        "jobs": list(_parse_jobs(output)),
+    }
+
+
+def trigger(service: str, host: str | None = None, user: str | None = None, runner: SSHRunner | None = None) -> Mapping[str, object]:
+    """Restart a ``systemd`` unit on the Jetson and report the outcome."""
+
+    if not service:
+        raise ValueError("service name required")
+
+    resolved_host, resolved_user = resolve_target(host, user)
+    runner = runner or _default_runner
+    cmd = [
+        "ssh",
+        f"{resolved_user}@{resolved_host}",
+        f"sudo systemctl restart {shlex.quote(service)}",
+    ]
+    result = runner(cmd)
+    error = result.stderr.strip()
+
+    return {
+        "ok": result.returncode == 0,
+        "host": resolved_host,
+        "user": resolved_user,
+        "service": service,
+        "error": error if error else None,
+    }
+
+
+__all__ = ["list_jobs", "trigger"]

--- a/services/jetson_bridge/telemetry.py
+++ b/services/jetson_bridge/telemetry.py
@@ -1,0 +1,97 @@
+"""Collect telemetry from the Jetson host via SSH."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from statistics import mean
+from typing import Callable, Dict, Mapping, MutableMapping, Sequence
+
+from .config import resolve_target
+
+SSHRunner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
+
+
+def _default_runner(cmd: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # type: ignore[arg-type]
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+
+
+def _parse_tegrastats(output: str) -> Dict[str, float]:
+    data: MutableMapping[str, float] = {}
+
+    ram_match = re.search(r"RAM\s+(?P<used>\d+)/(?:\d+)MB", output)
+    total_match = re.search(r"RAM\s+\d+/(?P<total>\d+)MB", output)
+    if ram_match:
+        data["ram_used_mb"] = float(ram_match.group("used"))
+    if total_match:
+        data["ram_total_mb"] = float(total_match.group("total"))
+
+    cpu_samples = [float(v) for v in re.findall(r"CPU\s*\[[^\]]*?(\d+)%@", output)]
+    if cpu_samples:
+        data["cpu_percent"] = mean(cpu_samples)
+
+    gpu_match = re.search(r"GPU\s*(\d+)%", output)
+    if gpu_match:
+        data["gpu_percent"] = float(gpu_match.group(1))
+
+    temp_cpu = re.search(r"Tcpu@(?P<temp>\d+)C", output)
+    if temp_cpu:
+        data["temp_cpu_c"] = float(temp_cpu.group("temp"))
+
+    temp_gpu = re.search(r"Tgpu@(?P<temp>\d+)C", output)
+    if temp_gpu:
+        data["temp_gpu_c"] = float(temp_gpu.group("temp"))
+
+    return dict(data)
+
+
+def collect(host: str | None = None, user: str | None = None, runner: SSHRunner | None = None) -> Mapping[str, object]:
+    """Return a telemetry snapshot from ``tegrastats``.
+
+    Parameters
+    ----------
+    host, user:
+        Optional overrides for the Jetson SSH target. When omitted the
+        ``JETSON_HOST`` and ``JETSON_USER`` environment variables are
+        consulted, falling back to ``jetson.local`` / ``jetson``.
+    runner:
+        Optional callable used to execute the SSH command. This makes the
+        module testable without opening a network connection.
+    """
+
+    resolved_host, resolved_user = resolve_target(host, user)
+    runner = runner or _default_runner
+
+    cmd = [
+        "ssh",
+        f"{resolved_user}@{resolved_host}",
+        "LANG=C tegrastats --interval 1000 --count 1",
+    ]
+    result = runner(cmd)
+    output = result.stdout.strip() or result.stderr.strip()
+
+    if result.returncode != 0:
+        return {
+            "ok": False,
+            "host": resolved_host,
+            "user": resolved_user,
+            "error": output or "tegrastats failed",
+        }
+
+    metrics = _parse_tegrastats(output)
+    return {
+        "ok": True,
+        "host": resolved_host,
+        "user": resolved_user,
+        "raw": output,
+        "metrics": metrics,
+    }
+
+
+__all__ = ["collect"]


### PR DESCRIPTION
## Summary
- add a services/jetson_bridge package that resolves the Jetson host/user from JETSON_HOST and JETSON_USER
- provide telemetry, job, and dashboard helpers that surface the active target and expose SSH runners for testing

## Testing
- python -m py_compile services/jetson_bridge/*.py

------
https://chatgpt.com/codex/tasks/task_e_68daf8d9b81c832995ede3c525e30724