### PR TITLE
Add maintenance mode guard for AutoPal global switch

### DIFF
--- a/config/autopal.json
+++ b/config/autopal.json
@@ -1,0 +1,21 @@
+{
+  "feature_flags": {
+    "global_enabled": true
+  },
+  "maintenance_mode": {
+    "allowlist_endpoints": [
+      "GET /health/live",
+      "GET /health/ready"
+    ],
+    "status_code": 503,
+    "retry_after_seconds": 60,
+    "message": "AutoPal is paused by ops.",
+    "hint": "Try again later or use runbooks.",
+    "runbook": "https://runbooks/autopal/maintenance",
+    "break_glass": {
+      "enabled": false,
+      "header": "X-Break-Glass",
+      "tokens": []
+    }
+  }
+}

--- a/srv/blackroad-api/lib/maintenanceConfig.js
+++ b/srv/blackroad-api/lib/maintenanceConfig.js
@@ -1,0 +1,165 @@
+const fs = require('fs');
+const path = require('path');
+const logger = require('./log');
+
+const DEFAULT_CONFIG = {
+  feature_flags: {
+    global_enabled: true,
+  },
+  maintenance_mode: {
+    allowlist_endpoints: ['GET /health/live', 'GET /health/ready'],
+    status_code: 503,
+    retry_after_seconds: 60,
+    message: 'AutoPal is paused by ops.',
+    hint: 'Try again later or use runbooks.',
+    runbook: 'https://runbooks/autopal/maintenance',
+    break_glass: {
+      enabled: false,
+      header: 'X-Break-Glass',
+      tokens: [],
+    },
+  },
+};
+
+let cachePath = null;
+let cacheMtime = 0;
+let cacheConfig = null;
+
+function normalizeAllowlistEntry(entry) {
+  if (!entry || typeof entry !== 'string') return null;
+  const trimmed = entry.trim();
+  if (!trimmed) return null;
+  const [method, ...rest] = trimmed.split(/\s+/);
+  if (!rest.length) return null;
+  const normalizedPath = rest.join(' ').trim() || '/';
+  return `${method.toUpperCase()} ${normalizedPath}`;
+}
+
+function mergeConfig(base, override) {
+  const result = {
+    feature_flags: { ...(base.feature_flags || {}) },
+    maintenance_mode: {
+      ...(base.maintenance_mode || {}),
+      allowlist_endpoints: [...(base.maintenance_mode?.allowlist_endpoints || [])],
+    },
+  };
+
+  if (override?.feature_flags) {
+    result.feature_flags = {
+      ...result.feature_flags,
+      ...override.feature_flags,
+    };
+  }
+
+  if (override?.maintenance_mode) {
+    const { allowlist_endpoints, ...rest } = override.maintenance_mode;
+    result.maintenance_mode = {
+      ...result.maintenance_mode,
+      ...rest,
+      allowlist_endpoints: [...result.maintenance_mode.allowlist_endpoints],
+    };
+
+    if (Array.isArray(allowlist_endpoints)) {
+      const set = new Set(result.maintenance_mode.allowlist_endpoints);
+      for (const entry of allowlist_endpoints) {
+        const normalized = normalizeAllowlistEntry(entry);
+        if (normalized) set.add(normalized);
+      }
+      result.maintenance_mode.allowlist_endpoints = Array.from(set);
+    }
+  }
+
+  return result;
+}
+
+function readConfigFromDisk(configPath) {
+  try {
+    const stat = fs.statSync(configPath);
+    if (
+      cacheConfig &&
+      cachePath === configPath &&
+      cacheMtime === stat.mtimeMs
+    ) {
+      return cacheConfig;
+    }
+    const raw = fs.readFileSync(configPath, 'utf8');
+    const parsed = raw ? JSON.parse(raw) : {};
+    cachePath = configPath;
+    cacheMtime = stat.mtimeMs;
+    cacheConfig = parsed;
+    return parsed;
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      try {
+        logger.warn({
+          event: 'maintenance_config_read_error',
+          message: err.message,
+          path: configPath,
+        });
+      } catch (_) {
+        // Swallow logging errors — never block on config read issues.
+      }
+    }
+    cachePath = configPath;
+    cacheMtime = 0;
+    cacheConfig = null;
+    return null;
+  }
+}
+
+function applyEnvOverrides(config) {
+  const result = { ...config };
+  result.feature_flags = { ...config.feature_flags };
+  result.maintenance_mode = { ...config.maintenance_mode };
+
+  const envGlobal = process.env.AUTOPAL_GLOBAL_ENABLED;
+  if (envGlobal !== undefined) {
+    const normalized = envGlobal.trim().toLowerCase();
+    result.feature_flags.global_enabled = !['false', '0', 'off', 'no'].includes(
+      normalized
+    );
+  }
+
+  const envStatus = process.env.AUTOPAL_MAINTENANCE_STATUS_CODE;
+  if (envStatus) {
+    const statusCode = Number.parseInt(envStatus, 10);
+    if (!Number.isNaN(statusCode) && statusCode > 0) {
+      result.maintenance_mode.status_code = statusCode;
+    }
+  }
+
+  const envRetry = process.env.AUTOPAL_RETRY_AFTER_SECONDS;
+  if (envRetry) {
+    const retryAfter = Number.parseInt(envRetry, 10);
+    if (!Number.isNaN(retryAfter) && retryAfter >= 0) {
+      result.maintenance_mode.retry_after_seconds = retryAfter;
+    }
+  }
+
+  const envAllowlist = process.env.AUTOPAL_ALLOWLIST;
+  if (envAllowlist) {
+    const set = new Set(result.maintenance_mode.allowlist_endpoints);
+    for (const entry of envAllowlist.split(',')) {
+      const normalized = normalizeAllowlistEntry(entry);
+      if (normalized) set.add(normalized);
+    }
+    result.maintenance_mode.allowlist_endpoints = Array.from(set);
+  }
+
+  return result;
+}
+
+function getMaintenanceConfig() {
+  const configPath =
+    process.env.AUTOPAL_CONFIG_PATH ||
+    path.resolve(__dirname, '../../../config/autopal.json');
+
+  const fileConfig = configPath ? readConfigFromDisk(configPath) : null;
+  const merged = mergeConfig(DEFAULT_CONFIG, fileConfig || {});
+  return applyEnvOverrides(merged);
+}
+
+module.exports = {
+  DEFAULT_CONFIG,
+  getMaintenanceConfig,
+};

--- a/srv/blackroad-api/modules/maintenanceGuard.js
+++ b/srv/blackroad-api/modules/maintenanceGuard.js
@@ -1,0 +1,195 @@
+const { getMaintenanceConfig } = require('../lib/maintenanceConfig');
+
+const SPECIAL_CASES = {
+  'POST /secrets/materialize': {
+    status: 403,
+    body: {
+      code: 'materialize_disabled',
+      message: 'Token minting disabled (global switch).',
+    },
+    includeRetryAfter: false,
+  },
+  'POST /secrets/resolve': {
+    status: 503,
+    body: {
+      code: 'maintenance_mode',
+      message: 'Secret operations are disabled by the global switch.',
+    },
+    includeRetryAfter: false,
+  },
+  'POST /fossil/override': {
+    status: 503,
+    body: {
+      code: 'maintenance_mode',
+      message: 'Overrides are disabled while AutoPal is paused.',
+    },
+    includeRetryAfter: false,
+  },
+};
+
+function normalizePath(pathname) {
+  if (!pathname) return '/';
+  if (pathname.length > 1 && pathname.endsWith('/')) {
+    return pathname.replace(/\/+$/, '');
+  }
+  return pathname;
+}
+
+function buildKey(method, pathname) {
+  return `${method.toUpperCase()} ${normalizePath(pathname)}`;
+}
+
+function toAllowlistSet(config) {
+  const allowlist = new Set();
+  const entries = config.maintenance_mode?.allowlist_endpoints || [];
+  for (const entry of entries) {
+    if (!entry || typeof entry !== 'string') continue;
+    const [method, ...rest] = entry.trim().split(/\s+/);
+    if (!rest.length) continue;
+    const normalized = buildKey(method, rest.join(' '));
+    allowlist.add(normalized);
+  }
+  return allowlist;
+}
+
+function isAllowlisted(method, pathname, allowlist) {
+  const key = buildKey(method, pathname);
+  if (allowlist.has(key)) return true;
+  if (method.toUpperCase() === 'HEAD') {
+    const altKey = buildKey('GET', pathname);
+    if (allowlist.has(altKey)) return true;
+  }
+  return false;
+}
+
+function shouldBypassWithBreakGlass(req, maintenanceConfig, logger) {
+  const breakGlass = maintenanceConfig?.break_glass;
+  if (!breakGlass || breakGlass.enabled === false) {
+    return { allowed: false, attempted: false };
+  }
+
+  const headerName = breakGlass.header || 'X-Break-Glass';
+  const token = req.get(headerName);
+  if (!token) {
+    return { allowed: false, attempted: false };
+  }
+
+  const tokens = Array.isArray(breakGlass.tokens) ? breakGlass.tokens : [];
+  const now = Date.now();
+  const matched = tokens.find((entry) => {
+    if (!entry) return false;
+    if (typeof entry === 'string') {
+      return entry === token;
+    }
+    if (typeof entry === 'object') {
+      const value = entry.token || entry.value || entry.signature;
+      if (!value || value !== token) {
+        return false;
+      }
+      if (entry.expires_at) {
+        const expires = new Date(entry.expires_at).getTime();
+        if (Number.isNaN(expires) || expires <= now) {
+          return false;
+        }
+      }
+      if (entry.ttl_seconds) {
+        const issuedAt = entry.issued_at
+          ? new Date(entry.issued_at).getTime()
+          : undefined;
+        if (issuedAt && !Number.isNaN(issuedAt)) {
+          if (issuedAt + Number(entry.ttl_seconds) * 1000 <= now) {
+            return false;
+          }
+        }
+      }
+      return true;
+    }
+    return false;
+  });
+
+  if (matched) {
+    try {
+      logger?.info?.({
+        event: 'maintenance_break_glass',
+        method: req.method,
+        path: req.originalUrl ? req.originalUrl.split('?')[0] : req.path,
+      });
+    } catch (_) {
+      // ignore logging errors
+    }
+    return { allowed: true, attempted: true };
+  }
+
+  return { allowed: false, attempted: true };
+}
+
+module.exports = function maintenanceGuard({ logger } = {}) {
+  return function maintenanceGuardMiddleware(req, res, next) {
+    const config = getMaintenanceConfig();
+    if (config.feature_flags?.global_enabled !== false) {
+      return next();
+    }
+
+    const allowlist = toAllowlistSet(config);
+    const breakGlass = shouldBypassWithBreakGlass(
+      req,
+      config.maintenance_mode,
+      logger
+    );
+
+    if (breakGlass.allowed) {
+      res.setHeader('X-AutoPal-Mode', 'maintenance');
+      return next();
+    }
+
+    if (isAllowlisted(req.method, req.path, allowlist)) {
+      res.setHeader('X-AutoPal-Mode', 'maintenance');
+      return next();
+    }
+
+    const key = buildKey(req.method, req.path);
+    const specialCase = SPECIAL_CASES[key];
+    const maintenanceSettings = config.maintenance_mode || {};
+
+    res.setHeader('X-AutoPal-Mode', 'maintenance');
+
+    const status = specialCase?.status || maintenanceSettings.status_code || 503;
+    const includeRetryAfter =
+      specialCase?.includeRetryAfter !== undefined
+        ? specialCase.includeRetryAfter
+        : status === 503;
+
+    if (includeRetryAfter && status === 503) {
+      const retryAfter = maintenanceSettings.retry_after_seconds;
+      if (retryAfter) {
+        res.setHeader('Retry-After', String(retryAfter));
+      }
+    }
+
+    const defaultBody = {
+      code: 'maintenance_mode',
+      message:
+        maintenanceSettings.message || 'AutoPal is paused by ops.',
+      hint: maintenanceSettings.hint || 'Try again later or use runbooks.',
+      runbook:
+        maintenanceSettings.runbook ||
+        'https://runbooks/autopal/maintenance',
+    };
+
+    const body = specialCase?.body || defaultBody;
+
+    try {
+      logger?.warn?.({
+        event: 'maintenance_block',
+        method: req.method,
+        path: req.originalUrl ? req.originalUrl.split('?')[0] : req.path,
+        status,
+        breakGlassAttempted: breakGlass.attempted,
+      });
+    } catch (_) {
+      // Never block on audit/logging failures during maintenance.
+    }
+
+    return res.status(status).json(body);
+  };
+};

--- a/srv/blackroad-api/server_full.js
+++ b/srv/blackroad-api/server_full.js
@@ -29,6 +29,7 @@ const Stripe = require('stripe');
 const verify = require('./lib/verify');
 const notify = require('./lib/notify');
 const logger = require('./lib/log');
+const maintenanceGuard = require('./modules/maintenanceGuard');
 const attachLlmRoutes = require('./routes/admin_llm');
 const gitRouter = require('./routes/git');
 const providersRouter = require('./routes/providers');
@@ -223,9 +224,25 @@ app.use(
   })
 );
 
+app.use(maintenanceGuard({ logger }));
+
 // --- Homepage
 app.get('/', (_, res) => {
   res.sendFile(path.join(WEB_ROOT, 'index.html'));
+});
+app.head('/health/live', (_req, res) => {
+  res.setHeader('Cache-Control', 'max-age=10');
+  res.status(200).end();
+});
+app.get('/health/live', (_req, res) => {
+  res.setHeader('Cache-Control', 'max-age=10');
+  res.json({ status: 'ok', ts: new Date().toISOString() });
+});
+app.head('/health/ready', (_req, res) => {
+  res.status(200).end();
+});
+app.get('/health/ready', (_req, res) => {
+  res.json({ status: 'ok', ts: new Date().toISOString() });
 });
 app.head('/health', (_req, res) => res.status(200).end());
 app.get('/health', (_req, res) => {

--- a/tests/maintenance_mode.test.js
+++ b/tests/maintenance_mode.test.js
@@ -1,0 +1,93 @@
+process.env.SESSION_SECRET = 'test-secret';
+process.env.INTERNAL_TOKEN = 'x';
+process.env.ALLOW_ORIGINS = 'https://example.com';
+
+const request = require('supertest');
+
+describe('maintenance mode global switch', () => {
+  let app;
+  let server;
+
+  beforeAll(() => {
+    process.env.AUTOPAL_GLOBAL_ENABLED = 'false';
+    ({ app, server } = require('../srv/blackroad-api/server_full.js'));
+  });
+
+  afterAll((done) => {
+    delete process.env.AUTOPAL_GLOBAL_ENABLED;
+    server.close(done);
+  });
+
+  it('allows live health endpoint when disabled globally', async () => {
+    const res = await request(app).get('/health/live');
+    expect(res.status).toBe(200);
+    expect(res.headers['x-autopal-mode']).toBe('maintenance');
+    expect(res.headers['cache-control']).toBe('max-age=10');
+    expect(res.body.status).toBe('ok');
+    expect(typeof res.body.ts).toBe('string');
+  });
+
+  it('allows ready health endpoint when disabled globally', async () => {
+    const res = await request(app).get('/health/ready');
+    expect(res.status).toBe(200);
+    expect(res.headers['x-autopal-mode']).toBe('maintenance');
+    expect(res.body.status).toBe('ok');
+  });
+
+  it('blocks non-allowlisted GET with retry-after', async () => {
+    const res = await request(app).get('/lines/open?service=ingest');
+    expect(res.status).toBe(503);
+    expect(res.headers['x-autopal-mode']).toBe('maintenance');
+    expect(res.headers['retry-after']).toBe('60');
+    expect(res.body).toMatchObject({
+      code: 'maintenance_mode',
+      message: 'AutoPal is paused by ops.',
+      hint: 'Try again later or use runbooks.',
+      runbook: 'https://runbooks/autopal/maintenance',
+    });
+  });
+
+  it('blocks secret resolution with specific message', async () => {
+    const res = await request(app).post('/secrets/resolve');
+    expect(res.status).toBe(503);
+    expect(res.headers['x-autopal-mode']).toBe('maintenance');
+    expect(res.headers['retry-after']).toBeUndefined();
+    expect(res.body).toEqual({
+      code: 'maintenance_mode',
+      message: 'Secret operations are disabled by the global switch.',
+    });
+  });
+
+  it('blocks materialization with 403', async () => {
+    const res = await request(app).post('/secrets/materialize');
+    expect(res.status).toBe(403);
+    expect(res.headers['x-autopal-mode']).toBe('maintenance');
+    expect(res.headers['retry-after']).toBeUndefined();
+    expect(res.body).toEqual({
+      code: 'materialize_disabled',
+      message: 'Token minting disabled (global switch).',
+    });
+  });
+
+  it('blocks fossil overrides with custom message', async () => {
+    const res = await request(app).post('/fossil/override');
+    expect(res.status).toBe(503);
+    expect(res.headers['x-autopal-mode']).toBe('maintenance');
+    expect(res.headers['retry-after']).toBeUndefined();
+    expect(res.body).toEqual({
+      code: 'maintenance_mode',
+      message: 'Overrides are disabled while AutoPal is paused.',
+    });
+  });
+
+  it('blocks unknown paths with maintenance payload', async () => {
+    const res = await request(app).get('/totally/unknown');
+    expect(res.status).toBe(503);
+    expect(res.headers['x-autopal-mode']).toBe('maintenance');
+    expect(res.headers['retry-after']).toBe('60');
+    expect(res.body).toMatchObject({
+      code: 'maintenance_mode',
+      message: 'AutoPal is paused by ops.',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable maintenance configuration loader and guard middleware for the AutoPal global switch
- expose /health/live and /health/ready endpoints that stay available when maintenance mode is active
- cover maintenance responses with a focused Jest test to lock in the contract

## Testing
- ❌ `npx jest --runTestsByPath tests/maintenance_mode.test.js` *(fails: npm cannot reach the verdaccio.internal registry to download jest)*

------
https://chatgpt.com/codex/tasks/task_e_68e17f0db2288329bff0d78f7b2b3762