### PR TITLE
Add self-healing agent scripts and timers

### DIFF
--- a/srv/blackroad/health/.gitignore
+++ b/srv/blackroad/health/.gitignore
@@ -1,0 +1,4 @@
+logs/
+state/
+!logs/.gitkeep
+!state/.gitkeep

--- a/srv/blackroad/health/README.md
+++ b/srv/blackroad/health/README.md
@@ -1,0 +1,40 @@
+# BlackRoad Self-Healing Agent
+
+This directory contains lightweight Bash tooling that keeps the production
+services in `/srv/blackroad` healthy.  It mirrors all tracked GitHub repositories,
+checks for drift and service health, and automatically rolls deployments back to
+known-good commits when repeated failures occur.
+
+## Components
+
+- `mirror_sync.sh` — maintains bare mirrors under `/srv/blackroad/mirror` and
+  working copies under `/srv/blackroad/work` for each tracked repository.
+- `health_check.sh` — runs the drift, process, port, and environment checks and
+  triggers healing actions.
+- `rollback.sh` — pins services to commits listed in
+  `state/known_good.txt` after repeated failures.
+- `logs/` — contains streaming logs produced by the scripts.
+- `state/` — stores counters, environment hashes, and the known-good manifest.
+
+The accompanying systemd units live in `../../../../systemd/`:
+
+- `blackroad-mirror.service` / `.timer`
+- `blackroad-health.service` / `.timer`
+
+## Usage
+
+1. Copy the scripts to `/srv/blackroad/health` on the droplet.
+2. Ensure the `REPOS` list in `mirror_sync.sh` and the `WATCH` array in
+   `health_check.sh` reflect all deployed services.
+3. Provide `state/known_good.txt` entries in the form `repo commit service` for
+   the rollback script.
+4. Install the systemd units and enable the timers:
+
+   ```bash
+   sudo cp systemd/blackroad-*.service systemd/blackroad-*.timer /etc/systemd/system/
+   sudo systemctl daemon-reload
+   sudo systemctl enable --now blackroad-mirror.timer blackroad-health.timer
+   ```
+
+Logs will accumulate in `/srv/blackroad/health/logs`, and notable events are
+also appended to `events.log` for external notification tooling.

--- a/srv/blackroad/health/health_check.sh
+++ b/srv/blackroad/health/health_check.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE=/srv/blackroad
+WRK="$BASE/work"
+HLT="$BASE/health"
+LOG="$HLT/logs"
+STATE="$HLT/state"
+
+mkdir -p "$LOG" "$STATE"
+
+exec > >(tee -a "$LOG/health.log") 2>&1
+
+ts() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
+ok() { echo "$(ts) OK  $*"; }
+bad() {
+  local msg="$(ts) BAD $*"
+  echo "$msg"
+  echo "$msg" >>"$LOG/events.log"
+}
+
+WATCH=(
+  "blackroad-api|blackroad-api.service|4000|/srv/blackroad-api/.env"
+  "lucidia-llm|lucidia-llm.service|8000|/srv/lucidia-llm/.env"
+)
+
+changed_env() {
+  local file="$1"
+  local key="envhash_$(basename "$file")"
+  [[ -f "$file" ]] || return 1
+
+  local current previous
+  current=$(sha256sum "$file" | awk '{print $1}')
+  previous=$(grep -m1 "^$key=" "$STATE/env.hash" 2>/dev/null | cut -d= -f2- || true)
+
+  if [[ "$current" != "$previous" ]]; then
+    sed -i "/^$key=/d" "$STATE/env.hash" 2>/dev/null || true
+    echo "$key=$current" >>"$STATE/env.hash"
+    return 0
+  fi
+
+  return 1
+}
+
+heal_repo() {
+  local repo="$1"
+  [[ -d "$WRK/$repo/.git" ]] || return
+  git -C "$WRK/$repo" reset --hard HEAD >>"$LOG/heal.log" 2>&1 || true
+  git -C "$WRK/$repo" clean -fd >>"$LOG/heal.log" 2>&1 || true
+  git -C "$WRK/$repo" pull --ff-only >>"$LOG/heal.log" 2>&1 || true
+}
+
+trigger_rollback() {
+  local svc="$1" count="$2"
+  echo "$(ts) triggering rollback for $svc after $count failures" >>"$LOG/events.log"
+  /bin/bash "$HLT/rollback.sh" >>"$LOG/heal.log" 2>&1 || true
+}
+
+update_fail_counter() {
+  local svc="$1" failed="$2"
+  local counter_file="$STATE/fails_${svc//[^A-Za-z0-9_.-]/_}"
+  local count=0
+
+  if [[ "$failed" == "1" ]]; then
+    if [[ -f "$counter_file" ]]; then
+      count=$(<"$counter_file")
+    fi
+    count=$((count + 1))
+    echo "$count" >"$counter_file"
+    if (( count >= 3 )); then
+      trigger_rollback "$svc" "$count"
+      echo 0 >"$counter_file"
+    fi
+  else
+    rm -f "$counter_file" 2>/dev/null || true
+  fi
+}
+
+for spec in "${WATCH[@]}"; do
+  IFS="|" read -r REPO SVC PORT ENVF <<<"$spec"
+  service_failed=0
+
+  if [[ -d "$WRK/$REPO/.git" ]]; then
+    git -C "$WRK/$REPO" fetch -q origin || true
+    local_head=$(git -C "$WRK/$REPO" rev-parse @)
+    remote_head=$(git -C "$WRK/$REPO" rev-parse @{u} 2>/dev/null || echo "")
+    dirt=$(git -C "$WRK/$REPO" status --porcelain)
+
+    if [[ -n "$dirt" ]] || { [[ -n "$remote_head" ]] && [[ "$local_head" != "$remote_head" ]]; }; then
+      bad "$REPO drift detected"
+      heal_repo "$REPO"
+      service_failed=1
+    else
+      ok "$REPO clean"
+    fi
+  else
+    bad "$REPO missing working tree"
+    service_failed=1
+  fi
+
+  if systemctl is-active --quiet "$SVC"; then
+    ok "$SVC active"
+  else
+    bad "$SVC down -> restarting"
+    systemctl restart "$SVC" || true
+    service_failed=1
+  fi
+
+  if ss -ltn | awk '{print $4}' | grep -q ":$PORT$"; then
+    ok "port $PORT listening"
+  else
+    bad "port $PORT not listening -> restart $SVC"
+    systemctl restart "$SVC" || true
+    service_failed=1
+  fi
+
+  if [[ -n "${ENVF:-}" && -f "$ENVF" ]] && changed_env "$ENVF"; then
+    bad "env changed for $SVC -> restart"
+    systemctl restart "$SVC" || true
+    service_failed=1
+  fi
+
+  update_fail_counter "$SVC" "$service_failed"
+done
+
+echo "$(ts) health_check done" >>"$LOG/events.log"

--- a/srv/blackroad/health/mirror_sync.sh
+++ b/srv/blackroad/health/mirror_sync.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPOS=(
+  "git@github.com:blackboxprogramming/blackroad-api.git"
+  "git@github.com:blackboxprogramming/lucidia-llm.git"
+)
+
+BASE=/srv/blackroad
+MIR="$BASE/mirror"
+WRK="$BASE/work"
+LOG="$BASE/health/logs"
+
+mkdir -p "$MIR" "$WRK" "$LOG"
+
+exec > >(tee -a "$LOG/mirror.log") 2>&1
+
+ts() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
+
+for URL in "${REPOS[@]}"; do
+  NAME=$(basename "$URL" .git)
+
+  if [[ ! -d "$MIR/$NAME.git" ]]; then
+    echo "$(ts) cloning mirror for $NAME"
+    git clone --mirror "$URL" "$MIR/$NAME.git" || true
+  else
+    echo "$(ts) updating mirror for $NAME"
+    git -C "$MIR/$NAME.git" remote update --prune || true
+  fi
+
+  if [[ ! -d "$WRK/$NAME/.git" ]]; then
+    echo "$(ts) creating worktree for $NAME"
+    git clone "$MIR/$NAME.git" "$WRK/$NAME" || true
+    git -C "$WRK/$NAME" checkout -q main || git -C "$WRK/$NAME" checkout -q master || true
+  else
+    echo "$(ts) refreshing worktree for $NAME"
+    git -C "$WRK/$NAME" fetch origin || true
+  fi
+
+done
+
+msg="$(ts) mirror_sync ok"
+echo "$msg"
+echo "$msg" >>"$LOG/events.log"

--- a/srv/blackroad/health/rollback.sh
+++ b/srv/blackroad/health/rollback.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE=/srv/blackroad
+WRK="$BASE/work"
+LOG="$BASE/health/logs"
+STATE="$BASE/health/state"
+PINFILE="$STATE/known_good.txt"
+
+mkdir -p "$LOG" "$STATE"
+
+ts() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
+
+[[ -f "$PINFILE" ]] || exit 0
+
+while read -r REPO COMMIT SVC; do
+  [[ -z "$REPO" || "$REPO" =~ ^# ]] && continue
+  if [[ -d "$WRK/$REPO/.git" ]]; then
+    echo "$(ts) rolling $REPO to $COMMIT"
+    git -C "$WRK/$REPO" fetch -q origin || true
+    git -C "$WRK/$REPO" reset --hard "$COMMIT" >>"$LOG/heal.log" 2>&1 || true
+    if [[ -n "${SVC:-}" ]]; then
+      systemctl restart "$SVC" >>"$LOG/heal.log" 2>&1 || true
+    fi
+    echo "$(ts) rolled $REPO to $COMMIT" >>"$LOG/events.log"
+  else
+    echo "$(ts) missing repo $REPO for rollback" >>"$LOG/events.log"
+  fi
+done <"$PINFILE"

--- a/systemd/blackroad-health.service
+++ b/systemd/blackroad-health.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=BlackRoad health and heal agent
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash /srv/blackroad/health/health_check.sh
+User=root

--- a/systemd/blackroad-health.timer
+++ b/systemd/blackroad-health.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run BlackRoad health checks every minute
+
+[Timer]
+OnBootSec=30s
+OnUnitActiveSec=1min
+Unit=blackroad-health.service
+
+[Install]
+WantedBy=timers.target

--- a/systemd/blackroad-mirror.service
+++ b/systemd/blackroad-mirror.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=BlackRoad mirror updater
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash /srv/blackroad/health/mirror_sync.sh
+User=root

--- a/systemd/blackroad-mirror.timer
+++ b/systemd/blackroad-mirror.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run BlackRoad mirror updater every 5 minutes
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=5min
+Unit=blackroad-mirror.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary
- add mirror maintenance, health checking, and rollback scripts under srv/blackroad/health
- persist failure counters and environment hashes to trigger rollbacks on repeated issues
- introduce systemd units and documentation for scheduling the mirror and health agents

## Testing
- bash -n srv/blackroad/health/mirror_sync.sh srv/blackroad/health/health_check.sh srv/blackroad/health/rollback.sh

------
https://chatgpt.com/codex/tasks/task_e_68e1766d39648329b7a71a4bad401aa0