### PR TITLE
Wire Stripe ingestion and metrics into PRISM

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -14,9 +14,12 @@
   "dependencies": {
     "@lucidia/ai": "^0.0.1",
     "@lucidia/core": "^0.0.1",
+    "@aws-sdk/client-ecs": "^3.635.0",
+    "@aws-sdk/client-ssm": "^3.635.0",
     "cors": "^2.8.5",
     "express": "^4.19.2",
-    "helmet": "^7.1.0"
+    "helmet": "^7.1.0",
+    "pg": "^8.11.3"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/apps/api/src/lib/db.ts
+++ b/apps/api/src/lib/db.ts
@@ -1,0 +1,38 @@
+import { Pool, PoolConfig, QueryResult } from 'pg';
+
+let pool: Pool | undefined;
+
+function getConfig(): PoolConfig {
+  const connectionString = process.env.PG_URL;
+  if (!connectionString) {
+    throw new Error('PG_URL is not configured');
+  }
+  const config: PoolConfig = {
+    connectionString,
+    application_name: 'prism-api',
+  };
+  if (process.env.PG_POOL_MAX) {
+    const max = Number(process.env.PG_POOL_MAX);
+    if (!Number.isNaN(max) && max > 0) {
+      config.max = max;
+    }
+  }
+  if (process.env.PG_SSL === 'true') {
+    config.ssl = { rejectUnauthorized: false } as any;
+  }
+  return config;
+}
+
+function getPool(): Pool {
+  if (!pool) {
+    pool = new Pool(getConfig());
+  }
+  return pool;
+}
+
+export async function query<T = any>(sql: string, params?: any[]): Promise<QueryResult<T>> {
+  const p = getPool();
+  return p.query<T>(sql, params);
+}
+
+export { getPool as pool };

--- a/apps/api/src/lib/ecs.ts
+++ b/apps/api/src/lib/ecs.ts
@@ -1,0 +1,57 @@
+import { ECSClient, RunTaskCommand } from '@aws-sdk/client-ecs';
+
+const client = new ECSClient({});
+
+export interface RunIngestOptions {
+  sourceId: string;
+  tokenParameter: string;
+}
+
+function parseList(input?: string) {
+  if (!input) return [] as string[];
+  return input.split(',').map((s) => s.trim()).filter(Boolean);
+}
+
+export async function triggerStripeIngest({ sourceId, tokenParameter }: RunIngestOptions) {
+  const cluster = process.env.STRIPE_INGEST_ECS_CLUSTER;
+  const taskDefinition = process.env.STRIPE_INGEST_ECS_TASK;
+  if (!cluster || !taskDefinition) {
+    console.warn('Stripe ingest ECS configuration missing, skipping RunTask trigger');
+    return { triggered: false } as const;
+  }
+  const containerName = process.env.STRIPE_INGEST_ECS_CONTAINER || 'app';
+  const securityGroups = parseList(process.env.STRIPE_INGEST_ECS_SECURITY_GROUPS);
+  const subnets = parseList(process.env.STRIPE_INGEST_ECS_SUBNETS);
+  const assignPublicIp = (process.env.STRIPE_INGEST_ECS_ASSIGN_PUBLIC_IP || 'ENABLED').toUpperCase();
+
+  await client.send(
+    new RunTaskCommand({
+      cluster,
+      taskDefinition,
+      launchType: 'FARGATE',
+      count: 1,
+      networkConfiguration:
+        subnets.length || securityGroups.length
+          ? {
+              awsvpcConfiguration: {
+                subnets,
+                securityGroups,
+                assignPublicIp: (assignPublicIp === 'DISABLED' ? 'DISABLED' : 'ENABLED') as 'ENABLED' | 'DISABLED',
+              },
+            }
+          : undefined,
+      overrides: {
+        containerOverrides: [
+          {
+            name: containerName,
+            environment: [
+              { name: 'SOURCE_ID', value: sourceId },
+              { name: 'STRIPE_TOKEN_PARAM', value: tokenParameter },
+            ],
+          },
+        ],
+      },
+    })
+  );
+  return { triggered: true } as const;
+}

--- a/apps/api/src/lib/ssm.ts
+++ b/apps/api/src/lib/ssm.ts
@@ -1,0 +1,20 @@
+import { PutParameterCommand, SSMClient } from '@aws-sdk/client-ssm';
+
+const client = new SSMClient({});
+
+export async function putSecureParameter(name: string, value: string) {
+  if (!name) {
+    throw new Error('Parameter name required');
+  }
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new Error('Parameter value required');
+  }
+  await client.send(
+    new PutParameterCommand({
+      Name: name,
+      Value: value,
+      Type: 'SecureString',
+      Overwrite: true,
+    })
+  );
+}

--- a/apps/api/src/routes/metrics.ts
+++ b/apps/api/src/routes/metrics.ts
@@ -1,4 +1,161 @@
 import { Router } from 'express';
-const r = Router();
-r.get('/', (_req, res) => res.json({ uptime: process.uptime(), ts: Date.now() }));
-export default r;
+import { query } from '../lib/db.js';
+
+const router = Router();
+
+const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+interface RangeResult {
+  from: Date;
+  to: Date;
+}
+
+function parseIso(value: string, field: string): Date {
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) {
+    throw new Error(`invalid_${field}`);
+  }
+  return d;
+}
+
+function parseRelative(value: string, to: Date): Date {
+  const match = /^-P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?$/i.exec(value);
+  if (!match) {
+    throw new Error('invalid_from');
+  }
+  const [, y, m, w, d] = match;
+  const days =
+    (y ? Number(y) * 365 : 0) +
+    (m ? Number(m) * 30 : 0) +
+    (w ? Number(w) * 7 : 0) +
+    (d ? Number(d) : 0);
+  const ms = days * 24 * 60 * 60 * 1000;
+  return new Date(to.getTime() - ms);
+}
+
+function range(queryParams: Record<string, any>): RangeResult {
+  const now = new Date();
+  const toRaw = typeof queryParams.to === 'string' ? queryParams.to : undefined;
+  const fromRaw = typeof queryParams.from === 'string' ? queryParams.from : undefined;
+  const to = toRaw ? parseIso(toRaw, 'to') : now;
+  let from: Date;
+  if (fromRaw) {
+    from = fromRaw.startsWith('-P') ? parseRelative(fromRaw, to) : parseIso(fromRaw, 'from');
+  } else {
+    from = new Date(to.getTime() - 7 * 24 * 60 * 60 * 1000);
+  }
+  if (from > to) {
+    throw new Error('invalid_range');
+  }
+  return { from, to };
+}
+
+router.get('/', (_req, res) => {
+  res.json({ uptime: process.uptime(), ts: Date.now() });
+});
+
+router.get('/events', (_req, res) => {
+  res.json([]);
+});
+
+router.get('/errors', (_req, res) => {
+  res.json([]);
+});
+
+router.get('/stripe/charges', async (req, res) => {
+  try {
+    const { from, to } = range(req.query as Record<string, any>);
+    const sourceId = typeof req.query.sourceId === 'string' ? req.query.sourceId : undefined;
+    if (sourceId && !uuidPattern.test(sourceId)) {
+      return res.status(400).json({ error: 'invalid_source_id' });
+    }
+    const params: any[] = sourceId ? [sourceId, from.toISOString(), to.toISOString()] : [from.toISOString(), to.toISOString()];
+    const whereSource = sourceId ? 'AND source_id = $1' : '';
+    const offset = sourceId ? 1 : 0;
+    const { rows } = await query<{ d: string; amt_cents: string | number }>(
+      `SELECT date_trunc('day', created_at) AS d, SUM(amount) AS amt_cents
+       FROM raw_stripe_charges
+       WHERE paid = TRUE AND refunded = FALSE AND created_at BETWEEN $${offset + 1} AND $${offset + 2}
+         ${whereSource}
+       GROUP BY 1
+       ORDER BY 1 ASC`,
+      params
+    );
+    res.json(
+      rows.map((row) => ({
+        t: new Date(row.d).toISOString(),
+        v: Number(row.amt_cents) / 100,
+      }))
+    );
+  } catch (err: any) {
+    if (err?.message && err.message.startsWith('invalid_')) {
+      return res.status(400).json({ error: err.message });
+    }
+    console.error('stripe_charges_error', err);
+    res.status(500).json({ error: 'server_error' });
+  }
+});
+
+router.get('/stripe/active_subs', async (req, res) => {
+  try {
+    const sourceId = typeof req.query.sourceId === 'string' ? req.query.sourceId : undefined;
+    if (sourceId && !uuidPattern.test(sourceId)) {
+      return res.status(400).json({ error: 'invalid_source_id' });
+    }
+    const params: any[] = sourceId ? [sourceId] : [];
+    const whereSource = sourceId ? 'AND source_id = $1' : '';
+    const { rows } = await query<{ c: string }>(
+      `SELECT COUNT(*) AS c
+       FROM raw_stripe_subscriptions
+       WHERE status IN ('active', 'trialing', 'past_due') ${whereSource}`,
+      params
+    );
+    res.json([
+      {
+        t: new Date().toISOString(),
+        v: Number(rows[0]?.c ?? 0),
+      },
+    ]);
+  } catch (err) {
+    console.error('stripe_active_subs_error', err);
+    res.status(500).json({ error: 'server_error' });
+  }
+});
+
+router.get('/stripe/mrr', async (req, res) => {
+  try {
+    const sourceId = typeof req.query.sourceId === 'string' ? req.query.sourceId : undefined;
+    if (sourceId && !uuidPattern.test(sourceId)) {
+      return res.status(400).json({ error: 'invalid_source_id' });
+    }
+    const params: any[] = sourceId ? [sourceId] : [];
+    const whereSource = sourceId ? 'AND si.source_id = $1' : '';
+    const { rows } = await query<{ mrr_cents: string | number | null }>(
+      `SELECT COALESCE(SUM(
+          CASE
+            WHEN interval = 'month' THEN unit_amount * COALESCE(quantity, 1)
+            WHEN interval = 'year' THEN (unit_amount * COALESCE(quantity, 1)) / 12.0
+            WHEN interval = 'week' THEN (unit_amount * COALESCE(quantity, 1)) * 4.345
+            WHEN interval = 'day' THEN (unit_amount * COALESCE(quantity, 1)) * 30.437
+            ELSE 0
+          END
+        ), 0) AS mrr_cents
+       FROM raw_stripe_subscription_items si
+       JOIN raw_stripe_subscriptions s ON s.id = si.subscription_id
+       WHERE s.status IN ('active', 'trialing', 'past_due') ${whereSource}`,
+      params
+    );
+    const cents = Number(rows[0]?.mrr_cents ?? 0);
+    res.json([
+      {
+        t: new Date().toISOString(),
+        v: Math.round(cents) / 100,
+      },
+    ]);
+  } catch (err) {
+    console.error('stripe_mrr_error', err);
+    res.status(500).json({ error: 'server_error' });
+  }
+});
+
+export default router;

--- a/apps/api/src/routes/sources.ts
+++ b/apps/api/src/routes/sources.ts
@@ -1,0 +1,97 @@
+import { Router } from 'express';
+import { randomUUID } from 'crypto';
+import { query } from '../lib/db.js';
+import { putSecureParameter } from '../lib/ssm.js';
+import { triggerStripeIngest } from '../lib/ecs.js';
+
+interface StripeAccountResponse {
+  id: string;
+  email?: string;
+  business_profile?: { name?: string };
+  settings?: { dashboard?: { display_name?: string } };
+}
+
+const router = Router();
+
+async function validateStripeToken(token: string): Promise<StripeAccountResponse> {
+  const resp = await fetch('https://api.stripe.com/v1/accounts', {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`stripe_auth_failed:${resp.status}:${text}`);
+  }
+  return (await resp.json()) as StripeAccountResponse;
+}
+
+function envPrefix() {
+  const raw = process.env.APP_ENV || process.env.NODE_ENV || 'dev';
+  return raw.replace(/[^a-z0-9-_]/gi, '').toLowerCase() || 'dev';
+}
+
+router.post('/', async (req, res) => {
+  try {
+    const { kind, token } = req.body ?? {};
+    if (kind !== 'stripe') {
+      return res.status(400).json({ error: 'unsupported_kind' });
+    }
+    if (typeof token !== 'string' || !token.startsWith('sk_')) {
+      return res.status(400).json({ error: 'invalid_token' });
+    }
+
+    const account = await validateStripeToken(token);
+    if (!account?.id) {
+      throw new Error('stripe_account_missing');
+    }
+
+    const sourceId = randomUUID();
+    const label =
+      account.settings?.dashboard?.display_name ||
+      account.business_profile?.name ||
+      account.email ||
+      `Stripe ${account.id}`;
+
+    await query(
+      `INSERT INTO integration_sources(id, kind, label)
+       VALUES ($1, $2, $3)`,
+      [sourceId, 'stripe', label]
+    );
+
+    await query(
+      `INSERT INTO stripe_sync_state(source_id)
+       VALUES ($1)
+       ON CONFLICT (source_id) DO NOTHING`,
+      [sourceId]
+    );
+
+    const paramName = `/blackroad/${envPrefix()}/sources/${sourceId}/stripe_token`;
+    await putSecureParameter(paramName, token);
+
+    let ingestTriggered = false;
+    try {
+      const result = await triggerStripeIngest({ sourceId, tokenParameter: paramName });
+      ingestTriggered = result.triggered;
+    } catch (err) {
+      console.error('stripe_ingest_trigger_failed', err);
+    }
+
+    res.status(201).json({
+      sourceId,
+      kind: 'stripe',
+      accountId: account.id,
+      label,
+      ingestTriggered,
+      tokenParameter: paramName,
+    });
+  } catch (err: any) {
+    if (typeof err?.message === 'string' && err.message.startsWith('stripe_auth_failed')) {
+      return res.status(401).json({ error: 'stripe_auth_failed' });
+    }
+    console.error('create_source_error', err);
+    res.status(500).json({ error: 'server_error' });
+  }
+});
+
+export default router;

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -2,6 +2,8 @@ import express from "express";
 import helmet from "helmet";
 import cors from "cors";
 import classifyRouter from "./routes/classify.js";
+import metricsRouter from "./routes/metrics.js";
+import sourcesRouter from "./routes/sources.js";
 
 const app = express();
 
@@ -19,6 +21,8 @@ app.get("/health", (_req, res) => {
 });
 
 app.use("/", classifyRouter);
+app.use("/v1/metrics", metricsRouter);
+app.use("/v1/sources", sourcesRouter);
 
 const port = Number(process.env.PORT ?? 4000);
 

--- a/apps/web/app/prism/page.tsx
+++ b/apps/web/app/prism/page.tsx
@@ -12,9 +12,12 @@ async function fetchSeries(path: string) {
 
 export default async function PrismDashboard() {
   // “from=-P7D” is ISO-8601 relative (handle this in your API or swap to explicit dates)
-  const [events, errors] = await Promise.all([
+  const [events, errors, charges, activeSubs, mrr] = await Promise.all([
     fetchSeries('/v1/metrics/events?from=-P7D'),
     fetchSeries('/v1/metrics/errors?from=-P7D'),
+    fetchSeries('/v1/metrics/stripe/charges?from=-P7D'),
+    fetchSeries('/v1/metrics/stripe/active_subs'),
+    fetchSeries('/v1/metrics/stripe/mrr'),
   ]);
 
   return (
@@ -23,6 +26,9 @@ export default async function PrismDashboard() {
       <div style={{ display: 'grid', gap: 16, gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))' }}>
         <Tile title="Events (7d)" series={events} />
         <Tile title="Errors (7d)" series={errors} />
+        <Tile title="Stripe: New Charges (7d, $)" series={charges} rangeLabel="7d" />
+        <Tile title="Stripe: Active Subs (now)" series={activeSubs} rangeLabel="now" />
+        <Tile title="Stripe: MRR (now, $)" series={mrr} rangeLabel="now" />
       </div>
     </main>
   );

--- a/apps/web/components/Tile.tsx
+++ b/apps/web/components/Tile.tsx
@@ -11,7 +11,11 @@ export default function Tile({
   series: Pt[];
   rangeLabel?: string;
 }) {
-  const total = (series ?? []).reduce((a, p) => a + (p?.v ?? 0), 0);
+  const totalRaw = (series ?? []).reduce((a, p) => a + (p?.v ?? 0), 0);
+  const formatter = new Intl.NumberFormat(undefined, {
+    maximumFractionDigits: 2,
+  });
+  const total = Number.isFinite(totalRaw) ? formatter.format(totalRaw) : '0';
   return (
     <div style={{ padding: 16, border: '1px solid #eee', borderRadius: 12 }}>
       <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between' }}>

--- a/br-ingest-stripe/.env.example
+++ b/br-ingest-stripe/.env.example
@@ -1,0 +1,3 @@
+PG_URL=postgres://user:pass@host:5432/app
+SOURCE_ID=00000000-0000-0000-0000-000000000000
+STRIPE_TOKEN_PARAM=/blackroad/dev/sources/<sourceId>/stripe_token

--- a/br-ingest-stripe/.github/workflows/ci.yml
+++ b/br-ingest-stripe/.github/workflows/ci.yml
@@ -1,0 +1,13 @@
+name: ingest-ci
+on: [pull_request, push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build

--- a/br-ingest-stripe/Dockerfile
+++ b/br-ingest-stripe/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=build /app/package*.json ./
+RUN npm ci --omit=dev
+COPY --from=build /app/dist ./dist
+CMD ["node", "dist/index.js"]

--- a/br-ingest-stripe/package-lock.json
+++ b/br-ingest-stripe/package-lock.json
@@ -1,0 +1,1584 @@
+{
+  "name": "br-ingest-stripe",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "br-ingest-stripe",
+      "dependencies": {
+        "@aws-sdk/client-ssm": "^3.635.0",
+        "dotenv": "^16.4.5",
+        "node-fetch": "^3.3.2",
+        "pg": "^8.11.3"
+      },
+      "devDependencies": {
+        "@types/node": "^20.11.30",
+        "@types/pg": "^8.15.5",
+        "typescript": "^5.5.4"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.901.0.tgz",
+      "integrity": "sha512-u0GoXcrxHIBpITZIfw8AUabjQutCbRFAoHl+zT0qLylZ5dOOVydP2++CI+DK6Z7ZcOluJorQ+z/53IniZqkjZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/credential-provider-node": "3.901.0",
+        "@aws-sdk/middleware-host-header": "3.901.0",
+        "@aws-sdk/middleware-logger": "3.901.0",
+        "@aws-sdk/middleware-recursion-detection": "3.901.0",
+        "@aws-sdk/middleware-user-agent": "3.901.0",
+        "@aws-sdk/region-config-resolver": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@aws-sdk/util-endpoints": "3.901.0",
+        "@aws-sdk/util-user-agent-browser": "3.901.0",
+        "@aws-sdk/util-user-agent-node": "3.901.0",
+        "@smithy/config-resolver": "^4.3.0",
+        "@smithy/core": "^3.14.0",
+        "@smithy/fetch-http-handler": "^5.3.0",
+        "@smithy/hash-node": "^4.2.0",
+        "@smithy/invalid-dependency": "^4.2.0",
+        "@smithy/middleware-content-length": "^4.2.0",
+        "@smithy/middleware-endpoint": "^4.3.0",
+        "@smithy/middleware-retry": "^4.4.0",
+        "@smithy/middleware-serde": "^4.2.0",
+        "@smithy/middleware-stack": "^4.2.0",
+        "@smithy/node-config-provider": "^4.3.0",
+        "@smithy/node-http-handler": "^4.3.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/smithy-client": "^4.7.0",
+        "@smithy/types": "^4.6.0",
+        "@smithy/url-parser": "^4.2.0",
+        "@smithy/util-base64": "^4.2.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.0",
+        "@smithy/util-defaults-mode-browser": "^4.2.0",
+        "@smithy/util-defaults-mode-node": "^4.2.0",
+        "@smithy/util-endpoints": "^3.2.0",
+        "@smithy/util-middleware": "^4.2.0",
+        "@smithy/util-retry": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/util-waiter": "^4.2.0",
+        "@smithy/uuid": "^1.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.901.0.tgz",
+      "integrity": "sha512-sGyDjjkJ7ppaE+bAKL/Q5IvVCxtoyBIzN+7+hWTS/mUxWJ9EOq9238IqmVIIK6sYNIzEf9yhobfMARasPYVTNg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/middleware-host-header": "3.901.0",
+        "@aws-sdk/middleware-logger": "3.901.0",
+        "@aws-sdk/middleware-recursion-detection": "3.901.0",
+        "@aws-sdk/middleware-user-agent": "3.901.0",
+        "@aws-sdk/region-config-resolver": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@aws-sdk/util-endpoints": "3.901.0",
+        "@aws-sdk/util-user-agent-browser": "3.901.0",
+        "@aws-sdk/util-user-agent-node": "3.901.0",
+        "@smithy/config-resolver": "^4.3.0",
+        "@smithy/core": "^3.14.0",
+        "@smithy/fetch-http-handler": "^5.3.0",
+        "@smithy/hash-node": "^4.2.0",
+        "@smithy/invalid-dependency": "^4.2.0",
+        "@smithy/middleware-content-length": "^4.2.0",
+        "@smithy/middleware-endpoint": "^4.3.0",
+        "@smithy/middleware-retry": "^4.4.0",
+        "@smithy/middleware-serde": "^4.2.0",
+        "@smithy/middleware-stack": "^4.2.0",
+        "@smithy/node-config-provider": "^4.3.0",
+        "@smithy/node-http-handler": "^4.3.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/smithy-client": "^4.7.0",
+        "@smithy/types": "^4.6.0",
+        "@smithy/url-parser": "^4.2.0",
+        "@smithy/util-base64": "^4.2.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.0",
+        "@smithy/util-defaults-mode-browser": "^4.2.0",
+        "@smithy/util-defaults-mode-node": "^4.2.0",
+        "@smithy/util-endpoints": "^3.2.0",
+        "@smithy/util-middleware": "^4.2.0",
+        "@smithy/util-retry": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.901.0.tgz",
+      "integrity": "sha512-brKAc3y64tdhyuEf+OPIUln86bRTqkLgb9xkd6kUdIeA5+qmp/N6amItQz+RN4k4O3kqkCPYnAd3LonTKluobw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.901.0",
+        "@aws-sdk/xml-builder": "3.901.0",
+        "@smithy/core": "^3.14.0",
+        "@smithy/node-config-provider": "^4.3.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/signature-v4": "^5.3.0",
+        "@smithy/smithy-client": "^4.7.0",
+        "@smithy/types": "^4.6.0",
+        "@smithy/util-base64": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.901.0.tgz",
+      "integrity": "sha512-5hAdVl3tBuARh3zX5MLJ1P/d+Kr5kXtDU3xm1pxUEF4xt2XkEEpwiX5fbkNkz2rbh3BCt2gOHsAbh6b3M7n+DA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.901.0.tgz",
+      "integrity": "sha512-Ggr7+0M6QZEsrqRkK7iyJLf4LkIAacAxHz9c4dm9hnDdU7vqrlJm6g73IxMJXWN1bIV7IxfpzB11DsRrB/oNjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/fetch-http-handler": "^5.3.0",
+        "@smithy/node-http-handler": "^4.3.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/smithy-client": "^4.7.0",
+        "@smithy/types": "^4.6.0",
+        "@smithy/util-stream": "^4.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.901.0.tgz",
+      "integrity": "sha512-zxadcDS0hNJgv8n4hFYJNOXyfjaNE1vvqIiF/JzZSQpSSYXzCd+WxXef5bQh+W3giDtRUmkvP5JLbamEFjZKyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/credential-provider-env": "3.901.0",
+        "@aws-sdk/credential-provider-http": "3.901.0",
+        "@aws-sdk/credential-provider-process": "3.901.0",
+        "@aws-sdk/credential-provider-sso": "3.901.0",
+        "@aws-sdk/credential-provider-web-identity": "3.901.0",
+        "@aws-sdk/nested-clients": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/credential-provider-imds": "^4.2.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/shared-ini-file-loader": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.901.0.tgz",
+      "integrity": "sha512-dPuFzMF7L1s/lQyT3wDxqLe82PyTH+5o1jdfseTEln64LJMl0ZMWaKX/C1UFNDxaTd35Cgt1bDbjjAWHMiKSFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.901.0",
+        "@aws-sdk/credential-provider-http": "3.901.0",
+        "@aws-sdk/credential-provider-ini": "3.901.0",
+        "@aws-sdk/credential-provider-process": "3.901.0",
+        "@aws-sdk/credential-provider-sso": "3.901.0",
+        "@aws-sdk/credential-provider-web-identity": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/credential-provider-imds": "^4.2.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/shared-ini-file-loader": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.901.0.tgz",
+      "integrity": "sha512-/IWgmgM3Cl1wTdJA5HqKMAojxLkYchh5kDuphApxKhupLu6Pu0JBOHU8A5GGeFvOycyaVwosod6zDduINZxe+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/shared-ini-file-loader": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.901.0.tgz",
+      "integrity": "sha512-SjmqZQHmqFSET7+6xcZgtH7yEyh5q53LN87GqwYlJZ6KJ5oNw11acUNEhUOL1xTSJEvaWqwTIkS2zqrzLcM9bw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.901.0",
+        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/token-providers": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/shared-ini-file-loader": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.901.0.tgz",
+      "integrity": "sha512-NYjy/6NLxH9m01+pfpB4ql8QgAorJcu8tw69kzHwUd/ql6wUDTbC7HcXqtKlIwWjzjgj2BKL7j6SyFapgCuafA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/nested-clients": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/shared-ini-file-loader": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.901.0.tgz",
+      "integrity": "sha512-yWX7GvRmqBtbNnUW7qbre3GvZmyYwU0WHefpZzDTYDoNgatuYq6LgUIQ+z5C04/kCRoFkAFrHag8a3BXqFzq5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.901.0.tgz",
+      "integrity": "sha512-UoHebjE7el/tfRo8/CQTj91oNUm+5Heus5/a4ECdmWaSCHCS/hXTsU3PTTHAY67oAQR8wBLFPfp3mMvXjB+L2A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.901.0.tgz",
+      "integrity": "sha512-Wd2t8qa/4OL0v/oDpCHHYkgsXJr8/ttCxrvCKAt0H1zZe2LlRhY9gpDVKqdertfHrHDj786fOvEQA28G1L75Dg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.901.0",
+        "@aws/lambda-invoke-store": "^0.0.1",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.901.0.tgz",
+      "integrity": "sha512-Zby4F03fvD9xAgXGPywyk4bC1jCbnyubMEYChLYohD+x20ULQCf+AimF/Btn7YL+hBpzh1+RmqmvZcx+RgwgNQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@aws-sdk/util-endpoints": "3.901.0",
+        "@smithy/core": "^3.14.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.901.0.tgz",
+      "integrity": "sha512-feAAAMsVwctk2Tms40ONybvpfJPLCmSdI+G+OTrNpizkGLNl6ik2Ng2RzxY6UqOfN8abqKP/DOUj1qYDRDG8ag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/middleware-host-header": "3.901.0",
+        "@aws-sdk/middleware-logger": "3.901.0",
+        "@aws-sdk/middleware-recursion-detection": "3.901.0",
+        "@aws-sdk/middleware-user-agent": "3.901.0",
+        "@aws-sdk/region-config-resolver": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@aws-sdk/util-endpoints": "3.901.0",
+        "@aws-sdk/util-user-agent-browser": "3.901.0",
+        "@aws-sdk/util-user-agent-node": "3.901.0",
+        "@smithy/config-resolver": "^4.3.0",
+        "@smithy/core": "^3.14.0",
+        "@smithy/fetch-http-handler": "^5.3.0",
+        "@smithy/hash-node": "^4.2.0",
+        "@smithy/invalid-dependency": "^4.2.0",
+        "@smithy/middleware-content-length": "^4.2.0",
+        "@smithy/middleware-endpoint": "^4.3.0",
+        "@smithy/middleware-retry": "^4.4.0",
+        "@smithy/middleware-serde": "^4.2.0",
+        "@smithy/middleware-stack": "^4.2.0",
+        "@smithy/node-config-provider": "^4.3.0",
+        "@smithy/node-http-handler": "^4.3.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/smithy-client": "^4.7.0",
+        "@smithy/types": "^4.6.0",
+        "@smithy/url-parser": "^4.2.0",
+        "@smithy/util-base64": "^4.2.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.0",
+        "@smithy/util-defaults-mode-browser": "^4.2.0",
+        "@smithy/util-defaults-mode-node": "^4.2.0",
+        "@smithy/util-endpoints": "^3.2.0",
+        "@smithy/util-middleware": "^4.2.0",
+        "@smithy/util-retry": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.901.0.tgz",
+      "integrity": "sha512-7F0N888qVLHo4CSQOsnkZ4QAp8uHLKJ4v3u09Ly5k4AEStrSlFpckTPyUx6elwGL+fxGjNE2aakK8vEgzzCV0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/node-config-provider": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "@smithy/util-config-provider": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.901.0.tgz",
+      "integrity": "sha512-pJEr1Ggbc/uVTDqp9IbNu9hdr0eQf3yZix3s4Nnyvmg4xmJSGAlbPC9LrNr5u3CDZoc8Z9CuLrvbP4MwYquNpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.901.0",
+        "@aws-sdk/nested-clients": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/shared-ini-file-loader": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.901.0.tgz",
+      "integrity": "sha512-FfEM25hLEs4LoXsLXQ/q6X6L4JmKkKkbVFpKD4mwfVHtRVQG6QxJiCPcrkcPISquiy6esbwK2eh64TWbiD60cg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.901.0.tgz",
+      "integrity": "sha512-5nZP3hGA8FHEtKvEQf4Aww5QZOkjLW1Z+NixSd+0XKfHvA39Ah5sZboScjLx0C9kti/K3OGW1RCx5K9Zc3bZqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/types": "^4.6.0",
+        "@smithy/url-parser": "^4.2.0",
+        "@smithy/util-endpoints": "^3.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.893.0.tgz",
+      "integrity": "sha512-T89pFfgat6c8nMmpI8eKjBcDcgJq36+m9oiXbcUzeU55MP9ZuGgBomGjGnHaEyF36jenW9gmg3NfZDm0AO2XPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.901.0.tgz",
+      "integrity": "sha512-Ntb6V/WFI21Ed4PDgL/8NSfoZQQf9xzrwNgiwvnxgAl/KvAvRBgQtqj5gHsDX8Nj2YmJuVoHfH9BGjL9VQ4WNg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/types": "^4.6.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.901.0.tgz",
+      "integrity": "sha512-l59KQP5TY7vPVUfEURc7P5BJKuNg1RSsAKBQW7LHLECXjLqDUbo2SMLrexLBEoArSt6E8QOrIN0C8z/0Xk0jYw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.901.0",
+        "@aws-sdk/types": "3.901.0",
+        "@smithy/node-config-provider": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.901.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.901.0.tgz",
+      "integrity": "sha512-pxFCkuAP7Q94wMTNPAwi6hEtNrp/BdFf+HOrIEeFQsk4EoOmpKY3I6S+u6A9Wg295J80Kh74LqDWM22ux3z6Aw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.6.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.0.1.tgz",
+      "integrity": "sha512-ORHRQ2tmvnBXc8t/X9Z8IcSbBA4xTLKuN873FopzklHMeqBst7YG0d+AX97inkvDX+NChYtSr+qGfcqGFaI8Zw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/abort-controller": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.0.tgz",
+      "integrity": "sha512-PLUYa+SUKOEZtXFURBu/CNxlsxfaFGxSBPcStL13KpVeVWIfdezWyDqkz7iDLmwnxojXD0s5KzuB5HGHvt4Aeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.3.0.tgz",
+      "integrity": "sha512-9oH+n8AVNiLPK/iK/agOsoWfrKZ3FGP3502tkksd6SRsKMYiu7AFX0YXo6YBADdsAj7C+G/aLKdsafIJHxuCkQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "@smithy/util-config-provider": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.14.0.tgz",
+      "integrity": "sha512-XJ4z5FxvY/t0Dibms/+gLJrI5niRoY0BCmE02fwmPcRYFPI4KI876xaE79YGWIKnEslMbuQPsIEsoU/DXa0DoA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-serde": "^4.2.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/types": "^4.6.0",
+        "@smithy/util-base64": "^4.2.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.0",
+        "@smithy/util-stream": "^4.4.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/uuid": "^1.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.0.tgz",
+      "integrity": "sha512-SOhFVvFH4D5HJZytb0bLKxCrSnwcqPiNlrw+S4ZXjMnsC+o9JcUQzbZOEQcA8yv9wJFNhfsUiIUKiEnYL68Big==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/types": "^4.6.0",
+        "@smithy/url-parser": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.0.tgz",
+      "integrity": "sha512-BG3KSmsx9A//KyIfw+sqNmWFr1YBUr+TwpxFT7yPqAk0yyDh7oSNgzfNH7pS6OC099EGx2ltOULvumCFe8bcgw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/querystring-builder": "^4.2.0",
+        "@smithy/types": "^4.6.0",
+        "@smithy/util-base64": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.0.tgz",
+      "integrity": "sha512-ugv93gOhZGysTctZh9qdgng8B+xO0cj+zN0qAZ+Sgh7qTQGPOJbMdIuyP89KNfUyfAqFSNh5tMvC+h2uCpmTtA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.6.0",
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.0.tgz",
+      "integrity": "sha512-ZmK5X5fUPAbtvRcUPtk28aqIClVhbfcmfoS4M7UQBTnDdrNxhsrxYVv0ZEl5NaPSyExsPWqL4GsPlRvtlwg+2A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
+      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.0.tgz",
+      "integrity": "sha512-6ZAnwrXFecrA4kIDOcz6aLBhU5ih2is2NdcZtobBDSdSHtE9a+MThB5uqyK4XXesdOCvOcbCm2IGB95birTSOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.0.tgz",
+      "integrity": "sha512-jFVjuQeV8TkxaRlcCNg0GFVgg98tscsmIrIwRFeC74TIUyLE3jmY9xgc1WXrPQYRjQNK3aRoaIk6fhFRGOIoGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.14.0",
+        "@smithy/middleware-serde": "^4.2.0",
+        "@smithy/node-config-provider": "^4.3.0",
+        "@smithy/shared-ini-file-loader": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "@smithy/url-parser": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.0.tgz",
+      "integrity": "sha512-yaVBR0vQnOnzex45zZ8ZrPzUnX73eUC8kVFaAAbn04+6V7lPtxn56vZEBBAhgS/eqD6Zm86o6sJs6FuQVoX5qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/service-error-classification": "^4.2.0",
+        "@smithy/smithy-client": "^4.7.0",
+        "@smithy/types": "^4.6.0",
+        "@smithy/util-middleware": "^4.2.0",
+        "@smithy/util-retry": "^4.2.0",
+        "@smithy/uuid": "^1.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.0.tgz",
+      "integrity": "sha512-rpTQ7D65/EAbC6VydXlxjvbifTf4IH+sADKg6JmAvhkflJO2NvDeyU9qsWUNBelJiQFcXKejUHWRSdmpJmEmiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.0.tgz",
+      "integrity": "sha512-G5CJ//eqRd9OARrQu9MK1H8fNm2sMtqFh6j8/rPozhEL+Dokpvi1Og+aCixTuwDAGZUkJPk6hJT5jchbk/WCyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.0.tgz",
+      "integrity": "sha512-5QgHNuWdT9j9GwMPPJCKxy2KDxZ3E5l4M3/5TatSZrqYVoEiqQrDfAq8I6KWZw7RZOHtVtCzEPdYz7rHZixwcA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/shared-ini-file-loader": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.3.0.tgz",
+      "integrity": "sha512-RHZ/uWCmSNZ8cneoWEVsVwMZBKy/8123hEpm57vgGXA3Irf/Ja4v9TVshHK2ML5/IqzAZn0WhINHOP9xl+Qy6Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.2.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/querystring-builder": "^4.2.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.0.tgz",
+      "integrity": "sha512-rV6wFre0BU6n/tx2Ztn5LdvEdNZ2FasQbPQmDOPfV9QQyDmsCkOAB0osQjotRCQg+nSKFmINhyda0D3AnjSBJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.0.tgz",
+      "integrity": "sha512-6POSYlmDnsLKb7r1D3SVm7RaYW6H1vcNcTWGWrF7s9+2noNYvUsm7E4tz5ZQ9HXPmKn6Hb67pBDRIjrT4w/d7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.0.tgz",
+      "integrity": "sha512-Q4oFD0ZmI8yJkiPPeGUITZj++4HHYCW3pYBYfIobUCkYpI6mbkzmG1MAQQ3lJYYWj3iNqfzOenUZu+jqdPQ16A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.6.0",
+        "@smithy/util-uri-escape": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.0.tgz",
+      "integrity": "sha512-BjATSNNyvVbQxOOlKse0b0pSezTWGMvA87SvoFoFlkRsKXVsN3bEtjCxvsNXJXfnAzlWFPaT9DmhWy1vn0sNEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.0.tgz",
+      "integrity": "sha512-Ylv1ttUeKatpR0wEOMnHf1hXMktPUMObDClSWl2TpCVT4DwtJhCeighLzSLbgH3jr5pBNM0LDXT5yYxUvZ9WpA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.6.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.3.0.tgz",
+      "integrity": "sha512-VCUPPtNs+rKWlqqntX0CbVvWyjhmX30JCtzO+s5dlzzxrvSfRh5SY0yxnkirvc1c80vdKQttahL71a9EsdolSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.0.tgz",
+      "integrity": "sha512-MKNyhXEs99xAZaFhm88h+3/V+tCRDQ+PrDzRqL0xdDpq4gjxcMmf5rBA3YXgqZqMZ/XwemZEurCBQMfxZOWq/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/types": "^4.6.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.0",
+        "@smithy/util-uri-escape": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.7.0.tgz",
+      "integrity": "sha512-3BDx/aCCPf+kkinYf5QQhdQ9UAGihgOVqI3QO5xQfSaIWvUE4KYLtiGRWsNe1SR7ijXC0QEPqofVp5Sb0zC8xQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.14.0",
+        "@smithy/middleware-endpoint": "^4.3.0",
+        "@smithy/middleware-stack": "^4.2.0",
+        "@smithy/protocol-http": "^5.3.0",
+        "@smithy/types": "^4.6.0",
+        "@smithy/util-stream": "^4.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.6.0.tgz",
+      "integrity": "sha512-4lI9C8NzRPOv66FaY1LL1O/0v0aLVrq/mXP/keUa9mJOApEeae43LsLd2kZRUJw91gxOQfLIrV3OvqPgWz1YsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.0.tgz",
+      "integrity": "sha512-AlBmD6Idav2ugmoAL6UtR6ItS7jU5h5RNqLMZC7QrLCoITA9NzIN3nx9GWi8g4z1pfWh2r9r96SX/jHiNwPJ9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.2.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.2.0.tgz",
+      "integrity": "sha512-+erInz8WDv5KPe7xCsJCp+1WCjSbah9gWcmUXc9NqmhyPx59tf7jqFz+za1tRG1Y5KM1Cy1rWCcGypylFp4mvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
+      "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.0.tgz",
+      "integrity": "sha512-U8q1WsSZFjXijlD7a4wsDQOvOwV+72iHSfq1q7VD+V75xP/pdtm0WIGuaFJ3gcADDOKj2MIBn4+zisi140HEnQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
+      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
+      "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.2.0.tgz",
+      "integrity": "sha512-qzHp7ZDk1Ba4LDwQVCNp90xPGqSu7kmL7y5toBpccuhi3AH7dcVBIT/pUxYcInK4jOy6FikrcTGq5wxcka8UaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/smithy-client": "^4.7.0",
+        "@smithy/types": "^4.6.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.0.tgz",
+      "integrity": "sha512-FxUHS3WXgx3bTWR6yQHNHHkQHZm/XKIi/CchTnKvBulN6obWpcbzJ6lDToXn+Wp0QlVKd7uYAz2/CTw1j7m+Kg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.3.0",
+        "@smithy/credential-provider-imds": "^4.2.0",
+        "@smithy/node-config-provider": "^4.3.0",
+        "@smithy/property-provider": "^4.2.0",
+        "@smithy/smithy-client": "^4.7.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.0.tgz",
+      "integrity": "sha512-TXeCn22D56vvWr/5xPqALc9oO+LN+QpFjrSM7peG/ckqEPoI3zaKZFp+bFwfmiHhn5MGWPaLCqDOJPPIixk9Wg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
+      "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.0.tgz",
+      "integrity": "sha512-u9OOfDa43MjagtJZ8AapJcmimP+K2Z7szXn8xbty4aza+7P1wjFmy2ewjSbhEiYQoW1unTlOAIV165weYAaowA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.0.tgz",
+      "integrity": "sha512-BWSiuGbwRnEE2SFfaAZEX0TqaxtvtSYPM/J73PFVm+A29Fg1HTPiYFb8TmX1DXp4hgcdyJcNQmprfd5foeORsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.2.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.4.0.tgz",
+      "integrity": "sha512-vtO7ktbixEcrVzMRmpQDnw/Ehr9UWjBvSJ9fyAbadKkC4w5Cm/4lMO8cHz8Ysb8uflvQUNRcuux/oNHKPXkffg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.3.0",
+        "@smithy/node-http-handler": "^4.3.0",
+        "@smithy/types": "^4.6.0",
+        "@smithy/util-base64": "^4.2.0",
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
+      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
+      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.0.tgz",
+      "integrity": "sha512-0Z+nxUU4/4T+SL8BCNN4ztKdQjToNvUYmkF1kXO5T7Yz3Gafzh0HeIG6mrkN8Fz3gn9hSyxuAT+6h4vM+iQSBQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.2.0",
+        "@smithy/types": "^4.6.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/uuid": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
+      "integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.19.tgz",
+      "integrity": "sha512-pb1Uqj5WJP7wrcbLU7Ru4QtA0+3kAXrkutGiD26wUKzSMgNNaPARTUDQmElUXp64kh3cWdou3Q0C7qwwxqSFmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.15.5",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.5.tgz",
+      "integrity": "sha512-LF7lF6zWEKxuT3/OR8wAZGzkg4ENGXFNyiV/JeOt9z5B+0ZVwbql9McqX5c/WStFq1GaGso7H1AzP/qSzmlCKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.12.1.tgz",
+      "integrity": "sha512-z4rE2Gxh7tvshQ4hluIT7XcFrgLIQaw9X3A+kTTRdovCz5PMukm/0QC/BKSYPj3omF5Qfypn9O/c5kgpmvYUCw==",
+      "license": "MIT"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/pg": {
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.7"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
+      "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
+      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
+      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    }
+  }
+}

--- a/br-ingest-stripe/package.json
+++ b/br-ingest-stripe/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "br-ingest-stripe",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p .",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@aws-sdk/client-ssm": "^3.635.0",
+    "dotenv": "^16.4.5",
+    "node-fetch": "^3.3.2",
+    "pg": "^8.11.3"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "@types/pg": "^8.15.5",
+    "typescript": "^5.5.4"
+  }
+}

--- a/br-ingest-stripe/src/index.ts
+++ b/br-ingest-stripe/src/index.ts
@@ -1,0 +1,83 @@
+import 'dotenv/config';
+import { pool } from './pg.js';
+import { getSecureParameter } from './ssm.js';
+import { listCharges, listSubscriptions, getSubscriptionItems } from './stripe.js';
+import { upsertCharges, upsertSubscriptions } from './upsert.js';
+
+async function main() {
+  const sourceId = process.env.SOURCE_ID;
+  const tokenParam = process.env.STRIPE_TOKEN_PARAM;
+  if (!sourceId) {
+    throw new Error('SOURCE_ID is required');
+  }
+  if (!tokenParam) {
+    throw new Error('STRIPE_TOKEN_PARAM is required');
+  }
+
+  const token = await getSecureParameter(tokenParam);
+  if (!token) {
+    throw new Error('Stripe token empty');
+  }
+
+  const client = await pool.connect();
+  try {
+    const state = await client.query<{ last_charge_ts: Date | null; last_sub_updated_ts: Date | null }>(
+      `SELECT last_charge_ts, last_sub_updated_ts FROM stripe_sync_state WHERE source_id = $1`,
+      [sourceId]
+    );
+    const lastChargeTs = state.rows[0]?.last_charge_ts ? new Date(state.rows[0].last_charge_ts) : new Date(0);
+    const lastSubTs = state.rows[0]?.last_sub_updated_ts ? new Date(state.rows[0].last_sub_updated_ts) : new Date(0);
+
+    let chargesCount = 0;
+    let latestChargeTs = lastChargeTs;
+    const createdGte = Math.floor(lastChargeTs.getTime() / 1000);
+    for await (const page of listCharges(token, { created: { gte: createdGte } })) {
+      if (!Array.isArray(page) || page.length === 0) continue;
+      chargesCount += await upsertCharges(client, page, sourceId);
+      const maxCreated = page.reduce((max: number, charge: any) => Math.max(max, Number(charge?.created ?? 0)), 0);
+      if (maxCreated) {
+        const createdAt = new Date(maxCreated * 1000);
+        if (createdAt > latestChargeTs) {
+          latestChargeTs = createdAt;
+        }
+      }
+    }
+
+    let subsCount = 0;
+    let latestSubUpdated = lastSubTs;
+    const updatedGte = Math.floor(lastSubTs.getTime() / 1000);
+    for await (const page of listSubscriptions(token, { updated: { gte: updatedGte } })) {
+      if (!Array.isArray(page) || page.length === 0) continue;
+      subsCount += await upsertSubscriptions(client, page, token, sourceId, getSubscriptionItems);
+      const pageMax = page.reduce((max: number, sub: any) => {
+        const ts = Number(sub?.updated ?? sub?.current_period_end ?? sub?.created ?? 0);
+        return Math.max(max, ts);
+      }, 0);
+      if (pageMax) {
+        const subDate = new Date(pageMax * 1000);
+        if (subDate > latestSubUpdated) {
+          latestSubUpdated = subDate;
+        }
+      }
+    }
+
+    const nextChargeTs = chargesCount > 0 ? latestChargeTs : lastChargeTs;
+    const nextSubTs = subsCount > 0 ? latestSubUpdated : lastSubTs;
+
+    await client.query(
+      `INSERT INTO stripe_sync_state(source_id, last_charge_ts, last_sub_updated_ts)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (source_id) DO UPDATE SET last_charge_ts = $2, last_sub_updated_ts = $3`,
+      [sourceId, nextChargeTs.toISOString(), nextSubTs.toISOString()]
+    );
+
+    console.log(`Stripe ingest complete: charges +${chargesCount}, subs +${subsCount}`);
+  } finally {
+    client.release();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/br-ingest-stripe/src/pg.ts
+++ b/br-ingest-stripe/src/pg.ts
@@ -1,0 +1,11 @@
+import { Pool } from 'pg';
+
+if (!process.env.PG_URL) {
+  throw new Error('PG_URL is required');
+}
+
+export const pool = new Pool({
+  connectionString: process.env.PG_URL,
+  application_name: 'br-ingest-stripe',
+  ssl: process.env.PG_SSL === 'true' ? { rejectUnauthorized: false } : undefined,
+});

--- a/br-ingest-stripe/src/ssm.ts
+++ b/br-ingest-stripe/src/ssm.ts
@@ -1,0 +1,20 @@
+import { GetParameterCommand, SSMClient } from '@aws-sdk/client-ssm';
+
+const client = new SSMClient({});
+
+export async function getSecureParameter(name: string): Promise<string> {
+  if (!name) {
+    throw new Error('parameter_name_required');
+  }
+  const resp = await client.send(
+    new GetParameterCommand({
+      Name: name,
+      WithDecryption: true,
+    })
+  );
+  const value = resp.Parameter?.Value;
+  if (!value) {
+    throw new Error(`parameter_missing:${name}`);
+  }
+  return value;
+}

--- a/br-ingest-stripe/src/stripe.ts
+++ b/br-ingest-stripe/src/stripe.ts
@@ -1,0 +1,95 @@
+import fetch from 'node-fetch';
+import { StripeCharge, StripeSubscription, StripeSubscriptionItem } from './types.js';
+
+const BASE = 'https://api.stripe.com/v1';
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function encodeParams(params: Record<string, any>) {
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null) continue;
+    if (Array.isArray(value)) {
+      value.forEach((v) => search.append(key, String(v)));
+    } else if (typeof value === 'object') {
+      for (const [subKey, subVal] of Object.entries(value)) {
+        if (subVal === undefined || subVal === null) continue;
+        search.append(`${key}[${subKey}]`, String(subVal));
+      }
+    } else {
+      search.append(key, String(value));
+    }
+  }
+  return search.toString();
+}
+
+async function getJSON<T>(path: string, token: string, params: Record<string, any> = {}, attempt = 0): Promise<T> {
+  const query = encodeParams({ ...params, limit: params.limit ?? 100 });
+  const url = `${BASE}${path}${query ? `?${query}` : ''}`;
+  const resp = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  if (resp.ok) {
+    return (await resp.json()) as T;
+  }
+  const retryAfter = resp.headers.get('retry-after');
+  const status = resp.status;
+  if ((status === 429 || status >= 500) && attempt < 5) {
+    let delayMs = Math.min(2 ** attempt * 500, 10_000);
+    if (retryAfter) {
+      const retrySeconds = Number(retryAfter);
+      if (!Number.isNaN(retrySeconds)) {
+        delayMs = retrySeconds * 1000;
+      }
+    }
+    await sleep(delayMs);
+    return getJSON<T>(path, token, params, attempt + 1);
+  }
+  const text = await resp.text();
+  throw new Error(`stripe_request_failed:${status}:${text}`);
+}
+
+export async function* listPaginated<T extends { data: { id: string }[]; has_more: boolean }>(
+  path: string,
+  token: string,
+  params: Record<string, any> = {}
+): AsyncGenerator<T['data'], void, unknown> {
+  let startingAfter: string | undefined;
+  while (true) {
+    const body = await getJSON<T>(path, token, {
+      ...params,
+      ...(startingAfter ? { starting_after: startingAfter } : {}),
+    });
+    const items = body.data || [];
+    if (!items.length) {
+      break;
+    }
+    yield items;
+    if (!body.has_more) {
+      break;
+    }
+    startingAfter = items[items.length - 1].id;
+  }
+}
+
+export const listCharges = (token: string, params: Record<string, any>) =>
+  listPaginated<{ data: StripeCharge[]; has_more: boolean }>(`/charges`, token, params);
+
+export const listSubscriptions = (token: string, params: Record<string, any>) =>
+  listPaginated<{ data: StripeSubscription[]; has_more: boolean }>('/subscriptions', token, params);
+
+export async function getSubscriptionItems(token: string, subscriptionId: string) {
+  const items: StripeSubscriptionItem[] = [];
+  for await (const page of listPaginated<{ data: StripeSubscriptionItem[]; has_more: boolean }>(
+    '/subscription_items',
+    token,
+    { subscription: subscriptionId }
+  )) {
+    items.push(...page);
+  }
+  return items;
+}

--- a/br-ingest-stripe/src/types.ts
+++ b/br-ingest-stripe/src/types.ts
@@ -1,0 +1,33 @@
+export interface StripeCharge {
+  id: string;
+  customer?: string | null;
+  amount: number;
+  currency: string;
+  paid: boolean;
+  status: string;
+  created: number;
+  refunded?: boolean;
+}
+
+export interface StripeSubscription {
+  id: string;
+  customer: string;
+  status: string;
+  current_period_start?: number;
+  current_period_end?: number;
+  canceled_at?: number;
+  cancel_at_period_end?: boolean;
+  created: number;
+  updated?: number;
+}
+
+export interface StripeSubscriptionItem {
+  id: string;
+  price?: {
+    id?: string;
+    currency?: string;
+    recurring?: { interval?: string; interval_count?: number };
+    unit_amount?: number | null;
+  };
+  quantity?: number | null;
+}

--- a/br-ingest-stripe/src/upsert.ts
+++ b/br-ingest-stripe/src/upsert.ts
@@ -1,0 +1,126 @@
+import { PoolClient } from 'pg';
+import { StripeCharge, StripeSubscription, StripeSubscriptionItem } from './types.js';
+
+type GetItemsFn = (token: string, subscriptionId: string) => Promise<StripeSubscriptionItem[]>;
+
+export async function upsertCharges(client: PoolClient, items: StripeCharge[], sourceId: string) {
+  if (!items.length) return 0;
+  const values: any[] = [];
+  const rows = items
+    .map((charge, idx) => {
+      const base = idx * 10;
+      values.push(
+        charge.id,
+        charge.customer ?? null,
+        charge.amount,
+        charge.currency,
+        charge.paid,
+        charge.status,
+        new Date(charge.created * 1000).toISOString(),
+        charge.refunded ?? false,
+        JSON.stringify(charge),
+        sourceId
+      );
+      return `($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4}, $${base + 5}, $${base + 6}, $${base + 7}, $${base + 8}, $${base + 9}, $${base + 10})`;
+    })
+    .join(',');
+  await client.query(
+    `INSERT INTO raw_stripe_charges(id, customer_id, amount, currency, paid, status, created_at, refunded, payload, source_id)
+     VALUES ${rows}
+     ON CONFLICT (id) DO UPDATE SET
+       customer_id = EXCLUDED.customer_id,
+       amount = EXCLUDED.amount,
+       currency = EXCLUDED.currency,
+       paid = EXCLUDED.paid,
+       status = EXCLUDED.status,
+       created_at = EXCLUDED.created_at,
+       refunded = EXCLUDED.refunded,
+       payload = EXCLUDED.payload,
+       source_id = EXCLUDED.source_id`,
+    values
+  );
+  return items.length;
+}
+
+export async function upsertSubscriptions(
+  client: PoolClient,
+  subs: StripeSubscription[],
+  token: string,
+  sourceId: string,
+  getItems: GetItemsFn
+) {
+  let count = 0;
+  for (const sub of subs) {
+    await client.query(
+      `INSERT INTO raw_stripe_subscriptions(
+         id, customer_id, status, current_period_start, current_period_end,
+         canceled_at, cancel_at_period_end, created_at, payload, source_id
+       )
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+       ON CONFLICT (id) DO UPDATE SET
+         customer_id = EXCLUDED.customer_id,
+         status = EXCLUDED.status,
+         current_period_start = EXCLUDED.current_period_start,
+         current_period_end = EXCLUDED.current_period_end,
+         canceled_at = EXCLUDED.canceled_at,
+         cancel_at_period_end = EXCLUDED.cancel_at_period_end,
+         created_at = EXCLUDED.created_at,
+         payload = EXCLUDED.payload,
+         source_id = EXCLUDED.source_id`,
+      [
+        sub.id,
+        sub.customer,
+        sub.status,
+        sub.current_period_start ? new Date(sub.current_period_start * 1000).toISOString() : null,
+        sub.current_period_end ? new Date(sub.current_period_end * 1000).toISOString() : null,
+        sub.canceled_at ? new Date(sub.canceled_at * 1000).toISOString() : null,
+        Boolean(sub.cancel_at_period_end),
+        new Date(sub.created * 1000).toISOString(),
+        JSON.stringify(sub),
+        sourceId,
+      ]
+    );
+    const items = await getItems(token, sub.id);
+    if (items.length) {
+      const vals: any[] = [];
+      const rows = items
+        .map((item, idx) => {
+          const base = idx * 10;
+          vals.push(
+            item.id,
+            sub.id,
+            item.price?.id ?? 'unknown',
+            item.price?.currency ?? 'usd',
+            item.price?.recurring?.interval ?? 'month',
+            item.price?.recurring?.interval_count ?? 1,
+            item.price?.unit_amount ?? null,
+            item.quantity ?? 1,
+            JSON.stringify(item),
+            sourceId
+          );
+          return `($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4}, $${base + 5}, $${base + 6}, $${base + 7}, $${base + 8}, $${base + 9}, $${base + 10})`;
+        })
+        .join(',');
+      await client.query(
+        `INSERT INTO raw_stripe_subscription_items(
+           id, subscription_id, price_id, currency, interval, interval_count,
+           unit_amount, quantity, payload, source_id
+         )
+         VALUES ${rows}
+         ON CONFLICT (id) DO UPDATE SET
+           subscription_id = EXCLUDED.subscription_id,
+           price_id = EXCLUDED.price_id,
+           currency = EXCLUDED.currency,
+           interval = EXCLUDED.interval,
+           interval_count = EXCLUDED.interval_count,
+           unit_amount = EXCLUDED.unit_amount,
+           quantity = EXCLUDED.quantity,
+           payload = EXCLUDED.payload,
+           source_id = EXCLUDED.source_id`,
+        vals
+      );
+    }
+    count += 1;
+  }
+  return count;
+}

--- a/br-ingest-stripe/tsconfig.json
+++ b/br-ingest-stripe/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/db/migrations/202502210900_stripe_ingest.sql
+++ b/db/migrations/202502210900_stripe_ingest.sql
@@ -1,0 +1,71 @@
+-- Stripe raw ingestion tables for PRISM
+CREATE TABLE IF NOT EXISTS integration_sources (
+  id UUID PRIMARY KEY,
+  kind TEXT NOT NULL,
+  label TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_integration_sources_kind ON integration_sources(kind);
+
+CREATE TABLE IF NOT EXISTS raw_stripe_customers (
+  id TEXT PRIMARY KEY,
+  email TEXT,
+  created_at TIMESTAMPTZ NOT NULL,
+  payload JSONB NOT NULL,
+  source_id UUID NOT NULL REFERENCES integration_sources(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS raw_stripe_subscriptions (
+  id TEXT PRIMARY KEY,
+  customer_id TEXT NOT NULL,
+  status TEXT NOT NULL,
+  current_period_start TIMESTAMPTZ,
+  current_period_end TIMESTAMPTZ,
+  canceled_at TIMESTAMPTZ,
+  cancel_at_period_end BOOLEAN,
+  created_at TIMESTAMPTZ NOT NULL,
+  payload JSONB NOT NULL,
+  source_id UUID NOT NULL REFERENCES integration_sources(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_rss_status ON raw_stripe_subscriptions(status);
+CREATE INDEX IF NOT EXISTS idx_rss_source ON raw_stripe_subscriptions(source_id);
+
+CREATE TABLE IF NOT EXISTS raw_stripe_subscription_items (
+  id TEXT PRIMARY KEY,
+  subscription_id TEXT NOT NULL,
+  price_id TEXT NOT NULL,
+  currency TEXT NOT NULL,
+  interval TEXT NOT NULL,
+  interval_count INT NOT NULL,
+  unit_amount BIGINT,
+  quantity INT,
+  payload JSONB NOT NULL,
+  source_id UUID NOT NULL REFERENCES integration_sources(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_rssi_subscription ON raw_stripe_subscription_items(subscription_id);
+CREATE INDEX IF NOT EXISTS idx_rssi_source ON raw_stripe_subscription_items(source_id);
+
+CREATE TABLE IF NOT EXISTS raw_stripe_charges (
+  id TEXT PRIMARY KEY,
+  customer_id TEXT,
+  amount BIGINT NOT NULL,
+  currency TEXT NOT NULL,
+  paid BOOLEAN NOT NULL,
+  status TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL,
+  refunded BOOLEAN NOT NULL DEFAULT FALSE,
+  payload JSONB NOT NULL,
+  source_id UUID NOT NULL REFERENCES integration_sources(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_rsc_created ON raw_stripe_charges(created_at);
+CREATE INDEX IF NOT EXISTS idx_rsc_source ON raw_stripe_charges(source_id);
+
+CREATE TABLE IF NOT EXISTS stripe_sync_state (
+  source_id UUID PRIMARY KEY REFERENCES integration_sources(id) ON DELETE CASCADE,
+  last_charge_ts TIMESTAMPTZ NOT NULL DEFAULT '1970-01-01',
+  last_sub_updated_ts TIMESTAMPTZ NOT NULL DEFAULT '1970-01-01'
+);


### PR DESCRIPTION
## Summary
- add Postgres migration for Stripe sources, raw objects, and sync state to support incremental ingest
- implement Stripe connector API flow including secure token storage, ECS kick-off, and metrics endpoints for charges, active subs, and MRR
- introduce the br-ingest-stripe worker to sync charges and subscriptions with pagination/backoff and surface the new metrics tiles in the PRISM UI

## Testing
- npm --prefix br-ingest-stripe run build

------
https://chatgpt.com/codex/tasks/task_e_68e187e2d4dc8329b11b02a136b0794c