### PR TITLE
Add anti-fragility Kubernetes starter stack

### DIFF
--- a/k8s/anti-fragility-starter/README.md
+++ b/k8s/anti-fragility-starter/README.md
@@ -1,0 +1,35 @@
+# Anti-Fragility Starter Stack
+
+This starter kit wires a minimal anti-fragile operations loop on Kubernetes. It combines telemetry, progressive delivery, automated remediation, and continuous learning so that stress hardens the platform instead of degrading it.
+
+## Components
+
+- **Namespace** – isolates demo resources under `anti-fragile-demo`.
+- **SLO** – an [OpenSLO](https://openslo.com/) objective for the demo service that feeds error-budget policy.
+- **Alert routing** – a Prometheus Operator `AlertmanagerConfig` that annotates incidents with context and sends them to chat and ticketing.
+- **Progressive delivery** – an Argo Rollouts canary with automatic rollback driven by golden-signal analysis.
+- **Incident-to-learning job** – a nightly CronJob that turns incidents into embeddings so anomaly detectors retrain on fresh patterns.
+
+## Deploy with GitOps
+
+Apply the manifests with Argo CD or `kubectl`:
+
+```bash
+kubectl apply -k k8s/anti-fragility-starter
+```
+
+For GitOps, point an Argo CD `Application` at this directory. The manifests are composable via kustomize overlays.
+
+## Flow
+
+1. Telemetry exports latency and error metrics that back the SLO objective.
+2. Alertmanager enriches burn-rate alerts with runbooks, deploy SHAs, and recent changes.
+3. Argo Rollouts gradually shifts traffic; analysis gates watch the SLO burn and error rate.
+4. If analysis fails, the rollout aborts and rolls back automatically.
+5. After incidents, the CronJob updates the feature store powering anomaly detectors so future responses improve.
+
+## Next Steps
+
+- Connect Prometheus and Alertmanager instances to these configs.
+- Plug the incident learning job into your real incident data source.
+- Extend SLO definitions per service and enforce budgets via admission control.

--- a/k8s/anti-fragility-starter/delivery/analysis-template.yaml
+++ b/k8s/anti-fragility-starter/delivery/analysis-template.yaml
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: demo-api-canary-checks
+spec:
+  args:
+    - name: service
+      value: demo-api
+  metrics:
+    - name: error-rate
+      interval: 1m
+      count: 5
+      successCondition: result < 0.02
+      failureCondition: result >= 0.02
+      provider:
+        prometheus:
+          address: http://prometheus.monitoring.svc.cluster.local:9090
+          query: |
+            sum(rate(http_requests_total{service="{{args.service}}",status=~"5.."}[1m]))
+            /
+            sum(rate(http_requests_total{service="{{args.service}}"}[1m]))
+    - name: slo-burn
+      interval: 1m
+      count: 5
+      failureCondition: result > 1
+      successCondition: result <= 1
+      provider:
+        prometheus:
+          address: http://prometheus.monitoring.svc.cluster.local:9090
+          query: |
+            slo_error_budget_burn_rate{service="{{args.service}}",window="5m"}

--- a/k8s/anti-fragility-starter/delivery/kustomization.yaml
+++ b/k8s/anti-fragility-starter/delivery/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: anti-fragile-demo
+resources:
+  - rollout.yaml
+  - analysis-template.yaml

--- a/k8s/anti-fragility-starter/delivery/rollout.yaml
+++ b/k8s/anti-fragility-starter/delivery/rollout.yaml
@@ -1,0 +1,76 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: demo-api
+spec:
+  replicas: 4
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: demo-api
+  strategy:
+    canary:
+      canaryService: demo-api-canary
+      stableService: demo-api-stable
+      trafficRouting:
+        istio:
+          virtualService:
+            name: demo-api
+            routes:
+              - http-route
+      steps:
+        - setWeight: 10
+        - pause: {duration: 2m}
+        - analysis:
+            templates:
+              - templateName: demo-api-canary-checks
+        - setWeight: 25
+        - pause: {duration: 2m}
+        - analysis:
+            templates:
+              - templateName: demo-api-canary-checks
+        - setWeight: 50
+        - pause: {duration: 5m}
+        - analysis:
+            templates:
+              - templateName: demo-api-canary-checks
+      maxSurge: 1
+      maxUnavailable: 0
+      abort:
+        enabled: true
+  template:
+    metadata:
+      labels:
+        app: demo-api
+    spec:
+      containers:
+        - name: demo-api
+          image: ghcr.io/blackroad/demo-api:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          env:
+            - name: DEPLOY_SHA
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['rollouts-pod-template-hash']
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi

--- a/k8s/anti-fragility-starter/kustomization.yaml
+++ b/k8s/anti-fragility-starter/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - observability
+  - delivery
+  - learning

--- a/k8s/anti-fragility-starter/learning/incident-learning-cronjob.yaml
+++ b/k8s/anti-fragility-starter/learning/incident-learning-cronjob.yaml
@@ -1,0 +1,44 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: incident-learning-nightly
+spec:
+  schedule: "30 2 * * *"
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: incident-learning
+        spec:
+          restartPolicy: OnFailure
+          serviceAccountName: incident-learning
+          containers:
+            - name: feature-builder
+              image: ghcr.io/blackroad/incident-learning:latest
+              imagePullPolicy: IfNotPresent
+              args:
+                - "--since"
+                - "24h"
+                - "--incident-api=https://incident-api.internal.example.com/v1"
+                - "--feature-store=postgresql://feature-writer:5432/observability"
+                - "--embedding-model=text-embedding-3-small"
+              env:
+                - name: INCIDENT_API_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: incident-writer
+                      key: token
+                - name: FEATURE_STORE_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: feature-store
+                      key: password
+              volumeMounts:
+                - name: runbook-cache
+                  mountPath: /var/runbooks
+          volumes:
+            - name: runbook-cache
+              emptyDir: {}

--- a/k8s/anti-fragility-starter/learning/kustomization.yaml
+++ b/k8s/anti-fragility-starter/learning/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: anti-fragile-demo
+resources:
+  - incident-learning-cronjob.yaml

--- a/k8s/anti-fragility-starter/namespace.yaml
+++ b/k8s/anti-fragility-starter/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: anti-fragile-demo
+  labels:
+    app.kubernetes.io/part-of: anti-fragility-stack
+    platform.blackroad.io/guardrails: enabled

--- a/k8s/anti-fragility-starter/observability/alertmanager-config.yaml
+++ b/k8s/anti-fragility-starter/observability/alertmanager-config.yaml
@@ -1,0 +1,46 @@
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  name: demo-api-routing
+  labels:
+    alertmanagerConfig: main
+spec:
+  route:
+    receiver: sre-chat
+    groupBy: ['alertname', 'service']
+    groupWait: 30s
+    groupInterval: 5m
+    repeatInterval: 2h
+    matchers:
+      - name: service
+        value: demo-api
+      - name: severity
+        value: critical
+    continue: true
+  receivers:
+    - name: sre-chat
+      slackConfigs:
+        - channel: '#sre-incidents'
+          sendResolved: true
+          title: '{{ .CommonLabels.alertname }} :: {{ .CommonLabels.service }}'
+          text: |
+            *SLO burn:* {{ .CommonAnnotations.burn_rate }}x
+            *Runbook:* {{ .CommonAnnotations.runbook }}
+            *Deploy SHA:* {{ .CommonAnnotations.deploy_sha }}
+            *Recent changes:* {{ .CommonAnnotations.change_summary }}
+    - name: incident-ticket
+      webhookConfigs:
+        - url: https://incident-api.internal.example.com/v1/incidents
+          sendResolved: true
+          httpConfig:
+            bearerTokenSecret:
+              name: incident-writer
+              key: token
+  inhibitRules:
+    - sourceMatch:
+        - name: severity
+          value: critical
+      targetMatch:
+        - name: severity
+          value: warning
+      equal: ['alertname', 'service']

--- a/k8s/anti-fragility-starter/observability/kustomization.yaml
+++ b/k8s/anti-fragility-starter/observability/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: anti-fragile-demo
+resources:
+  - slo-gateway.yaml
+  - alertmanager-config.yaml

--- a/k8s/anti-fragility-starter/observability/slo-gateway.yaml
+++ b/k8s/anti-fragility-starter/observability/slo-gateway.yaml
@@ -1,0 +1,42 @@
+apiVersion: openslo/v1alpha
+kind: ServiceLevelObjective
+metadata:
+  name: demo-api-latency
+  labels:
+    app.kubernetes.io/name: demo-api
+    slo.openslo.com/criticality: tier-1
+spec:
+  service: demo-api
+  description: 99% of requests for the demo API should complete within 300ms over 30 days.
+  indicator:
+    metadata:
+      displayName: Demo API latency under 300ms
+    ratioMetric:
+      counter: false
+      good:
+        metricSource: prometheus
+        query: sum(rate(http_request_duration_seconds_bucket{service="demo-api",le="0.3"}[5m]))
+      total:
+        metricSource: prometheus
+        query: sum(rate(http_request_duration_seconds_count{service="demo-api"}[5m]))
+  budgetingMethod: Occurrences
+  timeWindow:
+    rolling:
+      count: 30
+      unit: Day
+  objectives:
+    - displayName: 30-day latency
+      target: 0.99
+  alertPolicies:
+    - name: latency-burn
+      annotations:
+        runbook: https://runbooks.internal.example.com/demo-api-latency
+        owner: platform-sre
+        pagerduty_service: demo-api
+      conditions:
+        - condition: burn-rate-fast
+          threshold: 14
+          lookback: 5m
+        - condition: burn-rate-slow
+          threshold: 2
+          lookback: 1h


### PR DESCRIPTION
## Summary
- add a kustomize-based anti-fragility starter stack with namespace, SLO, alert routing, progressive delivery, and learning job manifests
- document how to deploy the stack and how the feedback loop fits together

## Testing
- kustomize build k8s/anti-fragility-starter *(fails: `kustomize` not installed in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68df5d99d0148329b173487d28c4c176