### PR TITLE
Add remote flashing API and dashboard panel

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,5 @@
+"""Agent control surface utilities."""
+
+from .flash import flash, list_devices
+
+__all__ = ["flash", "list_devices"]

--- a/agent/api.py
+++ b/agent/api.py
@@ -1,0 +1,45 @@
+"""FastAPI app exposing the Pi flasher controls."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from starlette.websockets import WebSocketState
+
+from agent import flash
+
+app = FastAPI(title="BlackRoad Agent API")
+
+
+@app.get("/flash/devices")
+def flash_devices() -> dict:
+    """Return removable devices available for flashing."""
+
+    return {"devices": flash.list_devices()}
+
+
+@app.websocket("/ws/flash")
+async def ws_flash(ws: WebSocket) -> None:
+    """Stream flashing progress to the dashboard."""
+
+    await ws.accept()
+    try:
+        msg = await ws.receive_json()
+        device = msg.get("device")
+        image_url = msg.get("image_url")
+        if not device or not image_url:
+            await ws.send_text("ERROR: device and image_url required")
+            await ws.send_text("[[BLACKROAD_DONE]]")
+            return
+
+        for line in flash.flash(image_url, device):
+            await ws.send_text(line)
+
+        await ws.send_text("[[BLACKROAD_DONE]]")
+    except WebSocketDisconnect:
+        return
+    except Exception as exc:  # pragma: no cover - network/runtime failure
+        await ws.send_text(f"ERROR: {exc}")
+        await ws.send_text("[[BLACKROAD_DONE]]")
+    finally:
+        if ws.application_state != WebSocketState.DISCONNECTED:
+            await ws.close()

--- a/agent/flash.py
+++ b/agent/flash.py
@@ -1,0 +1,156 @@
+"""Utilities for imaging removable devices from the Pi dashboard."""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+from typing import Dict, Generator, List
+
+
+TMP_IMAGE_PATH = "/tmp/blackroad.img.xz"
+
+
+def _sh(cmd: str) -> tuple[int, str]:
+    """Run *cmd* in a shell and return ``(returncode, output)``."""
+
+    try:
+        out = subprocess.check_output(shlex.split(cmd), text=True, stderr=subprocess.STDOUT)
+        return 0, out
+    except subprocess.CalledProcessError as exc:  # pragma: no cover - passthrough
+        return exc.returncode, exc.output
+
+
+def _root_disk(path: str) -> str:
+    """Strip partition suffixes from a block-device path."""
+
+    device = path.strip()
+    while device and device[-1].isdigit():
+        device = device[:-1]
+    if device.endswith("p"):
+        device = device[:-1]
+    return device
+
+
+def _partition_path(device: str, part: int) -> str:
+    """Return the path for ``part`` on ``device`` (handles mmc/nvme suffixes)."""
+
+    suffix = f"p{part}" if device and device[-1].isdigit() else str(part)
+    return f"{device}{suffix}"
+
+
+def list_devices() -> List[Dict[str, str]] | Dict[str, str]:
+    """Return removable, non-root block devices."""
+
+    try:
+        root = subprocess.check_output("findmnt -no SOURCE /", shell=True, text=True).strip()
+    except subprocess.CalledProcessError as exc:
+        return {"error": exc.output.strip() if exc.output else str(exc)}
+
+    rootdisk = _root_disk(root)
+    rc, out = _sh("lsblk -J -o NAME,SIZE,TYPE,MOUNTPOINT,RM,ROTA,MODEL,TRAN")
+    if rc:
+        return {"error": out.strip()}
+
+    info = json.loads(out)
+    devices: List[Dict[str, str]] = []
+
+    def walk(node: Dict[str, str]) -> None:
+        name = "/dev/" + node["name"]
+        if node.get("type") == "disk":
+            if name.startswith(rootdisk):
+                return
+            devices.append(
+                {
+                    "device": name,
+                    "size": node.get("size", ""),
+                    "model": node.get("model", ""),
+                    "rm": node.get("rm", 0),
+                    "tran": node.get("tran", ""),
+                }
+            )
+        for child in (node.get("children") or []):
+            walk(child)
+
+    for node in info.get("blockdevices", []) or []:
+        walk(node)
+
+    return devices
+
+
+def flash(image_url: str, device: str, safe_hdmi: bool = True, enable_ssh: bool = True) -> Generator[str, None, None]:
+    """Stream progress while flashing *image_url* to *device*."""
+
+    try:
+        root = subprocess.check_output("findmnt -no SOURCE /", shell=True, text=True).strip()
+    except subprocess.CalledProcessError as exc:
+        yield f"ERROR: unable to determine root disk: {exc.output.strip() if exc.output else exc}"
+        return
+
+    rootdisk = _root_disk(root)
+    if device.startswith(rootdisk):
+        yield "ERROR: Refusing to flash the system disk."
+        return
+
+    download_cmd = f"curl -L {shlex.quote(image_url)} -o {shlex.quote(TMP_IMAGE_PATH)}"
+    write_cmd = (
+        f"xzcat {shlex.quote(TMP_IMAGE_PATH)} | "
+        f"sudo dd of={shlex.quote(device)} bs=8M status=progress conv=fsync"
+    )
+
+    try:
+        proc = subprocess.Popen(  # noqa: S603  # shell needed for pipeline streaming
+            f"{download_cmd} && {write_cmd}",
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+    except OSError as exc:  # pragma: no cover - system-specific failure
+        yield f"ERROR: failed to start writer: {exc}"
+        return
+
+    try:
+        if proc.stdout is not None:
+            for line in proc.stdout:
+                yield line.rstrip("\n")
+        proc.wait()
+
+        if proc.returncode != 0:
+            yield f"ERROR: writer exited {proc.returncode}"
+            return
+
+        for cmd in ("sync", f"sudo partprobe {shlex.quote(device)}"):
+            rc, out = _sh(cmd)
+            if rc:
+                yield f"ERROR: command failed ({cmd}): {out.strip()}"
+                return
+
+        bootpart = _partition_path(device, 1)
+        try:
+            subprocess.run(["sudo", "mount", bootpart, "/mnt"], check=True)
+        except subprocess.CalledProcessError as exc:
+            yield f"ERROR: failed to mount {bootpart}: {exc}"
+            return
+
+        try:
+            with open("/mnt/config.txt", "a", encoding="utf-8") as cfg:
+                cfg.write("\nusb_max_current_enable=1\n")
+                if safe_hdmi:
+                    cfg.write("hdmi_safe=1\nhdmi_force_hotplug=1\n")
+            if enable_ssh:
+                open("/mnt/ssh", "w", encoding="utf-8").close()
+        except OSError as exc:
+            yield f"ERROR: failed to update boot partition: {exc}"
+        finally:
+            subprocess.run(["sudo", "umount", "/mnt"], check=False)
+
+        yield "[BLACKROAD_FLASH_DONE]"
+    finally:
+        try:
+            if os.path.exists(TMP_IMAGE_PATH):
+                os.remove(TMP_IMAGE_PATH)
+        except OSError:
+            pass

--- a/srv/blackroad/web/index.html
+++ b/srv/blackroad/web/index.html
@@ -148,6 +148,13 @@ function Dashboard({route}) {
   const [mem,setMEM]=useState(Array.from({length:40},()=>Math.random()*70+20));
   const [gpu,setGPU]=useState(Array.from({length:40},()=>Math.random()*90));
   const [build,setBuild]=useState(63); const [timeline,setTimeline]=useState([]); const [commits,setCommits]=useState([]); const [tasks,setTasks]=useState([]);
+  const [flashDevices,setFlashDevices]=useState([]);
+  const [flashDevice,setFlashDevice]=useState('');
+  const [flashUrl,setFlashUrl]=useState('');
+  const [flashLog,setFlashLog]=useState('');
+  const [flashBusy,setFlashBusy]=useState(false);
+  const flashSocket=useRef(null);
+  const flashLogRef=useRef(null);
 
   useEffect(()=>{Promise.allSettled([apiGet('/api/timeline'),apiGet('/api/tasks'),apiGet('/api/commits'),apiGet('/api/state')]).then(([tl,ts,cs,st])=>{
     if(tl.value)setTimeline(tl.value); if(ts.value)setTasks(ts.value); if(cs.value)setCommits(cs.value);
@@ -155,6 +162,62 @@ function Dashboard({route}) {
   }); const proto=location.protocol==='https:'?'wss':'ws'; const ws=new WebSocket(`${proto}://${location.host}/ws`);
   ws.onmessage=e=>{try{const m=JSON.parse(e.data); if(m.type==='activity') setTimeline(t=>[m.item,...t].slice(0,80)); if(m.type==='metrics'){setCPU(x=>[...x.slice(1),m.cpu]); setMEM(x=>[...x.slice(1),m.mem]); setGPU(x=>[...x.slice(1),m.gpu]);} if(m.type==='build') setBuild(m.progress); if(m.type==='wallet') setWallet(m.balance.toFixed(2)); }catch(_){} };
   return ()=>ws.close();},[]);
+
+  useEffect(()=>{return ()=>{if(flashSocket.current){flashSocket.current.close(); flashSocket.current=null;}};},[]);
+  useEffect(()=>{if(flashLogRef.current){const el=flashLogRef.current; el.scrollTop=el.scrollHeight;}},[flashLog]);
+
+  async function listFlashDevices(){
+    try{
+      const r=await fetch('/flash/devices');
+      const j=await r.json();
+      if(j && j.devices && !Array.isArray(j.devices) && j.devices.error){
+        setFlashLog(prev=>`${prev ? prev+'\n' : ''}ERROR: ${j.devices.error}`);
+        return;
+      }
+      const devices=Array.isArray(j.devices)?j.devices:[];
+      setFlashDevices(devices);
+      if(devices.length){
+        const found=devices.find(d=>d.device===flashDevice);
+        setFlashDevice(found?flashDevice:devices[0].device);
+      }
+      if(!devices.length){
+        setFlashLog(prev=>`${prev ? prev+'\n' : ''}No removable devices detected.`);
+      }
+    }catch(e){
+      setFlashLog(prev=>`${prev ? prev+'\n' : ''}ERROR: ${e.message||e}`);
+    }
+  }
+
+  function startFlash(){
+    const url=flashUrl.trim();
+    if(!url || !flashDevice){
+      setFlashLog('Select device and image URL');
+      return;
+    }
+    if(flashSocket.current){
+      flashSocket.current.close();
+      flashSocket.current=null;
+    }
+    setFlashLog('');
+    setFlashBusy(true);
+    const proto=location.protocol==='https:'?'wss':'ws';
+    const ws=new WebSocket(`${proto}://${location.host}/ws/flash`);
+    flashSocket.current=ws;
+    ws.onopen=()=>{ws.send(JSON.stringify({device:flashDevice,image_url:url}));};
+    ws.onmessage=ev=>{
+      const text=ev.data;
+      setFlashLog(prev=>`${prev ? prev+'\n' : ''}${text}`);
+      if(text==='[[BLACKROAD_DONE]]' || text==='[BLACKROAD_FLASH_DONE]' || text.startsWith('ERROR')){
+        setFlashBusy(false);
+      }
+    };
+    ws.onerror=()=>{
+      setFlashLog(prev=>`${prev ? prev+'\n' : ''}ERROR: websocket error`);
+      setFlashBusy(false);
+      ws.close();
+    };
+    ws.onclose=()=>{setFlashBusy(false); flashSocket.current=null;};
+  }
 
   const filteredTimeline=useMemo(()=>timeline.filter(x=>(x.title||'').toLowerCase().includes(filter.toLowerCase())||(x.desc||'').toLowerCase().includes(filter.toLowerCase())),[timeline,filter]);
   const [code,setCode]=useState(`// Example code\nconsole.log('BlackRoad online');`);
@@ -237,6 +300,24 @@ function Dashboard({route}) {
         <Card>
           <div style={{fontWeight:700}}>Session Notes</div>
           <textarea value={notes} onChange={e=>setNotes(e.target.value)} placeholder="Type notes…" style={{minHeight:120,background:'#09122a',border:'1px solid var(--border)',borderRadius:12,color:'#fff',padding:10}}/>
+        </Card>
+        <Card>
+          <div style={{fontWeight:700}}>Flasher</div>
+          <div style={{display:'flex',gap:8,flexWrap:'wrap',alignItems:'center',marginTop:8}}>
+            <button className="btn small" type="button" onClick={listFlashDevices} disabled={flashBusy}>List Devices</button>
+            <select value={flashDevice} onChange={e=>setFlashDevice(e.target.value)} style={{flex:1,minWidth:160,background:'#09122a',border:'1px solid var(--border)',borderRadius:12,color:'#fff',padding:'8px 10px'}} disabled={flashBusy}>
+              <option value="">Select device</option>
+              {flashDevices.map(d=>(<option key={d.device} value={d.device}>{(
+                `${d.device} ${d.size||''} ${d.model||''}`
+              ).trim()}</option>))}
+            </select>
+          </div>
+          <input value={flashUrl} onChange={e=>setFlashUrl(e.target.value)} placeholder="Image URL (xz)" style={{marginTop:8,width:'100%',padding:'10px',borderRadius:12,border:'1px solid var(--border)',background:'#09122a',color:'#fff'}} disabled={flashBusy}/>
+          <div style={{display:'flex',alignItems:'center',gap:8,marginTop:8}}>
+            <button className="btn small" type="button" onClick={startFlash} disabled={flashBusy}>Flash</button>
+            {flashBusy && <span className="chip">Flashing…</span>}
+          </div>
+          <pre ref={flashLogRef} style={{marginTop:10,background:'#000',color:'#0f0',padding:12,height:180,overflow:'auto',borderRadius:12,whiteSpace:'pre-wrap'}}>{flashLog || 'Ready.'}</pre>
         </Card>
       </Panel>
     </Body>


### PR DESCRIPTION
## Summary
- add a streaming flashing helper module and surface FastAPI endpoints for device discovery and imaging
- extend the dashboard with a Flasher panel that lists devices, opens a flashing websocket, and shows live log output

## Testing
- python -m py_compile agent/__init__.py agent/flash.py agent/api.py

------
https://chatgpt.com/codex/tasks/task_e_68dafb9a56b08329898817fd098f93f5