### PR TITLE
Add DisplayLink guide for Mac external displays

### DIFF
--- a/sites/blackroad/content/blog/displaylink-mac-external-display-guide.md
+++ b/sites/blackroad/content/blog/displaylink-mac-external-display-guide.md
@@ -1,0 +1,40 @@
+---
+title: "DisplayLink vs. Native Support: How Many Monitors Your Mac Can Drive"
+date: "2025-10-03"
+tags: [mac, hardware, productivity]
+description: "Quick guide to external display limits on modern Macs and when to reach for a DisplayLink dock."
+---
+
+Adding a second (or fifth) screen to a Mac used to mean scanning forums and spec sheets. Here is the practical cheat sheet I keep handing to teammates when they are wiring up their desks.
+
+## Native monitor limits by recent Mac
+
+| Mac model | Native external display support |
+| --- | --- |
+| **MacBook Air (M4, 2025)** | Up to two external displays with the lid open, driven off the Thunderbolt 4 ports. The built-in panel can stay on. |
+| **MacBook Air (M3, 2024)** | Two external displays when the lid is closed (clamshell mode). Lid open = one external plus the built-in screen. Requires macOS Sonoma 14.3 or newer for the dual-display mode. |
+| **MacBook Pro (M4 / M4 Pro)** | Up to two external displays while keeping the internal display active. |
+| **MacBook Pro (M4 Max)** | Up to four external displays. |
+| **Earlier base M1 / M2 Macs** | Generally limited to a single external display without help. Pro and Max-class chips in the same era natively handle more. |
+
+Apple’s individual product pages confirm the exact port and resolution combinations, but the table above reflects the real-world ceiling for most setups.
+
+## What DisplayLink actually does
+
+DisplayLink docks and USB adapters behave like a virtual graphics card. The macOS driver compresses each frame on the host, pushes it over USB, and the DisplayLink chipset inside the dock or dongle decompresses the stream into HDMI or DisplayPort for the monitor. This lets you add external displays **beyond** the hardware limit that macOS enforces on the GPU.
+
+Because the pixels are being encoded in software, expect a small CPU/GPU tax and a touch of latency that gamers or color-accuracy pros might notice. For spreadsheets, dashboards, IDEs, and messaging windows, the trade-off is usually worth it.
+
+## Pick the right dock for your Mac
+
+- **Running an M3 MacBook Air in clamshell with two monitors?** Stick with a standard Thunderbolt or USB-C dock—no DisplayLink required because Sonoma now enables the second screen natively.
+- **Need more monitors than the chip officially supports?** Choose a DisplayLink-equipped dock from vendors such as Plugable, Anker, Targus, Kensington, or Dell. Install the current DisplayLink Manager driver, and plan for the minor performance overhead.
+- **Mix and match intentionally.** You can run one or two native displays directly off Thunderbolt/HDMI and add additional DisplayLink outputs from the same dock to scale up.
+
+## Practical cautions
+
+- Keep latency-sensitive workloads (competitive gaming, live grading, or color-critical work) on the GPU-native outputs.
+- Budget for driver maintenance—DisplayLink Manager occasionally needs an update after major macOS releases.
+- When macOS throttles bandwidth on a single cable, plug the most demanding display (4K/120 Hz) straight into a native Thunderbolt/HDMI port and use the DisplayLink dock for auxiliary panels.
+
+Tell me the exact Mac model, chip, and how many screens you want. I can map a precise port plan, confirm which cables you need, and recommend a dock that fits.


### PR DESCRIPTION
## Summary
- add a new blog post covering native multi-monitor limits on recent Macs and how DisplayLink docks extend them

## Testing
- npm --prefix sites/blackroad run prebuild *(fails: missing gray-matter dependency because the site package dependencies are not installed in this environment)*
- npm --prefix sites/blackroad install *(fails: peer dependency conflict between @types/react 19.x and @types/react-dom 18.x in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df5d46fb7c8329bc81908f9c582fdf