### PR TITLE
Add AutoPal Express middleware scaffold

### DIFF
--- a/autopal.config.json
+++ b/autopal.config.json
@@ -1,0 +1,26 @@
+{
+  "version": "1.0",
+  "feature_flags": {
+    "global_enabled": true
+  },
+  "maintenance_mode": {
+    "allowlist_endpoints": ["GET /health/live", "GET /health/ready"],
+    "status_code": 503,
+    "retry_after_seconds": 60
+  },
+  "step_up": {
+    "rules": [
+      {
+        "match": { "endpoint": "POST /secrets/materialize" },
+        "required": true,
+        "mechanisms": ["mfa-approval"]
+      },
+      {
+        "match": { "endpoint": "POST /fossil/override" },
+        "required": true,
+        "mechanisms": ["dual-control"]
+      }
+    ]
+  },
+  "endpoints": {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,10 @@
     "": {
       "name": "blackroad-prism-console",
       "version": "0.0.0",
+      "dependencies": {
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1"
+      },
       "devDependencies": {
         "nodemon": "^3.0.2",
         "jest": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "node": ">=20"
   },
   "dependencies": {
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1",
     "bcrypt": "^5.1.1",
     "cookie-session": "^2.0.0",
     "cors": "^2.8.5",

--- a/src/autopal/config.schema.json
+++ b/src/autopal/config.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AutoPal Config",
+  "type": "object",
+  "required": [
+    "version",
+    "feature_flags",
+    "maintenance_mode",
+    "step_up",
+    "endpoints"
+  ],
+  "properties": {
+    "version": {
+      "type": "string",
+      "pattern": "^1\\.\\d+$"
+    },
+    "feature_flags": {
+      "type": "object",
+      "required": ["global_enabled"],
+      "properties": {
+        "global_enabled": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": true
+    },
+    "maintenance_mode": {
+      "type": "object",
+      "properties": {
+        "allowlist_endpoints": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "status_code": {
+          "type": "integer"
+        },
+        "retry_after_seconds": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": true
+    },
+    "step_up": {
+      "type": "object",
+      "properties": {
+        "rules": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "endpoints": {
+      "type": "object"
+    }
+  }
+}

--- a/src/autopal/config.ts
+++ b/src/autopal/config.ts
@@ -1,0 +1,56 @@
+import fs from "fs";
+import path from "path";
+import { EventEmitter } from "events";
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
+import schema from "./config.schema.json";
+
+export type AutoPalConfig = any;
+
+const ajv = new Ajv({ allErrors: true, strict: true });
+addFormats(ajv);
+const validate = ajv.compile(schema as any);
+
+export class Config extends EventEmitter {
+  private file: string;
+  private current: AutoPalConfig;
+
+  constructor(file = path.resolve(process.env.AUTOPAL_CONFIG ?? "autopal.config.json")) {
+    super();
+    this.file = file;
+    this.current = this.loadOrDie();
+    this.watch();
+  }
+
+  get value(): AutoPalConfig {
+    return this.current;
+  }
+
+  private loadOrDie(): AutoPalConfig {
+    const raw = fs.readFileSync(this.file, "utf8");
+    const parsed = JSON.parse(raw);
+    if (!validate(parsed)) {
+      const msg = (validate.errors ?? [])
+        .map((e) => `${e.instancePath} ${e.message}`)
+        .join("; ");
+      throw new Error("Config validation failed: " + msg);
+    }
+    return parsed;
+  }
+
+  private watch() {
+    fs.watchFile(this.file, { interval: 1000 }, () => {
+      try {
+        const next = this.loadOrDie();
+        this.current = next;
+        this.emit("reload", next);
+        console.log("[config] reloaded");
+      } catch (e) {
+        console.error(
+          "[config] reload failed, keeping previous:",
+          (e as Error).message
+        );
+      }
+    });
+  }
+}

--- a/src/autopal/guards.ts
+++ b/src/autopal/guards.ts
@@ -1,0 +1,59 @@
+import { Request, Response, NextFunction } from "express";
+import { Config } from "./config";
+
+const normalizeKey = (req: Request) => `${req.method.toUpperCase()} ${req.route?.path ?? req.path}`;
+
+export function maintenanceGuard(cfg: Config) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const c = cfg.value;
+    const on = !!c.feature_flags.global_enabled;
+    const allow = new Set<string>(c.maintenance_mode?.allowlist_endpoints ?? []);
+    const key = normalizeKey(req);
+
+    if (on || allow.has(key)) {
+      res.setHeader("X-AutoPal-Mode", on ? "normal" : "maintenance");
+      return next();
+    }
+    const status = c.maintenance_mode?.status_code ?? 503;
+    const retry = c.maintenance_mode?.retry_after_seconds;
+    if (retry) res.setHeader("Retry-After", String(retry));
+    res.setHeader("X-AutoPal-Mode", "maintenance");
+
+    if (key === "POST /secrets/materialize") {
+      return res.status(403).json({
+        code: "materialize_disabled",
+        message: "Token minting disabled (global switch).",
+      });
+    }
+    return res.status(status).json({
+      code: "maintenance_mode",
+      message: "AutoPal is paused by ops.",
+      hint: "Try later or use runbooks.",
+      runbook: "https://runbooks/autopal/maintenance",
+    });
+  };
+}
+
+export function stepUpGuard(cfg: Config) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const c = cfg.value;
+    const key = normalizeKey(req);
+    const rules = (c.step_up?.rules ?? []) as any[];
+
+    const hit = rules.find((r) => r.match?.endpoint === key);
+    const required = !!hit?.required || !!hit?.step_up_required;
+
+    if (!required) return next();
+
+    const approved = req.header("X-Step-Up-Approved") === "true";
+    if (!approved) {
+      return res.status(401).json({
+        code: "step_up_required",
+        message: "Additional approval needed",
+        mechanisms: hit?.mechanisms ?? [],
+        runbook: "https://runbooks/step-up",
+      });
+    }
+    return next();
+  };
+}

--- a/src/autopal/server.ts
+++ b/src/autopal/server.ts
@@ -1,0 +1,43 @@
+import express from "express";
+import { Config } from "./config";
+import { maintenanceGuard, stepUpGuard } from "./guards";
+
+const app = express();
+app.use(express.json());
+
+const cfg = new Config();
+
+app.use(maintenanceGuard(cfg));
+
+app.get("/health/live", (_req, res) =>
+  res.json({ status: "ok", ts: new Date().toISOString() })
+);
+app.get("/health/ready", (_req, res) =>
+  res.json({ status: "ok", deps: ["db", "queue"], ts: new Date().toISOString() })
+);
+
+app.post("/secrets/resolve", stepUpGuard(cfg), (req, res) => {
+  res.json({
+    role: req.body?.role ?? "unknown",
+    env: req.body?.env ?? "unknown",
+    provenance: "vault_rotation",
+    secret_ref: "vault://kv/example",
+    expires_at: new Date(Date.now() + 3_600_000).toISOString(),
+    least_privilege: true,
+    can_materialize: true,
+  });
+});
+
+app.post("/secrets/materialize", stepUpGuard(cfg), (_req, res) => {
+  res.json({
+    token: "redacted",
+    expires_at: new Date(Date.now() + 1_800_000).toISOString(),
+  });
+});
+
+app.post("/fossil/override", stepUpGuard(cfg), (_req, res) => {
+  res.status(202).json({ granted: "pending_second_approval", ticket: "FX-1243" });
+});
+
+const port = Number(process.env.PORT ?? 8080);
+app.listen(port, () => console.log(`AutoPal API on :${port}`));


### PR DESCRIPTION
## Summary
- add an AutoPal config schema, loader, and hot-reload support backed by AJV validation
- provide maintenance-mode and step-up Express guards plus sample routes that honor the global switch
- supply a default autopal.config.json and declare the new AJV dependencies

## Testing
- CI=1 npm test -- --runTestsByPath tests/api_health.test.js *(fails: aborted after extended runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68e1809d092c8329bcde8881f6bb6046