### PR TITLE
Add consent abandonment rule, harness, and docs

### DIFF
--- a/cmd/metrics-proxy/go.mod
+++ b/cmd/metrics-proxy/go.mod
@@ -1,0 +1,3 @@
+module github.com/blackroad/prism-console/cmd/metrics-proxy
+
+go 1.21

--- a/cmd/metrics-proxy/main.go
+++ b/cmd/metrics-proxy/main.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"time"
+)
+
+type Point struct {
+	T int64   `json:"t"`
+	V float64 `json:"v"`
+}
+
+type Series struct {
+	Points []Point `json:"points"`
+}
+
+type promValue struct {
+	Values [][]any `json:"values"`
+}
+
+type promResponse struct {
+	Data struct {
+		Result []promValue `json:"result"`
+	} `json:"data"`
+}
+
+var httpClient = &http.Client{Timeout: 10 * time.Second}
+
+func main() {
+	base := os.Getenv("PROM_URL")
+	http.HandleFunc("/metrics/consent_abandonment_rate", func(w http.ResponseWriter, r *http.Request) {
+		if base == "" {
+			http.Error(w, "PROM_URL not configured", http.StatusInternalServerError)
+			return
+		}
+		window := "7d"
+		step := "1h"
+		query := `(
+            increase(consent_escalations_started_total[` + window + `])
+            - increase(consent_escalations_resolved_total[` + window + `])
+        ) / clamp_min(increase(consent_escalations_started_total[` + window + `]),1)`
+		params := url.Values{
+			"query": {query},
+			"start": {time.Now().Add(-7 * 24 * time.Hour).Format(time.RFC3339)},
+			"end":   {time.Now().Format(time.RFC3339)},
+			"step":  {step},
+		}
+		upstream, err := url.Parse(base)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("invalid PROM_URL: %v", err), http.StatusInternalServerError)
+			return
+		}
+		upstream.RawQuery = params.Encode()
+
+		resp, err := httpClient.Get(upstream.String())
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode >= 400 {
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+			http.Error(w, fmt.Sprintf("upstream error %d: %s", resp.StatusCode, string(body)), http.StatusBadGateway)
+			return
+		}
+		var out promResponse
+		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
+		series := buildSeries(out)
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(series); err != nil {
+			log.Printf("encode response: %v", err)
+		}
+	})
+
+	log.Println("metrics proxy listening on :9099")
+	if err := http.ListenAndServe(":9099", nil); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func buildSeries(resp promResponse) Series {
+	var series Series
+	if len(resp.Data.Result) == 0 {
+		return series
+	}
+	for _, entry := range resp.Data.Result[0].Values {
+		if len(entry) < 2 {
+			continue
+		}
+		tsFloat, ok := entry[0].(float64)
+		if !ok {
+			continue
+		}
+		rawValue, ok := entry[1].(string)
+		if !ok {
+			continue
+		}
+		value, err := strconv.ParseFloat(rawValue, 64)
+		if err != nil {
+			continue
+		}
+		series.Points = append(series.Points, Point{T: int64(tsFloat * 1000), V: clamp01(value)})
+	}
+	return series
+}
+
+func clamp01(x float64) float64 {
+	if x < 0 {
+		return 0
+	}
+	if x > 1 {
+		return 1
+	}
+	return x
+}

--- a/docs/policies/consent-abandonment-exceeds-threshold.html
+++ b/docs/policies/consent-abandonment-exceeds-threshold.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Consent abandonment exceeds threshold</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; margin: 32px; color: #1f2933; }
+    h1 { margin-bottom: 0.25em; }
+    h2 { margin-top: 2.5em; }
+    pre { background: #f5f7fa; padding: 12px 16px; border-radius: 6px; overflow-x: auto; }
+    code { font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', monospace; font-size: 0.95em; }
+    table { border-collapse: collapse; margin-top: 1em; }
+    th, td { padding: 6px 12px; border-bottom: 1px solid #e5e9f0; text-align: left; }
+    ul { padding-left: 20px; }
+  </style>
+</head>
+<body>
+  <h1>Consent abandonment exceeds threshold</h1>
+  <p>Alerts when the fraction of consent escalations that are not resolved (no allow within 24h) exceeds 25% on a rolling 7-day window.</p>
+  <table>
+    <tr><th>Rule ID</th><td>CONSENT_ABANDONMENT_RATE-5a4f3a2a-6f9e-4d3e-a0b7-48c2c11e70de</td></tr>
+    <tr><th>Category</th><td>observe</td></tr>
+    <tr><th>Severity</th><td>Med</td></tr>
+    <tr><th>Owners</th><td>@platform-eng, @secops</td></tr>
+    <tr><th>Notify</th><td>slack:#platform</td></tr>
+    <tr><th>On match</th><td>Decision: notify<br/>Reason: consent_abandonment_spike</td></tr>
+  </table>
+
+  <h2>Expression</h2>
+  <pre><code>rate(consent_abandonment(), &quot;168h&quot;) &gt; 0.25
+</code></pre>
+
+  <h2>Metrics selectors</h2>
+  <h3>Prometheus</h3>
+  <pre><code>(
+  increase(consent_escalations_started_total[{{window}}])
+  -
+  increase(consent_escalations_resolved_total[{{window}}])
+)
+/
+clamp_min(increase(consent_escalations_started_total[{{window}}]), 1)</code></pre>
+  <h3>ClickHouse</h3>
+  <pre><code>WITH started AS (
+  SELECT correlation_id, min(ts) AS started_at
+  FROM audit_events
+  WHERE ts &gt;= now() - INTERVAL {{window}} AND outcome=&#x27;deny&#x27; AND deny_reason=&#x27;consent_required&#x27;
+  GROUP BY correlation_id
+),
+resolved AS (
+  SELECT a.correlation_id
+  FROM audit_events a
+  INNER JOIN started s USING (correlation_id)
+  WHERE a.outcome=&#x27;allow&#x27; AND a.ts BETWEEN s.started_at AND s.started_at + INTERVAL 24 HOUR
+  GROUP BY a.correlation_id
+)
+SELECT
+  (count() - countIf(correlation_id IN resolved)) / nullIf(count(), 0)
+FROM started</code></pre>
+
+  
+<h2>Live trend</h2>
+<div id="rule-chart" style="height:240px;max-width:720px;border:1px solid #e0e0e0;border-radius:6px;overflow:hidden;"></div>
+<script>
+(function(){
+  const endpoint = "/metrics/consent_abandonment_rate";
+  const title = "Consent Abandonment (7d)";
+  const el = document.getElementById('rule-chart');
+  if (!el || !endpoint) return;
+  fetch(endpoint).then(res => res.json()).then(data => {
+    const points = Array.isArray(data.points) ? data.points : [];
+    const w = el.clientWidth || 640;
+    const h = 240;
+    if (points.length === 0) {
+      el.innerHTML = '<div style="padding:16px;color:#666;font-size:14px;">No data available for the selected window.</div>';
+      return;
+    }
+    const xs = points.map(p => p.t);
+    const ys = points.map(p => p.v);
+    const x0 = Math.min(...xs);
+    const x1 = Math.max(...xs);
+    const toX = x => ((x - x0) / ((x1 - x0) || 1)) * (w - 2) + 1;
+    const toY = y => h - ((y - 0) / (1 || 1)) * (h - 2) - 1;
+    let d = 'M' + toX(xs[0]) + ',' + toY(ys[0]);
+    for (let i = 1; i < xs.length; i++) {
+      d += ' L' + toX(xs[i]) + ',' + toY(ys[i]);
+    }
+    const rightLabelX = Math.max(w - 48, 8);
+    el.innerHTML = '<svg width="' + w + '" height="' + h + '" viewBox="0 0 ' + w + ' ' + h + '"><rect width="' + w + '" height="' + h + '" fill="white" stroke="#ddd"/><path d="' + d + '" fill="none" stroke="#1f77b4" stroke-width="2"/><text x="8" y="18" font-size="12" fill="#333">' + title + '</text><text x="' + rightLabelX + '" y="18" font-size="12" fill="#333">ratio</text></svg>';
+  }).catch(() => {
+    el.innerHTML = '<div style="padding:16px;color:#b94a48;font-size:14px;">Unable to load live metrics.</div>';
+  });
+})();
+</script>
+
+</body>
+</html>

--- a/fixtures/consent/abandon.series.json
+++ b/fixtures/consent/abandon.series.json
@@ -1,0 +1,6 @@
+{"window":"168h","events":[
+  {"deny_reason":"consent_required"},
+  {"deny_reason":"consent_required"},
+  {"deny_reason":"consent_required"},
+  {"outcome":"allow"}
+]}

--- a/go.work
+++ b/go.work
@@ -1,0 +1,7 @@
+go 1.21
+
+use (
+    ./harness
+    ./cmd/metrics-proxy
+    ./compliance
+)

--- a/harness/go.mod
+++ b/harness/go.mod
@@ -1,0 +1,5 @@
+module github.com/blackroad/prism-console/harness
+
+go 1.21
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/harness/go.sum
+++ b/harness/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/harness/main.go
+++ b/harness/main.go
@@ -1,0 +1,287 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type onMatchConfig struct {
+	Decision string         `yaml:"decision"`
+	Reason   string         `yaml:"reason"`
+	Details  map[string]any `yaml:"details"`
+}
+
+type rawRule struct {
+	RuleID  string         `yaml:"rule_id"`
+	ID      string         `yaml:"id"`
+	Expr    string         `yaml:"expr"`
+	OnMatch *onMatchConfig `yaml:"on_match"`
+}
+
+type compiledRule struct {
+	ID        string
+	Expr      string
+	Threshold float64
+	OnMatch   onMatchConfig
+}
+
+type series struct {
+	Window string        `json:"window"`
+	Events []seriesEvent `json:"events"`
+}
+
+type seriesEvent struct {
+	Repeat int
+	Fields map[string]any
+}
+
+type decision struct {
+	Decision string  `json:"decision"`
+	Reason   string  `json:"reason,omitempty"`
+	Ratio    float64 `json:"ratio"`
+}
+
+func (e *seriesEvent) UnmarshalJSON(data []byte) error {
+	type alias struct {
+		Repeat *int           `json:"repeat"`
+		Each   map[string]any `json:"each"`
+	}
+	var a alias
+	if err := json.Unmarshal(data, &a); err == nil && a.Repeat != nil {
+		rep := *a.Repeat
+		if rep <= 0 {
+			rep = 1
+		}
+		e.Repeat = rep
+		e.Fields = cloneMap(a.Each)
+		return nil
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return err
+	}
+	repeat := 1
+	if rep, ok := obj["repeat"]; ok {
+		repeat = intFromAny(rep)
+		delete(obj, "repeat")
+	}
+	if each, ok := obj["each"].(map[string]any); ok {
+		e.Fields = cloneMap(each)
+	} else {
+		e.Fields = cloneMap(obj)
+	}
+	if repeat <= 0 {
+		repeat = 1
+	}
+	e.Repeat = repeat
+	return nil
+}
+
+func (s series) expand() []map[string]any {
+	var expanded []map[string]any
+	for _, ev := range s.Events {
+		repeat := ev.Repeat
+		if repeat <= 0 {
+			repeat = 1
+		}
+		for i := 0; i < repeat; i++ {
+			expanded = append(expanded, cloneMap(ev.Fields))
+		}
+	}
+	return expanded
+}
+
+func cloneMap(src map[string]any) map[string]any {
+	if src == nil {
+		return map[string]any{}
+	}
+	dst := make(map[string]any, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}
+
+func intFromAny(v any) int {
+	switch value := v.(type) {
+	case int:
+		return value
+	case int64:
+		return int(value)
+	case float64:
+		return int(value)
+	case json.Number:
+		n, _ := value.Int64()
+		return int(n)
+	case string:
+		if parsed, err := strconv.Atoi(value); err == nil {
+			return parsed
+		}
+	}
+	return 1
+}
+
+func compileFromYAML(path string) (compiledRule, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return compiledRule{}, err
+	}
+	var raw rawRule
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return compiledRule{}, err
+	}
+	id := raw.RuleID
+	if id == "" {
+		id = raw.ID
+	}
+	if id == "" {
+		return compiledRule{}, errors.New("rule id is required")
+	}
+	threshold, err := parseThreshold(raw.Expr)
+	if err != nil {
+		return compiledRule{}, err
+	}
+	compiled := compiledRule{
+		ID:        id,
+		Expr:      raw.Expr,
+		Threshold: threshold,
+	}
+	if raw.OnMatch != nil {
+		compiled.OnMatch = *raw.OnMatch
+	}
+	if compiled.OnMatch.Decision == "" {
+		compiled.OnMatch.Decision = "notify"
+	}
+	return compiled, nil
+}
+
+func parseThreshold(expr string) (float64, error) {
+	idx := strings.LastIndex(expr, ">")
+	if idx == -1 {
+		return 0, errors.New("expression must contain '>' comparison")
+	}
+	segment := strings.TrimSpace(expr[idx+1:])
+	if segment == "" {
+		return 0, errors.New("comparison threshold missing")
+	}
+	fields := strings.Fields(segment)
+	if len(fields) > 0 {
+		segment = fields[0]
+	}
+	segment = strings.Trim(segment, "()")
+	value, err := strconv.ParseFloat(segment, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid threshold %q: %w", segment, err)
+	}
+	return value, nil
+}
+
+func evaluateRuleForSeries(rule compiledRule, input series) (decision, error) {
+	events := input.expand()
+	started := 0
+	resolved := 0
+	for _, ev := range events {
+		denyReason := strings.ToLower(stringify(ev["deny_reason"]))
+		if denyReason == "consent_required" {
+			started++
+		}
+		outcome := strings.ToLower(stringify(ev["outcome"]))
+		if outcome == "allow" {
+			resolved++
+		}
+	}
+	ratio := 0.0
+	if started > 0 {
+		abandon := started - resolved
+		if abandon < 0 {
+			abandon = 0
+		}
+		ratio = float64(abandon) / float64(started)
+		if ratio < 0 {
+			ratio = 0
+		}
+		if ratio > 1 {
+			ratio = 1
+		}
+	}
+	result := decision{
+		Decision: "allow",
+		Ratio:    ratio,
+	}
+	if ratio > rule.Threshold {
+		result.Decision = rule.OnMatch.Decision
+		if result.Decision == "" {
+			result.Decision = "notify"
+		}
+		result.Reason = rule.OnMatch.Reason
+	}
+	return result, nil
+}
+
+func stringify(v any) string {
+	switch value := v.(type) {
+	case string:
+		return value
+	case fmt.Stringer:
+		return value.String()
+	case json.Number:
+		return value.String()
+	case nil:
+		return ""
+	default:
+		return fmt.Sprintf("%v", value)
+	}
+}
+
+func printDecision(dec decision) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(dec)
+}
+
+func fatal(err error) {
+	fmt.Fprintln(os.Stderr, "error:", err)
+	os.Exit(1)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "usage: %s <command> [args]\n", os.Args[0])
+		os.Exit(1)
+	}
+	switch os.Args[1] {
+	case "test:series":
+		if len(os.Args) < 4 {
+			fmt.Fprintln(os.Stderr, "usage: test:series <rule.yaml> <series.json>")
+			os.Exit(1)
+		}
+		rule, err := compileFromYAML(os.Args[2])
+		if err != nil {
+			fatal(err)
+		}
+		data, err := os.ReadFile(os.Args[3])
+		if err != nil {
+			fatal(err)
+		}
+		var ser series
+		if err := json.Unmarshal(data, &ser); err != nil {
+			fatal(err)
+		}
+		dec, err := evaluateRuleForSeries(rule, ser)
+		if err != nil {
+			fatal(err)
+		}
+		if err := printDecision(dec); err != nil {
+			fatal(err)
+		}
+	default:
+		fmt.Fprintf(os.Stderr, "unknown command %q\n", os.Args[1])
+		os.Exit(1)
+	}
+}

--- a/policy/rules_engine/docgen.py
+++ b/policy/rules_engine/docgen.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import argparse
+import html
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+import yaml
+
+
+def _slugify(value: str) -> str:
+    value = value.strip().lower()
+    if not value:
+        return "rule"
+    slug_chars: list[str] = []
+    for ch in value:
+        if ch.isalnum():
+            slug_chars.append(ch)
+        elif ch in {" ", "-", "_"}:
+            if not slug_chars or slug_chars[-1] != "-":
+                slug_chars.append("-")
+    slug = "".join(slug_chars).strip("-")
+    return slug or "rule"
+
+
+def _render_chart(config: Mapping[str, Any], title: str) -> str:
+    endpoint = config.get("endpoint")
+    if not endpoint:
+        return ""
+    endpoint_js = json.dumps(str(endpoint))
+    title_js = json.dumps(config.get("title") or title)
+    return f"""
+<h2>Live trend</h2>
+<div id=\"rule-chart\" style=\"height:240px;max-width:720px;border:1px solid #e0e0e0;border-radius:6px;overflow:hidden;\"></div>
+<script>
+(function(){{
+  const endpoint = {endpoint_js};
+  const title = {title_js};
+  const el = document.getElementById('rule-chart');
+  if (!el || !endpoint) return;
+  fetch(endpoint).then(res => res.json()).then(data => {{
+    const points = Array.isArray(data.points) ? data.points : [];
+    const w = el.clientWidth || 640;
+    const h = 240;
+    if (points.length === 0) {{
+      el.innerHTML = '<div style="padding:16px;color:#666;font-size:14px;">No data available for the selected window.</div>';
+      return;
+    }}
+    const xs = points.map(p => p.t);
+    const ys = points.map(p => p.v);
+    const x0 = Math.min(...xs);
+    const x1 = Math.max(...xs);
+    const toX = x => ((x - x0) / ((x1 - x0) || 1)) * (w - 2) + 1;
+    const toY = y => h - ((y - 0) / (1 || 1)) * (h - 2) - 1;
+    let d = 'M' + toX(xs[0]) + ',' + toY(ys[0]);
+    for (let i = 1; i < xs.length; i++) {{
+      d += ' L' + toX(xs[i]) + ',' + toY(ys[i]);
+    }}
+    const rightLabelX = Math.max(w - 48, 8);
+    el.innerHTML = '<svg width="' + w + '" height="' + h + '" viewBox="0 0 ' + w + ' ' + h + '"><rect width="' + w + '" height="' + h + '" fill="white" stroke="#ddd"/><path d="' + d + '" fill="none" stroke="#1f77b4" stroke-width="2"/><text x="8" y="18" font-size="12" fill="#333">' + title + '</text><text x="' + rightLabelX + '" y="18" font-size="12" fill="#333">ratio</text></svg>';
+  }}).catch(() => {{
+    el.innerHTML = '<div style="padding:16px;color:#b94a48;font-size:14px;">Unable to load live metrics.</div>';
+  }});
+}})();
+</script>
+"""
+
+
+def render_rule_document(rule: Mapping[str, Any]) -> str:
+    rule_id = str(rule.get("rule_id") or rule.get("id") or "")
+    name = str(rule.get("name") or rule_id or "Unnamed Rule")
+    description = (rule.get("description") or "").strip()
+    category = str(rule.get("category") or rule.get("mode") or "observe")
+    severity = str(rule.get("severity") or "").lower()
+    owners = [str(o) for o in rule.get("owners", [])]
+    channels = [str(c) for c in rule.get("notify", {}).get("channels", [])]
+    on_match = rule.get("on_match") or {}
+    expr = str(rule.get("expr") or "")
+    metrics_selector = rule.get("metrics_selector") or {}
+
+    chart_html = _render_chart(rule.get("docs_chart") or {}, name)
+
+    owners_html = ", ".join(html.escape(owner) for owner in owners) or "—"
+    channels_html = ", ".join(html.escape(ch) for ch in channels) or "—"
+    severity_label = severity.capitalize() if severity else "—"
+
+    prom_selector = html.escape(metrics_selector.get("prom", "").strip())
+    ch_selector = html.escape(metrics_selector.get("ch", "").strip())
+
+    on_match_reason = html.escape(str(on_match.get("reason") or "—"))
+    on_match_decision = html.escape(str(on_match.get("decision") or "notify"))
+
+    description_html = f"<p>{html.escape(description)}</p>" if description else ""
+
+    prom_block = f"<pre><code>{prom_selector}</code></pre>" if prom_selector else "<p>No Prometheus selector configured.</p>"
+    ch_block = f"<pre><code>{ch_selector}</code></pre>" if ch_selector else "<p>No ClickHouse selector configured.</p>"
+
+    expr_block = html.escape(expr)
+
+    return f"""<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+  <meta charset=\"utf-8\" />
+  <title>{html.escape(name)}</title>
+  <style>
+    body {{ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; margin: 32px; color: #1f2933; }}
+    h1 {{ margin-bottom: 0.25em; }}
+    h2 {{ margin-top: 2.5em; }}
+    pre {{ background: #f5f7fa; padding: 12px 16px; border-radius: 6px; overflow-x: auto; }}
+    code {{ font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', monospace; font-size: 0.95em; }}
+    table {{ border-collapse: collapse; margin-top: 1em; }}
+    th, td {{ padding: 6px 12px; border-bottom: 1px solid #e5e9f0; text-align: left; }}
+    ul {{ padding-left: 20px; }}
+  </style>
+</head>
+<body>
+  <h1>{html.escape(name)}</h1>
+  {description_html}
+  <table>
+    <tr><th>Rule ID</th><td>{html.escape(rule_id)}</td></tr>
+    <tr><th>Category</th><td>{html.escape(category)}</td></tr>
+    <tr><th>Severity</th><td>{html.escape(severity_label)}</td></tr>
+    <tr><th>Owners</th><td>{owners_html}</td></tr>
+    <tr><th>Notify</th><td>{channels_html}</td></tr>
+    <tr><th>On match</th><td>Decision: {on_match_decision}<br/>Reason: {on_match_reason}</td></tr>
+  </table>
+
+  <h2>Expression</h2>
+  <pre><code>{expr_block}</code></pre>
+
+  <h2>Metrics selectors</h2>
+  <h3>Prometheus</h3>
+  {prom_block}
+  <h3>ClickHouse</h3>
+  {ch_block}
+
+  {chart_html}
+</body>
+</html>
+"""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Render rule documentation HTML from YAML definitions.")
+    parser.add_argument("rule", help="Path to the rule YAML file")
+    parser.add_argument("output", help="Directory to write the HTML file into")
+    args = parser.parse_args()
+
+    rule_path = Path(args.rule)
+    if not rule_path.exists():
+        raise SystemExit(f"rule file not found: {rule_path}")
+
+    payload = yaml.safe_load(rule_path.read_text())
+    document = render_rule_document(payload)
+
+    name = str(payload.get("name") or payload.get("rule_id") or rule_path.stem)
+    slug = _slugify(name)
+    output_dir = Path(args.output)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / f"{slug}.html"
+    output_path.write_text(document, encoding="utf-8")
+    print(output_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/policy/rules_engine/evaluator.py
+++ b/policy/rules_engine/evaluator.py
@@ -178,6 +178,9 @@ class ExpressionEvaluator:
                 predicate_node = node.args[0]
                 window = self._eval_node(node.args[1], event, ctx) if len(node.args) > 1 else ""
                 series = ctx.series
+                if isinstance(predicate_node, ast.Call) and isinstance(predicate_node.func, ast.Name):
+                    if predicate_node.func.id == "consent_abandonment":
+                        return ctx.consent_abandonment_ratio(str(window), series)
                 predicate = lambda item: bool(self._eval_node(predicate_node, item, ctx))
                 return ctx.rate(predicate, window, series)
             if func_name == "distinct_over":

--- a/rules/consent_abandonment_rate.yaml
+++ b/rules/consent_abandonment_rate.yaml
@@ -1,0 +1,77 @@
+rule_id: "CONSENT_ABANDONMENT_RATE-5a4f3a2a-6f9e-4d3e-a0b7-48c2c11e70de"
+name: "Consent abandonment exceeds threshold"
+category: "observe"
+severity: "med"
+version: 1
+description: >
+  Alerts when the fraction of consent escalations that are not resolved
+  (no allow within 24h) exceeds 25% on a rolling 7-day window.
+inputs_schema:
+  - name: ts
+  - name: deny_reason
+  - name: outcome
+output_type: "json"
+expr: |
+  rate(consent_abandonment(), "168h") > 0.25
+metrics_selector:
+  prom: |
+    (
+      increase(consent_escalations_started_total[{{window}}])
+      -
+      increase(consent_escalations_resolved_total[{{window}}])
+    )
+    /
+    clamp_min(increase(consent_escalations_started_total[{{window}}]), 1)
+  ch: |
+    WITH started AS (
+      SELECT correlation_id, min(ts) AS started_at
+      FROM audit_events
+      WHERE ts >= now() - INTERVAL {{window}} AND outcome='deny' AND deny_reason='consent_required'
+      GROUP BY correlation_id
+    ),
+    resolved AS (
+      SELECT a.correlation_id
+      FROM audit_events a
+      INNER JOIN started s USING (correlation_id)
+      WHERE a.outcome='allow' AND a.ts BETWEEN s.started_at AND s.started_at + INTERVAL 24 HOUR
+      GROUP BY a.correlation_id
+    )
+    SELECT
+      (count() - countIf(correlation_id IN resolved)) / nullIf(count(), 0)
+    FROM started
+on_match:
+  decision: "notify"
+  reason: "consent_abandonment_spike"
+  details:
+    message: "Consent abandonment ratio is high; users may be stuck."
+    remediation: "Review scopes UX, reduce escalations, or add just-in-time guidance."
+notify:
+  channels: ["slack:#platform"]
+owners: ["@platform-eng", "@secops"]
+docs_url: "https://your.docs/policies/consent_abandonment_rate"
+docs_chart:
+  endpoint: "/metrics/consent_abandonment_rate"
+  title: "Consent Abandonment (7d)"
+tests:
+  - name: "healthy_rate"
+    guid: "0c3d6d5a-6e7f-4e6a-8f7a-8fb0d3f04e23"
+    series:
+      window: "168h"
+      events:
+        - repeat: 8
+          each: { deny_reason: "consent_required" }
+        - repeat: 7
+          each: { outcome: "allow" }
+    want: { decision: "allow", reason: "" }
+  - name: "spike"
+    guid: "e6f4b0d2-3e59-4f3e-98c1-35e1c8f4f2a1"
+    series:
+      window: "168h"
+      events:
+        - repeat: 8
+          each: { deny_reason: "consent_required" }
+        - repeat: 4
+          each: { outcome: "allow" }
+    want: { decision: "notify", reason: "consent_abandonment_spike" }
+comments:
+  - "Keep observe; consider enforce only to throttle upstream prompts, not users."


### PR DESCRIPTION
## Summary
- add a consent abandonment rate rule with metrics selectors, docs metadata, and fixtures
- extend the rule engine/test harness to handle richer test schemas and compute consent abandonment ratios
- add a Go series harness, Prometheus metrics proxy, and generate the corresponding rule documentation page

## Testing
- pytest tests/test_rule_engine.py
- go run ./harness test:series rules/consent_abandonment_rate.yaml fixtures/consent/abandon.series.json


------
https://chatgpt.com/codex/tasks/task_e_68e185232b0483299c432b3642847af7