### PR TITLE
Add Pi Cortex stack bundle

### DIFF
--- a/pi-cortex-stack/Makefile
+++ b/pi-cortex-stack/Makefile
@@ -1,0 +1,24 @@
+PYTHON ?= python
+VENV ?= ~/agent-venv
+
+ASSET ?= logo.png
+
+.PHONY: push-assets first-light install-mac-agent install-pi-services lint clean
+
+push-assets:
+	$(PYTHON) mac_agent.py push-assets --name $(ASSET)
+
+first-light:
+	$(PYTHON) first_light.py
+
+install-mac-agent:
+	./scripts/install_mac_agent.sh
+
+install-pi-services:
+	./scripts/install_pi_services.sh
+
+lint:
+	$(PYTHON) -m ruff check .
+
+clean:
+	rm -f ~/.pi-cortex-agent/logs/last_asset.png

--- a/pi-cortex-stack/README.md
+++ b/pi-cortex-stack/README.md
@@ -1,0 +1,155 @@
+# Pi Cortex Stack
+
+This bundle contains everything needed to stand up the Pi Cortex demo stack
+across a Mac orchestration node and one or more Raspberry Pi endpoints. It is
+intended as an easy way to run the "first light" demo that drives both the
+holographic renderer and the simulator panel via MQTT.
+
+## Repository layout
+
+```
+pi-cortex-stack/
+├── assets/                   # Drop shared assets like logo.png here
+├── first_light.py            # Smoke test script that triggers HELLO
+├── launch_agents/
+│   └── com.blackroad.pi-cortex-agent.plist  # LaunchAgent for auto start
+├── mac_agent.py              # Mac-side agent that pushes assets and commands
+├── Makefile                  # Convenience targets for day-to-day workflow
+├── pi/
+│   ├── pi_holo_renderer.py   # MQTT subscriber that renders holo frames
+│   ├── pi_ops_heartbeat.py   # Optional heartbeat logger
+│   ├── pi_sim_panel.py       # Simple FastAPI panel used by the simulator
+│   └── services/
+│       ├── pi-holo-renderer.service
+│       ├── pi-ops-heartbeat.service
+│       └── pi-sim-panel.service
+└── scripts/
+    ├── install_mac_agent.sh
+    └── install_pi_services.sh
+```
+
+## Quick start
+
+1. **Install dependencies on the Mac orchestration node.**
+
+   ```bash
+   python3 -m venv ~/agent-venv
+   source ~/agent-venv/bin/activate
+   pip install paho-mqtt pillow opencv-python fastapi uvicorn
+   ```
+
+2. **Bring up the Pi Ops box.** This system hosts Mosquitto (MQTT broker) and
+   the Samba share used for collecting logs and assets. Follow the steps in the
+   "Pi Ops bring-up" section below if you do not already have it running.
+
+3. **Populate the asset directory.** Drop a `logo.png` file into
+   `pi-cortex-stack/assets/`.
+
+4. **Push assets to the broker.**
+
+   ```bash
+   make push-assets
+   ```
+
+5. **Run the first light smoke test.**
+
+   ```bash
+   make first-light
+   ```
+
+   You should see "HELLO" appear on the holo display and the simulator panel
+   update accordingly.
+
+## Mac agent bring-up
+
+The Mac agent is a lightweight Python process that publishes commands to the
+MQTT broker and manages shared assets.
+
+### LaunchAgent
+
+A LaunchAgent plist is provided at
+`launch_agents/com.blackroad.pi-cortex-agent.plist`. Copy it to the user's
+`~/Library/LaunchAgents` directory and load it with:
+
+```bash
+launchctl load ~/Library/LaunchAgents/com.blackroad.pi-cortex-agent.plist
+```
+
+The agent expects the virtual environment created in the quick start section to
+be active when started. The provided LaunchAgent uses `launchctl setenv` to
+point at the virtual environment's Python interpreter.
+
+Update the `PI_CORTEX_MQTT_HOST` and `PI_CORTEX_MQTT_PORT` values inside the
+plist if your broker runs somewhere other than `localhost:1883`.
+
+### Manual execution
+
+To run the agent manually without launchd:
+
+```bash
+source ~/agent-venv/bin/activate
+python mac_agent.py run
+```
+
+## Raspberry Pi services
+
+All Raspberry Pi components run as `systemd` services. The provided helper
+script `scripts/install_pi_services.sh` installs the unit files into
+`/etc/systemd/system` and enables the services.
+
+### Pi Holo Renderer
+
+`pi_holo_renderer.py` subscribes to the `pi/holo/text` and `pi/holo/image`
+topics. The renderer stores the current text payload and the most recent asset
+frame under `/var/lib/pi-cortex/holo`. If an HDMI display is connected it will
+also open a simple OpenCV window. On a headless system you can disable the
+window by setting the `PI_CORTEX_HEADLESS=1` environment variable.
+
+### Pi Sim Panel
+
+`pi_sim_panel.py` runs a FastAPI server that exposes the most recent content the
+simulator received from MQTT. The service listens on port 8000 by default and
+serves a compact status dashboard at `/`.
+
+### Pi Ops Heartbeat (optional)
+
+The optional heartbeat service publishes a timestamped message to the
+`pi/ops/heartbeat` topic every 30 seconds so that monitoring systems can verify
+that the Pi stack is healthy.
+
+Enable it with:
+
+```bash
+sudo systemctl enable --now pi-ops-heartbeat.service
+```
+
+## Pi Ops bring-up
+
+1. Install Mosquitto and Samba on the Pi Ops host.
+2. Create a share named `pi-cortex` that points to `/var/lib/pi-cortex/shared`.
+3. Ensure the MQTT broker is reachable from both the Mac and the Pi endpoints.
+4. Update the `.env` files or environment variables on the Mac and Pi devices to
+   point at the broker's hostname or IP address.
+
+## Configuration
+
+Configuration is managed via environment variables. Create a `.env` file in the
+root of `pi-cortex-stack` and export it before running the agent, or use your
+shell's environment. The following variables are recognized:
+
+- `PI_CORTEX_MQTT_HOST` (default `localhost`)
+- `PI_CORTEX_MQTT_PORT` (default `1883`)
+- `PI_CORTEX_ASSET_DIR` (default `assets`)
+- `PI_CORTEX_ASSET_TOPIC` (default `pi/assets/logo`)
+- `PI_CORTEX_HOLO_TOPIC` (default `pi/holo/text`)
+- `PI_CORTEX_PANEL_TOPIC` (default `pi/panel/text`)
+- `PI_CORTEX_HEARTBEAT_TOPIC` (default `pi/ops/heartbeat`)
+
+## Development tips
+
+- Use `make lint` to run basic formatting checks (requires `ruff`).
+- Use the simulator panel while iterating so you do not have to have a holo
+  display connected.
+- The Mac agent logs verbosely to `~/.pi-cortex-agent/logs` by default. Rotate
+  the logs periodically when running in long-lived deployments.
+

--- a/pi-cortex-stack/first_light.py
+++ b/pi-cortex-stack/first_light.py
@@ -1,0 +1,35 @@
+"""Smoke test that performs the "first light" demo for the Pi Cortex stack."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import time
+
+from mac_agent import AgentConfig, PiCortexAgent
+
+
+def run_first_light(text: str, delay: float) -> None:
+    config = AgentConfig.from_env(os.environ)
+    agent = PiCortexAgent(config)
+    agent.connect()
+    try:
+        agent.push_assets()
+        time.sleep(delay)
+        agent.publish_text(text)
+    finally:
+        agent.stop()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Pi Cortex first light smoke test")
+    parser.add_argument("--text", default="HELLO", help="Text payload to publish")
+    parser.add_argument(
+        "--delay", type=float, default=1.0, help="Seconds to wait after pushing assets"
+    )
+    args = parser.parse_args()
+    run_first_light(args.text, args.delay)
+
+
+if __name__ == "__main__":
+    main()

--- a/pi-cortex-stack/launch_agents/com.blackroad.pi-cortex-agent.plist
+++ b/pi-cortex-stack/launch_agents/com.blackroad.pi-cortex-agent.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.blackroad.pi-cortex-agent</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-lc</string>
+        <string>source ~/agent-venv/bin/activate && cd ~/pi-cortex-stack && python mac_agent.py run</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PI_CORTEX_MQTT_HOST</key>
+        <string>localhost</string>
+        <key>PI_CORTEX_MQTT_PORT</key>
+        <string>1883</string>
+    </dict>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>$HOME/Library/Logs/pi-cortex-agent.log</string>
+    <key>StandardErrorPath</key>
+    <string>$HOME/Library/Logs/pi-cortex-agent.err</string>
+</dict>
+</plist>

--- a/pi-cortex-stack/mac_agent.py
+++ b/pi-cortex-stack/mac_agent.py
@@ -1,0 +1,241 @@
+"""Mac orchestration agent for the Pi Cortex stack.
+
+The agent publishes assets and control commands to the MQTT fabric. It is
+primarily designed to run on a Mac laptop or mini that is responsible for
+coordinating the demo experience.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import logging
+import os
+import signal
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional
+
+import paho.mqtt.client as mqtt
+from PIL import Image
+
+LOG_DIR = Path.home() / ".pi-cortex-agent" / "logs"
+DEFAULT_ASSET_NAME = "logo.png"
+
+
+def load_env_file(path: Path) -> Dict[str, str]:
+    """Load a very small .env style file into a dictionary."""
+
+    values: Dict[str, str] = {}
+    if not path.exists():
+        return values
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        values[key.strip()] = value.strip()
+    return values
+
+
+@dataclass
+class AgentConfig:
+    mqtt_host: str = "localhost"
+    mqtt_port: int = 1883
+    asset_dir: Path = Path("assets")
+    asset_topic: str = "pi/assets/logo"
+    holo_topic: str = "pi/holo/text"
+    panel_topic: str = "pi/panel/text"
+    heartbeat_topic: str = "pi/ops/heartbeat"
+    heartbeat_interval: int = 30
+
+    @classmethod
+    def from_env(cls, env: Optional[Dict[str, str]] = None) -> "AgentConfig":
+        env = dict(env or {})
+        dotenv = load_env_file(Path(".env"))
+        # Values from actual environment take precedence over .env file values.
+        for key, value in dotenv.items():
+            env.setdefault(key, value)
+        return cls(
+            mqtt_host=env.get("PI_CORTEX_MQTT_HOST", cls.mqtt_host),
+            mqtt_port=int(env.get("PI_CORTEX_MQTT_PORT", cls.mqtt_port)),
+            asset_dir=Path(env.get("PI_CORTEX_ASSET_DIR", str(cls.asset_dir))),
+            asset_topic=env.get("PI_CORTEX_ASSET_TOPIC", cls.asset_topic),
+            holo_topic=env.get("PI_CORTEX_HOLO_TOPIC", cls.holo_topic),
+            panel_topic=env.get("PI_CORTEX_PANEL_TOPIC", cls.panel_topic),
+            heartbeat_topic=env.get(
+                "PI_CORTEX_HEARTBEAT_TOPIC", cls.heartbeat_topic
+            ),
+            heartbeat_interval=int(
+                env.get("PI_CORTEX_HEARTBEAT_INTERVAL", cls.heartbeat_interval)
+            ),
+        )
+
+
+class PiCortexAgent:
+    """Utility class that manages MQTT interactions."""
+
+    def __init__(self, config: AgentConfig) -> None:
+        self.config = config
+        self._client = mqtt.Client()
+        self._client.on_connect = self._on_connect
+        self._client.on_disconnect = self._on_disconnect
+        self._stop_event = threading.Event()
+        self._heartbeat_thread: Optional[threading.Thread] = None
+
+        LOG_DIR.mkdir(parents=True, exist_ok=True)
+        logging.basicConfig(
+            filename=LOG_DIR / "agent.log",
+            level=logging.INFO,
+            format="%(asctime)s [%(levelname)s] %(message)s",
+        )
+        logging.getLogger().addHandler(logging.StreamHandler(sys.stdout))
+
+    # ------------------------------------------------------------------
+    # MQTT lifecycle
+    # ------------------------------------------------------------------
+    def connect(self) -> None:
+        logging.info(
+            "Connecting to MQTT broker at %s:%s",
+            self.config.mqtt_host,
+            self.config.mqtt_port,
+        )
+        self._client.connect(self.config.mqtt_host, self.config.mqtt_port, keepalive=60)
+        self._client.loop_start()
+
+    def disconnect(self) -> None:
+        logging.info("Disconnecting from MQTT broker")
+        self._client.loop_stop()
+        self._client.disconnect()
+
+    # ------------------------------------------------------------------
+    # Asset handling
+    # ------------------------------------------------------------------
+    def push_assets(self, asset_name: str = DEFAULT_ASSET_NAME) -> None:
+        asset_path = self.config.asset_dir / asset_name
+        if not asset_path.exists():
+            raise FileNotFoundError(
+                f"Asset {asset_path} not found. Ensure the file exists before pushing."
+            )
+        logging.info("Pushing asset %s", asset_path)
+        payload = self._prepare_image_payload(asset_path)
+        info = self._client.publish(self.config.asset_topic, payload, qos=1, retain=True)
+        info.wait_for_publish()
+        logging.info("Asset push complete. MQTT mid=%s", info.mid)
+
+    def _prepare_image_payload(self, path: Path) -> bytes:
+        with Image.open(path) as image:
+            image = image.convert("RGBA")
+            buffer = Path(LOG_DIR / "last_asset.png")
+            image.save(buffer)
+            data = buffer.read_bytes()
+        encoded = base64.b64encode(data).decode("ascii")
+        return json.dumps({"filename": path.name, "payload": encoded}).encode()
+
+    # ------------------------------------------------------------------
+    # Publishing helpers
+    # ------------------------------------------------------------------
+    def publish_text(self, text: str) -> None:
+        logging.info("Publishing text payload: %s", text)
+        for topic in (self.config.holo_topic, self.config.panel_topic):
+            info = self._client.publish(topic, text, qos=1, retain=True)
+            info.wait_for_publish()
+            logging.debug("Published to %s with mid=%s", topic, info.mid)
+
+    def start_heartbeat(self) -> None:
+        if self._heartbeat_thread and self._heartbeat_thread.is_alive():
+            return
+
+        def _beat() -> None:
+            logging.info(
+                "Starting heartbeat loop publishing to %s", self.config.heartbeat_topic
+            )
+            while not self._stop_event.is_set():
+                payload = json.dumps({"ts": time.time(), "source": "mac-agent"})
+                self._client.publish(self.config.heartbeat_topic, payload, qos=0)
+                time.sleep(self.config.heartbeat_interval)
+
+        self._heartbeat_thread = threading.Thread(target=_beat, daemon=True)
+        self._heartbeat_thread.start()
+
+    def stop(self) -> None:
+        logging.info("Stopping agent")
+        self._stop_event.set()
+        if self._heartbeat_thread:
+            self._heartbeat_thread.join(timeout=2)
+        self.disconnect()
+
+    # ------------------------------------------------------------------
+    # MQTT callbacks
+    # ------------------------------------------------------------------
+    def _on_connect(self, client: mqtt.Client, _userdata, _flags, rc: int) -> None:
+        if rc == 0:
+            logging.info("MQTT connection established")
+        else:
+            logging.error("MQTT connection failed with rc=%s", rc)
+
+    def _on_disconnect(self, client: mqtt.Client, _userdata, rc: int) -> None:
+        logging.warning("MQTT disconnected with rc=%s", rc)
+
+
+def _handle_run(agent: PiCortexAgent) -> None:
+    agent.connect()
+    agent.start_heartbeat()
+
+    def _signal_handler(_signum, _frame) -> None:
+        agent.stop()
+        sys.exit(0)
+
+    signal.signal(signal.SIGINT, _signal_handler)
+    signal.signal(signal.SIGTERM, _signal_handler)
+
+    logging.info("Agent is running. Press Ctrl+C to exit.")
+    while True:
+        time.sleep(1)
+
+
+def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Pi Cortex Mac agent")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser("run", help="Run the agent loop")
+
+    push_parser = subparsers.add_parser("push-assets", help="Push shared assets")
+    push_parser.add_argument(
+        "--name", default=DEFAULT_ASSET_NAME, help="Asset file name inside the assets directory"
+    )
+
+    publish_parser = subparsers.add_parser(
+        "publish", help="Publish a one-off message to the holo/panel topics"
+    )
+    publish_parser.add_argument("text", help="Text to publish")
+
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    args = _parse_args(argv)
+    config = AgentConfig.from_env(os.environ)
+    agent = PiCortexAgent(config)
+
+    if args.command == "run":
+        _handle_run(agent)
+    else:
+        agent.connect()
+        try:
+            if args.command == "push-assets":
+                agent.push_assets(asset_name=args.name)
+            elif args.command == "publish":
+                agent.publish_text(args.text)
+        finally:
+            agent.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/pi-cortex-stack/pi/pi_holo_renderer.py
+++ b/pi-cortex-stack/pi/pi_holo_renderer.py
@@ -1,0 +1,165 @@
+"""MQTT driven renderer for the Pi holographic display."""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import signal
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+
+import cv2  # type: ignore
+import paho.mqtt.client as mqtt
+
+STATE_DIR = Path(os.environ.get("PI_CORTEX_HOLO_STATE_DIR", "/var/lib/pi-cortex/holo"))
+
+logger = logging.getLogger("pi_holo_renderer")
+
+
+def ensure_state_dir() -> None:
+    global STATE_DIR
+    try:
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+    except PermissionError:
+        fallback = Path.home() / ".pi-cortex" / "holo"
+        fallback.mkdir(parents=True, exist_ok=True)
+        STATE_DIR = fallback
+    if logger.handlers:
+        return
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+    formatter = logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
+    stream_handler = logging.StreamHandler(sys.stdout)
+    stream_handler.setFormatter(formatter)
+    file_handler = logging.FileHandler(STATE_DIR / "pi-holo-renderer.log")
+    file_handler.setFormatter(formatter)
+    logger.addHandler(stream_handler)
+    logger.addHandler(file_handler)
+
+
+def load_env() -> dict[str, str]:
+    env_path = Path(".env")
+    values: dict[str, str] = {}
+    if env_path.exists():
+        for line in env_path.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            values[key.strip()] = value.strip()
+    values.update(os.environ)
+    return values
+
+
+def decode_asset(message: mqtt.MQTTMessage) -> Optional[Path]:
+    try:
+        payload = json.loads(message.payload.decode())
+        encoded = payload["payload"]
+        filename = payload.get("filename", "asset.png")
+        data = base64.b64decode(encoded)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("Failed to decode asset message: %s", exc)
+        return None
+    target = STATE_DIR / filename
+    target.write_bytes(data)
+    logger.info("Wrote asset frame to %s", target)
+    return target
+
+
+def update_text(message: mqtt.MQTTMessage) -> str:
+    text = message.payload.decode(errors="ignore")
+    (STATE_DIR / "text.txt").write_text(text)
+    logger.info("Updated holo text to %s", text)
+    return text
+
+
+def open_window() -> Optional[str]:
+    if os.environ.get("PI_CORTEX_HEADLESS") == "1":
+        logger.info("Running in headless mode; skipping OpenCV window")
+        return None
+    window_name = "Pi Holo Renderer"
+    cv2.namedWindow(window_name, cv2.WINDOW_AUTOSIZE)
+    return window_name
+
+
+def display_image(window_name: str, image_path: Path, text: str) -> None:
+    image = cv2.imread(str(image_path))
+    if image is None:
+        logger.warning("Unable to load asset image at %s", image_path)
+        return
+    overlay = image.copy()
+    font = cv2.FONT_HERSHEY_SIMPLEX
+    cv2.putText(
+        overlay,
+        text,
+        (20, overlay.shape[0] - 40),
+        font,
+        1.0,
+        (255, 255, 255),
+        2,
+        cv2.LINE_AA,
+    )
+    blended = cv2.addWeighted(overlay, 0.85, image, 0.15, 0)
+    cv2.imshow(window_name, blended)
+    cv2.waitKey(1)
+
+
+def main() -> None:
+    ensure_state_dir()
+    env = load_env()
+    broker = env.get("PI_CORTEX_MQTT_HOST", "localhost")
+    port = int(env.get("PI_CORTEX_MQTT_PORT", "1883"))
+    asset_topic = env.get("PI_CORTEX_ASSET_TOPIC", "pi/assets/logo")
+    holo_topic = env.get("PI_CORTEX_HOLO_TOPIC", "pi/holo/text")
+
+    client = mqtt.Client()
+    window_name = open_window()
+    latest_image: Optional[Path] = None
+    latest_text = ""
+
+    def on_connect(_client, _userdata, _flags, rc):
+        if rc == 0:
+            logger.info("Connected to MQTT broker at %s:%s", broker, port)
+            client.subscribe(asset_topic)
+            client.subscribe(holo_topic)
+        else:
+            logger.error("Failed to connect to MQTT broker rc=%s", rc)
+
+    def on_message(_client, _userdata, msg: mqtt.MQTTMessage):
+        nonlocal latest_image, latest_text
+        if msg.topic == asset_topic:
+            latest_image = decode_asset(msg)
+        elif msg.topic == holo_topic:
+            latest_text = update_text(msg)
+        if window_name and latest_image and latest_image.exists():
+            display_image(window_name, latest_image, latest_text)
+
+    client.on_connect = on_connect
+    client.on_message = on_message
+    client.connect(broker, port, keepalive=60)
+
+    def shutdown(_signum, _frame):
+        logger.info("Stopping renderer")
+        client.loop_stop()
+        cv2.destroyAllWindows()
+        sys.exit(0)
+
+    signal.signal(signal.SIGINT, shutdown)
+    signal.signal(signal.SIGTERM, shutdown)
+
+    client.loop_start()
+    logger.info("Renderer started; waiting for messages")
+    try:
+        signal.pause()
+    except AttributeError:
+        # Windows compatibility; we do not expect to run here but handle anyway.
+        while True:
+            time.sleep(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/pi-cortex-stack/pi/pi_ops_heartbeat.py
+++ b/pi-cortex-stack/pi/pi_ops_heartbeat.py
@@ -1,0 +1,82 @@
+"""Heartbeat publisher for the Pi Cortex stack."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import signal
+import time
+from pathlib import Path
+
+import paho.mqtt.client as mqtt
+
+LOG_PATH = Path("/var/log/pi-cortex/pi-ops-heartbeat.log")
+
+
+def configure_logging() -> None:
+    global LOG_PATH
+    try:
+        LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    except PermissionError:
+        fallback = Path.home() / ".pi-cortex" / "logs" / "pi-ops-heartbeat.log"
+        fallback.parent.mkdir(parents=True, exist_ok=True)
+        LOG_PATH = fallback
+    logging.basicConfig(
+        filename=LOG_PATH,
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
+
+
+configure_logging()
+logger = logging.getLogger(__name__)
+
+
+def load_env() -> dict[str, str]:
+    env_path = Path(".env")
+    values: dict[str, str] = {}
+    if env_path.exists():
+        for line in env_path.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            values[key.strip()] = value.strip()
+    values.update(os.environ)
+    return values
+
+
+def main() -> None:
+    env = load_env()
+    broker = env.get("PI_CORTEX_MQTT_HOST", "localhost")
+    port = int(env.get("PI_CORTEX_MQTT_PORT", "1883"))
+    topic = env.get("PI_CORTEX_HEARTBEAT_TOPIC", "pi/ops/heartbeat")
+    interval = int(env.get("PI_CORTEX_HEARTBEAT_INTERVAL", "30"))
+
+    client = mqtt.Client()
+    client.connect(broker, port, keepalive=60)
+    client.loop_start()
+
+    stop = False
+
+    def _shutdown(_signum, _frame):
+        nonlocal stop
+        stop = True
+        logger.info("Stopping heartbeat loop")
+
+    signal.signal(signal.SIGINT, _shutdown)
+    signal.signal(signal.SIGTERM, _shutdown)
+
+    logger.info("Starting heartbeat loop to %s", topic)
+    while not stop:
+        payload = json.dumps({"ts": time.time(), "source": "pi-ops"})
+        client.publish(topic, payload, qos=0)
+        time.sleep(interval)
+
+    client.loop_stop()
+    client.disconnect()
+
+
+if __name__ == "__main__":
+    main()

--- a/pi-cortex-stack/pi/pi_sim_panel.py
+++ b/pi-cortex-stack/pi/pi_sim_panel.py
@@ -1,0 +1,185 @@
+"""Simulator panel that mirrors MQTT content via a FastAPI dashboard."""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import threading
+import time
+from pathlib import Path
+from typing import Optional
+
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse, JSONResponse
+import paho.mqtt.client as mqtt
+import uvicorn
+
+STATE_DIR = Path(os.environ.get("PI_CORTEX_PANEL_STATE_DIR", "/var/lib/pi-cortex/panel"))
+
+
+def ensure_state_dir() -> Path:
+    global STATE_DIR
+    try:
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+    except PermissionError:
+        fallback = Path.home() / ".pi-cortex" / "panel"
+        fallback.mkdir(parents=True, exist_ok=True)
+        STATE_DIR = fallback
+    return STATE_DIR
+logger = logging.getLogger("pi_sim_panel")
+
+
+class PanelState:
+    def __init__(self) -> None:
+        self.text: str = ""
+        self.asset: Optional[Path] = None
+        self.updated_at: float = time.time()
+        self.lock = threading.Lock()
+
+    def to_dict(self) -> dict[str, Optional[str]]:
+        with self.lock:
+            return {
+                "text": self.text,
+                "asset": str(self.asset) if self.asset else None,
+                "updated_at": self.updated_at,
+            }
+
+    def update_text(self, text: str) -> None:
+        with self.lock:
+            self.text = text
+            self.updated_at = time.time()
+
+    def update_asset(self, payload: bytes, filename: str) -> None:
+        with self.lock:
+            target_dir = ensure_state_dir()
+            target = target_dir / filename
+            target.write_bytes(payload)
+            self.asset = target
+            self.updated_at = time.time()
+
+
+state = PanelState()
+app = FastAPI(title="Pi Cortex Simulator Panel")
+
+
+def configure_logging() -> None:
+    if logger.handlers:
+        return
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+    formatter = logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
+    console = logging.StreamHandler()
+    console.setFormatter(formatter)
+    logger.addHandler(console)
+
+
+@app.get("/", response_class=HTMLResponse)
+def dashboard() -> str:
+    data = state.to_dict()
+    asset_markup = ""
+    if data["asset"] and Path(str(data["asset"])).exists():
+        asset_path = Path(str(data["asset"]))
+        b64 = base64.b64encode(asset_path.read_bytes()).decode("ascii")
+        asset_markup = f'<img src="data:image/png;base64,{b64}" alt="Asset" style="max-width:100%;height:auto;" />'
+    return f"""
+    <html>
+        <head>
+            <title>Pi Cortex Panel</title>
+            <style>
+                body {{ font-family: -apple-system, BlinkMacSystemFont, sans-serif; margin: 40px; background: #111; color: #f5f5f5; }}
+                .container {{ max-width: 640px; margin: auto; background: #1c1c1e; padding: 24px; border-radius: 12px; box-shadow: 0 10px 30px rgba(0,0,0,0.5); }}
+                h1 {{ margin-top: 0; }}
+                .timestamp {{ opacity: 0.7; font-size: 0.9rem; }}
+                img {{ margin-top: 20px; border-radius: 10px; box-shadow: 0 10px 30px rgba(0,0,0,0.4); }}
+            </style>
+        </head>
+        <body>
+            <div class="container">
+                <h1>Simulator Panel</h1>
+                <p class="timestamp">Last update: {time.ctime(data['updated_at'])}</p>
+                <p style="font-size: 2rem;">{data['text']}</p>
+                {asset_markup}
+            </div>
+        </body>
+    </html>
+    """
+
+
+@app.get("/healthz", response_class=JSONResponse)
+def healthcheck() -> dict[str, str]:
+    return {"status": "ok", "updated_at": time.ctime(state.to_dict()["updated_at"]) }
+
+
+@app.get("/state", response_class=JSONResponse)
+def state_json() -> dict[str, Optional[str]]:
+    snapshot = state.to_dict()
+    return {
+        "text": snapshot["text"],
+        "asset": snapshot["asset"],
+        "updated_at": time.ctime(snapshot["updated_at"]),
+    }
+
+
+def load_env() -> dict[str, str]:
+    env_path = Path(".env")
+    values: dict[str, str] = {}
+    if env_path.exists():
+        for line in env_path.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            values[key.strip()] = value.strip()
+    values.update(os.environ)
+    return values
+
+
+def start_mqtt_thread(env: dict[str, str]) -> None:
+    broker = env.get("PI_CORTEX_MQTT_HOST", "localhost")
+    port = int(env.get("PI_CORTEX_MQTT_PORT", "1883"))
+    asset_topic = env.get("PI_CORTEX_ASSET_TOPIC", "pi/assets/logo")
+    panel_topic = env.get("PI_CORTEX_PANEL_TOPIC", "pi/panel/text")
+
+    client = mqtt.Client()
+
+    def on_connect(_client, _userdata, _flags, rc):
+        if rc == 0:
+            logger.info("Panel connected to MQTT %s:%s", broker, port)
+            client.subscribe(asset_topic)
+            client.subscribe(panel_topic)
+        else:
+            logger.error("Panel failed to connect to MQTT rc=%s", rc)
+
+    def on_message(_client, _userdata, msg: mqtt.MQTTMessage):
+        if msg.topic == asset_topic:
+            try:
+                payload = json.loads(msg.payload.decode())
+                data = base64.b64decode(payload["payload"])
+                filename = payload.get("filename", "asset.png")
+                state.update_asset(data, filename)
+                logger.info("Panel stored asset %s", filename)
+            except Exception as exc:  # noqa: BLE001
+                logger.exception("Failed to process asset payload: %s", exc)
+        elif msg.topic == panel_topic:
+            state.update_text(msg.payload.decode())
+            logger.info("Panel text updated to %s", state.to_dict()["text"])
+
+    client.on_connect = on_connect
+    client.on_message = on_message
+    client.connect(broker, port, keepalive=60)
+    client.loop_start()
+
+
+def main() -> None:
+    configure_logging()
+    env = load_env()
+    start_mqtt_thread(env)
+    host = env.get("PI_CORTEX_PANEL_HOST", "0.0.0.0")
+    port = int(env.get("PI_CORTEX_PANEL_PORT", "8000"))
+    uvicorn.run(app, host=host, port=port)
+
+
+if __name__ == "__main__":
+    main()

--- a/pi-cortex-stack/pi/services/pi-holo-renderer.service
+++ b/pi-cortex-stack/pi/services/pi-holo-renderer.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Pi Cortex Holo Renderer
+After=network.target
+
+[Service]
+Type=simple
+User=pi
+WorkingDirectory=/home/pi/pi-cortex-stack
+ExecStart=/home/pi/agent-venv/bin/python /home/pi/pi-cortex-stack/pi/pi_holo_renderer.py
+Restart=on-failure
+EnvironmentFile=/home/pi/pi-cortex-stack/.env
+
+[Install]
+WantedBy=multi-user.target

--- a/pi-cortex-stack/pi/services/pi-ops-heartbeat.service
+++ b/pi-cortex-stack/pi/services/pi-ops-heartbeat.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Pi Cortex Ops Heartbeat Publisher
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=pi
+WorkingDirectory=/home/pi/pi-cortex-stack
+ExecStart=/home/pi/agent-venv/bin/python /home/pi/pi-cortex-stack/pi/pi_ops_heartbeat.py
+Restart=on-failure
+EnvironmentFile=/home/pi/pi-cortex-stack/.env
+
+[Install]
+WantedBy=multi-user.target

--- a/pi-cortex-stack/pi/services/pi-sim-panel.service
+++ b/pi-cortex-stack/pi/services/pi-sim-panel.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Pi Cortex Simulator Panel
+After=network.target
+
+[Service]
+Type=simple
+User=pi
+WorkingDirectory=/home/pi/pi-cortex-stack
+ExecStart=/home/pi/agent-venv/bin/python -m uvicorn pi.pi_sim_panel:app --host 0.0.0.0 --port 8000
+Restart=on-failure
+EnvironmentFile=/home/pi/pi-cortex-stack/.env
+
+[Install]
+WantedBy=multi-user.target

--- a/pi-cortex-stack/scripts/install_mac_agent.sh
+++ b/pi-cortex-stack/scripts/install_mac_agent.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+STACK_DIR="$(cd "$(dirname "$0")"/.. && pwd)"
+PLIST_SRC="$STACK_DIR/launch_agents/com.blackroad.pi-cortex-agent.plist"
+PLIST_DEST="$HOME/Library/LaunchAgents/com.blackroad.pi-cortex-agent.plist"
+
+mkdir -p "$(dirname "$PLIST_DEST")"
+cp "$PLIST_SRC" "$PLIST_DEST"
+launchctl unload "$PLIST_DEST" >/dev/null 2>&1 || true
+launchctl load "$PLIST_DEST"
+echo "Loaded LaunchAgent at $PLIST_DEST"

--- a/pi-cortex-stack/scripts/install_pi_services.sh
+++ b/pi-cortex-stack/scripts/install_pi_services.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+STACK_DIR="$(cd "$(dirname "$0")"/.. && pwd)"
+SERVICE_DIR="$STACK_DIR/pi/services"
+TARGET_DIR="/etc/systemd/system"
+
+sudo cp "$SERVICE_DIR"/*.service "$TARGET_DIR"/
+sudo systemctl daemon-reload
+
+for service in "$SERVICE_DIR"/*.service; do
+  svc_name="$(basename "$service")"
+  sudo systemctl enable --now "$svc_name"
+  echo "Installed and started $svc_name"
+done


### PR DESCRIPTION
## Summary
- add a pi-cortex-stack bundle with documentation, make targets, and installer scripts for the Mac and Raspberry Pi nodes
- implement the mac orchestration agent plus first_light smoke test for pushing assets and demo text over MQTT
- provide Raspberry Pi renderer, simulator panel, and heartbeat services with matching systemd units

## Testing
- `python -m compileall pi-cortex-stack`


------
https://chatgpt.com/codex/tasks/task_e_68e1802c73d8832982ef77cbb4b61ba3