### PR TITLE
Add universal simulation benchmarking scaffold

### DIFF
--- a/universal-sim-starter/00_spec/spec.md
+++ b/universal-sim-starter/00_spec/spec.md
@@ -1,0 +1,31 @@
+# Universal Simulation Benchmark Spec
+
+## Scenario Overview
+- **Objective**: Evaluate Genesis-generated multiphysics scenes against reference solid and fluid simulations.
+- **Scope**: Focus on a hybrid scenario where a deformable solid impacts a shallow fluid domain, tracking contact, stress, and splash metrics.
+- **Datasets**: Genesis outputs (geometry, materials, boundary conditions) alongside reference solver results for both solid (MPM/FEM/SOFA) and fluid (SPH/FLIP) baselines.
+
+## Simulation Sequence
+1. Generate the canonical scene via Genesis using the prompt and configuration in `10_genesis/`.
+2. Run the solid benchmark in `20_bench_solid/` with the exported Genesis scene.
+3. Run the fluid benchmark in `30_bench_fluid/` using the same initial conditions.
+4. Post-process all outputs with the analytics helpers in `40_compare/`.
+
+## Required Artifacts
+- Genesis export: geometry, materials, time-series states, and metadata.
+- Solid benchmark dump: nodal positions, stresses, contact timings.
+- Fluid benchmark dump: particle positions, heights, and per-step masses.
+- Consolidated report captured in `90_reports/`.
+
+## Acceptance Criteria
+- ✅ Genesis and benchmark scripts produce reproducible outputs with command-line entrypoints.
+- ✅ Metrics compute without manual edits given `.npz`/`.ply` exports from the simulations.
+- ✅ Diagnostic plots highlight energy and mass trends for sanity checks.
+- ✅ Final report summarizes qualitative differences, metric tables, and screenshots.
+
+## Open Questions
+- How should Genesis map materials to downstream solvers?
+- What is the canonical timestep / frame rate for comparing contact events?
+- Which reference solvers should be considered authoritative for regression testing?
+
+Document outstanding decisions here as the project evolves.

--- a/universal-sim-starter/10_genesis/config.yaml
+++ b/universal-sim-starter/10_genesis/config.yaml
@@ -1,0 +1,15 @@
+scene_name: silicone_drop
+seed: 42
+resolution:
+  spatial: 0.01
+  temporal: 0.002
+export:
+  format: npz
+  output_dir: ../artifacts/genesis
+assets:
+  solid_material: silicone_soft
+  fluid_material: water
+  domain:
+    width: 1.0
+    depth: 1.0
+    height: 1.0

--- a/universal-sim-starter/10_genesis/prompt.txt
+++ b/universal-sim-starter/10_genesis/prompt.txt
@@ -1,0 +1,2 @@
+Generate a deformable silicone cube dropping into a shallow water tank with a rigid floor and side walls.
+Capture material properties, gravity, initial velocities, and boundary constraints suitable for downstream MPM and SPH solvers.

--- a/universal-sim-starter/10_genesis/run_genesis.py
+++ b/universal-sim-starter/10_genesis/run_genesis.py
@@ -1,0 +1,59 @@
+"""Entry point for executing a Genesis scene generation run."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+
+def load_prompt(prompt_path: Path) -> str:
+    return prompt_path.read_text(encoding="utf-8").strip()
+
+
+def load_config(config_path: Path) -> Dict[str, Any]:
+    with config_path.open("r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run Genesis scene generation.")
+    parser.add_argument("--prompt", type=Path, default=Path(__file__).with_name("prompt.txt"), help="Path to the prompt file.")
+    parser.add_argument("--config", type=Path, default=Path(__file__).with_name("config.yaml"), help="Path to the YAML config.")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path(__file__).parent.parent / "artifacts" / "genesis",
+        help="Directory to store Genesis outputs.",
+    )
+    args = parser.parse_args()
+
+    prompt = load_prompt(args.prompt)
+    config = load_config(args.config)
+
+    args.output.mkdir(parents=True, exist_ok=True)
+
+    # TODO: Replace the stub below with an actual Genesis API invocation.
+    # For example:
+    #   from genesis import Client
+    #   client = Client.from_env()
+    #   result = client.generate_scene(prompt=prompt, **config)
+    #   result.save(args.output)
+    run_metadata: Dict[str, Any] = {
+        "prompt": prompt,
+        "config": config,
+        "status": "stubbed",
+    }
+
+    run_meta_path = args.output / "run_meta.json"
+    with run_meta_path.open("w", encoding="utf-8") as handle:
+        json.dump(run_metadata, handle, indent=2)
+
+    print(f"Genesis stub completed. Metadata written to {run_meta_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/universal-sim-starter/20_bench_solid/run_mpm.py
+++ b/universal-sim-starter/20_bench_solid/run_mpm.py
@@ -1,0 +1,53 @@
+"""Stub entry point for running the solid mechanics benchmark."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Dict
+
+import numpy as np
+
+
+def simulate_stub(output_dir: Path) -> Dict[str, np.ndarray]:
+    timesteps = np.linspace(0.0, 1.0, num=11)
+    stress = np.linspace(0.0, 5.0e4, num=11)
+    contact_time = timesteps[np.argmax(stress > 1.0e4)]
+    nodal_positions = np.random.rand(11, 100, 3)
+
+    return {
+        "time": timesteps,
+        "stress": stress,
+        "contact_time": np.array([contact_time]),
+        "x": nodal_positions,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the solid benchmark.")
+    parser.add_argument(
+        "--input",
+        type=Path,
+        default=Path(__file__).parent.parent / "artifacts" / "genesis",
+        help="Directory containing Genesis exports.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path(__file__).parent.parent / "artifacts" / "solid",
+        help="Directory to store solid benchmark outputs.",
+    )
+    args = parser.parse_args()
+
+    args.output.mkdir(parents=True, exist_ok=True)
+
+    results = simulate_stub(args.output)
+
+    for key, value in results.items():
+        np.save(args.output / f"{key}.npy", value)
+
+    print(f"Solid benchmark stub completed. Outputs written to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/universal-sim-starter/30_bench_fluid/run_sph.py
+++ b/universal-sim-starter/30_bench_fluid/run_sph.py
@@ -1,0 +1,52 @@
+"""Stub entry point for running the fluid dynamics benchmark."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Dict
+
+import numpy as np
+
+
+def simulate_stub() -> Dict[str, np.ndarray]:
+    timesteps = np.linspace(0.0, 1.0, num=21)
+    heights = np.sin(timesteps * 3.14159) * 0.1 + 0.2
+    masses = np.full_like(timesteps, 1.0)
+    particle_positions = np.random.rand(timesteps.size, 500, 3)
+
+    return {
+        "time": timesteps,
+        "height": heights,
+        "mass": masses,
+        "positions": particle_positions,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the fluid benchmark.")
+    parser.add_argument(
+        "--input",
+        type=Path,
+        default=Path(__file__).parent.parent / "artifacts" / "genesis",
+        help="Directory containing Genesis exports.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path(__file__).parent.parent / "artifacts" / "fluid",
+        help="Directory to store fluid benchmark outputs.",
+    )
+    args = parser.parse_args()
+
+    args.output.mkdir(parents=True, exist_ok=True)
+
+    results = simulate_stub()
+    for key, value in results.items():
+        np.save(args.output / f"{key}.npy", value)
+
+    print(f"Fluid benchmark stub completed. Outputs written to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/universal-sim-starter/40_compare/metrics.py
+++ b/universal-sim-starter/40_compare/metrics.py
@@ -1,0 +1,77 @@
+"""Reusable metrics for comparing Genesis outputs to reference simulations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Tuple
+
+import numpy as np
+
+
+ArrayLike = np.ndarray
+
+
+def _ensure_array(points: Iterable[Iterable[float]]) -> ArrayLike:
+    array = np.asarray(points, dtype=np.float64)
+    if array.ndim != 2 or array.shape[1] != 3:
+        raise ValueError("Point clouds must be shaped (N, 3).")
+    return array
+
+
+def hausdorff_distance(points_a: Iterable[Iterable[float]], points_b: Iterable[Iterable[float]]) -> float:
+    """Compute the symmetric Hausdorff distance between two point clouds."""
+    a = _ensure_array(points_a)
+    b = _ensure_array(points_b)
+
+    if a.size == 0 or b.size == 0:
+        raise ValueError("Point clouds must be non-empty.")
+
+    d_ab = np.sqrt(((a[:, None, :] - b[None, :, :]) ** 2).sum(axis=2))
+    directed_ab = d_ab.min(axis=1).max()
+    directed_ba = d_ab.min(axis=0).max()
+    return float(max(directed_ab, directed_ba))
+
+
+def stress_L2(sigma_gen: ArrayLike, sigma_ref: ArrayLike) -> float:
+    """Return the L2 norm of the difference between generated and reference stress tensors."""
+    sigma_gen = np.asarray(sigma_gen, dtype=np.float64)
+    sigma_ref = np.asarray(sigma_ref, dtype=np.float64)
+    if sigma_gen.shape != sigma_ref.shape:
+        raise ValueError("Stress arrays must have identical shapes.")
+    diff = sigma_gen - sigma_ref
+    return float(np.linalg.norm(diff.ravel(), ord=2))
+
+
+def contact_time_diff(t_gen: float, t_ref: float) -> float:
+    """Absolute timing difference between generated and reference contact events."""
+    return float(abs(t_gen - t_ref))
+
+
+def splash_MSE(h_gen: ArrayLike, h_ref: ArrayLike) -> float:
+    """Mean-squared error between generated and reference free-surface heights."""
+    h_gen = np.asarray(h_gen, dtype=np.float64)
+    h_ref = np.asarray(h_ref, dtype=np.float64)
+    if h_gen.shape != h_ref.shape:
+        raise ValueError("Height arrays must have identical shapes.")
+    diff = h_gen - h_ref
+    return float(np.mean(diff ** 2))
+
+
+def mass_drift(mass_t: ArrayLike) -> Tuple[float, float]:
+    """Return the max absolute drift and final drift relative to the initial mass."""
+    mass = np.asarray(mass_t, dtype=np.float64)
+    if mass.ndim != 1:
+        raise ValueError("Mass trajectory must be a 1-D array.")
+    baseline = mass[0]
+    deviations = mass - baseline
+    max_drift = float(np.max(np.abs(deviations)))
+    final_drift = float(deviations[-1])
+    return max_drift, final_drift
+
+
+def load_npz(path: Path, key: str) -> ArrayLike:
+    """Convenience loader for `.npz` files with a single metric target."""
+    with np.load(path) as data:
+        if key not in data:
+            raise KeyError(f"Key '{key}' not found in {path}.")
+        return data[key]

--- a/universal-sim-starter/40_compare/plot_diagnostics.py
+++ b/universal-sim-starter/40_compare/plot_diagnostics.py
@@ -1,0 +1,42 @@
+"""Helpers for quickly visualizing diagnostic time series."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def plot_energy(time: np.ndarray, kinetic: np.ndarray, potential: np.ndarray, *, output: Optional[Path] = None) -> None:
+    plt.figure(figsize=(8, 4))
+    plt.plot(time, kinetic, label="Kinetic")
+    plt.plot(time, potential, label="Potential")
+    plt.plot(time, kinetic + potential, label="Total", linestyle="--")
+    plt.xlabel("Time [s]")
+    plt.ylabel("Energy [J]")
+    plt.title("Energy Diagnostics")
+    plt.legend()
+    plt.tight_layout()
+    if output is not None:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        plt.savefig(output)
+    else:
+        plt.show()
+    plt.close()
+
+
+def plot_mass(time: np.ndarray, mass: np.ndarray, *, output: Optional[Path] = None) -> None:
+    plt.figure(figsize=(8, 3))
+    plt.plot(time, mass, color="tab:blue")
+    plt.xlabel("Time [s]")
+    plt.ylabel("Mass [kg]")
+    plt.title("Mass Conservation")
+    plt.tight_layout()
+    if output is not None:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        plt.savefig(output)
+    else:
+        plt.show()
+    plt.close()

--- a/universal-sim-starter/90_reports/template.md
+++ b/universal-sim-starter/90_reports/template.md
@@ -1,0 +1,40 @@
+# Run Report
+
+## Overview
+- **Scene**: 
+- **Date**: 
+- **Operator**: 
+
+## Genesis Setup
+- Prompt summary: 
+- Config hash / seed: 
+- Export artifacts: 
+
+## Benchmarks
+### Solid Mechanics
+- Solver + version: 
+- Notable parameters: 
+- Key observations: 
+
+### Fluid Dynamics
+- Solver + version: 
+- Notable parameters: 
+- Key observations: 
+
+## Metrics
+| Metric | Value | Reference | Notes |
+| ------ | ----- | --------- | ----- |
+| Hausdorff Distance |  |  |  |
+| Stress L2 |  |  |  |
+| Contact Δt |  |  |  |
+| Splash MSE |  |  |  |
+| Mass Drift (max / final) |  |  |  |
+
+## Visuals
+- Solid deformation snapshots: 
+- Fluid splash captures: 
+- Diagnostics plots: 
+
+## Conclusions
+- Summary: 
+- Next actions: 

--- a/universal-sim-starter/Makefile
+++ b/universal-sim-starter/Makefile
@@ -1,0 +1,32 @@
+.PHONY: genesis solid fluid diag clean
+
+PYTHON ?= python3
+ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+ARTIFACTS := $(ROOT)/artifacts
+
+$(ARTIFACTS):
+	mkdir -p $(ARTIFACTS)
+
+artifacts/genesis: | $(ARTIFACTS)
+	mkdir -p $(ARTIFACTS)/genesis
+
+artifacts/solid: | $(ARTIFACTS)
+	mkdir -p $(ARTIFACTS)/solid
+
+artifacts/fluid: | $(ARTIFACTS)
+	mkdir -p $(ARTIFACTS)/fluid
+
+genesis: artifacts/genesis
+	$(PYTHON) 10_genesis/run_genesis.py --output $(ARTIFACTS)/genesis
+
+solid: artifacts/solid
+	$(PYTHON) 20_bench_solid/run_mpm.py --output $(ARTIFACTS)/solid
+
+fluid: artifacts/fluid
+	$(PYTHON) 30_bench_fluid/run_sph.py --output $(ARTIFACTS)/fluid
+
+diag: genesis solid fluid
+	@echo "Diagnostics ready. Wire in analysis via 40_compare/metrics.py"
+
+clean:
+	rm -rf $(ARTIFACTS)

--- a/universal-sim-starter/README.md
+++ b/universal-sim-starter/README.md
@@ -1,0 +1,26 @@
+# Universal Simulation Starter
+
+This scaffold mirrors the multiphysics benchmarking plan so you can wire in Genesis generation and downstream solvers quickly.
+
+## Layout
+- `00_spec/`: scenario definition and acceptance criteria.
+- `10_genesis/`: prompt, configuration, and run script for Genesis.
+- `20_bench_solid/`: solid mechanics benchmark entrypoint (e.g., Taichi-MPM, FEniCS, SOFA).
+- `30_bench_fluid/`: fluid benchmark entrypoint (e.g., DualSPHysics, PySPH, Taichi-FLIP).
+- `40_compare/`: metrics + plotting utilities for comparing outputs.
+- `90_reports/`: reporting template for summarizing each run.
+
+Artifacts are expected in `artifacts/` once the scripts are executed. Adjust the paths if your workflow differs.
+
+## Quickstart
+```bash
+make genesis   # run Genesis generation
+make solid     # run the solid benchmark
+make fluid     # run the fluid benchmark
+make diag      # generate diagnostics (extend as needed)
+```
+
+## Next Steps
+1. Replace the stubs in `run_genesis.py`, `run_mpm.py`, and `run_sph.py` with real solver integrations.
+2. Feed your solver outputs into the metric helpers to quantify differences.
+3. Capture qualitative evidence (screenshots, plots) and document in the report template.


### PR DESCRIPTION
## Summary
- add the universal-sim-starter workspace with spec, prompts, and configuration assets
- provide stub solid/fluid benchmark runners plus comparison metrics and plotting helpers
- include Makefile, README, and report template to drive the workflow end-to-end

## Testing
- python3 -m compileall universal-sim-starter

------
https://chatgpt.com/codex/tasks/task_e_68e17cde40648329b730d2b9b58a3e55