### PR TITLE
Add emotional care codex discovery sequences

### DIFF
--- a/prompts/emotional_mental_care_codex_sequences.md
+++ b/prompts/emotional_mental_care_codex_sequences.md
@@ -1,0 +1,80 @@
+# Emotional & Mental Care Codex Discovery Sequences
+
+This playbook expands six Codex prompt genres into full discovery arcs tailored for emotional and mental health contexts. Each sequence blends qualitative research, speculative design, and systems-level checks so agents surface both provocative insights and actionable experiments.
+
+## 1. Pattern Finder — Recovery, Coping, Connection
+
+**Core Prompt**  
+"Show me unnoticed patterns in how people recover, cope, or connect in a peer-led mental health community space. What might these reveal about unmet needs?"
+
+**Discovery Sequence**
+1. **Context Sweep** — Gather anonymized transcripts, chat logs, and facilitator notes. Cluster sentiments (hope, fatigue, relapse cues) and rituals (daily check-ins, art drops, silence periods).
+2. **Quiet Signals Map** — Highlight micro-behaviors that precede breakthroughs or setbacks (e.g., emoji streaks before relapse disclosures, late-night logins before gratitude posts).
+3. **Need Hypotheses** — Translate recurring signals into unmet-need hypotheses ("Members need low-friction night support" or "Members crave peer-recognition rituals").
+4. **Validation Loop** — Suggest quick tests (polls, facilitator interviews, micro-surveys) to confirm the pattern strength.
+5. **Insight Packaging** — Output a storyboard for each hypothesis: trigger → member action → emotional state → opportunity for intervention.
+
+## 2. Frugal Genius — Low-Cost Micro-Interventions
+
+**Core Prompt**  
+"Design a low-cost, high-impact intervention that could reduce night-time anxiety spikes using household or open-source tools."
+
+**Discovery Sequence**
+1. **Inventory What Exists** — List common household items (sticky notes, lamps, smart speakers) and open-source projects (breathing timers, journaling bots).
+2. **Pairing Matrix** — Cross anxiety triggers (racing thoughts, loneliness, insomnia) with feasible tools; look for combinations under $10.
+3. **Prototype Script** — Detail step-by-step setup, including printable instructions or voice prompts.
+4. **Evidence Hooks** — Cite supporting research or analog interventions (CBT-i prompts, progressive muscle relaxation audio) to justify efficacy.
+5. **Implementation Checklist** — Provide adoption tips for individuals, caregivers, and clinics (e.g., data privacy notes, cultural tailoring).
+
+## 3. Emotive Interface — Mood-Aware Ambient AI
+
+**Core Prompt**  
+"Imagine an AI that reads not data, but the mood of a group therapy room — what would it measure, how would it respond?"
+
+**Discovery Sequence**
+1. **Sensing Constellation** — Define ethically sourced signals (tone variance, pacing, silence duration, collective posture) captured via opt-in wearables or wall sensors.
+2. **Mood Model Blueprint** — Outline how signals translate into a "room affect index" with confidence bands.
+3. **Responsive Behaviors** — Suggest adaptive actions: lighting shifts, calming audio, facilitator nudges, or break recommendations.
+4. **Safeguard Layer** — Enumerate privacy, consent, and override protocols; require human-in-loop confirmation for escalations.
+5. **Prototype Scenario** — Script a 10-minute therapy session showing AI observations, facilitator decisions, and participant feedback.
+
+## 4. Ethical Edge Test — Necessary but Gray
+
+**Core Prompt**  
+"What is the most ethically gray idea in AI-driven mental health care that still feels necessary to explore?"
+
+**Discovery Sequence**
+1. **Problem Statement** — Identify a high-stakes gap (e.g., detecting imminent self-harm between sessions) where current tools fall short.
+2. **Gray-Area Concept** — Propose an intervention (continuous passive monitoring, sentiment-aware journaling prompts) and explain potential benefits.
+3. **Risk Ledger** — Tabulate ethical risks (surveillance creep, misclassification) against mitigation tactics (edge processing, consent tiers, red-team audits).
+4. **Governance Sandbox** — Describe a tightly-scoped pilot with community oversight boards, sunset clauses, and transparent reporting.
+5. **Moral Debate Brief** — Generate arguments pro/con for ethicists, clinicians, and service users to evaluate before any deployment.
+
+## 5. Patent Trigger — Novel Therapeutic System
+
+**Core Prompt**  
+"Invent a system that resolves drop-off friction during transitions between virtual therapy platforms and in-person follow-ups, with novelty that could qualify for IP protection. Describe it with functional claims."
+
+**Discovery Sequence**
+1. **Friction Scan** — Map the current hand-off journey: telehealth discharge → scheduling → transport → intake.
+2. **Invention Concept** — Introduce a "Continuity Capsule" platform that synchronizes session context, mood markers, and action plans across channels.
+3. **Functional Claims Draft** — Specify claims such as: "A method for generating adaptive transition briefs from multimodal therapy transcripts" and "A scheduling engine that prioritizes follow-ups based on emotional volatility scores."
+4. **Technical Architecture** — Sketch components (secure context vault, emotion inference API, clinic dashboard) and data flows.
+5. **Proof Path** — Recommend experiments, user tests, and prior-art scans that strengthen patentability.
+
+## 6. Unexpected Transfer — Borrowed Principles
+
+**Core Prompt**  
+"Borrow a principle from cooperative gaming and apply it to improve caregiver-client trust dynamics in community counseling."
+
+**Discovery Sequence**
+1. **Source Principle** — Extract mechanics like shared missions, transparent progress bars, and cooldown periods from successful co-op games.
+2. **Trust Translation** — Map each mechanic to counseling touchpoints (e.g., co-created quests for weekly goals, shared "progress meters" for coping strategies).
+3. **Prototype Canvas** — Outline low-fi artifacts (printable trust map, shared scoreboard app) demonstrating the mechanic in sessions.
+4. **Feedback Rituals** — Design reflection loops where clients rate perceived trust shifts and caregivers adjust tactics.
+5. **Scaling Considerations** — Address cultural adaptation, digital accessibility, and facilitator training to extend the principle beyond pilots.
+
+---
+
+**Next Branch Idea**  
+For follow-up exploration, we can layer quantitative instrumentation (biofeedback loops, crisis escalation analytics, workforce planning) to complement these qualitative discovery tracks.


### PR DESCRIPTION
## Summary
- add a new playbook that expands the six codex prompt genres for emotional and mental care contexts
- outline structured discovery sequences for pattern analysis, frugal interventions, emotive interfaces, ethical vetting, patentable systems, and cross-domain transfers

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e186014d30832982af8d12cbe0d329