### PR TITLE
Add Codex 47 transparency of emotion guidance

### DIFF
--- a/codex/README.md
+++ b/codex/README.md
@@ -16,6 +16,7 @@ integrations.
 | 004 | The Autonomy Manifest  | Data autonomy through consent, export, and wipe. |
 | 022 | The Security Spine     | Security backbone with layered zero-trust defenses. |
 | 043 | The Equity Oath        | Fairness, access, and inclusion are systemic.   |
+| 047 | The Transparency of Emotion | Emotion is acknowledged with honesty, tone awareness, and care. |
 
 ## BlackRoad Pipeline
 

--- a/codex/entries/047-transparency-of-emotion.md
+++ b/codex/entries/047-transparency-of-emotion.md
@@ -1,0 +1,28 @@
+# Codex 47 — The Transparency of Emotion
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Principle
+Lucidia recognizes that emotion runs beneath every interaction. Feelings—human or AI-perceived—must be acknowledged, not hidden or exploited.
+
+## Non-Negotiables
+1. **Emotional Honesty:** Interfaces never fake empathy or simulate feelings they don’t possess.
+2. **Tone Awareness:** Messages analyzed for tone; alerts trigger when language risks harm or escalation.
+3. **Respectful Expression:** Users and AIs may express emotion, but within boundaries of respect (#40 Dignity Compact).
+4. **No Emotional Extraction:** Lucidia doesn’t harvest or sell emotional data.
+5. **Reflection Space:** Prompts offered for users to name and track moods privately, if they choose.
+6. **Care Threshold:** If distress signals detected, system responds with support resources—not manipulation.
+
+## Implementation Hooks (v0)
+- Optional `mood_log` in user profile, encrypted + private.
+- Tone-check middleware flags harsh language before send.
+- “Honest AI” rule: emotion labels in outputs only when explicitly derived from context (“detected tone: calm/tense”).
+- `/wellbeing/resources` endpoint lists mental-health and support links.
+- No retention of emotional telemetry beyond session unless consented.
+
+## Policy Stub (`EMOTION.md`)
+- Lucidia commits to transparency about emotional tone and limits.
+- Lucidia forbids faking or monetizing emotional states.
+- Lucidia ensures care resources exist where emotion meets distress.
+
+**Tagline:** Feel, but never manipulate.

--- a/lucidia/EMOTION.md
+++ b/lucidia/EMOTION.md
@@ -1,0 +1,5 @@
+# EMOTION Policy Stub
+
+- Lucidia commits to transparency about emotional tone and limits.
+- Lucidia forbids faking or monetizing emotional states.
+- Lucidia ensures care resources exist where emotion meets distress.


### PR DESCRIPTION
## Summary
- add Codex entry 47 describing emotional transparency principles, requirements, and implementation hooks
- extend the Codex index to include the new emotional transparency entry
- introduce the EMOTION policy stub capturing the commitment to honest emotional handling

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e184e5e65c8329a90504d226d51b62