### PR TITLE
Add curated flash image selection and checksum verification

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,1 @@
+"""BlackRoad flashing agent package."""

--- a/agent/api.py
+++ b/agent/api.py
@@ -1,0 +1,84 @@
+"""FastAPI application exposing flashing utilities and dashboard UI."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.responses import HTMLResponse
+
+from .flash import flash, list_devices
+
+KNOWN_IMAGES = [
+    {
+        "name": "Raspberry Pi OS Lite (arm64)",
+        "url": "https://downloads.raspberrypi.com/raspios_lite_arm64_latest",
+    },
+    {
+        "name": "Ubuntu Server 24.04 (RPI arm64)",
+        "url": "https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04.1-preinstalled-server-arm64+raspi.img.xz",
+    },
+    {
+        "name": "BlackRoad OS (latest)",
+        "url": "https://your.host/blackroad/latest.img.xz",
+        "sha256": "https://your.host/blackroad/latest.sha256",
+    },
+]
+
+app = FastAPI(title="BlackRoad Flasher")
+
+
+@app.get("/")
+def dashboard() -> HTMLResponse:
+    """Serve the dashboard interface."""
+    html_path = Path(__file__).resolve().parent.parent / "dashboard.html"
+    html = html_path.read_text(encoding="utf-8")
+    return HTMLResponse(html)
+
+
+@app.get("/flash/devices")
+def flash_devices() -> dict:
+    """List available block devices."""
+    return {"devices": list_devices()}
+
+
+@app.get("/flash/images")
+def flash_images() -> dict:
+    """Return curated image suggestions."""
+    return {"images": KNOWN_IMAGES}
+
+
+@app.websocket("/ws/flash")
+async def ws_flash(websocket: WebSocket) -> None:
+    await websocket.accept()
+    try:
+        payload_raw = await websocket.receive_text()
+    except WebSocketDisconnect:
+        return
+
+    try:
+        payload = json.loads(payload_raw)
+    except json.JSONDecodeError:
+        await websocket.send_text("ERROR: invalid payload")
+        await websocket.close()
+        return
+
+    device = payload.get("device", "").strip()
+    image_url = payload.get("image_url", "").strip()
+    sha_url: Optional[str] = (payload.get("sha256_url") or payload.get("sha_url") or "").strip() or None
+
+    if not device or not image_url:
+        await websocket.send_text("ERROR: device and image_url required")
+        await websocket.close()
+        return
+
+    try:
+        for line in flash(device, image_url, sha_url):
+            await websocket.send_text(line)
+    except WebSocketDisconnect:
+        return
+    except Exception as exc:  # noqa: BLE001
+        await websocket.send_text(f"ERROR: {exc}")
+    finally:
+        await websocket.close()

--- a/agent/flash.py
+++ b/agent/flash.py
@@ -1,0 +1,139 @@
+"""Utilities for listing block devices and flashing disk images."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Dict, Iterator, List, Optional, Tuple
+
+LSBLK_FIELDS = ["NAME", "KNAME", "TYPE", "SIZE", "MODEL", "TRAN"]
+
+
+def _run(command: List[str]) -> subprocess.CompletedProcess:
+    """Run a command and return the completed process."""
+    return subprocess.run(command, check=True, capture_output=True, text=True)
+
+
+def list_devices() -> List[Dict[str, str]]:
+    """Return block devices detected via lsblk."""
+    try:
+        result = _run(["lsblk", "-J", "-o", ",".join(LSBLK_FIELDS)])
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return []
+
+    info = json.loads(result.stdout or "{}")
+    devices: List[Dict[str, str]] = []
+    for block in info.get("blockdevices", []):
+        if block.get("type") != "disk":
+            continue
+        devices.append(
+            {
+                "device": f"/dev/{block.get('kname', block.get('name', ''))}",
+                "name": block.get("name", ""),
+                "size": block.get("size", ""),
+                "model": block.get("model", ""),
+                "transport": block.get("tran", ""),
+            }
+        )
+    return devices
+
+
+def _download(url: str, out: str) -> str:
+    """Download a file to the specified output path."""
+    import urllib.request
+
+    urllib.request.urlretrieve(url, out)
+    return out
+
+
+def verify_sha256(file_path: str, sha256_url: str) -> Tuple[bool, str]:
+    """Fetch the expected SHA256 checksum and compare it with the local file."""
+    import hashlib
+    import urllib.request
+
+    try:
+        expected = (
+            urllib.request.urlopen(sha256_url)
+            .read()
+            .decode()
+            .split()[0]
+            .strip()
+        )
+    except Exception as exc:  # noqa: BLE001 - propagate message via return value
+        return False, f"error: {exc}"
+
+    hasher = hashlib.sha256()
+    with open(file_path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest() == expected, expected
+
+
+def flash(device: str, image_url: str, sha256_url: Optional[str] = None) -> Iterator[str]:
+    """Flash an xz-compressed image to the specified block device."""
+    tmp_dir = tempfile.gettempdir()
+    xz_path = str(Path(tmp_dir) / "blackroad.img.xz")
+
+    yield f"Downloading image: {image_url}"
+    try:
+        _download(image_url, xz_path)
+    except Exception as exc:  # noqa: BLE001
+        yield f"ERROR: download failed ({exc})"
+        return
+
+    yield f"Downloaded to {xz_path}"
+
+    sha_source = sha256_url or os.environ.get("BLACKROAD_SHA256_URL", "").strip()
+    if sha_source:
+        ok, expected = verify_sha256(xz_path, sha_source)
+        if ok:
+            yield f"SHA256 OK: {expected}"
+        else:
+            yield f"WARNING: SHA256 mismatch or unavailable ({expected})"
+
+    dd_cmd = ["dd", f"of={device}", "bs=4M", "conv=fsync", "status=progress"]
+    if os.geteuid() != 0:
+        dd_cmd.insert(0, "sudo")
+
+    yield "Writing image to device..."
+
+    try:
+        with subprocess.Popen(  # noqa: P201
+            ["xzcat", xz_path], stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+        ) as xz_proc:
+            assert xz_proc.stdout is not None
+            with subprocess.Popen(
+                dd_cmd,
+                stdin=xz_proc.stdout,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            ) as dd_proc:
+                xz_proc.stdout.close()
+                assert dd_proc.stdout is not None
+                for line in dd_proc.stdout:
+                    yield line.strip()
+                dd_return = dd_proc.wait()
+            xz_return = xz_proc.wait()
+    except FileNotFoundError as exc:
+        yield f"ERROR: required command missing ({exc})"
+        return
+
+    if dd_return != 0 or xz_return != 0:
+        yield f"ERROR: flashing failed (xz exit {xz_return}, dd exit {dd_return})"
+        return
+
+    yield "Syncing writes..."
+    try:
+        subprocess.run(["sync"], check=True)
+    except subprocess.CalledProcessError:
+        yield "WARNING: sync command reported an error"
+
+    try:
+        Path(xz_path).unlink()
+    except OSError:
+        pass
+
+    yield "Flash complete"

--- a/dashboard.html
+++ b/dashboard.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>BlackRoad Prism Console</title>
+  <style>
+    body { font-family: Arial, sans-serif; background:#0b0d10; color:#f2f5f8; margin:0; padding:20px; }
+    .card { background:#151a21; border-radius:12px; padding:20px; box-shadow:0 12px 30px rgba(0,0,0,0.4); max-width:720px; }
+    .title { font-size:1.4rem; font-weight:bold; margin-bottom:12px; }
+    button { background:#2563eb; border:none; color:#fff; padding:8px 14px; border-radius:6px; cursor:pointer; }
+    button:hover { background:#1d4ed8; }
+    select, input { background:#0f141b; color:#f2f5f8; border:1px solid #1f2937; border-radius:6px; padding:6px; }
+    small { color:#9ca3af; }
+    code { background:#111827; padding:2px 4px; border-radius:4px; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="title">Flasher</div>
+    <div>
+      <button id="listBtn">List Devices</button>
+      <select id="devSel"></select>
+    </div>
+
+    <div style="margin-top:8px;">
+      <button id="loadImgs">Load Known Images</button>
+      <select id="imgSel" style="width:70%"></select>
+    </div>
+
+    <input type="text" id="imgUrl" placeholder="Or paste custom image URL (.xz)" style="width:70%; margin-top:8px">
+
+    <div style="margin-top:8px;">
+      <small>Type device name to confirm (e.g. <code>/dev/sda</code>)</small><br>
+      <input type="text" id="confirmTxt" placeholder="/dev/xxx" style="width:40%">
+    </div>
+
+    <button id="flashBtn" style="margin-top:10px;">Flash</button>
+    <div id="flashLog" style="margin-top:10px;background:#000;color:#0f0;padding:1em;height:180px;overflow:auto;border-radius:6px;"></div>
+  </div>
+
+  <script>
+  const devSel = document.getElementById('devSel');
+  const imgSel = document.getElementById('imgSel');
+  const loadImgs = document.getElementById('loadImgs');
+  const flashBtn = document.getElementById('flashBtn');
+  const imgUrl = document.getElementById('imgUrl');
+  const flog = document.getElementById('flashLog');
+  const confirmTxt = document.getElementById('confirmTxt');
+
+  document.getElementById('listBtn').onclick = async () => {
+    flog.textContent = '';
+    try {
+      const r = await fetch('/flash/devices');
+      const j = await r.json();
+      devSel.innerHTML = '';
+      (j.devices||[]).forEach(d=>{
+        const o=document.createElement('option');
+        o.value=d.device; o.text=`${d.device} ${d.size||''} ${d.model||''}`.trim();
+        devSel.appendChild(o);
+      });
+    } catch (err) {
+      flog.textContent = `Failed to list devices: ${err}`;
+    }
+  };
+
+  loadImgs.onclick = async () => {
+    try {
+      const r = await fetch('/flash/images');
+      const j = await r.json();
+      imgSel.innerHTML = '';
+      (j.images||[]).forEach(im=>{
+        const o=document.createElement('option');
+        o.value=im.url; o.text=im.name; o.dataset.sha = im.sha256 || "";
+        imgSel.appendChild(o);
+      });
+      imgSel.onchange = ()=> { imgUrl.value = imgSel.value; };
+      if (imgSel.options.length > 0) {
+        imgSel.selectedIndex = 0;
+        imgSel.dispatchEvent(new Event('change'));
+      }
+    } catch (err) {
+      flog.textContent = `Failed to load images: ${err}`;
+    }
+  };
+
+  flashBtn.onclick = () => {
+    flog.textContent = '';
+    const d = devSel.value;
+    const selectedIndex = imgSel.selectedIndex;
+    const selected = selectedIndex >= 0 ? imgSel.options[selectedIndex] : null;
+    const sha = selected ? selected.dataset.sha : '';
+    const u = (imgUrl.value || imgSel.value).trim();
+    if(!u || !d){flog.textContent='Select device and image URL'; return;}
+    if(confirmTxt.value.trim() !== d){flog.textContent='Type the device name exactly to confirm.'; return;}
+    const proto = location.protocol === 'https:' ? 'wss':'ws';
+    const ws = new WebSocket(`${proto}://${location.host}/ws/flash`);
+    ws.onopen = ()=> ws.send(JSON.stringify({device:d, image_url:u, sha256_url: sha}));
+    ws.onmessage = ev => { flog.textContent += ev.data + "\n"; flog.scrollTop=flog.scrollHeight; };
+    ws.onerror = () => { flog.textContent += "\nERROR: websocket failure"; };
+  };
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a curated image catalogue endpoint that feeds the dashboard and passes optional checksums to the flasher service
- extend the flashing pipeline with reusable download helpers and SHA256 verification before writing devices
- refresh the dashboard flasher panel with known-image loading, confirm-to-flash safety, and websocket logging

## Testing
- python -m compileall agent

------
https://chatgpt.com/codex/tasks/task_e_68dafc2036c08329b02a1ac4caa3474a