### PR TITLE
Add Minnesota licensing reinstatement roadmap

### DIFF
--- a/docs/regulatory/minnesota-multi-license-roadmap.md
+++ b/docs/regulatory/minnesota-multi-license-roadmap.md
@@ -1,0 +1,51 @@
+# Minnesota Licensing Reinstatement & Expansion Plan
+
+This playbook consolidates the reinstatement path for Minnesota-based operations across securities, insurance, and real estate licenses, then outlines how to scale the process into other states. Use it as a planning aid and confirm every requirement directly with the Minnesota Department of Commerce, FINRA, and counterpart regulators before filing.
+
+## Minnesota reinstatement overview
+
+| Track | Core authority | Primary steps | Notes & pitfalls |
+| --- | --- | --- | --- |
+| **Securities / Investment Adviser** | Minnesota Statutes Chapter 80A; Minnesota Rules Chapter 2876 | 1. Download your full CRD / BrokerCheck record.<br>2. Confirm whether you must register as an Investment Adviser Representative (IAR) in Minnesota.<br>3. Satisfy Minnesota's exam requirement (Series 65 or Series 66 + Series 7) or confirm an accepted professional designation exemption.<br>4. File Form U4 for yourself via FINRA's IARD/CRD.<br>5. If you operate an advisory firm, submit Form ADV Parts 1 & 2 through IARD, provide supporting financials, and meet any surety bond requirement.<br>6. Pay the state filing fees ($100 firm / $50 IAR annually) and FINRA processing fees.<br>7. Track amendments—U4 updates are due within 30 days of any material change. | * Minnesota Order 2013 designates exam waivers for certain credentials (CFP, CFA, ChFC, CIC, PFS).<br>* Review Minn. R. 2876.4061 for net capital and bonding obligations.<br>* Prepare for additional questions if past disclosures exist—have explanations and remediation ready. |
+| **Insurance Producer** | Minnesota Department of Commerce, Insurance Division | 1. Inventory the lines of authority you previously held (life, health, property, casualty, variable lines, etc.).<br>2. Check status in Sircon / MN licensing portal.<br>3. If lapsed ≤12 months, complete reinstatement online and pay the doubled renewal fee.<br>4. Finish 24 hours of CE (minimum 3 ethics) for the applicable period.<br>5. If lapsed >12 months, repeat pre-licensing education, pass the state exam, and reapply.<br>6. Submit fingerprints / background check if required.<br>7. Re-establish carrier appointments once the license is active. | * Missing the 12-month reinstatement window forces a full relicensing path.<br>* Track CE completions by line to avoid renewal denials.<br>* Carrier appointments lapse with the license—confirm reinstatement steps with each insurer. |
+| **Real Estate Salesperson/Broker** | Minnesota Department of Commerce, Real Estate & Appraiser Licensing | 1. Confirm former license class (salesperson vs. broker) and expiration timeline.<br>2. Review Commerce rules for late renewal vs. reinstatement—complete required CE or schedule exam retake if lapsed too long.<br>3. File the reinstatement or renewal application with fees and proof of CE/exam.<br>4. Reaffiliate with a broker of record (if salesperson) or reactivate brokerage entity filings (if broker).<br>5. Resume annual CE tracking and board/association membership updates. | * Commerce distinguishes between licenses expired <2 years (eligible for late renewal) and >2 years (require new application/exam). Verify current thresholds.<br>* If operating a brokerage, confirm entity filings with the Secretary of State and trust account audits. |
+
+## Immediate data to collect
+
+1. Full CRD / BrokerCheck history, including disclosure explanations and termination details.
+2. Prior Minnesota insurance license numbers, lines of authority, CE transcripts, and reinstatement deadlines.
+3. Real estate license history, CE credits, and brokerage affiliation records.
+4. Proof of professional designations (CFP®, CFA®, ChFC®, CIC, PFS, etc.) to document exam exemptions.
+5. Copies of prior exam results (Series exams, state insurance, real estate).
+6. Calendar of renewal dates, grace periods, and continuing education cutoffs for each license class.
+7. Current text of Minnesota statutes, rules, bulletins, and Department of Commerce guidance for each license.
+
+## Minnesota compliance controls to refresh
+
+- **Disclosure management:** Build a task to review CRD/IARD and Sircon profiles quarterly; reconcile disclosures with internal compliance logs.
+- **Surety bond & financial reporting:** If the advisory firm falls below Minnesota's net capital thresholds, set calendar reminders for bond renewals and financial statement submissions.
+- **CE monitoring:** Centralize continuing education tracking (insurance + real estate) in the compliance calendar with automated reminders 90/60/30 days out.
+- **Carrier & broker affiliations:** Maintain a checklist for reinstating carrier appointments and brokerage affiliations immediately after license reactivation.
+- **Incident response:** Document contact routes for the Minnesota Department of Commerce securities, insurance, and real estate teams for rapid outreach when filings stall.
+
+## Scaling to additional states
+
+1. **State selection:** Prioritize states based on client demand and reciprocity benefits. Build a pipeline of target jurisdictions.
+2. **Regulatory gap analysis:** For each state, capture statutes, rules, reinstatement windows, CE requirements, fees, bonding, and background check expectations for securities, insurance, and real estate.
+3. **Licensing tracker:** Extend the compliance tracker with state-by-state modules covering deadlines, required forms (U4/U5, Form ADV amendments, insurance applications, real estate renewals), fingerprints, and sponsor requirements.
+4. **Document library:** Store state-specific templates (cover letters, disclosure explanations, CE certificates) in a shared repository. Version-control updates as statutes change.
+5. **Operational sequencing:** Schedule filings to avoid overlapping CE deadlines and ensure fingerprint/background checks are submitted first in states with long processing times.
+6. **Change management:** When expanding, update supervisory procedures (WSPs, insurance compliance manuals, brokerage policies) to incorporate the new state's rules.
+7. **Ongoing monitoring:** Subscribe to regulator bulletins (state securities divisions, NAIC alerts, ARELLO) and track renewal cycles via compliance software.
+
+## Risk watchpoints
+
+- **Disclosure sensitivity:** Any disciplinary history will trigger deeper review—prepare narratives, restitution proof, and compliance enhancements before filing.
+- **Financial responsibility:** Advisory firms must evidence minimum capital or bonding; insurance producers need to resolve any outstanding premium trust obligations.
+- **Timing gaps:** Letting CE or renewals slip in one state can cascade across reciprocals—establish redundant reminders and assign ownership.
+- **Data accuracy:** Inconsistent Form U4/U5 responses versus insurance/real estate applications can lead to denials. Cross-audit all disclosures before submission.
+- **Scaling strain:** Expanding too quickly without staffing compliance support risks missed filings. Align hiring or third-party compliance support with the expansion roadmap.
+
+## Next step
+
+If you want a comparative matrix for additional target states (top five), capture the candidate list and start a companion worksheet. Each column should mirror the Minnesota table headings so you can contrast reinstatement windows, exams, fees, and CE rules at a glance.


### PR DESCRIPTION
## Summary
- add a detailed playbook covering Minnesota reinstatement steps for securities, insurance, and real estate licenses
- document data collection needs, compliance controls, multi-state expansion workflow, and risk considerations

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e18e479bac8329ab9cc02a03414ddc