### PR TITLE
Add token authentication middleware for BlackRoad agent

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,3 @@
+"""BlackRoad agent package."""
+
+from .config import load, save, auth_token  # noqa: F401

--- a/agent/api.py
+++ b/agent/api.py
@@ -1,0 +1,39 @@
+"""FastAPI application exposing the BlackRoad agent API."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from fastapi import FastAPI
+
+from agent.auth import TokenAuthMiddleware
+from agent.config import auth_token as get_auth_token
+from agent.config import load as load_cfg
+from agent.config import save as save_cfg
+
+app = FastAPI(title="BlackRoad Agent API", version="1.0.0")
+app.add_middleware(TokenAuthMiddleware)
+
+
+@app.get("/healthz")
+def healthcheck() -> Dict[str, Any]:
+    """Return a minimal health payload."""
+    return {"ok": True, "auth": bool(get_auth_token())}
+
+
+@app.get("/settings")
+def read_settings() -> Dict[str, Any]:
+    """Return the current configuration."""
+    return load_cfg()
+
+
+@app.post("/settings/auth")
+def set_auth_token(payload: Dict[str, Any] | None) -> Dict[str, Any]:
+    """Persist a new shared authentication token."""
+    token = (payload or {}).get("token", "")
+    if token is None:
+        token = ""
+    token = str(token).strip()
+    cfg = load_cfg()
+    cfg.setdefault("auth", {})["token"] = token
+    save_cfg(cfg)
+    return {"ok": True, "enabled": bool(token)}

--- a/agent/auth.py
+++ b/agent/auth.py
@@ -1,0 +1,75 @@
+"""Simple token authentication middleware for HTTP and WebSocket traffic."""
+from __future__ import annotations
+
+from typing import Callable, Dict
+from urllib.parse import parse_qs
+
+from fastapi import Request
+from fastapi.responses import JSONResponse
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from agent.config import auth_token
+
+
+def _normalize_headers(raw_headers) -> Dict[str, str]:
+    headers: Dict[str, str] = {}
+    for key, value in raw_headers or []:
+        headers[key.decode("latin-1").lower()] = value.decode("latin-1")
+    return headers
+
+
+def _token_matches(candidate: str) -> bool:
+    token = auth_token()
+    if not token:
+        return True
+    return candidate == token
+
+
+class TokenAuthMiddleware(BaseHTTPMiddleware):
+    """Middleware enforcing a shared bearer token for HTTP and WebSocket traffic."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        super().__init__(app)
+
+    async def dispatch(self, request: Request, call_next: Callable):
+        token = auth_token()
+        if not token:
+            return await call_next(request)
+
+        auth_header = request.headers.get("authorization", "")
+        qs_token = request.query_params.get("token", "")
+        candidate = ""
+        if auth_header.lower().startswith("bearer "):
+            candidate = auth_header.split(None, 1)[1].strip()
+        elif qs_token:
+            candidate = qs_token
+
+        if not _token_matches(candidate):
+            return JSONResponse({"error": "unauthorized"}, status_code=401)
+        return await call_next(request)
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] == "websocket":
+            token = auth_token()
+            if not token:
+                await self.app(scope, receive, send)
+                return
+
+            headers = _normalize_headers(scope.get("headers"))
+            auth_header = headers.get("authorization", "")
+            query = parse_qs(scope.get("query_string", b"").decode("latin-1"))
+            candidate = ""
+            if auth_header.lower().startswith("bearer "):
+                candidate = auth_header.split(None, 1)[1].strip()
+            elif "token" in query and query["token"]:
+                candidate = query["token"][0]
+
+            if not _token_matches(candidate):
+                await send({"type": "websocket.close", "code": 4401})
+                return
+
+            await self.app(scope, receive, send)
+            return
+
+        await super().__call__(scope, receive, send)

--- a/agent/config.py
+++ b/agent/config.py
@@ -1,0 +1,51 @@
+"""Configuration helpers for the BlackRoad agent services."""
+from __future__ import annotations
+
+import os
+from copy import deepcopy
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+CONFIG_PATH = Path(os.environ.get("BLACKROAD_CONFIG", "/etc/blackroad/config.yaml"))
+
+DEFAULTS: Dict[str, Any] = {
+    "jetson": {"host": "192.168.4.23", "user": "jetson"},
+    "auth": {"token": ""},
+}
+
+
+def _deep_update(base: Dict[str, Any], updates: Dict[str, Any]) -> Dict[str, Any]:
+    for key, value in updates.items():
+        if isinstance(value, dict) and isinstance(base.get(key), dict):
+            base[key] = _deep_update(dict(base[key]), value)
+        else:
+            base[key] = value
+    return base
+
+
+def load() -> Dict[str, Any]:
+    """Load the persisted configuration merged with defaults."""
+    data: Dict[str, Any] = {}
+    if CONFIG_PATH.exists():
+        try:
+            raw = yaml.safe_load(CONFIG_PATH.read_text())
+            if isinstance(raw, dict):
+                data = raw
+        except yaml.YAMLError:
+            data = {}
+    merged = deepcopy(DEFAULTS)
+    return _deep_update(merged, data)
+
+
+def save(config: Dict[str, Any]) -> None:
+    """Persist the configuration to disk."""
+    CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with CONFIG_PATH.open("w", encoding="utf-8") as handle:
+        yaml.safe_dump(config, handle, sort_keys=True)
+
+
+def auth_token() -> str:
+    """Return the configured authentication token (empty when disabled)."""
+    return str(load().get("auth", {}).get("token", ""))

--- a/agent/dashboard.py
+++ b/agent/dashboard.py
@@ -1,0 +1,22 @@
+"""FastAPI application serving the BlackRoad dashboard."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+
+from agent.auth import TokenAuthMiddleware
+
+BASE_DIR = Path(__file__).resolve().parent
+templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
+
+app = FastAPI(title="BlackRoad Dashboard", version="1.0.0")
+app.add_middleware(TokenAuthMiddleware)
+
+
+@app.get("/", response_class=HTMLResponse)
+async def dashboard(request: Request) -> HTMLResponse:
+    """Render the dashboard UI."""
+    return templates.TemplateResponse("dashboard.html", {"request": request})

--- a/agent/templates/dashboard.html
+++ b/agent/templates/dashboard.html
@@ -1,0 +1,136 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>BlackRoad Dashboard</title>
+    <style>
+      body { font-family: sans-serif; margin: 0; background: #0f172a; color: #e2e8f0; }
+      header { padding: 1.5rem 2rem; background: #111827; border-bottom: 1px solid #1f2937; }
+      main { padding: 2rem; display: grid; gap: 1.5rem; }
+      .card { background: #1f2937; padding: 1.5rem; border-radius: 1rem; box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.15); }
+      .title { font-size: 1.1rem; font-weight: 600; margin-bottom: 0.75rem; }
+      input[type="password"], input[type="text"] { padding: 0.6rem 0.75rem; border-radius: 0.6rem; border: 1px solid #334155; background: #0f172a; color: inherit; }
+      button { margin-left: 0.75rem; padding: 0.55rem 1.2rem; border-radius: 0.6rem; border: none; background: #2563eb; color: white; font-weight: 600; cursor: pointer; }
+      button:hover { background: #1d4ed8; }
+      small { display: block; margin-top: 0.5rem; color: #94a3b8; }
+      pre { background: #0f172a; padding: 1rem; border-radius: 0.75rem; overflow: auto; border: 1px solid #334155; }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>BlackRoad Control Plane</h1>
+    </header>
+    <main>
+      <div class="card">
+        <div class="title">Security</div>
+        <input id="brToken" type="password" placeholder="Set or paste BlackRoad token" style="width:60%;" />
+        <button id="saveToken">Save Token</button>
+        <small id="tokHelp">Token applies immediately; keep it safe.</small>
+      </div>
+      <div class="card">
+        <div class="title">Configuration Snapshot</div>
+        <pre id="cfgDump">{}</pre>
+      </div>
+    </main>
+    <script>
+      let BR_TOKEN = localStorage.getItem('BLACKROAD_TOKEN') || "";
+
+      const tokenInput = document.getElementById('brToken');
+      if (BR_TOKEN) {
+        tokenInput.value = BR_TOKEN;
+      }
+
+      function authHeaders(h = {}) {
+        const headers = { ...h };
+        if (BR_TOKEN) {
+          headers['Authorization'] = 'Bearer ' + BR_TOKEN;
+        }
+        return headers;
+      }
+
+      function authedFetch(url, opts = {}) {
+        const options = { ...opts };
+        options.headers = authHeaders(options.headers || {});
+        return fetch(url, options);
+      }
+
+      function wsUrl(path) {
+        const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+        const qp = BR_TOKEN ? `?token=${encodeURIComponent(BR_TOKEN)}` : '';
+        return `${proto}://${location.host}${path}${qp}`;
+      }
+
+      async function refreshConfig() {
+        try {
+          const response = await authedFetch('/settings');
+          if (!response.ok) throw new Error('Request failed');
+          const data = await response.json();
+          document.getElementById('cfgDump').textContent = JSON.stringify(data, null, 2);
+        } catch (err) {
+          document.getElementById('cfgDump').textContent = 'Unable to fetch settings. ' + err.message;
+        }
+      }
+
+      document.getElementById('saveToken').onclick = async () => {
+        const t = (tokenInput.value || '').trim();
+        const res = await authedFetch('/settings/auth', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ token: t })
+        });
+        if (res.ok) {
+          BR_TOKEN = t;
+          localStorage.setItem('BLACKROAD_TOKEN', BR_TOKEN);
+          alert('Token saved.');
+          await refreshConfig();
+        } else {
+          alert('Failed to save token.');
+        }
+      };
+
+      const API = {
+        loadSettings: () => authedFetch('/settings'),
+        updateJetson: (payload) => authedFetch('/settings/jetson', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload || {})
+        }),
+        testConnection: (payload) => authedFetch('/connect/test', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload || {})
+        }),
+        installKey: (payload) => authedFetch('/connect/install-key', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload || {})
+        }),
+        listFlashDevices: () => authedFetch('/flash/devices'),
+        listFlashImages: () => authedFetch('/flash/images'),
+        flashSocket: () => new WebSocket(wsUrl('/ws/flash')),
+        listJobs: () => authedFetch('/jobs'),
+        getJob: (id) => authedFetch(`/jobs/${encodeURIComponent(id)}`),
+        downloadJob: (id) => authedFetch(`/jobs/${encodeURIComponent(id)}/download`),
+        killJob: (id) => authedFetch(`/jobs/${encodeURIComponent(id)}/kill`, { method: 'POST' }),
+        listModels: () => authedFetch('/models'),
+        runModel: (payload) => authedFetch('/models/run', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload || {})
+        }),
+        modelSocket: () => new WebSocket(wsUrl('/ws/model')),
+        uploadTranscribe: (formData) => authedFetch('/transcribe/upload', {
+          method: 'POST',
+          body: formData
+        }),
+        transcribeSocket: () => new WebSocket(wsUrl('/ws/transcribe/run')),
+        transcribeGpuSocket: () => new WebSocket(wsUrl('/ws/transcribe/run_gpu')),
+        flashRunSocket: () => new WebSocket(wsUrl('/ws/run'))
+      };
+
+      window.BlackRoadAPI = API;
+      refreshConfig();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a configuration helper with auth token support for the agent services
- guard the API and dashboard FastAPI apps with shared token middleware
- add dashboard UI controls and helpers so browser calls send the configured token

## Testing
- python -m py_compile agent/*.py

------
https://chatgpt.com/codex/tasks/task_e_68db0d37da7c83299d8620c93afe8ad3