### PR TITLE
Add blog coverage for SEC generic crypto ETP approvals

### DIFF
--- a/sites/blackroad/content/blog/sec-generic-crypto-etps.md
+++ b/sites/blackroad/content/blog/sec-generic-crypto-etps.md
@@ -1,0 +1,56 @@
+---
+title: "SEC Fast-Tracks Generic Listings for Crypto and Commodity ETPs"
+date: "2025-09-17"
+tags: [crypto, regulation, markets]
+description: "Accelerated approval for generic Commodity-Based Trust Share listings opens a rapid path for altcoin ETPs and puts more oversight burden on exchanges."
+---
+
+The U.S. Securities and Exchange Commission just gave the exchanges a powerful
+shortcut. On **September 17, 2025** the SEC granted accelerated approval for
+Nasdaq, Cboe BZX, and NYSE Arca to adopt **generic listing standards** for
+Commodity-Based Trust Shares, explicitly including products that hold digital
+assets. When an exchange-traded product (ETP) satisfies the new rulebook, the
+exchange can list it without waiting on a bespoke Rule 19b-4 order.
+
+## Why this is a hinge moment
+
+- **Speed to market compresses**: What used to be a multi-quarter review cycle
+  could now shrink to weeks as long as products fall within the pre-vetted
+  parameters.
+- **Altcoins get a realistic runway**: Assets beyond Bitcoin and Ethereum—think
+  XRP, Solana, Dogecoin—can now hit U.S. markets once they meet the objective
+  criteria.
+- **Oversight shifts toward exchanges**: The exchanges must prove they can
+  police surveillance, disclosures, custody, and settlement without the SEC
+  hand-holding every listing.
+- **Regulators remain split**: Commissioners like Caroline Crenshaw warn that
+  speeding approvals may dilute scrutiny for still-nascent digital assets.
+
+## Pipeline to watch
+
+- **Application surge**: Issuers including REX and Osprey have already lined up
+  dozens of filings covering Cardano, Stellar, and other networks.
+- **October launch window**: Market analysts expect the first wave of products
+  under the generic regime to reach the tape as early as October 2025.
+- **Eligibility thresholds**: To ride the fast track, a token typically needs a
+  regulated futures market operating for six months or an existing ETF with at
+  least 40% direct exposure.
+- **Investor guardrails**: Accelerated does not mean lax—issuers must keep
+  surveillance sharing, custody attestations, and risk disclosures airtight.
+
+## Action items for market teams
+
+1. **Audit the pipeline**: Map client demand against the new eligibility
+   requirements to prioritize which assets warrant product work.
+2. **Revisit surveillance agreements**: Exchanges bear more liability; broker
+   and market making desks need clarity on how data sharing will extend to new
+   products.
+3. **Update investor comms**: Shorter launch windows mean marketing, compliance,
+   and operations teams must sync earlier to avoid last-minute fire drills.
+4. **Model liquidity scenarios**: Evaluate how incremental ETP supply could pull
+   activity from offshore venues or futures markets and what that implies for
+   hedging.
+
+The regulatory door just opened wider. Firms that adapt their listing and
+coverage playbooks now will be the first to capture the next wave of regulated
+crypto exposure.


### PR DESCRIPTION
## Summary
- add a blog post detailing the SEC's accelerated approval of generic listing standards for crypto and commodity ETPs
- highlight implications for speed to market, oversight responsibilities, and upcoming product pipeline

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e1765035c0832984da3b4e99a939ce