### PR TITLE
Add alice-pi device to registry and partner relay defaults

### DIFF
--- a/data/admin/devices.json
+++ b/data/admin/devices.json
@@ -12,6 +12,18 @@
     "lastSeen": 1759012961427
   },
   {
+    "deviceId": "alice-pi",
+    "owner": "alice",
+    "platform": "raspberry-pi-4",
+    "role": "pi_led_agent",
+    "attached": true,
+    "encrypted": true,
+    "compliant": true,
+    "operatorAccount": "alice",
+    "notes": "Alice's dedicated Pi for LED prototyping",
+    "lastSeen": 1759012961427
+  },
+  {
     "deviceId": "jetson-01",
     "owner": "ml",
     "platform": "jetson-orin",

--- a/docs/DEVICES.md
+++ b/docs/DEVICES.md
@@ -5,6 +5,7 @@ The device registry is stored in [`data/admin/devices.json`](../data/admin/devic
 | Device ID     | Hardware          | Role               | Owner | Attached | Notes |
 | ------------- | ----------------- | ------------------ | ----- | -------- | ----- |
 | `pi-01`       | Raspberry Pi 5    | Emotion LED agent  | Ops   | ✅       | Hosts the LED ring and the local operator console account.
+| `alice-pi`    | Raspberry Pi 4    | Emotion LED dev rig  | Alice | ✅       | Personal Pi for Alice with LED and sensor prototyping tools.
 | `jetson-01`   | Jetson Orin Nano  | LLM / display GPU  | ML    | ✅       | Drives the main HDMI panel and coordinates inference jobs.
 | `display-mini`| Pi SPI display    | Status panel       | Ops   | ✅       | 2.8" SPI panel wired into `pi-01` for mini status readouts.
 | `display-main`| HDMI monitor      | Primary display    | Ops   | ✅       | Main wall display connected to `jetson-01`.

--- a/srv/blackroad-api/modules/partner_relay_mtls.js
+++ b/srv/blackroad-api/modules/partner_relay_mtls.js
@@ -9,7 +9,7 @@ module.exports = function attachPartnerRelay({ app }) {
 
   const ORIGIN_KEY_PATH = process.env.ORIGIN_KEY_PATH || '/srv/secrets/origin.key';
   const ALLOW_SUBJECTS = (process.env.PARTNER_SUBJECTS || 'Claude-Partner').split(',').map(s=>s.trim()).filter(Boolean);
-  const ALLOW_DEVICES  = (process.env.PARTNER_DEVICES  || 'pi-01,jetson-01,display-mini,display-main').split(',').map(s=>s.trim()).filter(Boolean);
+  const ALLOW_DEVICES  = (process.env.PARTNER_DEVICES  || 'pi-01,alice-pi,jetson-01,display-mini,display-main').split(',').map(s=>s.trim()).filter(Boolean);
   const LOG_DIR = '/var/log/blackroad';
   const LOG_FILE = path.join(LOG_DIR, 'partner-relay.log');
 


### PR DESCRIPTION
## Summary
- add an alice-pi record to the admin device registry with owner, posture, and notes
- surface the new device in the hardware inventory documentation
- include alice-pi in the default partner relay allowlist so remote commands are accepted

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e07172ab2c8329a9b5df513b275a69