### PR TITLE
feat: add remote job control with stop support

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,5 @@
+"""Agent utilities for remote job orchestration."""
+
+from . import jobs, store  # noqa: F401
+
+__all__ = ["jobs", "store"]

--- a/agent/jobs.py
+++ b/agent/jobs.py
@@ -1,0 +1,158 @@
+"""Remote job execution helpers for Jetson hosts."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+from typing import Dict, Generator
+
+JETSON_HOST = os.getenv("JETSON_HOST", "jetson.local")
+JETSON_USER = os.getenv("JETSON_USER", "jetson")
+
+
+def _host_user(host: str | None = None, user: str | None = None) -> tuple[str, str]:
+    """Resolve the host and user, falling back to defaults."""
+
+    return (host or JETSON_HOST, user or JETSON_USER)
+
+
+def run_remote_stream(
+    host: str | None = None,
+    command: str = "",
+    user: str | None = None,
+) -> Generator[str, None, None]:
+    """Legacy helper that streams a one-shot remote command."""
+
+    host, user = _host_user(host, user)
+    proc = subprocess.Popen(
+        ["ssh", f"{user}@{host}", command],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+    try:
+        if proc.stdout is None:  # pragma: no cover - defensive guard
+            return
+        for line in proc.stdout:
+            yield line.rstrip("\n")
+    finally:
+        if proc.stdout is not None:
+            proc.stdout.close()
+        proc.wait()
+
+
+def start_remote_logged(
+    jid: int,
+    command: str,
+    host: str | None = None,
+    user: str | None = None,
+) -> Dict[str, object]:
+    """Start a remote job detached from SSH and capture PID/log paths."""
+
+    host, user = _host_user(host, user)
+    log = f"/tmp/blackroad_job_{jid}.log"
+    pidf = f"/tmp/blackroad_job_{jid}.pid"
+    quoted_cmd = shlex.quote(f"exec setsid bash -lc '{command}'")
+    remote = (
+        "bash -lc 'set -m; "
+        f"rm -f {shlex.quote(log)} {shlex.quote(pidf)}; "
+        f"nohup bash -lc {quoted_cmd} "
+        f"> {shlex.quote(log)} 2>&1 & echo $! > {shlex.quote(pidf)}; "
+        f"disown; sleep 0.2; cat {shlex.quote(pidf)}'"
+    )
+    pid = subprocess.check_output(["ssh", f"{user}@{host}", remote], text=True).strip()
+    return {"pid": int(pid), "log": log, "pidfile": pidf}
+
+
+def tail_remote_log(
+    log_path: str,
+    host: str | None = None,
+    user: str | None = None,
+) -> Generator[str, None, None]:
+    """Stream a remote logfile until EOF (caller decides when to stop)."""
+
+    host, user = _host_user(host, user)
+    cmd = [
+        "ssh",
+        f"{user}@{host}",
+        "bash",
+        "-lc",
+        f"tail -n +1 -F {shlex.quote(log_path)}",
+    ]
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+    try:
+        if proc.stdout is None:  # pragma: no cover - defensive guard
+            return
+        for line in proc.stdout:
+            yield line.rstrip("\n")
+    finally:
+        if proc.stdout is not None:
+            proc.stdout.close()
+        proc.terminate()
+        try:
+            proc.wait(timeout=2)
+        except Exception:
+            proc.kill()
+
+
+def remote_is_running(
+    jid: int,
+    host: str | None = None,
+    user: str | None = None,
+) -> bool:
+    """Return True if the PID recorded for ``jid`` is still alive."""
+
+    host, user = _host_user(host, user)
+    pidf = f"/tmp/blackroad_job_{jid}.pid"
+    try:
+        out = subprocess.check_output(
+            [
+                "ssh",
+                f"{user}@{host}",
+                "bash",
+                "-lc",
+                "pid=$(cat {pid} 2>/dev/null || echo); "
+                'test -n "$pid" && kill -0 $pid 2>/dev/null && echo RUN || echo DEAD'
+                .format(pid=shlex.quote(pidf)),
+            ],
+            text=True,
+        ).strip()
+        return out == "RUN"
+    except Exception:
+        return False
+
+
+def remote_kill(
+    jid: int,
+    host: str | None = None,
+    user: str | None = None,
+    sig: str = "TERM",
+) -> bool:
+    """Send ``sig`` to the remote process associated with ``jid``."""
+
+    host, user = _host_user(host, user)
+    pidf = f"/tmp/blackroad_job_{jid}.pid"
+    try:
+        subprocess.check_call(
+            [
+                "ssh",
+                f"{user}@{host}",
+                "bash",
+                "-lc",
+                "pid=$(cat {pid} 2>/dev/null || echo); "
+                'test -n "$pid" && kill -s {sig} $pid 2>/dev/null || true'.format(
+                    pid=shlex.quote(pidf), sig=shlex.quote(sig)
+                ),
+            ]
+        )
+        return True
+    except Exception:
+        return False

--- a/agent/store.py
+++ b/agent/store.py
@@ -1,0 +1,77 @@
+"""SQLite-backed job store for the dashboard."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import threading
+import time
+from pathlib import Path
+
+_DB_PATH = Path(os.getenv("BLACKROAD_DASHBOARD_DB", "/tmp/blackroad_dashboard.db"))
+_LOCK = threading.Lock()
+
+
+def _ensure_schema() -> None:
+    _DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(_DB_PATH) as conn:
+        conn.executescript(
+            """
+            PRAGMA journal_mode=WAL;
+            CREATE TABLE IF NOT EXISTS jobs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                command TEXT NOT NULL,
+                status TEXT NOT NULL,
+                log TEXT DEFAULT '',
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL,
+                finished_at REAL
+            );
+            """
+        )
+
+
+_ensure_schema()
+
+
+def _execute(sql: str, params: tuple[object, ...]) -> None:
+    with sqlite3.connect(_DB_PATH) as conn:
+        conn.execute(sql, params)
+        conn.commit()
+
+
+def new_job(command: str) -> int:
+    """Record a newly started job and return its identifier."""
+
+    now = time.time()
+    with _LOCK, sqlite3.connect(_DB_PATH) as conn:
+        cur = conn.execute(
+            "INSERT INTO jobs(command, status, log, created_at, updated_at) VALUES(?,?,?,?,?)",
+            (command, "running", "", now, now),
+        )
+        conn.commit()
+        return int(cur.lastrowid)
+
+
+def append(jid: int, data: str) -> None:
+    """Append log ``data`` to the job's aggregated log buffer."""
+
+    if not data:
+        return
+    now = time.time()
+    with _LOCK:
+        _execute(
+            "UPDATE jobs SET log = COALESCE(log, '') || ?, updated_at=? WHERE id=?",
+            (data, now, jid),
+        )
+
+
+def finish(jid: int, status: str) -> None:
+    """Mark ``jid`` as finished with the provided ``status``."""
+
+    now = time.time()
+    with _LOCK:
+        _execute(
+            "UPDATE jobs SET status=?, finished_at=?, updated_at=? WHERE id=?",
+            (status, now, now, jid),
+        )

--- a/srv/blackroad-dashboard/api.py
+++ b/srv/blackroad-dashboard/api.py
@@ -1,0 +1,86 @@
+"""FastAPI application providing the Prism dashboard job controls."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Optional
+
+from fastapi import Body, FastAPI, WebSocket, WebSocketDisconnect
+
+from agent import jobs, store
+
+app = FastAPI(title="BlackRoad Dashboard API")
+
+
+@app.websocket("/ws/run")
+async def ws_run(websocket: WebSocket) -> None:
+    await websocket.accept()
+    jid: Optional[int] = None
+    tail_thread: Optional[threading.Thread] = None
+    queue: asyncio.Queue[Optional[str]] = asyncio.Queue()
+
+    try:
+        cmd = await websocket.receive_text()
+        jid = store.new_job(cmd)
+        await websocket.send_text(f"[[BLACKROAD_JOB_ID:{jid}]]")
+
+        meta = jobs.start_remote_logged(jid=jid, command=cmd)
+        await websocket.send_text(f"[[BLACKROAD_PID:{meta['pid']}]]")
+        await websocket.send_text(f"[[BLACKROAD_LOG:{meta['log']}]]")
+
+        loop = asyncio.get_running_loop()
+
+        def _push(item: Optional[str]) -> None:
+            asyncio.run_coroutine_threadsafe(queue.put(item), loop)
+
+        def _tail() -> None:
+            try:
+                for line in jobs.tail_remote_log(meta["log"]):
+                    _push(line)
+                    if jid is not None and not jobs.remote_is_running(jid):
+                        break
+            except Exception as exc:  # pragma: no cover - defensive guard
+                _push(f"[error] {exc}")
+            finally:
+                _push(None)
+
+        tail_thread = threading.Thread(target=_tail, name=f"job-tail-{jid}", daemon=True)
+        tail_thread.start()
+
+        while True:
+            line = await queue.get()
+            if line is None:
+                break
+            if jid is not None:
+                store.append(jid, line + "\n")
+            await websocket.send_text(line)
+
+        is_running = jobs.remote_is_running(jid) if jid is not None else False
+        status = "running" if is_running else "ok"
+        if jid is not None:
+            store.finish(jid, status)
+        await websocket.send_text("[[BLACKROAD_DONE]]")
+
+    except WebSocketDisconnect:
+        if jid is not None:
+            store.finish(jid, "disconnected")
+    except Exception as exc:
+        if jid is not None:
+            store.finish(jid, f"error: {exc}")
+        await websocket.send_text(f"[error] {exc}")
+    finally:
+        if tail_thread and tail_thread.is_alive():
+            tail_thread.join(timeout=0.2)
+        try:
+            await websocket.close()
+        except RuntimeError:
+            # WebSocket already closed.
+            pass
+
+
+@app.post("/jobs/{jid}/kill")
+async def jobs_kill(jid: int, payload: dict = Body(default={})) -> dict[str, object]:
+    sig = payload.get("signal", "TERM")
+    ok = jobs.remote_kill(jid, sig=sig)
+    return {"ok": ok, "signal": sig}

--- a/srv/blackroad-dashboard/static/dashboard.html
+++ b/srv/blackroad-dashboard/static/dashboard.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>BlackRoad Job Runner</title>
+  <style>
+    body { font-family: system-ui, sans-serif; background: #0b1220; color: #e2e8f0; margin: 0; padding: 1.5rem; }
+    form { display: flex; gap: 0.5rem; margin-bottom: 1rem; }
+    input { flex: 1; padding: 0.5rem 0.75rem; border-radius: 0.5rem; border: 1px solid #1f2a44; background: #09122a; color: inherit; }
+    button { padding: 0.5rem 1rem; border-radius: 0.5rem; border: none; cursor: pointer; font-weight: 600; }
+    #runBtn { background: linear-gradient(135deg, #FF4FD8, #0096FF); color: #0b1220; }
+    #stopBtn { background: #1f2a44; color: inherit; }
+    #log { background: #020617; border: 1px solid #1f2a44; border-radius: 0.75rem; padding: 1rem; min-height: 320px; overflow-y: auto; white-space: pre-wrap; }
+  </style>
+</head>
+<body>
+  <h1>BlackRoad Remote Jobs</h1>
+  <form id="runForm" onsubmit="return false;">
+    <input type="text" id="cmd" placeholder="Enter command (e.g. nvidia-smi)" />
+    <button id="runBtn">Run (stream)</button>
+    <button id="stopBtn" type="button">Stop</button>
+  </form>
+  <div id="log"></div>
+
+  <script>
+    const cmdEl = document.getElementById('cmd');
+    const logEl = document.getElementById('log');
+    const runBtn = document.getElementById('runBtn');
+    const stopBtn = document.getElementById('stopBtn');
+    let ws = null;
+    let currentJobId = null;
+
+    function append(line) {
+      logEl.textContent += line + '\n';
+      logEl.scrollTop = logEl.scrollHeight;
+    }
+
+    runBtn.addEventListener('click', () => {
+      if (ws) { ws.close(); ws = null; }
+      logEl.textContent = '';
+      currentJobId = null;
+
+      const cmd = (cmdEl.value || '').trim() || 'nvidia-smi';
+      const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+      ws = new WebSocket(`${proto}://${location.host}/ws/run`);
+      ws.onopen = () => ws.send(cmd);
+      ws.onmessage = (ev) => {
+        const data = String(ev.data || '');
+        if (data.startsWith('[[BLACKROAD_JOB_ID:')) {
+          const match = data.match(/\[\[BLACKROAD_JOB_ID:(\d+)\]\]/);
+          if (match) currentJobId = match[1];
+        } else if (data === '[[BLACKROAD_DONE]]') {
+          append('--- done ---');
+          ws.close();
+          ws = null;
+        } else {
+          append(data);
+        }
+      };
+      ws.onerror = () => append('[error] websocket error');
+      ws.onclose = () => { ws = null; };
+    });
+
+    stopBtn.addEventListener('click', async () => {
+      if (!currentJobId) {
+        append('[no job to stop]');
+        return;
+      }
+      try {
+        await fetch(`/jobs/${currentJobId}/kill`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ signal: 'TERM' })
+        });
+        append('--- sent SIGTERM ---');
+      } catch (err) {
+        append(`[error] ${err}`);
+      }
+      setTimeout(async () => {
+        try {
+          await fetch(`/jobs/${currentJobId}/kill`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ signal: 'KILL' })
+          });
+          append('--- sent SIGKILL ---');
+        } catch (err) {
+          append(`[error] ${err}`);
+        }
+      }, 5000);
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add an agent package that exposes remote Jetson job helpers and a SQLite-backed job store
- implement a FastAPI dashboard API with WebSocket streaming and job kill endpoint
- wire a dashboard HTML page with Run/Stop controls that call the new API

## Testing
- python -m py_compile agent/__init__.py agent/jobs.py agent/store.py srv/blackroad-dashboard/api.py

------
https://chatgpt.com/codex/tasks/task_e_68dafdc2e2a88329b40bf9d7d9956cf0