### PR TITLE
Add reusable Three-Pass Speculative Sketch card

### DIFF
--- a/docs/THREE_PASS_SPECULATIVE_SKETCH.md
+++ b/docs/THREE_PASS_SPECULATIVE_SKETCH.md
@@ -1,0 +1,30 @@
+# Three-Pass Speculative Sketch
+
+**Timer:** 12 minutes total  
+**Word target:** 150–200 words
+
+---
+
+## Pass 1 — Bold Claim _(4 minutes)_
+- **Prompt:** Make a confident statement about your idea.
+- **Write:** `Claim:`
+
+## Pass 2 — Counter-Argument _(4 minutes)_
+- **Prompt:** Become your own critic and argue the opposite.
+- **Write:** `Opposite:`
+
+## Pass 3 — Third Path _(3 minutes)_
+- **Prompt:** Blend the first two passes into a smarter middle way.
+- **Write:** `Third path (synthesis):`
+
+## Pass 4 — Tiny Experiment _(1 minute)_
+- **Prompt:** Commit to a quick test you can run today.
+- **Write:** `Today’s 10-minute experiment:`
+
+---
+
+**Timer log:** `Start ____ / Finish ____`
+
+**Word count:** `_____`
+
+> Tip: Copy this card into Notion or any Markdown workspace. Start a 12-minute timer, fill each prompt in sequence, and jot the total word count at the end.


### PR DESCRIPTION
## Summary
- add a markdown card for the Three-Pass Speculative Sketch with timer and word count prompts

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1772a87248329b311af8b92edddf5