### PR TITLE
feat(prism): add resilient job runner service

### DIFF
--- a/apps/prism/server/__init__.py
+++ b/apps/prism/server/__init__.py
@@ -1,0 +1,5 @@
+"""Prism console server package."""
+
+from .main import app
+
+__all__ = ["app"]

--- a/apps/prism/server/agent/__init__.py
+++ b/apps/prism/server/agent/__init__.py
@@ -1,0 +1,5 @@
+"""Prism console agent helpers."""
+
+from . import jobs, store
+
+__all__ = ["jobs", "store"]

--- a/apps/prism/server/agent/jobs.py
+++ b/apps/prism/server/agent/jobs.py
@@ -1,0 +1,82 @@
+"""Job execution helpers for the Prism console agent."""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import subprocess
+from typing import Iterable, Iterator, List
+
+
+def _build_ssh_command(command: str) -> List[str]:
+    host = os.getenv("BLACKROAD_REMOTE_HOST")
+    if not host:
+        return []
+
+    user = os.getenv("BLACKROAD_REMOTE_USER")
+    port = os.getenv("BLACKROAD_REMOTE_PORT")
+    identity = os.getenv("BLACKROAD_REMOTE_IDENTITY")
+
+    dest = f"{user}@{host}" if user else host
+    ssh_cmd: List[str] = [
+        os.getenv("BLACKROAD_SSH_BIN", "ssh"),
+        "-o",
+        "BatchMode=yes",
+    ]
+    if port:
+        ssh_cmd.extend(["-p", str(port)])
+    if identity:
+        ssh_cmd.extend(["-i", identity])
+    ssh_cmd.append(dest)
+
+    remote_shell = os.getenv("BLACKROAD_REMOTE_SHELL")
+    if remote_shell:
+        ssh_cmd.extend([remote_shell, "-lc", command])
+    else:
+        ssh_cmd.append(command)
+    return ssh_cmd
+
+
+def _build_local_command(command: str) -> List[str]:
+    shell = os.getenv("BLACKROAD_LOCAL_SHELL")
+    if shell:
+        return [shell, "-lc", command]
+    return ["/bin/bash", "-lc", command] if os.path.exists("/bin/bash") else ["sh", "-c", command]
+
+
+def _iter_process_lines(proc: subprocess.Popen[str]) -> Iterator[str]:
+    assert proc.stdout is not None
+    for raw_line in iter(proc.stdout.readline, ""):
+        yield raw_line.rstrip("\n")
+
+
+def run_remote_stream(command: str) -> Iterable[str]:
+    """Execute ``command`` locally or over SSH and yield output lines."""
+    if not command.strip():
+        raise ValueError("command must not be empty")
+
+    ssh_cmd = _build_ssh_command(command)
+    if ssh_cmd:
+        popen_args = ssh_cmd
+    else:
+        popen_args = _build_local_command(command)
+
+    proc = subprocess.Popen(  # noqa: S603
+        popen_args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+        universal_newlines=True,
+    )
+    try:
+        yield from _iter_process_lines(proc)
+        returncode = proc.wait()
+        if returncode:
+            raise RuntimeError(f"command exited with status {returncode}")
+    finally:
+        with contextlib.suppress(Exception):
+            proc.stdout and proc.stdout.close()
+        with contextlib.suppress(Exception):
+            if proc.poll() is None:
+                proc.kill()

--- a/apps/prism/server/agent/store.py
+++ b/apps/prism/server/agent/store.py
@@ -1,0 +1,134 @@
+"""SQLite-backed job store for the Prism console agent."""
+
+from __future__ import annotations
+
+import pathlib
+import sqlite3
+import threading
+import time
+from typing import Any, Dict, List, Optional
+
+DB = pathlib.Path("/var/lib/blackroad/jobs.sqlite")
+DB.parent.mkdir(parents=True, exist_ok=True)
+
+_lock = threading.Lock()
+_conn_singleton: Optional[sqlite3.Connection] = None
+
+
+def _get_conn() -> sqlite3.Connection:
+    """Return the singleton SQLite connection configured for concurrency."""
+    global _conn_singleton
+    if _conn_singleton is None:
+        conn = sqlite3.connect(DB, check_same_thread=False)
+        conn.execute("PRAGMA journal_mode=WAL;")
+        conn.execute("PRAGMA synchronous=NORMAL;")
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS jobs(
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                cmd TEXT NOT NULL,
+                started REAL NOT NULL,
+                ended REAL,
+                status TEXT NOT NULL,
+                output TEXT
+            )
+            """
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_jobs_started ON jobs(started DESC)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_jobs_status ON jobs(status)"
+        )
+        conn.commit()
+        _conn_singleton = conn
+    return _conn_singleton
+
+
+def new_job(cmd: str) -> int:
+    """Create a new job record and return its identifier."""
+    with _lock:
+        conn = _get_conn()
+        cur = conn.execute(
+            "INSERT INTO jobs(cmd, started, status, output) VALUES(?, ?, ?, ?)",
+            (cmd, time.time(), "running", ""),
+        )
+        conn.commit()
+        return int(cur.lastrowid)
+
+
+def append(job_id: int, text: str, max_bytes: int = 256 * 1024) -> None:
+    """Append log output to a job while trimming to the newest ``max_bytes``."""
+    if max_bytes <= 0:
+        raise ValueError("max_bytes must be positive")
+
+    with _lock:
+        conn = _get_conn()
+        start = -int(max_bytes)
+        conn.execute(
+            """
+            UPDATE jobs
+               SET output = substr(COALESCE(output, '') || ?, ?)
+             WHERE id = ?
+            """,
+            (text, start, job_id),
+        )
+        conn.commit()
+
+
+def finish(job_id: int, status: str) -> None:
+    """Mark a job as finished with the provided status."""
+    with _lock:
+        conn = _get_conn()
+        conn.execute(
+            "UPDATE jobs SET ended = ?, status = ? WHERE id = ?",
+            (time.time(), status, job_id),
+        )
+        conn.commit()
+
+
+def list_jobs(limit: int = 20) -> List[Dict[str, Any]]:
+    """Return the newest jobs limited by ``limit``."""
+    conn = _get_conn()
+    rows = conn.execute(
+        """
+        SELECT id, cmd, started, ended, status
+          FROM jobs
+         ORDER BY id DESC
+         LIMIT ?
+        """,
+        (int(limit),),
+    ).fetchall()
+    return [
+        {
+            "id": row[0],
+            "cmd": row[1],
+            "started": row[2],
+            "ended": row[3],
+            "status": row[4],
+        }
+        for row in rows
+    ]
+
+
+def get_job(job_id: int) -> Optional[Dict[str, Any]]:
+    """Fetch a single job by identifier."""
+    conn = _get_conn()
+    row = conn.execute(
+        """
+        SELECT id, cmd, started, ended, status, output
+          FROM jobs
+         WHERE id = ?
+        """,
+        (job_id,),
+    ).fetchone()
+    if not row:
+        return None
+    return {
+        "id": row[0],
+        "cmd": row[1],
+        "started": row[2],
+        "ended": row[3],
+        "status": row[4],
+        "output": row[5] or "",
+    }

--- a/apps/prism/server/main.py
+++ b/apps/prism/server/main.py
@@ -1,0 +1,60 @@
+"""FastAPI service powering the BlackRoad Prism console job runner."""
+
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect
+from starlette.websockets import WebSocketState
+
+from .agent import jobs, store
+
+app = FastAPI(title="BlackRoad Prism Console API")
+
+
+@app.get("/jobs")
+def list_jobs(limit: int = 20) -> List[dict]:
+    """Return the most recent jobs."""
+    safe_limit = max(1, min(int(limit), 200))
+    return store.list_jobs(limit=safe_limit)
+
+
+@app.get("/jobs/{job_id}")
+def get_job(job_id: int) -> dict:
+    """Return details for a specific job."""
+    job = store.get_job(job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="job not found")
+    return job
+
+
+@app.websocket("/ws/run")
+async def ws_run(websocket: WebSocket) -> None:
+    await websocket.accept()
+    jid: int | None = None
+    try:
+        cmd = await websocket.receive_text()
+        if not cmd.strip():
+            await websocket.send_text("[error] command required")
+            return
+        jid = store.new_job(cmd)
+        await websocket.send_text(f"[[BLACKROAD_JOB_ID:{jid}]]")
+
+        for line in jobs.run_remote_stream(command=cmd):
+            payload = line if line.endswith("\n") else f"{line}\n"
+            store.append(jid, payload)
+            await websocket.send_text(line)
+
+        store.finish(jid, "ok")
+        await websocket.send_text("[[BLACKROAD_DONE]]")
+    except WebSocketDisconnect:
+        if jid is not None:
+            store.finish(jid, "disconnected")
+    except Exception as exc:  # noqa: BLE001
+        if jid is not None:
+            store.finish(jid, f"error: {exc}")
+        if websocket.application_state == WebSocketState.CONNECTED:
+            await websocket.send_text(f"[error] {exc}")
+    finally:
+        if websocket.application_state == WebSocketState.CONNECTED:
+            await websocket.close()


### PR DESCRIPTION
## Summary
- add a FastAPI Prism console service with job listing and streaming run websocket
- implement a concurrency-safe SQLite job store with WAL mode and capped log retention
- add a job execution helper that streams local or SSH command output to the store

## Testing
- python -m py_compile apps/prism/server/main.py apps/prism/server/agent/*.py

------
https://chatgpt.com/codex/tasks/task_e_68dafd841c0c832986ae9178cec3722b