### PR TITLE
Add Sustainability Charter codex entry and policy stub

### DIFF
--- a/SUSTAINABILITY.md
+++ b/SUSTAINABILITY.md
@@ -1,0 +1,5 @@
+# Sustainability Policy Stub
+
+- Lucidia commits to long-term health over short-term expansion.
+- Lucidia rejects funding that conflicts with its ethical codices.
+- Lucidia keeps finances transparent to the community.

--- a/codex/README.md
+++ b/codex/README.md
@@ -16,6 +16,7 @@ integrations.
 | 004 | The Autonomy Manifest  | Data autonomy through consent, export, and wipe. |
 | 022 | The Security Spine     | Security backbone with layered zero-trust defenses. |
 | 043 | The Equity Oath        | Fairness, access, and inclusion are systemic.   |
+| 046 | The Sustainability Charter | Ethical, diversified funding keeps Lucidia stable. |
 
 ## BlackRoad Pipeline
 

--- a/codex/entries/046-sustainability-charter.md
+++ b/codex/entries/046-sustainability-charter.md
@@ -1,0 +1,28 @@
+# Codex 46 — The Sustainability Charter
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Principle
+Lucidia must endure—ethically, financially, and operationally. Stability funds creativity; integrity keeps the lights on.
+
+## Non-Negotiables
+1. **Ethical Revenue:** Money only from sources aligned with Codex 11 (Ethical North Star).
+2. **Diverse Streams:** Multiple small flows—subscriptions, donations, grants, services—so no single patron dictates direction.
+3. **Open Accounting:** Financial reports published quarterly, including donor influence and spend categories.
+4. **Fair Compensation:** Contributors and custodians paid equitably; no unpaid essential labor.
+5. **Long-Term Horizon:** Decisions weighed for their decade impact, not quarter profit.
+6. **Simplicity in Scale:** Growth capped at what can be maintained securely and sanely.
+
+## Implementation Hooks (v0)
+- `/finance/ledger.csv` public summary of income/expense classes.
+- Funding policy doc: criteria for accepting or declining sponsors.
+- Grants & donations board rotates quarterly to avoid capture.
+- Budget tool in governance repo with projections three cycles ahead.
+- Compensation equity review each year.
+
+## Policy Stub (`SUSTAINABILITY.md`)
+- Lucidia commits to long-term health over short-term expansion.
+- Lucidia rejects funding that conflicts with its ethical codices.
+- Lucidia keeps finances transparent to the community.
+
+**Tagline:** Stay solvent, stay clean.


### PR DESCRIPTION
## Summary
- add Codex 46 entry detailing Lucidia's sustainability commitments
- record the sustainability policy stub for community transparency
- include the new charter in the Codex README index

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e18157362083299162a702172123f1