### PR TITLE
Add compliance harness loader and Slack notifier

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,8 @@ OKTA_REDIRECT_URI=https://blackroad.io/api/auth/okta/callback
 # Data warehouse
 WAREHOUSE_URL=
 WAREHOUSE_TOKEN=
+
+# Slack notifications
+SLACK_WEBHOOK_URL=
+SLACK_BOT_TOKEN=
+SLACK_CHANNEL=#secops

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .RECIPEPREFIX = >
-.PHONY: setup test lint demo validate dc-up dc-test dc-shell build run deploy preview-destroy
+.PHONY: setup test lint demo validate dc-up dc-test dc-shell build run deploy preview-destroy notify
 
 setup:
 >python -m venv .venv && . .venv/bin/activate && pip install -U pip pytest jsonschema ruff
@@ -12,6 +12,9 @@ lint:
 
 validate:
 >. .venv/bin/activate && python scripts/validate_contracts.py
+
+notify:
+>cd compliance && SLACK_WEBHOOK_URL="$(SLACK_WEBHOOK_URL)" go run ./cmd/harness test:mirror
 
 demo:
 >brc plm:items:load --dir fixtures/plm/items && \

--- a/compliance/cmd/harness/main.go
+++ b/compliance/cmd/harness/main.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/blackroad/prism-console/compliance/harness"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+	}
+
+	switch os.Args[1] {
+	case "test:mirror":
+		cr := must(harness.CompileMirror())
+		runFixtureEvent(cr, "fixtures/mirror/deny_secret.json")
+		runFixtureEvent(cr, "fixtures/mirror/allow_internal.json")
+	default:
+		usage()
+	}
+}
+
+func runFixtureEvent(cr harness.CompiledRule, path string) {
+	data := must(readFile(path))
+	ev := map[string]any{}
+	must(0, json.Unmarshal(data, &ev))
+	dec, err := harness.EvaluateEvent(cr, ev)
+	if err != nil {
+		panic(err)
+	}
+	_ = harness.EnforceOrNotify(cr, dec)
+	harness.PrintDecision(dec)
+}
+
+func usage() {
+	fmt.Fprintf(os.Stderr, "usage: %s <command>\n", os.Args[0])
+	fmt.Fprintln(os.Stderr, "commands:")
+	fmt.Fprintln(os.Stderr, "  test:mirror    Evaluate mirror fixtures")
+	os.Exit(2)
+}
+
+func must[T any](val T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return val
+}
+
+func readFile(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err == nil {
+		return data, nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return os.ReadFile(filepath.Join("..", path))
+	}
+	return nil, err
+}

--- a/compliance/go.mod
+++ b/compliance/go.mod
@@ -14,4 +14,5 @@ require (
 	golang.org/x/text v0.8.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230525234030-28d5490b6b19 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/compliance/go.sum
+++ b/compliance/go.sum
@@ -30,3 +30,5 @@ google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqw
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/compliance/harness/compile.go
+++ b/compliance/harness/compile.go
@@ -1,0 +1,52 @@
+package harness
+
+import (
+	"fmt"
+
+	"github.com/google/cel-go/cel"
+)
+
+type CompiledRule struct {
+	ID       string
+	Category string
+	Severity string
+	Expr     string
+	Program  cel.Program
+	OnMatch  OnMatch
+	Notify   NotifySpec
+}
+
+func CompileFromYAML(path string) (CompiledRule, error) {
+	spec, err := LoadRuleYAML(path)
+	if err != nil {
+		return CompiledRule{}, err
+	}
+
+	env := EnvWithBuiltins()
+	ast, iss := env.Parse(spec.Expr)
+	if iss.Err() != nil {
+		return CompiledRule{}, fmt.Errorf("parse CEL: %w", iss.Err())
+	}
+	checked, iss := env.Check(ast)
+	if iss.Err() == nil {
+		ast = checked
+	}
+	prg, err := env.Program(ast)
+	if err != nil {
+		return CompiledRule{}, fmt.Errorf("program: %w", err)
+	}
+
+	return CompiledRule{
+		ID:       spec.RuleID,
+		Category: spec.Category,
+		Severity: spec.Severity,
+		Expr:     spec.Expr,
+		Program:  prg,
+		OnMatch:  spec.OnMatch,
+		Notify:   spec.Notify,
+	}, nil
+}
+
+func CompileMirror() (CompiledRule, error) {
+	return CompileFromYAML("rules/mirror_class_limit.yaml")
+}

--- a/compliance/harness/enforce.go
+++ b/compliance/harness/enforce.go
@@ -1,0 +1,29 @@
+package harness
+
+import "fmt"
+
+func EnforceOrNotify(rule CompiledRule, dec RuleDecision) error {
+	switch dec.Decision {
+	case "deny":
+		return fmt.Errorf("%w:%s:%s", ErrPolicyViolation, dec.Reason, dec.RuleID)
+	case "notify":
+		details := map[string]any{}
+		if dec.Details != nil {
+			details = dec.Details
+		}
+		payload := map[string]any{
+			"text":    details["message"],
+			"rule_id": dec.RuleID,
+			"reason":  dec.Reason,
+			"details": details,
+		}
+		channel := ""
+		if ch := GetEnv("SLACK_CHANNEL", ""); ch != "" {
+			channel = ch
+		} else if len(rule.Notify.Channels) > 0 {
+			channel = rule.Notify.Channels[0]
+		}
+		_ = PostSlackMessage(channel, payload)
+	}
+	return nil
+}

--- a/compliance/harness/env.go
+++ b/compliance/harness/env.go
@@ -1,0 +1,57 @@
+package harness
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/google/cel-go/cel"
+
+	"github.com/blackroad/prism-console/compliance/rules"
+)
+
+type RuleDecision struct {
+	Decision string         `json:"decision"`
+	Reason   string         `json:"reason"`
+	RuleID   string         `json:"rule_id"`
+	Details  map[string]any `json:"details,omitempty"`
+}
+
+func EnvWithBuiltins() *cel.Env {
+	env, err := rules.NewComplianceEnv()
+	if err != nil {
+		panic(fmt.Sprintf("cel env: %v", err))
+	}
+	return env
+}
+
+func NormalizeEvent(event map[string]any) map[string]any {
+	if event == nil {
+		return map[string]any{}
+	}
+	return event
+}
+
+func cloneMap(src map[string]any) map[string]any {
+	if src == nil {
+		return map[string]any{}
+	}
+	out := make(map[string]any, len(src))
+	for k, v := range src {
+		out[k] = v
+	}
+	return out
+}
+
+func PrintDecision(dec RuleDecision) {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(dec)
+}
+
+func GetEnv(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/compliance/harness/eval.go
+++ b/compliance/harness/eval.go
@@ -1,0 +1,42 @@
+package harness
+
+import (
+	"errors"
+	"fmt"
+)
+
+var ErrPolicyViolation = errors.New("policy_violation")
+
+func EvaluateEvent(rule CompiledRule, event map[string]any) (RuleDecision, error) {
+	ev := NormalizeEvent(event)
+	out, _, err := rule.Program.Eval(ev)
+	if err != nil {
+		return RuleDecision{}, fmt.Errorf("eval: %w", err)
+	}
+
+	match, ok := out.Value().(bool)
+	if !ok {
+		return RuleDecision{}, fmt.Errorf("eval not boolean")
+	}
+
+	if !match {
+		return RuleDecision{Decision: "allow", Reason: "", RuleID: rule.ID, Details: map[string]any{}}, nil
+	}
+
+	dec := RuleDecision{
+		Decision: rule.OnMatch.Decision,
+		Reason:   rule.OnMatch.Reason,
+		RuleID:   rule.ID,
+		Details:  cloneMap(rule.OnMatch.Details),
+	}
+	if dec.Decision == "" {
+		dec.Decision = "deny"
+	}
+	if dec.Reason == "" {
+		dec.Reason = rule.ID
+	}
+	if dec.Details == nil {
+		dec.Details = map[string]any{}
+	}
+	return dec, nil
+}

--- a/compliance/harness/loader.go
+++ b/compliance/harness/loader.go
@@ -1,0 +1,98 @@
+package harness
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+type OnMatch struct {
+	Decision string         `yaml:"decision"`
+	Reason   string         `yaml:"reason"`
+	Details  map[string]any `yaml:"details"`
+}
+
+type NotifySpec struct {
+	Channels  []string       `yaml:"channels"`
+	Ticketing map[string]any `yaml:"ticketing"`
+}
+
+type Series struct {
+	Window string           `yaml:"window"`
+	Events []map[string]any `yaml:"series"`
+}
+
+type TestCase struct {
+	Name          string         `yaml:"name"`
+	GUID          string         `yaml:"guid"`
+	Input         map[string]any `yaml:"input"`
+	Series        *Series        `yaml:"series"`
+	Fixture       string         `yaml:"fixture"`
+	Window        string         `yaml:"window"`
+	Want          any            `yaml:"want"`
+	ExpectDetails map[string]any `yaml:"expect_details"`
+}
+
+type RuleYAML struct {
+	RuleID         string           `yaml:"rule_id"`
+	LegacyID       string           `yaml:"id"`
+	Name           string           `yaml:"name"`
+	Category       string           `yaml:"category"`
+	Mode           string           `yaml:"mode"`
+	Severity       string           `yaml:"severity"`
+	Version        int              `yaml:"version"`
+	Description    string           `yaml:"description"`
+	InputsSchema   []map[string]any `yaml:"inputs_schema"`
+	OutputType     string           `yaml:"output_type"`
+	OutputContract any              `yaml:"output_contract"`
+	Expr           string           `yaml:"expr"`
+	OnMatch        OnMatch          `yaml:"on_match"`
+	Notify         NotifySpec       `yaml:"notify"`
+	Tests          []TestCase       `yaml:"tests"`
+	Comments       []string         `yaml:"comments"`
+}
+
+func LoadRuleYAML(path string) (RuleYAML, error) {
+	var spec RuleYAML
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			alt := filepath.Join("..", path)
+			if bAlt, readErr := os.ReadFile(alt); readErr == nil {
+				b = bAlt
+			} else {
+				return spec, fmt.Errorf("read rule yaml: %w", err)
+			}
+		} else {
+			return spec, fmt.Errorf("read rule yaml: %w", err)
+		}
+	}
+	if err := yaml.Unmarshal(b, &spec); err != nil {
+		return spec, fmt.Errorf("parse rule yaml: %w", err)
+	}
+
+	if spec.RuleID == "" {
+		spec.RuleID = spec.LegacyID
+	}
+	if spec.Category == "" {
+		spec.Category = spec.Mode
+	}
+	if spec.OnMatch.Details == nil {
+		spec.OnMatch.Details = map[string]any{}
+	}
+	if spec.OnMatch.Decision == "" {
+		if spec.Category == "enforce" {
+			spec.OnMatch.Decision = "deny"
+		} else {
+			spec.OnMatch.Decision = "notify"
+		}
+	}
+	if spec.OnMatch.Reason == "" {
+		spec.OnMatch.Reason = spec.RuleID
+	}
+
+	return spec, nil
+}

--- a/compliance/harness/slack.go
+++ b/compliance/harness/slack.go
@@ -1,0 +1,110 @@
+package harness
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+)
+
+type slackMsg struct {
+	Text        string        `json:"text"`
+	Blocks      []any         `json:"blocks,omitempty"`
+	Attachments []slackAttach `json:"attachments,omitempty"`
+}
+
+type slackAttach struct {
+	Color  string       `json:"color,omitempty"`
+	Fields []slackField `json:"fields,omitempty"`
+}
+
+type slackField struct {
+	Title string `json:"title"`
+	Value string `json:"value"`
+	Short bool   `json:"short"`
+}
+
+func PostSlackMessage(channel string, payload map[string]any) error {
+	webhook := os.Getenv("SLACK_WEBHOOK_URL")
+	token := os.Getenv("SLACK_BOT_TOKEN")
+	if webhook == "" && token == "" {
+		return fmt.Errorf("no slack creds: set SLACK_WEBHOOK_URL or SLACK_BOT_TOKEN")
+	}
+
+	text := payload["text"]
+	if text == nil {
+		text = ":rotating_light: Compliance notification"
+	}
+	msg := slackMsg{Text: fmt.Sprintf("%v", text)}
+
+	if det, ok := payload["details"].(map[string]any); ok {
+		msg.Attachments = []slackAttach{{
+			Color: "#d0021b",
+			Fields: []slackField{
+				{Title: "Rule", Value: getString(payload, "rule_id"), Short: true},
+				{Title: "Reason", Value: getString(payload, "reason"), Short: true},
+				{Title: "Message", Value: fmt.Sprintf("%v", det["message"]), Short: false},
+				{Title: "Remediation", Value: fmt.Sprintf("%v", det["remediation"]), Short: false},
+			},
+		}}
+	}
+
+	if webhook != "" {
+		return postWebhook(webhook, msg)
+	}
+	return postChatAPI(token, channel, msg)
+}
+
+func getString(m map[string]any, key string) string {
+	if v, ok := m[key]; ok {
+		return fmt.Sprintf("%v", v)
+	}
+	return ""
+}
+
+func postWebhook(url string, msg slackMsg) error {
+	b, _ := json.Marshal(msg)
+	req, _ := http.NewRequest("POST", url, bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("slack webhook status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func postChatAPI(tok, channel string, msg slackMsg) error {
+	body := map[string]any{
+		"channel": channel,
+		"text":    msg.Text,
+	}
+	if len(msg.Attachments) > 0 {
+		var sb strings.Builder
+		for _, f := range msg.Attachments[0].Fields {
+			if f.Value == "" {
+				continue
+			}
+			sb.WriteString(fmt.Sprintf("*%s*: %s\n", f.Title, f.Value))
+		}
+		body["text"] = body["text"].(string) + "\n" + sb.String()
+	}
+	b, _ := json.Marshal(body)
+	req, _ := http.NewRequest("POST", "https://slack.com/api/chat.postMessage", bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	req.Header.Set("Authorization", "Bearer "+tok)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("slack api status %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/fixtures/mirror/allow_internal.json
+++ b/fixtures/mirror/allow_internal.json
@@ -1,0 +1,5 @@
+{
+  "action": "mirror",
+  "resource_class": "internal",
+  "repo": "payments/api"
+}

--- a/rules/mirror_class_limit.yaml
+++ b/rules/mirror_class_limit.yaml
@@ -1,22 +1,50 @@
+rule_id: MIRROR_CLASS_LIMIT
 id: MIRROR_CLASS_LIMIT
+name: Mirror class limit
+description: Block mirrors on restricted or secret repositories.
+category: enforce
 mode: enforce
 severity: high
+version: 1
 block_on_error: true
 metadata:
   runbook: docs/runbooks/mirror_class_limit.md
   summary: Block mirrors on restricted or secret repositories.
   block_message: "Blocked by policy MIRROR_CLASS_LIMIT. Reason: repo classified '{resource_class}'. See runbook for exception steps."
 expr: action == "mirror" && (resource_class == "restricted" || resource_class == "secret")
+on_match:
+  decision: deny
+  reason: mirror_restricted_repo
+  details:
+    message: "Blocked by policy MIRROR_CLASS_LIMIT. Reason: repo classified '{resource_class}'. See runbook for exception steps."
+    remediation: Request a reclassification or exception through the security runbook.
+notify:
+  channels:
+    - "#secops"
 tests:
   - name: deny_secret
-    input: { action: "mirror", resource_class: "secret", repo: "api/core" }
-    want: true
+    input:
+      action: mirror
+      resource_class: secret
+      repo: api/core
+    want:
+      decision: deny
   - name: deny_restricted
-    input: { action: "mirror", resource_class: "restricted", repo: "ml/labs" }
-    want: true
+    input:
+      action: mirror
+      resource_class: restricted
+      repo: ml/labs
+    want:
+      decision: deny
   - name: allow_internal
-    input: { action: "mirror", resource_class: "internal" }
-    want: false
+    input:
+      action: mirror
+      resource_class: internal
+    want:
+      decision: allow
   - name: allow_other_action
-    input: { action: "deploy", resource_class: "secret" }
-    want: false
+    input:
+      action: deploy
+      resource_class: secret
+    want:
+      decision: allow

--- a/rules/secret_expiry_cluster.yaml
+++ b/rules/secret_expiry_cluster.yaml
@@ -1,10 +1,24 @@
+rule_id: SECRET_EXPIRY_CLUSTER
 id: SECRET_EXPIRY_CLUSTER
+name: Secret expiry cluster
+description: Cluster secret-expired errors to trigger automated rotation.
+category: observe
 mode: observe
 severity: high
 metadata:
   product: Secret Hygiene
   description: Cluster secret-expired errors to trigger automated rotation.
 expr: rate(error_kind == "secret_expired", "10m") >= 0.3
+on_match:
+  decision: notify
+  reason: secret_expiry_cluster
+  details:
+    message: Multiple secret expirations detected within 10 minutes.
+    remediation: Trigger automated rotation for affected secrets and investigate upstream causes.
+notify:
+  channels:
+    - "#secops"
+    - "#platform-alerts"
 tests:
   - name: ok_fixture
     fixture: secret/ok.series.json


### PR DESCRIPTION
## Summary
- add a compliance harness package that loads YAML rules, compiles CEL expressions, and wires Slack notifications
- expose a CLI entry point for running mirror fixtures and print canonical decisions while triggering optional Slack posts
- expand rule specs, fixtures, and local env config to support on_match metadata and a notify smoke test

## Testing
- cd compliance && go test ./...
- cd compliance && go run ./cmd/harness test:mirror


------
https://chatgpt.com/codex/tasks/task_e_68e17d7751148329a56ae3e3d016f5d0