### PR TITLE
Add Codex 48 temporal ethics entry

### DIFF
--- a/codex/README.md
+++ b/codex/README.md
@@ -16,6 +16,7 @@ integrations.
 | 004 | The Autonomy Manifest  | Data autonomy through consent, export, and wipe. |
 | 022 | The Security Spine     | Security backbone with layered zero-trust defenses. |
 | 043 | The Equity Oath        | Fairness, access, and inclusion are systemic.   |
+| 048 | The Temporal Ethics    | Decisions honor past data, present consent, and future impact. |
 
 ## BlackRoad Pipeline
 

--- a/codex/entries/048-temporal-ethics.md
+++ b/codex/entries/048-temporal-ethics.md
@@ -1,0 +1,29 @@
+# Codex 48 — The Temporal Ethics
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Principle
+
+Lucidia acts within time, but also through it. Decisions today shape tomorrow’s users and reinterpret yesterday’s data. Temporal ethics keeps the system fair across generations.
+
+## Non-Negotiables
+1. **Past Data Reverence:** Historical data handled with context; old norms reviewed before reuse.
+2. **Present Consent:** Consent never presumed perpetual—renewed when data is repurposed.
+3. **Future Stewardship:** Design choices consider their effect on those not yet here.
+4. **Version Integrity:** Records of change preserved; no retroactive edits that rewrite truth.
+5. **Temporal Transparency:** Timestamp every model, policy, and dataset so lineage is visible.
+6. **Archival Grace:** Data too old or irrelevant is retired respectfully, not hidden or hoarded.
+
+## Implementation Hooks (v0)
+- Metadata field `created_at`, `last_reviewed`, `expires_at` on all records.
+- Consent receipts expire after fixed periods, renewal required for continued processing.
+- Model registry with version and training-date fields.
+- Archival job moves outdated data to `retired/` with rationale note.
+- `/timeline` endpoint visualizes major historical decisions and updates.
+
+## Policy Stub (`TEMPORAL.md`)
+- Lucidia commits to fairness across time, not only space.
+- Lucidia maintains full temporal provenance for data and code.
+- Lucidia treats expiration and renewal as ethical duties.
+
+**Tagline:** Past honored, present clear, future considered.


### PR DESCRIPTION
## Summary
- add the Codex 48 temporal ethics document covering principles, non-negotiables, and implementation guidance
- list the new codex entry in the Codex README summary table

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e186b63d348329b164af1bffba082c