### PR TITLE
Add Lucidia harmony coordinator and console controls

### DIFF
--- a/lucidia/__init__.py
+++ b/lucidia/__init__.py
@@ -1,6 +1,7 @@
 """Lucidia engines and utilities."""
 
-from .rpg import Character, Game
 from .core import Vector3
+from .harmony import HarmonyCoordinator, NodeProfile
+from .rpg import Character, Game
 
-__all__ = ["Character", "Game", "Vector3"]
+__all__ = ["Character", "Game", "Vector3", "HarmonyCoordinator", "NodeProfile"]

--- a/lucidia/__main__.py
+++ b/lucidia/__main__.py
@@ -1,29 +1,115 @@
-"""Command-line interface for Lucidia.
-
-Provides a tiny REPL so users can run Python snippets. On startup,
-Lucidia introduces herself with a short message about her origins and
-abilities.
-"""
-
+"""Lucidia's interactive console with Codex coordination helpers."""
 from __future__ import annotations
 
 import io
+import json
 from contextlib import redirect_stdout
+from typing import Iterable
+
+from .harmony import HarmonyCoordinator
+
+PROMPT = "lucidia> "
+CAPABILITIES = ["repl", "hologram-console", "lucidia-link"]
+CHANNELS = ["lucidia-link", "hologram-console"]
+
+
+def _print_intro() -> None:
+    print("Hello, I'm Lucidia. I was built by BlackRoad!")
+    print("I love coding, can talk, and I'm super fast.")
+    print("Type Python code to run it. Prefix commands with ':' to control the console.")
+    print("Commands: :ping <remote> [intent] [k=v...], :status, :history [n], :help, :exit")
+
+
+def _format_state_snapshot(state: dict[str, object]) -> str:
+    return json.dumps(state, indent=2, sort_keys=True)
+
+
+def _handle_command(command: str, coordinator: HarmonyCoordinator) -> bool:
+    tokens = command.split()
+    if not tokens:
+        return True
+    name = tokens[0].lower()
+    if name in {":exit", ":quit"}:
+        return False
+    if name == ":help":
+        _print_intro()
+        return True
+    if name == ":status":
+        snapshot = coordinator.export_state()
+        print(_format_state_snapshot(snapshot))
+        return True
+    if name == ":history":
+        limit = 5
+        if len(tokens) > 1:
+            try:
+                limit = max(1, int(tokens[1]))
+            except ValueError:
+                print("History limit must be an integer.")
+                return True
+        for entry in coordinator.list_recent_handshakes(limit=limit):
+            print(
+                f"[{entry['timestamp']}] {entry['from']} -> {entry['to']} "
+                f"intent={entry['intent']} channel={entry['channel']}"
+            )
+        return True
+    if name == ":ping":
+        if len(tokens) < 2:
+            print("Usage: :ping <remote> [intent] [key=value ...]")
+            return True
+        remote = tokens[1]
+        intent = tokens[2] if len(tokens) > 2 else "sync"
+        metadata_tokens: Iterable[str] = tokens[3:]
+        payload: dict[str, str] = {}
+        for item in metadata_tokens:
+            if "=" not in item:
+                print(f"Ignoring metadata token '{item}' (missing '=')")
+                continue
+            key, value = item.split("=", 1)
+            payload[key] = value
+        handshake = coordinator.ping_remote(remote_node=remote, intent=intent, payload=payload)
+        print(
+            f"Handshake queued → {handshake['to']} intent={handshake['intent']} "
+            f"channel={handshake['channel']}"
+        )
+        return True
+    print(f"Unknown command: {command}")
+    return True
 
 
 def main() -> None:
     """Run the Lucidia REPL."""
-    print("Hello, I'm Lucidia. I was built by BlackRoad!")
-    print("I love coding, can talk, and I'm super fast.")
-    print("Type Python code to run it. Enter 'exit' to quit.")
+
+    coordinator = HarmonyCoordinator(
+        local_node="lucidia",
+        role="hologram-console",
+        status="booting",
+        capabilities=CAPABILITIES,
+        channels=CHANNELS,
+    )
+    coordinator.update_local_status(
+        role="hologram-console",
+        status="ready",
+        capabilities=CAPABILITIES,
+        channels=CHANNELS,
+    )
+
+    _print_intro()
     while True:
         try:
-            code = input("lucidia> ")
+            code = input(PROMPT)
         except EOFError:
             print()
             break
-        if not code.strip() or code.strip().lower() in {"exit", "quit"}:
+        stripped = code.strip()
+        if not stripped:
+            continue
+        lowered = stripped.lower()
+        if lowered in {"exit", "quit"}:
             break
+        if stripped.startswith(":"):
+            if not _handle_command(stripped, coordinator):
+                break
+            continue
         local_vars: dict[str, object] = {}
         stdout = io.StringIO()
         try:
@@ -34,6 +120,12 @@ def main() -> None:
                 print(output)
         except Exception as exc:  # noqa: BLE001 - broad for user feedback
             print(f"Error: {exc}")
+    coordinator.update_local_status(
+        role="hologram-console",
+        status="offline",
+        capabilities=CAPABILITIES,
+        channels=CHANNELS,
+    )
     print("Goodbye!")
 
 

--- a/lucidia/harmony.py
+++ b/lucidia/harmony.py
@@ -1,0 +1,188 @@
+"""Utilities to coordinate Lucidia with sibling Codex deployments."""
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Mapping, MutableMapping, Optional
+
+DEFAULT_LEDGER_PATH = Path.home() / ".lucidia" / "harmony.json"
+
+
+@dataclass
+class NodeProfile:
+    """Metadata describing a Lucidia-aligned node or console."""
+
+    name: str
+    role: str
+    status: str
+    capabilities: List[str] = field(default_factory=list)
+    channels: List[str] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    last_seen: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a JSON serialisable representation of the profile."""
+
+        payload = deepcopy(self.__dict__)
+        payload["capabilities"] = sorted(payload.get("capabilities", []))
+        payload["channels"] = sorted(payload.get("channels", []))
+        return payload
+
+
+class HarmonyCoordinator:
+    """Persist lightweight coordination events for multi-node Lucidia setups.
+
+    The coordinator keeps a small JSON ledger describing the local node as well
+    as any handshakes initiated with sibling Codex deployments.  It does not
+    assume bidirectional connectivity; instead it records intent so an
+    out-of-band transport (SSH, MQTT, etc.) can replay the handshake.
+    """
+
+    def __init__(
+        self,
+        local_node: str,
+        *,
+        role: str = "console",
+        status: str = "initialising",
+        capabilities: Optional[Iterable[str]] = None,
+        channels: Optional[Iterable[str]] = None,
+        ledger_path: Optional[Path | str] = None,
+    ) -> None:
+        self.local_node = local_node
+        self._ledger_path = Path(ledger_path) if ledger_path is not None else DEFAULT_LEDGER_PATH
+        self._ledger_path.parent.mkdir(parents=True, exist_ok=True)
+        self._state: MutableMapping[str, Any] = {"nodes": {}, "handshakes": []}
+        self._load_state()
+        self.update_local_status(
+            role=role,
+            status=status,
+            capabilities=capabilities or [],
+            channels=channels or [],
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _load_state(self) -> None:
+        if not self._ledger_path.exists():
+            return
+        try:
+            data = json.loads(self._ledger_path.read_text())
+        except (OSError, json.JSONDecodeError):  # pragma: no cover - defensive
+            return
+        if isinstance(data, Mapping):
+            nodes = data.get("nodes", {})
+            handshakes = data.get("handshakes", [])
+            if isinstance(nodes, Mapping):
+                self._state["nodes"].update({str(k): dict(v) for k, v in nodes.items() if isinstance(v, Mapping)})
+            if isinstance(handshakes, list):
+                self._state["handshakes"].extend(
+                    handshake
+                    for handshake in handshakes
+                    if isinstance(handshake, Mapping)
+                )
+
+    def _write_state(self) -> None:
+        payload = {
+            "nodes": {name: deepcopy(profile) for name, profile in self._state["nodes"].items()},
+            "handshakes": list(self._state["handshakes"]),
+        }
+        self._ledger_path.write_text(json.dumps(payload, indent=2, sort_keys=True))
+
+    def _touch_local(self) -> None:
+        now = datetime.now(timezone.utc).isoformat()
+        profile = self._state["nodes"].get(self.local_node)
+        if isinstance(profile, MutableMapping):
+            profile["last_seen"] = now
+        else:  # pragma: no cover - sanity guard
+            self._state["nodes"][self.local_node] = {"name": self.local_node, "last_seen": now}
+        self._write_state()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def update_local_status(
+        self,
+        *,
+        role: str,
+        status: str,
+        capabilities: Iterable[str] | None = None,
+        channels: Iterable[str] | None = None,
+        metadata: Optional[Mapping[str, Any]] = None,
+    ) -> NodeProfile:
+        """Update the local node profile and persist it to disk."""
+
+        now = datetime.now(timezone.utc).isoformat()
+        profile = NodeProfile(
+            name=self.local_node,
+            role=role,
+            status=status,
+            capabilities=list(dict.fromkeys(capabilities or [])),
+            channels=list(dict.fromkeys(channels or [])),
+            metadata=dict(metadata or {}),
+            last_seen=now,
+        )
+        self._state["nodes"][self.local_node] = profile.to_dict()
+        self._write_state()
+        return profile
+
+    def ping_remote(
+        self,
+        remote_node: str,
+        *,
+        intent: str = "sync",
+        channel: str = "hologram-console",
+        payload: Optional[Mapping[str, Any]] = None,
+        transmitter: Optional[Callable[[Mapping[str, Any]], None]] = None,
+    ) -> Dict[str, Any]:
+        """Record an outgoing handshake toward ``remote_node``.
+
+        ``transmitter`` can be supplied to forward the handshake through a
+        concrete transport (HTTP request, MQTT publish, etc.).  The function is
+        expected to be synchronous and raise if it fails so the caller can
+        surface the error to the operator.
+        """
+
+        timestamp = datetime.now(timezone.utc).isoformat()
+        handshake = {
+            "from": self.local_node,
+            "to": remote_node,
+            "intent": intent,
+            "channel": channel,
+            "payload": dict(payload or {}),
+            "timestamp": timestamp,
+        }
+        self._state.setdefault("handshakes", []).append(handshake)
+        nodes = self._state.setdefault("nodes", {})
+        remote_profile = nodes.get(remote_node, {"name": remote_node})
+        remote_profile.setdefault("channels", [])
+        remote_profile.setdefault("capabilities", [])
+        remote_profile["last_seen"] = timestamp
+        remote_profile.setdefault("status", "unknown")
+        nodes[remote_node] = remote_profile
+        self._touch_local()
+        self._write_state()
+        if transmitter is not None:
+            transmitter(handshake)
+        return handshake
+
+    def list_recent_handshakes(self, *, limit: int = 10) -> List[Dict[str, Any]]:
+        """Return the most recent handshake records (newest first)."""
+
+        if limit <= 0:
+            return []
+        return list(reversed(self._state.get("handshakes", [])[-limit:]))
+
+    def export_state(self) -> Dict[str, Any]:
+        """Return a deep copy of the ledger state."""
+
+        return {
+            "nodes": {name: deepcopy(data) for name, data in self._state.get("nodes", {}).items()},
+            "handshakes": list(self._state.get("handshakes", [])),
+        }
+
+
+__all__ = ["HarmonyCoordinator", "NodeProfile"]

--- a/tests/test_lucidia_harmony.py
+++ b/tests/test_lucidia_harmony.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from lucidia.harmony import HarmonyCoordinator
+
+
+def read_state(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text())
+
+
+def test_ping_remote_records_handshake(tmp_path: Path) -> None:
+    ledger = tmp_path / "ledger.json"
+    coordinator = HarmonyCoordinator(
+        "lucidia",
+        role="hologram-console",
+        status="booting",
+        capabilities=["repl"],
+        channels=["hologram"],
+        ledger_path=ledger,
+    )
+    coordinator.update_local_status(
+        role="hologram-console",
+        status="ready",
+        capabilities=["repl"],
+        channels=["hologram"],
+        metadata={"node": "lucidia"},
+    )
+
+    handshake = coordinator.ping_remote(
+        "alice",
+        intent="sync",
+        channel="hologram-console",
+        payload={"mode": "cooperative"},
+    )
+
+    assert handshake["to"] == "alice"
+    assert handshake["payload"] == {"mode": "cooperative"}
+
+    state = read_state(ledger)
+    assert "handshakes" in state
+    assert state["handshakes"][-1]["to"] == "alice"
+    assert state["nodes"]["lucidia"]["status"] == "ready"
+    assert state["nodes"]["lucidia"]["metadata"]["node"] == "lucidia"
+    assert state["nodes"]["alice"]["status"] == "unknown"
+
+
+def test_list_recent_handshakes_returns_newest_first(tmp_path: Path) -> None:
+    ledger = tmp_path / "ledger.json"
+    coordinator = HarmonyCoordinator(
+        "lucidia",
+        role="hologram-console",
+        status="booting",
+        capabilities=["repl"],
+        channels=["hologram"],
+        ledger_path=ledger,
+    )
+
+    coordinator.ping_remote("alice", intent="calibration")
+    coordinator.ping_remote("bob", intent="sync")
+    coordinator.ping_remote("carol", intent="status")
+
+    history = coordinator.list_recent_handshakes(limit=2)
+    assert [entry["to"] for entry in history] == ["carol", "bob"]
+
+
+def test_export_state_returns_copy(tmp_path: Path) -> None:
+    ledger = tmp_path / "ledger.json"
+    coordinator = HarmonyCoordinator(
+        "lucidia",
+        role="hologram-console",
+        status="booting",
+        ledger_path=ledger,
+    )
+    state = coordinator.export_state()
+    state["nodes"]["lucidia"]["status"] = "mutated"
+
+    refreshed = coordinator.export_state()
+    assert refreshed["nodes"]["lucidia"]["status"] != "mutated"


### PR DESCRIPTION
## Summary
- introduce a HarmonyCoordinator module that records Lucidia node profiles and handshakes
- extend the Lucidia console with coordination commands for pinging remote Codex deployments
- add unit tests covering handshake recording and history export behaviour

## Testing
- pytest tests/test_lucidia_harmony.py

------
https://chatgpt.com/codex/tasks/task_e_68e07246237c8329af12ed07fd65dba0