### PR TITLE
feat(agent): add configurable jetson connectivity

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,5 @@
+"""BlackRoad agent service helpers."""
+
+from . import api, config, flash, jobs, telemetry  # noqa: F401
+
+__all__ = ["api", "config", "flash", "jobs", "telemetry"]

--- a/agent/api.py
+++ b/agent/api.py
@@ -1,0 +1,164 @@
+"""FastAPI application exposing BlackRoad agent controls."""
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+from typing import Any, Dict
+
+from fastapi import Body, FastAPI, WebSocket, WebSocketDisconnect
+
+from agent import flash, jobs, telemetry
+from agent.config import active_target, load as load_cfg, set_target
+
+app = FastAPI(title="BlackRoad Agent")
+
+
+class ConnectionManager:
+    """Minimal WebSocket manager for streaming logs."""
+
+    def __init__(self) -> None:
+        self._connections: set[WebSocket] = set()
+
+    async def connect(self, websocket: WebSocket) -> None:
+        await websocket.accept()
+        self._connections.add(websocket)
+
+    def disconnect(self, websocket: WebSocket) -> None:
+        self._connections.discard(websocket)
+
+    async def broadcast(self, message: str) -> None:
+        for ws in list(self._connections):
+            try:
+                await ws.send_text(message)
+            except RuntimeError:
+                self.disconnect(ws)
+
+
+manager = ConnectionManager()
+
+
+@app.websocket("/ws/logs")
+async def logs_websocket(websocket: WebSocket) -> None:
+    """Simple echo socket that allows clients to keep an open channel."""
+    await manager.connect(websocket)
+    try:
+        while True:
+            try:
+                payload = await websocket.receive_text()
+            except RuntimeError:
+                break
+            await manager.broadcast(json.dumps({"echo": payload}))
+    except WebSocketDisconnect:
+        pass
+    finally:
+        manager.disconnect(websocket)
+
+
+@app.get("/settings")
+def get_settings() -> Dict[str, Any]:
+    """Return the active Jetson settings and raw configuration."""
+    host, user = active_target()
+    return {"jetson": {"host": host, "user": user}, "raw": load_cfg()}
+
+
+@app.post("/settings/jetson")
+def set_jetson(jetson: Dict[str, Any] = Body(...)) -> Dict[str, Any]:
+    host = (jetson or {}).get("host")
+    user = (jetson or {}).get("user", "jetson")
+    if not host:
+        return {"ok": False, "error": "host required"}
+    set_target(host, user)
+    return {"ok": True, "jetson": {"host": host, "user": user}}
+
+
+@app.get("/connect/test")
+def connect_test() -> Dict[str, Any]:
+    """Attempt to gather telemetry from the Pi and Jetson."""
+    try:
+        pi = telemetry.collect_local()
+        jetson = telemetry.collect_remote()
+        ok = all(not str(value).startswith("error") for value in jetson.values())
+        return {"ok": ok, "pi": pi, "jetson": jetson}
+    except Exception as exc:  # pragma: no cover - defensive
+        return {"ok": False, "error": str(exc)}
+
+
+@app.post("/connect/install-key")
+def install_key() -> Dict[str, Any]:
+    """Generate an SSH key for the `pi` user and copy it to the Jetson target."""
+    host, user = active_target()
+    home = pathlib.Path("/home/pi")
+    ssh_dir = home / ".ssh"
+    ssh_dir.mkdir(parents=True, exist_ok=True)
+    key_path = ssh_dir / "id_rsa"
+
+    if not key_path.exists():
+        subprocess.run(
+            [
+                "sudo",
+                "-u",
+                "pi",
+                "ssh-keygen",
+                "-t",
+                "rsa",
+                "-N",
+                "",
+                "-f",
+                str(key_path),
+            ],
+            check=True,
+        )
+
+    result = subprocess.call(
+        [
+            "sudo",
+            "-u",
+            "pi",
+            "ssh-copy-id",
+            "-i",
+            f"{key_path}.pub",
+            f"{user}@{host}",
+        ]
+    )
+    note = (
+        "If this returned false, run ssh-copy-id manually in a shell to enter the password."
+    )
+    return {"ok": result == 0, "note": note}
+
+
+@app.get("/telemetry/local")
+def telemetry_local() -> Dict[str, Any]:
+    """Expose local telemetry for the dashboard."""
+    return telemetry.collect_local()
+
+
+@app.get("/telemetry/remote")
+def telemetry_remote(host: str | None = None, user: str | None = None) -> Dict[str, Any]:
+    """Expose remote telemetry, allowing overrides via query parameters."""
+    return telemetry.collect_remote(host=host, user=user)
+
+
+@app.post("/jobs/run")
+def run_job(payload: Dict[str, Any] = Body(...)) -> Dict[str, Any]:
+    """Execute a remote command on the Jetson target."""
+    command = payload.get("command")
+    host = payload.get("host")
+    user = payload.get("user")
+    if not command:
+        return {"ok": False, "error": "command required"}
+    result = jobs.run_remote(command, host=host, user=user)
+    return {
+        "ok": result.returncode == 0,
+        "stdout": (result.stdout or "").strip(),
+        "stderr": (result.stderr or "").strip(),
+    }
+
+
+@app.get("/flash/probe")
+def flash_probe(host: str | None = None, user: str | None = None) -> Dict[str, Any]:
+    """Call the flash probe helper."""
+    return flash.probe(host=host, user=user)
+
+
+__all__ = ["app"]

--- a/agent/config.py
+++ b/agent/config.py
@@ -1,0 +1,55 @@
+"""Persistent configuration store for BlackRoad agent settings."""
+from __future__ import annotations
+
+import os
+import pathlib
+from typing import Tuple
+
+import yaml
+
+CONF_PATH = pathlib.Path(os.getenv("BLACKROAD_CONF", "/etc/blackroad/config.yaml"))
+
+DEFAULTS = {
+    "jetson": {"host": "192.168.4.23", "user": "jetson"},
+}
+
+
+def ensure_dir() -> None:
+    """Ensure the configuration directory exists."""
+    CONF_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def load() -> dict:
+    """Load configuration file, falling back to defaults on error."""
+    try:
+        with open(CONF_PATH, "r", encoding="utf-8") as file:
+            data = yaml.safe_load(file) or {}
+            merged = DEFAULTS.copy()
+            merged.update(data)
+            return merged
+    except Exception:
+        return DEFAULTS.copy()
+
+
+def save(cfg: dict) -> None:
+    """Persist configuration to disk."""
+    ensure_dir()
+    with open(CONF_PATH, "w", encoding="utf-8") as file:
+        yaml.safe_dump(cfg, file, sort_keys=False)
+
+
+def active_target() -> Tuple[str, str]:
+    """Return the currently configured Jetson host and user."""
+    cfg = load()
+    jetson = cfg.get("jetson", {})
+    return (
+        jetson.get("host", DEFAULTS["jetson"]["host"]),
+        jetson.get("user", DEFAULTS["jetson"]["user"]),
+    )
+
+
+def set_target(host: str, user: str) -> None:
+    """Persist a new Jetson target."""
+    cfg = load()
+    cfg["jetson"] = {"host": host, "user": user}
+    save(cfg)

--- a/agent/flash.py
+++ b/agent/flash.py
@@ -1,0 +1,28 @@
+"""Placeholder helpers for firmware/OS flashing routines."""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from agent import jobs
+
+
+def probe(host: Optional[str] = None, user: Optional[str] = None) -> Dict[str, Any]:
+    """Check if the remote target is reachable."""
+    try:
+        result = jobs.run_remote("uname -a", host=host, user=user)
+        ok = result.returncode == 0
+        return {"ok": ok, "output": result.stdout.strip() if ok else result.stderr.strip()}
+    except Exception as exc:  # pragma: no cover - defensive
+        return {"ok": False, "error": str(exc)}
+
+
+def reboot(host: Optional[str] = None, user: Optional[str] = None) -> Dict[str, Any]:
+    """Request a remote reboot. Users must ensure they have sudo rights."""
+    try:
+        result = jobs.run_remote("sudo reboot", host=host, user=user)
+        return {"ok": result.returncode == 0}
+    except Exception as exc:  # pragma: no cover - defensive
+        return {"ok": False, "error": str(exc)}
+
+
+__all__ = ["probe", "reboot"]

--- a/agent/jobs.py
+++ b/agent/jobs.py
@@ -1,0 +1,150 @@
+"""Helpers for executing jobs on the Jetson target over SSH."""
+from __future__ import annotations
+
+import os
+import subprocess
+from typing import Iterator, Mapping, Sequence
+
+from agent.config import active_target
+
+
+def _target() -> tuple[str, str]:
+    env_host = os.getenv("JETSON_HOST")
+    env_user = os.getenv("JETSON_USER")
+    host, user = active_target()
+    if env_host or env_user:
+        return env_host or host, env_user or user
+    return host, user
+
+
+def _resolve(host: str | None, user: str | None) -> tuple[str, str]:
+    default_host, default_user = _target()
+    return host or default_host, user or default_user
+
+
+def _ssh_command(host: str, user: str, command: Sequence[str] | str) -> list[str]:
+    if isinstance(command, str):
+        remote = ["bash", "-lc", command]
+    else:
+        remote = list(command)
+    return [
+        "ssh",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "StrictHostKeyChecking=no",
+        "-o",
+        "UserKnownHostsFile=/dev/null",
+        "-o",
+        "ConnectTimeout=5",
+        f"{user}@{host}",
+        *remote,
+    ]
+
+
+def run_remote(
+    command: Sequence[str] | str,
+    *,
+    host: str | None = None,
+    user: str | None = None,
+    check: bool = False,
+    timeout: int | None = None,
+    env: Mapping[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run a command on the Jetson via SSH."""
+    host, user = _resolve(host, user)
+    ssh_cmd = _ssh_command(host, user, command)
+    return subprocess.run(
+        ssh_cmd,
+        check=check,
+        text=True,
+        capture_output=True,
+        timeout=timeout,
+        env=env,
+    )
+
+
+def stream_remote(
+    command: Sequence[str] | str,
+    *,
+    host: str | None = None,
+    user: str | None = None,
+    timeout: int | None = None,
+) -> Iterator[str]:
+    """Yield lines from a remote command, useful for long-running jobs."""
+    host, user = _resolve(host, user)
+    ssh_cmd = _ssh_command(host, user, command)
+    with subprocess.Popen(
+        ssh_cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    ) as proc:
+        try:
+            while True:
+                line = proc.stdout.readline()
+                if not line:
+                    break
+                yield line.rstrip("\n")
+            proc.wait(timeout=timeout)
+        finally:
+            if proc.poll() is None:
+                proc.terminate()
+
+
+def copy_to_remote(
+    local_path: str,
+    remote_path: str,
+    *,
+    host: str | None = None,
+    user: str | None = None,
+    recursive: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    """Copy a local file or directory to the Jetson target using scp."""
+    host, user = _resolve(host, user)
+    cmd = [
+        "scp",
+        "-o",
+        "StrictHostKeyChecking=no",
+        "-o",
+        "UserKnownHostsFile=/dev/null",
+        "-o",
+        "ConnectTimeout=5",
+    ]
+    if recursive:
+        cmd.append("-r")
+    cmd.extend([local_path, f"{user}@{host}:{remote_path}"])
+    return subprocess.run(cmd, text=True, capture_output=True)
+
+
+def copy_from_remote(
+    remote_path: str,
+    local_path: str,
+    *,
+    host: str | None = None,
+    user: str | None = None,
+    recursive: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    """Copy a remote file or directory from the Jetson target."""
+    host, user = _resolve(host, user)
+    cmd = [
+        "scp",
+        "-o",
+        "StrictHostKeyChecking=no",
+        "-o",
+        "UserKnownHostsFile=/dev/null",
+        "-o",
+        "ConnectTimeout=5",
+    ]
+    if recursive:
+        cmd.append("-r")
+    cmd.extend([f"{user}@{host}:{remote_path}", local_path])
+    return subprocess.run(cmd, text=True, capture_output=True)
+
+
+__all__ = [
+    "run_remote",
+    "stream_remote",
+    "copy_to_remote",
+    "copy_from_remote",
+]

--- a/agent/telemetry.py
+++ b/agent/telemetry.py
@@ -1,0 +1,139 @@
+"""Telemetry helpers for Raspberry Pi and Jetson targets."""
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+from pathlib import Path
+from typing import Dict, Mapping, Sequence
+
+from agent.config import active_target
+
+CommandMap = Mapping[str, Sequence[str] | str]
+
+
+def _target() -> tuple[str, str]:
+    """Return the preferred Jetson target considering environment overrides."""
+    env_host = os.getenv("JETSON_HOST")
+    env_user = os.getenv("JETSON_USER")
+    host, user = active_target()
+    if env_host or env_user:
+        return env_host or host, env_user or user
+    return host, user
+
+
+def _run_command(cmd: Sequence[str], timeout: int = 10) -> str:
+    """Execute a command and return stripped stdout or an error prefix."""
+    try:
+        out = subprocess.check_output(
+            cmd,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=timeout,
+        )
+        return out.strip()
+    except FileNotFoundError:
+        return f"error: command not found: {cmd[0]}"
+    except subprocess.TimeoutExpired:
+        return "error: timeout"
+    except subprocess.CalledProcessError as exc:
+        output = exc.output.strip() if exc.output else str(exc)
+        return f"error: {output or exc.returncode}"
+
+
+def _collect(commands: CommandMap) -> Dict[str, str]:
+    return {name: _run_command(_ensure_sequence(cmd)) for name, cmd in commands.items()}
+
+
+def _ensure_sequence(cmd: Sequence[str] | str) -> Sequence[str]:
+    if isinstance(cmd, str):
+        return shlex.split(cmd)
+    return list(cmd)
+
+
+def _ssh_command(host: str, user: str, command: Sequence[str] | str) -> Sequence[str]:
+    if isinstance(command, str):
+        remote = ["bash", "-lc", command]
+    else:
+        remote = list(command)
+    return [
+        "ssh",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "StrictHostKeyChecking=no",
+        "-o",
+        "UserKnownHostsFile=/dev/null",
+        "-o",
+        "ConnectTimeout=5",
+        f"{user}@{host}",
+        *remote,
+    ]
+
+
+LOCAL_COMMANDS: Dict[str, Sequence[str] | str] = {
+    "hostname": ["hostname"],
+    "uptime": ["uptime", "-p"],
+    "loadavg": ["cat", "/proc/loadavg"],
+    "disk_root": ["df", "-h", "/"],
+    "memory": ["free", "-m"],
+}
+
+REMOTE_COMMANDS: Dict[str, Sequence[str] | str] = {
+    "hostname": "hostname",
+    "uptime": "uptime -p",
+    "loadavg": "cat /proc/loadavg",
+    "disk_root": "df -h /",
+    "memory": "free -m",
+    "gpu": "command -v tegrastats >/dev/null 2>&1 && tegrastats --interval 1000 --count 1 | head -n 1 || echo 'tegrastats unavailable'",
+}
+
+
+def collect_local(extra_commands: CommandMap | None = None) -> Dict[str, str]:
+    """Return a dictionary of local telemetry data."""
+    commands: Dict[str, Sequence[str] | str] = dict(LOCAL_COMMANDS)
+    if extra_commands:
+        commands.update(extra_commands)
+
+    results = _collect(commands)
+
+    # Attach CPU temperature if available via sysfs (common on Pi)
+    thermal_path = Path("/sys/class/thermal/thermal_zone0/temp")
+    if thermal_path.exists():
+        try:
+            raw = thermal_path.read_text().strip()
+            if raw:
+                results.setdefault("cpu_temp_c", f"{float(raw) / 1000.0:.1f}")
+        except Exception:
+            results.setdefault("cpu_temp_c", "error: read failure")
+    else:
+        temp_result = _run_command(["vcgencmd", "measure_temp"])
+        if not temp_result.startswith("error"):
+            results.setdefault("cpu_temp", temp_result)
+    return results
+
+
+def collect_remote(
+    host: str | None = None,
+    user: str | None = None,
+    commands: CommandMap | None = None,
+) -> Dict[str, str]:
+    """Gather telemetry from the remote Jetson via SSH."""
+    default_host, default_user = _target()
+    host = host or default_host
+    user = user or default_user
+    command_map: Dict[str, Sequence[str] | str] = dict(REMOTE_COMMANDS)
+    if commands:
+        command_map.update(commands)
+
+    results: Dict[str, str] = {}
+    for name, command in command_map.items():
+        ssh_cmd = _ssh_command(host, user, command)
+        results[name] = _run_command(ssh_cmd, timeout=20)
+    return results
+
+
+__all__ = [
+    "collect_local",
+    "collect_remote",
+]

--- a/agent/templates/dashboard.html
+++ b/agent/templates/dashboard.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>BlackRoad Agent Dashboard</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        background: #0f1115;
+        color: #f3f6ff;
+        margin: 0;
+        padding: 24px;
+      }
+      .title {
+        font-size: 20px;
+        font-weight: 600;
+        margin-bottom: 12px;
+      }
+      .card {
+        background: rgba(255, 255, 255, 0.04);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        border-radius: 12px;
+        padding: 16px;
+        margin-bottom: 24px;
+        box-shadow: 0 12px 32px rgba(0, 0, 0, 0.4);
+      }
+      input[type="text"] {
+        background: rgba(255, 255, 255, 0.1);
+        border: 1px solid rgba(255, 255, 255, 0.2);
+        border-radius: 6px;
+        color: #f3f6ff;
+        padding: 8px 10px;
+      }
+      button {
+        background: linear-gradient(135deg, #4f46e5, #7c3aed);
+        border: none;
+        color: #fff;
+        padding: 8px 14px;
+        border-radius: 6px;
+        cursor: pointer;
+        transition: transform 0.1s ease;
+      }
+      button:hover {
+        transform: translateY(-1px);
+      }
+      pre {
+        background: rgba(0, 0, 0, 0.35);
+        border-radius: 8px;
+        padding: 12px;
+        overflow-x: auto;
+        max-height: 320px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>BlackRoad Brainstem</h1>
+    <div class="card">
+      <div class="title">Settings</div>
+      <div style="display:flex; gap:8px; align-items:center; flex-wrap:wrap;">
+        <label>Jetson host:</label><input id="host" type="text" placeholder="192.168.4.23" />
+        <label>User:</label><input id="user" type="text" value="jetson" style="width:120px" />
+        <button id="saveBtn">Save</button>
+        <button id="testBtn">Test Connection</button>
+        <button id="keyBtn">Install SSH Key</button>
+      </div>
+      <pre id="settingsLog"></pre>
+    </div>
+
+    <script>
+      async function loadSettings() {
+        const r = await fetch('/settings');
+        const j = await r.json();
+        document.getElementById('host').value = j.jetson.host;
+        document.getElementById('user').value = j.jetson.user;
+        document.getElementById('settingsLog').textContent = JSON.stringify(j.raw, null, 2);
+      }
+      document.addEventListener('DOMContentLoaded', () => {
+        loadSettings();
+        document.getElementById('saveBtn').onclick = async () => {
+          const host = document.getElementById('host').value.trim();
+          const user = document.getElementById('user').value.trim() || 'jetson';
+          const r = await fetch('/settings/jetson', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ host, user })
+          });
+          document.getElementById('settingsLog').textContent = await r.text();
+        };
+        document.getElementById('testBtn').onclick = async () => {
+          const r = await fetch('/connect/test');
+          document.getElementById('settingsLog').textContent = await r.text();
+        };
+        document.getElementById('keyBtn').onclick = async () => {
+          const r = await fetch('/connect/install-key', { method: 'POST' });
+          document.getElementById('settingsLog').textContent = await r.text();
+        };
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- introduce an `agent` package with a YAML-backed config store for Jetson targets and reusable SSH helpers
- expose FastAPI endpoints for settings management, connectivity tests, remote jobs, and flash probes that honour the stored target
- add a dashboard Settings card with save/test/install-key controls powered by the new API

## Testing
- python -m compileall agent

------
https://chatgpt.com/codex/tasks/task_e_68dafc64f7f88329990a03f52d0b88f0