### PR TITLE
Add blog post covering ChatGPT instant checkout

### DIFF
--- a/sites/blackroad/content/blog/chatgpt-instant-checkout.md
+++ b/sites/blackroad/content/blog/chatgpt-instant-checkout.md
@@ -1,0 +1,30 @@
+---
+title: "ChatGPT Tries Instant Checkout"
+date: "2025-02-15"
+tags: [openai, commerce, agents]
+description: "OpenAI turns ChatGPT into a single-item shopping flow powered by the Agentic Commerce Protocol."
+---
+
+OpenAI is turning ChatGPT into more than a conversational assistant. The company just
+launched **Instant Checkout** for U.S. users, allowing them to buy eligible items from
+Etsy sellers without ever leaving the chat. When shoppers ask for suggestions—say,
+"best gift for a potter"—the interface can surface listings that include a "Buy" button.
+Transactions are limited to a single product today, but the roadmap promises multi-item
+carts, more merchant types, and international availability.
+
+The new flow runs on the open-source **Agentic Commerce Protocol (ACP)** co-developed
+with Stripe. ACP defines how an agent like ChatGPT can request product information,
+collect purchase intent, and hand off payments without exposing raw card data. Stripe's
+Shared Payment Token is the first payment method built for the spec, and Shopify
+merchants are next in line with a turnkey integration promised soon.
+
+For sellers, fulfillment, support, and returns remain their responsibility. However, the
+shift means discoverability will depend on clearing ChatGPT's relevance ranking instead
+of just marketplace SEO. OpenAI now participates in the transaction, creating a fresh
+revenue stream while raising questions about platform dependence, buyer trust for
+high-ticket purchases, and future regulatory scrutiny if agent-run storefronts take off.
+
+Instant Checkout is rolling out only in the United States and to users with existing
+payment methods saved inside ChatGPT. Even with the limited scope, the experiment
+signals how quickly general-purpose agents are evolving into fully fledged commerce
+front doors.


### PR DESCRIPTION
## Summary
- add a blog post outlining OpenAI's new ChatGPT Instant Checkout flow and Agentic Commerce Protocol details

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc2f368e1883298fdedb8b927cd604