### PR TITLE
Add multi-provider rule updates and docs generator

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,26 +1,33 @@
-name: dbt-docs
-
+name: build-docs
 on:
   push:
-    branches: [main]
-
+    branches: ["main"]
+    paths:
+      - "rules/**"
+      - "compliance/cmd/ruledocs/**"
+      - "compliance/harness/**"
 jobs:
-  build-publish:
+  docs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-go@v5
         with:
-          python-version: '3.11'
-      - run: pip install dbt-snowflake
-      - run: dbt deps
-      - run: dbt docs generate --profiles-dir .
-        env:
-          SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
-          SNOWFLAKE_USER: ${{ secrets.SNOWFLAKE_USER }}
-          SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
-      - name: Publish
-        uses: peaceiris/actions-gh-pages@v3
+          go-version: "1.22"
+      - run: make docs
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: target
+          path: docs
+  deploy:
+    needs: docs
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .RECIPEPREFIX = >
-.PHONY: setup test lint demo validate dc-up dc-test dc-shell build run deploy preview-destroy
+.PHONY: setup test lint demo validate dc-up dc-test dc-shell build run deploy preview-destroy docs
 
 setup:
 >python -m venv .venv && . .venv/bin/activate && pip install -U pip pytest jsonschema ruff
@@ -48,3 +48,6 @@ dc-test:
 
 dc-shell:
 >docker compose run --rm app bash
+
+docs:
+>cd compliance && go run ./cmd/ruledocs ../rules ../docs/rules

--- a/compliance/cmd/ruledocs/main.go
+++ b/compliance/cmd/ruledocs/main.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"html/template"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/blackroad/prism-console/compliance/harness"
+)
+
+const mdTemplate = `---
+title: "{{ .Name }}"
+rule_id: "{{ .RuleID }}"
+category: "{{ .Category }}"
+severity: "{{ .Severity }}"
+version: {{ .Version }}
+owners:
+{{- if .Owners }}
+{{- range .Owners }}
+  - "{{ . }}"
+{{- end }}
+{{- else }}
+  []
+{{- end }}
+---
+
+# {{ .Name }}
+
+**Rule ID:** ` + "`{{ .RuleID }}`" + `  
+**Category:** {{ .Category }}  
+**Severity:** {{ .Severity }}  
+**Version:** {{ .Version }}
+
+{{- if .Description }}
+## What it does
+{{ .Description }}
+{{- end }}
+
+{{- if .OnMatch.Decision }}
+## Decision on match
+- **decision:** ` + "`{{ .OnMatch.Decision }}`" + `
+{{- if .OnMatch.Reason }}
+- **reason:** ` + "`{{ .OnMatch.Reason }}`" + `
+{{- end }}
+{{- if .OnMatch.Details }}
+{{- if index .OnMatch.Details "message" }}
+- **message:** {{ index .OnMatch.Details "message" }}
+{{- end }}
+{{- if index .OnMatch.Details "remediation" }}
+- **remediation:** {{ index .OnMatch.Details "remediation" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+## Inputs
+{{- if .InputsSchema }}
+{{- range .InputsSchema }}
+- ` + "`{{ .Name }}`" + `{{ if .Description }} — {{ .Description }}{{ end }}
+{{- end }}
+{{- else }}
+- _No explicit schema provided._
+{{- end }}
+
+{{- if .Expr }}
+## Expression
+{{ fence "cel" }}
+{{ .Expr }}
+{{ fence "" }}
+{{- end }}
+
+{{- if .MetricsSelector }}
+## Metrics selectors
+{{- range $key := sortedKeys .MetricsSelector }}
+- **{{ $key }}**
+{{ fence "" }}
+{{ index $.MetricsSelector $key }}
+{{ fence "" }}
+{{- end }}
+{{- end }}
+
+## Examples
+{{- if .Tests }}
+{{- range .Tests }}
+- **{{ .Name }}**{{ if .GUID }} (` + "`{{ .GUID }}`" + `){{ end }}
+{{- if .Fixture }}
+  - Fixture: ` + "`{{ .Fixture }}`" + `
+{{- end }}
+{{- if .Window }}
+  - Window: ` + "`{{ .Window }}`" + `
+{{- end }}
+{{- if .Series }}
+  - Series:
+{{ fence "json" }}
+{{ toJSON .Series }}
+{{ fence "" }}
+{{- end }}
+{{- if .Input }}
+  - Input:
+{{ fence "json" }}
+{{ toJSON .Input }}
+{{ fence "" }}
+{{- end }}
+{{- if .Want }}
+  - Expected:
+{{ fence "json" }}
+{{ toJSON .Want }}
+{{ fence "" }}
+{{- end }}
+{{- end }}
+{{- else }}
+- _No example tests defined._
+{{- end }}
+
+{{- if .Owners }}
+## Ownership
+{{- range .Owners }}
+- {{ . }}
+{{- end }}
+{{- end }}
+
+{{- if .DocsURL }}
+[Documentation]({{ .DocsURL }})
+{{- end }}
+`
+
+func main() {
+	if len(os.Args) != 3 {
+		log.Fatalf("usage: ruledocs <rules_dir> <out_dir>")
+	}
+
+	rulesDir := os.Args[1]
+	outDir := os.Args[2]
+
+	entries, err := os.ReadDir(rulesDir)
+	if err != nil {
+		log.Fatalf("read rules dir: %v", err)
+	}
+
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		log.Fatalf("create output dir: %v", err)
+	}
+
+	tpl := template.Must(template.New("rulemd").Funcs(template.FuncMap{
+		"toJSON":     harness.ToJSON,
+		"sortedKeys": sortedKeys,
+		"fence":      fence,
+	}).Parse(mdTemplate))
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if !strings.HasSuffix(entry.Name(), ".yaml") && !strings.HasSuffix(entry.Name(), ".yml") {
+			continue
+		}
+		path := filepath.Join(rulesDir, entry.Name())
+		spec, err := harness.LoadRuleYAML(path)
+		if err != nil {
+			log.Fatalf("parse %s: %v", entry.Name(), err)
+		}
+
+		var buf bytes.Buffer
+		if err := tpl.Execute(&buf, spec); err != nil {
+			log.Fatalf("render %s: %v", entry.Name(), err)
+		}
+
+		fname := fmt.Sprintf("%s.md", spec.RuleID)
+		if spec.RuleID == "" {
+			fname = strings.TrimSuffix(entry.Name(), filepath.Ext(entry.Name())) + ".md"
+		}
+		outPath := filepath.Join(outDir, fname)
+		if err := os.WriteFile(outPath, buf.Bytes(), 0o644); err != nil {
+			log.Fatalf("write %s: %v", outPath, err)
+		}
+		log.Printf("wrote %s", outPath)
+	}
+}
+
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func fence(lang string) string {
+	if lang == "" {
+		return "```"
+	}
+	return "```" + lang
+}

--- a/compliance/go.mod
+++ b/compliance/go.mod
@@ -5,6 +5,7 @@ go 1.21
 require (
 	github.com/google/cel-go v0.17.7
 	google.golang.org/genproto/googleapis/api v0.0.0-20230525234035-dd9d682886f9
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/compliance/go.sum
+++ b/compliance/go.sum
@@ -27,6 +27,9 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20230525234030-28d5490b6b19/go.
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
 google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/compliance/harness/cel_env_extras.go
+++ b/compliance/harness/cel_env_extras.go
@@ -1,0 +1,46 @@
+package harness
+
+import (
+	"time"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/interpreter/functions"
+)
+
+// DistinctExtras exposes a CEL helper that returns the count of distinct values
+// for the supplied field over a rolling window backed by the WindowStore.
+func DistinctExtras(store *WindowStore) cel.ProgramOption {
+	return cel.Functions(
+		&functions.Overload{
+			Operator: "distinct_over_field_window",
+			Binary: func(lhs, rhs ref.Val) ref.Val {
+				field, ok := lhs.Value().(string)
+				if !ok {
+					return types.NewErr("distinct_over: field argument must be a string")
+				}
+
+				windowText, ok := rhs.Value().(string)
+				if !ok {
+					return types.NewErr("distinct_over: window argument must be a duration string")
+				}
+
+				win, err := time.ParseDuration(windowText)
+				if err != nil {
+					return types.NewErr("distinct_over: invalid window %q", windowText)
+				}
+
+				events := store.Snapshot(win, time.Now().UTC())
+				seen := make(map[any]struct{}, len(events))
+				for _, event := range events {
+					if value, ok := event[field]; ok {
+						seen[value] = struct{}{}
+					}
+				}
+
+				return types.Int(int64(len(seen)))
+			},
+		},
+	)
+}

--- a/compliance/harness/spec.go
+++ b/compliance/harness/spec.go
@@ -1,0 +1,195 @@
+package harness
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// RuleSpec captures the superset of attributes supported by policy rule YAML.
+type RuleSpec struct {
+	RuleID          string            `yaml:"rule_id"`
+	LegacyID        string            `yaml:"id"`
+	Name            string            `yaml:"name"`
+	Category        string            `yaml:"category"`
+	Mode            string            `yaml:"mode"`
+	Canary          bool              `yaml:"canary"`
+	Severity        string            `yaml:"severity"`
+	Version         int               `yaml:"version"`
+	Description     string            `yaml:"description"`
+	Metadata        map[string]any    `yaml:"metadata"`
+	InputsSchema    []InputField      `yaml:"inputs_schema"`
+	OutputType      string            `yaml:"output_type"`
+	Expr            string            `yaml:"expr"`
+	MetricsSelector map[string]string `yaml:"metrics_selector"`
+	OnMatch         DecisionBlock     `yaml:"on_match"`
+	Notify          NotifyBlock       `yaml:"notify"`
+	Owners          []string          `yaml:"owners"`
+	DocsURL         string            `yaml:"docs_url"`
+	Tests           []RuleTest        `yaml:"tests"`
+	Comments        []string          `yaml:"comments"`
+
+	Source string `yaml:"-"`
+}
+
+// InputField documents an individual attribute required by the rule.
+type InputField struct {
+	Name        string `yaml:"name"`
+	Type        string `yaml:"type"`
+	Description string `yaml:"description"`
+}
+
+// DecisionBlock describes the decision emitted when a rule matches.
+type DecisionBlock struct {
+	Decision string            `yaml:"decision"`
+	Reason   string            `yaml:"reason"`
+	Details  map[string]string `yaml:"details"`
+}
+
+// NotifyBlock describes downstream notification hooks for the rule.
+type NotifyBlock struct {
+	Channels []string `yaml:"channels"`
+}
+
+// RuleTest models a single test case as defined in the YAML file.
+type RuleTest struct {
+	Name    string         `yaml:"name"`
+	GUID    string         `yaml:"guid"`
+	Fixture string         `yaml:"fixture"`
+	Window  string         `yaml:"window"`
+	Series  any            `yaml:"series"`
+	Input   map[string]any `yaml:"input"`
+	Want    any            `yaml:"want"`
+}
+
+// LoadRuleYAML parses a rule specification from disk and performs normalization
+// so downstream tooling can operate on both legacy and modern schemas.
+func LoadRuleYAML(path string) (*RuleSpec, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("load rule: %w", err)
+	}
+
+	var spec RuleSpec
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		return nil, fmt.Errorf("parse rule yaml: %w", err)
+	}
+
+	spec.Source = path
+	spec.normalize()
+	return &spec, nil
+}
+
+func (r *RuleSpec) normalize() {
+	if r.RuleID == "" {
+		r.RuleID = r.LegacyID
+	}
+	if r.Name == "" {
+		if summary, ok := r.MetadataValue("summary").(string); ok {
+			r.Name = summary
+		} else if desc, ok := r.MetadataValue("description").(string); ok {
+			r.Name = desc
+		} else if r.RuleID != "" {
+			r.Name = r.RuleID
+		}
+	}
+	if r.Category == "" {
+		if r.Mode != "" {
+			r.Category = strings.ToLower(r.Mode)
+		} else if r.OnMatch.Decision != "" {
+			r.Category = "enforce"
+		}
+	}
+	if r.Description == "" {
+		if desc, ok := r.MetadataValue("description").(string); ok {
+			r.Description = desc
+		}
+	}
+	if r.Severity == "" {
+		if sev, ok := r.MetadataValue("severity").(string); ok {
+			r.Severity = sev
+		}
+	}
+	if r.Version == 0 {
+		switch v := r.MetadataValue("version").(type) {
+		case int:
+			if v > 0 {
+				r.Version = v
+			}
+		case int64:
+			if v > 0 {
+				r.Version = int(v)
+			}
+		case float64:
+			if v > 0 {
+				r.Version = int(v)
+			}
+		}
+		if r.Version == 0 {
+			r.Version = 1
+		}
+	}
+	r.Severity = strings.ToLower(r.Severity)
+	if r.Category != "" {
+		r.Category = strings.ToLower(r.Category)
+	}
+	if r.OnMatch.Decision == "" {
+		switch strings.ToLower(r.Mode) {
+		case "enforce":
+			r.OnMatch.Decision = "deny"
+		case "observe":
+			r.OnMatch.Decision = "notify"
+		}
+	}
+	if len(r.Owners) == 0 {
+		if owners, ok := r.MetadataValue("owners").([]any); ok {
+			extracted := make([]string, 0, len(owners))
+			for _, raw := range owners {
+				if s, ok := raw.(string); ok {
+					extracted = append(extracted, s)
+				}
+			}
+			r.Owners = extracted
+		}
+	}
+}
+
+// MetadataValue fetches a metadata attribute defensively.
+func (r *RuleSpec) MetadataValue(key string) any {
+	if r.Metadata == nil {
+		return nil
+	}
+	return r.Metadata[key]
+}
+
+// SortedMetricKeys returns a stable ordering of metrics selector keys to ease
+// deterministic template rendering.
+func (r *RuleSpec) SortedMetricKeys() []string {
+	keys := make([]string, 0, len(r.MetricsSelector))
+	for k := range r.MetricsSelector {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// ToJSON renders the provided value as pretty JSON with HTML escaping disabled
+// so it can be embedded directly into Markdown templates.
+func ToJSON(v any) string {
+	if v == nil {
+		return "{}"
+	}
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(v); err != nil {
+		return "{}"
+	}
+	return strings.TrimSpace(buf.String())
+}

--- a/compliance/harness/window_store.go
+++ b/compliance/harness/window_store.go
@@ -1,0 +1,67 @@
+package harness
+
+import (
+	"sync"
+	"time"
+)
+
+// TimedEvent tracks an individual event and the timestamp used for window
+// calculations. The event payload is stored as a shallow copy of the input map
+// to avoid accidental mutation by callers after insertion.
+type TimedEvent struct {
+	Timestamp time.Time
+	Fields    map[string]any
+}
+
+// WindowStore provides a minimal in-memory buffer of recent events for helper
+// functions such as distinct_over(). It is deliberately simple for harness
+// usage and does not implement eviction beyond the Snapshot window filter.
+type WindowStore struct {
+	mu     sync.RWMutex
+	events []TimedEvent
+}
+
+// NewWindowStore creates an empty store ready for event ingestion.
+func NewWindowStore() *WindowStore {
+	return &WindowStore{}
+}
+
+// Add records an event at the provided timestamp. Callers are responsible for
+// supplying timestamps in UTC to keep comparisons consistent.
+func (s *WindowStore) Add(ts time.Time, event map[string]any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	clone := make(map[string]any, len(event))
+	for k, v := range event {
+		clone[k] = v
+	}
+
+	s.events = append(s.events, TimedEvent{Timestamp: ts, Fields: clone})
+}
+
+// Snapshot returns all events that fall within the provided rolling window
+// ending at the supplied reference time.
+func (s *WindowStore) Snapshot(window time.Duration, now time.Time) []map[string]any {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if window < 0 {
+		window = 0
+	}
+
+	cutoff := now.Add(-window)
+	results := make([]map[string]any, 0, len(s.events))
+	for _, event := range s.events {
+		if event.Timestamp.Before(cutoff) {
+			continue
+		}
+		clone := make(map[string]any, len(event.Fields))
+		for k, v := range event.Fields {
+			clone[k] = v
+		}
+		results = append(results, clone)
+	}
+
+	return results
+}

--- a/docs/rules/.gitignore
+++ b/docs/rules/.gitignore
@@ -1,0 +1,2 @@
+# Generated rule documentation
+*.md

--- a/rules/multi_provider_single_role.yaml
+++ b/rules/multi_provider_single_role.yaml
@@ -1,25 +1,72 @@
-id: MULTI_PROVIDER_SINGLE_ROLE
-mode: enforce
-severity: medium
-block_on_error: true
-metadata:
-  product: Mirror Guard
-  description: Block low-privilege users from fanning out mirrors across providers.
-  block_message: "Blocked by policy MULTI_PROVIDER_SINGLE_ROLE. Reason: low-role user touched multiple providers in 5m window."
-expr: action in ["mirror", "pr.create"] && user_role in ["viewer", "contributor"] && distinct_over("resource_provider", "5m") >= 2
+rule_id: "MULTI_PROVIDER_SINGLE_ROLE-2f7a2f54-2c2e-4a66-9c8d-0d3b94f88c2b"
+name: "Block high-impact actions across multiple providers on low role"
+category: "enforce"
+canary: true
+severity: "med"
+version: 1
+description: >
+  If a user with a low role (viewer/contributor) attempts high-impact actions
+  (mirror, pr.create) across ≥2 providers within 5 minutes, flag and (post-canary) block.
+inputs_schema:
+  - name: user_id
+  - name: user_role
+  - name: action
+  - name: resource_provider
+  - name: ts
+output_type: "json"
+expr: |
+  (action == "mirror" || action == "pr.create") &&
+  (user_role == "viewer" || user_role == "contributor") &&
+  distinct_over("resource_provider", "5m") >= 2
+metrics_selector:
+  prom: |
+    (
+      sum(count_over_time(audit_actions_total{action=~"mirror|pr.create",user_role=~"viewer|contributor"}[{{window}}])
+          by (user_id, resource_provider) > 0)
+      by (user_id)
+    ) >= 2
+  ch: |
+    SELECT user_id
+    FROM audit_events
+    WHERE ts >= now() - INTERVAL {{window}}
+      AND action IN ('mirror','pr.create')
+      AND user_role IN ('viewer','contributor')
+    GROUP BY user_id
+    HAVING uniqExact(resource_provider) >= 2
+on_match:
+  decision: "deny"
+  reason: "multi_provider_single_role"
+  details:
+    message: "High-impact actions across providers by low role."
+    remediation: "Escalate role or restrict to a single provider for this task."
+notify:
+  channels: ["slack:#secops"]
+owners: ["@oncall-security", "security@company.com"]
+docs_url: "https://your.docs/policies/multi_provider_single_role"
 tests:
-  - name: viewer_multi_provider_blocks
-    fixture: multi/multi_provider_window.series.json
-    want: true
-  - name: contributor_single_provider_allows
-    window: "5m"
+  - name: "two_providers_low_role"
+    guid: "c8b2f1b6-2082-4d2d-a6a9-0e1dc6a3a0c7"
     series:
-      - { action: "mirror", resource_provider: "github", user_role: "contributor" }
-      - { action: "mirror", resource_provider: "github", user_role: "contributor" }
-    want: false
-  - name: admin_multi_provider_allows
-    window: "5m"
+      window: "5m"
+      events:
+        - {user_id: 101, user_role: "viewer", action: "mirror", resource_provider: "github"}
+        - {user_id: 101, user_role: "viewer", action: "mirror", resource_provider: "gitlab"}
+    want: {decision: "deny", reason: "multi_provider_single_role"}
+  - name: "same_provider_ok"
+    guid: "b2bfae85-7a1e-4a8d-8c0a-2b2f9a1c1d33"
     series:
-      - { action: "mirror", resource_provider: "github", user_role: "admin" }
-      - { action: "mirror", resource_provider: "gitlab", user_role: "admin" }
-    want: false
+      window: "5m"
+      events:
+        - {user_id: 202, user_role: "viewer", action: "mirror", resource_provider: "github"}
+        - {user_id: 202, user_role: "viewer", action: "pr.create", resource_provider: "github"}
+    want: {decision: "allow", reason: ""}
+  - name: "higher_role_ok"
+    guid: "2b6c8b44-3d7b-4b12-9b63-55c6ad1c2ea1"
+    series:
+      window: "5m"
+      events:
+        - {user_id: 303, user_role: "maintainer", action: "mirror", resource_provider: "github"}
+        - {user_id: 303, user_role: "maintainer", action: "mirror", resource_provider: "gitlab"}
+    want: {decision: "allow", reason: ""}
+comments:
+  - "Keep canary=true for a week to measure noise; then flip."


### PR DESCRIPTION
## Summary
- add the multi-provider single-role rule with metrics selectors, tests, and on-match metadata
- build a harness package with YAML loading, window store helpers, and a docs CLI that emits rule pages
- wire a docs make target and workflow to publish generated rule documentation

## Testing
- go test ./harness
- go test ./cmd/...


------
https://chatgpt.com/codex/tasks/task_e_68e181ca13808329965b7fff12c72af7