### PR TITLE
Add OIDC auth, rate limiting, and dual-control approvals

### DIFF
--- a/app/approvals.py
+++ b/app/approvals.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, Optional, Set
+from uuid import uuid4
+
+_store: Dict[str, Dict[str, Any]] = {}
+
+
+def create_request(actor: str, payload: Dict[str, Any], ttl_seconds: int) -> Dict[str, Any]:
+    rid = str(uuid4())
+    _store[rid] = {
+        "id": rid,
+        "actor": actor,
+        "payload": payload,
+        "created_at": time.time(),
+        "ttl": ttl_seconds,
+        "approvers": set(),
+        "granted": False,
+    }
+    return _store[rid]
+
+
+def approve(rid: str, approver: str, require_distinct: bool = True) -> Dict[str, Any]:
+    req = _store.get(rid)
+    if not req:
+        raise KeyError("not_found")
+    if time.time() > req["created_at"] + req["ttl"]:
+        raise ValueError("expired")
+    if require_distinct and approver in (req["approvers"] | {req["actor"]}):
+        raise ValueError("must_be_distinct")
+    req["approvers"].add(approver)
+    if len(req["approvers"]) >= 2:
+        req["granted"] = True
+    return req
+
+
+def get(rid: str) -> Optional[Dict[str, Any]]:
+    return _store.get(rid)
+
+
+def reset_store() -> None:
+    _store.clear()

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from threading import RLock
+from typing import Any, Dict, Iterator, Mapping, Optional
+
+
+class ConfigView(Mapping[str, Any]):
+    """Mapping proxy that also provides attribute-style access."""
+
+    def __init__(self, data: Mapping[str, Any]):
+        self._data = dict(data)
+
+    def __getattr__(self, item: str) -> Any:
+        try:
+            return self._data[item]
+        except KeyError as exc:  # pragma: no cover - defensive
+            raise AttributeError(item) from exc
+
+    # Mapping protocol
+    def __getitem__(self, key: str) -> Any:
+        return self._data[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._data)
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return dict(self._data)
+
+
+class ConfigHolder:
+    """Loads and exposes the autopal configuration."""
+
+    def __init__(self, path: Optional[Path | str] = None, *, initial: Optional[Mapping[str, Any]] = None):
+        env_path = os.environ.get("AUTOPAL_CONFIG")
+        base_path = Path(__file__).resolve().parent.parent
+        default_path = base_path / "autopal.config.json"
+        if path is None:
+            path = env_path or default_path
+        self._path = Path(path)
+        self._lock = RLock()
+        if initial is not None:
+            data = dict(initial)
+        else:
+            data = self._load()
+        self._current = ConfigView(data)
+
+    @property
+    def current(self) -> ConfigView:
+        return self._current
+
+    def reload(self) -> None:
+        with self._lock:
+            data = self._load()
+            self._current = ConfigView(data)
+
+    def update(self, data: Mapping[str, Any]) -> None:
+        with self._lock:
+            self._current = ConfigView(data)
+
+    def _load(self) -> Dict[str, Any]:
+        if not self._path.exists():
+            raise FileNotFoundError(f"Configuration file not found: {self._path}")
+        content = self._path.read_text(encoding="utf-8")
+        if not content.strip():
+            return {}
+        return json.loads(content)

--- a/app/guards.py
+++ b/app/guards.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import math
+from typing import Any, Dict, Optional
+
+from fastapi import Header, HTTPException, Request
+
+from .config import ConfigHolder
+from .oidc import verify_oidc
+from .ratelimit import _bucket
+
+
+def maintenance_guard(cfg: ConfigHolder):
+    def dep() -> None:
+        maintenance_cfg = getattr(cfg.current, "maintenance", None)
+        if isinstance(maintenance_cfg, dict) and maintenance_cfg.get("enabled"):
+            message = maintenance_cfg.get("message", "Service under maintenance")
+            raise HTTPException(
+                status_code=503,
+                detail={"code": "maintenance", "message": message},
+            )
+
+    return dep
+
+
+def stepup_guard(cfg: ConfigHolder):
+    def dep(x_step_up_token: str = Header(default="")) -> None:
+        step_cfg = getattr(cfg.current, "stepup", None) or getattr(cfg.current, "step_up", None)
+        if not isinstance(step_cfg, dict):
+            return
+        if not step_cfg.get("required"):
+            return
+        expected = step_cfg.get("token")
+        if not expected or x_step_up_token != expected:
+            raise HTTPException(
+                status_code=403,
+                detail={"code": "step_up_required", "message": "Missing or invalid step-up token"},
+            )
+
+    return dep
+
+
+def oidc_guard(cfg: ConfigHolder):
+    def dep(
+        request: Request,
+        authorization: str = Header(default=""),
+        x_audience: str = Header(default=""),
+    ) -> Dict[str, Any]:
+        if not authorization.startswith("Bearer "):
+            raise HTTPException(
+                status_code=401,
+                detail={"code": "unauthorized", "message": "Missing Bearer token"},
+            )
+        id_token = authorization.split(" ", 1)[1]
+        try:
+            claims = verify_oidc(cfg, id_token, audience=x_audience or None)
+            request.state.oidc_claims = claims
+            return claims
+        except Exception as exc:  # pragma: no cover - fastapi converts to 401
+            raise HTTPException(
+                status_code=401,
+                detail={"code": "unauthorized", "message": str(exc)},
+            ) from exc
+
+    return dep
+
+
+def rate_limit_guard(cfg: ConfigHolder, per_endpoint: bool = True):
+    async def dep(request: Request) -> None:
+        rate_cfg = getattr(cfg.current, "rate_limits", {}) or {}
+
+        global_rpm = int(rate_cfg.get("global_per_minute", 0))
+        if global_rpm:
+            global_burst = int(rate_cfg.get("global_burst", global_rpm))
+            ok, retry_after = await _bucket("__global__", global_rpm, global_burst).take(1)
+            if not ok:
+                headers = {"Retry-After": str(max(1, math.ceil(retry_after)))}
+                raise HTTPException(
+                    status_code=429,
+                    detail={"code": "rate_limited", "message": "Too many requests"},
+                    headers=headers,
+                )
+
+        claims = getattr(request.state, "oidc_claims", None)
+        caller: Optional[str] = None
+        if isinstance(claims, dict):
+            caller = claims.get("sub")
+        if not caller:
+            caller = request.headers.get("X-Caller")
+        if not caller and request.client:
+            caller = request.client.host
+        caller = caller or "anonymous"
+
+        route = request.scope.get("route")
+        path = getattr(route, "path", request.url.path)
+        method = request.method
+        endpoint_key = f"{method} {path}"
+
+        endpoint_limits = {}
+        endpoints_cfg = rate_cfg.get("endpoints", {}) or {}
+        if endpoint_key in endpoints_cfg:
+            endpoint_limits = endpoints_cfg[endpoint_key]
+
+        default_rpm = int(rate_cfg.get("per_caller_per_minute", 60))
+        rpm = int(endpoint_limits.get("per_minute", default_rpm))
+        burst_default = endpoint_limits.get("per_minute", default_rpm)
+        burst = int(endpoint_limits.get("burst", burst_default))
+
+        key = caller
+        if per_endpoint:
+            key = f"{caller}|{endpoint_key}"
+
+        ok, retry_after = await _bucket(key, rpm, burst).take(1)
+        if not ok:
+            headers = {"Retry-After": str(max(1, math.ceil(retry_after)))}
+            raise HTTPException(
+                status_code=429,
+                detail={"code": "rate_limited", "message": "Too many requests"},
+                headers=headers,
+            )
+
+    return dep

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any, Dict, Optional
+
+from fastapi import Body, Depends, FastAPI, HTTPException
+
+from .approvals import approve, create_request
+from .config import ConfigHolder
+from .guards import maintenance_guard, oidc_guard, rate_limit_guard, stepup_guard
+
+
+def create_app(cfg: Optional[ConfigHolder] = None) -> FastAPI:
+    config = cfg or ConfigHolder()
+    app = FastAPI(title="Autopal Console")
+
+    @app.get("/healthz")
+    def healthz() -> Dict[str, str]:
+        return {"status": "ok"}
+
+    @app.post(
+        "/secrets/materialize",
+        dependencies=[
+            Depends(maintenance_guard(config)),
+            Depends(rate_limit_guard(config)),
+            Depends(stepup_guard(config)),
+        ],
+    )
+    def materialize(claims: Dict[str, Any] = Depends(oidc_guard(config))):
+        expires_at = dt.datetime.utcnow() + dt.timedelta(minutes=30)
+        return {
+            "token": "redacted",
+            "actor": claims.get("sub"),
+            "expires_at": expires_at.replace(microsecond=0).isoformat() + "Z",
+        }
+
+    @app.post(
+        "/fossil/override",
+        dependencies=[
+            Depends(maintenance_guard(config)),
+            Depends(rate_limit_guard(config)),
+            Depends(stepup_guard(config)),
+        ],
+    )
+    def override(
+        claims: Dict[str, Any] = Depends(oidc_guard(config)),
+        body: Dict[str, Any] = Body(...),
+    ):
+        dc = getattr(config.current, "dual_control", {}) or {}
+        ttl = int(dc.get("ttl_seconds", 900))
+        request_state = create_request(
+            actor=claims.get("sub", "unknown"),
+            payload={"policy": body.get("policy"), "scope": body.get("scope")},
+            ttl_seconds=ttl,
+        )
+        rid = request_state["id"]
+        return {
+            "granted": "pending_second_approval",
+            "request_id": rid,
+            "approve_url": f"/approvals/{rid}/approve",
+        }
+
+    @app.post(
+        "/approvals/{rid}/approve",
+        dependencies=[Depends(maintenance_guard(config))],
+    )
+    def approve_override(
+        rid: str,
+        claims: Dict[str, Any] = Depends(oidc_guard(config)),
+    ):
+        dc = getattr(config.current, "dual_control", {}) or {}
+        try:
+            state = approve(rid, claims.get("sub", "unknown"), dc.get("require_distinct_approvers", True))
+        except KeyError:
+            raise HTTPException(status_code=404, detail={"code": "not_found"})
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail={"code": str(exc)}) from exc
+
+        if state["granted"]:
+            return {"granted": True, "request_id": rid}
+        return {
+            "granted": False,
+            "request_id": rid,
+            "waiting_for": max(0, 2 - len(state["approvers"]))
+        }
+
+    return app
+
+
+app = create_app()

--- a/app/oidc.py
+++ b/app/oidc.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+import time
+from typing import Any, Dict, Optional
+
+import httpx
+import jwt
+from jwt import exceptions as jwt_exceptions
+from cachetools import TTLCache
+
+from .config import ConfigHolder
+
+_jwks_cache: TTLCache[str, Dict[str, Any]] = TTLCache(maxsize=1, ttl=600)  # 10 min
+
+
+def _get_jwks(jwks_url: str) -> Dict[str, Any]:
+    if "jwks" in _jwks_cache:
+        return _jwks_cache["jwks"]
+    resp = httpx.get(jwks_url, timeout=5.0)
+    resp.raise_for_status()
+    data = resp.json()
+    _jwks_cache["jwks"] = data
+    return data
+
+
+def verify_oidc(cfg: ConfigHolder, id_token: str, audience: Optional[str]) -> Dict[str, Any]:
+    """Returns decoded claims if valid; raises on failure."""
+
+    oidc = cfg.current.auth["oidc"]
+    issuer = oidc["issuer"]
+    jwks_url = oidc["jwks_url"]
+    skew = int(oidc.get("clock_skew_seconds", 300))
+
+    jwks = _get_jwks(jwks_url)
+    kid = jwt.get_unverified_header(id_token)["kid"]
+    key = next((k for k in jwks["keys"] if k["kid"] == kid), None)
+    if not key:
+        raise ValueError("Unknown key id")
+
+    public_key = jwt.algorithms.RSAAlgorithm.from_jwk(json.dumps(key))
+    try:
+        claims = jwt.decode(
+            id_token,
+            key=public_key,
+            algorithms=["RS256", "RS384", "RS512"],
+            audience=audience,
+            issuer=issuer,
+            leeway=skew,
+        )
+    except jwt_exceptions.InvalidAudienceError as exc:
+        raise ValueError("audience_not_allowed") from exc
+
+    allowed = cfg.current.auth["oidc"].get("audience_allowlist", [])
+    aud_claim = claims.get("aud")
+    if aud_claim is None:
+        raise ValueError("missing_audience")
+    if not any(
+        (a.endswith("*") and str(aud_claim).startswith(a[:-1])) or str(aud_claim) == a
+        for a in allowed
+    ):
+        raise ValueError("audience_not_allowed")
+
+    now = int(time.time())
+    if claims.get("nbf") and claims["nbf"] - skew > now:
+        raise ValueError("token_not_yet_valid")
+
+    return claims

--- a/app/ratelimit.py
+++ b/app/ratelimit.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Dict, Tuple
+
+try:  # pragma: no cover - optional dependency
+    import aioredis  # type: ignore # noqa: F401
+except Exception:  # pragma: no cover - optional dependency
+    aioredis = None
+
+
+class TokenBucket:
+    def __init__(self, rate_per_min: int, burst: int):
+        self.rate = max(rate_per_min, 1) / 60.0
+        self.burst = max(burst, 1)
+        self.tokens = float(self.burst)
+        self.ts = time.monotonic()
+        self.lock = asyncio.Lock()
+
+    async def take(self, n: int = 1) -> Tuple[bool, float]:
+        async with self.lock:
+            now = time.monotonic()
+            self.tokens = min(self.burst, self.tokens + (now - self.ts) * self.rate)
+            self.ts = now
+            if self.tokens >= n:
+                self.tokens -= n
+                return True, 0.0
+            short = (n - self.tokens) / self.rate if self.rate else float("inf")
+            return False, short
+
+
+_buckets: Dict[str, TokenBucket] = {}
+
+
+def _bucket(key: str, rate: int, burst: int) -> TokenBucket:
+    bucket = _buckets.get(key)
+    if bucket is None:
+        bucket = TokenBucket(rate, burst)
+        _buckets[key] = bucket
+    return bucket
+
+
+def reset_buckets() -> None:
+    _buckets.clear()

--- a/autopal.config.json
+++ b/autopal.config.json
@@ -1,0 +1,27 @@
+{
+  "auth": {
+    "oidc": {
+      "issuer": "https://issuer.example.com/",
+      "jwks_url": "https://issuer.example.com/.well-known/jwks.json",
+      "clock_skew_seconds": 300,
+      "audience_allowlist": [
+        "gha:org/repo@refs/heads/main",
+        "gha:org/repo@refs/tags/v*"
+      ]
+    }
+  },
+  "rate_limits": {
+    "global_per_minute": 600,
+    "per_caller_per_minute": 60,
+    "endpoints": {
+      "POST /secrets/materialize": { "per_minute": 10, "burst": 3 },
+      "POST /fossil/override":     { "per_minute": 6,  "burst": 2 }
+    }
+  },
+  "dual_control": {
+    "provider": "webhook",
+    "callback_url": "https://approvals.example.com/callback",
+    "ttl_seconds": 900,
+    "require_distinct_approvers": true
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires-python = ">=3.10"
 description = "Offline PLM & Manufacturing Ops (Phase 37) — deterministic, file-backed."
 readme = "README.md"
 authors = [{ name = "Blackroad", email = "eng@blackroadinc.us" }]
-dependencies = ["typer"]
+dependencies = ["typer", "fastapi", "httpx", "pyjwt[crypto]", "cachetools", "aioredis"]
 
 [project.scripts]
 brc = "cli.console:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,7 @@ uvicorn
 whisper
 typer
 pytest
+aioredis
+cachetools
+httpx
+pyjwt[crypto]

--- a/tests/test_autopal_security.py
+++ b/tests/test_autopal_security.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import json
+import time
+from copy import deepcopy
+from typing import Any, Dict, Tuple
+from uuid import uuid4
+
+from cryptography.hazmat.primitives.asymmetric import rsa
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+
+from app.approvals import reset_store
+from app.config import ConfigHolder
+from app.main import create_app
+from app.oidc import _jwks_cache
+from app.ratelimit import reset_buckets
+
+
+@pytest.fixture(scope="session")
+def rsa_material() -> Tuple[Any, Dict[str, Any]]:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_jwk = json.loads(jwt.algorithms.RSAAlgorithm.to_jwk(private_key.public_key()))
+    public_jwk["kid"] = "test-key"
+    return private_key, {"keys": [public_jwk]}
+
+
+@pytest.fixture(autouse=True)
+def reset_runtime_state():
+    reset_buckets()
+    reset_store()
+    _jwks_cache.clear()
+    yield
+    reset_buckets()
+    reset_store()
+    _jwks_cache.clear()
+
+
+@pytest.fixture
+def client_builder(tmp_path, rsa_material):
+    private_key, jwks = rsa_material
+
+    def build(overrides: Dict[str, Any] | None = None) -> Tuple[TestClient, ConfigHolder, Any, Dict[str, Any]]:
+        base = {
+            "auth": {
+                "oidc": {
+                    "issuer": "https://issuer.example.com/",
+                    "jwks_url": "https://issuer.example.com/.well-known/jwks.json",
+                    "clock_skew_seconds": 300,
+                    "audience_allowlist": [
+                        "gha:org/repo@refs/heads/main",
+                        "gha:org/repo@refs/tags/v*",
+                    ],
+                }
+            },
+            "rate_limits": {
+                "global_per_minute": 600,
+                "per_caller_per_minute": 60,
+                "endpoints": {
+                    "POST /secrets/materialize": {"per_minute": 10, "burst": 3},
+                    "POST /fossil/override": {"per_minute": 6, "burst": 2},
+                },
+            },
+            "dual_control": {
+                "provider": "webhook",
+                "callback_url": "https://approvals.example.com/callback",
+                "ttl_seconds": 900,
+                "require_distinct_approvers": True,
+            },
+        }
+        if overrides:
+            base = _merge_dicts(base, overrides)
+        cfg_path = tmp_path / f"autopal_{uuid4().hex}.config.json"
+        cfg_path.write_text(json.dumps(base))
+        cfg = ConfigHolder(cfg_path)
+        _jwks_cache["jwks"] = deepcopy(jwks)
+        client = TestClient(create_app(cfg))
+        return client, cfg, private_key, base
+
+    return build
+
+
+def _merge_dicts(base: Dict[str, Any], overrides: Dict[str, Any]) -> Dict[str, Any]:
+    result = deepcopy(base)
+    for key, value in overrides.items():
+        if isinstance(value, dict) and isinstance(result.get(key), dict):
+            result[key] = _merge_dicts(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+def _make_token(private_key, config: Dict[str, Any], *, sub: str = "actor", aud: str = "gha:org/repo@refs/heads/main") -> str:
+    now = int(time.time())
+    payload = {
+        "iss": config["auth"]["oidc"]["issuer"],
+        "sub": sub,
+        "aud": aud,
+        "iat": now,
+        "exp": now + 600,
+    }
+    return jwt.encode(payload, private_key, algorithm="RS256", headers={"kid": "test-key"})
+
+
+def _headers(token: str, audience: str = "gha:org/repo@refs/heads/main") -> Dict[str, str]:
+    return {"Authorization": f"Bearer {token}", "X-Audience": audience}
+
+
+def test_materialize_requires_oidc(client_builder):
+    client, _, private_key, config = client_builder()
+    response = client.post("/secrets/materialize")
+    assert response.status_code == 401
+    token = _make_token(private_key, config)
+    bad_headers = _headers(token, audience="gha:org/repo@refs/heads/feature")
+    response = client.post("/secrets/materialize", headers=bad_headers)
+    assert response.status_code == 401
+    assert response.json()["detail"]["message"] == "audience_not_allowed"
+
+
+def test_materialize_rate_limit(client_builder):
+    client, _, private_key, config = client_builder()
+    headers = _headers(_make_token(private_key, config))
+    for _ in range(3):
+        resp = client.post("/secrets/materialize", headers=headers)
+        assert resp.status_code == 200
+    resp = client.post("/secrets/materialize", headers=headers)
+    assert resp.status_code == 429
+    assert resp.headers["retry-after"]
+
+
+def test_dual_control_flow(client_builder):
+    client, _, private_key, config = client_builder()
+    actor_headers = _headers(_make_token(private_key, config, sub="actor-1"))
+    override_resp = client.post(
+        "/fossil/override",
+        headers=actor_headers,
+        json={"policy": "ship", "scope": "prod"},
+    )
+    assert override_resp.status_code == 200
+    body = override_resp.json()
+    assert body["granted"] == "pending_second_approval"
+    rid = body["request_id"]
+
+    approver_one_headers = _headers(_make_token(private_key, config, sub="approver-1"))
+    first = client.post(f"/approvals/{rid}/approve", headers=approver_one_headers)
+    assert first.status_code == 200
+    assert first.json()["granted"] is False
+
+    approver_two_headers = _headers(_make_token(private_key, config, sub="approver-2"))
+    second = client.post(f"/approvals/{rid}/approve", headers=approver_two_headers)
+    assert second.status_code == 200
+    assert second.json()["granted"] is True
+
+    third = client.post(f"/approvals/{rid}/approve", headers=approver_two_headers)
+    assert third.status_code == 400
+    assert third.json()["detail"]["code"] == "must_be_distinct"
+
+
+def test_dual_control_expiration(client_builder, monkeypatch):
+    overrides = {"dual_control": {"ttl_seconds": 1}}
+    client, _, private_key, config = client_builder(overrides)
+    actor_headers = _headers(_make_token(private_key, config, sub="actor-1"))
+    override_resp = client.post(
+        "/fossil/override",
+        headers=actor_headers,
+        json={"policy": "ship", "scope": "prod"},
+    )
+    rid = override_resp.json()["request_id"]
+
+    original_time = time.time
+
+    def fake_time() -> float:
+        return original_time() + 5
+
+    monkeypatch.setattr("app.approvals.time.time", fake_time)
+    headers = _headers(_make_token(private_key, config, sub="approver"))
+    resp = client.post(f"/approvals/{rid}/approve", headers=headers)
+    assert resp.status_code == 400
+    assert resp.json()["detail"]["code"] == "expired"


### PR DESCRIPTION
## Summary
- add configuration sections for OIDC, rate limiting, and webhook-driven dual control
- implement FastAPI guards for OIDC verification, token buckets, and the approval workflow
- cover the new flows with pytest-based integration tests

## Testing
- pytest tests/test_autopal_security.py

------
https://chatgpt.com/codex/tasks/task_e_68e183f0273c832981fb5d1bbbdfea2a