### PR TITLE
Refine portal layout and API helpers

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,41 +1,56 @@
-import React, { useEffect, useState } from 'react'
-import { Routes, Route, useNavigate } from 'react-router-dom'
+import React, { useEffect, useRef, useState } from 'react'
+import { Routes, Route, NavLink, useLocation } from 'react-router-dom'
 import io from 'socket.io-client'
-import { API_BASE, setToken, login, me, fetchTimeline, fetchTasks, fetchCommits, fetchAgents, fetchRoadcoinWallet, fetchContradictions, getNotes, setNotes, action } from './api'
-import { API_BASE, setToken, login, me, fetchTimeline, fetchTasks, fetchCommits, fetchAgents, fetchWallet, fetchContradictions, getNotes, setNotes, action } from './api'
+import {
+  API_BASE,
+  setToken,
+  login,
+  me,
+  fetchTimeline,
+  fetchTasks,
+  fetchCommits,
+  fetchAgents,
+  fetchRoadcoinWallet,
+  fetchContradictions,
+  getNotes,
+  setNotes as saveNotes,
+  action,
+} from './api'
 import Guardian from './Guardian.jsx'
-import { Activity, Brain, Cpu, Database, GitCommit, LayoutGrid, Rocket, Settings, ShieldCheck, SquareDashedMousePointer, Wallet } from 'lucide-react'
-import { Activity, Brain, Cpu, Database, GitCommit, LayoutGrid, Rocket, Settings, ShieldCheck, SquareDashedMousePointer, Wallet, User } from 'lucide-react'
-import { Activity, Brain, Cpu, Database, GitCommit, LayoutGrid, Rocket, Settings, ShieldCheck, SquareDashedMousePointer, Wallet, BookOpen } from 'lucide-react'
-import io from 'socket.io-client'
-import { Routes, Route, NavLink } from 'react-router-dom'
-import { API_BASE, setToken, login, me, fetchTimeline, fetchTasks, fetchCommits, fetchAgents, fetchWallet, fetchContradictions, getNotes, setNotes, action } from './api'
-import { Activity, Brain, Database, LayoutGrid, Rocket, Settings, ShieldCheck, SquareDashedMousePointer, Wallet } from 'lucide-react'
+import {
+  Activity,
+  Brain,
+  Cpu,
+  GitCommit,
+  LayoutGrid,
+  Rocket,
+  ShieldCheck,
+  HeartPulse,
+  Sparkles,
+  Wallet,
+  User,
+  BookOpen,
+} from 'lucide-react'
 import Timeline from './components/Timeline.jsx'
 import Tasks from './components/Tasks.jsx'
 import Commits from './components/Commits.jsx'
 import AgentStack from './components/AgentStack.jsx'
 import Login from './components/Login.jsx'
 import RoadCoin from './components/RoadCoin.jsx'
-import Dashboard from './components/Dashboard.jsx'
 import You from './components/You.jsx'
 import Claude from './components/Claude.jsx'
 import Codex from './components/Codex.jsx'
 import Roadbook from './components/Roadbook.jsx'
 import Subscribe from './Subscribe.jsx'
-import io from 'socket.io-client'
-import { Routes, Route, NavLink } from 'react-router-dom'
-import { API_BASE, setToken, login, me, fetchTimeline, fetchTasks, fetchCommits, fetchAgents, fetchWallet, fetchContradictions, getNotes, setNotes, action } from './api'
-import { Activity, Brain, Database, LayoutGrid, Settings, ShieldCheck, SquareDashedMousePointer, HeartPulse, Sparkles } from 'lucide-react'
-import Login from './components/Login.jsx'
-import Dashboard from './pages/Dashboard.jsx'
-import RoadView from './pages/RoadView.jsx'
 import Orchestrator from './Orchestrator.jsx'
 import Manifesto from './components/Manifesto.jsx'
 import AutoHeal from './pages/AutoHeal.jsx'
+import RoadView from './pages/RoadView.jsx'
 import Git from './pages/Git.jsx'
 
 export default function App(){
+  const location = useLocation()
+  const [authChecked, setAuthChecked] = useState(false)
   const [user, setUser] = useState(null)
   const [tab, setTab] = useState('timeline')
   const [timeline, setTimeline] = useState([])
@@ -47,182 +62,220 @@ export default function App(){
   const [system, setSystem] = useState({ cpu: 0, mem: 0, gpu: 0, net: 0 })
   const [notes, setNotesState] = useState('')
   const [stream, setStream] = useState(true)
-  const path = window.location.pathname
-  const isRoadcoin = path === '/roadcoin'
-  const route = window.location.pathname
-  const isDashboard = path === '/dashboard'
-  const isYou = path === '/you'
-  const isClaude = path === '/claude'
-  const isDashboard = path === '/dashboard'
-  const isYou = path === '/you'
-  const isCodex = path === '/codex'
-  const isSubscribe = path === '/subscribe'
+  const [socket, setSocket] = useState(null)
+  const socketRef = useRef(null)
+  const streamRef = useRef(stream)
+
+  useEffect(()=>{ streamRef.current = stream }, [stream])
 
   useEffect(()=>{
     const token = localStorage.getItem('token')
-    if (token) setToken(token)
-    (async()=>{
-      try {
-        if (token) {
-          const u = await me()
-          setUser(u)
-          await bootData()
-          connectSocket()
-        }
-      } catch(e) {
-        if (e?.response?.status === 401) {
+    if(!token){
+      setAuthChecked(true)
+      return
+    }
+    setToken(token)
+    me()
+      .then(async(u)=>{
+        setUser(u)
+        await bootData()
+        connectSocket()
+      })
+      .catch(err=>{
+        if(err?.response?.status === 401){
           localStorage.removeItem('token')
           setToken('')
         }
-      }
-    })()
+      })
+      .finally(()=>setAuthChecked(true))
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
+  useEffect(()=>()=>{ socketRef.current?.close() }, [])
+
   async function bootData(){
-    const [tl, ts, cs, ag, w, c, n] = await Promise.all([
-      fetchTimeline(), fetchTasks(), fetchCommits(), fetchAgents(), fetchRoadcoinWallet(), fetchContradictions(), getNotes()
+    const results = await Promise.allSettled([
+      fetchTimeline(),
+      fetchTasks(),
+      fetchCommits(),
+      fetchAgents(),
+      fetchRoadcoinWallet(),
+      fetchContradictions(),
+      getNotes(),
     ])
-    setTimeline(tl); setTasks(ts); setCommits(cs); setAgents(ag); setWallet({ rc: w.balance }); setContradictions(c); setNotesState(n || '')
+    const [tl, ts, cs, ag, w, c, n] = results
+    if(tl.status === 'fulfilled') setTimeline(tl.value || [])
+    else setTimeline([])
+    if(ts.status === 'fulfilled') setTasks(ts.value || [])
+    else setTasks([])
+    if(cs.status === 'fulfilled') setCommits(cs.value || [])
+    else setCommits([])
+    if(ag.status === 'fulfilled') setAgents(ag.value || [])
+    else setAgents([])
+    if(w.status === 'fulfilled'){
+      const data = w.value
+      const balance = typeof data?.balance === 'number' ? data.balance : typeof data?.rc === 'number' ? data.rc : 0
+      setWallet({ rc: balance })
+    }
+    if(c.status === 'fulfilled') setContradictions(c.value || { issues: 0 })
+    else setContradictions({ issues: 0 })
+    if(n.status === 'fulfilled') setNotesState(n.value || '')
+    else setNotesState('')
   }
 
   function connectSocket(){
+    socketRef.current?.close()
     const s = io(API_BASE, { transports: ['websocket'] })
-    s.on('system:update', d => stream && setSystem(d))
-    s.on('timeline:new', d => setTimeline(prev => [d.item, ...prev]))
-    s.on('wallet:update', w => setWallet(w))
-    s.on('notes:update', n => setNotesState(n || ''))
+    socketRef.current = s
+    setSocket(s)
+
+    s.on('system:update', payload => {
+      if(streamRef.current && payload){
+        setSystem({
+          cpu: payload.cpu ?? 0,
+          mem: payload.mem ?? 0,
+          gpu: payload.gpu ?? 0,
+          net: payload.net ?? 0,
+        })
+      }
+    })
+
+    s.on('timeline:new', message => {
+      if(message?.item){
+        setTimeline(prev => [message.item, ...prev])
+      }
+    })
+
+    s.on('wallet:update', payload => {
+      const balance = typeof payload?.balance === 'number'
+        ? payload.balance
+        : typeof payload?.rc === 'number'
+          ? payload.rc
+          : null
+      if(balance !== null){
+        setWallet({ rc: balance })
+      }
+    })
+
+    s.on('notes:update', value => {
+      setNotesState(value || '')
+    })
+
+    s.on('agents:update', value => {
+      if(Array.isArray(value)) setAgents(value)
+    })
   }
 
-  async function handleLogin(usr, pass){
-    const { token, user } = await login(usr, pass)
+  async function handleLogin(username, password){
+    const { token, user: nextUser } = await login(username, password)
     localStorage.setItem('token', token)
     setToken(token)
-    setUser(user)
+    setUser(nextUser)
     await bootData()
     connectSocket()
   }
 
-  async function onAction(name){
-    await action(name)
+  async function handleAction(name){
+    try{
+      await action(name)
+    }catch(err){
+      console.error('Action failed', err)
+    }
   }
 
-  if (isSubscribe) {
+  async function handleNotesChange(value){
+    setNotesState(value)
+    try{
+      await saveNotes(value)
+    }catch(err){
+      console.error('Failed to save notes', err)
+    }
+  }
+
+  function handleWalletUpdate(data){
+    const balance = typeof data?.balance === 'number' ? data.balance : typeof data?.rc === 'number' ? data.rc : wallet.rc
+    setWallet({ rc: balance })
+  }
+
+  if(location.pathname === '/subscribe'){
     return <Subscribe />
   }
 
+  if(!authChecked){
+    return <div className="min-h-screen bg-slate-950" />
+  }
+
+  const currentPath = location.pathname
+  const navItems = [
+    { key: 'dashboard', to: '/dashboard', text: 'Dashboard', icon: <Activity size={18} />, match: path => path === '/' || path === '/dashboard' },
+    { key: 'you', to: '/you', text: 'You', icon: <User size={18} /> },
+    { key: 'roadview', to: '/roadview', text: 'RoadView', icon: <LayoutGrid size={18} /> },
+    { key: 'autoheal', to: '/autoheal', text: 'Auto-Heal', icon: <HeartPulse size={18} /> },
+    { key: 'guardian', to: '/guardian', text: 'Guardian', icon: <ShieldCheck size={18} /> },
+    { key: 'claude', to: '/claude', text: 'Claude', icon: <Cpu size={18} /> },
+    { key: 'codex', to: '/codex', text: 'Codex', icon: <Brain size={18} /> },
+    { key: 'roadcoin', to: '/roadcoin', text: 'RoadCoin', icon: <Wallet size={18} /> },
+    { key: 'orchestrator', to: '/orchestrator', text: 'Orchestrator', icon: <Rocket size={18} /> },
+    { key: 'roadbook', to: '/roadbook', text: 'Roadbook', icon: <BookOpen size={18} /> },
+    { key: 'manifesto', to: '/manifesto', text: 'Manifesto', icon: <BookOpen size={18} /> },
+    { key: 'git', to: '/git', text: 'Git', icon: <GitCommit size={18} /> },
+    { key: 'subscribe', href: '/subscribe', text: 'Subscribe', icon: <Rocket size={18} /> },
+    { key: 'novelty', to: '/novelty', text: 'Novelty Dashboard', icon: <Sparkles size={18} /> },
+  ]
+
   return (
-    <div className="min-h-screen flex">
+    <div className="min-h-screen flex bg-slate-950 text-slate-100">
       {!user && <Login onLogin={handleLogin} />}
       {user && (
         <>
-          {/* Sidebar */}
           <aside className="w-64 p-4 space-y-6 border-r border-slate-800 bg-slate-950/60">
             <div className="flex items-center gap-2 text-xl font-semibold">
               <div className="w-8 h-8 rounded-lg bg-gradient-to-tr from-pink-500 to-indigo-500" />
               BlackRoad.io
             </div>
-
             <nav className="space-y-1">
-              <NavItem icon={<Activity size={18} />} text="Dashboard" href="/dashboard" />
-              <NavItem icon={<User size={18} />} text="You" href="/you" />
-              <NavItem icon={<LayoutGrid size={18} />} text="Workspace" href="/" />
-              <NavItem icon={<SquareDashedMousePointer size={18} />} text="Projects" />
-              <NavItem icon={<Brain size={18} />} text="Agents" />
-              <NavItem icon={<Database size={18} />} text="Datasets" />
-              <NavItem icon={<ShieldCheck size={18} />} text="Models" />
-              <NavItem icon={<Settings size={18} />} text="Integrations" />
-              <NavItem icon={<Cpu size={18} />} text="Claude" href="/claude" />
-              <NavItem icon={<Cpu size={18} />} text="Codex" href="/codex" />
-              <NavItem icon={<Wallet size={18} />} text="RoadCoin" href="/roadcoin" />
-              <NavItem icon={<Rocket size={18} />} text="Subscribe" href="/subscribe" />
-              <NavItem icon={<BookOpen size={18} />} text="Roadbook" to="/roadbook" />
-              <NavItem to="/" icon={<Activity size={18} />} text="Chat" />
-              <NavItem to="/projects" icon={<SquareDashedMousePointer size={18} />} text="Projects" />
-              <NavItem to="/agents" icon={<Brain size={18} />} text="Agents" />
-              <NavItem to="/datasets" icon={<Database size={18} />} text="Datasets" />
-              <NavItem to="/models" icon={<ShieldCheck size={18} />} text="Models" />
-              <NavItem to="/integrations" icon={<Settings size={18} />} text="Integrations" />
-              <NavItem to="/git" icon={<GitCommit size={18} />} text="Git" />
-              <NavItem to="/roadview" icon={<LayoutGrid size={18} />} text="RoadView" />
-              <NavItem to="/autoheal" icon={<HeartPulse size={18} />} text="Auto-Heal" />
-              <NavItem to="/novelty" icon={<Sparkles size={18} />} text="Novelty Dashboard" />
-              <NavItem icon={<Rocket size={18} />} text="Orchestrator" to="/orchestrator" />
-              <NavItem icon={<Rocket size={18} />} text="Manifesto" href="/manifesto" />
+              {navItems.map(item => (
+                <NavItem
+                  key={item.key}
+                  icon={item.icon}
+                  text={item.text}
+                  to={item.to}
+                  href={item.href}
+                  currentPath={currentPath}
+                  match={item.match}
+                />
+              ))}
             </nav>
           </aside>
 
-          {/* Main */}
-          <main className="flex-1 px-6 py-4 grid grid-cols-12 gap-6">
-            <section className="col-span-8">
-              {isDashboard && <Dashboard />}
-              {isYou && <You />}
-              {!isDashboard && !isYou && !isRoadcoin && (
-              {!isRoadcoin && !isClaude && (
-              {isRoadcoin && <RoadCoin onUpdate={(data)=>setWallet({ rc: data.balance })} />}
-              {isCodex && <Codex socket={socket} />}
-              {!isRoadcoin && !isCodex && (
-              {path === '/manifesto' ? (
-                <Manifesto />
-              ) : (
-                <>
-                  <header className="flex items-center gap-8 border-b border-slate-800 mb-4">
-                    <Tab onClick={()=>setTab('timeline')} active={tab==='timeline'}>Timeline</Tab>
-                    <Tab onClick={()=>setTab('tasks')} active={tab==='tasks'}>Tasks</Tab>
-                    <Tab onClick={()=>setTab('commits')} active={tab==='commits'}>Commits</Tab>
-                    <div className="ml-auto flex items-center gap-2 py-3">
-                      <button className="badge" onClick={()=>onAction('run')}>Run</button>
-                      <button className="badge" onClick={()=>onAction('revert')}>Revert</button>
-                      <button className="badge" onClick={()=>onAction('mint')}><Wallet size={14}/> Mint</button>
-                    </div>
-                  </header>
-
-                  {tab==='timeline' && <Timeline items={timeline} />}
-                  {tab==='tasks' && <Tasks items={tasks} />}
-                  {tab==='commits' && <Commits items={commits} />}
-                </>
-              )}
-              {isRoadcoin && <RoadCoin onUpdate={(data)=>setWallet({ rc: data.balance })} />}
-              {isClaude && <Claude socket={socket} />}
-              <Routes>
-                <Route path="/roadbook" element={<Roadbook />} />
-                <Route path="*" element={<Dashboard tab={tab} setTab={setTab} timeline={timeline} tasks={tasks} commits={commits} onAction={onAction} />} />
-              <Routes>
-                <Route path="/" element={<Dashboard tab={tab} setTab={setTab} timeline={timeline} tasks={tasks} commits={commits} onAction={onAction} />} />
-                <Route path="/orchestrator" element={<Orchestrator socket={socket} />} />
-              </Routes>
-            </section>
-            {route === '/guardian' ? (
-              <Guardian />
-            ) : (
-              <section className="col-span-8">
-                <header className="flex items-center gap-8 border-b border-slate-800 mb-4">
-                  <Tab onClick={()=>setTab('timeline')} active={tab==='timeline'}>Timeline</Tab>
-                  <Tab onClick={()=>setTab('tasks')} active={tab==='tasks'}>Tasks</Tab>
-                  <Tab onClick={()=>setTab('commits')} active={tab==='commits'}>Commits</Tab>
-                  <div className="ml-auto flex items-center gap-2 py-3">
-                    <button className="badge" onClick={()=>onAction('run')}>Run</button>
-                    <button className="badge" onClick={()=>onAction('revert')}>Revert</button>
-                    <button className="badge" onClick={()=>onAction('mint')}><Wallet size={14}/> Mint</button>
-                  </div>
-                </header>
-
-                {tab==='timeline' && <Timeline items={timeline} />}
-                {tab==='tasks' && <Tasks items={tasks} />}
-                {tab==='commits' && <Commits items={commits} />}
-              </section>
-            )}
-
-            {/* Right bar */}
-            <section className="col-span-4 flex flex-col gap-4">
-              <AgentStack stream={stream} setStream={setStream} system={system} wallet={wallet} contradictions={contradictions}
-                notes={notes} setNotes={async (v)=>{ setNotesState(v); await setNotes(v); }} />
-            </section>
+          <main className="flex-1 px-6 py-4 grid grid-cols-12 gap-6 items-start">
             <Routes>
-              <Route path="/" element={<Dashboard tab={tab} setTab={setTab} timeline={timeline} tasks={tasks} commits={commits} onAction={onAction} stream={stream} setStream={setStream} system={system} wallet={wallet} contradictions={contradictions} notes={notes} setNotes={async (v)=>{ setNotesState(v); await setNotes(v); }} />} />
-              <Route path="/roadview" element={<RoadView agents={agents} stream={stream} setStream={setStream} system={system} wallet={wallet} contradictions={contradictions} notes={notes} setNotes={async (v)=>{ setNotesState(v); await setNotes(v); }} />} />
-              <Route path="/autoheal" element={<AutoHeal />} />
-              <Route path="/git" element={<Git />} />
+              <Route path="/" element={<HomeView tab={tab} setTab={setTab} timeline={timeline} tasks={tasks} commits={commits} onAction={handleAction} />} />
+              <Route path="/dashboard" element={<HomeView tab={tab} setTab={setTab} timeline={timeline} tasks={tasks} commits={commits} onAction={handleAction} />} />
+              <Route path="/you" element={<Section><You /></Section>} />
+              <Route path="/roadview" element={<Section><RoadView agents={agents} /></Section>} />
+              <Route path="/autoheal" element={<Section><AutoHeal /></Section>} />
+              <Route path="/guardian" element={<Guardian />} />
+              <Route path="/claude" element={<Section><Claude socket={socket} /></Section>} />
+              <Route path="/codex" element={<Section><Codex socket={socket} /></Section>} />
+              <Route path="/roadcoin" element={<Section><RoadCoin onUpdate={handleWalletUpdate} /></Section>} />
+              <Route path="/orchestrator" element={<Section><Orchestrator socket={socket} /></Section>} />
+              <Route path="/roadbook" element={<Section><Roadbook /></Section>} />
+              <Route path="/manifesto" element={<Section><Manifesto /></Section>} />
+              <Route path="/git" element={<Section><Git /></Section>} />
             </Routes>
+
+            <section className="col-span-4 flex flex-col gap-4">
+              <AgentStack
+                stream={stream}
+                setStream={setStream}
+                system={system}
+                wallet={wallet}
+                contradictions={contradictions}
+                notes={notes}
+                setNotes={handleNotesChange}
+              />
+            </section>
           </main>
         </>
       )}
@@ -230,64 +283,35 @@ export default function App(){
   )
 }
 
-function NavItem({ icon, text, href }){
-  const className = "flex items-center gap-3 px-2 py-2 rounded-xl hover:bg-slate-900 cursor-pointer";
-  return href ? (
-    <a href={href} className={className}>{icon}<span>{text}</span></a>
-  ) : (
-    <div className={className}>{icon}<span>{text}</span></div>
-  );
-function NavItem({ icon, text, to }){
-  const navigate = useNavigate()
-  return (
-    <div onClick={()=> to && navigate(to)} className="flex items-center gap-3 px-2 py-2 rounded-xl hover:bg-slate-900 cursor-pointer">
-function NavItem({ icon, text, to }){
-  return (
-    <NavLink to={to} className={({isActive})=>`flex items-center gap-3 px-2 py-2 rounded-xl hover:bg-slate-900 ${isActive?'text-white':'text-slate-300'}`}>
-      {icon}<span>{text}</span>
-    </NavLink>
-  )
-function NavItem({ icon, text, to }){
-  const cls = 'flex items-center gap-3 px-2 py-2 rounded-xl hover:bg-slate-900 cursor-pointer'
-  if (to) {
+function NavItem({ icon, text, to, href, currentPath, match }){
+  const base = 'flex items-center gap-3 px-2 py-2 rounded-xl transition-colors'
+  const isActive = match ? match(currentPath) : to ? currentPath === to : false
+  const className = `${base} ${isActive ? 'bg-slate-900 text-white' : 'text-slate-300 hover:bg-slate-900/60'}`
+
+  if(href){
     return (
-      <NavLink to={to} className={({isActive}) => `${cls} ${isActive ? 'bg-slate-900 text-white' : ''}`}>
-        {icon}<span>{text}</span>
-      </NavLink>
+      <a href={href} className={className}>
+        {icon}
+        <span>{text}</span>
+      </a>
     )
   }
-  return (<div className={cls}>{icon}<span>{text}</span></div>)
-}
 
-function Dashboard({ tab, setTab, timeline, tasks, commits, onAction }){
   return (
-    <>
-      <header className="flex items-center gap-8 border-b border-slate-800 mb-4">
-        <Tab onClick={()=>setTab('timeline')} active={tab==='timeline'}>Timeline</Tab>
-        <Tab onClick={()=>setTab('tasks')} active={tab==='tasks'}>Tasks</Tab>
-        <Tab onClick={()=>setTab('commits')} active={tab==='commits'}>Commits</Tab>
-        <div className="ml-auto flex items-center gap-2 py-3">
-          <button className="badge" onClick={()=>onAction('run')}>Run</button>
-          <button className="badge" onClick={()=>onAction('revert')}>Revert</button>
-          <button className="badge" onClick={()=>onAction('mint')}><Wallet size={14}/> Mint</button>
-        </div>
-      </header>
-
-      {tab==='timeline' && <Timeline items={timeline} />}
-      {tab==='tasks' && <Tasks items={tasks} />}
-      {tab==='commits' && <Commits items={commits} />}
-    </>
-  const Comp = href ? 'a' : 'div'
-  return (
-    <Comp href={href} className="flex items-center gap-3 px-2 py-2 rounded-xl hover:bg-slate-900 cursor-pointer">
-      {icon}<span>{text}</span>
-    </Comp>
+    <NavLink to={to} className={className}>
+      {icon}
+      <span>{text}</span>
+    </NavLink>
   )
 }
 
-function Dashboard({ tab, setTab, timeline, tasks, commits, onAction }){
+function Section({ children }){
+  return <section className="col-span-8">{children}</section>
+}
+
+function HomeView({ tab, setTab, timeline, tasks, commits, onAction }){
   return (
-    <>
+    <section className="col-span-8">
       <header className="flex items-center gap-8 border-b border-slate-800 mb-4">
         <Tab onClick={()=>setTab('timeline')} active={tab==='timeline'}>Timeline</Tab>
         <Tab onClick={()=>setTab('tasks')} active={tab==='tasks'}>Tasks</Tab>
@@ -302,6 +326,17 @@ function Dashboard({ tab, setTab, timeline, tasks, commits, onAction }){
       {tab==='timeline' && <Timeline items={timeline} />}
       {tab==='tasks' && <Tasks items={tasks} />}
       {tab==='commits' && <Commits items={commits} />}
-    </>
+    </section>
+  )
+}
+
+function Tab({ children, active, onClick }){
+  return (
+    <button
+      onClick={onClick}
+      className={`py-3 border-b-2 ${active ? 'border-indigo-500 text-white' : 'border-transparent text-slate-400 hover:text-slate-200'}`}
+    >
+      {children}
+    </button>
   )
 }

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -20,14 +20,17 @@ export async function fetchTimeline(){
   const { data } = await axios.get(`${API_BASE}/api/timeline`)
   return data.timeline
 }
+
 export async function fetchTasks(){
   const { data } = await axios.get(`${API_BASE}/api/tasks`)
   return data.tasks
 }
+
 export async function fetchCommits(){
   const { data } = await axios.get(`${API_BASE}/api/commits`)
   return data.commits
 }
+
 export async function fetchAgents(){
   const { data } = await axios.get(`${API_BASE}/api/agents`)
   return data.agents
@@ -42,6 +45,7 @@ export async function controlAgent(id, action){
   const { data } = await axios.post(`${API_BASE}/api/orchestrator/control/${id}`, { action })
   return data
 }
+
 export async function fetchWallet(){
   const { data } = await axios.get(`${API_BASE}/api/wallet`)
   return data.wallet
@@ -56,18 +60,22 @@ export async function mintRoadcoin(){
   const { data } = await axios.post(`${API_BASE}/api/roadcoin/mint`)
   return data
 }
+
 export async function fetchContradictions(){
   const { data } = await axios.get(`${API_BASE}/api/contradictions`)
   return data.contradictions
 }
+
 export async function getNotes(){
   const { data } = await axios.get(`${API_BASE}/api/notes`)
   return data.notes
 }
+
 export async function setNotes(notes){
   const { data } = await axios.post(`${API_BASE}/api/notes`, { notes })
   return data
 }
+
 export async function action(name){
   const { data } = await axios.post(`${API_BASE}/api/actions/${name}`)
   return data
@@ -83,9 +91,11 @@ export async function fetchGuardianAlerts(){
   return data.alerts
 }
 
-export async function resolveGuardianAlert(id, status='resolved'){
+export async function resolveGuardianAlert(id, status = 'resolved'){
   const { data } = await axios.post(`${API_BASE}/api/guardian/alerts/${id}/resolve`, { status })
   return data.alert
+}
+
 export async function fetchDashboardSystem(){
   const { data } = await axios.get(`${API_BASE}/api/dashboard/system`)
   return data
@@ -98,7 +108,9 @@ export async function fetchDashboardFeed(){
 
 export async function fetchProfile(){
   const { data } = await axios.get(`${API_BASE}/api/you/profile`)
-  return data
+  return data.profile
+}
+
 export async function claudeChat(prompt){
   const { data } = await axios.post(`${API_BASE}/api/claude/chat`, { prompt })
   return data
@@ -107,6 +119,8 @@ export async function claudeChat(prompt){
 export async function fetchClaudeHistory(){
   const { data } = await axios.get(`${API_BASE}/api/claude/history`)
   return data.history
+}
+
 export async function runCodex(prompt){
   const { data } = await axios.post(`${API_BASE}/api/codex/run`, { prompt })
   return data

--- a/frontend/src/pages/RoadView.jsx
+++ b/frontend/src/pages/RoadView.jsx
@@ -1,30 +1,69 @@
 import React, { useEffect, useState } from 'react'
-import AgentStack from '../components/AgentStack.jsx'
 import { fetchRoadviewStreams } from '../api'
 
 const colors = ['var(--accent)', 'var(--accent-2)', 'var(--accent-3)']
 
-export default function RoadView({ agents, stream, setStream, system, wallet, contradictions, notes, setNotes }){
+export default function RoadView({ agents = [] }){
   const [streams, setStreams] = useState([])
-  useEffect(()=>{ (async()=>{ try{ const s = await fetchRoadviewStreams(); setStreams(s) } catch{} })() }, [])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let alive = true
+    ;(async () => {
+      try {
+        const list = await fetchRoadviewStreams()
+        if (alive) setStreams(Array.isArray(list) ? list : [])
+      } catch {
+        if (alive) setStreams([])
+      } finally {
+        if (alive) setLoading(false)
+      }
+    })()
+    return () => {
+      alive = false
+    }
+  }, [])
+
   return (
-    <>
-      <section className="col-span-8">
-        <h1 className="text-xl font-semibold mb-4">RoadView</h1>
-        <div className="grid grid-cols-2 gap-4">
-          {streams.map(s => (
-            <div key={s.id} className="card flex items-center justify-center h-40 text-slate-400">Coming Soon</div>
+    <section className="col-span-8">
+      <h1 className="text-xl font-semibold mb-4">RoadView</h1>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {loading && (
+          <div className="col-span-full card flex items-center justify-center h-40 text-slate-500">
+            Loading streams…
+          </div>
+        )}
+        {!loading && streams.length === 0 && (
+          <div className="col-span-full card flex items-center justify-center h-40 text-slate-500">
+            No active streams yet.
+          </div>
+        )}
+        {streams.map((stream) => (
+          <div key={stream.id || stream.name} className="card p-4 h-40 flex flex-col justify-between">
+            <div>
+              <div className="text-lg font-semibold">{stream.name || stream.id}</div>
+              <div className="text-sm text-slate-400 mt-1">
+                {stream.status || stream.description || 'Coming soon'}
+              </div>
+            </div>
+            {stream.lastUpdate && (
+              <div className="text-xs text-slate-500">Updated {new Date(stream.lastUpdate).toLocaleString()}</div>
+            )}
+          </div>
+        ))}
+      </div>
+      {agents.length > 0 && (
+        <div className="flex items-center gap-2 mt-6">
+          {agents.map((agent, index) => (
+            <div
+              key={agent.id || agent.key || index}
+              title={agent.name || agent.username || 'agent'}
+              className="w-3 h-3 rounded-full"
+              style={{ backgroundColor: colors[index % colors.length] }}
+            />
           ))}
         </div>
-        <div className="flex items-center gap-2 mt-4">
-          {agents.map((a,i)=>(
-            <div key={a.id||i} title={a.name||a.username} className="w-3 h-3 rounded-full" style={{ backgroundColor: colors[i%colors.length] }}></div>
-          ))}
-        </div>
-      </section>
-      <section className="col-span-4 flex flex-col gap-4">
-        <AgentStack stream={stream} setStream={setStream} system={system} wallet={wallet} contradictions={contradictions} notes={notes} setNotes={setNotes} />
-      </section>
-    </>
+      )}
+    </section>
   )
 }


### PR DESCRIPTION
## Summary
- rebuild the main App layout to remove merge artifacts, manage auth/socket boot, and provide a consistent navigation/sidebar experience
- restore the API helper module so dashboard components can call the expected endpoints without syntax errors
- simplify the RoadView page to display fetched stream placeholders while the shared AgentStack sidebar handles metrics

## Testing
- npm run build *(fails: missing @vitejs/plugin-react in the workspace template)*

------
https://chatgpt.com/codex/tasks/task_e_68ddbd0bf9e88329a9dbaaf321b24346