### PR TITLE
Add Jetson GPU transcription pipeline

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,4 @@
+"""Utilities for the BlackRoad Pi voice pipeline."""
+
+__all__ = ["config", "store", "transcribe"]
+

--- a/agent/config.py
+++ b/agent/config.py
@@ -1,0 +1,43 @@
+"""Runtime configuration helpers for Pi ↔ Jetson orchestration."""
+
+from __future__ import annotations
+
+import os
+from typing import Tuple
+
+
+def active_target() -> Tuple[str, str]:
+    """Return the SSH target (host, user) for the Jetson worker.
+
+    The helper checks the following environment variables in order:
+
+    1. ``JETSON_TARGET`` – formatted as ``"user@host"`` or just ``"host"``
+       (falls back to ``JETSON_USER``/``JETSON_HOST`` for missing pieces).
+    2. ``JETSON_HOST`` and ``JETSON_USER`` individually.
+
+    If nothing is configured, ``jetson.local`` and ``ubuntu`` are returned so
+    the rest of the stack has sensible defaults during development.
+    """
+
+    target = os.environ.get("JETSON_TARGET", "").strip()
+    host = os.environ.get("JETSON_HOST", "").strip()
+    user = os.environ.get("JETSON_USER", "").strip()
+
+    if target:
+        if "@" in target:
+            user_part, host_part = target.split("@", 1)
+            user = user or user_part
+            host = host or host_part
+        else:
+            host = host or target
+
+    if not host:
+        host = "jetson.local"
+    if not user:
+        user = "ubuntu"
+
+    return host, user
+
+
+__all__ = ["active_target"]
+

--- a/agent/store.py
+++ b/agent/store.py
@@ -1,0 +1,143 @@
+"""SQLite-backed helpers for rolling transcription storage."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+DB_PATH = Path(os.environ.get("BLACKROAD_DB", "blackroad.db")).resolve()
+_lock = threading.RLock()
+_conn: Optional[sqlite3.Connection] = None
+_schema_ready = False
+
+
+def _get_conn() -> sqlite3.Connection:
+    global _conn
+    if _conn is None:
+        DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _conn = sqlite3.connect(DB_PATH, check_same_thread=False)
+        _conn.row_factory = sqlite3.Row
+    return _conn
+
+
+def _ensure_schema() -> None:
+    global _schema_ready
+    if _schema_ready:
+        return
+    with _lock:
+        if _schema_ready:
+            return
+        conn = _get_conn()
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS transcripts (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              session TEXT,
+              started REAL,
+              ended REAL,
+              text TEXT
+            )
+            """
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_transcripts_session ON transcripts(session)"
+        )
+        conn.commit()
+        _schema_ready = True
+
+
+def transcript_start(session: str) -> None:
+    """Create (or reset) the rolling transcript row for *session*."""
+
+    if not session:
+        raise ValueError("session id required")
+    _ensure_schema()
+    with _lock:
+        conn = _get_conn()
+        conn.execute("DELETE FROM transcripts WHERE session=?", (session,))
+        conn.execute(
+            "INSERT INTO transcripts(session, started, text) VALUES(?,?,?)",
+            (session, time.time(), ""),
+        )
+        conn.commit()
+
+
+def transcript_append(session: str, chunk: str, max_bytes: int = 512 * 1024) -> None:
+    """Append *chunk* to the transcript while keeping the last ``max_bytes`` bytes."""
+
+    if not session or chunk is None:
+        return
+    _ensure_schema()
+    with _lock:
+        conn = _get_conn()
+        row = conn.execute(
+            "SELECT text FROM transcripts WHERE session=?", (session,)
+        ).fetchone()
+        if row is None:
+            # If start wasn't called, create the row lazily.
+            conn.execute(
+                "INSERT INTO transcripts(session, started, text) VALUES(?,?,?)",
+                (session, time.time(), ""),
+            )
+            text = ""
+        else:
+            text = row["text"] or ""
+
+        text_bytes = (text + chunk).encode("utf-8")
+        if max_bytes and len(text_bytes) > max_bytes:
+            text_bytes = text_bytes[-max_bytes:]
+            text = text_bytes.decode("utf-8", errors="ignore")
+        else:
+            text = text_bytes.decode("utf-8", errors="ignore")
+
+        conn.execute(
+            "UPDATE transcripts SET text=? WHERE session=?",
+            (text, session),
+        )
+        conn.commit()
+
+
+def transcript_finish(session: str) -> None:
+    if not session:
+        return
+    _ensure_schema()
+    with _lock:
+        conn = _get_conn()
+        conn.execute(
+            "UPDATE transcripts SET ended=? WHERE session=?",
+            (time.time(), session),
+        )
+        conn.commit()
+
+
+def transcript_get(session: str) -> Optional[Dict[str, Any]]:
+    if not session:
+        return None
+    _ensure_schema()
+    conn = _get_conn()
+    row = conn.execute(
+        "SELECT session, started, ended, text FROM transcripts WHERE session=?",
+        (session,),
+    ).fetchone()
+    if row is None:
+        return None
+    return {
+        "session": row["session"],
+        "started": row["started"],
+        "ended": row["ended"],
+        "text": row["text"] or "",
+    }
+
+
+__all__ = [
+    "transcript_start",
+    "transcript_append",
+    "transcript_finish",
+    "transcript_get",
+]
+

--- a/agent/transcribe.py
+++ b/agent/transcribe.py
@@ -1,0 +1,46 @@
+"""Temporary storage helpers for uploaded audio."""
+
+from __future__ import annotations
+
+import os
+import secrets
+from pathlib import Path
+from typing import BinaryIO
+
+
+TMP_DIR = Path(os.environ.get("BLACKROAD_TRANSCRIBE_TMP", "/tmp/blackroad-transcribe"))
+TMP_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _token(suffix: str | None = None) -> str:
+    body = secrets.token_hex(16)
+    if suffix:
+        suffix = suffix if suffix.startswith(".") else f".{suffix}"
+        return f"{body}{suffix}"
+    return body
+
+
+def allocate_path(filename: str | None = None) -> Path:
+    """Return an absolute path under :data:`TMP_DIR` for the upload."""
+
+    suffix = None
+    if filename:
+        suffix = Path(filename).suffix
+    return (TMP_DIR / _token(suffix)).resolve()
+
+
+def write_temp(stream: BinaryIO, filename: str | None = None) -> Path:
+    """Persist *stream* to disk and return the resolved path."""
+
+    dest = allocate_path(filename)
+    with open(dest, "wb") as fh:
+        while True:
+            chunk = stream.read(1024 * 1024)
+            if not chunk:
+                break
+            fh.write(chunk)
+    return dest
+
+
+__all__ = ["TMP_DIR", "allocate_path", "write_temp"]
+

--- a/frontend/src/components/WhisperCard.jsx
+++ b/frontend/src/components/WhisperCard.jsx
@@ -1,0 +1,170 @@
+import React, { useEffect, useRef, useState } from 'react'
+import { API_BASE } from '../api'
+
+function makeApiUrl(path) {
+  const base = (API_BASE || '').replace(/\/$/, '')
+  if (!base) return path
+  return `${base}${path}`
+}
+
+function makeWsUrl(path) {
+  const base = (API_BASE || '').trim()
+  if (!base) {
+    const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+    return `${proto}//${window.location.host}${path}`
+  }
+  try {
+    const url = new URL(base)
+    url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
+    const rootPath = url.pathname.replace(/\/$/, '')
+    url.pathname = `${rootPath}${path}`
+    return url.toString()
+  } catch {
+    const proto = base.startsWith('https') ? 'wss:' : 'ws:'
+    const host = base.replace(/^https?:\/\//, '').replace(/\/$/, '')
+    return `${proto}//${host}${path}`
+  }
+}
+
+export default function WhisperCard(){
+  const fileRef = useRef(null)
+  const logRef = useRef(null)
+  const wsRef = useRef(null)
+  const [log, setLog] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [session, setSession] = useState(null)
+
+  useEffect(()=>{
+    return ()=>{
+      if (wsRef.current) {
+        wsRef.current.close()
+        wsRef.current = null
+      }
+    }
+  },[])
+
+  function append(line){
+    setLog(prev => (prev ? `${prev}\n${line}` : line))
+    requestAnimationFrame(()=>{
+      const el = logRef.current
+      if (el) el.scrollTop = el.scrollHeight
+    })
+  }
+
+  async function uploadFile(){
+    const file = fileRef.current?.files?.[0]
+    if (!file){
+      append('Pick an audio file.')
+      return null
+    }
+    const fd = new FormData()
+    fd.append('file', file)
+    const res = await fetch(makeApiUrl('/transcribe/upload'), {
+      method: 'POST',
+      body: fd
+    })
+    if (!res.ok){
+      append('[error] upload failed')
+      return null
+    }
+    const data = await res.json()
+    if (!data?.token){
+      append('[error] missing token from upload')
+      return null
+    }
+    return data.token
+  }
+
+  function startSocket(path, token){
+    return new Promise((resolve, reject)=>{
+      const ws = new WebSocket(makeWsUrl(path))
+      wsRef.current = ws
+      ws.onopen = ()=>{
+        ws.send(JSON.stringify({ token, lang: 'en', model: 'base', beam: 5 }))
+        resolve(ws)
+      }
+      ws.onerror = (err)=>{
+        append('[error] websocket error')
+        wsRef.current = null
+        reject(err)
+      }
+    })
+  }
+
+  async function startRun(path){
+    try {
+      setBusy(true)
+      setLog('')
+      setSession(null)
+      const token = await uploadFile()
+      if (!token){
+        setBusy(false)
+        return
+      }
+      const ws = await startSocket(path, token)
+      ws.onmessage = ev => {
+        const line = ev.data
+        if (line === '[[BLACKROAD_WHISPER_DONE]]'){
+          append('[done]')
+          setBusy(false)
+          ws.close()
+          return
+        }
+        if (line.startsWith('[[BLACKROAD_SESSION:')){
+          const id = line.slice(line.indexOf(':') + 1, line.lastIndexOf(']'))
+          setSession(id)
+          append(`session=${id}`)
+          return
+        }
+        append(line)
+      }
+      ws.onclose = ()=>{
+        wsRef.current = null
+        setBusy(false)
+      }
+    } catch (err) {
+      append(`[error] ${err?.message || err}`)
+      setBusy(false)
+    }
+  }
+
+  async function downloadTranscript(){
+    if (!session){
+      append('[error] no session to download')
+      return
+    }
+    try {
+      const res = await fetch(makeApiUrl(`/transcripts/${encodeURIComponent(session)}`))
+      const data = await res.json()
+      if (res.status >= 400 || data?.error){
+        throw new Error(data?.error || 'not found')
+      }
+      const blob = new Blob([data.text || ''], { type: 'text/plain' })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `${session}.txt`
+      document.body.appendChild(a)
+      a.click()
+      a.remove()
+      URL.revokeObjectURL(url)
+    } catch (err) {
+      append(`[error] ${err?.message || err}`)
+    }
+  }
+
+  return (
+    <div className="card p-4 space-y-3">
+      <div className="font-semibold">Whisper (Streaming)</div>
+      <input id="audioFile" ref={fileRef} type="file" accept="audio/*" disabled={busy} />
+      <div className="flex items-center gap-2">
+        <button id="whisperGo" className="btn" onClick={()=>startRun('/ws/transcribe/run')} disabled={busy}>Transcribe (stream)</button>
+        <button id="whisperGoGPU" className="btn" onClick={()=>startRun('/ws/transcribe/run_gpu')} disabled={busy}>Transcribe on Jetson (GPU)</button>
+        <button className="btn" onClick={downloadTranscript} disabled={!session}>Save transcript</button>
+      </div>
+      <pre id="whisperLog" ref={logRef} className="bg-slate-900 text-xs p-3 rounded h-36 overflow-auto whitespace-pre-wrap">{log || '[idle]'}</pre>
+      {session && <div className="text-xs text-slate-400">Session: {session}</div>}
+    </div>
+  )
+}
+

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -4,6 +4,7 @@ import Timeline from '../components/Timeline.jsx'
 import Tasks from '../components/Tasks.jsx'
 import Commits from '../components/Commits.jsx'
 import AgentStack from '../components/AgentStack.jsx'
+import WhisperCard from '../components/WhisperCard.jsx'
 
 export default function Dashboard({ tab, setTab, timeline, tasks, commits, onAction, stream, setStream, system, wallet, contradictions, notes, setNotes }){
   return (
@@ -25,6 +26,7 @@ export default function Dashboard({ tab, setTab, timeline, tasks, commits, onAct
       </section>
       <section className="col-span-4 flex flex-col gap-4">
         <AgentStack stream={stream} setStream={setStream} system={system} wallet={wallet} contradictions={contradictions} notes={notes} setNotes={setNotes} />
+        <WhisperCard />
       </section>
     </>
   )

--- a/pi/__init__.py
+++ b/pi/__init__.py
@@ -1,0 +1,2 @@
+"""BlackRoad Pi API package."""
+

--- a/pi/api.py
+++ b/pi/api.py
@@ -1,0 +1,226 @@
+"""FastAPI application exposing the Pi transcription workflow."""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import json
+import subprocess
+import uuid
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+from fastapi import FastAPI, File, HTTPException, UploadFile, WebSocket, WebSocketDisconnect
+from fastapi.responses import JSONResponse
+
+from agent.config import active_target
+from agent import store, transcribe
+
+
+app = FastAPI(title="BlackRoad Pi API")
+
+
+def _validate_token(token: str) -> str:
+    if not token:
+        raise ValueError("missing token")
+    name = Path(token).name
+    if name != token:
+        raise ValueError("invalid token")
+    return token
+
+
+def _local_transcribe(path: str, model: str, lang: str, beam: int) -> List[str]:
+    from faster_whisper import WhisperModel
+
+    cache_key = (model, "cpu")
+    if cache_key not in _LOCAL_MODEL_CACHE:
+        _LOCAL_MODEL_CACHE[cache_key] = WhisperModel(
+            model, device="cpu", compute_type="int8"
+        )
+    whisper_model = _LOCAL_MODEL_CACHE[cache_key]
+    language = None if lang == "auto" else lang
+    segments, _ = whisper_model.transcribe(path, language=language, beam_size=beam)
+    return [f"[{seg.start:.2f}-{seg.end:.2f}] {seg.text}" for seg in segments]
+
+
+_LOCAL_MODEL_CACHE: Dict[Tuple[str, str], object] = {}
+
+
+@app.post("/transcribe/upload")
+async def upload_audio(file: UploadFile = File(...)) -> JSONResponse:
+    if file is None:
+        raise HTTPException(400, "file required")
+
+    data = await file.read()
+    if not data:
+        raise HTTPException(400, "empty file")
+
+    dest = transcribe.allocate_path(file.filename)
+    dest.write_bytes(data)
+    return JSONResponse({"token": dest.name})
+
+
+@app.websocket("/ws/transcribe/run")
+async def ws_transcribe_run(ws: WebSocket) -> None:
+    await ws.accept()
+    session_id = None
+    finished = False
+    try:
+        payload = await ws.receive_text()
+        req = json.loads(payload)
+        token = _validate_token(req.get("token", ""))
+        lang = req.get("lang", "en")
+        model = req.get("model", "base")
+        beam = max(1, int(req.get("beam", 5)))
+
+        local_path = (transcribe.TMP_DIR / token).resolve()
+        if not local_path.exists():
+            await ws.send_text("[error] missing audio")
+            return
+
+        session_id = req.get("session") or f"cpu-{uuid.uuid4().hex[:8]}"
+        store.transcript_start(session_id)
+        await ws.send_text(f"[[BLACKROAD_SESSION:{session_id}]]")
+
+        loop = asyncio.get_running_loop()
+        lines = await loop.run_in_executor(
+            None,
+            functools.partial(
+                _local_transcribe, str(local_path), model, lang, max(1, beam)
+            ),
+        )
+
+        for line in lines:
+            store.transcript_append(session_id, line + "\n")
+            await ws.send_text(line)
+
+        store.transcript_finish(session_id)
+        finished = True
+        await ws.send_text("[[BLACKROAD_WHISPER_DONE]]")
+    except WebSocketDisconnect:
+        pass
+    except Exception as exc:  # noqa: BLE001 - convert to stream message
+        message = f"[error] {exc}"
+        if session_id:
+            store.transcript_append(session_id, message + "\n")
+        await ws.send_text(message)
+    finally:
+        if session_id and not finished:
+            store.transcript_finish(session_id)
+        await ws.close()
+
+
+@app.websocket("/ws/transcribe/run_gpu")
+async def ws_transcribe_gpu(ws: WebSocket) -> None:
+    await ws.accept()
+    session_id = None
+    finished = False
+    proc: subprocess.Popen[str] | None = None
+    host: str | None = None
+    user: str | None = None
+    remote_path: str | None = None
+    try:
+        payload = await ws.receive_text()
+        req = json.loads(payload)
+        token = _validate_token(req.get("token", ""))
+        lang = req.get("lang", "en")
+        model = req.get("model", "base")
+        beam = max(1, int(req.get("beam", 5)))
+
+        local_path = (transcribe.TMP_DIR / token).resolve()
+        if not local_path.exists():
+            await ws.send_text("[error] missing audio")
+            return
+
+        host, user = active_target()
+        remote_dir = "/tmp/blackroad_whisper"
+        remote_path = f"{remote_dir}/{token}"
+
+        subprocess.check_call(["ssh", f"{user}@{host}", "mkdir", "-p", remote_dir])
+        subprocess.check_call(
+            ["scp", str(local_path), f"{user}@{host}:{remote_path}"]
+        )
+
+        session_id = req.get("session") or f"gpu-{uuid.uuid4().hex[:8]}"
+        store.transcript_start(session_id)
+        await ws.send_text(f"[[BLACKROAD_SESSION:{session_id}]]")
+
+        remote_py = f"""
+import os
+from faster_whisper import WhisperModel
+
+model_name = {model!r}
+audio_path = {remote_path!r}
+lang = {lang!r}
+beam = {beam}
+device = "cuda" if os.environ.get("USE_CUDA", "1") == "1" else "cpu"
+
+model = WhisperModel(model_name, device=device, compute_type="float16" if device == "cuda" else "int8")
+segments, _ = model.transcribe(audio_path, language=None if lang == "auto" else lang, beam_size=beam)
+for seg in segments:
+    print(f"[{{seg.start:.2f}}-{{seg.end:.2f}}] {{seg.text}}", flush=True)
+print("[[BLACKROAD_WHISPER_DONE]]", flush=True)
+"""
+
+        proc = subprocess.Popen(  # noqa: PLP2004 - streaming stdout
+            ["ssh", f"{user}@{host}", "python3", "-u", "-c", remote_py],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+
+        assert proc.stdout is not None
+        saw_done = False
+        for raw_line in proc.stdout:
+            line = raw_line.rstrip("\n")
+            if not line:
+                continue
+            if line == "[[BLACKROAD_WHISPER_DONE]]":
+                saw_done = True
+                continue
+            store.transcript_append(session_id, line + "\n")
+            await ws.send_text(line)
+
+        return_code = proc.wait()
+        if return_code != 0:
+            raise RuntimeError(f"remote whisper exited with {return_code}")
+
+        store.transcript_finish(session_id)
+        finished = True
+        await ws.send_text("[[BLACKROAD_WHISPER_DONE]]")
+    except WebSocketDisconnect:
+        pass
+    except subprocess.CalledProcessError as exc:
+        message = f"[error] {exc}"
+        if session_id:
+            store.transcript_append(session_id, message + "\n")
+        await ws.send_text(message)
+    except Exception as exc:  # noqa: BLE001 - convert to stream message
+        message = f"[error] {exc}"
+        if session_id:
+            store.transcript_append(session_id, message + "\n")
+        await ws.send_text(message)
+    finally:
+        if proc and proc.stdout:
+            proc.stdout.close()
+        if remote_path and host and user:
+            subprocess.run(
+                ["ssh", f"{user}@{host}", "rm", "-f", remote_path],
+                check=False,
+            )
+        if session_id and not finished:
+            store.transcript_finish(session_id)
+        await ws.close()
+
+
+@app.get("/transcripts/{session}")
+def get_transcript(session: str) -> JSONResponse:
+    doc = store.transcript_get(session)
+    if not doc:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    return JSONResponse(doc)
+
+
+__all__ = ["app"]
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 anthropic
 boto3
 fastapi
+faster-whisper
 matplotlib==3.9.4
 mpmath
 notion-client


### PR DESCRIPTION
## Summary
- add FastAPI endpoints for local and Jetson GPU Whisper streaming with transcript persistence
- add agent utilities for active target resolution, temp storage, and SQLite transcript bookkeeping
- surface a Whisper card in the dashboard UI and require faster-whisper for the new pipeline

## Testing
- python -m py_compile agent/*.py pi/*.py

------
https://chatgpt.com/codex/tasks/task_e_68db09c42e8883299e83bf60b40fb004