### PR TITLE
Add Oct 2025 Cloudflare and Copilot incident dispatch

### DIFF
--- a/docs/incidents/2025-10-03-cloudflare-github-copilot.md
+++ b/docs/incidents/2025-10-03-cloudflare-github-copilot.md
@@ -1,0 +1,32 @@
+# Incident Dispatch — 03 Oct 2025
+
+This dispatch summarizes two service disruptions observed on 3–4 Oct 2025 affecting Cloudflare networking surfaces and GitHub Copilot's AI assistance. The intent is to capture the known timelines, operational impact, and immediate mitigations that BlackRoad teams should consider while providers continue their investigations.
+
+## Cloudflare: Tunnel Health Checks & Browser Isolation
+- **Timeline**:
+  - 03 Oct 2025 00:19 UTC — Cloudflare reported degraded tunnel health monitoring for a subset of Magic Transit and Magic WAN tunnels.
+  - 03 Oct 2025 13:57 UTC — A fix rollout began across the impacted fleet.
+  - 04 Oct 2025 00:29 UTC — Cloudflare projected full resolution by 16:00 UTC the same day.
+  - 03 Oct 2025 15:55 UTC — A separate Cloudflare Browser Isolation availability incident started; Cloudflare later marked it resolved.
+- **Operational impact**:
+  - Tunnel health checks may flap or report false negatives even when data-plane traffic continues to flow, potentially triggering noise in monitoring or automated failovers.
+  - Browser Isolation sessions could experience connection errors or degraded availability during the incident window.
+- **Recommended actions**:
+  - Validate GRE/IPsec fallback paths and confirm automated tunnel failover logic matches current production topology.
+  - Tune alerting thresholds or suppression windows so transient health check misses do not page teams unnecessarily.
+  - Review Browser Isolation access logs and user feedback to ensure no lingering connectivity issues.
+
+## GitHub Copilot: Degraded Performance
+- **Timeline**:
+  - 03 Oct 2025 02:41 UTC — GitHub flagged degraded performance across Copilot services.
+  - 03 Oct 2025 03:47 UTC — Follow-up update indicated ongoing investigation; third-party monitors measured roughly one hour of disruption.
+- **Operational impact**:
+  - Developers depending on Copilot may observe slow or failed completions, reducing throughput during time-sensitive delivery windows.
+- **Recommended actions**:
+  - Keep native language-server or completion plugins enabled as a local fallback when Copilot responses stall.
+  - Communicate expected slowdowns to teams operating on tight deadlines and encourage manual code review for critical changes.
+  - Monitor GitHub's status page and incident RSS feeds for closure notes or post-incident analysis.
+
+---
+*Prepared by: Autonomous Agent*
+*Date: 04 Oct 2025*


### PR DESCRIPTION
## Summary
- add an incident dispatch memo for the 3–4 Oct 2025 Cloudflare tunnel and Browser Isolation disruptions
- document the 3 Oct 2025 GitHub Copilot degraded performance incident with timeline, impact, and mitigations

## Testing
- not run (documentation change)

------
https://chatgpt.com/codex/tasks/task_e_68e1760199c483299f241eaaac98c0e1