### PR TITLE
Add remote flashing agent and dashboard panel

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,5 @@
+"""Agent package for BlackRoad Pi services."""
+
+from . import flash  # re-export for convenience
+
+__all__ = ["flash"]

--- a/agent/api.py
+++ b/agent/api.py
@@ -1,0 +1,107 @@
+"""FastAPI endpoints exposing device flashing capabilities."""
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Any, Dict, Optional
+
+from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect
+from starlette.websockets import WebSocketState
+
+from agent import flash
+
+app = FastAPI(title="BlackRoad Agent API")
+
+
+async def _list_devices() -> list[dict[str, Any]]:
+    data = await asyncio.to_thread(flash.list_devices)
+    if isinstance(data, dict):
+        message = data.get("error", "Failed to enumerate devices")
+        raise HTTPException(status_code=500, detail=message)
+    return data
+
+
+@app.get("/flash/devices")
+async def flash_devices() -> Dict[str, Any]:
+    """Return removable block devices available for flashing."""
+
+    devices = await _list_devices()
+    return {"devices": devices}
+
+
+def _start_flash_worker(
+    queue: "asyncio.Queue[str | None]",
+    loop: asyncio.AbstractEventLoop,
+    device: str,
+    image_url: str,
+    safe_hdmi: bool,
+    enable_ssh: bool,
+    stop: threading.Event,
+) -> threading.Thread:
+    def worker() -> None:
+        try:
+            for line in flash.flash(
+                image_url,
+                device,
+                safe_hdmi=safe_hdmi,
+                enable_ssh=enable_ssh,
+            ):
+                if stop.is_set():
+                    break
+                asyncio.run_coroutine_threadsafe(queue.put(line), loop)
+        except Exception as exc:  # pragma: no cover - safety net
+            asyncio.run_coroutine_threadsafe(queue.put(f"ERROR: {exc}"), loop)
+        finally:
+            asyncio.run_coroutine_threadsafe(queue.put(None), loop)
+
+    thread = threading.Thread(target=worker, name="flash-writer", daemon=True)
+    thread.start()
+    return thread
+
+
+@app.websocket("/ws/flash")
+async def ws_flash(ws: WebSocket) -> None:
+    await ws.accept()
+    stop = threading.Event()
+    queue: "asyncio.Queue[str | None]" = asyncio.Queue()
+    thread: Optional[threading.Thread] = None
+
+    try:
+        msg = await ws.receive_json()
+        device = msg.get("device")
+        image_url = msg.get("image_url")
+        safe_hdmi = bool(msg.get("safe_hdmi", True))
+        enable_ssh = bool(msg.get("enable_ssh", True))
+
+        if not device or not image_url:
+            await ws.send_text("ERROR: device and image_url are required")
+            return
+
+        loop = asyncio.get_running_loop()
+        thread = _start_flash_worker(
+            queue,
+            loop,
+            device,
+            image_url,
+            safe_hdmi,
+            enable_ssh,
+            stop,
+        )
+
+        while True:
+            line = await queue.get()
+            if line is None:
+                break
+            await ws.send_text(line)
+
+        await ws.send_text("[[BLACKROAD_DONE]]")
+    except WebSocketDisconnect:
+        stop.set()
+    except Exception as exc:  # pragma: no cover - defensive guard
+        await ws.send_text(f"ERROR: {exc}")
+    finally:
+        stop.set()
+        if thread is not None:
+            thread.join(timeout=1)
+        if ws.client_state == WebSocketState.CONNECTED:
+            await ws.close()

--- a/agent/flash.py
+++ b/agent/flash.py
@@ -1,0 +1,245 @@
+"""Storage flashing helpers for the BlackRoad Pi dashboard."""
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+from pathlib import Path
+from typing import Iterable, Optional
+
+__all__ = ["list_devices", "flash"]
+
+_IMAGE_PATH = Path("/tmp/blackroad.img.xz")
+_MOUNT_POINT = Path("/mnt")
+
+
+def _sh(cmd: str) -> tuple[int, str]:
+    """Execute *cmd* returning ``(returncode, stdout)``.
+
+    The command is executed using ``shell=False`` with ``shlex.split`` to
+    avoid surprises with shell interpretation.  Stderr is redirected to
+    stdout so callers receive a combined stream.
+    """
+
+    try:
+        out = subprocess.check_output(
+            shlex.split(cmd), text=True, stderr=subprocess.STDOUT
+        )
+        return 0, out
+    except subprocess.CalledProcessError as exc:  # pragma: no cover - depends on system
+        return exc.returncode, exc.output
+
+
+def _root_disk() -> Optional[str]:
+    """Return the absolute path of the block device that backs ``/``.
+
+    On typical installations ``findmnt -no SOURCE /`` returns a partition
+    such as ``/dev/sda1`` or ``/dev/mmcblk0p2``.  We resolve that to the
+    parent disk so we can exclude it from flashing targets.
+    """
+
+    try:
+        root = subprocess.check_output(
+            ["findmnt", "-no", "SOURCE", "/"], text=True
+        ).strip()
+    except subprocess.CalledProcessError:  # pragma: no cover - depends on system
+        return None
+
+    if not root:
+        return None
+
+    rc, parent = _sh(f"lsblk -no pkname {shlex.quote(root)}")
+    if rc == 0 and parent.strip():
+        return f"/dev/{parent.strip()}"
+
+    # Fallback: trim trailing digits (partitions) and optional 'p'
+    disk = root.rstrip("0123456789")
+    if disk.endswith("p"):
+        disk = disk[:-1]
+    return disk or root
+
+
+def _normalise_device(device: str) -> str:
+    """Return ``device`` with symlinks resolved and without surrounding whitespace."""
+
+    resolved = os.path.realpath(device.strip())
+    return resolved
+
+
+def _is_system_disk(device: str, rootdisk: Optional[str]) -> bool:
+    if not rootdisk:
+        return False
+    dev = _normalise_device(device)
+    rd = _normalise_device(rootdisk)
+    return dev == rd or dev.startswith(f"{rd}")
+
+
+def list_devices() -> list[dict[str, object]] | dict[str, str]:
+    """Return metadata for removable, non-root block devices.
+
+    The structure mirrors the ``lsblk`` JSON schema so the dashboard can
+    display size/model/transport details.  On error a dict with an
+    ``"error"`` key is returned.
+    """
+
+    rootdisk = _root_disk()
+    rc, out = _sh("lsblk -J -o NAME,SIZE,TYPE,MOUNTPOINT,RM,ROTA,MODEL,TRAN")
+    if rc != 0:
+        return {"error": out.strip() or "lsblk failed"}
+
+    try:
+        info = json.loads(out)
+    except json.JSONDecodeError as exc:  # pragma: no cover - depends on system
+        return {"error": f"Failed to parse lsblk output: {exc}"}
+
+    devices: list[dict[str, object]] = []
+
+    def walk(node: dict[str, object]) -> None:
+        name = f"/dev/{node['name']}"
+        if node.get("type") == "disk":
+            if _is_system_disk(name, rootdisk):
+                return
+            devices.append(
+                {
+                    "device": name,
+                    "size": node.get("size", ""),
+                    "model": node.get("model", ""),
+                    "rm": node.get("rm", 0),
+                    "tran": node.get("tran", ""),
+                }
+            )
+        for child in node.get("children") or []:
+            walk(child)
+
+    for node in info.get("blockdevices", []) or []:
+        walk(node)
+
+    return devices
+
+
+def _partition_name(device: str, index: int = 1) -> str:
+    """Return the partition path for ``device`` (handles ``sdX`` vs ``nvme``/``mmc``)."""
+
+    suffix = f"p{index}" if device[-1].isdigit() else f"{index}"
+    return f"{device}{suffix}"
+
+
+def _cleanup_image() -> None:
+    try:
+        _IMAGE_PATH.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def _write_file(path: Path, contents: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(contents)
+
+
+def flash(
+    image_url: str,
+    device: str,
+    *,
+    safe_hdmi: bool = True,
+    enable_ssh: bool = True,
+) -> Iterable[str]:
+    """Flash ``image_url`` to ``device`` yielding progress messages.
+
+    This generator streams human-readable status strings suitable for
+    forwarding over a WebSocket.  The calling code is expected to handle
+    cancellation by simply stopping iteration.
+    """
+
+    if not image_url:
+        yield "ERROR: image_url is required"
+        return
+
+    if not device.startswith("/dev/"):
+        yield "ERROR: device path must start with /dev/"
+        return
+
+    rootdisk = _root_disk()
+    if _is_system_disk(device, rootdisk):
+        yield "ERROR: Refusing to flash the system disk."
+        return
+
+    if not Path(device).exists():
+        yield f"ERROR: Device {device} not found"
+        return
+
+    _cleanup_image()
+    download_cmd = f"curl -L {shlex.quote(image_url)} -o {_IMAGE_PATH}"
+    yield f"Downloading image from {image_url}"
+    rc, out = _sh(download_cmd)
+    if rc != 0:
+        _cleanup_image()
+        yield f"ERROR: download failed ({rc})\n{out.strip()}"
+        return
+
+    write_cmd = (
+        f"xzcat {_IMAGE_PATH} | sudo dd of={shlex.quote(device)} bs=8M "
+        "status=progress conv=fsync"
+    )
+    yield "Writing image to device"
+    proc = subprocess.Popen(  # noqa: S603 - command constructed above
+        write_cmd,
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+
+    try:
+        assert proc.stdout is not None  # for type checkers
+        for line in proc.stdout:
+            yield line.rstrip("\n")
+    finally:
+        proc.wait()
+
+    if proc.returncode != 0:
+        _cleanup_image()
+        yield f"ERROR: writer exited {proc.returncode}"
+        return
+
+    yield "Syncing data"
+    subprocess.run(["sync"], check=False)
+    subprocess.run(["sudo", "partprobe", device], check=False)
+
+    boot_part = _partition_name(device, 1)
+    mount_args = ["sudo", "mount", boot_part, str(_MOUNT_POINT)]
+    yield f"Mounting boot partition {boot_part}"
+    try:
+        subprocess.run(
+            mount_args,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except subprocess.CalledProcessError as exc:
+        _cleanup_image()
+        stderr = exc.stderr.decode().strip() if exc.stderr else str(exc)
+        yield f"ERROR: Failed to mount {boot_part}: {stderr}"
+        return
+
+    try:
+        config_path = _MOUNT_POINT / "config.txt"
+        if config_path.exists():
+            additions = ["", "usb_max_current_enable=1"]
+            if safe_hdmi:
+                additions.append("hdmi_safe=1")
+                additions.append("hdmi_force_hotplug=1")
+            _write_file(config_path, "\n".join(additions) + "\n")
+        else:
+            yield "WARNING: config.txt not found; skipping HDMI tweaks"
+
+        if enable_ssh:
+            ssh_flag = _MOUNT_POINT / "ssh"
+            ssh_flag.touch(exist_ok=True)
+    finally:
+        subprocess.run(["sudo", "umount", str(_MOUNT_POINT)], check=False)
+        _cleanup_image()
+
+    yield "[BLACKROAD_FLASH_DONE]"

--- a/srv/blackroad/web/index.html
+++ b/srv/blackroad/web/index.html
@@ -148,6 +148,15 @@ function Dashboard({route}) {
   const [mem,setMEM]=useState(Array.from({length:40},()=>Math.random()*70+20));
   const [gpu,setGPU]=useState(Array.from({length:40},()=>Math.random()*90));
   const [build,setBuild]=useState(63); const [timeline,setTimeline]=useState([]); const [commits,setCommits]=useState([]); const [tasks,setTasks]=useState([]);
+  const [flashDevices,setFlashDevices]=useState([]);
+  const [flashDevice,setFlashDevice]=useState('');
+  const [flashUrl,setFlashUrl]=useState('');
+  const [flashLog,setFlashLog]=useState('');
+  const [flashSafeHdmi,setFlashSafeHdmi]=useState(true);
+  const [flashEnableSsh,setFlashEnableSsh]=useState(true);
+  const [isFlashing,setIsFlashing]=useState(false);
+  const flashSocket=useRef(null);
+  const flashLogRef=useRef(null);
 
   useEffect(()=>{Promise.allSettled([apiGet('/api/timeline'),apiGet('/api/tasks'),apiGet('/api/commits'),apiGet('/api/state')]).then(([tl,ts,cs,st])=>{
     if(tl.value)setTimeline(tl.value); if(ts.value)setTasks(ts.value); if(cs.value)setCommits(cs.value);
@@ -155,8 +164,47 @@ function Dashboard({route}) {
   }); const proto=location.protocol==='https:'?'wss':'ws'; const ws=new WebSocket(`${proto}://${location.host}/ws`);
   ws.onmessage=e=>{try{const m=JSON.parse(e.data); if(m.type==='activity') setTimeline(t=>[m.item,...t].slice(0,80)); if(m.type==='metrics'){setCPU(x=>[...x.slice(1),m.cpu]); setMEM(x=>[...x.slice(1),m.mem]); setGPU(x=>[...x.slice(1),m.gpu]);} if(m.type==='build') setBuild(m.progress); if(m.type==='wallet') setWallet(m.balance.toFixed(2)); }catch(_){} };
   return ()=>ws.close();},[]);
+  useEffect(()=>()=>{if(flashSocket.current) flashSocket.current.close();},[]);
+  useEffect(()=>{if(flashLogRef.current) flashLogRef.current.scrollTop=flashLogRef.current.scrollHeight;},[flashLog]);
 
   const filteredTimeline=useMemo(()=>timeline.filter(x=>(x.title||'').toLowerCase().includes(filter.toLowerCase())||(x.desc||'').toLowerCase().includes(filter.toLowerCase())),[timeline,filter]);
+  const appendFlashLog=line=>setFlashLog(prev=>prev?prev+'\n'+String(line):String(line));
+  async function loadFlashDevices(){
+    try{
+      const res=await fetch('/flash/devices');
+      const data=await res.json().catch(()=>({}));
+      if(!res.ok){
+        const detail=data.detail||data.error||'Failed to list devices';
+        appendFlashLog(`ERROR: ${detail}`);
+        setFlashDevices([]);
+        setFlashDevice('');
+        return;
+      }
+      const list=data.devices||[];
+      setFlashDevices(list);
+      if(!list.find(d=>d.device===flashDevice)){
+        setFlashDevice(list.length?list[0].device:'');
+      }
+      if(list.length===0){
+        appendFlashLog('No removable devices detected');
+      }
+    }catch(e){appendFlashLog(`ERROR: ${(e&&e.message)||e}`);}
+  }
+  const startFlash=()=>{
+    if(isFlashing) return;
+    const url=flashUrl.trim();
+    if(!url||!flashDevice){appendFlashLog('Select device and image URL');return;}
+    setFlashLog('');
+    const proto=location.protocol==='https:'?'wss':'ws';
+    const ws=new WebSocket(`${proto}://${location.host}/ws/flash`);
+    flashSocket.current=ws;
+    setIsFlashing(true);
+    ws.onopen=()=>ws.send(JSON.stringify({device:flashDevice,image_url=url,safe_hdmi:flashSafeHdmi,enable_ssh:flashEnableSsh}));
+    ws.onmessage=e=>appendFlashLog(e.data);
+    ws.onerror=()=>appendFlashLog('ERROR: WebSocket error');
+    ws.onclose=()=>{setIsFlashing(false); if(flashSocket.current===ws) flashSocket.current=null;};
+  };
+  const canFlash=Boolean(flashDevice && flashUrl.trim() && !isFlashing);
   const [code,setCode]=useState(`// Example code\nconsole.log('BlackRoad online');`);
   const runCode=()=>{const frame=document.getElementById('sandbox');const payload=`<!doctype html><html><body><script>const log=(...a)=>parent.postMessage({type:'log',data:a.join(' ')},'*');console.log=log;console.error=(...a)=>parent.postMessage({type:'log',data:'! '+a.join(' ')},'*');try{${code}}catch(e){console.error(e.message)}<\/script></body></html>`; frame.srcdoc=payload}
   const onCommand=async(cmd)=>{const [c,...rest]=cmd.split(/\s+/);switch(c){case 'help':return['commands: help, run, build, commit <msg>, git status, agents, stake <amt>, mint, revert, clear, whoami, logout'];case 'run':runCode();return['executing current editor code…'];case 'build':await apiPost('/api/build/start',{});return['build started…'];case 'commit':{const msg=rest.join(' ')||'Update from terminal';await apiPost('/api/commit',{msg});return[`committed: ${msg}`]}case 'git':if(rest[0]==='status')return['on branch main','nothing to commit'];break;case 'agents':return[`Phi:${agents.Phi?'on':'off'} GPT:${agents.GPT?'on':'off'} Mistral:${agents.Mistral?'on':'off'}`];case 'stake':{const amt=parseFloat(rest[0]||'0');if(!amt)return['usage: stake <amount>'];const r=await apiPost('/api/wallet/stake',{amount:amt});return[`staked ${amt.toFixed(2)} RC (bal ${r.balance.toFixed(2)})`]}case 'mint':{const r=await apiPost('/api/wallet/mint',{});return[`minted 0.05 RC (bal ${r.balance.toFixed(2)})`]}case 'revert':await apiPost('/api/revert',{});return['revert queued'];case 'clear':return['\u0007'];case 'whoami':return['root'];case 'logout':await apiPost('/api/logout',{});location.reload()}return[`unknown command: ${cmd}. type 'help'.`]}
@@ -237,6 +285,25 @@ function Dashboard({route}) {
         <Card>
           <div style={{fontWeight:700}}>Session Notes</div>
           <textarea value={notes} onChange={e=>setNotes(e.target.value)} placeholder="Type notes…" style={{minHeight:120,background:'#09122a',border:'1px solid var(--border)',borderRadius:12,color:'#fff',padding:10}}/>
+        </Card>
+        <Card>
+          <div style={{display:'grid',gap:8}}>
+            <div style={{display:'flex',justifyContent:'space-between',alignItems:'center'}}>
+              <div style={{fontWeight:700}}>Flasher</div>
+              <button className="btn small" onClick={()=>loadFlashDevices()} disabled={isFlashing}>List Devices</button>
+            </div>
+            <select value={flashDevice} onChange={e=>setFlashDevice(e.target.value)} disabled={!flashDevices.length} style={{background:'#09122a',border:'1px solid var(--border)',borderRadius:10,color:'#fff',padding:'8px'}}>
+              <option value="">Select device…</option>
+              {flashDevices.map(d=>{const meta=[d.size,d.model].filter(Boolean).join(' ');return <option key={d.device} value={d.device}>{meta?`${d.device} ${meta}`:d.device}</option>;})}
+            </select>
+            <input value={flashUrl} onChange={e=>setFlashUrl(e.target.value)} placeholder="Image URL (xz)" style={{background:'#09122a',border:'1px solid var(--border)',borderRadius:10,color:'#fff',padding:'8px'}}/>
+            <div style={{display:'flex',gap:12,flexWrap:'wrap'}}>
+              <label style={{display:'inline-flex',alignItems:'center',gap:6,cursor:'pointer'}}><input type="checkbox" checked={flashSafeHdmi} onChange={()=>setFlashSafeHdmi(v=>!v)}/> <span>Safe HDMI</span></label>
+              <label style={{display:'inline-flex',alignItems:'center',gap:6,cursor:'pointer'}}><input type="checkbox" checked={flashEnableSsh} onChange={()=>setFlashEnableSsh(v=>!v)}/> <span>Enable SSH</span></label>
+            </div>
+            <button className={canFlash?'btn primary':'btn'} onClick={startFlash} disabled={!canFlash}>{isFlashing?'Flashing…':'Flash Drive'}</button>
+            <div ref={flashLogRef} style={{background:'#000',color:'#0f0',padding:'10px',borderRadius:10,height:150,overflow:'auto',fontFamily:'monospace',whiteSpace:'pre-wrap'}}>{flashLog||'Ready.'}</div>
+          </div>
         </Card>
       </Panel>
     </Body>


### PR DESCRIPTION
## Summary
- add an agent-side flashing module that lists removable devices and streams dd progress
- expose FastAPI endpoints plus a WebSocket to drive flashing from the dashboard UI
- extend the dashboard with a flasher panel for selecting devices, sending image URLs, and monitoring logs

## Testing
- python -m compileall agent

------
https://chatgpt.com/codex/tasks/task_e_68dafb6fe91c8329bcd1f80b40382104