### PR TITLE
Add briefing on OpenAI Sora 2 rights dynamics

### DIFF
--- a/docs/sora2_rights_landscape.md
+++ b/docs/sora2_rights_landscape.md
@@ -1,0 +1,25 @@
+# OpenAI Sora 2 Rights & Risk Landscape
+
+## Product Snapshot
+- **Availability**: Standalone Sora 2 video app for users in the United States and Canada.
+- **Format**: Short-form, ~10 second vertical clips with swipe-based discovery similar to TikTok.
+- **Remix Culture**: Users can remix each other's videos, and cameo slots allow verified individuals to insert their likenesses.
+
+## Rights Holder Controls
+- **Granular Permissions**: Studios and IP owners can configure how their characters and catalog assets are available inside Sora 2, including full opt-out.
+- **Default Exposure**: Content may appear in generated videos unless rights holders proactively opt out, creating passive consent dynamics.
+- **Revenue Sharing**: Participants that keep their IP accessible can receive revenue shares tied to usage.
+
+## Emerging Pushback
+- **Disney Opt-Out**: Disney has already exercised the opt-out to keep its characters from being used within Sora 2.
+- **Opt-Out Burden**: Rights holders warn that default-inclusion forces ongoing monitoring to prevent unauthorized uses.
+- **Opaque Training Data**: OpenAI has not disclosed detailed Sora training sources, heightening concerns that unlicensed or scraped content underpins the system.
+
+## Misuse & Safety Risks
+- **Deepfake Vectors**: The ability to insert real people and remix content raises impersonation and disinformation risks.
+- **Governance Needs**: Effective safeguards will need to balance creative experimentation with IP enforcement, identity verification, and abuse mitigation.
+
+## Watch List
+- Track additional studio participation or withdrawals to gauge industry alignment.
+- Monitor legal developments regarding training data transparency and opt-out defaults.
+- Evaluate the effectiveness of OpenAI's enforcement and revenue-sharing mechanics as early case studies emerge.


### PR DESCRIPTION
## Summary
- add documentation outlining Sora 2's product model, rights-holder controls, and emerging industry pushback
- highlight potential misuse risks and key items to monitor as the rollout evolves

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e176e2774c8329829bb2dbf1350665