### PR TITLE
feat: stream local llama tokens to dashboard

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,5 @@
+"""Agent service package exposing the FastAPI application."""
+
+from .api import app
+
+__all__ = ["app"]

--- a/agent/api.py
+++ b/agent/api.py
@@ -1,0 +1,51 @@
+"""FastAPI endpoints for streaming local model tokens to the dashboard."""
+
+from __future__ import annotations
+
+import contextlib
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.responses import JSONResponse
+
+from . import models
+
+app = FastAPI(title="BlackRoad Local Models")
+
+
+@app.get("/models")
+async def get_models() -> JSONResponse:
+    """Return the available local models."""
+
+    return JSONResponse({"models": models.list_local_models()})
+
+
+@app.websocket("/ws/model")
+async def ws_model(ws: WebSocket) -> None:
+    """Stream llama.cpp output over the websocket connection."""
+
+    await ws.accept()
+    try:
+        message = await ws.receive_json()
+        model = message.get("model")
+        prompt = message.get("prompt", "")
+        try:
+            n_predict = int(message.get("n", 128))
+        except (TypeError, ValueError):
+            n_predict = 128
+
+        if not model:
+            await ws.send_text("[error] model path missing")
+            await ws.send_text("[[BLACKROAD_MODEL_DONE]]")
+            return
+
+        for token in models.run_llama_stream(model, prompt, n_predict=n_predict):
+            await ws.send_text(token)
+
+        await ws.send_text("[[BLACKROAD_MODEL_DONE]]")
+    except WebSocketDisconnect:
+        return
+    except Exception as exc:  # pragma: no cover - defensive; websocket lifecycle
+        await ws.send_text(f"[error] {exc}")
+        await ws.send_text("[[BLACKROAD_MODEL_DONE]]")
+    finally:
+        with contextlib.suppress(RuntimeError):
+            await ws.close()

--- a/agent/models.py
+++ b/agent/models.py
@@ -1,0 +1,100 @@
+"""Helpers for discovering and streaming local llama.cpp models."""
+
+from __future__ import annotations
+
+import subprocess
+import shutil
+from pathlib import Path
+from typing import Generator
+
+MODEL_DIRECTORIES: tuple[Path, ...] = (
+    Path("/var/lib/blackroad/models"),
+    Path("/opt/blackroad/models"),
+    Path("./models"),
+)
+
+
+def list_local_models() -> list[dict[str, str]]:
+    """Return discovered GGUF models.
+
+    Searches the known model directories and returns a list of dictionaries with
+    ``name`` (for display) and ``path`` (absolute path used when invoking
+    ``llama.cpp``).
+    """
+
+    models: list[dict[str, str]] = []
+    seen: set[Path] = set()
+    for base in MODEL_DIRECTORIES:
+        if not base.is_dir():
+            continue
+        for entry in sorted(base.glob("*.gguf")):
+            try:
+                resolved = entry.resolve(strict=True)
+            except FileNotFoundError:
+                continue
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            models.append({
+                "name": entry.stem,
+                "path": str(resolved),
+            })
+    return models
+
+
+def run_llama_stream(model_path: str, prompt: str, n_predict: int = 128) -> Generator[str, None, None]:
+    """Yield llama.cpp output in streaming mode.
+
+    Parameters
+    ----------
+    model_path:
+        Full path to the GGUF model file.
+    prompt:
+        Prompt text to feed into the model.
+    n_predict:
+        Maximum number of tokens to generate.
+    """
+
+    if not model_path:
+        yield "[error] model path missing"
+        return
+
+    model_file = Path(model_path)
+    if not model_file.exists():
+        yield f"[error] model not found: {model_path}"
+        return
+
+    exe = shutil.which("llama") or shutil.which("main")
+    if not exe:
+        yield "[error] llama.cpp binary not found"
+        return
+
+    cmd = [exe, "-m", str(model_file), "-p", prompt, "-n", str(n_predict)]
+
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+    except OSError as exc:
+        yield f"[error] failed to start llama.cpp: {exc}"
+        return
+
+    return_code: int | None = None
+    try:
+        assert proc.stdout is not None
+        for line in proc.stdout:
+            yield line.rstrip("\n")
+    except Exception as exc:  # pragma: no cover - defensive; streaming loop
+        yield f"[error] runtime failure: {exc}"
+        proc.kill()
+    finally:
+        if proc.stdout:
+            proc.stdout.close()
+        return_code = proc.wait()
+
+    if return_code not in (0, None):
+        yield f"[error] llama.cpp exited with code {return_code}"

--- a/var/www/blackroad/dashboard.html
+++ b/var/www/blackroad/dashboard.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>BlackRoad • Local Models</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      font-family: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+    }
+    body {
+      margin: 0;
+      padding: 0;
+      min-height: 100vh;
+      background: radial-gradient(circle at top, #161b33, #0b0d19 65%);
+      color: #e5ecff;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .wrap {
+      width: min(720px, 92vw);
+      margin: 40px auto;
+    }
+    .card {
+      background: rgba(8, 11, 26, 0.92);
+      border-radius: 16px;
+      border: 1px solid rgba(79, 140, 255, 0.2);
+      padding: 20px;
+      box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
+    }
+    .card .title {
+      font-size: 1.1rem;
+      font-weight: 600;
+      letter-spacing: 0.03em;
+      margin-bottom: 12px;
+    }
+    button,
+    select,
+    textarea {
+      font: inherit;
+      border-radius: 8px;
+      border: 1px solid rgba(128, 151, 255, 0.35);
+      background: rgba(12, 16, 34, 0.85);
+      color: inherit;
+      padding: 8px 10px;
+      transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    }
+    button {
+      cursor: pointer;
+      border: none;
+      background: linear-gradient(120deg, #ff4fd8, #0096ff);
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      padding: 10px 14px;
+      margin-right: 6px;
+    }
+    button:hover {
+      box-shadow: 0 0 12px rgba(0, 150, 255, 0.35);
+    }
+    select {
+      width: 100%;
+      margin-top: 8px;
+    }
+    textarea:focus,
+    select:focus {
+      outline: none;
+      border-color: rgba(0, 150, 255, 0.8);
+      box-shadow: 0 0 0 2px rgba(0, 150, 255, 0.25);
+    }
+    pre {
+      border: 1px solid rgba(0, 255, 128, 0.18);
+      background: #000;
+      color: #3dff8a;
+      font-family: "Fira Mono", "SFMono-Regular", ui-monospace, "Cascadia Code", monospace;
+      border-radius: 12px;
+      padding: 16px;
+      height: 240px;
+      overflow: auto;
+      margin-top: 12px;
+      white-space: pre-wrap;
+    }
+    .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      align-items: center;
+      margin-bottom: 8px;
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="card">
+      <div class="title">Local Models (Streaming)</div>
+      <div class="actions">
+        <button id="loadModels">Load Models</button>
+        <button id="runModel" disabled>Run (stream)</button>
+      </div>
+      <select id="modelSel"></select>
+      <textarea id="prompt" placeholder="Enter prompt..."></textarea>
+      <pre id="modelOut"></pre>
+    </div>
+  </div>
+
+  <script>
+  const modelSel = document.getElementById('modelSel');
+  const promptEl = document.getElementById('prompt');
+  const modelOut = document.getElementById('modelOut');
+  const runBtn = document.getElementById('runModel');
+  const loadBtn = document.getElementById('loadModels');
+
+  async function loadModels() {
+    runBtn.disabled = true;
+    runBtn.textContent = 'Run (stream)';
+    modelSel.innerHTML = '';
+    try {
+      const r = await fetch('/models');
+      if (!r.ok) throw new Error('failed to load models');
+      const j = await r.json();
+      (j.models || []).forEach(m => {
+        const o = document.createElement('option');
+        o.value = m.path;
+        o.textContent = m.name || m.path;
+        modelSel.appendChild(o);
+      });
+      if (modelSel.options.length === 0) {
+        const o = document.createElement('option');
+        o.value = '';
+        o.textContent = 'No models found';
+        modelSel.appendChild(o);
+      } else {
+        runBtn.disabled = false;
+      }
+    } catch (err) {
+      modelSel.innerHTML = '';
+      const o = document.createElement('option');
+      o.value = '';
+      o.textContent = '[error] ' + err.message;
+      modelSel.appendChild(o);
+    }
+  }
+
+  loadBtn.onclick = loadModels;
+
+  runBtn.onclick = () => {
+    const model = modelSel.value;
+    if (!model) {
+      modelOut.textContent = '[error] select a model first';
+      return;
+    }
+    const prompt = promptEl.value;
+    modelOut.textContent = '';
+    const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+    const ws = new WebSocket(`${proto}://${location.host}/ws/model`);
+    ws.onopen = () => ws.send(JSON.stringify({ model, prompt, n: 128 }));
+    ws.onmessage = (ev) => {
+      if (ev.data === '[[BLACKROAD_MODEL_DONE]]') {
+        ws.close();
+        return;
+      }
+      modelOut.textContent += ev.data;
+      modelOut.scrollTop = modelOut.scrollHeight;
+    };
+    ws.onerror = (ev) => {
+      modelOut.textContent += `\n[error] websocket error`;
+    };
+    ws.onclose = () => {
+      runBtn.disabled = false;
+      runBtn.textContent = 'Run (stream)';
+    };
+    runBtn.disabled = true;
+    runBtn.textContent = 'Streaming…';
+  };
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add local llama.cpp streaming helpers and FastAPI websocket endpoint
- expose `/models` listing and `/ws/model` streaming interface for tokens
- refresh dashboard UI with streaming console for local models

## Testing
- python -m py_compile agent/*.py

------
https://chatgpt.com/codex/tasks/task_e_68db01d658e08329a195997265cecf14