### PR TITLE
Add local Whisper transcription endpoint and dashboard panel

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,5 @@
+"""Agent service package."""
+
+__all__ = [
+    "transcribe",
+]

--- a/agent/api.py
+++ b/agent/api.py
@@ -1,0 +1,28 @@
+"""FastAPI surface for agent utilities."""
+
+from __future__ import annotations
+
+import pathlib
+import tempfile
+
+from fastapi import FastAPI, File, UploadFile
+
+from agent import transcribe
+
+app = FastAPI(title="BlackRoad Agent API")
+
+
+@app.post("/transcribe")
+async def transcribe_audio(file: UploadFile = File(...)) -> dict[str, str]:
+    """Accept an uploaded audio file and run whisper.cpp locally."""
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as tmp:
+        data = await file.read()
+        tmp.write(data)
+        tmp_path = pathlib.Path(tmp.name)
+
+    try:
+        text = transcribe.run_whisper(str(tmp_path))
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+    return {"text": text}

--- a/agent/transcribe.py
+++ b/agent/transcribe.py
@@ -1,0 +1,33 @@
+"""Local wrapper for whisper.cpp transcription."""
+
+from __future__ import annotations
+
+import pathlib
+import shutil
+import subprocess
+import tempfile
+
+
+def run_whisper(audio_path: str, model_path: str | None = None, lang: str = "en") -> str:
+    """Run whisper.cpp binary against the provided audio file."""
+    exe = shutil.which("whisper") or shutil.which("main")  # adjust to your whisper.cpp binary
+    if not exe:
+        return "[error] whisper.cpp binary not found"
+
+    audio_file = pathlib.Path(audio_path).expanduser()
+    if not audio_file.exists():
+        return "[error] audio file not found"
+
+    model_path = model_path or "/var/lib/blackroad/models/ggml-base.en.bin"
+    cmd = [exe, "-m", model_path, "-l", lang, str(audio_file)]
+
+    try:
+        out = subprocess.check_output(
+            cmd,
+            text=True,
+            stderr=subprocess.STDOUT,
+            cwd=tempfile.gettempdir(),
+        )
+        return out
+    except subprocess.CalledProcessError as exc:  # pragma: no cover - passthrough error text
+        return f"[error] {exc.output}"


### PR DESCRIPTION
## Summary
- add a whisper.cpp wrapper for offline transcription and expose it through a FastAPI endpoint
- surface a Whisper Transcription card on the dashboard so operators can upload audio and view the decoded text

## Testing
- npm --prefix frontend run build *(fails: missing @vitejs/plugin-react in existing setup)*

------
https://chatgpt.com/codex/tasks/task_e_68db020b10f4832984fa76374461d803