### PR TITLE
Add Codex Infinity prompt rendering toolkit

### DIFF
--- a/codex_infinity_prompts/README.md
+++ b/codex_infinity_prompts/README.md
@@ -1,0 +1,58 @@
+# Codex Infinity Prompt Pack
+
+A lightweight prompt renderer for shipping consistent, parameterized briefs to Infinity lab nodes (Jetson agent, Pi-Holo, Pi-Ops, Pi Zero sim, and Arduino UNO bridge).
+
+## What's inside
+
+- `render.py` — tiny CLI that turns Markdown templates into filled prompts.
+- `example.sh` — renders two ready-to-paste prompts into `out/`.
+- `templates/` — reusable Markdown prompt blueprints with `{{variables}}`.
+
+## Quick start
+
+```bash
+cd codex_infinity_prompts
+./example.sh
+```
+
+The script drops sample prompts into `out/GENERAL_PROMPT.md` and `out/PI_OPS_PROMPT.md`.
+
+## Custom rendering
+
+Render any template by name and override the placeholders inline:
+
+```bash
+python3 render.py pi_ops \
+  --project ops \
+  --node pi_ops \
+  --lang python \
+  --goal "Curses dashboard for MQTT heartbeats" \
+  --io "{input: mqtt, output: tty ui}" \
+  --constraints "- 1600x600 UI\\n- <100MB RAM\\n- SQLite ring buffer" \
+  --out out/PI_OPS_PROMPT.md
+```
+
+- Every `--key value` pair maps to a `{{key}}` placeholder in the template.
+- Strings like `\n` are converted into real newlines so you can pass multi-line bullets.
+- Use `--strict` to abort if any placeholder goes unresolved.
+- `--show-vars` echoes the placeholders for a template before rendering.
+
+## Listing templates
+
+```bash
+python3 render.py --list
+```
+
+To inspect the placeholders without rendering:
+
+```bash
+python3 render.py jetson_agent --show-vars --strict --out /tmp/dry-run
+```
+
+## Suggested workflow
+
+1. Use the CSV preview already in this repo as a source for constraints or context.
+2. Render prompts into `out/` and commit them with your task branch.
+3. Drop the Markdown prompt into your coding model to bootstrap agent plans.
+
+Feel free to fork the templates or wire the CLI into your own orchestration scripts.

--- a/codex_infinity_prompts/example.sh
+++ b/codex_infinity_prompts/example.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUT_DIR="$ROOT_DIR/out"
+
+mkdir -p "$OUT_DIR"
+
+python3 "$ROOT_DIR/render.py" general \
+  --project "Infinity Lab" \
+  --node "umbrella" \
+  --goal "Kick off a cohesive Infinity deployment across every node." \
+  --io "Input: orchestration brief. Output: signed deployment plan." \
+  --constraints "- Sync Jetson + Pi timelines\\n- Keep ops < 8h total\\n- Document fallbacks" \
+  --context "Use this as the umbrella prompt that seeds every downstream agent." \
+  --deliverables "- Deployment backlog\\n- Risk register\\n- Review cadence" \
+  --quality "- Align with Codex Infinity mission\\n- Call out integration hotspots" \
+  --references "Infinity manifest, ops playbooks" \
+  --notes "Drop into Codex-capable model as starter brief." \
+  --out "$OUT_DIR/GENERAL_PROMPT.md"
+
+python3 "$ROOT_DIR/render.py" pi_ops \
+  --project "Infinity Lab" \
+  --node "pi_ops" \
+  --lang "python" \
+  --deployment "systemd service" \
+  --goal "Curses dashboard for MQTT heartbeats" \
+  --io "{input: mqtt, output: tty ui}" \
+  --constraints "- 1600x600 UI\\n- <100MB RAM\\n- SQLite ring buffer" \
+  --ui_surface "ncurses full-screen dashboard" \
+  --persistence "sqlite ring buffer" \
+  --ops_metrics "- Refresh every 1s\\n- Surface stale nodes\\n- Log outages locally" \
+  --telemetry "topic=/infinity/ops/heartbeat\\npayload={node, status, ts, watt}" \
+  --integration "Bridge to Pi-Holo via shared MQTT topics" \
+  --deliverables "- curses dashboard module\\n- sqlite ring buffer schema\\n- deployment README" \
+  --validation "- Simulate broker outage\\n- Verify backlog replay\\n- Capture asciinema demo" \
+  --out "$OUT_DIR/PI_OPS_PROMPT.md"
+
+printf '\nRendered prompts saved to %s\n' "$OUT_DIR"

--- a/codex_infinity_prompts/render.py
+++ b/codex_infinity_prompts/render.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Render Codex Infinity prompt templates with CLI variables."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Dict, Iterable, Tuple
+import re
+
+TEMPLATE_DIR = Path(__file__).resolve().parent / "templates"
+TEMPLATE_MAP = {
+    "general": "GENERAL.md",
+    "jetson_agent": "JETSON_AGENT.md",
+    "pi_holo": "PI_HOLO.md",
+    "pi_ops": "PI_OPS.md",
+    "pi_zero": "PI_ZERO.md",
+    "arduino_uno": "ARDUINO_UNO.md",
+}
+PLACEHOLDER_PATTERN = re.compile(r"{{\s*([a-zA-Z0-9_]+)\s*}}")
+
+
+def list_templates() -> str:
+    longest = max(len(name) for name in TEMPLATE_MAP)
+    lines = ["Available templates:"]
+    for name, filename in sorted(TEMPLATE_MAP.items()):
+        lines.append(f"  {name.ljust(longest)} -> {filename}")
+    return "\n".join(lines)
+
+
+def load_template(name: str) -> Tuple[Path, str]:
+    try:
+        filename = TEMPLATE_MAP[name]
+    except KeyError as exc:
+        raise SystemExit(f"Unknown template '{name}'. Use --list to inspect options.") from exc
+    path = TEMPLATE_DIR / filename
+    if not path.exists():
+        raise SystemExit(f"Template file missing: {path}")
+    return path, path.read_text(encoding="utf-8")
+
+
+def extract_placeholders(content: str) -> Iterable[str]:
+    return sorted(set(PLACEHOLDER_PATTERN.findall(content)))
+
+
+def parse_context(pairs: Iterable[str]) -> Dict[str, str]:
+    pairs = list(pairs)
+    context: Dict[str, str] = {}
+    i = 0
+    while i < len(pairs):
+        key = pairs[i]
+        if not key.startswith("--"):
+            raise SystemExit(f"Unexpected argument '{key}'. Did you forget to prefix it with --?")
+        key = key[2:]
+        if not key:
+            raise SystemExit("Empty key provided. Use --name value format.")
+        i += 1
+        if i >= len(pairs):
+            raise SystemExit(f"Missing value for --{key}.")
+        value = pairs[i]
+        value = value.replace("\\n", "\n")
+        context[key] = value
+        i += 1
+    return context
+
+
+def render_template(content: str, context: Dict[str, str]) -> Tuple[str, Iterable[str]]:
+    missing = []
+
+    def replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        if key in context:
+            return context[key]
+        missing.append(key)
+        return match.group(0)
+
+    rendered = PLACEHOLDER_PATTERN.sub(replace, content)
+    return rendered, missing
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("template", nargs="?", choices=sorted(TEMPLATE_MAP), help="Template name to render")
+    parser.add_argument("--out", type=Path, help="Optional path to write the rendered prompt")
+    parser.add_argument("--list", action="store_true", help="List available templates and exit")
+    parser.add_argument("--show-vars", action="store_true", help="Display placeholders before rendering")
+    parser.add_argument("--strict", action="store_true", help="Exit with error when placeholders are missing")
+    parser.add_argument("--dump-context", type=Path, help="Write the merged context values as JSON alongside the prompt")
+    args, unknown = parser.parse_known_args(argv)
+
+    if args.list:
+        print(list_templates())
+        return 0
+
+    if not args.template:
+        parser.error("template is required unless --list is set")
+
+    context = parse_context(unknown)
+    _template_path, template_text = load_template(args.template)
+
+    if args.show_vars:
+        placeholders = extract_placeholders(template_text)
+        if placeholders:
+            print("Placeholders:")
+            for key in placeholders:
+                value = context.get(key, "<unset>")
+                print(f"  {key}: {value}")
+        else:
+            print("Template has no placeholders.")
+
+    rendered, missing = render_template(template_text, context)
+    if missing:
+        unique_missing = sorted(set(missing))
+        msg = (
+            "Unresolved placeholders: "
+            + ", ".join(f"{{{{{key}}}}}" for key in unique_missing)
+            + ". Provide matching --key values."
+        )
+        if args.strict:
+            raise SystemExit(msg)
+        print(msg, file=sys.stderr)
+
+    if args.dump_context:
+        args.dump_context.parent.mkdir(parents=True, exist_ok=True)
+        args.dump_context.write_text(json.dumps(context, indent=2, sort_keys=True), encoding="utf-8")
+
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(rendered, encoding="utf-8")
+    else:
+        sys.stdout.write(rendered)
+        if not rendered.endswith("\n"):
+            sys.stdout.write("\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/codex_infinity_prompts/templates/ARDUINO_UNO.md
+++ b/codex_infinity_prompts/templates/ARDUINO_UNO.md
@@ -1,0 +1,31 @@
+# {{project}} Arduino UNO :: Sensor Bridge Brief
+
+## Mission
+{{goal}}
+
+## Hardware Stack
+- Sensors: {{sensors}}
+- Shield / breakout: {{shield}}
+- Power / wiring: {{power}}
+
+## Firmware Plan
+- Language / framework: {{firmware_lang}}
+- Sampling cadence: {{sampling_rate}}
+- Data shaping: {{data_format}}
+
+## Connectivity
+- Upstream link: {{uplink}}
+- Protocol framing: {{protocol}}
+- Error handling: {{error_handling}}
+
+## Constraints
+{{constraints}}
+
+## Deliverables
+{{deliverables}}
+
+## Validation
+{{validation}}
+
+## References
+{{references}}

--- a/codex_infinity_prompts/templates/GENERAL.md
+++ b/codex_infinity_prompts/templates/GENERAL.md
@@ -1,0 +1,25 @@
+# {{project}} :: {{node}} Infinity Brief
+
+## Mission
+{{goal}}
+
+## Interfaces
+{{io}}
+
+## Constraints
+{{constraints}}
+
+## Context
+{{context}}
+
+## Deliverables
+{{deliverables}}
+
+## Quality Bar
+{{quality}}
+
+## References
+{{references}}
+
+## Notes
+{{notes}}

--- a/codex_infinity_prompts/templates/JETSON_AGENT.md
+++ b/codex_infinity_prompts/templates/JETSON_AGENT.md
@@ -1,0 +1,33 @@
+# {{project}} Jetson Agent :: Deployment Blueprint
+
+## Objective
+{{goal}}
+
+## Hardware Profile
+- Jetson model: {{jetson_model}}
+- CUDA / TensorRT targets: {{compute_targets}}
+- Sensor stack: {{sensors}}
+
+## Runtime Plan
+- Base image / OS: {{os_image}}
+- Containerization: {{container_strategy}}
+- Inference loop: {{inference_loop}}
+
+## Data + IO
+- Inputs: {{io_inputs}}
+- Outputs: {{io_outputs}}
+- Edge buffering: {{buffering}}
+
+## Constraints
+{{constraints}}
+
+## Safety + Ops
+- Watchdogs: {{watchdogs}}
+- Telemetry uplink: {{telemetry}}
+- Recovery steps: {{recovery}}
+
+## Deliverables
+{{deliverables}}
+
+## References
+{{references}}

--- a/codex_infinity_prompts/templates/PI_HOLO.md
+++ b/codex_infinity_prompts/templates/PI_HOLO.md
@@ -1,0 +1,31 @@
+# {{project}} Pi-Holo :: Pepper's Ghost Renderer Plan
+
+## Vision Brief
+{{goal}}
+
+## Display & Optics
+- Projection rig: {{projection_rig}}
+- Acrylic size / angle: {{acrylic_specs}}
+- Ambient light constraints: {{lighting}}
+
+## Rendering Stack
+- Engine / library: {{render_engine}}
+- Content pipeline: {{content_pipeline}}
+- Refresh cadence: {{refresh_rate}}
+
+## Control + Sync
+- Input channels: {{control_inputs}}
+- Coordination with Jetson: {{jetson_link}}
+- Heartbeat expectations: {{heartbeat}}
+
+## Constraints
+{{constraints}}
+
+## Deliverables
+{{deliverables}}
+
+## Testing Checklist
+{{testing}}
+
+## References
+{{references}}

--- a/codex_infinity_prompts/templates/PI_OPS.md
+++ b/codex_infinity_prompts/templates/PI_OPS.md
@@ -1,0 +1,32 @@
+# {{project}} Pi-Ops :: MQTT Operations Console
+
+## Mission
+{{goal}}
+
+## Runtime Targets
+- Language / stack: {{lang}}
+- Host node: {{node}}
+- Deployment mode: {{deployment}}
+
+## Interfaces
+- Input topics: {{io}}
+- Output surface: {{ui_surface}}
+- Persistence: {{persistence}}
+
+## Constraints
+{{constraints}}
+
+## Ops Metrics
+{{ops_metrics}}
+
+## Telemetry Format
+{{telemetry}}
+
+## Integration Points
+{{integration}}
+
+## Deliverables
+{{deliverables}}
+
+## Validation
+{{validation}}

--- a/codex_infinity_prompts/templates/PI_ZERO.md
+++ b/codex_infinity_prompts/templates/PI_ZERO.md
@@ -1,0 +1,31 @@
+# {{project}} Pi Zero :: Simulator Display Brief
+
+## Mission
+{{goal}}
+
+## Hardware Constraints
+- Model: {{pi_model}}
+- Power budget: {{power_budget}}
+- Peripherals: {{peripherals}}
+
+## Rendering Plan
+- Display medium: {{display}}
+- Refresh cadence: {{refresh_rate}}
+- Content pipeline: {{content_pipeline}}
+
+## IO & Messaging
+- Inputs: {{inputs}}
+- Outputs: {{outputs}}
+- Sync with Pi-Ops: {{sync_plan}}
+
+## Constraints
+{{constraints}}
+
+## Deliverables
+{{deliverables}}
+
+## Test Matrix
+{{testing}}
+
+## References
+{{references}}


### PR DESCRIPTION
## Summary
- add a codex_infinity_prompts workspace with a README and reusable markdown templates for each hardware node
- implement render.py to fill templates from CLI variables and support listing placeholders or strict validation
- include an example.sh helper that renders umbrella and Pi-Ops prompts with sensible defaults

## Testing
- ./codex_infinity_prompts/example.sh
- python -m compileall codex_infinity_prompts


------
https://chatgpt.com/codex/tasks/task_e_68e185c59e60832983079b62c7f377b0