### PR TITLE
Add Pi stack v2 automation and Mac control server

### DIFF
--- a/agent/mac/__init__.py
+++ b/agent/mac/__init__.py
@@ -1,0 +1,1 @@
+"""Utilities for running the BlackRoad control server on macOS."""

--- a/agent/mac/api.py
+++ b/agent/mac/api.py
@@ -1,0 +1,77 @@
+"""FastAPI application exposing local controls for Pi-Holo and Pi-Sim."""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from fastapi import Body, FastAPI, HTTPException, Query
+from pydantic import BaseModel, ValidationError
+
+from agent.mac.mqtt import publish_payload
+from agent.mac.validators import build_holo_text_payload, build_sim_panel_payload
+
+app = FastAPI(title="BlackRoad Mac Control API", version="2.0.0")
+
+
+@app.get("/ping")
+def ping() -> Dict[str, Any]:
+    """Return a simple readiness response."""
+    return {"ok": True, "message": "pong"}
+
+
+@app.post("/holo/text")
+def holo_text(
+    text: str = Query(..., min_length=1, max_length=512),
+    duration_ms: int = Query(4000, ge=250, le=600_000),
+    size: int = Query(64, ge=8, le=256),
+    effect: Optional[str] = Query(None, max_length=64),
+    topic: str = Query("holo/text", min_length=1),
+) -> Dict[str, Any]:
+    """Send a text command to the holographic display."""
+    payload = build_holo_text_payload(text=text, duration_ms=duration_ms, size=size, effect=effect)
+    publish_payload(topic, payload)
+    return {"ok": True, "topic": topic, "payload": payload}
+
+
+class PanelLineModel(BaseModel):
+    text: str
+    icon: Optional[str] = None
+
+    class Config:
+        anystr_strip_whitespace = True
+
+
+class PanelRequest(BaseModel):
+    panel_id: str
+    lines: List[PanelLineModel]
+    duration_ms: Optional[int] = None
+    accent: Optional[str] = None
+    brightness: Optional[int] = None
+    topic: str = "sim/panel"
+
+    class Config:
+        anystr_strip_whitespace = True
+
+
+@app.post("/sim/panel")
+def sim_panel(request: PanelRequest = Body(...)) -> Dict[str, Any]:
+    """Update the simulator panel with validated content."""
+    try:
+        payload = build_sim_panel_payload(
+            panel_id=request.panel_id,
+            lines=[line.dict(exclude_none=True) for line in request.lines],
+            duration_ms=request.duration_ms,
+            accent=request.accent,
+            brightness=request.brightness,
+        )
+    except ValidationError as exc:
+        raise HTTPException(status_code=400, detail=exc.errors()) from exc
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    publish_payload(request.topic, payload)
+    return {"ok": True, "topic": request.topic, "payload": payload}
+
+
+@app.get("/healthz")
+def healthcheck() -> Dict[str, Any]:
+    """Compatibility endpoint mirroring the primary agent."""
+    return {"ok": True}

--- a/agent/mac/mqtt.py
+++ b/agent/mac/mqtt.py
@@ -1,0 +1,39 @@
+"""MQTT publishing helpers for the macOS control server."""
+from __future__ import annotations
+
+import json
+import os
+import ssl
+from typing import Any, Dict, Optional
+
+from paho.mqtt import publish as mqtt_publish
+
+
+def _tls_config() -> Optional[Dict[str, Any]]:
+    flag = os.environ.get("MQTT_TLS", "").lower()
+    if flag not in {"1", "true", "yes"}:
+        return None
+    ca_file = os.environ.get("MQTT_CA_FILE")
+    tls: Dict[str, Any] = {"cert_reqs": ssl.CERT_REQUIRED}
+    if ca_file:
+        tls["ca_certs"] = ca_file
+    return tls
+
+
+def publish_payload(topic: str, payload: Dict[str, Any]) -> None:
+    """Publish a payload to the configured MQTT broker."""
+    host = os.environ.get("MQTT_HOST", "localhost")
+    port = int(os.environ.get("MQTT_PORT", "1883"))
+    auth = None
+    username = os.environ.get("MQTT_USERNAME")
+    if username:
+        auth = {"username": username, "password": os.environ.get("MQTT_PASSWORD")}
+    mqtt_publish.single(
+        topic,
+        json.dumps(payload, ensure_ascii=False),
+        hostname=host,
+        port=port,
+        auth=auth,
+        keepalive=int(os.environ.get("MQTT_KEEPALIVE", "60")),
+        tls=_tls_config(),
+    )

--- a/agent/mac/validators.py
+++ b/agent/mac/validators.py
@@ -1,0 +1,54 @@
+"""Validate payloads before publishing to MQTT."""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field, validator
+
+
+class HoloTextPayload(BaseModel):
+    """Schema for holographic text commands."""
+
+    text: str = Field(..., min_length=1, max_length=512)
+    duration_ms: int = Field(4000, ge=250, le=600_000)
+    size: int = Field(64, ge=8, le=256)
+    effect: Optional[str] = Field(default=None, max_length=64)
+
+
+class PanelLine(BaseModel):
+    """Single line of text for the simulator panel."""
+
+    text: str = Field(..., min_length=1, max_length=96)
+    icon: Optional[str] = Field(default=None, max_length=32)
+
+
+class SimPanelPayload(BaseModel):
+    """Payload describing a simulator panel update."""
+
+    panel_id: str = Field(..., min_length=1, max_length=32)
+    lines: List[PanelLine]
+    duration_ms: int = Field(5000, ge=500, le=600_000)
+    accent: Optional[str] = Field(default=None, regex=r"^#[0-9A-Fa-f]{6}$")
+    brightness: Optional[int] = Field(default=None, ge=0, le=100)
+
+    @validator("lines", pre=True)
+    def _coerce_lines(cls, value: Any) -> List[PanelLine]:  # noqa: N805
+        if isinstance(value, dict):
+            raise TypeError("lines must be a list of objects")
+        return value
+
+
+def build_holo_text_payload(**kwargs: Any) -> Dict[str, Any]:
+    """Return a validated hologram payload."""
+    payload = HoloTextPayload(**kwargs)
+    data = payload.dict(exclude_none=True)
+    return data
+
+
+def build_sim_panel_payload(**kwargs: Any) -> Dict[str, Any]:
+    """Return a validated simulator panel payload."""
+    payload = SimPanelPayload(**kwargs)
+    data = payload.dict(exclude_none=True)
+    # Convert lines back to list of dicts for JSON serialization
+    data["lines"] = [line.dict(exclude_none=True) for line in payload.lines]
+    return data

--- a/docs/pi/stack_v2.md
+++ b/docs/pi/stack_v2.md
@@ -1,0 +1,47 @@
+# Pi Stack v2 Upgrade Notes
+
+This bundle includes the automation for promoting the bench setup into a fully networked "living system". Use it in tandem with the existing Day 1 setup guide.
+
+## Display Config Templates
+
+Templates for /boot/config.txt live in `pis/display-configs/`:
+
+- `720x720_config.txt` for the square hologram panel.
+- `1600x600_config.txt` for the ultrawide dashboard panel.
+- `1024x600_config.txt` for the 9.3" status panel.
+
+Copy the desired block into `/boot/config.txt`, reboot, and then tune brightness/rotation as needed.
+
+## Heartbeat Services
+
+`pis/heartbeat.py` emits temperature, uptime, load averages, memory, and disk data to MQTT. It publishes to `system/heartbeat/<node>` every 30 seconds by default.
+
+Installer scripts:
+
+- `scripts/push_pi_holo.sh` uploads the heartbeat publisher to `pi-holo.local` and enables the service.
+- `scripts/push_pi_sim.sh` does the same for `pi-sim.local`.
+- Both wrap `scripts/install_pi_node.sh`, which creates a virtualenv, installs dependencies, and sets up the systemd unit.
+
+The Pi-Ops node collects these heartbeats via `pis/pi-ops/hb_log.py`. Push `scripts/install_pi_ops.sh` and `pis/pi-ops/hb_log.py` to `pi-ops.local`, then run the installer to provision Mosquitto, Samba, and the logging service.
+
+## macOS Control Server
+
+Run `python agent/mac/api.py` inside your agent virtualenv to expose:
+
+- `GET /ping` – health check used during bring-up.
+- `POST /holo/text` – send validated text to the hologram display.
+- `POST /sim/panel` – update the simulator panel payload.
+
+The server uses the MQTT payload validator in `agent/mac/validators.py` and the publisher helper in `agent/mac/mqtt.py` to lint every message before it leaves the laptop.
+
+## Validation Flow
+
+Every command passes through the Pydantic validators before it hits MQTT. Any malformed payload yields a `400` with validation errors so you can fix the command before it reaches hardware.
+
+## Quick Start
+
+1. Copy `scripts/install_pi_ops.sh` and `pis/pi-ops/hb_log.py` to the Pi-Ops host and run the installer.
+2. Execute `scripts/push_pi_holo.sh` and `scripts/push_pi_sim.sh` from your workstation to deploy heartbeat publishers.
+3. Activate the agent virtualenv on macOS and start `agent/mac/api.py` (FastAPI + Uvicorn) to drive `/holo/text` and `/sim/panel` endpoints.
+
+This aligns with the "fast path" checklist in the release notes.

--- a/pis/display-configs/1024x600_config.txt
+++ b/pis/display-configs/1024x600_config.txt
@@ -1,0 +1,13 @@
+# Raspberry Pi display configuration template for 1024x600 IPS panels
+# Copy these directives into /boot/config.txt and reboot to apply.
+
+hdmi_force_hotplug=1
+hdmi_group=2
+hdmi_mode=87
+hdmi_cvt=1024 600 60 1 0 0 0
+framebuffer_width=1024
+framebuffer_height=600
+max_framebuffer_width=1024
+max_framebuffer_height=600
+# Optional rotation
+# display_rotate=1

--- a/pis/display-configs/1600x600_config.txt
+++ b/pis/display-configs/1600x600_config.txt
@@ -1,0 +1,13 @@
+# Raspberry Pi display configuration template for 1600x600 ultrawide panels
+# Copy these directives into /boot/config.txt and reboot to apply.
+
+hdmi_force_hotplug=1
+hdmi_group=2
+hdmi_mode=87
+hdmi_cvt=1600 600 60 1 0 0 0
+framebuffer_width=1600
+framebuffer_height=600
+max_framebuffer_width=1600
+max_framebuffer_height=600
+# Optional rotation
+# display_rotate=1

--- a/pis/display-configs/720x720_config.txt
+++ b/pis/display-configs/720x720_config.txt
@@ -1,0 +1,13 @@
+# Raspberry Pi display configuration template for 720x720 square panels
+# Copy these directives into /boot/config.txt and reboot to apply.
+
+hdmi_force_hotplug=1
+hdmi_group=2
+hdmi_mode=87
+hdmi_cvt=720 720 60 1 0 0 0
+framebuffer_width=720
+framebuffer_height=720
+max_framebuffer_width=720
+max_framebuffer_height=720
+# Optional: rotate display if mounted in portrait orientation
+# display_rotate=1

--- a/pis/heartbeat.py
+++ b/pis/heartbeat.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Publish Raspberry Pi heartbeat telemetry over MQTT."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import sys
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, Optional
+
+import psutil
+from paho.mqtt import client as mqtt
+
+
+def read_cpu_temperature() -> Optional[float]:
+    """Attempt to read the CPU temperature in Celsius."""
+    temps = psutil.sensors_temperatures(fahrenheit=False)
+    for key in ("cpu-thermal", "soc", "coretemp", "cpu_thermal"):
+        readings = temps.get(key)
+        if readings:
+            return float(readings[0].current)
+    thermal_zone = "/sys/class/thermal/thermal_zone0/temp"
+    try:
+        with open(thermal_zone, "r", encoding="utf-8") as handle:
+            raw = handle.read().strip()
+        return int(raw) / 1000.0
+    except (FileNotFoundError, ValueError):
+        return None
+
+
+def collect_metrics() -> Dict[str, Any]:
+    """Collect uptime, load, temperature, and memory usage data."""
+    uptime_seconds = int(time.time() - psutil.boot_time())
+    load1, load5, load15 = os.getloadavg()
+    memory = psutil.virtual_memory()
+    disk = psutil.disk_usage("/")
+    return {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "hostname": socket.gethostname(),
+        "uptime_seconds": uptime_seconds,
+        "load": {
+            "1m": round(load1, 2),
+            "5m": round(load5, 2),
+            "15m": round(load15, 2),
+        },
+        "memory": {
+            "total_mb": round(memory.total / 1024 / 1024, 2),
+            "used_mb": round(memory.used / 1024 / 1024, 2),
+            "percent": memory.percent,
+        },
+        "disk": {
+            "total_gb": round(disk.total / 1024 / 1024 / 1024, 2),
+            "used_gb": round(disk.used / 1024 / 1024 / 1024, 2),
+            "percent": disk.percent,
+        },
+        "cpu_temp_c": read_cpu_temperature(),
+    }
+
+
+def build_payload(node: str) -> Dict[str, Any]:
+    payload = collect_metrics()
+    payload["node"] = node
+    return payload
+
+
+def create_client(args: argparse.Namespace) -> mqtt.Client:
+    client = mqtt.Client()
+    if args.username:
+        client.username_pw_set(args.username, args.password or None)
+    return client
+
+
+def publish(client: mqtt.Client, topic: str, payload: Dict[str, Any]) -> None:
+    result = client.publish(topic, json.dumps(payload, ensure_ascii=False))
+    if result.rc != mqtt.MQTT_ERR_SUCCESS:
+        raise RuntimeError(f"Failed to publish heartbeat: {mqtt.error_string(result.rc)}")
+
+
+def parse_args(argv: Optional[Iterable[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--node", default=os.environ.get("NODE_NAME", "pi"), help="Node name appended to the heartbeat topic")
+    parser.add_argument("--mqtt-host", default=os.environ.get("MQTT_HOST", "pi-ops.local"))
+    parser.add_argument("--mqtt-port", type=int, default=int(os.environ.get("MQTT_PORT", "1883")))
+    parser.add_argument("--topic-base", default=os.environ.get("MQTT_TOPIC_BASE", "system/heartbeat"))
+    parser.add_argument("--interval", type=int, default=int(os.environ.get("HEARTBEAT_INTERVAL", "30")), help="Publish interval in seconds")
+    parser.add_argument("--username", default=os.environ.get("MQTT_USERNAME"))
+    parser.add_argument("--password", default=os.environ.get("MQTT_PASSWORD"))
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    args = parse_args(argv)
+    topic = f"{args.topic_base.rstrip('/')}/{args.node}"
+    client = create_client(args)
+    client.connect(args.mqtt_host, args.mqtt_port, keepalive=max(60, args.interval + 30))
+    client.loop_start()
+    try:
+        while True:
+            payload = build_payload(args.node)
+            publish(client, topic, payload)
+            time.sleep(args.interval)
+    except KeyboardInterrupt:
+        return 0
+    finally:
+        client.loop_stop()
+        client.disconnect()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pis/pi-ops/hb_log.py
+++ b/pis/pi-ops/hb_log.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""MQTT heartbeat logger for the Pi-Ops node."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import signal
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import paho.mqtt.client as mqtt
+
+LOGGER = logging.getLogger("pi_ops.heartbeat")
+
+
+def expand_path(path: str) -> Path:
+    """Resolve a user-provided path into a Path object."""
+    return Path(os.path.expanduser(path)).resolve()
+
+
+def ensure_log_dir(base: Path) -> Path:
+    """Create the logging directory if it does not already exist."""
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+class HeartbeatLogger:
+    """Subscribe to heartbeat topics and append JSONL logs."""
+
+    def __init__(self) -> None:
+        self.host = os.environ.get("MQTT_HOST", "localhost")
+        self.port = int(os.environ.get("MQTT_PORT", "1883"))
+        self.topic = os.environ.get("MQTT_TOPIC", "system/heartbeat/#")
+        log_dir = os.environ.get("HB_LOG_DIR", "~/pi-ops/logs")
+        self.log_dir = ensure_log_dir(expand_path(log_dir))
+        self.log_file = self.log_dir / "heartbeat.jsonl"
+        self.client = mqtt.Client()
+        username = os.environ.get("MQTT_USERNAME")
+        password = os.environ.get("MQTT_PASSWORD")
+        if username:
+            self.client.username_pw_set(username, password or None)
+        self.client.on_connect = self._on_connect
+        self.client.on_message = self._on_message
+
+    def start(self) -> None:
+        """Begin the MQTT loop and wait for incoming messages."""
+        LOGGER.info("Connecting to MQTT broker %s:%s", self.host, self.port)
+        self.client.connect(self.host, self.port, keepalive=60)
+        self.client.loop_start()
+        signal.signal(signal.SIGTERM, self._graceful_exit)
+        signal.signal(signal.SIGINT, self._graceful_exit)
+        # Block forever while the background loop handles callbacks
+        signal.pause()
+
+    def _graceful_exit(self, *_: Any) -> None:
+        LOGGER.info("Shutting down heartbeat logger")
+        self.client.loop_stop()
+        self.client.disconnect()
+        sys.exit(0)
+
+    def _on_connect(self, client: mqtt.Client, _userdata: Any, _flags: Any, rc: int) -> None:
+        if rc != 0:
+            LOGGER.error("MQTT connection failed with result code %s", rc)
+            sys.exit(1)
+        LOGGER.info("Connected to MQTT broker, subscribing to %s", self.topic)
+        client.subscribe(self.topic)
+
+    def _on_message(self, _client: mqtt.Client, _userdata: Any, msg: mqtt.MQTTMessage) -> None:
+        payload = self._parse_payload(msg.payload)
+        entry = {
+            "topic": msg.topic,
+            "received_at": datetime.now(timezone.utc).isoformat(),
+            "payload": payload,
+        }
+        with self.log_file.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(entry, ensure_ascii=False) + "\n")
+        LOGGER.debug("Logged heartbeat message from %s", msg.topic)
+
+    @staticmethod
+    def _parse_payload(raw: bytes) -> Any:
+        try:
+            text = raw.decode("utf-8")
+        except UnicodeDecodeError:
+            return {"raw": list(raw)}
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            return {"text": text}
+
+
+def configure_logging() -> None:
+    level = logging.INFO
+    if os.environ.get("HB_DEBUG"):
+        level = logging.DEBUG
+    logging.basicConfig(level=level, format="%(asctime)s [%(levelname)s] %(message)s")
+
+
+def main() -> None:
+    configure_logging()
+    HeartbeatLogger().start()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ matplotlib==3.9.4
 mpmath
 notion-client
 numpy==1.26.4
+paho-mqtt
 openai==1.30.1
 pydantic
 pyarrow==16.1.0

--- a/scripts/install_pi_node.sh
+++ b/scripts/install_pi_node.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Install the heartbeat publisher on a Raspberry Pi node.
+set -euo pipefail
+
+NODE_NAME=${1:-${NODE_NAME:-}}
+if [[ -z "$NODE_NAME" ]]; then
+  echo "Usage: NODE_NAME=<node> bash install_pi_node.sh" >&2
+  exit 1
+fi
+
+USER_NAME=${PI_USER:-pi}
+HOME_DIR=$(getent passwd "$USER_NAME" | cut -d: -f6)
+STACK_DIR="${HOME_DIR}/pi-stack"
+SCRIPT_SOURCE="${HOME_DIR}/heartbeat.py"
+VENV_DIR="${STACK_DIR}/.venv"
+MQTT_HOST=${MQTT_HOST:-pi-ops.local}
+SERVICE_NAME="pi-heartbeat.service"
+
+if [[ ! -f "$SCRIPT_SOURCE" ]]; then
+  echo "heartbeat.py must be uploaded to ${HOME_DIR} before running this installer" >&2
+  exit 1
+fi
+
+sudo apt-get update
+sudo apt-get install -y python3-venv python3-pip python3-psutil || true
+
+mkdir -p "$STACK_DIR"
+install -m 0755 "$SCRIPT_SOURCE" "${STACK_DIR}/heartbeat.py"
+
+python3 -m venv "$VENV_DIR"
+"${VENV_DIR}/bin/pip" install --upgrade pip
+"${VENV_DIR}/bin/pip" install paho-mqtt psutil
+
+cat <<SERVICE | sudo tee /etc/systemd/system/${SERVICE_NAME} >/dev/null
+[Unit]
+Description=Pi Heartbeat Publisher (${NODE_NAME})
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=${USER_NAME}
+Group=${USER_NAME}
+WorkingDirectory=${STACK_DIR}
+Environment=PYTHONUNBUFFERED=1
+Environment=NODE_NAME=${NODE_NAME}
+Environment=MQTT_HOST=${MQTT_HOST}
+ExecStart=${VENV_DIR}/bin/python ${STACK_DIR}/heartbeat.py --node ${NODE_NAME}
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+SERVICE
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now ${SERVICE_NAME}
+
+echo "Heartbeat publisher installed for ${NODE_NAME}."

--- a/scripts/install_pi_ops.sh
+++ b/scripts/install_pi_ops.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Bootstrap Mosquitto, Samba, and the heartbeat logger on pi-ops.
+set -euo pipefail
+
+USER_NAME=${PI_USER:-pi}
+HOME_DIR=$(getent passwd "$USER_NAME" | cut -d: -f6)
+INSTALL_DIR="${HOME_DIR}/pi-ops"
+VENV_DIR="${INSTALL_DIR}/.venv"
+SERVICE_NAME="pi-ops-heartbeat-logger.service"
+LOG_SOURCE="${HOME_DIR}/hb_log.py"
+
+if [[ ! -f "$LOG_SOURCE" ]]; then
+  SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+  if [[ -f "${SCRIPT_DIR}/hb_log.py" ]]; then
+    LOG_SOURCE="${SCRIPT_DIR}/hb_log.py"
+  else
+    echo "hb_log.py not found next to installer or in home directory" >&2
+    exit 1
+  fi
+fi
+
+sudo apt-get update
+sudo apt-get install -y mosquitto mosquitto-clients samba python3-venv python3-pip
+
+sudo systemctl enable --now mosquitto
+
+sudo mkdir -p "$INSTALL_DIR"
+sudo chown -R "$USER_NAME":"$USER_NAME" "$INSTALL_DIR"
+
+python3 -m venv "$VENV_DIR"
+"${VENV_DIR}/bin/pip" install --upgrade pip
+"${VENV_DIR}/bin/pip" install paho-mqtt
+
+install -m 0755 "$LOG_SOURCE" "${INSTALL_DIR}/hb_log.py"
+
+LOG_DIR="${INSTALL_DIR}/logs"
+mkdir -p "$LOG_DIR"
+
+cat <<SERVICE | sudo tee /etc/systemd/system/${SERVICE_NAME} >/dev/null
+[Unit]
+Description=Pi-Ops Heartbeat Logger
+After=network-online.target mosquitto.service
+Wants=network-online.target
+Requires=mosquitto.service
+
+[Service]
+Type=simple
+User=${USER_NAME}
+Group=${USER_NAME}
+WorkingDirectory=${INSTALL_DIR}
+Environment=PYTHONUNBUFFERED=1
+Environment=HB_LOG_DIR=${INSTALL_DIR}/logs
+ExecStart=${VENV_DIR}/bin/python ${INSTALL_DIR}/hb_log.py
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target
+SERVICE
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now ${SERVICE_NAME}
+
+echo "Heartbeat logger installed and running." 
+
+SHARE_DIR="${HOME_DIR}/share"
+mkdir -p "$SHARE_DIR"
+chmod 0775 "$SHARE_DIR"
+
+if ! grep -q "\[piops\]" /etc/samba/smb.conf; then
+  cat <<CONF | sudo tee -a /etc/samba/smb.conf >/dev/null
+[piops]
+   path = ${SHARE_DIR}
+   browseable = yes
+   read only = no
+   guest ok = yes
+   create mask = 0664
+   directory mask = 0775
+CONF
+fi
+
+sudo systemctl enable --now smbd nmbd
+
+echo "Samba share available at //$(hostname)/piops"

--- a/scripts/push_pi_holo.sh
+++ b/scripts/push_pi_holo.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Copy heartbeat tooling to pi-holo and install the service.
+set -euo pipefail
+
+HOST=${1:-pi-holo.local}
+MQTT_HOST=${MQTT_HOST:-pi-ops.local}
+
+scp pis/heartbeat.py scripts/install_pi_node.sh "pi@${HOST}:/home/pi/"
+ssh "pi@${HOST}" "MQTT_HOST=${MQTT_HOST} NODE_NAME=pi-holo bash /home/pi/install_pi_node.sh"

--- a/scripts/push_pi_sim.sh
+++ b/scripts/push_pi_sim.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Copy heartbeat tooling to pi-sim and install the service.
+set -euo pipefail
+
+HOST=${1:-pi-sim.local}
+MQTT_HOST=${MQTT_HOST:-pi-ops.local}
+
+scp pis/heartbeat.py scripts/install_pi_node.sh "pi@${HOST}:/home/pi/"
+ssh "pi@${HOST}" "MQTT_HOST=${MQTT_HOST} NODE_NAME=pi-sim bash /home/pi/install_pi_node.sh"


### PR DESCRIPTION
## Summary
- add display configuration templates and documentation for the Pi stack v2 rollout
- introduce heartbeat publishers for Pi-Holo/Pi-Sim and a Pi-Ops MQTT logging service with installation scripts
- ship a FastAPI-based Mac control server with MQTT payload validation and publishing helpers

## Testing
- python -m compileall agent/mac pis

------
https://chatgpt.com/codex/tasks/task_e_68e1827767b88329ad1b1ca3348bf03f