### PR TITLE
Add Pi-Ops kiosk bundle and first-light tooling

### DIFF
--- a/docs/pi/pi-ops-first-light.md
+++ b/docs/pi/pi-ops-first-light.md
@@ -1,0 +1,49 @@
+# Pi-Ops First-Light Checklist
+
+Use the `scripts/pi_ops_first_light.sh` helper after deploying the kiosk
+bundle to drive the displays, publish device heartbeats, and push a status
+card to the mini panel (or a sim panel endpoint).
+
+## Prerequisites
+
+- The Pi kiosk service is installed via `install_pi_ops_kiosk.sh`.
+- The Grafana dashboard with UID `pi-ops-ultra` is imported on your
+  workstation or observability host.
+- The backplane API is reachable from where you run the script
+  (defaults to `http://127.0.0.1:4000`).
+- The API expects an `X-BlackRoad-Key` header; export `BR_KEY` if so.
+
+## Run the script
+
+```sh
+# From the repo root
+BR_KEY=your-origin-key \
+BACKPLANE_URL=http://pi-ops.local:4000 \
+GRAFANA_URL=http://mac-host:3000/d/pi-ops-ultra/ops?orgId=1&kiosk&refresh=5s \
+scripts/pi_ops_first_light.sh
+```
+
+Environment variables:
+
+| Variable            | Default                                                              | Description |
+| ------------------- | -------------------------------------------------------------------- | ----------- |
+| `BACKPLANE_URL`     | `http://127.0.0.1:4000`                                              | Base URL for `/api/devices/*` endpoints. |
+| `GRAFANA_URL`       | `http://127.0.0.1:3000/d/pi-ops-ultra/ops?orgId=1&kiosk&refresh=5s` | URL pushed into the kiosk + status card. |
+| `DISPLAY_MINI_ID`   | `display-mini`                                                       | Device ID for the mini SPI display. |
+| `DISPLAY_MAIN_ID`   | `display-main`                                                       | Device ID for the ultrawide monitor. |
+| `LED_DEVICE_ID`     | `pi-01`                                                              | Device ID for the LED Pi heartbeat. |
+| `JETSON_DEVICE_ID`  | `jetson-01`                                                          | Device ID for Jetson telemetry. |
+| `SIM_PANEL_URL`     | *(empty)*                                                            | Optional endpoint to receive a JSON status post. |
+| `BR_KEY`            | *(empty)*                                                            | API key appended as `X-BlackRoad-Key`. |
+
+The script executes the following steps:
+
+1. Wake both displays via `display.wake` commands.
+2. Push vivid SVG test patterns to the mini and main panels.
+3. Publish telemetry heartbeats for the Pi LED and Jetson agents.
+4. Attempt to post a `pi-ops.first-light` event to `SIM_PANEL_URL`; if the
+   endpoint is unset or fails, a fallback status card is rendered on the
+   mini display instead.
+
+On success you should see the ultrawide Grafana view on the main display
+and a “First light complete” card on the mini panel.

--- a/pis/pi-ops/kiosk/README.md
+++ b/pis/pi-ops/kiosk/README.md
@@ -1,0 +1,38 @@
+# Pi-Ops Kiosk Bundle (v4)
+
+This bundle ships the Pi-Ops kiosk configuration and a companion Grafana
+layout. Copy this directory to the Pi alongside
+`scripts/install_pi_ops_kiosk.sh`, then execute the installer from the Pi
+user account:
+
+```sh
+scp -r pis/pi-ops/kiosk scripts/install_pi_ops_kiosk.sh pi@pi-ops.local:/home/pi/
+ssh pi@pi-ops.local 'bash install_pi_ops_kiosk.sh'
+```
+
+After the installer completes, update `/etc/systemd/system/kiosk.service`
+so that `GRAFANA_URL` points at your dashboard host (replace the
+`MAC_OR_IP_PLACEHOLDER` value), reload systemd, and start the kiosk
+service:
+
+```sh
+sudo nano /etc/systemd/system/kiosk.service
+sudo systemctl daemon-reload
+sudo systemctl restart kiosk
+```
+
+## Contents
+
+- `grafana/pi_ops_ultra.json` — Ultrawide Grafana dashboard exported with
+  the stable UID `pi-ops-ultra`. Import it on the Mac/host Grafana so the
+  kiosk URL remains predictable.
+- `bin/pi_ops_kiosk_session.sh` — Launches Chromium in fullscreen kiosk
+  mode with blanking disabled and cursor hidden.
+- `systemd/kiosk.service` — Systemd unit pre-wired for the kiosk session
+  (edit the Grafana URL before enabling).
+- `systemd/getty-autologin.conf` — Optional drop-in to auto-login the
+  `pi` user on tty1.
+- `xinitrc` — Minimal X session that calls the kiosk launcher.
+
+All files are designed to be installed by
+`scripts/install_pi_ops_kiosk.sh`.

--- a/pis/pi-ops/kiosk/bin/pi_ops_kiosk_session.sh
+++ b/pis/pi-ops/kiosk/bin/pi_ops_kiosk_session.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${GRAFANA_URL:=http://localhost:3000/d/pi-ops-ultra/ops?orgId=1&kiosk&refresh=5s}"
+
+export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+if [ ! -d "$XDG_RUNTIME_DIR" ]; then
+  mkdir -p "$XDG_RUNTIME_DIR"
+  chmod 700 "$XDG_RUNTIME_DIR"
+fi
+
+# Disable screen blanking / power management.
+xset -dpms || true
+xset s off || true
+xset s noblank || true
+
+# Hide the cursor when idle.
+if command -v unclutter >/dev/null 2>&1; then
+  unclutter --timeout 0 --jitter 0 --hide-on-touch --ignore-scrolling &
+  UNC_PID=$!
+  trap 'kill "$UNC_PID" >/dev/null 2>&1 || true' EXIT
+fi
+
+# Launch Chromium in kiosk mode; restart if it ever exits.
+while true; do
+  chromium-browser \
+    --kiosk \
+    --app="$GRAFANA_URL" \
+    --check-for-update-interval=31536000 \
+    --start-maximized \
+    --window-size=1600,600 \
+    --noerrdialogs \
+    --disable-translate \
+    --overscroll-history-navigation=0 \
+    --simulate-outdated-no-au='Tue, 31 Dec 2099 23:59:59 GMT' \
+    --incognito \
+    --disable-session-crashed-bubble || true
+  sleep 2
+  echo "[pi-ops-kiosk] restarting chromium..." >&2
+  sleep 3
+done

--- a/pis/pi-ops/kiosk/grafana/pi_ops_ultra.json
+++ b/pis/pi-ops/kiosk/grafana/pi_ops_ultra.json
@@ -1,0 +1,193 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": false,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": null,
+      "gridPos": { "h": 4, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "content": "<h1 style=\"margin:0;color:#8be9fd;font-size:42px;font-weight:600\">Pi-Ops Ultrawide</h1><p style=\"margin:4px 0 0;color:#f8f8f2;font-size:18px\">Grafana UID: <code>pi-ops-ultra</code> — refresh every 5 seconds.</p>",
+        "mode": "html"
+      },
+      "pluginVersion": "10.4.3",
+      "title": "Header",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "influxdb-pi-ops"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 80 }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 11, "w": 12, "x": 0, "y": 4 },
+      "id": 2,
+      "options": {
+        "graphMode": "area",
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "influxdb-pi-ops"
+          },
+          "groupBy": [
+            { "params": ["$__interval"], "type": "time" },
+            { "params": ["none"], "type": "fill" }
+          ],
+          "measurement": "pi_ops_system",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              { "params": ["cpu"], "type": "field" },
+              { "params": [], "type": "mean" }
+            ]
+          ],
+          "tags": [
+            { "key": "host", "operator": "=", "value": "pi-ops" }
+          ]
+        }
+      ],
+      "title": "CPU Load",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "influxdb-pi-ops"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-BlPu"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 65 },
+              { "color": "red", "value": 85 }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 11, "w": 12, "x": 12, "y": 4 },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "influxdb-pi-ops"
+          },
+          "groupBy": [
+            { "params": ["$__interval"], "type": "time" },
+            { "params": ["none"], "type": "fill" }
+          ],
+          "measurement": "pi_ops_thermal",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              { "params": ["temp"], "type": "field" },
+              { "params": [], "type": "last" }
+            ]
+          ],
+          "tags": [
+            { "key": "device", "operator": "=", "value": "jetson-01" }
+          ]
+        }
+      ],
+      "title": "Jetson Temperature",
+      "type": "stat"
+    },
+    {
+      "datasource": null,
+      "gridPos": { "h": 5, "w": 24, "x": 0, "y": 15 },
+      "id": 4,
+      "options": {
+        "content": "<div style=\"font-size:18px;color:#f8f8f2\">Edit these panels to point at your Influx bucket or other Pi-Ops datasource. This JSON only pins the UID so the kiosk URL remains stable.</div>",
+        "mode": "html"
+      },
+      "pluginVersion": "10.4.3",
+      "title": "Notes",
+      "type": "text"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["pi-ops", "kiosk"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Pi-Ops Ultrawide",
+  "uid": "pi-ops-ultra",
+  "version": 1,
+  "weekStart": ""
+}

--- a/pis/pi-ops/kiosk/systemd/getty-autologin.conf
+++ b/pis/pi-ops/kiosk/systemd/getty-autologin.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=-/sbin/agetty --autologin pi --noclear %I $TERM

--- a/pis/pi-ops/kiosk/systemd/kiosk.service
+++ b/pis/pi-ops/kiosk/systemd/kiosk.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Pi-Ops Grafana kiosk
+After=network-online.target systemd-user-sessions.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=pi
+Environment=HOME=/home/pi
+Environment=DISPLAY=:0
+Environment=XAUTHORITY=/home/pi/.Xauthority
+Environment=GRAFANA_URL=http://MAC_OR_IP_PLACEHOLDER:3000/d/pi-ops-ultra/ops?orgId=1&kiosk&refresh=5s
+Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus
+ExecStart=/usr/bin/startx /usr/local/bin/pi_ops_kiosk_session.sh -- :0 -nocursor
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/pis/pi-ops/kiosk/xinitrc
+++ b/pis/pi-ops/kiosk/xinitrc
@@ -1,0 +1,5 @@
+#!/bin/sh
+if command -v openbox-session >/dev/null 2>&1; then
+  openbox-session &
+fi
+exec /usr/local/bin/pi_ops_kiosk_session.sh

--- a/scripts/install_pi_ops_kiosk.sh
+++ b/scripts/install_pi_ops_kiosk.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() { printf '\n[%s] %s\n' "pi-ops-kiosk" "$*"; }
+fail() { printf '\n[pi-ops-kiosk] ERROR: %s\n' "$*" >&2; exit 1; }
+
+KIOSK_DIR="${KIOSK_DIR:-$PWD/kiosk}"
+TARGET_USER="${TARGET_USER:-pi}"
+APT_UPDATE="${APT_UPDATE:-1}"
+PKG_LIST=(chromium-browser xserver-xorg x11-xserver-utils openbox xinit unclutter fonts-noto fonts-noto-cjk fonts-noto-color-emoji)
+
+if [ ! -d "$KIOSK_DIR" ]; then
+  if [ -d "$PWD/pi-ops/kiosk" ]; then
+    KIOSK_DIR="$PWD/pi-ops/kiosk"
+  else
+    fail "Could not locate kiosk payload. Set KIOSK_DIR to the extracted bundle."
+  fi
+fi
+
+if ! command -v sudo >/dev/null 2>&1; then
+  fail "sudo is required to install packages and copy system files."
+fi
+
+if ! id "$TARGET_USER" >/dev/null 2>&1; then
+  fail "Target user '$TARGET_USER' does not exist on this system."
+fi
+
+TARGET_HOME=$(eval echo "~$TARGET_USER")
+if [ ! -d "$TARGET_HOME" ]; then
+  fail "Home directory for '$TARGET_USER' not found."
+fi
+
+log "Installing X/kiosk packages (${PKG_LIST[*]})"
+if [ "${APT_UPDATE}" = "1" ]; then
+  sudo apt-get update -y
+fi
+sudo apt-get install -y --no-install-recommends "${PKG_LIST[@]}"
+
+log "Deploying kiosk session scripts"
+sudo install -m 0755 "$KIOSK_DIR/bin/pi_ops_kiosk_session.sh" /usr/local/bin/pi_ops_kiosk_session.sh
+sudo install -m 0644 "$KIOSK_DIR/xinitrc" "$TARGET_HOME/.xinitrc"
+sudo chown "$TARGET_USER":"$TARGET_USER" "$TARGET_HOME/.xinitrc"
+
+log "Configuring systemd units"
+sudo install -m 0644 "$KIOSK_DIR/systemd/kiosk.service" /etc/systemd/system/kiosk.service
+sudo install -d -m 0755 /etc/systemd/system/getty@tty1.service.d
+sudo install -m 0644 "$KIOSK_DIR/systemd/getty-autologin.conf" /etc/systemd/system/getty@tty1.service.d/autologin.conf
+sudo systemctl daemon-reload
+sudo systemctl enable kiosk.service
+
+log "Kiosk assets installed"
+cat <<INSTRUCTIONS
+Next steps:
+  1. Edit /etc/systemd/system/kiosk.service and replace MAC_OR_IP_PLACEHOLDER with your Grafana host.
+  2. Optionally adjust TARGET_USER via sudo systemctl edit kiosk if you deploy under another account.
+  3. Run 'sudo systemctl daemon-reload' then 'sudo systemctl restart kiosk'.
+
+A Grafana dashboard with UID pi-ops-ultra is bundled under grafana/pi_ops_ultra.json.
+Import it into your Grafana before starting the kiosk so the URL resolves.
+INSTRUCTIONS

--- a/scripts/pi_ops_first_light.sh
+++ b/scripts/pi_ops_first_light.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() { printf '\n[%s] %s\n' "pi-ops-first-light" "$*"; }
+warn() { printf '[pi-ops-first-light] WARN: %s\n' "$*" >&2; }
+
+: "${BACKPLANE_URL:=http://127.0.0.1:4000}"
+: "${GRAFANA_URL:=http://127.0.0.1:3000/d/pi-ops-ultra/ops?orgId=1&kiosk&refresh=5s}"
+: "${DISPLAY_MINI_ID:=display-mini}"
+: "${DISPLAY_MAIN_ID:=display-main}"
+: "${LED_DEVICE_ID:=pi-01}"
+: "${JETSON_DEVICE_ID:=jetson-01}"
+: "${SIM_PANEL_URL:=}"
+: "${BR_KEY:=}"
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "curl is required" >&2
+  exit 1
+fi
+
+b64enc() {
+  printf '%s' "$1" | base64 | tr -d '\n'
+}
+
+curl_headers=(-H "Content-Type: application/json")
+if [ -n "$BR_KEY" ]; then
+  curl_headers+=(-H "X-BlackRoad-Key: $BR_KEY")
+fi
+
+curl_opts=(--silent --show-error --fail --retry 2 --retry-delay 1 --retry-connrefused --max-time 15)
+
+post_device_command() {
+  local device="$1" payload="$2"
+  curl "${curl_opts[@]}" "${curl_headers[@]}" -XPOST "$BACKPLANE_URL/api/devices/${device}/command" -d "$payload" >/dev/null
+}
+
+post_device_telemetry() {
+  local device="$1" payload="$2"
+  curl "${curl_opts[@]}" "${curl_headers[@]}" -XPOST "$BACKPLANE_URL/api/devices/${device}/telemetry" -d "$payload" >/dev/null
+}
+
+send_sim_panel() {
+  if [ -z "$SIM_PANEL_URL" ]; then
+    return 1
+  fi
+  local ts
+  ts=$(date -u +"%FT%TZ")
+  local payload
+  payload=$(cat <<JSON
+{"event":"pi-ops.first-light","ts":"${ts}","summary":"Displays verified and heartbeats sent","grafanaUrl":"${GRAFANA_URL}"}
+JSON
+)
+  local url="$SIM_PANEL_URL"
+  local headers=(-H "Content-Type: application/json")
+  if [ -n "$BR_KEY" ]; then
+    headers+=(-H "X-BlackRoad-Key: $BR_KEY")
+  fi
+  curl "${curl_opts[@]}" "${headers[@]}" -XPOST "$url" -d "$payload" >/dev/null
+}
+
+# Prepare SVG patterns
+read -r -d '' MINI_PATTERN <<'SVG' || true
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#50fa7b"/>
+      <stop offset="50%" stop-color="#ffb86c"/>
+      <stop offset="100%" stop-color="#ff5555"/>
+    </linearGradient>
+  </defs>
+  <rect width="320" height="240" fill="url(#grad)"/>
+  <g font-family="Inter,Segoe UI,Arial" font-weight="600" text-anchor="middle">
+    <text x="160" y="110" font-size="42" fill="#282a36">PI-OPS</text>
+    <text x="160" y="160" font-size="24" fill="#f8f8f2">Mini panel test</text>
+  </g>
+</svg>
+SVG
+
+read -r -d '' MAIN_PATTERN <<'SVG' || true
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 600">
+  <defs>
+    <pattern id="checker" x="0" y="0" width="80" height="80" patternUnits="userSpaceOnUse">
+      <rect x="0" y="0" width="80" height="80" fill="#1e1f29"/>
+      <rect x="0" y="0" width="40" height="40" fill="#bd93f9" opacity="0.7"/>
+      <rect x="40" y="40" width="40" height="40" fill="#8be9fd" opacity="0.7"/>
+    </pattern>
+  </defs>
+  <rect width="1600" height="600" fill="url(#checker)"/>
+  <g font-family="Inter,Segoe UI,Arial" font-weight="600" text-anchor="middle">
+    <text x="800" y="260" font-size="96" fill="#f8f8f2">Pi-Ops Kiosk</text>
+    <text x="800" y="360" font-size="54" fill="#ff79c6">Ultrawide diagnostics</text>
+  </g>
+</svg>
+SVG
+
+MINI_DATA_URI="data:image/svg+xml;base64,$(b64enc "$MINI_PATTERN")"
+MAIN_DATA_URI="data:image/svg+xml;base64,$(b64enc "$MAIN_PATTERN")"
+
+log "Waking displays"
+post_device_command "$DISPLAY_MINI_ID" '{"type":"display.wake"}'
+post_device_command "$DISPLAY_MAIN_ID" '{"type":"display.wake"}'
+
+log "Pushing test patterns"
+post_device_command "$DISPLAY_MINI_ID" "{\"type\":\"display.show\",\"target\":\"mini\",\"mode\":\"image\",\"src\":\"$MINI_DATA_URI\"}"
+post_device_command "$DISPLAY_MAIN_ID" "{\"type\":\"display.show\",\"target\":\"main\",\"mode\":\"image\",\"src\":\"$MAIN_DATA_URI\"}"
+
+log "Posting telemetry heartbeats"
+ts=$(date -u +"%FT%TZ")
+pi_payload=$(cat <<JSON
+{"id":"${LED_DEVICE_ID}","role":"pi_led","ts":"${ts}","cpu":37.5,"state":"ok","heartbeat":"first-light"}
+JSON
+)
+jetson_payload=$(cat <<JSON
+{"id":"${JETSON_DEVICE_ID}","role":"jetson","ts":"${ts}","cpu":41.2,"gpu":35.4,"llm":{"state":"idle","tps":0},"heartbeat":"first-light"}
+JSON
+)
+post_device_telemetry "$LED_DEVICE_ID" "$pi_payload"
+post_device_telemetry "$JETSON_DEVICE_ID" "$jetson_payload"
+
+log "Announcing status"
+if ! send_sim_panel; then
+  warn "SIM_PANEL_URL not set or POST failed; showing status on ${DISPLAY_MINI_ID} instead"
+fi
+status_html=$(cat <<HTML
+<!doctype html><html><head><meta charset="utf-8"><title>Pi-Ops First Light</title>
+<style>body{margin:0;background:#282a36;color:#f8f8f2;font-family:Inter,Segoe UI,Arial;display:flex;align-items:center;justify-content:center;height:100vh;text-align:center}h1{font-size:2.4rem;margin-bottom:0.6rem}p{margin:0;font-size:1.1rem}</style></head>
+<body><div><h1>First light complete</h1><p>Displays verified • Heartbeats posted</p><p><small>Dashboard: ${GRAFANA_URL}</small></p></div></body></html>
+HTML
+)
+status_data_uri="data:text/html;base64,$(b64enc "$status_html")"
+post_device_command "$DISPLAY_MINI_ID" "{\"type\":\"display.show\",\"target\":\"mini\",\"mode\":\"url\",\"src\":\"$status_data_uri\"}"
+
+log "Complete"


### PR DESCRIPTION
## Summary
- add the Pi-Ops kiosk bundle with Grafana dashboard export, Chromium session launcher, and systemd unit templates
- provide a one-shot installer that installs kiosk dependencies and deploys the bundle onto the Pi
- document and script a "first light" check that drives the displays, emits telemetry heartbeats, and posts a status card

## Testing
- bash -n scripts/install_pi_ops_kiosk.sh
- bash -n scripts/pi_ops_first_light.sh
- bash -n pis/pi-ops/kiosk/bin/pi_ops_kiosk_session.sh

------
https://chatgpt.com/codex/tasks/task_e_68e187b829b48329a32e15e53a5bdf86