### PR TITLE
Introduce contract-driven orchestrator for core automation agents

### DIFF
--- a/contracts/agents/build_blackroad_site.yaml
+++ b/contracts/agents/build_blackroad_site.yaml
@@ -1,0 +1,21 @@
+name: build_blackroad_site
+version: 1.0.0
+inputs: []
+outputs:
+  - id: build_exit_code
+    type: integer
+    constraints:
+      allowed: [0, 1]
+    description: Zero on success, non-zero on failure.
+side_effects:
+  - type: process
+    resource: npm
+    ops: [run_build]
+  - type: filesystem
+    resource: sites/blackroad/.next
+    ops: [write]
+failure_modes:
+  - id: NPM_UNAVAILABLE
+    retryable: false
+  - id: BUILD_FAILED
+    retryable: true

--- a/contracts/agents/cleanup_bot.yaml
+++ b/contracts/agents/cleanup_bot.yaml
@@ -1,0 +1,31 @@
+name: cleanup_git_branches
+version: 1.0.0
+inputs:
+  - id: base_branch
+    type: string
+    required: false
+    description: Git branch used as the merge base for discovery.
+  - id: branches
+    type: array[string]
+    required: false
+    description: Explicit branches to delete. If omitted the agent will discover merged branches.
+  - id: dry_run
+    type: boolean
+    required: false
+    default: false
+    description: When true, no destructive git commands are executed.
+outputs:
+  - id: cleanup_report
+    type: object
+    description: Mapping of branch names to deletion success booleans.
+side_effects:
+  - type: process
+    resource: git
+    ops: [branch_delete, push_delete]
+failure_modes:
+  - id: DISCOVERY_FAILED
+    retryable: false
+  - id: DELETE_FAILED
+    retryable: true
+observability:
+  idempotency_key: branch_name

--- a/contracts/agents/deploy_website.yaml
+++ b/contracts/agents/deploy_website.yaml
@@ -1,0 +1,39 @@
+name: deploy_blackroad_site
+version: 1.0.0
+inputs:
+  - id: deploy_command
+    type: array[string]
+    required: false
+    default: ["/deploy", "blackroad", "pages"]
+  - id: build_exit_code
+    type: integer
+    required: true
+    description: Exit code from the build step; must be zero to proceed.
+  - id: purge_cache
+    type: boolean
+    required: false
+    default: true
+  - id: warm_cache
+    type: boolean
+    required: false
+    default: true
+outputs:
+  - id: deployment_summary
+    type: object
+    description: Status flags for deploy, purge, and warm operations.
+side_effects:
+  - type: process
+    resource: deployment_cli
+    ops: [deploy]
+  - type: process
+    resource: cache_cli
+    ops: [purge, warm]
+failure_modes:
+  - id: DEPLOY_FAILED
+    retryable: true
+  - id: CACHE_PURGE_FAILED
+    retryable: true
+  - id: CACHE_WARM_FAILED
+    retryable: true
+  - id: BUILD_NOT_READY
+    retryable: false

--- a/orchestrator/contract_models.py
+++ b/orchestrator/contract_models.py
@@ -1,0 +1,143 @@
+"""Utilities for loading and validating agent contracts."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Mapping, MutableMapping
+
+import yaml
+
+
+@dataclass(frozen=True)
+class FieldSchema:
+    """Schema definition for an input or output field."""
+
+    id: str
+    type: str
+    required: bool = True
+    description: str | None = None
+    constraints: Mapping[str, Any] | None = None
+    default: Any | None = None
+
+
+@dataclass(frozen=True)
+class SideEffect:
+    """Declared side-effect for an agent."""
+
+    type: str
+    resource: str
+    ops: List[str]
+
+
+@dataclass(frozen=True)
+class FailureMode:
+    """Known failure mode for an agent."""
+
+    id: str
+    retryable: bool
+
+
+@dataclass(frozen=True)
+class AgentContract:
+    """Represents the static contract for an agent."""
+
+    name: str
+    version: str
+    inputs: List[FieldSchema] = field(default_factory=list)
+    outputs: List[FieldSchema] = field(default_factory=list)
+    side_effects: List[SideEffect] = field(default_factory=list)
+    failure_modes: List[FailureMode] = field(default_factory=list)
+    metadata: Mapping[str, Any] | None = None
+
+    def input_by_id(self, field_id: str) -> FieldSchema | None:
+        return next((field for field in self.inputs if field.id == field_id), None)
+
+    def output_ids(self) -> List[str]:
+        return [field.id for field in self.outputs]
+
+
+class ContractRegistry:
+    """Loads contracts and binds them to callable executors."""
+
+    def __init__(self) -> None:
+        self._contracts: Dict[str, AgentContract] = {}
+        self._executors: Dict[str, Callable[[MutableMapping[str, Any]], Mapping[str, Any]]] = {}
+
+    @property
+    def contracts(self) -> Mapping[str, AgentContract]:
+        return self._contracts
+
+    def load_directory(self, directory: Path) -> None:
+        for path in sorted(directory.glob("*.yaml")):
+            contract = self._load_contract(path)
+            self._contracts[contract.name] = contract
+
+    def register_executor(
+        self,
+        agent_name: str,
+        executor: Callable[[MutableMapping[str, Any]], Mapping[str, Any]],
+    ) -> None:
+        if agent_name not in self._contracts:
+            raise KeyError(f"Contract for '{agent_name}' has not been loaded")
+        self._executors[agent_name] = executor
+
+    def get(self, agent_name: str) -> AgentContract:
+        return self._contracts[agent_name]
+
+    def executor_for(
+        self, agent_name: str
+    ) -> Callable[[MutableMapping[str, Any]], Mapping[str, Any]]:
+        return self._executors[agent_name]
+
+    @staticmethod
+    def _load_contract(path: Path) -> AgentContract:
+        with path.open("r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle)
+
+        def build_fields(section: Iterable[Mapping[str, Any]]) -> List[FieldSchema]:
+            fields: List[FieldSchema] = []
+            for item in section:
+                fields.append(
+                    FieldSchema(
+                        id=item["id"],
+                        type=item["type"],
+                        required=item.get("required", True),
+                        description=item.get("description"),
+                        constraints=item.get("constraints"),
+                        default=item.get("default"),
+                    )
+                )
+            return fields
+
+        def build_side_effects(section: Iterable[Mapping[str, Any]]) -> List[SideEffect]:
+            side_effects: List[SideEffect] = []
+            for item in section:
+                side_effects.append(
+                    SideEffect(
+                        type=item["type"],
+                        resource=item["resource"],
+                        ops=list(item.get("ops", [])),
+                    )
+                )
+            return side_effects
+
+        def build_failure_modes(section: Iterable[Mapping[str, Any]]) -> List[FailureMode]:
+            failures: List[FailureMode] = []
+            for item in section:
+                failures.append(
+                    FailureMode(
+                        id=item["id"],
+                        retryable=bool(item.get("retryable", False)),
+                    )
+                )
+            return failures
+
+        return AgentContract(
+            name=data["name"],
+            version=data["version"],
+            inputs=build_fields(data.get("inputs", [])),
+            outputs=build_fields(data.get("outputs", [])),
+            side_effects=build_side_effects(data.get("side_effects", [])),
+            failure_modes=build_failure_modes(data.get("failure_modes", [])),
+            metadata=data.get("observability"),
+        )

--- a/orchestrator/contract_runtime.py
+++ b/orchestrator/contract_runtime.py
@@ -1,0 +1,27 @@
+"""Factory helpers for the contract-based orchestrator."""
+from __future__ import annotations
+
+from pathlib import Path
+from .contract_models import ContractRegistry
+from .executors import EXECUTOR_MAP
+from .simple_orchestrator import SimpleOrchestrator
+
+
+def build_registry(contracts_path: str | Path) -> ContractRegistry:
+    """Load all contracts from ``contracts_path`` and bind executors."""
+
+    registry = ContractRegistry()
+    registry.load_directory(Path(contracts_path))
+    for agent_name, executor in EXECUTOR_MAP.items():
+        registry.register_executor(agent_name, executor)
+    return registry
+
+
+def build_orchestrator(contracts_path: str | Path) -> SimpleOrchestrator:
+    """Create a :class:`SimpleOrchestrator` with loaded contracts."""
+
+    registry = build_registry(contracts_path)
+    return SimpleOrchestrator(registry)
+
+
+__all__ = ["build_orchestrator", "build_registry"]

--- a/orchestrator/executors.py
+++ b/orchestrator/executors.py
@@ -1,0 +1,110 @@
+"""Bindings between contract names and concrete agent implementations."""
+from __future__ import annotations
+
+import logging
+import subprocess
+from typing import Any, Dict, MutableMapping
+
+from agents.build_blackroad_site_agent import build_site
+from agents.cleanup_bot import CleanupBot
+from agents.website_bot import WebsiteBot
+
+LOGGER = logging.getLogger(__name__)
+
+
+class AgentExecutionError(RuntimeError):
+    """Wrap low-level exceptions with a contract failure identifier."""
+
+    def __init__(self, failure_mode: str, message: str, *, cause: Exception | None = None) -> None:
+        super().__init__(message)
+        self.failure_mode = failure_mode
+        self.__cause__ = cause
+
+
+def cleanup_git_branches_executor(context: MutableMapping[str, Any]) -> Dict[str, Any]:
+    """Execute the cleanup bot using either explicit branches or discovery."""
+
+    dry_run = bool(context.get("dry_run", False))
+    branches = context.get("branches")
+    base_branch = context.get("base_branch", "main")
+
+    try:
+        if branches:
+            bot = CleanupBot(branches=list(branches), dry_run=dry_run)
+        else:
+            bot = CleanupBot.from_merged(base=base_branch, dry_run=dry_run)
+    except RuntimeError as exc:  # discovery failed
+        raise AgentExecutionError("DISCOVERY_FAILED", str(exc), cause=exc) from exc
+
+    results = bot.cleanup()
+    if not all(results.values()):
+        LOGGER.warning("Some branches failed to delete", extra={"results": results})
+    return {"cleanup_report": results}
+
+
+def build_blackroad_site_executor(context: MutableMapping[str, Any]) -> Dict[str, Any]:
+    """Run the npm build and capture the exit code."""
+
+    exit_code = build_site()
+    if exit_code != 0:
+        LOGGER.error("Site build returned non-zero exit code", extra={"code": exit_code})
+    return {"build_exit_code": exit_code}
+
+
+def deploy_blackroad_site_executor(context: MutableMapping[str, Any]) -> Dict[str, Any]:
+    """Deploy the website and optionally manage cache."""
+
+    deploy_command = context.get("deploy_command") or ["/deploy", "blackroad", "pages"]
+    purge_cache = context.get("purge_cache", True)
+    warm_cache = context.get("warm_cache", True)
+    build_exit_code = context.get("build_exit_code")
+
+    if build_exit_code is None or build_exit_code != 0:
+        raise AgentExecutionError(
+            "BUILD_NOT_READY",
+            "Deployment requires a successful build exit code of 0",
+        )
+
+    bot = WebsiteBot(
+        deploy_cmd=list(deploy_command),
+    )
+
+    summary: Dict[str, Any] = {"deployed": False, "cache_purged": False, "cache_warmed": False}
+
+    try:
+        bot.deploy()
+        summary["deployed"] = True
+    except subprocess.CalledProcessError as exc:
+        raise AgentExecutionError("DEPLOY_FAILED", "Website deploy failed", cause=exc) from exc
+
+    if purge_cache:
+        try:
+            bot.purge_cache()
+            summary["cache_purged"] = True
+        except subprocess.CalledProcessError as exc:
+            raise AgentExecutionError("CACHE_PURGE_FAILED", "Cache purge failed", cause=exc) from exc
+
+    if warm_cache:
+        try:
+            bot.warm_cache()
+            summary["cache_warmed"] = True
+        except subprocess.CalledProcessError as exc:
+            raise AgentExecutionError("CACHE_WARM_FAILED", "Cache warm failed", cause=exc) from exc
+
+    return {"deployment_summary": summary}
+
+
+EXECUTOR_MAP = {
+    "cleanup_git_branches": cleanup_git_branches_executor,
+    "build_blackroad_site": build_blackroad_site_executor,
+    "deploy_blackroad_site": deploy_blackroad_site_executor,
+}
+
+
+__all__ = [
+    "AgentExecutionError",
+    "EXECUTOR_MAP",
+    "build_blackroad_site_executor",
+    "cleanup_git_branches_executor",
+    "deploy_blackroad_site_executor",
+]

--- a/orchestrator/simple_orchestrator.py
+++ b/orchestrator/simple_orchestrator.py
@@ -1,0 +1,156 @@
+"""Minimal orchestrator that plans and runs agent contracts."""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, Iterable, List, Mapping, MutableMapping, Sequence, Set
+
+from .contract_models import AgentContract, ContractRegistry, FieldSchema
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ContractValidationError(RuntimeError):
+    """Raised when an agent input or output violates its contract."""
+
+
+class PlanCompilationError(RuntimeError):
+    """Raised when the orchestrator cannot produce a valid DAG for the goal."""
+
+
+@dataclass
+class PlanStep:
+    """Single step in an agent execution plan."""
+
+    agent_name: str
+
+
+class SimpleOrchestrator:
+    """Contract-driven orchestrator for deterministic agent execution."""
+
+    def __init__(self, registry: ContractRegistry) -> None:
+        self._registry = registry
+
+    def compile_to_dag(
+        self, goal_outputs: Sequence[str], available_keys: Iterable[str],
+    ) -> List[PlanStep]:
+        """Compile a simple DAG that fulfills ``goal_outputs``.
+
+        The planner selects agents whose outputs intersect with the unresolved goal
+        set and whose required inputs are already satisfied. The resulting list is
+        ordered topologically.
+        """
+
+        resolved: Set[str] = set(available_keys)
+        outstanding: Set[str] = set(goal_outputs) - resolved
+        steps: List[PlanStep] = []
+        used_agents: Set[str] = set()
+
+        while outstanding:
+            progress_made = False
+            for contract in self._registry.contracts.values():
+                if contract.name in used_agents:
+                    continue
+                output_ids = set(contract.output_ids())
+                if not output_ids & outstanding:
+                    continue
+                if not self._inputs_available(contract, resolved):
+                    continue
+                steps.append(PlanStep(agent_name=contract.name))
+                used_agents.add(contract.name)
+                resolved.update(output_ids)
+                outstanding.difference_update(output_ids)
+                progress_made = True
+            if not progress_made:
+                raise PlanCompilationError(
+                    "Unable to construct plan: insufficient inputs for remaining goals"
+                )
+        return steps
+
+    def run_plan(
+        self, goal_outputs: Sequence[str], context: MutableMapping[str, Any]
+    ) -> MutableMapping[str, Any]:
+        steps = self.compile_to_dag(goal_outputs, context.keys())
+        for step in steps:
+            contract = self._registry.get(step.agent_name)
+            executor = self._registry.executor_for(step.agent_name)
+            LOGGER.info("Running agent", extra={"agent": contract.name})
+            self._validate_inputs(contract, context)
+            before_hash = self._hash_subset(context, contract.inputs)
+            outputs = executor(context)
+            self._validate_outputs(contract, outputs)
+            context.update(outputs)
+            after_hash = self._hash_subset(outputs, contract.outputs)
+            LOGGER.info(
+                "Agent completed",
+                extra={
+                    "agent": contract.name,
+                    "inputs_hash": before_hash,
+                    "outputs_hash": after_hash,
+                },
+            )
+        return context
+
+    def _inputs_available(self, contract: AgentContract, resolved: Set[str]) -> bool:
+        for field in contract.inputs:
+            if field.required and field.id not in resolved:
+                return False
+        return True
+
+    def _validate_inputs(
+        self, contract: AgentContract, context: MutableMapping[str, Any]
+    ) -> None:
+        for field in contract.inputs:
+            if field.required and field.id not in context:
+                raise ContractValidationError(
+                    f"Missing required input '{field.id}' for agent {contract.name}"
+                )
+            if field.id in context:
+                self._validate_type(field, context[field.id], "input")
+
+    def _validate_outputs(self, contract: AgentContract, outputs: Mapping[str, Any]) -> None:
+        for field in contract.outputs:
+            if field.id not in outputs:
+                raise ContractValidationError(
+                    f"Missing required output '{field.id}' from agent {contract.name}"
+                )
+            self._validate_type(field, outputs[field.id], "output")
+
+    def _validate_type(self, field: FieldSchema, value: Any, direction: str) -> None:
+        if not self._matches_type(field.type, value):
+            raise ContractValidationError(
+                f"{direction.title()} '{field.id}' expected {field.type} but received {type(value).__name__}"
+            )
+
+    def _matches_type(self, declared: str, value: Any) -> bool:
+        if declared == "string":
+            return isinstance(value, str)
+        if declared == "integer":
+            return isinstance(value, int)
+        if declared == "boolean":
+            return isinstance(value, bool)
+        if declared == "object":
+            return isinstance(value, dict)
+        if declared.startswith("array[") and declared.endswith("]"):
+            subtype = declared[len("array[") : -1]
+            if not isinstance(value, list):
+                return False
+            return all(self._matches_type(subtype, item) for item in value)
+        return True
+
+    def _hash_subset(
+        self, data: Mapping[str, Any], fields: Sequence[FieldSchema]
+    ) -> str:
+        subset = {field.id: data.get(field.id) for field in fields if field.id in data}
+        encoded = json.dumps(subset, sort_keys=True).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+
+__all__ = [
+    "ContractValidationError",
+    "PlanCompilationError",
+    "PlanStep",
+    "SimpleOrchestrator",
+]

--- a/tests/test_contract_orchestrator_runtime.py
+++ b/tests/test_contract_orchestrator_runtime.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from orchestrator.contract_runtime import build_orchestrator
+from orchestrator.simple_orchestrator import ContractValidationError
+
+
+@pytest.fixture()
+def contracts_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "contracts" / "agents"
+
+
+@pytest.fixture()
+def stubbed_orchestrator(monkeypatch, contracts_path: Path):
+    calls = {"cleanup": 0, "build": 0, "deploy": 0}
+
+    class StubCleanup:
+        def __init__(self, branches, dry_run):
+            self.branches = branches or ["auto"]
+            self.dry_run = dry_run
+
+        @classmethod
+        def from_merged(cls, base: str = "main", dry_run: bool = False):
+            return cls(branches=["auto"], dry_run=dry_run)
+
+        def cleanup(self):
+            calls["cleanup"] += 1
+            return {branch: True for branch in self.branches}
+
+    class StubWebsiteBot:
+        def __init__(self, deploy_cmd):
+            self.deploy_cmd = deploy_cmd
+
+        def deploy(self):
+            calls["deploy"] += 1
+
+        def purge_cache(self):
+            calls.setdefault("purge", 0)
+            calls["purge"] += 1
+
+        def warm_cache(self):
+            calls.setdefault("warm", 0)
+            calls["warm"] += 1
+
+    monkeypatch.setattr("orchestrator.executors.CleanupBot", StubCleanup)
+    monkeypatch.setattr("orchestrator.executors.WebsiteBot", StubWebsiteBot)
+
+    def fake_build_site() -> int:
+        calls["build"] += 1
+        return 0
+
+    monkeypatch.setattr("orchestrator.executors.build_site", fake_build_site)
+
+    orchestrator = build_orchestrator(contracts_path)
+    return orchestrator, calls
+
+
+def test_plan_execution_updates_context(stubbed_orchestrator):
+    orchestrator, calls = stubbed_orchestrator
+    context = {
+        "branches": ["feature/x"],
+        "dry_run": False,
+        "purge_cache": False,
+        "warm_cache": False,
+    }
+
+    result = orchestrator.run_plan(
+        ["cleanup_report", "build_exit_code", "deployment_summary"], context
+    )
+
+    assert result["cleanup_report"] == {"feature/x": True}
+    assert result["build_exit_code"] == 0
+    assert result["deployment_summary"]["deployed"] is True
+    assert calls["cleanup"] == 1
+    assert calls["deploy"] == 1
+
+
+def test_output_validation_failure(monkeypatch, contracts_path: Path):
+    orchestrator = build_orchestrator(contracts_path)
+
+    def bad_cleanup(_context):
+        return {"cleanup_report": "not a dict"}
+
+    orchestrator._registry.register_executor("cleanup_git_branches", bad_cleanup)
+
+    with pytest.raises(ContractValidationError):
+        orchestrator.run_plan(["cleanup_report"], {})


### PR DESCRIPTION
## Summary
- add YAML contracts for the cleanup, build, and deploy agents including side-effect and failure metadata
- implement a contract registry, executor bindings, and a simple orchestrator that validates inputs/outputs
- cover the new workflow with tests that exercise planning, execution, and contract validation failures

## Testing
- pytest tests/test_contract_orchestrator_runtime.py

------
https://chatgpt.com/codex/tasks/task_e_68df5d617084832984e7b5d1b91f3382