### PR TITLE
Add synthetic simulation pipeline scaffolding

### DIFF
--- a/10_genesis/.gitignore
+++ b/10_genesis/.gitignore
@@ -1,0 +1,1 @@
+outputs/

--- a/10_genesis/dummy_generate.py
+++ b/10_genesis/dummy_generate.py
@@ -1,0 +1,144 @@
+"""Utility to generate synthetic Genesis artifacts for local testing.
+
+This script fabricates mesh, volume, and video artifacts so the rest of the
+pipeline can be exercised without a physics engine.  The output is written to
+``10_genesis/outputs/<timestamp>`` with default timestamp ``t000400``.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict
+
+import numpy as np
+
+# A single-frame MP4 encoded as base64.  This keeps the script self-contained
+# and avoids needing ffmpeg on the host.
+_PLACEHOLDER_MP4 = (
+    b"\x00\x00\x00\x20ftypisom\x00\x00\x02\x00isomiso2avc1mp41\x00\x00\x00\x08free"
+    b"\x00\x00\x00,mdat\x00\x00\x00\x01\x00\x00\x00\x01"
+)
+
+
+def _write_mesh(path: Path, name: str) -> None:
+    """Create a minimal ASCII PLY mesh for debugging."""
+    vertices = [
+        (0.0, 0.0, 0.0),
+        (1.0, 0.0, 0.0),
+        (1.0, 1.0, 0.0),
+        (0.0, 1.0, 0.0),
+    ]
+    faces = [(0, 1, 2), (0, 2, 3)]
+
+    with path.open("w", encoding="utf-8") as fh:
+        fh.write("ply\n")
+        fh.write("format ascii 1.0\n")
+        fh.write(f"comment synthetic mesh for {name}\n")
+        fh.write(f"element vertex {len(vertices)}\n")
+        fh.write("property float x\n")
+        fh.write("property float y\n")
+        fh.write("property float z\n")
+        fh.write(f"element face {len(faces)}\n")
+        fh.write("property list uchar int vertex_indices\n")
+        fh.write("end_header\n")
+        for v in vertices:
+            fh.write(f"{v[0]} {v[1]} {v[2]}\n")
+        for f in faces:
+            fh.write(f"3 {f[0]} {f[1]} {f[2]}\n")
+
+
+def _create_solid_volume(grid: np.ndarray) -> Dict[str, np.ndarray]:
+    x, y, z = grid
+    displacement = np.stack([
+        np.sin(x / 10.0),
+        np.cos(y / 10.0),
+        np.sin(z / 15.0),
+    ], axis=-1)
+    stress = 0.1 + 0.05 * np.sin((x + y + z) / 8.0)
+    return {
+        "displacement": displacement.astype(np.float32),
+        "stress": stress.astype(np.float32),
+    }
+
+
+def _create_fluid_volume(grid: np.ndarray) -> Dict[str, np.ndarray]:
+    x, y, z = grid
+    density = 1.0 + 0.02 * np.cos((x - y) / 12.0)
+    vx = 0.1 * np.sin(x / 20.0)
+    vy = 0.1 * np.sin(y / 18.0)
+    vz = 0.05 * np.cos(z / 25.0)
+    velocity = np.stack([vx, vy, vz], axis=-1)
+    return {
+        "density": density.astype(np.float32),
+        "velocity": velocity.astype(np.float32),
+    }
+
+
+def _write_video(path: Path) -> None:
+    path.write_bytes(_PLACEHOLDER_MP4)
+
+
+def generate(timestamp: str, out_dir: Path, grid_shape: int) -> Path:
+    """Generate the synthetic dataset and return the output directory."""
+    output_root = out_dir / timestamp
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    # Meshes
+    _write_mesh(output_root / "solid_surface.ply", "solid_surface")
+    _write_mesh(output_root / "fluid_surface.ply", "fluid_surface")
+
+    grid = np.indices((grid_shape, grid_shape, grid_shape))
+
+    # Volumes
+    solid = _create_solid_volume(grid)
+    fluid = _create_fluid_volume(grid)
+    np.savez_compressed(output_root / "solid_volume.npz", **solid)
+    np.savez_compressed(output_root / "fluid_volume.npz", **fluid)
+
+    # Diagnostics video placeholder
+    _write_video(output_root / "diagnostics.mp4")
+
+    # Metadata for traceability
+    metadata = {
+        "timestamp": timestamp,
+        "grid_shape": grid_shape,
+        "fields": {
+            "solid_volume": list(solid.keys()),
+            "fluid_volume": list(fluid.keys()),
+        },
+    }
+    (output_root / "metadata.json").write_text(
+        json.dumps(metadata, indent=2), encoding="utf-8"
+    )
+
+    return output_root
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--timestamp",
+        default="t000400",
+        help="Timestamp identifier for the synthetic run.",
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=Path(__file__).parent / "outputs",
+        help="Root directory for generated artifacts.",
+    )
+    parser.add_argument(
+        "--grid",
+        type=int,
+        default=48,
+        help="Resolution of the generated 3D grid.",
+    )
+    args = parser.parse_args()
+
+    output = generate(args.timestamp, args.out_dir, args.grid)
+    print(f"Synthetic Genesis artifacts written to {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/20_bench_solid/.gitignore
+++ b/20_bench_solid/.gitignore
@@ -1,0 +1,1 @@
+outputs/

--- a/30_bench_fluid/.gitignore
+++ b/30_bench_fluid/.gitignore
@@ -1,0 +1,1 @@
+outputs/

--- a/40_compare/check_thresholds.py
+++ b/40_compare/check_thresholds.py
@@ -1,0 +1,148 @@
+"""Compare Genesis outputs to benchmark volumes and enforce success thresholds."""
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Tuple
+
+import numpy as np
+
+DEFAULT_TIMESTAMP = "t000400"
+DEFAULT_GENESIS_DIR = Path("10_genesis/outputs")
+DEFAULT_SOLID_DIR = Path("20_bench_solid/outputs")
+DEFAULT_FLUID_DIR = Path("30_bench_fluid/outputs")
+DEFAULT_THRESHOLDS = Path("40_compare/thresholds.json")
+
+
+@dataclass
+class MetricResult:
+    name: str
+    value: float
+    limit: float
+    passed: bool
+
+
+def _load_npz(path: Path) -> Dict[str, np.ndarray]:
+    with np.load(path) as data:  # type: ignore[call-arg]
+        return {name: data[name] for name in data.files}
+
+
+def _compute_metrics(a: np.ndarray, b: np.ndarray) -> Dict[str, float]:
+    diff = a - b
+    return {
+        "mae": float(np.mean(np.abs(diff))),
+        "max_abs": float(np.max(np.abs(diff))),
+        "rmse": float(np.sqrt(np.mean(diff**2))),
+    }
+
+
+def _check_field(
+    field: str,
+    generated: np.ndarray,
+    reference: np.ndarray,
+    thresholds: Dict[str, float],
+) -> Iterable[MetricResult]:
+    metrics = _compute_metrics(generated, reference)
+    for metric_name, limit in thresholds.items():
+        value = metrics.get(metric_name)
+        if value is None:
+            raise KeyError(f"Metric '{metric_name}' not supported for {field}")
+        yield MetricResult(metric_name, value, limit, value <= limit)
+
+
+def _resolve_paths(base: Path, timestamp: str) -> Path:
+    path = base / timestamp
+    if not path.exists():
+        raise FileNotFoundError(f"Expected directory not found: {path}")
+    return path
+
+
+def _evaluate_volume(
+    label: str,
+    generated: Path,
+    benchmark: Path,
+    thresholds: Dict[str, Dict[str, Dict[str, float]]],
+) -> Tuple[bool, Dict[str, Iterable[MetricResult]]]:
+    gen_npz = generated / f"{label}_volume.npz"
+    bench_npz = benchmark / f"{label}_volume.npz"
+    if not gen_npz.exists():
+        raise FileNotFoundError(f"Missing generated volume: {gen_npz}")
+    if not bench_npz.exists():
+        raise FileNotFoundError(f"Missing benchmark volume: {bench_npz}")
+
+    gen_fields = _load_npz(gen_npz)
+    bench_fields = _load_npz(bench_npz)
+
+    all_pass = True
+    results: Dict[str, Iterable[MetricResult]] = {}
+    for field, metric_limits in thresholds.get(f"{label}_volume", {}).items():
+        if field not in gen_fields:
+            raise KeyError(f"Field '{field}' not found in {gen_npz}")
+        if field not in bench_fields:
+            raise KeyError(f"Field '{field}' not found in {bench_npz}")
+        metrics = list(
+            _check_field(field, gen_fields[field], bench_fields[field], metric_limits)
+        )
+        results[field] = metrics
+        all_pass &= all(m.passed for m in metrics)
+    return all_pass, results
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--timestamp", default=DEFAULT_TIMESTAMP)
+    parser.add_argument("--genesis", type=Path, default=DEFAULT_GENESIS_DIR)
+    parser.add_argument("--solid", type=Path, default=DEFAULT_SOLID_DIR)
+    parser.add_argument("--fluid", type=Path, default=DEFAULT_FLUID_DIR)
+    parser.add_argument("--thresholds", type=Path, default=DEFAULT_THRESHOLDS)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    thresholds = json.loads(args.thresholds.read_text())
+
+    try:
+        solid_dir = _resolve_paths(args.solid, args.timestamp)
+        fluid_dir = _resolve_paths(args.fluid, args.timestamp)
+        genesis_dir = _resolve_paths(args.genesis, args.timestamp)
+    except FileNotFoundError as exc:
+        print(f"ERROR: {exc}")
+        raise SystemExit(2)
+
+    success = True
+
+    solid_pass, solid_results = _evaluate_volume(
+        "solid", genesis_dir, solid_dir, thresholds
+    )
+    fluid_pass, fluid_results = _evaluate_volume(
+        "fluid", genesis_dir, fluid_dir, thresholds
+    )
+    success &= solid_pass and fluid_pass
+
+    def report(label: str, results: Dict[str, Iterable[MetricResult]]) -> None:
+        print(f"=== {label.upper()} VOLUME ===")
+        for field, metrics in results.items():
+            print(f"Field: {field}")
+            for metric in metrics:
+                status = "PASS" if metric.passed else "FAIL"
+                print(
+                    f"  {metric.name:>7}: {metric.value:.6f}"
+                    f" (limit {metric.limit:.6f}) -> {status}"
+                )
+            print()
+
+    report("solid", solid_results)
+    report("fluid", fluid_results)
+
+    if success:
+        print("All thresholds satisfied.")
+        raise SystemExit(0)
+    print("Threshold check failed.")
+    raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/40_compare/thresholds.json
+++ b/40_compare/thresholds.json
@@ -1,0 +1,26 @@
+{
+  "solid_volume": {
+    "displacement": {
+      "mae": 0.15,
+      "max_abs": 0.5,
+      "rmse": 0.2
+    },
+    "stress": {
+      "mae": 0.05,
+      "max_abs": 0.2,
+      "rmse": 0.08
+    }
+  },
+  "fluid_volume": {
+    "density": {
+      "mae": 0.02,
+      "max_abs": 0.05,
+      "rmse": 0.03
+    },
+    "velocity": {
+      "mae": 0.05,
+      "max_abs": 0.15,
+      "rmse": 0.07
+    }
+  }
+}

--- a/40_compare/view_quick.py
+++ b/40_compare/view_quick.py
@@ -1,0 +1,71 @@
+"""Quick inspection utility for volume datasets."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+
+DEFAULT_VOLUME = Path("10_genesis/outputs/t000400/fluid_volume.npz")
+
+
+def _load_npz(path: Path) -> Iterable[tuple[str, np.ndarray]]:
+    with np.load(path) as data:  # type: ignore[call-arg]
+        for name in data.files:
+            yield name, data[name]
+
+
+def _describe_field(name: str, array: np.ndarray) -> None:
+    print(f"Field: {name}")
+    print(f"  dtype: {array.dtype}")
+    print(f"  shape: {array.shape}")
+    print(
+        "  stats: min={:.6f} max={:.6f} mean={:.6f} std={:.6f}".format(
+            float(np.min(array)),
+            float(np.max(array)),
+            float(np.mean(array)),
+            float(np.std(array)),
+        )
+    )
+
+    if array.ndim < 3:
+        print("  mid-slice: n/a (array has fewer than 3 dimensions)")
+        return
+
+    mid_index = array.shape[0] // 2
+    slice_view = array[mid_index]
+    if slice_view.ndim == 2:
+        printable = slice_view
+    else:
+        printable = np.linalg.norm(slice_view, axis=-1)
+    np.set_printoptions(precision=3, suppress=True, linewidth=120)
+    print("  mid-slice magnitude:")
+    print(printable)
+    print()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "volume",
+        nargs="?",
+        default=DEFAULT_VOLUME,
+        type=Path,
+        help="Path to the npz volume file to inspect.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    path = args.volume
+    if not path.exists():
+        raise SystemExit(f"Volume file not found: {path}")
+    print(f"Inspecting {path}")
+    for name, array in _load_npz(path):
+        _describe_field(name, array)
+
+
+if __name__ == "__main__":
+    main()

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .RECIPEPREFIX = >
-.PHONY: setup test lint demo validate dc-up dc-test dc-shell build run deploy preview-destroy
+.PHONY: setup test lint demo validate dc-up dc-test dc-shell build run deploy preview-destroy dummy check view
 
 setup:
 >python -m venv .venv && . .venv/bin/activate && pip install -U pip pytest jsonschema ruff
@@ -48,3 +48,12 @@ dc-test:
 
 dc-shell:
 >docker compose run --rm app bash
+
+dummy:
+>python 10_genesis/dummy_generate.py
+
+check:
+>python 40_compare/check_thresholds.py
+
+view:
+>python 40_compare/view_quick.py


### PR DESCRIPTION
## Summary
- add a dummy Genesis generator that produces meshes, volumes, and a placeholder video for test runs
- provide comparison tooling with configurable thresholds and a quick volume viewer utility
- wire helper make targets and ignore generated output directories for future data drops

## Testing
- make dummy
- make view
- make check *(fails: benchmark outputs not yet provided)*

------
https://chatgpt.com/codex/tasks/task_e_68e1819c88888329a69a0eb28c3b2cad