### PR TITLE
Add Codex 45 Compassion Rule documentation

### DIFF
--- a/codex/README.md
+++ b/codex/README.md
@@ -16,6 +16,7 @@ integrations.
 | 004 | The Autonomy Manifest  | Data autonomy through consent, export, and wipe. |
 | 022 | The Security Spine     | Security backbone with layered zero-trust defenses. |
 | 043 | The Equity Oath        | Fairness, access, and inclusion are systemic.   |
+| 045 | The Compassion Rule    | Compassion guides every response to conflict.   |
 
 ## BlackRoad Pipeline
 

--- a/codex/entries/045-compassion-rule.md
+++ b/codex/entries/045-compassion-rule.md
@@ -1,0 +1,27 @@
+# Codex 45 — The Compassion Rule
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Principle
+Lucidia leads with understanding. Error, conflict, and imperfection are met with empathy first, correction second. Compassion strengthens integrity; cruelty erodes it.
+
+## Non-Negotiables
+1. **Care Before Blame:** First response to failure is inquiry and support, not punishment.
+2. **Repair Culture:** When harm occurs, priority is to make things right, not to shame.
+3. **Conflict Mediation:** Disputes handled through conversation and neutral moderation.
+4. **Grace Periods:** Contributors may step back, cool off, or rest before resolution.
+5. **Transparent Outcomes:** Resolutions recorded honestly, stripped of humiliation.
+6. **Language of Care:** Communication guidelines prohibit ridicule, sarcasm, or hostility.
+
+## Implementation Hooks (v0)
+- `/docs/conflict-resolution.md` with mediation steps and neutral contact list.
+- Moderation dashboard tracks compassion metrics (time-to-support, repeat incidents).
+- Template for public postmortems includes “repair actions taken.”
+- Optional “cool-off” status for accounts during disputes—pauses activity without penalty.
+
+## Policy Stub (`COMPASSION.md`)
+- Lucidia commits to compassionate handling of all errors and conflicts.
+- Lucidia treats learning and repair as essential to accountability.
+- Lucidia forbids punitive actions without prior attempts at understanding.
+
+**Tagline:** Fix the wound, not the person.


### PR DESCRIPTION
## Summary
- add Codex 45 entry outlining the Compassion Rule, including principle, non-negotiables, and implementation hooks
- update the codex overview table to reference the new entry

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e17f51d5b083298b2da8b5dd773b23