### PR TITLE
Add local model streaming panel to lucidia dev UI

### DIFF
--- a/srv/blackroad/static/lucidia-dev.html
+++ b/srv/blackroad/static/lucidia-dev.html
@@ -37,9 +37,19 @@
       }
       .wrap {
         display: grid;
-        grid-template-columns: 1.4fr 0.6fr;
+        grid-template-columns: minmax(0, 1.4fr) minmax(0, 0.6fr);
         gap: 16px;
         padding: 16px;
+      }
+      @media (max-width: 900px) {
+        .wrap {
+          grid-template-columns: 1fr;
+        }
+      }
+      .side {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
       }
       .panel {
         background: #10131a;
@@ -48,6 +58,10 @@
         overflow: hidden;
         display: flex;
         flex-direction: column;
+      }
+      .local-panel {
+        padding: 16px;
+        gap: 12px;
       }
       .messages {
         padding: 16px;
@@ -118,6 +132,45 @@
         font-size: 12px;
         opacity: 0.8;
       }
+      .local-header {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        justify-content: space-between;
+      }
+      .local-header .title {
+        font-weight: 600;
+        font-size: 14px;
+      }
+      .ghost {
+        background: #1a1d29;
+        border: 1px solid #2b2f42;
+        color: #e8e8e8;
+      }
+      .ghost:hover {
+        background: #22263a;
+      }
+      button:disabled,
+      .ghost:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+      }
+      .local-panel textarea {
+        width: 100%;
+        min-height: 110px;
+        resize: vertical;
+      }
+      .local-output {
+        background: #05060b;
+        border: 1px solid #1d2030;
+        border-radius: 12px;
+        padding: 12px;
+        height: 220px;
+        overflow: auto;
+        white-space: pre-wrap;
+        font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+        color: #7fffd4;
+      }
     </style>
   </head>
   <body>
@@ -139,37 +192,58 @@
         </div>
       </div>
 
-      <div class="panel">
-        <div class="kv">
-          <div>
-            <label>Preset</label>
-            <select id="preset">
-              <option value="codex">codex</option>
-              <option value="lucidia">lucidia</option>
-              <option value="chit_chat">chit_chat</option>
-            </select>
+      <div class="side">
+        <div class="panel">
+          <div class="kv">
+            <div>
+              <label>Preset</label>
+              <select id="preset">
+                <option value="codex">codex</option>
+                <option value="lucidia">lucidia</option>
+                <option value="chit_chat">chit_chat</option>
+              </select>
+            </div>
+            <div>
+              <label>Model (backend-specific)</label>
+              <input type="text" id="model" placeholder="phi3:mini (ollama) / llama3.1 (llamacpp)" />
+            </div>
+            <div>
+              <label>Temperature</label>
+              <input type="text" id="temp" value="0.7" />
+            </div>
+            <div>
+              <label>Top-p</label>
+              <input type="text" id="topp" value="0.9" />
+            </div>
+            <div>
+              <label>Max tokens</label>
+              <input type="text" id="maxtok" value="1024" />
+            </div>
           </div>
-          <div>
-            <label>Model (backend-specific)</label>
-            <input type="text" id="model" placeholder="phi3:mini (ollama) / llama3.1 (llamacpp)" />
-          </div>
-          <div>
-            <label>Temperature</label>
-            <input type="text" id="temp" value="0.7" />
-          </div>
-          <div>
-            <label>Top-p</label>
-            <input type="text" id="topp" value="0.9" />
-          </div>
-          <div>
-            <label>Max tokens</label>
-            <input type="text" id="maxtok" value="1024" />
+          <div class="meta">
+            <div>
+              GET <code>/health</code> to verify; POST <code>/api/chitchat</code> streams SSE deltas.
+            </div>
           </div>
         </div>
-        <div class="meta">
-          <div>
-            GET <code>/health</code> to verify; POST <code>/api/chitchat</code> streams SSE deltas.
+
+        <div class="panel local-panel">
+          <div class="local-header">
+            <div class="title">Local Models (Streaming)</div>
+            <button id="loadModels" type="button" class="ghost">Load Models</button>
           </div>
+          <label>
+            Model
+            <select id="modelSel">
+              <option value="">(backend default)</option>
+            </select>
+          </label>
+          <label>
+            Prompt
+            <textarea id="prompt" placeholder="Enter prompt…"></textarea>
+          </label>
+          <button id="runModel" type="button">Run (stream)</button>
+          <pre id="modelOut" class="local-output">Load models to get started.</pre>
         </div>
       </div>
     </div>
@@ -185,8 +259,153 @@
       const elMaxTok = document.getElementById('maxtok');
       const elBackend = document.getElementById('backend');
       const elStatus = document.getElementById('status');
+      const elLoadModels = document.getElementById('loadModels');
+      const elModelSel = document.getElementById('modelSel');
+      const elPrompt = document.getElementById('prompt');
+      const elRunModel = document.getElementById('runModel');
+      const elModelOut = document.getElementById('modelOut');
 
       let history = [];
+
+      function drainSSE(buffer, callback) {
+        const parts = buffer.split('\n\n');
+        buffer = parts.pop() || '';
+        for (const part of parts) {
+          if (!part) continue;
+          const lines = part.split('\n');
+          let event = 'delta';
+          let data = '';
+          for (const line of lines) {
+            if (line.startsWith('event:')) event = line.slice(6).trim();
+            if (line.startsWith('data:')) data += line.slice(5).trim();
+          }
+          callback(event, data);
+        }
+        return buffer;
+      }
+
+      async function loadModelsList() {
+        if (!elLoadModels || !elModelSel || !elModelOut) return;
+        elLoadModels.disabled = true;
+        elModelOut.textContent = 'Loading models…';
+        try {
+          const res = await fetch('/api/models');
+          if (!res.ok) {
+            const txt = await res.text();
+            throw new Error(`${res.status} ${res.statusText}${txt ? ` — ${txt}` : ''}`);
+          }
+          const data = await res.json();
+          const models = Array.isArray(data.models) ? data.models.filter(Boolean) : [];
+          elModelSel.innerHTML = '';
+          const placeholder = document.createElement('option');
+          placeholder.value = '';
+          placeholder.textContent = '(backend default)';
+          elModelSel.appendChild(placeholder);
+          models.forEach((name) => {
+            const opt = document.createElement('option');
+            opt.value = name;
+            opt.textContent = name;
+            elModelSel.appendChild(opt);
+          });
+          if (models.length) {
+            elModelSel.value = models[0];
+          }
+          if (data.error) {
+            elModelOut.textContent = `Warning: ${data.error}`;
+          } else {
+            const backend = data.backend || 'backend';
+            elModelOut.textContent = `Loaded ${models.length} models from ${backend}.`;
+          }
+        } catch (err) {
+          elModelOut.textContent = `Error loading models: ${err.message || err}`;
+          console.error('loadModelsList', err);
+        } finally {
+          elLoadModels.disabled = false;
+        }
+      }
+
+      async function runLocalModel() {
+        if (!elRunModel || !elPrompt || !elModelOut) return;
+        const prompt = (elPrompt.value || '').trim();
+        if (!prompt) {
+          elModelOut.textContent = 'Enter a prompt to run the model.';
+          return;
+        }
+
+        elRunModel.disabled = true;
+        elModelOut.textContent = 'Streaming…';
+
+        let acc = '';
+        try {
+          const payload = {
+            messages: [{ role: 'user', content: prompt }],
+            stream: true,
+          };
+          const selectedModel = elModelSel ? elModelSel.value.trim() : '';
+          if (selectedModel) payload.model = selectedModel;
+
+          const res = await fetch('/api/chitchat', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+          });
+          if (!res.ok) {
+            const txt = await res.text();
+            throw new Error(`${res.status} ${res.statusText}${txt ? ` — ${txt}` : ''}`);
+          }
+          if (!res.body || !res.body.getReader) {
+            const txt = await res.text();
+            elModelOut.textContent = txt || 'Streaming not supported in this browser.';
+            return;
+          }
+
+          const reader = res.body.getReader();
+          const decoder = new TextDecoder();
+          let buffer = '';
+
+          const handleEvent = (event, chunk) => {
+            if (!chunk) return;
+            try {
+              const data = JSON.parse(chunk);
+              if (event === 'open' && data.status) {
+                elModelOut.textContent = data.status;
+                return;
+              }
+              if (event === 'delta' && data.content) {
+                acc += data.content;
+                elModelOut.textContent = acc;
+              } else if (event === 'done') {
+                if (data.content) {
+                  acc = data.content;
+                }
+                const elapsed = typeof data.elapsed_ms === 'number' ? `\n\n⏱ ${data.elapsed_ms} ms` : '';
+                elModelOut.textContent = acc ? acc + elapsed : `Done.${elapsed ? ` ${elapsed}` : ''}`;
+              }
+            } catch (parseErr) {
+              if (event === 'delta') {
+                acc += chunk;
+                elModelOut.textContent = acc;
+              }
+            }
+          };
+
+          while (true) {
+            const { value, done } = await reader.read();
+            if (done) break;
+            buffer += decoder.decode(value, { stream: true });
+            buffer = drainSSE(buffer, handleEvent);
+          }
+          buffer = drainSSE(buffer, handleEvent);
+          if (!acc) {
+            elModelOut.textContent = 'No response received.';
+          }
+        } catch (err) {
+          elModelOut.textContent = `Error running model: ${err.message || err}`;
+          console.error('runLocalModel', err);
+        } finally {
+          elRunModel.disabled = false;
+        }
+      }
 
       async function boot() {
         try {
@@ -281,6 +500,8 @@
           send();
         }
       });
+      if (elLoadModels) elLoadModels.addEventListener('click', loadModelsList);
+      if (elRunModel) elRunModel.addEventListener('click', runLocalModel);
 
       boot();
     </script>


### PR DESCRIPTION
## Summary
- rework the lucidia dev UI layout to host an additional tools column
- add a Local Models (Streaming) panel with load/run controls and streaming output
- wire front-end logic to fetch /api/models and consume SSE responses from /api/chitchat

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68db01f303a48329aeb29e018f04fe93