### PR TITLE
Add remote job exit codes and dashboard updates

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,21 @@
+"""Utility helpers for the lightweight BlackRoad job runner."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Tuple
+
+__all__ = ["DEFAULT_REMOTE_HOST", "DEFAULT_REMOTE_USER", "DEFAULT_DB_PATH", "_host_user"]
+
+DEFAULT_REMOTE_HOST = os.getenv("BLACKROAD_REMOTE_HOST", "jetson-01")
+DEFAULT_REMOTE_USER = os.getenv("BLACKROAD_REMOTE_USER", "pi")
+DEFAULT_DB_PATH = Path(os.getenv("BLACKROAD_JOBS_DB", "/var/lib/blackroad/jobs.db"))
+
+
+def _host_user(host: str | None = None, user: str | None = None) -> Tuple[str, str]:
+    """Resolve the remote host/user pair for SSH operations."""
+
+    resolved_host = host or DEFAULT_REMOTE_HOST
+    resolved_user = user or DEFAULT_REMOTE_USER
+    return resolved_host, resolved_user

--- a/agent/jobs.py
+++ b/agent/jobs.py
@@ -1,0 +1,49 @@
+"""Remote job helpers for the Jetson runner."""
+
+from __future__ import annotations
+
+import shlex
+import subprocess
+from typing import Dict, Optional
+
+from . import _host_user
+
+
+def start_remote_logged(jid: int, command: str, host: str | None = None, user: str | None = None) -> Dict[str, str]:
+    """Launch ``command`` on the remote host and capture output to a log file."""
+
+    host, user = _host_user(host, user)
+    log = f"/tmp/blackroad_job_{jid}.log"
+    pidf = f"/tmp/blackroad_job_{jid}.pid"
+    exitf = f"/tmp/blackroad_job_{jid}.exit"
+    inner = f"( exec setsid bash -lc '{command}'; echo $? > {shlex.quote(exitf)} )"
+    remote = (
+        "bash -lc 'set -m; "
+        f"rm -f {shlex.quote(log)} {shlex.quote(pidf)} {shlex.quote(exitf)}; "
+        f"nohup bash -lc {shlex.quote(inner)} "
+        f"> {shlex.quote(log)} 2>&1 & echo $! > {shlex.quote(pidf)}; "
+        f"disown; sleep 0.2; cat {shlex.quote(pidf)}'"
+    )
+    pid = subprocess.check_output(["ssh", f"{user}@{host}", remote], text=True).strip()
+    return {"pid": int(pid), "log": log, "pidfile": pidf, "exitfile": exitf}
+
+
+def remote_exit_code(jid: int, host: str | None = None, user: str | None = None) -> Optional[int]:
+    """Fetch the exit code for ``jid`` from the remote sidecar file."""
+
+    host, user = _host_user(host, user)
+    exitf = f"/tmp/blackroad_job_{jid}.exit"
+    try:
+        out = subprocess.check_output(
+            [
+                "ssh",
+                f"{user}@{host}",
+                "bash",
+                "-lc",
+                f"cat {shlex.quote(exitf)} 2>/dev/null || true",
+            ],
+            text=True,
+        ).strip()
+        return int(out) if out != "" else None
+    except Exception:
+        return None

--- a/agent/store.py
+++ b/agent/store.py
@@ -1,0 +1,130 @@
+"""SQLite-backed job store for the dashboard."""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+import time
+from typing import Dict, List, Optional
+
+from . import DEFAULT_DB_PATH
+
+_MAX_OUTPUT = 256 * 1024
+_lock = threading.Lock()
+_conn: sqlite3.Connection | None = None
+
+
+def _get_conn() -> sqlite3.Connection:
+    global _conn
+    if _conn is None:
+        db_path = DEFAULT_DB_PATH
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        _conn = sqlite3.connect(db_path, check_same_thread=False)
+        _conn.row_factory = sqlite3.Row
+        _init_schema(_conn)
+    return _conn
+
+
+def _init_schema(conn: sqlite3.Connection) -> None:
+    c = conn.cursor()
+    c.execute(
+        """
+        CREATE TABLE IF NOT EXISTS jobs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            cmd TEXT NOT NULL,
+            started REAL NOT NULL,
+            ended REAL,
+            status TEXT NOT NULL,
+            output TEXT
+        )
+        """
+    )
+    try:
+        c.execute("ALTER TABLE jobs ADD COLUMN exit_code INTEGER")
+    except Exception:
+        pass
+    c.execute("CREATE INDEX IF NOT EXISTS idx_jobs_exit ON jobs(exit_code)")
+    conn.commit()
+
+
+def create_job(cmd: str) -> int:
+    with _lock:
+        conn = _get_conn()
+        now = time.time()
+        cur = conn.execute(
+            "INSERT INTO jobs(cmd, started, status, output, exit_code) VALUES(?,?,?,?,?)",
+            (cmd, now, "running", "", None),
+        )
+        conn.commit()
+        return int(cur.lastrowid)
+
+
+def append_output(job_id: int, chunk: str) -> None:
+    if not chunk:
+        return
+    with _lock:
+        conn = _get_conn()
+        row = conn.execute("SELECT output FROM jobs WHERE id=?", (job_id,)).fetchone()
+        if row is None:
+            return
+        current = row[0] or ""
+        new = (current + chunk)[-_MAX_OUTPUT:]
+        conn.execute("UPDATE jobs SET output=? WHERE id=?", (new, job_id))
+        conn.commit()
+
+
+def finish(job_id: int, status: str, exit_code: int | None = None) -> None:
+    with _lock:
+        conn = _get_conn()
+        conn.execute(
+            "UPDATE jobs SET ended=?, status=?, exit_code=? WHERE id=?",
+            (time.time(), status, exit_code, job_id),
+        )
+        conn.commit()
+
+
+def list_jobs(limit: int = 50) -> List[Dict[str, Optional[float]]]:
+    conn = _get_conn()
+    rows = conn.execute(
+        """
+        SELECT id, cmd, started, ended, status, exit_code
+        FROM jobs
+        ORDER BY id DESC
+        LIMIT ?
+        """,
+        (limit,),
+    ).fetchall()
+    return [
+        {
+            "id": row[0],
+            "cmd": row[1],
+            "started": row[2],
+            "ended": row[3],
+            "status": row[4],
+            "exit_code": row[5],
+        }
+        for row in rows
+    ]
+
+
+def get_job(job_id: int) -> Dict[str, Optional[str]]:
+    conn = _get_conn()
+    row = conn.execute(
+        """
+        SELECT id, cmd, started, ended, status, output, exit_code
+        FROM jobs
+        WHERE id=?
+        """,
+        (job_id,),
+    ).fetchone()
+    if row is None:
+        raise KeyError(job_id)
+    return {
+        "id": row[0],
+        "cmd": row[1],
+        "started": row[2],
+        "ended": row[3],
+        "status": row[4],
+        "output": row[5] or "",
+        "exit_code": row[6],
+    }

--- a/dashboard/__init__.py
+++ b/dashboard/__init__.py
@@ -1,0 +1,5 @@
+"""Dashboard package exposing the FastAPI app."""
+
+from .app import app
+
+__all__ = ["app"]

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,0 +1,137 @@
+"""FastAPI application exposing the Jetson job runner."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import shlex
+import subprocess
+from typing import Any, Dict
+
+from fastapi import FastAPI, HTTPException, Response, WebSocket, WebSocketDisconnect
+
+from agent import _host_user
+from agent import jobs as job_runner
+from agent import store
+
+app = FastAPI(title="BlackRoad Dashboard")
+
+
+@app.get("/jobs")
+def jobs_list(limit: int = 50) -> Dict[str, Any]:
+    return {"jobs": store.list_jobs(limit)}
+
+
+@app.get("/jobs/{job_id}")
+def jobs_get(job_id: int) -> Dict[str, Any]:
+    try:
+        return store.get_job(job_id)
+    except KeyError as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=404, detail="job not found") from exc
+
+
+@app.get("/jobs/{jid}/download")
+def jobs_download(jid: int) -> Response:
+    log_path = f"/tmp/blackroad_job_{jid}.log"
+    host, user = _host_user()
+    try:
+        out = subprocess.check_output(
+            ["ssh", f"{user}@{host}", "bash", "-lc", f"cat {shlex.quote(log_path)}"],
+            text=True,
+        )
+    except subprocess.CalledProcessError:
+        out = ""
+    return Response(content=out, media_type="text/plain")
+
+
+async def _stream_log(websocket: WebSocket, jid: int, log_path: str) -> None:
+    host, user = _host_user()
+    tail_cmd = [
+        "ssh",
+        f"{user}@{host}",
+        "bash",
+        "-lc",
+        f"touch {shlex.quote(log_path)}; tail -n +1 -F {shlex.quote(log_path)}",
+    ]
+    proc = await asyncio.create_subprocess_exec(
+        *tail_cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+    try:
+        while True:
+            line = await proc.stdout.readline()
+            if not line:
+                if proc.returncode is not None:
+                    break
+                exit_code = job_runner.remote_exit_code(jid, host=host, user=user)
+                if exit_code is not None:
+                    proc.terminate()
+                    try:
+                        await asyncio.wait_for(proc.wait(), timeout=1)
+                    except asyncio.TimeoutError:
+                        proc.kill()
+                        await proc.wait()
+                    break
+                await asyncio.sleep(0.2)
+                continue
+            text = line.decode(errors="replace")
+            await websocket.send_text(text)
+            store.append_output(jid, text)
+    finally:
+        if proc.returncode is None:
+            proc.terminate()
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=1)
+            except asyncio.TimeoutError:
+                proc.kill()
+                await proc.wait()
+
+
+@app.websocket("/ws/run")
+async def ws_run(websocket: WebSocket) -> None:
+    await websocket.accept()
+    try:
+        payload = await websocket.receive_text()
+    except WebSocketDisconnect:
+        return
+
+    cmd: str
+    try:
+        data = json.loads(payload)
+        cmd = data.get("cmd") or data.get("command") or ""
+    except json.JSONDecodeError:
+        cmd = payload
+
+    cmd = (cmd or "").strip()
+    if not cmd:
+        await websocket.send_text("[[BLACKROAD_ERROR:missing command]]")
+        await websocket.close()
+        return
+
+    jid = store.create_job(cmd)
+    await websocket.send_text(f"[[BLACKROAD_JOB_ID:{jid}]]")
+
+    try:
+        meta = job_runner.start_remote_logged(jid=jid, command=cmd)
+    except Exception as exc:  # pragma: no cover - remote failure path
+        store.finish(jid, "failed", exit_code=None)
+        await websocket.send_text("[[BLACKROAD_EXIT:NA]]")
+        await websocket.send_text("[[BLACKROAD_DONE]]")
+        raise exc
+
+    try:
+        await _stream_log(websocket, jid, meta["log"])
+    except WebSocketDisconnect:
+        await asyncio.sleep(0.2)
+    except Exception:
+        store.append_output(jid, "\n[log stream error]\n")
+        raise
+
+    exit_code = job_runner.remote_exit_code(jid)
+    status = "ok" if exit_code == 0 else ("failed" if exit_code is not None else "unknown")
+    store.finish(jid, status, exit_code)
+    await websocket.send_text(
+        f"[[BLACKROAD_EXIT:{exit_code if exit_code is not None else 'NA'}]]"
+    )
+    await websocket.send_text("[[BLACKROAD_DONE]]")

--- a/var/www/blackroad/admin/index.html
+++ b/var/www/blackroad/admin/index.html
@@ -25,18 +25,87 @@ button { background:var(--accent); color:#fff; border:none; padding:0.5rem 1rem;
     <input id="rollbackId" placeholder="Release ID" />
     <button onclick="rollback()">Rollback</button>
   </div>
-  <table id="jobs"></table>
-  <pre id="log"></pre>
+  <div style="margin:1rem 0;display:flex;gap:1rem;align-items:center;">
+    <button id="refreshJobs">Refresh Jobs</button>
+  </div>
+  <table id="jobsTbl" style="width:100%;border-collapse:collapse;">
+    <thead>
+      <tr>
+        <th>ID</th>
+        <th>Command</th>
+        <th>Status</th>
+        <th>Started</th>
+        <th>Ended</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+  <pre id="jobOut" style="margin-top:1rem;background:#000;color:#0f0;padding:1rem;height:200px;overflow:auto;"></pre>
 </div>
 <script>
 let token='';
 async function login(){ token=document.getElementById('token').value; document.getElementById('login').style.display='none'; document.getElementById('app').style.display='block'; load(); }
-async function load(){ const h=await fetch('/api/health').then(r=>r.json()); document.getElementById('health').innerText='API OK: '+h.ok; refreshJobs(); }
-async function refreshJobs(){ const j=await fetch('/api/jobs').then(r=>r.json()); const tbl=document.getElementById('jobs'); tbl.innerHTML='<tr><th>ID</th><th>Type</th><th>Status</th></tr>'; j.forEach(job=>{ const tr=document.createElement('tr'); tr.innerHTML=`<td>${job.id}</td><td>${job.type}</td><td>${job.status}</td>`; tr.onclick=()=>watch(job.id); tbl.appendChild(tr); }); }
-function watch(id){ const log=document.getElementById('log'); log.textContent=''; const es=new EventSource(`/api/jobs/${id}/log`); es.onmessage=e=>{log.textContent+=e.data+'\n'; log.scrollTop=log.scrollHeight;}; es.addEventListener('end',()=>es.close()); }
+async function load(){ const h=await fetch('/api/health').then(r=>r.json()); document.getElementById('health').innerText='API OK: '+h.ok; loadJobs(); }
 async function dryRun(){ await fetch('/api/deploy/plan',{method:'POST',headers:{'X-Internal-Token':token}}).then(r=>r.json()).then(alert); }
-async function deploy(){ await fetch('/api/deploy/execute',{method:'POST',headers:{'Content-Type':'application/json','X-Internal-Token':token},body:JSON.stringify({})}).then(r=>r.json()).then(()=>refreshJobs()); }
-async function rollback(){ const id=document.getElementById('rollbackId').value; await fetch('/api/rollback/'+id,{method:'POST',headers:{'X-Internal-Token':token}}).then(r=>r.json()).then(()=>refreshJobs()); }
+async function deploy(){ await fetch('/api/deploy/execute',{method:'POST',headers:{'Content-Type':'application/json','X-Internal-Token':token},body:JSON.stringify({})}).then(r=>r.json()).then(()=>loadJobs()); }
+async function rollback(){ const id=document.getElementById('rollbackId').value; await fetch('/api/rollback/'+id,{method:'POST',headers:{'X-Internal-Token':token}}).then(r=>r.json()).then(()=>loadJobs()); }
+
+const jobsTbl = document.querySelector('#jobsTbl tbody');
+const jobOut  = document.getElementById('jobOut');
+
+function pill(status, exitCode){
+  const color = status === 'ok' ? '#0f0' :
+                status === 'failed' ? '#f55' :
+                status === 'running' ? '#ff0' :
+                '#aaa';
+  const ec = (exitCode === null || exitCode === undefined) ? '' : ` (exit ${exitCode})`;
+  return `<span style="background:${color};color:#000;padding:2px 6px;border-radius:12px;">${status}${ec}</span>`;
+}
+
+async function loadJobs(){
+  const r = await fetch('/jobs'); const j = await r.json();
+  jobsTbl.innerHTML = '';
+  (j.jobs||[]).forEach(row=>{
+    const tr = document.createElement('tr');
+    const t = (ts)=> ts? new Date(ts*1000).toLocaleTimeString() : '-';
+    tr.innerHTML = `
+      <td>${row.id}</td>
+      <td style="max-width:360px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;" title="${row.cmd}">${row.cmd}</td>
+      <td>${pill(row.status, row.exit_code)}</td>
+      <td>${t(row.started)}</td>
+      <td>${t(row.ended)}</td>
+      <td>
+        <button data-id="${row.id}" class="open">Open</button>
+        <a href="/jobs/${row.id}/download" target="_blank">Download</a>
+      </td>`;
+    tr.querySelector('button.open').onclick = async (ev)=>{
+      const id = ev.target.dataset.id;
+      const r = await fetch('/jobs/'+id); const j = await r.json();
+      jobOut.textContent = j.output || JSON.stringify(j,null,2);
+      jobOut.scrollTop = jobOut.scrollHeight;
+    };
+    jobsTbl.appendChild(tr);
+  });
+}
+document.getElementById('refreshJobs').onclick = loadJobs;
+document.addEventListener('DOMContentLoaded', loadJobs);
+
+(function(){
+  const origWS = window.WebSocket;
+  window.WebSocket = function(url){
+    const ws = new origWS(url);
+    ws.addEventListener('message', (ev)=>{
+      const m = String(ev.data||'');
+      if(m.startsWith('[[BLACKROAD_JOB_ID:')) {
+        loadJobs();
+      } else if (m.startsWith('[[BLACKROAD_EXIT:')) {
+        setTimeout(loadJobs, 500);
+      }
+    });
+    return ws;
+  };
+})();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a lightweight agent package with SSH helpers that persist remote exit codes alongside job metadata
- extend the SQLite-backed job store and FastAPI app to expose exit codes plus a download endpoint for full logs
- refresh the admin dashboard table with status pills, exit code display, and log download/open actions that refresh after WebSocket updates

## Testing
- python -m py_compile agent/__init__.py agent/jobs.py agent/store.py dashboard/app.py

------
https://chatgpt.com/codex/tasks/task_e_68db00d1d62c8329bcd67a0ea97ee420