### PR TITLE
feat: stream whisper from jetson gpu

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,5 @@
+"""Core helpers for the Pi transcription pipeline."""
+
+from . import config, store, transcribe  # re-export for convenience
+
+__all__ = ["config", "store", "transcribe"]

--- a/agent/config.py
+++ b/agent/config.py
@@ -1,0 +1,33 @@
+"""Runtime configuration helpers for remote GPU transcription."""
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from typing import Tuple
+
+_DEFAULT_TARGET = ("jetson.local", "ubuntu")
+
+
+def _parse_target(target: str) -> Tuple[str, str]:
+    """Parse a "user@host" style target string."""
+    if "@" in target:
+        user, host = target.split("@", 1)
+        user = user or _DEFAULT_TARGET[1]
+        host = host or _DEFAULT_TARGET[0]
+        return host, user
+    return (target or _DEFAULT_TARGET[0], _DEFAULT_TARGET[1])
+
+
+@lru_cache(maxsize=1)
+def active_target() -> Tuple[str, str]:
+    """Return the SSH host/user tuple for the Jetson target."""
+    target = os.getenv("JETSON_TARGET")
+    host_env = os.getenv("JETSON_HOST") or os.getenv("BLACKROAD_JETSON_HOST")
+    user_env = os.getenv("JETSON_USER") or os.getenv("BLACKROAD_JETSON_USER")
+
+    if target:
+        host, user = _parse_target(target)
+    else:
+        host = host_env or _DEFAULT_TARGET[0]
+        user = user_env or _DEFAULT_TARGET[1]
+    return host, user

--- a/agent/store.py
+++ b/agent/store.py
@@ -1,0 +1,78 @@
+"""SQLite-backed transcript persistence for streaming sessions."""
+from __future__ import annotations
+
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+_DB_PATH = Path.home() / ".blackroad"
+_DB_PATH.mkdir(parents=True, exist_ok=True)
+_DB_FILE = _DB_PATH / "transcripts.sqlite3"
+
+_lock = threading.RLock()
+_conn = sqlite3.connect(_DB_FILE, check_same_thread=False)
+_conn.execute("PRAGMA journal_mode=WAL")
+_conn.execute(
+    """
+    CREATE TABLE IF NOT EXISTS transcripts(
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session TEXT,
+      started REAL,
+      ended REAL,
+      text TEXT
+    )
+    """
+)
+_conn.execute(
+    "CREATE INDEX IF NOT EXISTS idx_transcripts_session ON transcripts(session)"
+)
+_conn.commit()
+
+
+def transcript_start(session: str) -> None:
+    with _lock:
+        _conn.execute(
+            "INSERT INTO transcripts(session, started, text) VALUES(?,?,?)",
+            (session, time.time(), ""),
+        )
+        _conn.commit()
+
+
+def transcript_append(session: str, chunk: str, max_bytes: int = 512 * 1024) -> None:
+    with _lock:
+        _conn.execute(
+            """
+            UPDATE transcripts
+               SET text = substr(COALESCE(text, '') || ?, ?)
+             WHERE session=?
+            """,
+            (chunk, -max_bytes, session),
+        )
+        _conn.commit()
+
+
+def transcript_finish(session: str) -> None:
+    with _lock:
+        _conn.execute(
+            "UPDATE transcripts SET ended=? WHERE session=?",
+            (time.time(), session),
+        )
+        _conn.commit()
+
+
+def transcript_get(session: str) -> Optional[Dict[str, Any]]:
+    cur = _conn.execute(
+        "SELECT session, started, ended, text FROM transcripts WHERE session=?",
+        (session,),
+    )
+    row = cur.fetchone()
+    if not row:
+        return None
+    return {
+        "session": row[0],
+        "started": row[1],
+        "ended": row[2],
+        "text": row[3] or "",
+    }

--- a/agent/transcribe.py
+++ b/agent/transcribe.py
@@ -1,0 +1,11 @@
+"""Local file management for transcription uploads."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+_DEFAULT_TMP = Path(os.getenv("BLACKROAD_TRANSCRIBE_TMP", "/tmp/blackroad_transcribe"))
+TMP_DIR = _DEFAULT_TMP
+TMP_DIR.mkdir(parents=True, exist_ok=True)
+
+__all__ = ["TMP_DIR"]

--- a/pi_dashboard/__init__.py
+++ b/pi_dashboard/__init__.py
@@ -1,0 +1,1 @@
+"""Pi dashboard API package."""

--- a/pi_dashboard/api.py
+++ b/pi_dashboard/api.py
@@ -1,0 +1,169 @@
+"""FastAPI application for Pi dashboard transcription with Jetson offload."""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import uuid
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from fastapi import FastAPI, File, HTTPException, UploadFile, WebSocket, WebSocketDisconnect
+from fastapi.responses import JSONResponse
+
+from agent import store, transcribe
+from agent.config import active_target
+
+logger = logging.getLogger(__name__)
+app = FastAPI(title="BlackRoad Pi Dashboard", version="0.1.0")
+
+
+async def _run_checked(cmd: list[str]) -> None:
+    """Execute a command and raise if it fails."""
+    proc = await asyncio.create_subprocess_exec(*cmd)
+    code = await proc.wait()
+    if code != 0:
+        raise RuntimeError(f"command {' '.join(cmd)} exited with {code}")
+
+
+@app.post("/transcribe/upload")
+async def upload_audio(file: UploadFile = File(...)) -> Dict[str, Any]:
+    if not file:
+        raise HTTPException(status_code=400, detail="missing file")
+
+    suffix = Path(file.filename or "audio").suffix
+    token = f"{uuid.uuid4().hex}{suffix}"
+    dest = transcribe.TMP_DIR / token
+    size = 0
+    try:
+        with dest.open("wb") as out:
+            while True:
+                chunk = await file.read(1 << 20)
+                if not chunk:
+                    break
+                out.write(chunk)
+                size += len(chunk)
+    except Exception as exc:  # pragma: no cover - defensive
+        if dest.exists():
+            dest.unlink(missing_ok=True)
+        raise HTTPException(status_code=500, detail=f"upload failed: {exc}")
+
+    if size == 0:
+        dest.unlink(missing_ok=True)
+        raise HTTPException(status_code=400, detail="empty file")
+
+    return {"token": token, "size": size}
+
+
+async def _stream_remote_python(cmd: list[str], ws: WebSocket, session: str) -> bool:
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+        limit=1 << 16,
+    )
+    done_seen = False
+    try:
+        assert proc.stdout is not None
+        while True:
+            line = await proc.stdout.readline()
+            if not line:
+                break
+            text = line.decode("utf-8", errors="replace").rstrip("\r\n")
+            if not text:
+                continue
+            if text == "[[BLACKROAD_WHISPER_DONE]]":
+                done_seen = True
+            store.transcript_append(session, text + "\n")
+            await ws.send_text(text)
+    finally:
+        if proc.stdout:
+            proc.stdout.close()
+        await proc.wait()
+    return done_seen
+
+
+@app.websocket("/ws/transcribe/run_gpu")
+async def ws_transcribe_gpu(ws: WebSocket) -> None:
+    await ws.accept()
+    session: Optional[str] = None
+    done_sent = False
+    try:
+        message = await ws.receive_text()
+        try:
+            req = json.loads(message)
+        except json.JSONDecodeError:
+            await ws.send_text("[error] invalid payload")
+            return
+
+        token = str(req.get("token") or "").strip()
+        lang = (req.get("lang") or "en").strip()
+        model = (req.get("model") or "base").strip()
+        beam = int(req.get("beam") or 5)
+        if not token:
+            await ws.send_text("[error] missing token")
+            return
+
+        local_path = (transcribe.TMP_DIR / token).resolve()
+        if not local_path.exists():
+            await ws.send_text("[error] file not found")
+            return
+
+        session = (req.get("session") or f"gpu-{uuid.uuid4().hex[:8]}")
+        store.transcript_start(session)
+        await ws.send_text(f"[[BLACKROAD_SESSION:{session}]]")
+
+        host, user = active_target()
+        remote_dir = "/tmp/blackroad_whisper"
+        remote_path = f"{remote_dir}/{token}"
+
+        await _run_checked(["ssh", f"{user}@{host}", "mkdir", "-p", remote_dir])
+        await _run_checked(["scp", str(local_path), f"{user}@{host}:{remote_path}"])
+
+        py = f"""
+import os
+from faster_whisper import WhisperModel
+
+model_name = {model!r}
+audio_path = {remote_path!r}
+lang = {lang!r}
+beam = {beam}
+device = "cuda" if os.environ.get("USE_CUDA", "1") == "1" else "cpu"
+
+model = WhisperModel(model_name, device=device, compute_type="float16" if device == "cuda" else "int8")
+segments, info = model.transcribe(audio_path, language=None if lang == "auto" else lang, beam_size=beam)
+for seg in segments:
+    print(f"[{{seg.start:.2f}}-{{seg.end:.2f}}] {{seg.text}}", flush=True)
+print("[[BLACKROAD_WHISPER_DONE]]", flush=True)
+"""
+        cmd = ["ssh", f"{user}@{host}", "python3", "-u", "-c", py]
+        done_sent = await _stream_remote_python(cmd, ws, session)
+        store.transcript_finish(session)
+    except WebSocketDisconnect:
+        if session:
+            store.transcript_finish(session)
+        return
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.exception("GPU transcription failed: %s", exc)
+        if session:
+            store.transcript_append(session, f"[error] {exc}\n")
+            store.transcript_finish(session)
+        await ws.send_text(f"[error] {exc}")
+    finally:
+        if session and not done_sent:
+            try:
+                await ws.send_text("[[BLACKROAD_WHISPER_DONE]]")
+            except Exception:  # pragma: no cover - defensive
+                pass
+        try:
+            await ws.close()
+        except Exception:  # pragma: no cover - defensive
+            pass
+
+
+@app.get("/transcripts/{session}")
+async def get_transcript(session: str) -> JSONResponse:
+    data = store.transcript_get(session)
+    if not data:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    return JSONResponse(data)

--- a/srv/blackroad/web/index.html
+++ b/srv/blackroad/web/index.html
@@ -113,7 +113,140 @@ function CanvasPage(){const ref=useRef(null);const[draw,setDraw]=useState(false)
 function EditorPage({onRun,onCommit,code,setCode}){return(<div style={{display:'grid',gap:10}}><div style={{display:'flex',justify-content:'space-between'}}><strong>Editor</strong><div style={{display:'flex',gap:8}}><button class="btn small" onClick={onRun}>Run</button><button class="btn small" onClick={onCommit}>Commit</button></div></div><div onDragOver={e=>e.preventDefault()} onDrop={e=>{e.preventDefault();const f=e.dataTransfer.files?.[0];if(!f)return;const r=new FileReader();r.onload=()=>setCode(String(r.result));r.readAsText(f)}}><CodeEditor value={code} onChange={setCode}/></div></div>)}
 function TerminalPage({onCommand}){return <Terminal onCommand={onCommand}/>}
 function RoadViewPage({timeline,filteredTimeline,filter,setFilter,modal,setModal,itemAction,build,cpu,mem,gpu}){return(<div style={{display:'grid',gap:10}}><div style={{display:'flex',alignItems:'center',gap:8}}><input value={filter} onChange={e=>setFilter(e.target.value)} placeholder="Search timeline…" style={{flex:1,background:'#09122a',border:'1px solid var(--border)',borderRadius:10,color:'var(--text)',padding:'8px 10px'}}/></div><div style={{display:'grid',gap:10}}>{filteredTimeline.map(item=><ActivityItem key={item.id} item={{...item,onAction:itemAction}} onOpen={setModal}/>)}</div><div style={{display:'grid',gap:10}}><div style={{fontWeight:700}}>Build</div><div style={{height:10,background:'#0b1324',border:'1px solid var(--border)',borderRadius:10,overflow:'hidden'}}><div style={{height:'100%',width:build+'%',background:'linear-gradient(90deg,var(--accent),var(--accent-2))',transition:'width .6s'}}></div></div><div style={{display:'grid',gap:6}}><div style={{display:'flex',justifyContent:'space-between'}}><span>CPU</span><span>{Math.round(cpu.at(-1))}%</span></div><Sparkline data={cpu} color={theme.colors.accent2}/><div style={{display:'flex',justifyContent:'space-between'}}><span>Memory</span><span>{Math.round(mem.at(-1))}%</span></div><Sparkline data={mem} color={theme.colors.accent}/><div style={{display:'flex',justifyContent:'space-between'}}><span>GPU</span><span>{Math.round(gpu.at(-1))}%</span></div><Sparkline data={gpu} color={theme.colors.accent3}/></div></div>)}
-function BackRoadPage({agents,setAgents,streamOn,setStreamOn,wallet,setWallet,notes,setNotes}){return(<div style={{display:'grid',gap:10}}><div style={{fontWeight:700}}>Agent Stack</div><div style={{display:'flex',gap:8}}>{Object.keys(agents).map(k=>(<label key={k} class="chip" style={{cursor:'pointer'}}><input type="checkbox" checked={agents[k]} onChange={()=>setAgents(a=>({...a,[k]:!a[k]}))}/> {k}</label>))}</div><label style={{display:'inline-flex',alignItems:'center',gap:8}}><input type="checkbox" checked={streamOn} onChange={()=>setStreamOn(s=>!s)}/><span>Stream</span></label><div style={{display:'flex',justifyContent:'space-between',alignItems:'center'}}><div><div style={{fontWeight:700}}>Wallet</div><div class="chip">{wallet} RC</div></div><div style={{display:'flex',gap:8}}><button class="btn small" onClick={()=>setWallet(w=>(parseFloat(w)+0.1).toFixed(2))}>Stake</button><button class="btn small" onClick={()=>setWallet(w=>(Math.max(0,parseFloat(w)-0.1)).toFixed(2))}>Unstake</button></div></div><div style={{fontWeight:700}}>Session Notes</div><textarea value={notes} onChange={e=>setNotes(e.target.value)} placeholder="Type notes…" style={{minHeight:140,background:'#09122a',border:'1px solid var(--border)',borderRadius:12,color:'#fff',padding:10}}/></div>)}
+function BackRoadPage({agents,setAgents,streamOn,setStreamOn,wallet,setWallet,notes,setNotes}){
+  const audioRef = useRef(null);
+  const wsRef = useRef(null);
+  const [whisperLog,setWhisperLog] = useState('');
+  const [whisperSession,setWhisperSession] = useState('');
+  const [whisperBusy,setWhisperBusy] = useState(false);
+
+  const closeWs = () => {
+    if(wsRef.current){
+      try{ wsRef.current.close(); }catch(_){/* noop */}
+      wsRef.current = null;
+    }
+  };
+
+  useEffect(()=>{
+    return ()=>closeWs();
+  },[]);
+
+  const appendLog = line => setWhisperLog(prev => prev ? `${prev}\n${line}` : line);
+
+  function startStream(path, token){
+    closeWs();
+    const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+    const ws = new WebSocket(`${proto}://${location.host}${path}`);
+    wsRef.current = ws;
+    ws.onopen = () => {
+      const payload = { token, lang:'en', model:'base', beam:5 };
+      ws.send(JSON.stringify(payload));
+    };
+    ws.onmessage = ev => {
+      const data = typeof ev.data === 'string' ? ev.data : '';
+      if(!data) return;
+      if(data.startsWith('[[BLACKROAD_SESSION:')){
+        const id = data.replace('[[BLACKROAD_SESSION:','').replace(']]','');
+        setWhisperSession(id);
+        return;
+      }
+      if(data === '[[BLACKROAD_WHISPER_DONE]]'){
+        appendLog('[done]');
+        setWhisperBusy(false);
+        ws.close();
+        return;
+      }
+      appendLog(data);
+    };
+    ws.onerror = () => {
+      appendLog('[error] stream error');
+      setWhisperBusy(false);
+    };
+    ws.onclose = () => {
+      wsRef.current = null;
+      setWhisperBusy(false);
+    };
+  }
+
+  async function uploadAndStream(mode){
+    const file = audioRef.current?.files?.[0];
+    if(!file){
+      setWhisperLog('Pick an audio file.');
+      setWhisperSession('');
+      return;
+    }
+    setWhisperLog('Uploading audio…');
+    setWhisperSession('');
+    setWhisperBusy(true);
+    try{
+      const fd = new FormData();
+      fd.append('file', file);
+      const res = await fetch('/transcribe/upload',{method:'POST',body:fd});
+      if(!res.ok) throw new Error(await res.text());
+      const data = await res.json();
+      if(!data?.token) throw new Error('Upload failed');
+      appendLog(mode==='gpu' ? 'Starting Jetson stream…' : 'Starting local stream…');
+      startStream(mode==='gpu'?'/ws/transcribe/run_gpu':'/ws/transcribe/run', data.token);
+    }catch(err){
+      setWhisperBusy(false);
+      appendLog(`[error] ${err?.message || err}`);
+    }
+  }
+
+  async function downloadTranscript(){
+    if(!whisperSession) return;
+    try{
+      const res = await fetch(`/transcripts/${encodeURIComponent(whisperSession)}`);
+      if(!res.ok) throw new Error(await res.text());
+      const data = await res.json();
+      if(!data?.text) throw new Error(data?.error || 'Transcript empty');
+      const blob = new Blob([data.text],{type:'text/plain'});
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `${whisperSession}.txt`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    }catch(err){
+      appendLog(`[error] transcript download failed: ${err?.message || err}`);
+    }
+  }
+
+  return(
+    <div style={{display:'grid',gap:10}}>
+      <div style={{fontWeight:700}}>Agent Stack</div>
+      <div style={{display:'flex',gap:8}}>{Object.keys(agents).map(k=>(<label key={k} class="chip" style={{cursor:'pointer'}}><input type="checkbox" checked={agents[k]} onChange={()=>setAgents(a=>({...a,[k]:!a[k]}))}/> {k}</label>))}</div>
+      <label style={{display:'inline-flex',alignItems:'center',gap:8}}><input type="checkbox" checked={streamOn} onChange={()=>setStreamOn(s=>!s)}/><span>Stream</span></label>
+      <div style={{display:'flex',justifyContent:'space-between',alignItems:'center'}}>
+        <div>
+          <div style={{fontWeight:700}}>Wallet</div>
+          <div class="chip">{wallet} RC</div>
+        </div>
+        <div style={{display:'flex',gap:8}}>
+          <button class="btn small" onClick={()=>setWallet(w=>(parseFloat(w)+0.1).toFixed(2))}>Stake</button>
+          <button class="btn small" onClick={()=>setWallet(w=>(Math.max(0,parseFloat(w)-0.1)).toFixed(2))}>Unstake</button>
+        </div>
+      </div>
+      <div style={{fontWeight:700}}>Session Notes</div>
+      <textarea value={notes} onChange={e=>setNotes(e.target.value)} placeholder="Type notes…" style={{minHeight:140,background:'#09122a',border:'1px solid var(--border)',borderRadius:12,color:'#fff',padding:10}}/>
+      <div style={{marginTop:6,padding:12,border:'1px solid var(--border)',borderRadius:12,background:'#0b1324',display:'grid',gap:10}}>
+        <div style={{fontWeight:700}}>Whisper (Streaming)</div>
+        <div style={{display:'flex',gap:8,flexWrap:'wrap',alignItems:'center'}}>
+          <input type="file" accept="audio/*" ref={audioRef} disabled={whisperBusy}/>
+          <button class="btn small" disabled={whisperBusy} onClick={()=>uploadAndStream('cpu')}>Transcribe (stream)</button>
+          <button class="btn small" disabled={whisperBusy} onClick={()=>uploadAndStream('gpu')}>Transcribe on Jetson (GPU)</button>
+        </div>
+        <div style={{display:'flex',gap:8,flexWrap:'wrap',alignItems:'center'}}>
+          <button class="btn small" disabled={!whisperSession} onClick={downloadTranscript}>Download transcript</button>
+          {whisperSession && <div class="chip">Session: {whisperSession}</div>}
+        </div>
+        <pre style={{minHeight:140,background:'#09122a',border:'1px solid var(--border)',borderRadius:12,color:'#e2e8f0',padding:10,whiteSpace:'pre-wrap'}}>{whisperLog || 'Pick an audio file and start a run.'}</pre>
+      </div>
+    </div>
+  )
+}
 function CrudPage({kind,title,fields}){const[list,setList]=useState([]);const[loading,setLoading]=useState(true);const[modalOpen,setModalOpen]=useState(false);const[item,setItem]=useState({});const[query,setQuery]=useState('');async function load(){try{const d=await apiGet(`/api/${kind}`);setList(d)}catch{setList([])}finally{setLoading(false)}}useEffect(()=>{load()},[kind]);function edit(x){setItem(x||{});setModalOpen(true)}async function save(){const body={...item};if(item.id){await apiPut(`/api/${kind}/${item.id}`,body)}else{await apiPost(`/api/${kind}`,body)}setModalOpen(false);load()}async function del(id){if(!confirm('Delete?'))return;await apiDel(`/api/${kind}/${id}`);load()}const cols=fields.map(f=>f.name);const filtered=list.filter(r=>JSON.stringify(r).toLowerCase().includes(query.toLowerCase()));return(<div style={{display:'grid',gap:10}}><div style={{display:'flex',justify-content:'space-between',alignItems:'center'}}><strong>{title}</strong><div style={{display:'flex',gap:8}}><input value={query} onChange={e=>setQuery(e.target.value)} placeholder="Search…" style={{background:'#09122a',border:'1px solid var(--border)',borderRadius:10,color:'#fff',padding:'8px 10px'}}/><button class="btn small" onClick={()=>edit({})}>New</button></div></div><div style={{overflow:'auto',border:'1px solid var(--border)',borderRadius:12}}><table style={{width:'100%',borderCollapse:'collapse'}}><thead><tr>{cols.map(c=><th key={c} style={{textAlign:'left',padding:'10px 12px',borderBottom:'1px solid var(--border)',color:'var(--muted)'}}>{c}</th>)}<th style={{padding:'10px 12px',borderBottom:'1px solid var(--border)'}}></th></tr></thead><tbody>{loading?<tr><td colSpan={cols.length+1} style={{padding:12}}>Loading…</td></tr>:filtered.map(row=>(<tr key={row.id}><>{cols.map(c=><td key={c} style={{padding:'10px 12px',borderBottom:'1px solid var(--border)'}}>{String(row[c]??'')}</td>)}</><td style={{padding:'10px 12px',borderBottom:'1px solid var(--border)'}}><button class="btn small" onClick={()=>edit(row)}>Edit</button> <button class="btn small" onClick={()=>del(row.id)}>Delete</button></td></tr>))}</tbody></table></div><Modal open={modalOpen} onClose={()=>setModalOpen(false)} title={item.id?'Edit':'New'}><div style={{display:'grid',gap:8}}>{fields.map(f=>(<div key={f.name} style={{display:'grid',gap:6}}><label style={{color:'var(--muted)'}}>{f.name}</label><input value={item[f.name]||''} onChange={e=>setItem({...item,[f.name]:e.target.value})} placeholder={f.placeholder||''} style={{background:'#09122a',border:'1px solid var(--border)',borderRadius:10,color:'#fff',padding:'8px 10px'}}/></div>))}<div style={{display:'flex',gap:8,justifyContent:'flex-end',marginTop:6}}><button class="btn" onClick={()=>setModalOpen(false)}>Cancel</button><button class="btn primary" onClick={save}>Save</button></div></div></Modal></div>)}
 function S3Uploader(){
   const [file,setFile]=useState(null);


### PR DESCRIPTION
## Summary
- add a Pi dashboard FastAPI module that uploads audio, proxies Jetson GPU transcription, and exposes saved transcripts
- add agent helpers for Jetson target configuration, upload storage, and SQLite transcript persistence
- update the BackRoad dashboard Whisper card with GPU streaming controls, live logs, and transcript download support

## Testing
- python -m py_compile agent/__init__.py agent/config.py agent/store.py agent/transcribe.py pi_dashboard/api.py

------
https://chatgpt.com/codex/tasks/task_e_68db04b85a088329b557f320ee52653a