### PR TITLE
Create Minnesota licensing reinstatement roadmap

### DIFF
--- a/docs/compliance/minnesota_license_reinstatement_plan.md
+++ b/docs/compliance/minnesota_license_reinstatement_plan.md
@@ -1,0 +1,141 @@
+# Minnesota Licensing Reinstatement Roadmap for Alexa Louise Amundson
+
+> **Important:** This document summarizes publicly available regulatory processes for Minnesota and common FINRA/state registration workflows. It is not legal advice. Confirm every step with the relevant regulator, and consult compliance counsel if you encounter statutory bars or unresolved disclosures.
+
+## 1. Establish the Baseline
+
+1. **Pull the full CRD/IARD records.**
+   - Request Alexa Louise Amundson's complete CRD snapshot (Form U4/U5 history, disclosures, exams, CE status).
+   - Verify whether any statutory disqualifications, bars, or pending customer disputes exist. If a bar is active, reinstatement is not possible until it is lifted or expires.
+2. **Inventory all licenses.**
+   - Securities (FINRA registrations, state registrations, S63/S65/S66, principal licenses).
+   - Insurance producer appointments (life/health, variable lines, etc.) across states.
+   - Real estate license(s) tied to NAR membership.
+3. **Document lapse timelines.**
+   - Capture expiration dates, termination reasons, whether termination was voluntary, for cause, or due to inactivity.
+   - Record continuing education (CE) completions and gaps for each credential.
+
+Deliverables: consolidated spreadsheet (license, jurisdiction, status, CE due, reinstatement window), and a disclosure summary showing any impediments.
+
+## 2. Securities (FINRA & Minnesota Department of Commerce)
+
+### 2.1 Resolve Eligibility Questions
+
+1. **Determine current registration status.**
+   - Check FINRA Gateway for Alexa's status; if terminated for cause or subject to a statutory disqualification, coordinate with FINRA Member Supervision.
+2. **Assess disclosure remediation.**
+   - For any customer complaints, regulatory actions, or financial events, gather supporting documents and verify whether amendments are required.
+
+### 2.2 Identify Sponsoring Broker-Dealer or RIA
+
+- Re-registration generally requires association with a FINRA member or a registered RIA.
+- Define whether the path is:
+  - **Broker-Dealer route:** identify a member firm willing to file Form U4 and supervise securities activities.
+  - **Investment Adviser Representative (IAR) route:** form/register an RIA (state-registered in Minnesota unless AUM > $100M) and file Form U4 via IARD with a Minnesota-registered firm.
+
+### 2.3 Complete Regulatory Requirements
+
+1. **Continuing Education (CE).**
+   - FINRA Regulatory Element: confirm if CE cycles were missed; schedule make-up via FINRA CE Online platform.
+   - Firm Element: coordinate with sponsor firm to document completion or remediate gaps.
+2. **Exams.**
+   - If more than two years have elapsed since termination, FINRA may require re-examination (e.g., S7, S63/S66). Verify eligibility for exam waivers or the Maintaining Qualifications Program (MQP) if previously enrolled.
+3. **Minnesota state registration.**
+   - For broker representatives, the sponsoring firm files Form U4 adding Minnesota (jurisdiction code MN) and pays state fees via CRD.
+   - For IARs of a state-registered RIA, file Form U4 through IARD and submit Form ADV Parts 1 & 2 for the firm if not already active.
+4. **Background updates.**
+   - Provide fingerprints if the previous set is older than 180 days or if required for new association.
+5. **Submit filings.**
+   - Sponsor files Form U4; respond promptly to any Minnesota Department of Commerce deficiency letters.
+   - If forming a new RIA, include compliance documents: compliance manual, code of ethics, advisory contracts, financials.
+
+### 2.4 Post-Approval Controls
+
+- Establish written supervisory procedures (WSPs) tailored to a low-headcount structure.
+- Set quarterly compliance reviews, annual Rule 206(4)-7 review (if RIA), and incident logging.
+
+## 3. Insurance Producer Licenses (Minnesota Primary, Other States Secondary)
+
+### 3.1 Minnesota Department of Commerce
+
+1. **Check license status in Sircon/NIPR.** Note the lines of authority previously held (e.g., life, accident & health, variable annuity).
+2. **Determine lapse period.**
+   - Minnesota allows renewal without re-exam if completed within 12 months of expiration with CE satisfied. Beyond 12 months, reapplication and examinations may be required.
+3. **Continuing Education.**
+   - Minnesota requires 24 CE credits per two-year cycle (including 3 hours ethics). Audit CE transcript; schedule make-up courses through approved providers.
+4. **Submit reinstatement or new application.**
+   - If within reinstatement window: file late renewal via Sircon/NIPR, pay renewal + late fees, attest to CE.
+   - If beyond window: complete prelicensing (if required), schedule exams through PSI, fingerprint, and submit new resident producer application.
+5. **Reappoint insurers.**
+   - After license activation, coordinate with each carrier to file new appointments in Minnesota.
+
+### 3.2 Additional States
+
+- Prioritize states based on client footprint.
+- For each state, document reinstatement rules (grace period, CE requirements, exam retake thresholds).
+- Utilize NIPR's multi-state renewal to streamline filings where reciprocity applies.
+
+## 4. Real Estate License (Assuming Minnesota Primary)
+
+1. **Verify status with Minnesota Department of Commerce Licensing Portal.**
+2. **If expired <2 years:**
+   - Complete required continuing education for the missed cycle(s).
+   - Apply for reinstatement; pay renewal and late fees.
+3. **If expired ≥2 years:**
+   - You must complete pre-licensing coursework, pass the state & national exams via Pearson VUE, and submit a new salesperson/broker application.
+4. **Brokerage affiliation.**
+   - Minnesota requires an active broker of record to sponsor; if forming your own brokerage, register the entity and comply with trust account and recordkeeping rules.
+5. **Reinstate NAR membership** once the state license is active (membership is optional but often necessary for MLS access).
+
+## 5. Compliance & Operations Infrastructure
+
+### 5.1 License & CE Tracking
+
+- Implement a centralized tracker (spreadsheet or compliance tool) with:
+  - Credential, jurisdiction, status, renewal date, CE hours, responsible party.
+  - Automated alerts at 90/60/30/7 days before deadlines.
+
+### 5.2 Document Management
+
+- Store WSPs, advisory agreements, insurance carrier agreements, and real estate brokerage policies in a controlled repository (with versioning).
+- Maintain a disclosure log for Form U4/U5/Form ADV amendments.
+
+### 5.3 Supervision & Audit Cadence
+
+- Quarterly self-audits covering trade reviews, suitability, client communications, complaints.
+- Annual compliance review and risk assessment; document findings and remediation plans.
+
+### 5.4 Technology Stack Considerations
+
+- Consider compliance platforms (e.g., ComplySci, Redtail Compliance, SmartRIA) sized for solo practices.
+- Integrate CE providers and background check services via API where available.
+- Automate NIPR/Sircon data pulls if volume warrants.
+
+## 6. Decision Checklist
+
+| Workstream | Key Questions | Next Action |
+|------------|---------------|-------------|
+| Securities | Do any FINRA/state bars exist? Who will sponsor? | Obtain CRD file, engage prospective broker-dealer or register RIA |
+| Insurance  | Are CE credits current? Within MN reinstatement window? | Pull CE transcript, schedule courses, file Sircon late renewal |
+| Real Estate | How long since expiration? Solo brokerage or team? | Confirm status, plan CE/exam, file reinstatement |
+| Compliance Ops | What tooling budget & oversight tolerance? | Select tracking platform, design WSPs, set audit calendar |
+
+## 7. Immediate Next Steps (0-30 Days)
+
+1. Request comprehensive CRD report and verify disclosure status.
+2. Build the license inventory spreadsheet (include non-Minnesota jurisdictions you plan to serve).
+3. Contact Minnesota Department of Commerce for securities and insurance reinstatement specifics based on your lapse period.
+4. Begin outreach to prospective broker-dealer/RIA partners willing to sponsor or collaborate on supervision.
+5. Enroll in outstanding CE courses (securities MQP/CE, insurance CE, real estate CE).
+6. Draft or update your compliance manual and supervisory procedures to present to potential sponsors and regulators.
+
+## 8. 30-90 Day Outlook
+
+- File Form U4 and related reinstatement applications once sponsorship secured and CE completed.
+- Submit Minnesota insurance reinstatement/new application; repeat for priority non-resident states.
+- Reinitiate real estate license process (CE or exam) and align brokerage affiliation.
+- Deploy compliance tooling and establish monitoring dashboards.
+
+---
+
+Keep this document updated as regulators respond; add deficiency letters, response deadlines, and status notes to avoid missing critical follow-ups.


### PR DESCRIPTION
## Summary
- add a Minnesota-focused roadmap outlining steps to reinstate securities, insurance, and real estate licenses
- document compliance infrastructure recommendations to support ongoing supervision and CE tracking

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e18e17b39483298ef4ab7d9c477de6