### PR TITLE
Add blog post covering September 29 spot ETF inflows

### DIFF
--- a/sites/blackroad/content/blog/spot-etf-inflows-2025-09-29.md
+++ b/sites/blackroad/content/blog/spot-etf-inflows-2025-09-29.md
@@ -1,0 +1,49 @@
+---
+title: "Capital Rush Back Into Spot Bitcoin and Ethereum ETFs"
+date: "2025-09-30"
+tags: [markets, institutional]
+description: "A sharp rebound in U.S. spot BTC and ETH ETF inflows signals institutions are rebuilding crypto exposure."
+---
+
+Institutional desks leaned back into regulated crypto vehicles to close out
+September, posting one of the strongest single-day intake figures since the
+summer pullback.
+
+## What the tape showed on 29 September 2025
+
+- **Bitcoin spot ETFs pulled in a net $518 million.** Fidelity's FBTC led with
+  $298.7 million while Bitwise's BITB added $47.2 million. BlackRock's IBIT was
+  the lone laggard, shedding $46.6 million as allocators rebalanced toward
+  peers.
+- **Ethereum spot ETFs saw an even bigger $546.9 million net intake.** Fidelity
+  FETH captured $202.2 million, BlackRock ETHA $154.2 million, and Grayscale
+  ETHE $99.8 million. The scale of ETH inflows outpaced BTC products for the
+  day.
+
+## How to read the rotation
+
+- **Growth appetite is back.** The ETH-heavy flow mix suggests desks are
+  reaching for higher beta smart-contract exposure after weeks of defensive
+  positioning.
+- **Allocators are diversifying beyond the dominant wrappers.** IBIT's outflow
+  highlights a willingness to shift between issuers or pivot the risk budget
+  toward Ethereum after months of Bitcoin leadership.
+- **Regulation is turning into a tailwind.** The SEC's streamlined review
+  timelines are lowering operational friction for new products, keeping the
+  pipeline warm for additional issuers and making it easier for funds to scale
+  without headline risk.
+
+## What to watch next
+
+- Track whether Ethereum keeps the momentum over the next one to three months.
+  Sustained outperformance in ETF flows could feed into staking demand and
+  Layer-2 liquidity.
+- Monitor IBIT's share of total Bitcoin ETF assets. Continued redemptions there
+  could embolden competitors or push more capital toward ETH allocations.
+- Pair the flow data with price and volatility dashboards. A synchronized pick
+  up in ETF intake and spot volumes would confirm institutions are putting risk
+  capital back to work rather than simply rotating exposure.
+
+Ping if you need the longer-term flow charts — we can layer one- and
+three-month trends to show whether this was a blip or the start of a broader
+cycle.


### PR DESCRIPTION
## Summary
- add a markets update post covering the September 29, 2025 spot bitcoin and ethereum ETF flow surge, issuer breakdowns, and implications.

## Testing
- not run (content change)


------
https://chatgpt.com/codex/tasks/task_e_68dc2ff828b483298669579c4bf8a497