### PR TITLE
Add nightly stack heartbeat monitoring

### DIFF
--- a/systemd/stack-heartbeat.service
+++ b/systemd/stack-heartbeat.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Nightly stack heartbeat (journalctl p3 + failed units)
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/stack-heartbeat.sh

--- a/systemd/stack-heartbeat.timer
+++ b/systemd/stack-heartbeat.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run stack heartbeat nightly at 02:05
+
+[Timer]
+OnCalendar=*-*-* 02:05:00
+Persistent=true
+Unit=stack-heartbeat.service
+
+[Install]
+WantedBy=timers.target

--- a/usr/local/bin/stack-heartbeat.sh
+++ b/usr/local/bin/stack-heartbeat.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export SYSTEMD_PAGER=""
+export SYSTEMD_COLORS="0"
+
+OUT="/var/log/stack_heartbeat.log"
+TMP="$(mktemp)"
+NOW="$(date -Is)"
+
+{
+  echo "=== STACK HEARTBEAT @ ${NOW} ==="
+  echo
+  echo "## Critical errors since last boot (journalctl -p 3 -xb)"
+  journalctl -p 3 -xb --no-pager || true
+  echo
+  echo "## Failed units (systemctl list-units --failed)"
+  systemctl list-units --failed --no-pager || true
+  echo
+} > "$TMP"
+
+mv "$TMP" "$OUT"
+chmod 0644 "$OUT"
+
+if grep -qiE 'error|failed|failure' "$OUT"; then
+  # Uncomment the next line after installing and configuring a local MTA
+  # mail -s "STACK ALERT: issues detected $(hostname) @ ${NOW}" you@example.com < "$OUT"
+  logger -t stack-heartbeat "Issues detected; see $OUT"
+fi


### PR DESCRIPTION
## Summary
- add a stack-heartbeat shell script that records critical journal errors and failed services
- provision systemd unit and timer to run the heartbeat nightly at 02:05 and log/alert on failures

## Testing
- not run (infrastructure scripts only)


------
https://chatgpt.com/codex/tasks/task_e_68e1761f8f348329b05fd7ef20d66274