### PR TITLE
Add generative care framework codex entry

### DIFF
--- a/codex/README.md
+++ b/codex/README.md
@@ -16,6 +16,7 @@ integrations.
 | 004 | The Autonomy Manifest  | Data autonomy through consent, export, and wipe. |
 | 022 | The Security Spine     | Security backbone with layered zero-trust defenses. |
 | 043 | The Equity Oath        | Fairness, access, and inclusion are systemic.   |
+| 055 | Generative Care Frameworks | Signal loops, micro-AIs, and rituals that propagate care inventions. |
 
 ## BlackRoad Pipeline
 

--- a/codex/entries/055-generative-care-frameworks.md
+++ b/codex/entries/055-generative-care-frameworks.md
@@ -1,0 +1,68 @@
+# Codex 55 — Generative Care Frameworks
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Intent
+Create reusable scaffolds that can generate entire families of care inventions. Each framework links a provocation, an actionable loop, and propagation cues so the idea can replicate, adapt, and bond with other care primitives.
+
+## 1. Signal-to-Meaning Loop
+- **Prompt:** Trace how a single physiological or behavioral signal (e.g., micro tremor, tone shift, blink rate) could evolve into a meaningful feedback system for care.
+- **Goal:** Turn raw signals into interpretable, actionable data loops.
+- **Framework Backbone:**
+  1. **Sensing:** Select one atomic signal and define safe capture bounds (privacy, consent, sampling window).
+  2. **Interpretation Layer:** Map the signal to states using explainable models (thresholds, Bayesian update, embodied heuristics). Attach confidence metadata.
+  3. **Feedback Loop:** Route insights to caregivers, self-coaching scripts, or micro-automations with closed-loop learning (reinforcement from outcomes, user corrections).
+  4. **Escalation Mesh:** Encode when to notify clinicians, peers, or AI custodians; log rationales for transparency.
+- **Propagation Hooks:** Each new signal inherits the sensing → interpretation → feedback schema. Shareable templates turn signals into plug-in modules for broader care stacks.
+
+## 2. Care Mesh
+- **Prompt:** Design a decentralized network of micro-AIs, each performing a tiny caregiving role, that together create emergent intelligence.
+- **Goal:** Collective behavior — like an ant colony for wellbeing.
+- **Framework Backbone:**
+  1. **Micro-Agent Charter:** Define <5 second, single-capability agents (hydrate reminder, posture nudge, mood check) with explicit guardrails.
+  2. **Local Protocols:** Micro-agents exchange state via signed notes (need, fulfillment, anomaly) using gossip-style propagation.
+  3. **Emergent Orchestrator:** Consensus emerges from weighted voting, confidence beacons, and duty-of-care interrupts. No central brain; resilience via redundancy.
+  4. **Learning Layer:** Agents publish learnings to a shared ledger for periodic pruning, upgrades, and retirement ceremonies.
+- **Propagation Hooks:** Spin up new meshes by mixing micro-agent archetypes. Mesh blueprints describe density, failover, and empathy scoring.
+
+## 3. Emotional Provenance
+- **Prompt:** Map the emotional ‘supply chain’ of a care moment — who influences what feeling, when, and how could AI make that chain visible?
+- **Goal:** Transparency in empathy.
+- **Framework Backbone:**
+  1. **Moment Ledger:** Log every touchpoint (person, AI, artifact) contributing to the emotional state with timestamp, intention, and medium.
+  2. **Causal Threads:** Trace influence arcs (inspired, soothed, destabilized) and annotate the degree of contribution.
+  3. **Visibility Canvas:** Render the chain as a heatmap or narrative timeline with consent-aware redactions.
+  4. **Ethical Guardrails:** Highlight bottlenecks, over-dependence, or missing voices. Embed prompts for consent refresh.
+- **Propagation Hooks:** Reapply the ledger schema to any care moment (birthdays, discharge planning, end-of-life). AI copilots summarize shifts and surface unseen contributors.
+
+## 4. Adaptive Rituals
+- **Prompt:** Invent a daily or weekly ritual supported by AI that subtly reinforces resilience, not dependency.
+- **Goal:** Tech as scaffolding, not crutch.
+- **Framework Backbone:**
+  1. **Ritual Seed:** Pair a human act (breathing check-in, gratitude note) with an AI mirror (contextual reflection, pattern detection).
+  2. **Adaptive Dial:** Adjust cadence, difficulty, and modality based on the participant’s resilience signal (sleep, voice affect, journaling tone) while keeping human agency central.
+  3. **Release Valve:** Build sunset conditions and off-ramps so rituals never lock in by default.
+  4. **Resilience Ledger:** Track micro-wins, setbacks, and recovery time with narrative summaries instead of scores.
+- **Propagation Hooks:** Publish ritual recipes with parameter sets for different populations (caregivers, teenagers, elders). Encourage forks that add cultural layers, seasonal arcs, or collective editions.
+
+## 5. Latent Empathy Model
+- **Prompt:** What would an AI trained not on words or images, but on gestures of care, learn to prioritize?
+- **Goal:** Cross-sensory empathy encoding.
+- **Framework Backbone:**
+  1. **Gesture Corpus:** Capture multimodal signals (touch pressure maps, shared meal timing, co-regulated breathing) with explicit consent.
+  2. **Embodied Encoding:** Transform gestures into latent vectors emphasizing attunement, repair attempts, and consent boundaries.
+  3. **Prioritization Heuristics:** Teach the AI to amplify restorative gestures, flag coercive patterns, and preserve cultural nuance.
+  4. **Interpretability Layer:** Provide traceable pathways showing which gestures informed each suggestion.
+- **Propagation Hooks:** Allow communities to train local empathy models, swap gesture packs, and federate learnings without exporting raw data.
+
+## 6. Time-Reversal Thinking
+- **Prompt:** Imagine a care system designed by the future self of the patient — what would they insist we build now?
+- **Goal:** Long-term, self-informed design.
+- **Framework Backbone:**
+  1. **Future Self Interviews:** Generate scenarios where individuals narrate needs from 5, 10, 30 years ahead.
+  2. **Temporal Backcasting:** Translate future insistences into present-day build queues with milestones and dependency maps.
+  3. **Continuity Vault:** Store commitments, preferences, and red lines in tamper-evident vaults accessible to guardians and AIs.
+  4. **Revision Ritual:** Schedule periodic checkpoints where the present self can renegotiate with the projected future self.
+- **Propagation Hooks:** Use the time-reversal pattern for chronic care, aging-in-place, neurodiversity support. Provide templates to rehearse futures and seed product roadmaps.
+
+**Tagline:** Build care DNA that keeps copying itself into kinder forms.


### PR DESCRIPTION
## Summary
- add Codex 55 entry detailing generative care frameworks that turn prompts into reusable invention scaffolds
- list the new entry in the codex index for discovery

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e18841ffa0832996b738c7d9f777af