### PR TITLE
Add LAN discovery and target selection panel

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,3 @@
+"""BlackRoad device agent package."""
+
+__all__ = ["api", "config", "discover"]

--- a/agent/api.py
+++ b/agent/api.py
@@ -1,0 +1,57 @@
+"""FastAPI surface for the BlackRoad device dashboard."""
+
+from pathlib import Path
+from typing import Any, Dict
+
+from fastapi import Body, FastAPI, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+
+from agent import discover
+from agent.config import DEFAULT_USER, active_target, set_target
+
+app = FastAPI(title="BlackRoad Device Agent")
+
+templates = Jinja2Templates(directory=str(Path(__file__).parent / "templates"))
+
+
+@app.get("/", response_class=HTMLResponse)
+def dashboard(request: Request) -> HTMLResponse:
+    context: Dict[str, Any] = {
+        "request": request,
+        "target": active_target(),
+    }
+    return templates.TemplateResponse("dashboard.html", context)
+
+
+@app.get("/discover/scan")
+def discover_scan() -> Dict[str, Any]:
+    return discover.scan()
+
+
+@app.post("/discover/set")
+def discover_set(payload: Dict[str, Any] = Body(...)) -> Dict[str, Any]:
+    host = payload.get("host")
+    user = payload.get("user", DEFAULT_USER)
+    if not host:
+        return {"ok": False, "error": "host required"}
+    try:
+        set_target(host, user)
+    except ValueError as exc:
+        return {"ok": False, "error": str(exc)}
+    except OSError as exc:
+        return {"ok": False, "error": str(exc)}
+    except Exception:
+        return {"ok": False, "error": "failed to update target"}
+    return {"ok": True, "jetson": {"host": host, "user": user}}
+
+
+@app.get("/discover/target")
+def get_target() -> Dict[str, Any]:
+    target = active_target()
+    if not target:
+        return {"ok": False, "jetson": None}
+    return {"ok": True, "jetson": target}
+
+
+__all__ = ["app"]

--- a/agent/config.py
+++ b/agent/config.py
@@ -1,0 +1,72 @@
+"""Configuration helpers for tracking the active Jetson target."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import yaml
+
+DEFAULT_USER = "jetson"
+CONFIG_ENV_VAR = "BLACKROAD_CONFIG"
+DEFAULT_CONFIG_PATH = Path("/etc/blackroad/config.yaml")
+
+
+def _config_path() -> Path:
+    """Resolve the configuration path, honoring overrides."""
+    env_path = os.environ.get(CONFIG_ENV_VAR)
+    if env_path:
+        return Path(env_path)
+    return DEFAULT_CONFIG_PATH
+
+
+def _load_config() -> Dict[str, Any]:
+    path = _config_path()
+    if not path.exists():
+        return {}
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+            if isinstance(data, dict):
+                return data
+    except yaml.YAMLError:
+        # Corrupt YAML shouldn't crash the dashboard; treat as empty.
+        return {}
+    except OSError:
+        return {}
+    return {}
+
+
+def _write_config(data: Dict[str, Any]) -> None:
+    path = _config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    with tmp_path.open("w", encoding="utf-8") as fh:
+        yaml.safe_dump(data, fh, sort_keys=True)
+    tmp_path.replace(path)
+
+
+def active_target() -> Optional[Dict[str, str]]:
+    cfg = _load_config()
+    target = cfg.get("jetson") if isinstance(cfg, dict) else None
+    if isinstance(target, dict):
+        host = target.get("host")
+        user = target.get("user", DEFAULT_USER)
+        if host:
+            return {"host": host, "user": user}
+    return None
+
+
+def set_target(host: str, user: str = DEFAULT_USER) -> None:
+    if not host:
+        raise ValueError("host must be provided")
+    user = user or DEFAULT_USER
+    cfg = _load_config()
+    if not isinstance(cfg, dict):
+        cfg = {}
+    cfg["jetson"] = {"host": host, "user": user}
+    _write_config(cfg)
+
+
+__all__ = ["active_target", "set_target", "DEFAULT_USER"]

--- a/agent/discover.py
+++ b/agent/discover.py
@@ -1,0 +1,89 @@
+import ipaddress
+import subprocess
+import shlex
+
+
+def _run(cmd):
+    try:
+        return subprocess.check_output(shlex.split(cmd), text=True).strip()
+    except Exception:
+        return ""
+
+
+def _subnet():
+    # grab first IPv4 interface that's UP and not loopback
+    lines = _run("ip -br -4 addr").splitlines()
+    for ln in lines:
+        parts = ln.split()
+        if len(parts) >= 3 and parts[0] != "lo":
+            cidr = parts[2]        # e.g. 192.168.4.12/24
+            return ipaddress.ip_interface(cidr).network
+    return None
+
+
+def _ping(ip):
+    try:
+        subprocess.check_output(["ping", "-c", "1", "-W", "1", str(ip)],
+                                stderr=subprocess.DEVNULL)
+        return True
+    except Exception:
+        return False
+
+
+def _mdns_name(ip):
+    # try avahi-resolve (if present)
+    out = _run(f"avahi-resolve -a {ip}")
+    if out and " " in out:
+        return out.split(" ", 1)[1].strip()
+    return ""
+
+
+def _ssh_ok(ip, user="jetson"):
+    try:
+        subprocess.check_output(
+            ["ssh", "-o", "ConnectTimeout=1", "-o", "BatchMode=yes", f"{user}@{ip}", "true"],
+            stderr=subprocess.DEVNULL
+        )
+        return True
+    except Exception:
+        return False
+
+
+def _is_jetson(ip, user="jetson"):
+    try:
+        out = subprocess.check_output(
+            ["ssh", "-o", "ConnectTimeout=2", f"{user}@{ip}",
+             "uname -a && command -v nvidia-smi >/dev/null && nvidia-smi --query-gpu=name --format=csv,noheader || echo no-gpu"],
+            text=True, stderr=subprocess.DEVNULL
+        )
+        return "no-gpu" not in out
+    except Exception:
+        return False
+
+
+def scan():
+    net = _subnet()
+    if not net:
+        return {"error": "no subnet"}
+    hosts = []
+    for ip in net.hosts():
+        ip_s = str(ip)
+        if not _ping(ip_s):
+            continue
+        name = _mdns_name(ip_s)
+        ssh_jetson = _ssh_ok(ip_s)
+        ssh_ubuntu = _ssh_ok(ip_s, "ubuntu")
+        ssh_nvidia = _ssh_ok(ip_s, "nvidia")
+        ssh = ssh_jetson or ssh_ubuntu or ssh_nvidia
+        kind = "unknown"
+        is_jetson = False
+        if ssh:
+            if ssh_jetson and _is_jetson(ip_s, "jetson"):
+                is_jetson = True
+            elif ssh_ubuntu and _is_jetson(ip_s, "ubuntu"):
+                is_jetson = True
+            elif ssh_nvidia and _is_jetson(ip_s, "nvidia"):
+                is_jetson = True
+            kind = "jetson" if is_jetson else "ssh"
+        hosts.append({"ip": ip_s, "name": name, "ssh": ssh, "kind": kind})
+    return {"network": str(net), "hosts": hosts}

--- a/agent/templates/dashboard.html
+++ b/agent/templates/dashboard.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>BlackRoad Device Dashboard</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 0; padding: 24px; background: #0f172a; color: #e2e8f0; }
+    h1 { margin-bottom: 16px; }
+    .status { margin-bottom: 24px; display: flex; align-items: center; gap: 8px; }
+    .status button { padding: 6px 12px; background: #22d3ee; border: none; border-radius: 4px; cursor: pointer; color: #0f172a; font-weight: 600; }
+    .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 16px; }
+    .card { background: #1e293b; border-radius: 12px; padding: 16px; box-shadow: 0 6px 16px rgba(15, 23, 42, 0.4); }
+    .title { font-size: 18px; font-weight: 600; margin-bottom: 12px; }
+    button { cursor: pointer; padding: 8px 12px; background: #38bdf8; color: #0f172a; border: none; border-radius: 6px; font-weight: 600; }
+    button:hover { background: #0ea5e9; }
+    table { border-collapse: collapse; width: 100%; }
+    th, td { border-bottom: 1px solid rgba(148, 163, 184, 0.2); padding: 6px 4px; }
+    th { text-transform: uppercase; font-size: 12px; color: #94a3b8; }
+    tbody tr:hover { background: rgba(148, 163, 184, 0.12); }
+    small { color: #94a3b8; }
+  </style>
+</head>
+<body>
+  <h1>BlackRoad Device Dashboard</h1>
+  <div class="status">
+    <strong>Active Target:</strong>
+    <span id="targetInfo">
+      {% if target %}
+        {{ target.host }} ({{ target.user }})
+      {% else %}
+        None configured
+      {% endif %}
+    </span>
+    <button id="refreshTarget">Refresh</button>
+  </div>
+
+  <div class="grid">
+    <div class="card">
+      <div class="title">Discover Devices</div>
+      <button id="scanBtn">Scan LAN</button>
+      <div id="scanLog"><small>Finds hosts on your subnet via ping + mDNS, then probes for SSH and Jetson.</small></div>
+      <table id="scanTable" style="width:100%; margin-top:8px;">
+        <thead><tr><th align="left">IP</th><th align="left">Name</th><th align="left">Kind</th><th align="left">SSH</th><th></th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </div>
+
+    <div class="card" id="flasherCard">
+      <div class="title">Flasher</div>
+      <p><small>Firmware flashing controls coming soon.</small></p>
+    </div>
+  </div>
+
+  <script>
+  const scanBtn = document.getElementById('scanBtn');
+  const scanLog = document.getElementById('scanLog');
+  const scanBody = document.querySelector('#scanTable tbody');
+  const targetInfo = document.getElementById('targetInfo');
+  const refreshBtn = document.getElementById('refreshTarget');
+
+  const initialTarget = {{ target | tojson | safe }};
+
+  function updateTargetDisplay(target) {
+    if (target && target.host) {
+      targetInfo.textContent = `${target.host} (${target.user || 'jetson'})`;
+    } else {
+      targetInfo.textContent = 'None configured';
+    }
+  }
+
+  async function refreshTarget() {
+    try {
+      const r = await fetch('/discover/target');
+      const j = await r.json();
+      if (j.ok && j.jetson) {
+        updateTargetDisplay(j.jetson);
+      } else {
+        updateTargetDisplay(null);
+      }
+    } catch (err) {
+      console.error('Failed to refresh target', err);
+    }
+  }
+
+  scanBtn.onclick = async () => {
+    scanLog.textContent = 'Scanning… (takes ~15–45s)';
+    const r = await fetch('/discover/scan'); const j = await r.json();
+    scanLog.textContent = `Network: ${j.network || 'unknown'} • Found: ${(j.hosts||[]).length}`;
+    scanBody.innerHTML = '';
+    (j.hosts||[]).forEach(h=>{
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td>${h.ip}</td>
+        <td>${h.name || '-'}</td>
+        <td>${h.kind}</td>
+        <td>${h.ssh ? 'yes' : 'no'}</td>
+        <td><button data-ip="${h.ip}">Set as target</button></td>`;
+      tr.querySelector('button').onclick = async (ev)=>{
+        const ip = ev.target.dataset.ip;
+        const r = await fetch('/discover/set',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({host:ip,user:'jetson'})});
+        const t = await r.json();
+        if (t.ok) {
+          alert(`Target set to ${ip}`);
+          updateTargetDisplay(t.jetson);
+        } else {
+          alert(`Failed: ${t.error || 'unknown'}`);
+        }
+      };
+      scanBody.appendChild(tr);
+    });
+  };
+
+  refreshBtn.onclick = refreshTarget;
+  updateTargetDisplay(initialTarget);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a discovery module that pings the local subnet, inspects mDNS, and probes SSH/Jetson capabilities
- extend the device agent API with discovery scan/set routes and a target lookup helper
- update the dashboard template with a discovery card and wiring to set the active target

## Testing
- python -m compileall agent

------
https://chatgpt.com/codex/tasks/task_e_68dafcf8d6ac8329a91f356b21fa03ef