### PR TITLE
Add interactive RoadView scaffolding

### DIFF
--- a/frontend/src/components/roadview/HotspotCard.jsx
+++ b/frontend/src/components/roadview/HotspotCard.jsx
@@ -1,0 +1,102 @@
+import { HelpCircle, Link2, Tag, X } from 'lucide-react'
+import QuizCard from './QuizCard.jsx'
+
+const typeMeta = {
+  quiz: { icon: HelpCircle, label: 'Quiz' },
+  note: { icon: Tag, label: 'Key Insight' },
+  link: { icon: Link2, label: 'Source' }
+}
+
+export default function HotspotCard({ hotspot, onDismiss, onSaveForLater, onComplete }) {
+  if (!hotspot) return null
+
+  const meta = typeMeta[hotspot.type] ?? typeMeta.note
+  const Icon = meta.icon
+
+  return (
+    <div className="w-96 max-w-full rounded-2xl border border-slate-800 bg-slate-950/90 shadow-xl backdrop-blur">
+      <header className="flex items-start gap-3 p-4">
+        <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-slate-800/60 text-slate-200">
+          <Icon size={20} />
+        </span>
+        <div className="flex-1">
+          <p className="text-xs uppercase tracking-widest text-slate-400">{meta.label}</p>
+          <h3 className="text-base font-semibold text-slate-50">
+            {hotspot.payload?.title || `Moment ${formatTimestamp(hotspot.start)}–${formatTimestamp(hotspot.end)}`}
+          </h3>
+        </div>
+        <button
+          type="button"
+          className="rounded-lg p-1 text-slate-400 transition hover:bg-slate-800 hover:text-slate-100"
+          onClick={onDismiss}
+          aria-label="Dismiss hotspot"
+        >
+          <X size={16} />
+        </button>
+      </header>
+
+      <div className="border-t border-slate-800" />
+
+      <section className="space-y-4 p-4 text-sm text-slate-200">
+        {hotspot.type === 'quiz' ? (
+          <QuizCard quiz={hotspot.payload?.quiz ?? hotspot.payload} onComplete={onComplete} />
+        ) : (
+          <>
+            {hotspot.payload?.summary && (
+              <p className="text-slate-300">{hotspot.payload.summary}</p>
+            )}
+            {Array.isArray(hotspot.payload?.keyTerms) && hotspot.payload.keyTerms.length > 0 && (
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Key terms</p>
+                <div className="mt-1 flex flex-wrap gap-2">
+                  {hotspot.payload.keyTerms.map(term => (
+                    <span
+                      key={term}
+                      className="rounded-full bg-slate-800/70 px-2 py-1 text-xs font-medium text-slate-200"
+                    >
+                      {term}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+            {hotspot.payload?.link && (
+              <a
+                href={hotspot.payload.link}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1 text-xs font-semibold text-sky-300 hover:text-sky-200"
+              >
+                <Link2 size={14} />
+                Open reference
+              </a>
+            )}
+          </>
+        )}
+      </section>
+
+      <footer className="flex items-center justify-between gap-3 border-t border-slate-800 p-4">
+        <button
+          type="button"
+          className="text-xs font-medium text-slate-400 hover:text-slate-200"
+          onClick={onSaveForLater}
+        >
+          Save for later
+        </button>
+        <button
+          type="button"
+          className="rounded-lg bg-sky-500/90 px-3 py-1.5 text-xs font-semibold text-slate-900 transition hover:bg-sky-400"
+          onClick={onComplete}
+        >
+          Mark complete
+        </button>
+      </footer>
+    </div>
+  )
+}
+
+function formatTimestamp(seconds = 0) {
+  const mins = Math.floor(seconds / 60)
+  const secs = Math.floor(seconds % 60)
+  return `${String(mins).padStart(2, '0')}:${String(secs).padStart(2, '0')}`
+}

--- a/frontend/src/components/roadview/MindMapPanel.jsx
+++ b/frontend/src/components/roadview/MindMapPanel.jsx
@@ -1,0 +1,108 @@
+import { Fragment, useMemo } from 'react'
+import { MessageCircle, Network } from 'lucide-react'
+
+export default function MindMapPanel({ clusters = [], activeClusterId = null, onSelectComment, onToggleCluster }) {
+  const orderedClusters = useMemo(
+    () =>
+      [...clusters].sort((a, b) => {
+        const aCount = a.comments?.length ?? 0
+        const bCount = b.comments?.length ?? 0
+        if (aCount === bCount) return (a.topic || '').localeCompare(b.topic || '')
+        return bCount - aCount
+      }),
+    [clusters]
+  )
+
+  if (orderedClusters.length === 0) {
+    return (
+      <div className="rounded-2xl border border-slate-800 bg-slate-950/80 p-6 text-sm text-slate-300">
+        <p>No discussions yet. Encourage learners to drop the first question or insight.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <header className="flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-slate-400">
+        <Network size={14} />
+        Discussion Map
+      </header>
+      <div className="grid gap-4 md:grid-cols-2">
+        {orderedClusters.map(cluster => {
+          const comments = Array.isArray(cluster.comments) ? cluster.comments : []
+          const commentCount = comments.length
+          const isActive = cluster.id === activeClusterId
+          const collapsed = !isActive && commentCount > 3
+          const commentsToShow = collapsed ? comments.slice(0, 3) : comments
+
+          return (
+            <article
+              key={cluster.id}
+              className={[
+                'relative overflow-hidden rounded-2xl border p-4 shadow-lg transition',
+                isActive
+                  ? 'border-sky-500/80 bg-sky-500/5'
+                  : 'border-slate-800 bg-slate-950/70 hover:border-slate-600'
+              ].join(' ')}
+            >
+              <header className="mb-3 flex items-start justify-between gap-3">
+                <div>
+                  <h3 className="text-sm font-semibold text-slate-100">{cluster.topic || 'Untitled idea'}</h3>
+                  <p className="text-xs text-slate-400">{commentCount} notes</p>
+                </div>
+                <button
+                  type="button"
+                  className="rounded-lg bg-slate-900/70 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-slate-300"
+                  onClick={() => onToggleCluster?.(cluster.id)}
+                >
+                  {isActive ? 'Collapse' : 'Expand'}
+                </button>
+              </header>
+
+              <ol className="space-y-2">
+                {commentsToShow.map(comment => (
+                  <Fragment key={comment.id}>
+                    <li>
+                      <button
+                        type="button"
+                        className="w-full rounded-xl border border-transparent bg-slate-900/60 px-3 py-2 text-left text-xs text-slate-200 transition hover:border-slate-600"
+                        onClick={() => onSelectComment?.(comment)}
+                      >
+                        <div className="flex items-start gap-2">
+                          <span className="mt-0.5 rounded-full bg-slate-800 p-1 text-slate-400">
+                            <MessageCircle size={12} />
+                          </span>
+                          <div>
+                            <p className="font-semibold">{comment.author || 'Learner'}</p>
+                            <p className="text-[11px] text-slate-300">{comment.text}</p>
+                            {typeof comment.timestamp === 'number' && (
+                              <p className="mt-1 text-[10px] uppercase tracking-wide text-slate-500">
+                                Jump to {formatTimestamp(comment.timestamp)}
+                              </p>
+                            )}
+                          </div>
+                        </div>
+                      </button>
+                    </li>
+                  </Fragment>
+                ))}
+
+                {collapsed && (
+                  <li className="text-[11px] font-medium uppercase tracking-wide text-slate-400">
+                    + {commentCount - commentsToShow.length} more in cluster
+                  </li>
+                )}
+              </ol>
+            </article>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function formatTimestamp(seconds = 0) {
+  const mins = Math.floor(seconds / 60)
+  const secs = Math.floor(seconds % 60)
+  return `${String(mins).padStart(2, '0')}:${String(secs).padStart(2, '0')}`
+}

--- a/frontend/src/components/roadview/QuizCard.jsx
+++ b/frontend/src/components/roadview/QuizCard.jsx
@@ -1,0 +1,106 @@
+import { useMemo, useState } from 'react'
+
+export default function QuizCard({ quiz, onComplete }) {
+  const [selection, setSelection] = useState(null)
+  const [submitted, setSubmitted] = useState(false)
+
+  const normalized = useMemo(() => normalizeQuiz(quiz), [quiz])
+
+  if (!normalized) {
+    return (
+      <div className="space-y-2">
+        <p className="text-slate-300">No quiz content yet. Add a question to keep learners engaged.</p>
+      </div>
+    )
+  }
+
+  const { question, choices, correctIndex, hint } = normalized
+  const isCorrect = submitted && selection === correctIndex
+
+  function handleSubmit(event) {
+    event.preventDefault()
+    setSubmitted(true)
+    if (selection === correctIndex && typeof onComplete === 'function') {
+      onComplete({ correct: true })
+    }
+  }
+
+  return (
+    <form className="space-y-3" onSubmit={handleSubmit}>
+      <fieldset className="space-y-3">
+        <legend className="text-sm font-semibold text-slate-100">{question}</legend>
+        <div className="space-y-2">
+          {choices.map((choice, idx) => {
+            const checked = selection === idx
+            const choiceState = submitted
+              ? idx === correctIndex
+                ? 'correct'
+                : checked
+                  ? 'incorrect'
+                  : 'neutral'
+              : 'neutral'
+
+            return (
+              <label
+                key={choice.id || idx}
+                className={[
+                  'flex cursor-pointer items-center gap-2 rounded-xl border px-3 py-2 text-xs font-medium transition',
+                  choiceState === 'correct' && 'border-emerald-500/80 bg-emerald-500/10 text-emerald-200',
+                  choiceState === 'incorrect' && 'border-rose-500/70 bg-rose-500/10 text-rose-200',
+                  choiceState === 'neutral' && 'border-slate-700/80 bg-slate-900/60 text-slate-200 hover:border-slate-500'
+                ]
+                  .filter(Boolean)
+                  .join(' ')
+              >
+                <input
+                  type="radio"
+                  name="quiz-choice"
+                  value={choice.id || idx}
+                  checked={checked}
+                  onChange={() => setSelection(idx)}
+                  className="h-3 w-3"
+                  aria-label={choice.label}
+                />
+                <span>{choice.label}</span>
+              </label>
+            )
+          })}
+        </div>
+      </fieldset>
+
+      <div className="flex items-center justify-between">
+        {submitted && selection !== correctIndex && hint && (
+          <p className="text-xs text-slate-300">Hint: {hint}</p>
+        )}
+        <button
+          type="submit"
+          className="ml-auto rounded-lg bg-sky-500 px-3 py-1.5 text-xs font-semibold text-slate-950 transition hover:bg-sky-400"
+          disabled={selection === null}
+        >
+          {submitted ? (isCorrect ? 'Nice work!' : 'Try again') : 'Check answer'}
+        </button>
+      </div>
+    </form>
+  )
+}
+
+function normalizeQuiz(quiz) {
+  if (!quiz) return null
+
+  const question = quiz.question || quiz.draftQuestion
+  const rawChoices = quiz.choices || quiz.draftChoices
+  if (!question || !Array.isArray(rawChoices) || rawChoices.length === 0) return null
+
+  const choices = rawChoices.map((choice, idx) =>
+    typeof choice === 'string' ? { id: `choice-${idx}`, label: choice } : choice
+  )
+
+  const correctIndex = typeof quiz.correctIndex === 'number' ? quiz.correctIndex : 0
+
+  return {
+    question,
+    choices,
+    correctIndex,
+    hint: quiz.hint
+  }
+}

--- a/frontend/src/components/roadview/index.js
+++ b/frontend/src/components/roadview/index.js
@@ -1,0 +1,3 @@
+export { default as HotspotCard } from './HotspotCard.jsx'
+export { default as QuizCard } from './QuizCard.jsx'
+export { default as MindMapPanel } from './MindMapPanel.jsx'

--- a/frontend/src/roadview/agent.js
+++ b/frontend/src/roadview/agent.js
@@ -1,0 +1,238 @@
+import { createAgentContext } from './schema.js'
+
+export function createVideoAgent({ videoId, transcript, glossary = [], sources = [] }) {
+  const context = createAgentContext({ videoId, transcript, glossary, sources })
+  const index = buildAgentIndex(context)
+
+  return {
+    context,
+    index,
+    answer(question) {
+      return answerQuestion(question, index)
+    }
+  }
+}
+
+export function buildAgentIndex({ videoId, transcript, glossary = [], sources = [] }) {
+  const chunks = chunkTranscript(transcript).map((chunk, idx) => ({
+    id: `${videoId || 'video'}-chunk-${idx}`,
+    text: chunk.text,
+    timestamp: chunk.timestamp,
+    terms: vectorize(chunk.text)
+  }))
+
+  const glossaryVectors = glossary.map(entry => ({
+    term: entry.term,
+    definition: entry.definition,
+    terms: vectorize(`${entry.term} ${entry.definition}`)
+  }))
+
+  const sourceVectors = sources.map(source => ({
+    title: source.title,
+    url: source.url,
+    terms: vectorize(`${source.title} ${source.summary ?? ''}`),
+    timestamp: source.timestamp
+  }))
+
+  return { videoId, chunks, glossary: glossaryVectors, sources: sourceVectors }
+}
+
+export function answerQuestion(question, index) {
+  if (!question?.trim()) {
+    return {
+      answer: 'Ask a question about the video to get started.',
+      citations: []
+    }
+  }
+
+  const queryVector = vectorize(question)
+
+  const scoredChunks = index.chunks
+    .map(chunk => ({
+      chunk,
+      score: cosineSimilarity(queryVector, chunk.terms)
+    }))
+    .filter(entry => entry.score > 0)
+    .sort((a, b) => b.score - a.score)
+
+  const topChunk = scoredChunks[0]?.chunk
+  const glossaryMatches = matchGlossary(queryVector, index.glossary).slice(0, 3)
+  const sourceMatches = matchSources(queryVector, index.sources).slice(0, 3)
+
+  if (!topChunk) {
+    return {
+      answer: "I couldn't find that in the current video. Try rephrasing or jumping to a specific moment.",
+      citations: []
+    }
+  }
+
+  const answer = buildAnswer(question, topChunk, glossaryMatches, sourceMatches)
+  const citations = [
+    {
+      type: 'transcript',
+      timestamp: topChunk.timestamp,
+      text: topChunk.text
+    },
+    ...glossaryMatches.map(match => ({ type: 'glossary', term: match.term })),
+    ...sourceMatches.map(match => ({ type: 'source', url: match.url }))
+  ]
+
+  return { answer, citations }
+}
+
+function buildAnswer(question, chunk, glossaryMatches, sourceMatches) {
+  const segments = [
+    chunk.text,
+    glossaryMatches.length > 0
+      ? `Key terms: ${glossaryMatches.map(match => match.term).join(', ')}.`
+      : null,
+    sourceMatches.length > 0
+      ? `Related sources: ${sourceMatches.map(match => match.title || match.url).join('; ')}.`
+      : null,
+    `Jump back to ${formatTimestamp(chunk.timestamp)} for the walkthrough.`
+  ].filter(Boolean)
+
+  return segments.join(' ')
+}
+
+function matchGlossary(queryVector, glossary) {
+  return glossary
+    .map(entry => ({
+      ...entry,
+      score: cosineSimilarity(queryVector, entry.terms)
+    }))
+    .filter(entry => entry.score > 0)
+    .sort((a, b) => b.score - a.score)
+}
+
+function matchSources(queryVector, sources) {
+  return sources
+    .map(source => ({
+      ...source,
+      score: cosineSimilarity(queryVector, source.terms)
+    }))
+    .filter(entry => entry.score > 0)
+    .sort((a, b) => b.score - a.score)
+}
+
+function chunkTranscript(transcript, sentencesPerChunk = 3) {
+  if (!transcript) return []
+
+  const sentences = transcript.split(/(?<=[.!?])\s+/).map(sentence => sentence.trim()).filter(Boolean)
+  const chunks = []
+
+  for (let i = 0; i < sentences.length; i += sentencesPerChunk) {
+    const group = sentences.slice(i, i + sentencesPerChunk)
+    const text = group.join(' ')
+    const timestamp = Math.max(0, Math.round((i / sentences.length) * estimateDuration(transcript)))
+    chunks.push({ text, timestamp })
+  }
+
+  return chunks
+}
+
+function estimateDuration(transcript) {
+  const words = transcript.split(/\s+/).filter(Boolean).length
+  return Math.max(60, Math.round((words / 150) * 60))
+}
+
+function vectorize(text) {
+  const terms = text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .split(/\s+/)
+    .filter(Boolean)
+
+  const termCounts = new Map()
+  terms.forEach(term => {
+    if (stopWords.has(term)) return
+    termCounts.set(term, (termCounts.get(term) || 0) + 1)
+  })
+
+  return termCounts
+}
+
+function cosineSimilarity(mapA, mapB) {
+  const intersection = new Set([...mapA.keys()].filter(key => mapB.has(key)))
+  if (intersection.size === 0) return 0
+
+  let dot = 0
+  intersection.forEach(key => {
+    dot += (mapA.get(key) || 0) * (mapB.get(key) || 0)
+  })
+
+  const magnitudeA = Math.sqrt(sumSquares(mapA))
+  const magnitudeB = Math.sqrt(sumSquares(mapB))
+  if (magnitudeA === 0 || magnitudeB === 0) return 0
+
+  return dot / (magnitudeA * magnitudeB)
+}
+
+function sumSquares(map) {
+  let sum = 0
+  map.forEach(value => {
+    sum += value * value
+  })
+  return sum
+}
+
+const stopWords = new Set([
+  'a',
+  'an',
+  'the',
+  'and',
+  'or',
+  'but',
+  'if',
+  'to',
+  'of',
+  'for',
+  'in',
+  'on',
+  'at',
+  'by',
+  'with',
+  'is',
+  'are',
+  'was',
+  'were',
+  'be',
+  'been',
+  'being',
+  'this',
+  'that',
+  'it',
+  'as',
+  'from',
+  'about',
+  'into',
+  'over',
+  'after',
+  'before',
+  'between',
+  'through',
+  'during',
+  'without',
+  'within',
+  'also',
+  'can',
+  'could',
+  'should',
+  'would',
+  'may',
+  'might',
+  'will',
+  'just',
+  'like',
+  'than',
+  'too',
+  'very',
+  'more',
+  'most'
+])
+
+function formatTimestamp(seconds = 0) {
+  const mins = Math.floor(seconds / 60)
+  const secs = Math.floor(seconds % 60)
+  return `${String(mins).padStart(2, '0')}:${String(secs).padStart(2, '0')}`
+}

--- a/frontend/src/roadview/schema.js
+++ b/frontend/src/roadview/schema.js
@@ -1,0 +1,178 @@
+/**
+ * RoadView interactive video data model helpers.
+ * The helpers provide ergonomic constructors and utility transforms
+ * for hotspots, quizzes, comments, and agent context payloads.
+ */
+
+export const HotspotType = Object.freeze({
+  QUIZ: 'quiz',
+  NOTE: 'note',
+  LINK: 'link'
+})
+
+export function createVideo({ id, title, src, transcript = '', topics = [] }) {
+  return {
+    id,
+    title,
+    src,
+    transcript,
+    topics: [...new Set(topics.map(t => t.trim()).filter(Boolean))]
+  }
+}
+
+export function createHotspot({
+  videoId,
+  start,
+  end,
+  type = HotspotType.NOTE,
+  payload = {}
+}) {
+  return {
+    videoId,
+    start,
+    end,
+    type,
+    payload
+  }
+}
+
+export function createQuiz({ hotspotId, question, choices, correctIndex = 0, hint = '' }) {
+  if (!Array.isArray(choices) || choices.length < 2) {
+    throw new Error('Quiz choices must include at least two options.')
+  }
+
+  if (correctIndex < 0 || correctIndex >= choices.length) {
+    throw new Error('correctIndex must point to a valid choice.')
+  }
+
+  return {
+    hotspotId,
+    question,
+    choices: choices.map(choice => ({ id: randomId(), label: choice })),
+    correctIndex,
+    hint
+  }
+}
+
+export function createComment({ videoId, timestamp, text, parentId = null, clusterId = null }) {
+  return {
+    id: randomId(),
+    videoId,
+    timestamp,
+    text,
+    parentId,
+    clusterId
+  }
+}
+
+export function createAgentContext({ videoId, transcript, glossary = [], sources = [] }) {
+  return {
+    videoId,
+    transcript,
+    glossary,
+    sources
+  }
+}
+
+export function draftHotspotsFromTranscript(transcript, { quizEvery = 120, noteEvery = 90 } = {}) {
+  if (!transcript) return []
+
+  const sentences = splitTranscript(transcript)
+  const hotspots = []
+
+  let elapsed = 0
+  sentences.forEach((sentence, idx) => {
+    const seconds = Math.max(8, Math.round(sentence.wordCount / 2))
+    elapsed += seconds
+
+    if (idx % Math.max(1, Math.round(quizEvery / seconds)) === 0) {
+      hotspots.push(
+        createHotspot({
+          videoId: null,
+          start: Math.max(0, elapsed - seconds),
+          end: elapsed,
+          type: HotspotType.QUIZ,
+          payload: {
+            draftQuestion: `What did the instructor cover in the segment around ${formatTimestamp(elapsed)}?`,
+            draftChoices: buildDraftChoices(sentence.text)
+          }
+        })
+      )
+    } else if (idx % Math.max(1, Math.round(noteEvery / seconds)) === 0) {
+      hotspots.push(
+        createHotspot({
+          videoId: null,
+          start: Math.max(0, elapsed - seconds),
+          end: elapsed,
+          type: HotspotType.NOTE,
+          payload: {
+            summary: sentence.text,
+            keyTerms: sentence.keyTerms
+          }
+        })
+      )
+    }
+  })
+
+  return hotspots
+}
+
+function splitTranscript(transcript) {
+  return transcript
+    .split(/(?<=[.!?])\s+/)
+    .map(text => text.trim())
+    .filter(Boolean)
+    .map(text => ({
+      text,
+      wordCount: text.split(/\s+/).filter(Boolean).length,
+      keyTerms: extractKeyTerms(text)
+    }))
+}
+
+function extractKeyTerms(text) {
+  const words = text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, '')
+    .split(/\s+/)
+    .filter(Boolean)
+
+  const termCounts = new Map()
+  words.forEach(word => {
+    if (stopWords.has(word)) return
+    termCounts.set(word, (termCounts.get(word) || 0) + 1)
+  })
+
+  return Array.from(termCounts.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 3)
+    .map(([term]) => term)
+}
+
+function buildDraftChoices(text) {
+  const keyTerms = extractKeyTerms(text)
+  if (keyTerms.length >= 3) return keyTerms
+
+  const filler = ['I am not sure', 'None of the above', 'This was not covered yet']
+  return [...keyTerms, ...filler].slice(0, 4)
+}
+
+function formatTimestamp(seconds) {
+  const mins = Math.floor(seconds / 60)
+  const secs = seconds % 60
+  return `${String(mins).padStart(2, '0')}:${String(secs).padStart(2, '0')}`
+}
+
+function randomId() {
+  if (typeof globalThis !== 'undefined' && globalThis.crypto?.randomUUID) {
+    return globalThis.crypto.randomUUID()
+  }
+
+  return `id_${Math.random().toString(16).slice(2)}`
+}
+
+const stopWords = new Set([
+  'a', 'an', 'the', 'and', 'or', 'but', 'if', 'to', 'of', 'for', 'in', 'on', 'at', 'by', 'with', 'is', 'are', 'was', 'were',
+  'be', 'been', 'being', 'this', 'that', 'it', 'as', 'from', 'about', 'into', 'over', 'after', 'before', 'between', 'through',
+  'during', 'without', 'within', 'also', 'can', 'could', 'should', 'would', 'may', 'might', 'will', 'just', 'like', 'than',
+  'too', 'very', 'more', 'most'
+])


### PR DESCRIPTION
## Summary
- add RoadView schema helpers for videos, hotspots, quizzes, comments, and agent context
- create reusable HotspotCard, QuizCard, and MindMapPanel React components for interactive playback
- implement a lightweight retrieval index and answer function for the per-video tutor agent

## Testing
- npm install --loglevel error
- npm run build *(fails: missing @vitejs/plugin-react referenced by existing vite.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e17709ea60832998f76a9878e6f304