### PR TITLE
Add Pi Cortex observability bundle

### DIFF
--- a/observability/README.md
+++ b/observability/README.md
@@ -1,0 +1,87 @@
+# Pi Cortex Observability Bundle (v3)
+
+This bundle wires up a lightweight observability stack for the Pi Cortex fleet:
+
+- **InfluxDB 2.x** for time-series storage
+- **Grafana** pre-provisioned with an InfluxDB datasource and the "Pi Cortex – Ops Panel" dashboard
+- **Telegraf** agent configurations for Raspberry Pi nodes and the Pi Ops MQTT heartbeat stream
+
+The directory layout mirrors the environments you need to touch:
+
+```
+observability/
+├── mac/                  # Docker compose stack for your Mac (InfluxDB + Grafana)
+│   ├── docker-compose.yml
+│   ├── .env.example      # Copy to .env and drop in secrets (Influx token)
+│   └── grafana/
+│       └── provisioning/ # Datasource + dashboard provisioning
+└── pis/
+    ├── telegraf.pi.conf
+    └── telegraf.pi-ops.mqtt.conf
+```
+
+## Quick start
+
+### 1. Bring up InfluxDB + Grafana on your Mac
+
+```bash
+cd observability/mac
+cp .env.example .env  # optional: you can leave GF_INFLUX_TOKEN blank for the first boot
+# start the stack
+docker compose up -d
+open http://localhost:8086
+```
+
+InfluxDB is bootstrapped with the following defaults:
+
+| Setting | Value |
+| --- | --- |
+| Username | `admin` |
+| Password | `adminadmin` |
+| Organization | `pi-cortex` |
+| Bucket | `telemetry` |
+
+Log into the InfluxDB UI and create a **Read/Write token** for the `telemetry` bucket. Copy the token somewhere safe.
+
+Update `observability/mac/.env` and set `GF_INFLUX_TOKEN` to the new token, then reload Grafana so the datasource picks it up:
+
+```bash
+printf 'GF_INFLUX_TOKEN=%s\n' '<paste token>' > observability/mac/.env  # this overwrites the file
+cd observability/mac
+docker compose up -d grafana
+open http://localhost:3000  # admin/adminadmin
+```
+
+### 2. Point each Pi to your Mac
+
+For every Raspberry Pi, edit the corresponding Telegraf config file under `observability/pis/` and replace the placeholders:
+
+- `{INFLUX_HOST}` – the IP or hostname of your Mac (reachable from the Pi network)
+- `{INFLUX_TOKEN}` – the Read/Write token you generated for the `telemetry` bucket
+- `{MQTT_HOST}` / `{MQTT_USERNAME}` / `{MQTT_PASSWORD}` – only in the Pi Ops MQTT config
+
+Then copy the config to the Pi and restart Telegraf. Example for `pi-holo` and `pi-sim`:
+
+```bash
+sudo apt update && sudo apt install -y telegraf
+scp observability/pis/telegraf.pi.conf pi@pi-holo.local:/home/pi/telegraf.conf
+ssh pi@pi-holo.local 'sudo mv telegraf.conf /etc/telegraf/telegraf.conf && sudo systemctl enable --now telegraf'
+```
+
+For Pi Ops (MQTT heartbeat stream), push the MQTT variant:
+
+```bash
+scp observability/pis/telegraf.pi-ops.mqtt.conf pi@pi-ops.local:/home/pi/telegraf.conf
+ssh pi@pi-ops.local 'sudo mv telegraf.conf /etc/telegraf/telegraf.conf && sudo systemctl restart telegraf'
+```
+
+### 3. Watch the dashboard
+
+Grafana lives at [http://localhost:3000](http://localhost:3000) (credentials `admin/adminadmin`). The **Pi Cortex – Ops Panel** dashboard will light up as soon as the first metrics land.
+
+## Telegraf configuration notes
+
+- `telegraf.pi.conf` collects CPU, memory, disk, system uptime, and Raspberry Pi SoC temperature (`/sys/class/thermal/thermal_zone0/temp`).
+- `telegraf.pi-ops.mqtt.conf` subscribes to `system/heartbeat/+` via MQTT and writes any JSON payload fields into InfluxDB along with topic metadata.
+
+Feel free to customize intervals, measurement tags, or additional inputs as you expand observability coverage.

--- a/observability/mac/.env.example
+++ b/observability/mac/.env.example
@@ -1,0 +1,3 @@
+# Copy to .env and fill in the values that should stay out of git.
+# Grafana picks up the InfluxDB token from this variable during provisioning.
+GF_INFLUX_TOKEN=

--- a/observability/mac/docker-compose.yml
+++ b/observability/mac/docker-compose.yml
@@ -1,0 +1,45 @@
+services:
+  influxdb:
+    image: influxdb:2.7
+    container_name: pi-cortex-influxdb
+    restart: unless-stopped
+    ports:
+      - "8086:8086"
+    environment:
+      DOCKER_INFLUXDB_INIT_MODE: setup
+      DOCKER_INFLUXDB_INIT_USERNAME: admin
+      DOCKER_INFLUXDB_INIT_PASSWORD: adminadmin
+      DOCKER_INFLUXDB_INIT_ORG: pi-cortex
+      DOCKER_INFLUXDB_INIT_BUCKET: telemetry
+    volumes:
+      - influxdb-data:/var/lib/influxdb2
+      - influxdb-config:/etc/influxdb2
+    healthcheck:
+      test: ["CMD", "influx", "ping", "--host", "http://localhost:8086"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  grafana:
+    image: grafana/grafana:10.3.3
+    container_name: pi-cortex-grafana
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: adminadmin
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_AUTH_ANONYMOUS_ENABLED: "false"
+      GF_SERVER_ROOT_URL: http://localhost:3000
+      GF_INFLUX_TOKEN: ${GF_INFLUX_TOKEN:-}
+    depends_on:
+      - influxdb
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning
+
+volumes:
+  influxdb-data:
+  influxdb-config:
+  grafana-data:

--- a/observability/mac/grafana/provisioning/dashboards/dashboard.yml
+++ b/observability/mac/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: Pi Cortex Dashboards
+    orgId: 1
+    folder: Pi Cortex
+    folderUid: pi_cortex
+    type: file
+    disableDeletion: true
+    editable: false
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/observability/mac/grafana/provisioning/dashboards/pi-cortex-ops-panel.json
+++ b/observability/mac/grafana/provisioning/dashboards/pi-cortex-ops-panel.json
@@ -1,0 +1,336 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "pi_cortex_telemetry"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "pi_cortex_telemetry"
+          },
+          "query": "import \"regexp\"\nhostFilter = if v.host == \"\" then \".*\" else v.host\n\nfrom(bucket: \"telemetry\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"cpu\")\n  |> filter(fn: (r) => r[\"_field\"] == \"usage_active\")\n  |> filter(fn: (r) => r[\"cpu\"] == \"cpu-total\")\n  |> filter(fn: (r) => regexp.matchRegexpString(r: r[\"host\"], re: regexp.compile(v: hostFilter)))\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"cpu_active\")",
+          "refId": "A"
+        }
+      ],
+      "title": "CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "pi_cortex_telemetry"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 75
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "pi_cortex_telemetry"
+          },
+          "query": "import \"regexp\"\nhostFilter = if v.host == \"\" then \".*\" else v.host\n\nfrom(bucket: \"telemetry\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"mem\")\n  |> filter(fn: (r) => r[\"_field\"] == \"used_percent\")\n  |> filter(fn: (r) => regexp.matchRegexpString(r: r[\"host\"], re: regexp.compile(v: hostFilter)))\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"mem_used_percent\")",
+          "refId": "A"
+        }
+      ],
+      "title": "Memory Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "pi_cortex_telemetry"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 65
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "pi_cortex_telemetry"
+          },
+          "query": "import \"regexp\"\nhostFilter = if v.host == \"\" then \".*\" else v.host\n\nfrom(bucket: \"telemetry\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"pi_soc_temp\")\n  |> filter(fn: (r) => r[\"_field\"] == \"temperature_c\")\n  |> filter(fn: (r) => regexp.matchRegexpString(r: r[\"host\"], re: regexp.compile(v: hostFilter)))\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"soc_temp\")",
+          "refId": "A"
+        }
+      ],
+      "title": "SoC Temperature",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "pi_cortex_telemetry"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "blue",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "pi_cortex_telemetry"
+          },
+          "query": "import \"regexp\"\nhostFilter = if v.host == \"\" then \".*\" else v.host\n\nfrom(bucket: \"telemetry\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"system\")\n  |> filter(fn: (r) => r[\"_field\"] == \"uptime\")\n  |> filter(fn: (r) => regexp.matchRegexpString(r: r[\"host\"], re: regexp.compile(v: hostFilter)))\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"uptime\")",
+          "refId": "A"
+        }
+      ],
+      "title": "System Uptime",
+      "type": "stat"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [
+    "pi-cortex",
+    "ops"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": ".*"
+        },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "pi_cortex_telemetry"
+        },
+        "definition": "import \"influxdata/influxdb/schema\"\nschema.tagValues(bucket: \"telemetry\", tag: \"host\")",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Host",
+        "multi": false,
+        "name": "host",
+        "query": "import \"influxdata/influxdb/schema\"\nschema.tagValues(bucket: \"telemetry\", tag: \"host\")",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Pi Cortex – Ops Panel",
+  "uid": "pi_cortex_ops_panel",
+  "version": 1,
+  "weekStart": ""
+}

--- a/observability/mac/grafana/provisioning/datasources/datasource.yml
+++ b/observability/mac/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,17 @@
+apiVersion: 1
+
+datasources:
+  - name: Pi Cortex Telemetry
+    type: influxdb
+    access: proxy
+    isDefault: true
+    uid: pi_cortex_telemetry
+    url: http://influxdb:8086
+    jsonData:
+      httpMode: POST
+      organization: pi-cortex
+      defaultBucket: telemetry
+      version: Flux
+    secureJsonData:
+      token: ${GF_INFLUX_TOKEN}
+    editable: false

--- a/observability/pis/telegraf.pi-ops.mqtt.conf
+++ b/observability/pis/telegraf.pi-ops.mqtt.conf
@@ -1,0 +1,39 @@
+# Pi Ops MQTT heartbeat Telegraf configuration
+# Replace the placeholder values before deploying.
+
+[agent]
+  interval = "10s"
+  flush_interval = "10s"
+  flush_jitter = "5s"
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  collection_jitter = "0s"
+
+[global_tags]
+  fleet = "pi-cortex"
+  source = "pi-ops"
+
+[[outputs.influxdb_v2]]
+  urls = ["http://{INFLUX_HOST}:8086"]
+  token = "{INFLUX_TOKEN}"
+  organization = "pi-cortex"
+  bucket = "telemetry"
+
+[[inputs.mqtt_consumer]]
+  servers = ["tcp://{MQTT_HOST}:1883"]
+  topics = ["system/heartbeat/+"]
+  qos = 1
+  connection_timeout = "30s"
+  persistent_session = false
+  client_id = "telegraf-pi-ops"
+  # Leave username/password empty if your broker does not require auth.
+  username = "{MQTT_USERNAME}"
+  password = "{MQTT_PASSWORD}"
+  data_format = "json"
+  name_override = "pi_ops_heartbeat"
+  tag_keys = ["topic"]
+  json_string_fields = ["status", "state", "mode"]
+  # Uncomment the lines below if your payload includes a Unix timestamp field.
+  # json_time_key = "timestamp"
+  # json_time_format = "unix"
+  topic_tag = "topic"

--- a/observability/pis/telegraf.pi.conf
+++ b/observability/pis/telegraf.pi.conf
@@ -1,0 +1,41 @@
+# Pi Cortex Raspberry Pi Telegraf configuration
+# Replace {INFLUX_HOST} and {INFLUX_TOKEN} before deploying.
+
+[agent]
+  interval = "10s"
+  flush_interval = "10s"
+  flush_jitter = "5s"
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  collection_jitter = "0s"
+
+[global_tags]
+  fleet = "pi-cortex"
+
+[[outputs.influxdb_v2]]
+  urls = ["http://{INFLUX_HOST}:8086"]
+  token = "{INFLUX_TOKEN}"
+  organization = "pi-cortex"
+  bucket = "telemetry"
+
+[[inputs.cpu]]
+  percpu = false
+  totalcpu = true
+  collect_cpu_time = false
+  report_active = true
+
+[[inputs.mem]]
+
+[[inputs.disk]]
+  mount_points = ["/"]
+  ignore_fs = ["tmpfs", "devtmpfs", "overlay", "aufs", "squashfs"]
+
+[[inputs.system]]
+
+# Raspberry Pi SoC temperature (°C) from /sys/class/thermal/thermal_zone0/temp
+[[inputs.exec]]
+  commands = ["/bin/sh", "-c", "awk '{printf \"{\\\"temperature_c\\\": %.2f}\n\", $1/1000}' /sys/class/thermal/thermal_zone0/temp"]
+  timeout = "5s"
+  data_format = "json"
+  name_override = "pi_soc_temp"
+  tagexclude = ["command"]


### PR DESCRIPTION
## Summary
- add an observability bundle under `observability/` with a Mac docker-compose stack for InfluxDB 2 and Grafana
- provision Grafana with a Pi Cortex datasource and "Pi Cortex – Ops Panel" dashboard covering CPU, memory, SoC temp, and uptime
- supply Telegraf configs for Raspberry Pi nodes and the Pi Ops MQTT heartbeat pipeline plus setup instructions

## Testing
- not run (documentation and configuration only)


------
https://chatgpt.com/codex/tasks/task_e_68e185a267dc83298ab161579f127384