### PR TITLE
Add job history storage and dashboard integration

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,5 @@
+"""BlackRoad backend helper modules."""
+
+from . import jobs, telemetry, store
+
+__all__ = ["jobs", "telemetry", "store"]

--- a/agent/jobs.py
+++ b/agent/jobs.py
@@ -1,0 +1,42 @@
+"""Helpers for executing shell jobs and streaming their output."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Iterable
+
+
+def _prepare_command(command: str) -> str:
+    if not command:
+        raise ValueError("command must be non-empty")
+    return command
+
+
+def run_remote_stream(command: str) -> Iterable[str]:
+    """Run *command* locally and yield stdout/stderr lines as they arrive."""
+
+    cmd = _prepare_command(command)
+    proc = subprocess.Popen(
+        cmd,
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+        executable="/bin/bash",
+    )
+
+    assert proc.stdout is not None
+    try:
+        for line in proc.stdout:
+            yield line.rstrip("\n")
+        return_code = proc.wait()
+        if return_code != 0:
+            raise RuntimeError(f"command exited with code {return_code}")
+    finally:
+        try:
+            proc.stdout.close()
+        except Exception:
+            pass
+        if proc.poll() is None:
+            proc.kill()

--- a/agent/store.py
+++ b/agent/store.py
@@ -1,0 +1,62 @@
+import sqlite3
+import pathlib
+import time
+from typing import Dict, List, Optional
+
+DB = pathlib.Path("/var/lib/blackroad/jobs.sqlite")
+DB.parent.mkdir(parents=True, exist_ok=True)
+
+def _conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(DB)
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS jobs(
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        cmd TEXT, started REAL, ended REAL, status TEXT, output TEXT
+    )"""
+    )
+    return conn
+
+def new_job(cmd: str) -> int:
+    with _conn() as c:
+        cur = c.execute(
+            "INSERT INTO jobs(cmd,started,status,output) VALUES(?,?,?,?)",
+            (cmd, time.time(), "running", ""),
+        )
+        return cur.lastrowid
+
+def append(job_id: int, text: str) -> None:
+    with _conn() as c:
+        c.execute(
+            "UPDATE jobs SET output=COALESCE(output,'')||? WHERE id=?",
+            (text, job_id),
+        )
+
+def finish(job_id: int, status: str) -> None:
+    with _conn() as c:
+        c.execute(
+            "UPDATE jobs SET ended=?, status=? WHERE id=?",
+            (time.time(), status, job_id),
+        )
+
+def list_jobs(limit: int = 20) -> List[Dict[str, Optional[float]]]:
+    with _conn() as c:
+        rows = c.execute(
+            "SELECT id,cmd,started,ended,status FROM jobs ORDER BY id DESC LIMIT ?",
+            (limit,),
+        ).fetchall()
+        return [
+            dict(id=r[0], cmd=r[1], started=r[2], ended=r[3], status=r[4])
+            for r in rows
+        ]
+
+def get_job(job_id: int) -> Optional[Dict[str, Optional[float]]]:
+    with _conn() as c:
+        r = c.execute(
+            "SELECT id,cmd,started,ended,status,output FROM jobs WHERE id=?",
+            (job_id,),
+        ).fetchone()
+        if not r:
+            return None
+        return dict(
+            id=r[0], cmd=r[1], started=r[2], ended=r[3], status=r[4], output=r[5] or ""
+        )

--- a/agent/telemetry.py
+++ b/agent/telemetry.py
@@ -1,0 +1,105 @@
+"""Lightweight telemetry helpers for the BlackRoad dashboard."""
+
+from __future__ import annotations
+
+import asyncio
+import random
+import time
+from collections import deque
+from typing import Any, AsyncIterator, Deque, Dict, Iterable, List
+
+_TIMELINE: Deque[Dict[str, Any]] = deque(
+    [
+        {
+            "id": 1,
+            "title": "Deployment complete",
+            "desc": "Prism console deployed to staging",
+            "ts": time.time() - 1800,
+        },
+        {
+            "id": 2,
+            "title": "Notebook synced",
+            "desc": "Jetson telemetry heartbeat registered",
+            "ts": time.time() - 1200,
+        },
+        {
+            "id": 3,
+            "title": "Code review finished",
+            "desc": "Merged agent orchestrator patch",
+            "ts": time.time() - 600,
+        },
+    ],
+    maxlen=200,
+)
+_TASKS: List[Dict[str, Any]] = [
+    {"id": 1, "title": "Wire Jetson metrics", "status": "in-progress"},
+    {"id": 2, "title": "Audit API keys", "status": "pending"},
+]
+_COMMITS: List[Dict[str, Any]] = [
+    {
+        "id": "f9a3c21",
+        "author": "codex",
+        "title": "Improve agent resilience",
+        "ts": time.time() - 2600,
+    }
+]
+_STATE: Dict[str, Any] = {
+    "wallet": 1.20,
+    "agents": {"Phi": True, "GPT": True, "Mistral": True},
+    "build": 63,
+}
+
+
+def timeline() -> List[Dict[str, Any]]:
+    return list(_TIMELINE)
+
+
+def tasks() -> List[Dict[str, Any]]:
+    return list(_TASKS)
+
+
+def commits() -> List[Dict[str, Any]]:
+    return list(_COMMITS)
+
+
+def state() -> Dict[str, Any]:
+    return dict(_STATE)
+
+
+def record_activity(title: str, desc: str) -> Dict[str, Any]:
+    entry = {
+        "id": int(time.time() * 1000),
+        "title": title,
+        "desc": desc,
+        "ts": time.time(),
+    }
+    _TIMELINE.appendleft(entry)
+    return entry
+
+
+async def stream() -> AsyncIterator[Dict[str, Any]]:
+    rng = random.Random()
+    wallet = float(_STATE.get("wallet", 0))
+    build = float(_STATE.get("build", 0))
+    while True:
+        cpu = rng.uniform(20, 90)
+        mem = rng.uniform(30, 80)
+        gpu = rng.uniform(10, 95)
+        yield {"type": "metrics", "cpu": cpu, "mem": mem, "gpu": gpu}
+
+        if _TIMELINE and rng.random() < 0.35:
+            item = rng.choice(list(_TIMELINE))
+            yield {"type": "activity", "item": item}
+
+        if rng.random() < 0.25:
+            build = min(100.0, build + rng.uniform(0.5, 2.5))
+            _STATE["build"] = build
+            yield {"type": "build", "progress": build}
+
+        if rng.random() < 0.2:
+            delta = rng.uniform(-0.05, 0.08)
+            wallet = max(0.0, wallet + delta)
+            _STATE["wallet"] = round(wallet, 2)
+            yield {"type": "wallet", "balance": _STATE["wallet"]}
+
+        await asyncio.sleep(1.5)

--- a/srv/blackroad-backend/api/server.py
+++ b/srv/blackroad-backend/api/server.py
@@ -2,10 +2,17 @@
 Lucidia API Server – WebSocket + REST
 Exposes Roadie and Guardian functions via simple endpoints.
 """
-from fastapi import FastAPI
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.responses import JSONResponse
-from agents.roadie import Roadie
+
+from agent import jobs, store, telemetry
 from agents.guardian import Guardian
+from agents.roadie import Roadie
 
 app = FastAPI(title="Lucidia API")
 
@@ -15,17 +22,99 @@ guardian = Guardian(memory_dir="/srv/blackroad-backend/memory")
 
 
 @app.get("/")
-def home():
+def home() -> Dict[str, str]:
     return {"status": "Lucidia API online"}
 
 
 @app.get("/search/{query}")
-def search(query: str):
+def search(query: str) -> JSONResponse:
     results = roadie.search(query)
     return JSONResponse(content={"results": results})
 
 
 @app.get("/audit")
-def audit():
+def audit() -> JSONResponse:
     result = guardian.verify_integrity()
     return JSONResponse(content={"result": result})
+
+
+@app.get("/api/timeline")
+def api_timeline() -> Any:
+    return telemetry.timeline()
+
+
+@app.get("/api/tasks")
+def api_tasks() -> Any:
+    return telemetry.tasks()
+
+
+@app.get("/api/commits")
+def api_commits() -> Any:
+    return telemetry.commits()
+
+
+@app.get("/api/state")
+def api_state() -> Dict[str, Any]:
+    return telemetry.state()
+
+
+@app.websocket("/ws")
+async def ws_dashboard(websocket: WebSocket) -> None:
+    await websocket.accept()
+    stream = telemetry.stream()
+    try:
+        async for message in stream:
+            await websocket.send_text(json.dumps(message))
+    except WebSocketDisconnect:
+        pass
+    finally:
+        try:
+            await stream.aclose()  # type: ignore[attr-defined]
+        except Exception:
+            pass
+        try:
+            await websocket.close()
+        except Exception:
+            pass
+
+
+@app.websocket("/ws/run")
+async def ws_run(websocket: WebSocket) -> None:
+    await websocket.accept()
+    jid = None
+    try:
+        cmd = await websocket.receive_text()
+        jid = store.new_job(cmd)
+        telemetry.record_activity(f"Job #{jid} queued", cmd)
+        await websocket.send_text(f"[[BLACKROAD_JOB_ID:{jid}]]")
+        for line in jobs.run_remote_stream(command=cmd):
+            store.append(jid, line + "\n")
+            await websocket.send_text(line)
+        store.finish(jid, "ok")
+        telemetry.record_activity(f"Job #{jid} complete", "Job finished successfully")
+        await websocket.send_text("[[BLACKROAD_DONE]]")
+    except WebSocketDisconnect:
+        if jid is not None:
+            store.finish(jid, "disconnected")
+            telemetry.record_activity(f"Job #{jid} disconnected", "Client closed stream")
+    except Exception as exc:  # pragma: no cover - defensive
+        if jid is not None:
+            store.finish(jid, f"error: {exc}")
+            telemetry.record_activity(f"Job #{jid} error", str(exc))
+        await websocket.send_text(f"[error] {exc}")
+    finally:
+        try:
+            await websocket.close()
+        except Exception:
+            pass
+
+
+@app.get("/jobs")
+def jobs_list() -> Dict[str, Any]:
+    return {"jobs": store.list_jobs(50)}
+
+
+@app.get("/jobs/{jid}")
+def jobs_get(jid: int) -> Dict[str, Any]:
+    job = store.get_job(jid)
+    return job or {"error": "not found"}

--- a/srv/blackroad/web/index.html
+++ b/srv/blackroad/web/index.html
@@ -45,7 +45,7 @@
 <body>
 <div id="root"></div>
 <script type="text/babel">
-const {useState,useEffect,useMemo,useRef} = React; const styled = window.styled;
+const {useState,useEffect,useMemo,useRef,useCallback} = React; const styled = window.styled;
 /* ------------ API helpers ------------- */
 async function apiGet(p){const r=await fetch(p,{credentials:"include"});if(!r.ok)throw new Error(await r.text());return r.json()}
 async function apiPost(p,b={}){const r=await fetch(p,{method:"POST",headers:{"Content-Type":"application/json"},credentials:"include",body:JSON.stringify(b)});if(!r.ok)throw new Error(await r.text());return r.json()}
@@ -148,13 +148,25 @@ function Dashboard({route}) {
   const [mem,setMEM]=useState(Array.from({length:40},()=>Math.random()*70+20));
   const [gpu,setGPU]=useState(Array.from({length:40},()=>Math.random()*90));
   const [build,setBuild]=useState(63); const [timeline,setTimeline]=useState([]); const [commits,setCommits]=useState([]); const [tasks,setTasks]=useState([]);
+  const [jobs,setJobs]=useState([]);
+  const [jobOutput,setJobOutput]=useState('');
+  const jobOutRef=useRef(null);
+  const activeJobRef=useRef(null);
+
+  const loadJobs=useCallback(async()=>{try{const res=await fetch('/jobs');const data=await res.json();setJobs(Array.isArray(data.jobs)?data.jobs:[]);}catch(err){console.error('jobs load failed',err);}},[]);
+  const openJob=useCallback(async(id)=>{activeJobRef.current=id;try{const res=await fetch(`/jobs/${id}`);const data=await res.json();const text=data.output||JSON.stringify(data,null,2);setJobOutput(text);setTimeout(()=>{if(jobOutRef.current){jobOutRef.current.scrollTop=jobOutRef.current.scrollHeight;}},0);}catch(err){setJobOutput(String(err));}},[]);
 
   useEffect(()=>{Promise.allSettled([apiGet('/api/timeline'),apiGet('/api/tasks'),apiGet('/api/commits'),apiGet('/api/state')]).then(([tl,ts,cs,st])=>{
     if(tl.value)setTimeline(tl.value); if(ts.value)setTasks(ts.value); if(cs.value)setCommits(cs.value);
-    if(st.value){setWallet(st.value.wallet); setAgents(st.value.agents); setBuild(st.value.build)}
-  }); const proto=location.protocol==='https:'?'wss':'ws'; const ws=new WebSocket(`${proto}://${location.host}/ws`);
-  ws.onmessage=e=>{try{const m=JSON.parse(e.data); if(m.type==='activity') setTimeline(t=>[m.item,...t].slice(0,80)); if(m.type==='metrics'){setCPU(x=>[...x.slice(1),m.cpu]); setMEM(x=>[...x.slice(1),m.mem]); setGPU(x=>[...x.slice(1),m.gpu]);} if(m.type==='build') setBuild(m.progress); if(m.type==='wallet') setWallet(m.balance.toFixed(2)); }catch(_){} };
-  return ()=>ws.close();},[]);
+    if(st.value){setWallet(st.value.wallet); setAgents(st.value.agents); setBuild(st.value.build);}
+  }); loadJobs(); const proto=location.protocol==='https:'?'wss':'ws'; const ws=new WebSocket(`${proto}://${location.host}/ws`);
+  ws.onmessage=e=>{const raw=typeof e.data==='string'?e.data:''; try{const m=JSON.parse(raw); if(m.type==='activity') setTimeline(t=>[m.item,...t].slice(0,80)); if(m.type==='metrics'){setCPU(x=>[...x.slice(1),m.cpu]); setMEM(x=>[...x.slice(1),m.mem]); setGPU(x=>[...x.slice(1),m.gpu]);} if(m.type==='build') setBuild(m.progress); if(m.type==='wallet') setWallet(m.balance.toFixed(2)); }catch(err){}};
+  return ()=>ws.close();},[loadJobs]);
+
+  useEffect(()=>{const origWS=window.WebSocket; const patched=function(url,protocols){const ws=protocols!==undefined?new origWS(url,protocols):new origWS(url); const handler=(event)=>{const raw=String(event.data??''); if(raw.startsWith('[[BLACKROAD_JOB_ID:')){const match=raw.match(/\d+/); const id=match?Number(match[0]):null; if(id){activeJobRef.current=id; setJobOutput(''); loadJobs().then(()=>openJob(id)).catch(()=>{});} return;} if(raw==='[[BLACKROAD_DONE]]'){const id=activeJobRef.current; loadJobs().then(()=>{if(id) openJob(id);}).catch(()=>{}); return;} if(raw.startsWith('[error]')){setJobOutput(prev=>prev?`${prev}\n${raw}`:raw); setTimeout(()=>{if(jobOutRef.current){jobOutRef.current.scrollTop=jobOutRef.current.scrollHeight;}},0); loadJobs().then(()=>{const id=activeJobRef.current; if(id) openJob(id);}).catch(()=>{});} }; ws.addEventListener('message',handler); return ws;};
+  Object.assign(patched,origWS); patched.prototype=origWS.prototype; window.WebSocket=patched; return()=>{window.WebSocket=origWS;};},[loadJobs,openJob]);
+
+  const formatTs=ts=>ts?new Date(ts*1000).toLocaleTimeString():'-';
 
   const filteredTimeline=useMemo(()=>timeline.filter(x=>(x.title||'').toLowerCase().includes(filter.toLowerCase())||(x.desc||'').toLowerCase().includes(filter.toLowerCase())),[timeline,filter]);
   const [code,setCode]=useState(`// Example code\nconsole.log('BlackRoad online');`);
@@ -227,6 +239,29 @@ function Dashboard({route}) {
             <div style={{display:'flex',justifyContent:'space-between'}}><span>GPU</span><span>{Math.round(gpu.at(-1))}%</span></div>
             <Sparkline data={gpu} color={theme.colors.accent3}/>
           </div>
+        </Card>
+        <Card>
+          <div style={{display:'flex',justifyContent:'space-between',alignItems:'center'}}>
+            <div style={{fontWeight:700}}>Jobs</div>
+            <button className="btn small" onClick={loadJobs}>Refresh</button>
+          </div>
+          <table style={{width:'100%',marginTop:8,fontSize:12,borderCollapse:'collapse'}}>
+            <thead><tr><th>ID</th><th>Cmd</th><th>Status</th><th>Started</th><th>Ended</th><th>View</th></tr></thead>
+            <tbody>
+              {jobs.map(job=>(
+                <tr key={job.id}>
+                  <td>{job.id}</td>
+                  <td style={{maxWidth:360,overflow:'hidden',textOverflow:'ellipsis',whiteSpace:'nowrap'}} title={job.cmd}>{job.cmd}</td>
+                  <td>{job.status}</td>
+                  <td>{formatTs(job.started)}</td>
+                  <td>{formatTs(job.ended)}</td>
+                  <td><button className="btn small" onClick={()=>openJob(job.id)}>Open</button></td>
+                </tr>
+              ))}
+              {!jobs.length && <tr><td colSpan="6" style={{padding:'8px 4px',color:'var(--muted)'}}>No jobs yet</td></tr>}
+            </tbody>
+          </table>
+          <pre ref={jobOutRef} style={{background:'#000',color:'#0f0',padding:'1em',height:220,overflow:'auto',borderRadius:6,marginTop:8}}>{jobOutput}</pre>
         </Card>
         <Card>
           <div style={{display:'flex',justifyContent:'space-between',alignItems:'center'}}>


### PR DESCRIPTION
## Summary
- add a lightweight agent package with SQLite job storage, shell streaming helpers, and telemetry seeds
- extend the FastAPI backend with job list/detail endpoints and WebSocket handlers that record output
- refresh the dashboard to show a Jobs panel and hook WebSocket traffic so job runs auto-populate logs

## Testing
- python -m compileall agent srv/blackroad-backend/api/server.py

------
https://chatgpt.com/codex/tasks/task_e_68dafd7122cc832984c3d162c9bea5d7