### PR TITLE
Add Autopal FastAPI scaffold with security controls

### DIFF
--- a/autopal/Dockerfile
+++ b/autopal/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8080
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/autopal/README.md
+++ b/autopal/README.md
@@ -1,0 +1,42 @@
+# Autopal Console Service
+
+This directory contains a FastAPI reference implementation for a secrets materialization
+workflow with audience validation, step-up enforcement, per-endpoint rate limiting, and a
+dual-control approval flow.
+
+## Running locally
+
+```bash
+pip install -r requirements.txt
+AUTOPAL_CONFIG=./autopal.config.json uvicorn app.main:app --reload --port 8080
+```
+
+## Docker
+
+```bash
+docker build -t autopal .
+docker run -p 8080:8080 -e AUTOPAL_CONFIG=/app/autopal.config.json autopal
+```
+
+## Quick smoke tests
+
+```bash
+curl -i localhost:8080/health/live
+curl -i -X POST localhost:8080/secrets/materialize \
+  -H 'Authorization: Bearer test-token' \
+  -H 'X-Audience: gha:org/repo@refs/heads/main' \
+  -H 'X-Step-Up-Approved: true' \
+  -H 'X-Approval-Id: <approval-id>'
+```
+
+Create the approval id first by staging and confirming a dual-control request:
+
+```bash
+curl -X POST localhost:8080/secrets/approvals/request \
+  -H 'Content-Type: application/json' \
+  -d '{"context": "/secrets/materialize", "requested_by": "alice"}'
+
+curl -X POST localhost:8080/secrets/approvals/<approval-id>/approve \
+  -H 'Content-Type: application/json' \
+  -d '{"approved_by": "bob"}'
+```

--- a/autopal/app/config.py
+++ b/autopal/app/config.py
@@ -1,0 +1,58 @@
+"""Configuration loading for the Autopal FastAPI service."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel, Field, ValidationError
+
+
+class RateLimitConfig(BaseModel):
+    """Window based rate limit configuration."""
+
+    limit: int = Field(..., gt=0)
+    window_seconds: int = Field(..., gt=0)
+
+
+class EndpointPolicy(BaseModel):
+    """Security policy for a single endpoint."""
+
+    required_audience: List[str] = Field(default_factory=list)
+    step_up_required: bool = False
+    dual_control_required: bool = False
+    rate_limit: Optional[RateLimitConfig] = None
+
+
+class AppConfig(BaseModel):
+    """Top level application configuration."""
+
+    global_enabled: bool = True
+    dual_control_timeout_seconds: int = Field(600, gt=0)
+    endpoints: Dict[str, EndpointPolicy] = Field(default_factory=dict)
+
+    def policy_for(self, path: str) -> EndpointPolicy:
+        """Return the policy for a given path if defined, otherwise an empty policy."""
+
+        return self.endpoints.get(path, EndpointPolicy())
+
+
+class ConfigError(RuntimeError):
+    """Raised when configuration cannot be loaded."""
+
+
+def load_config(path: Path) -> AppConfig:
+    """Load and validate configuration from ``path``."""
+
+    try:
+        data = json.loads(path.read_text())
+    except FileNotFoundError as exc:  # pragma: no cover - explicit messaging
+        raise ConfigError(f"Configuration file not found: {path}") from exc
+    except json.JSONDecodeError as exc:  # pragma: no cover - explicit messaging
+        raise ConfigError(f"Invalid JSON configuration: {exc}") from exc
+
+    try:
+        return AppConfig.model_validate(data)
+    except ValidationError as exc:  # pragma: no cover - explicit messaging
+        raise ConfigError(f"Invalid configuration: {exc}") from exc

--- a/autopal/app/dependencies.py
+++ b/autopal/app/dependencies.py
@@ -1,0 +1,88 @@
+"""Reusable FastAPI dependencies."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from fastapi import Depends, Header, HTTPException, Request
+
+from .config import AppConfig, ConfigError, load_config
+from .dual_control import DualControlError, DualControlRegistry
+from .rate_limiter import InMemoryRateLimiter, RateLimitExceeded
+
+
+def get_config(request: Request) -> AppConfig:
+    """Return the active application configuration."""
+
+    return request.app.state.config
+
+
+def get_dual_control_registry(request: Request) -> DualControlRegistry:
+    """Return the dual control registry from the application state."""
+
+    return request.app.state.dual_control
+
+
+def enforce_security(path: str):
+    """Return a dependency callable that enforces security for ``path``."""
+
+    async def dependency(
+        request: Request,
+        audience: Optional[str] = Header(default=None, alias="X-Audience"),
+        step_up: Optional[str] = Header(default=None, alias="X-Step-Up-Approved"),
+        approval_id: Optional[str] = Header(default=None, alias="X-Approval-Id"),
+        authorization: Optional[str] = Header(default=None, alias="Authorization"),
+        config: AppConfig = Depends(get_config),
+        dual_control: DualControlRegistry = Depends(get_dual_control_registry),
+    ) -> None:
+        if not config.global_enabled:
+            raise HTTPException(status_code=503, detail="Service is currently disabled")
+
+        policy = config.policy_for(path)
+
+        if policy.required_audience:
+            if audience is None:
+                raise HTTPException(status_code=403, detail="Missing audience header")
+            if audience not in policy.required_audience:
+                raise HTTPException(status_code=403, detail="Unauthorized audience")
+
+        if policy.step_up_required:
+            if step_up is None:
+                raise HTTPException(status_code=403, detail="Step-up approval required")
+            if step_up.lower() not in {"true", "1", "yes"}:
+                raise HTTPException(status_code=403, detail="Invalid step-up header value")
+
+        if policy.dual_control_required:
+            if approval_id is None:
+                raise HTTPException(status_code=403, detail="Dual-control approval required")
+            try:
+                approval_record = await dual_control.consume(approval_id, context=path)
+            except DualControlError as exc:
+                raise HTTPException(status_code=403, detail=str(exc)) from exc
+            else:
+                request.state.dual_control_record = approval_record
+
+        if policy.rate_limit is not None:
+            limiter: InMemoryRateLimiter = request.app.state.rate_limiter
+            caller = authorization or (request.client.host if request.client else None) or "anonymous"
+            key = (path, caller)
+            try:
+                await limiter.hit(key, policy.rate_limit.limit, policy.rate_limit.window_seconds)
+            except RateLimitExceeded as exc:
+                raise HTTPException(
+                    status_code=429,
+                    detail="Rate limit exceeded",
+                    headers={"Retry-After": f"{int(exc.retry_after) + 1}"},
+                ) from exc
+
+    return dependency
+
+
+def load_initial_config(path: Path) -> AppConfig:
+    """Load configuration during application startup."""
+
+    try:
+        return load_config(path)
+    except ConfigError as exc:
+        raise RuntimeError(str(exc)) from exc

--- a/autopal/app/dual_control.py
+++ b/autopal/app/dual_control.py
@@ -1,0 +1,110 @@
+"""Dual control approval flow primitives."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+
+class DualControlError(RuntimeError):
+    """Raised when a dual-control action cannot be completed."""
+
+
+@dataclass
+class ApprovalRecord:
+    """Represents the lifecycle of a dual-control request."""
+
+    approval_id: str
+    context: str
+    requested_by: str
+    created_at: float
+    approved_by: Optional[str] = None
+    approved_at: Optional[float] = None
+    consumed_at: Optional[float] = None
+    metadata: Dict[str, str] = field(default_factory=dict)
+
+    @property
+    def is_approved(self) -> bool:
+        return self.approved_by is not None
+
+    @property
+    def is_consumed(self) -> bool:
+        return self.consumed_at is not None
+
+
+class DualControlRegistry:
+    """In-memory registry for dual-control approvals."""
+
+    def __init__(self, timeout_seconds: int) -> None:
+        self._timeout_seconds = timeout_seconds
+        self._records: Dict[str, ApprovalRecord] = {}
+        self._lock = asyncio.Lock()
+
+    async def request(self, *, context: str, requested_by: str, metadata: Optional[Dict[str, str]] = None) -> ApprovalRecord:
+        """Create a new approval request."""
+
+        approval_id = str(uuid.uuid4())
+        record = ApprovalRecord(
+            approval_id=approval_id,
+            context=context,
+            requested_by=requested_by,
+            created_at=time.time(),
+            metadata=metadata or {},
+        )
+        async with self._lock:
+            self._records[approval_id] = record
+        return record
+
+    async def approve(self, approval_id: str, *, approved_by: str) -> ApprovalRecord:
+        """Approve an existing request with a different operator."""
+
+        async with self._lock:
+            record = self._get_record(approval_id)
+            self._ensure_active(record)
+            if record.is_approved:
+                raise DualControlError("Approval already dual-approved")
+            if record.requested_by == approved_by:
+                raise DualControlError("Second approver must differ from requester")
+            record.approved_by = approved_by
+            record.approved_at = time.time()
+            return record
+
+    async def consume(self, approval_id: str, *, context: str) -> ApprovalRecord:
+        """Mark an approved request as consumed."""
+
+        async with self._lock:
+            record = self._get_record(approval_id)
+            self._ensure_active(record)
+            if record.context != context:
+                raise DualControlError("Approval context mismatch")
+            if not record.is_approved:
+                raise DualControlError("Approval has not been dual-approved yet")
+            record.consumed_at = time.time()
+            return record
+
+    async def get(self, approval_id: str) -> ApprovalRecord:
+        async with self._lock:
+            record = self._get_record(approval_id)
+            if not record.is_consumed and self._is_expired(record):
+                raise DualControlError("Approval expired")
+            return record
+
+    def _get_record(self, approval_id: str) -> ApprovalRecord:
+        try:
+            record = self._records[approval_id]
+        except KeyError as exc:
+            raise DualControlError("Unknown approval identifier") from exc
+        return record
+
+    def _ensure_active(self, record: ApprovalRecord) -> None:
+        if record.is_consumed:
+            raise DualControlError("Approval already consumed")
+        if self._is_expired(record):
+            raise DualControlError("Approval expired")
+
+    def _is_expired(self, record: ApprovalRecord) -> bool:
+        now = time.time()
+        return now - record.created_at > self._timeout_seconds and not record.is_consumed

--- a/autopal/app/main.py
+++ b/autopal/app/main.py
@@ -1,0 +1,174 @@
+"""Autopal FastAPI entrypoint."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Dict
+
+from fastapi import Depends, FastAPI, HTTPException, Request, status
+
+from .config import AppConfig
+from .dependencies import enforce_security, get_config, get_dual_control_registry, load_initial_config
+from .dual_control import DualControlError, DualControlRegistry
+from .rate_limiter import InMemoryRateLimiter
+from .schemas import ApprovalConfirm, ApprovalRequest, ApprovalResponse, MaterializeResponse
+
+APP_TITLE = "Autopal Console"
+APP_VERSION = "0.1.0"
+
+app = FastAPI(title=APP_TITLE, version=APP_VERSION)
+
+
+def _default_config_path() -> Path:
+    """Resolve the configuration file path, honoring the ``AUTOPAL_CONFIG`` env var."""
+
+    override = os.getenv("AUTOPAL_CONFIG")
+    if override:
+        return Path(override).expanduser()
+    return Path(__file__).resolve().parents[1] / "autopal.config.json"
+
+
+def _normalize_context(raw: str) -> str:
+    """Ensure the approval context is a normalized endpoint path."""
+
+    context = raw.strip()
+    if not context.startswith("/"):
+        context = f"/{context}"
+    return context
+
+
+@app.on_event("startup")
+async def startup_event() -> None:
+    config_path = _default_config_path()
+    app.state.config_path = config_path
+    config = load_initial_config(config_path)
+    app.state.config = config
+    app.state.rate_limiter = InMemoryRateLimiter()
+    app.state.dual_control = DualControlRegistry(config.dual_control_timeout_seconds)
+
+
+@app.get("/health/live")
+async def live() -> Dict[str, str]:
+    """Liveness probe."""
+
+    return {"status": "live"}
+
+
+@app.get("/health/ready")
+async def ready(config: AppConfig = Depends(get_config)) -> Dict[str, str]:
+    """Readiness probe that surfaces the global switch state."""
+
+    return {"status": "ready", "global_enabled": "true" if config.global_enabled else "false"}
+
+
+@app.get("/config")
+async def current_config(config: AppConfig = Depends(get_config)) -> Dict[str, object]:
+    """Expose the current configuration (sans secrets)."""
+
+    return config.model_dump()
+
+
+@app.post("/config/reload", status_code=status.HTTP_202_ACCEPTED)
+async def reload_config(request: Request) -> Dict[str, str]:
+    """Reload configuration from disk."""
+
+    config_path: Path = request.app.state.config_path
+    config = load_initial_config(config_path)
+    request.app.state.config = config
+    request.app.state.dual_control = DualControlRegistry(config.dual_control_timeout_seconds)
+    return {"status": "reloaded"}
+
+
+@app.post(
+    "/secrets/approvals/request",
+    status_code=status.HTTP_201_CREATED,
+    response_model=ApprovalResponse,
+    dependencies=[Depends(enforce_security("/secrets/approvals/request"))],
+)
+async def create_approval(
+    payload: ApprovalRequest,
+    registry: DualControlRegistry = Depends(get_dual_control_registry),
+) -> ApprovalResponse:
+    """Stage a dual-control approval."""
+
+    context = _normalize_context(payload.context)
+    record = await registry.request(
+        context=context,
+        requested_by=payload.requested_by,
+        metadata=payload.metadata,
+    )
+    return ApprovalResponse(
+        approval_id=record.approval_id,
+        context=record.context,
+        requested_by=record.requested_by,
+        approved_by=record.approved_by,
+        consumed_at=record.consumed_at,
+    )
+
+
+@app.post(
+    "/secrets/approvals/{approval_id}/approve",
+    response_model=ApprovalResponse,
+    dependencies=[Depends(enforce_security("/secrets/approvals/approve"))],
+)
+async def approve_request(
+    approval_id: str,
+    payload: ApprovalConfirm,
+    registry: DualControlRegistry = Depends(get_dual_control_registry),
+) -> ApprovalResponse:
+    """Confirm an existing dual-control approval."""
+
+    try:
+        record = await registry.approve(approval_id, approved_by=payload.approved_by)
+    except DualControlError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return ApprovalResponse(
+        approval_id=record.approval_id,
+        context=record.context,
+        requested_by=record.requested_by,
+        approved_by=record.approved_by,
+        consumed_at=record.consumed_at,
+    )
+
+
+@app.get(
+    "/secrets/approvals/{approval_id}",
+    response_model=ApprovalResponse,
+    dependencies=[Depends(enforce_security("/secrets/approvals/status"))],
+)
+async def get_approval(
+    approval_id: str,
+    registry: DualControlRegistry = Depends(get_dual_control_registry),
+) -> ApprovalResponse:
+    """Inspect the current state of an approval."""
+
+    try:
+        record = await registry.get(approval_id)
+    except DualControlError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    return ApprovalResponse(
+        approval_id=record.approval_id,
+        context=record.context,
+        requested_by=record.requested_by,
+        approved_by=record.approved_by,
+        consumed_at=record.consumed_at,
+    )
+
+
+@app.post(
+    "/secrets/materialize",
+    response_model=MaterializeResponse,
+    dependencies=[Depends(enforce_security("/secrets/materialize"))],
+)
+async def materialize_secret(request: Request) -> MaterializeResponse:
+    """Materialize a secret once all controls pass."""
+
+    approval_record = getattr(request.state, "dual_control_record", None)
+    if approval_record is None:
+        raise HTTPException(status_code=500, detail="Dual-control record missing")
+
+    secret_handle = f"secret::{approval_record.approval_id}"
+    return MaterializeResponse(status="ok", approval_id=approval_record.approval_id, secret_handle=secret_handle)

--- a/autopal/app/rate_limiter.py
+++ b/autopal/app/rate_limiter.py
@@ -1,0 +1,46 @@
+"""Simple in-memory rate limiting utilities."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections import defaultdict, deque
+from typing import Deque, Dict, Tuple
+
+
+class RateLimitExceeded(RuntimeError):
+    """Raised when a caller exceeds an endpoint's configured rate limit."""
+
+    def __init__(self, retry_after: float) -> None:
+        super().__init__("Rate limit exceeded")
+        self.retry_after = retry_after
+
+
+class InMemoryRateLimiter:
+    """Naïve in-memory rate limiter keyed by caller identifier."""
+
+    def __init__(self) -> None:
+        self._hits: Dict[Tuple[str, str], Deque[float]] = defaultdict(deque)
+        self._lock = asyncio.Lock()
+
+    async def hit(self, key: Tuple[str, str], limit: int, window_seconds: int) -> None:
+        """Record a hit for ``key`` and raise ``RateLimitExceeded`` if it is over the limit."""
+
+        now = time.monotonic()
+        async with self._lock:
+            hits = self._hits[key]
+            threshold = now - window_seconds
+            while hits and hits[0] <= threshold:
+                hits.popleft()
+
+            if len(hits) >= limit:
+                retry_after = hits[0] + window_seconds - now
+                raise RateLimitExceeded(max(retry_after, 0.0))
+
+            hits.append(now)
+
+    async def reset(self, key: Tuple[str, str]) -> None:
+        """Clear the hit counter for ``key``."""
+
+        async with self._lock:
+            self._hits.pop(key, None)

--- a/autopal/app/schemas.py
+++ b/autopal/app/schemas.py
@@ -1,0 +1,39 @@
+"""Pydantic models for the Autopal service."""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+from pydantic import BaseModel, Field
+
+
+class ApprovalRequest(BaseModel):
+    """Payload to initiate a dual-control approval."""
+
+    context: str = Field(..., description="Endpoint path this approval applies to")
+    requested_by: str = Field(..., description="Identifier for the requesting operator")
+    metadata: Dict[str, str] = Field(default_factory=dict)
+
+
+class ApprovalResponse(BaseModel):
+    """Metadata returned when creating or fetching an approval."""
+
+    approval_id: str
+    context: str
+    requested_by: str
+    approved_by: Optional[str] = None
+    consumed_at: Optional[float] = None
+
+
+class ApprovalConfirm(BaseModel):
+    """Payload to confirm an existing approval."""
+
+    approved_by: str = Field(..., description="Identifier for the second operator")
+
+
+class MaterializeResponse(BaseModel):
+    """Response for the materialize endpoint."""
+
+    status: str
+    approval_id: str
+    secret_handle: str

--- a/autopal/autopal.config.json
+++ b/autopal/autopal.config.json
@@ -1,0 +1,17 @@
+{
+  "global_enabled": true,
+  "dual_control_timeout_seconds": 900,
+  "endpoints": {
+    "/secrets/materialize": {
+      "required_audience": [
+        "gha:org/repo@refs/heads/main"
+      ],
+      "step_up_required": true,
+      "dual_control_required": true,
+      "rate_limit": {
+        "limit": 5,
+        "window_seconds": 60
+      }
+    }
+  }
+}

--- a/autopal/requirements.txt
+++ b/autopal/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.110.0
+uvicorn[standard]==0.27.1
+pydantic-settings==2.2.1


### PR DESCRIPTION
## Summary
- add the Autopal FastAPI starter service with a config-driven security posture (global toggle, audience validation, step-up, rate limiting, dual control)
- implement in-memory dual-control approvals and per-endpoint rate limiting utilities backing the secrets API
- provide project metadata including Dockerfile, requirements, sample config, and README usage instructions

## Testing
- python -m compileall autopal/app

------
https://chatgpt.com/codex/tasks/task_e_68e186636c388329956d7d5953059c0f