### PR TITLE
Add aliases for fix-comments bot mentions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,5 +10,5 @@
 - [ ] API /api/health returns 200
 - [ ] Updated docs/tests as needed
 
-> Comment `@codex fix comments` to trigger bot autofix.
+> Comment `@codex fix comments` (or `@cadillac`, `@lucidia`, `@bbpteam`, `@blackboxprogramming`) to trigger bot autofix.
 

--- a/.github/workflows/codex-bridge.yml
+++ b/.github/workflows/codex-bridge.yml
@@ -3,7 +3,17 @@ on: { issue_comment: { types: [created] } }
 permissions: { contents: write, pull-requests: write, issues: write }
 jobs:
   apply:
-    if: startsWith(github.event.comment.body, '/codex ') || startsWith(github.event.comment.body, '@codex ')
+    if: |
+      startsWith(github.event.comment.body, '/codex ')
+      || startsWith(github.event.comment.body, '@codex')
+      || startsWith(github.event.comment.body, '@cadillac')
+      || startsWith(github.event.comment.body, '@Cadillac')
+      || startsWith(github.event.comment.body, '@lucidia')
+      || startsWith(github.event.comment.body, '@Lucidia')
+      || startsWith(github.event.comment.body, '@bbpteam')
+      || startsWith(github.event.comment.body, '@BBPTeam')
+      || startsWith(github.event.comment.body, '@blackboxprogramming')
+      || startsWith(github.event.comment.body, '@Blackboxprogramming')
     runs-on: ubuntu-latest
     env:
       BOT_TOKEN: ${{ secrets.BOT_TOKEN }}


### PR DESCRIPTION
## Summary
- allow @cadillac, @lucidia, @bbpteam, and @blackboxprogramming mentions to be translated into Codex commands
- run the Codex Bridge workflow when comments start with the new bot handles
- document the additional handles in the PR template tip

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68debc85dd808329be5203e238e54eb9