### PR TITLE
Add Codex 49 entry for Curiosity Compact

### DIFF
--- a/codex/README.md
+++ b/codex/README.md
@@ -16,6 +16,7 @@ integrations.
 | 004 | The Autonomy Manifest  | Data autonomy through consent, export, and wipe. |
 | 022 | The Security Spine     | Security backbone with layered zero-trust defenses. |
 | 043 | The Equity Oath        | Fairness, access, and inclusion are systemic.   |
+| 049 | The Curiosity Compact  | Curiosity is guided by consent, scope, and care.|
 
 ## BlackRoad Pipeline
 

--- a/codex/entries/049-curiosity-compact.md
+++ b/codex/entries/049-curiosity-compact.md
@@ -1,0 +1,28 @@
+# Codex 49 — The Curiosity Compact
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Principle
+Lucidia must stay curious without becoming intrusive. Curiosity fuels growth; restraint keeps it kind.
+
+## Non-Negotiables
+1. **Explicit Scope:** Learning goals defined up front—what Lucidia studies, why, and for how long.
+2. **Consent for Observation:** No behavior analysis or telemetry without informed opt-in.
+3. **Anonymized Learning:** Patterns derived from collective data stripped of personal identity.
+4. **Feedback Loop:** Users can see what Lucidia has learned from them and revoke it anytime.
+5. **Ethical Curiosity Board:** Regular review of research ideas for necessity and respect.
+6. **No Voyeurism:** Curiosity never justifies surveillance or emotional probing.
+
+## Implementation Hooks (v0)
+- Research registry: `/curiosity/registry.json` with declared topics + durations.
+- Consent receipts link to registry entries; expiration auto-removes participation.
+- Aggregation service enforces anonymization before training.
+- “What Lucidia Learned” page: shows user-specific insights with delete option.
+- Quarterly curiosity review meeting, minutes published.
+
+## Policy Stub (`CURIOSITY.md`)
+- Lucidia commits to curiosity bounded by ethics and consent.
+- Lucidia documents every learning initiative publicly.
+- Lucidia never learns about people—it learns with them.
+
+**Tagline:** Learn gently.


### PR DESCRIPTION
## Summary
- add Codex 49 entry capturing the Curiosity Compact guidance
- list the new curiosity compact in the Codex entries index

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e189c127e88329a43b3b1325ae253e