### PR TITLE
Add Codex 44 transparency of process entry

### DIFF
--- a/codex/README.md
+++ b/codex/README.md
@@ -16,6 +16,7 @@ integrations.
 | 004 | The Autonomy Manifest  | Data autonomy through consent, export, and wipe. |
 | 022 | The Security Spine     | Security backbone with layered zero-trust defenses. |
 | 043 | The Equity Oath        | Fairness, access, and inclusion are systemic.   |
+| 044 | The Transparency of Process | Trust grows when workflows stay visible end-to-end. |
 
 ## BlackRoad Pipeline
 

--- a/codex/entries/044-transparency-of-process.md
+++ b/codex/entries/044-transparency-of-process.md
@@ -1,0 +1,28 @@
+# Codex 44 — The Transparency of Process
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Principle
+Outcomes alone don’t build trust. People must see the path, not just the result. Lucidia makes its processes visible, so confidence comes from clarity, not mystery.
+
+## Non-Negotiables
+1. **Open Workflows:** Development pipelines, governance steps, and decision paths documented in real time.
+2. **Traceable Commits:** Every code change linked to its issue, rationale, and codex reference.
+3. **Visible Ops:** Deployments, outages, and fixes broadcast in process, not only after.
+4. **Review Logs:** All reviews (code, design, governance) stored and accessible.
+5. **Audit Trails:** Automated systems generate tamper-evident trails of every workflow.
+6. **No Black Rooms:** No invisible committees or hidden pipelines.
+
+## Implementation Hooks (v0)
+- CI/CD pipelines publish status to `/process-dashboard`.
+- Commit footer requires codex reference + issue link.
+- Governance bot posts live status of proposals → discussion → vote.
+- Review comments archived in `/reviews/`.
+- Ops runbooks open-sourced where security allows.
+
+## Policy Stub (`PROCESS.md`)
+- Lucidia commits to visible, traceable processes at every level.
+- Lucidia prohibits hidden workstreams or silent decisions.
+- Lucidia ensures anyone can follow the steps that led to an outcome.
+
+**Tagline:** The path is part of the proof.


### PR DESCRIPTION
## Summary
- add Codex 44 entry capturing the Transparency of Process principle
- document the non-negotiables, implementation hooks, and policy stub for visibility
- update the Codex index to reference the new principle

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e17e0aa140832989776ebace7d7b4c