### PR TITLE
Add mac Firstlight add-on scripts

### DIFF
--- a/agents/mac/README.md
+++ b/agents/mac/README.md
@@ -1,0 +1,36 @@
+# Firstlight Add-on (macOS)
+
+The Firstlight bundle contains two small utilities that exercise the
+Prism stack from a local macOS console.
+
+## Scripts
+
+- `full_first_light.py` — announces **SYSTEM ONLINE** to the holo,
+  posts a simulator panel, listens for heartbeat traffic, and prints a
+  summary of which nodes checked in along with the average latency
+  observed for each heartbeat.
+- `test_patterns.py` — runs a quick visual sweep by cycling text sizes
+  on the holo, showing an optional logo image, and emitting a panel plus
+  a tiny chart to the simulator.
+
+## Usage
+
+```bash
+# Activate your environment first
+source ~/agent-venv/bin/activate
+
+# Full bootstrap and heartbeat sweep
+python agents/mac/full_first_light.py
+
+# Visual sanity pass
+python agents/mac/test_patterns.py
+```
+
+Environment variables are supported for overriding the MQTT host, port,
+and timing parameters:
+
+```bash
+MQTT_HOST=pi-ops.local MQTT_PORT=1883 WINDOW_S=15 \
+    python agents/mac/full_first_light.py
+CYCLE_DELAY=2.0 python agents/mac/test_patterns.py
+```

--- a/agents/mac/full_first_light.py
+++ b/agents/mac/full_first_light.py
@@ -1,0 +1,237 @@
+"""Firstlight bootstrap routines for macOS consoles.
+
+This module contains a small utility that publishes introductory
+telemetry to the holo and simulator topics and then listens for
+heartbeat events.  It is intended to be the first smoke test after
+installing a fresh stack.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import queue
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+try:
+    import paho.mqtt.client as mqtt
+except ImportError as exc:  # pragma: no cover - executed during runtime
+    raise SystemExit(
+        "paho-mqtt is required for the Firstlight add-on. "
+        "Install it with 'pip install paho-mqtt'."
+    ) from exc
+
+
+DEFAULT_HEARTBEAT_WINDOW = 10.0
+EXPECTED_NODES = ("mac", "pi-ops", "pi-holo", "pi-sim")
+HOLO_TOPIC = "holo/display"
+SIM_PANEL_TOPIC = "sim/panel"
+SIM_EVENT_TOPIC = "sim/events"
+HEARTBEAT_TOPIC = "system/heartbeat/#"
+
+
+@dataclass
+class HeartbeatSample:
+    """A single heartbeat observation from a remote node."""
+
+    latency_ms: Optional[float] = None
+    topic: Optional[str] = None
+    raw_payload: Optional[str] = None
+
+
+@dataclass
+class HeartbeatLedger:
+    """Keeps track of which nodes have checked in and their latencies."""
+
+    samples: Dict[str, List[HeartbeatSample]] = field(default_factory=dict)
+
+    def record(self, node: str, sample: HeartbeatSample) -> None:
+        self.samples.setdefault(node, []).append(sample)
+
+    def observed_nodes(self) -> List[str]:
+        return sorted(self.samples)
+
+    def average_latency(self, node: str) -> Optional[float]:
+        latencies = [s.latency_ms for s in self.samples.get(node, []) if s.latency_ms is not None]
+        if not latencies:
+            return None
+        return sum(latencies) / len(latencies)
+
+    def format_summary(self) -> str:
+        lines = ["Heartbeat summary:"]
+        for node in EXPECTED_NODES:
+            if node in self.samples:
+                avg_latency = self.average_latency(node)
+                latency_text = f"avg latency {avg_latency:.1f}ms" if avg_latency is not None else "latency n/a"
+                lines.append(f"  ✓ {node:<7} — {latency_text}")
+            else:
+                lines.append(f"  ✗ {node:<7} — no heartbeat observed")
+        missing = [node for node in EXPECTED_NODES if node not in self.samples]
+        if missing:
+            lines.append("")
+            lines.append("Missing nodes: " + ", ".join(missing))
+        else:
+            lines.append("")
+            lines.append("All expected nodes checked in. ✨")
+        return "\n".join(lines)
+
+
+def _payload_to_sample(topic: str, payload: bytes) -> HeartbeatSample:
+    text = payload.decode("utf-8", errors="replace")
+    latency = None
+
+    try:
+        body = json.loads(text)
+    except json.JSONDecodeError:
+        body = None
+
+    if isinstance(body, dict):
+        candidate = body.get("latency_ms") or body.get("latency")
+        if isinstance(candidate, (int, float)):
+            latency = float(candidate)
+        elif isinstance(candidate, str):
+            try:
+                latency = float(candidate)
+            except ValueError:
+                latency = None
+        if latency is None:
+            sent_ts = body.get("sent_at") or body.get("sent_ts")
+            if isinstance(sent_ts, (int, float)):
+                latency = max((time.time() - float(sent_ts)) * 1000.0, 0.0)
+    return HeartbeatSample(latency_ms=latency, topic=topic, raw_payload=text)
+
+
+def publish_boot_messages(client: mqtt.Client, window_seconds: float) -> None:
+    """Send greeting messages to the holo and simulator."""
+
+    greeting = {
+        "mode": "text",
+        "title": "FIRSTLIGHT",
+        "message": "SYSTEM ONLINE",
+        "ttl": max(window_seconds, 5.0),
+    }
+    client.publish(HOLO_TOPIC, json.dumps(greeting), qos=1, retain=False)
+
+    panel = {
+        "panel": {
+            "title": "Firstlight",
+            "status": "online",
+            "description": "Stack bootstrap smoke-check",
+            "window_s": window_seconds,
+        }
+    }
+    client.publish(SIM_PANEL_TOPIC, json.dumps(panel), qos=1, retain=False)
+
+    event = {
+        "event": "firstlight",
+        "severity": "info",
+        "message": "mac console announced system online",
+        "timestamp": time.time(),
+    }
+    client.publish(SIM_EVENT_TOPIC, json.dumps(event), qos=0, retain=False)
+
+
+def collect_heartbeats(client: mqtt.Client, window_seconds: float) -> HeartbeatLedger:
+    """Subscribe to heartbeat traffic and collect samples for the window."""
+
+    ledger = HeartbeatLedger()
+    messages: "queue.Queue[tuple[str, bytes]]" = queue.Queue()
+
+    original_handler = client.on_message
+
+    def on_message(_: mqtt.Client, __, msg: mqtt.MQTTMessage) -> None:
+        messages.put((msg.topic, msg.payload))
+
+    client.on_message = on_message
+    client.subscribe(HEARTBEAT_TOPIC)
+    deadline = time.time() + window_seconds
+
+    try:
+        while time.time() < deadline:
+            try:
+                topic, payload = messages.get(timeout=0.25)
+            except queue.Empty:
+                continue
+            node = topic.split("/")[-1]
+            ledger.record(node, _payload_to_sample(topic, payload))
+    finally:
+        client.on_message = original_handler
+        try:
+            client.unsubscribe(HEARTBEAT_TOPIC)
+        except Exception:  # pragma: no cover - best effort cleanup
+            pass
+
+    return ledger
+
+
+def connect_client(host: str, port: int, timeout: float = 5.0) -> mqtt.Client:
+    client = mqtt.Client()
+    connect_event = threading.Event()
+
+    def on_connect(_: mqtt.Client, __, ___, rc: int) -> None:
+        if rc == 0:
+            connect_event.set()
+        else:
+            logging.error("MQTT connection failed with code %s", rc)
+
+    client.on_connect = on_connect
+    client.connect(host, port)
+    client.loop_start()
+    if not connect_event.wait(timeout):
+        client.loop_stop()
+        raise TimeoutError(f"Timed out connecting to MQTT broker at {host}:{port}")
+    return client
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Firstlight bootstrap script")
+    parser.add_argument(
+        "--window",
+        "-w",
+        type=float,
+        default=float(os.environ.get("WINDOW_S", DEFAULT_HEARTBEAT_WINDOW)),
+        help="Listening window for heartbeats in seconds (default: 10)",
+    )
+    parser.add_argument(
+        "--host",
+        default=os.environ.get("MQTT_HOST", "localhost"),
+        help="MQTT broker hostname",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.environ.get("MQTT_PORT", "1883")),
+        help="MQTT broker port",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable debug logging",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO)
+
+    logging.info("Connecting to MQTT broker at %s:%s", args.host, args.port)
+    client = connect_client(args.host, args.port)
+    try:
+        publish_boot_messages(client, args.window)
+        logging.info("Listening for heartbeat topics for %.1fs", args.window)
+        ledger = collect_heartbeats(client, args.window)
+    finally:
+        client.loop_stop()
+        client.disconnect()
+
+    print(ledger.format_summary())
+
+
+if __name__ == "__main__":
+    main()

--- a/agents/mac/test_patterns.py
+++ b/agents/mac/test_patterns.py
@@ -1,0 +1,167 @@
+"""Visual smoke tests for the holo and simulator outputs."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import logging
+import os
+import pathlib
+import threading
+import time
+from typing import Iterable
+
+try:
+    import paho.mqtt.client as mqtt
+except ImportError as exc:  # pragma: no cover - executed during runtime
+    raise SystemExit(
+        "paho-mqtt is required for the Firstlight add-on. "
+        "Install it with 'pip install paho-mqtt'."
+    ) from exc
+
+
+HOLO_TOPIC = "holo/display"
+HOLO_IMAGE_TOPIC = "holo/image"
+SIM_PANEL_TOPIC = "sim/panel"
+SIM_CHART_TOPIC = "sim/chart"
+DEFAULT_CYCLE_DELAY = 1.5
+DEFAULT_TEXT = "Prism Console Test"
+
+
+def connect_client(host: str, port: int, timeout: float = 5.0) -> mqtt.Client:
+    client = mqtt.Client()
+    connect_event = threading.Event()
+
+    def on_connect(_: mqtt.Client, __, ___, rc: int) -> None:
+        if rc == 0:
+            connect_event.set()
+        else:
+            logging.error("MQTT connection failed with code %s", rc)
+
+    client.on_connect = on_connect
+    client.connect(host, port)
+    client.loop_start()
+    if not connect_event.wait(timeout):
+        client.loop_stop()
+        raise TimeoutError(f"Timed out connecting to MQTT broker at {host}:{port}")
+    return client
+
+
+def publish_text_patterns(client: mqtt.Client, message: str, sizes: Iterable[str], delay: float) -> None:
+    for size in sizes:
+        payload = {
+            "mode": "text",
+            "title": f"TEXT {size.upper()}",
+            "message": message,
+            "text_size": size,
+            "ttl": max(delay * 1.2, 1.0),
+        }
+        client.publish(HOLO_TOPIC, json.dumps(payload), qos=1, retain=False)
+        time.sleep(delay)
+
+
+def maybe_publish_logo(client: mqtt.Client, path: pathlib.Path, delay: float) -> bool:
+    if not path.exists():
+        logging.info("Logo asset %s not found; skipping image push", path)
+        return False
+
+    encoded = base64.b64encode(path.read_bytes()).decode("ascii")
+    payload = {
+        "mode": "image",
+        "title": "Logo",
+        "data_uri": f"data:image/png;base64,{encoded}",
+        "ttl": max(delay * 2.0, 2.0),
+    }
+    client.publish(HOLO_IMAGE_TOPIC, json.dumps(payload), qos=1, retain=False)
+    time.sleep(delay)
+    return True
+
+
+def publish_sim_panel(client: mqtt.Client, delay: float) -> None:
+    panel = {
+        "panel": {
+            "title": "Test Patterns",
+            "status": "running",
+            "description": "Visual sanity sweep",
+            "window_s": delay * 4,
+        }
+    }
+    client.publish(SIM_PANEL_TOPIC, json.dumps(panel), qos=1, retain=False)
+
+    chart = {
+        "chart": {
+            "title": "Signal",
+            "series": [
+                {
+                    "label": "demo",
+                    "values": [0, 0.2, 0.8, 1.0, 0.4, 0.1],
+                }
+            ],
+        }
+    }
+    client.publish(SIM_CHART_TOPIC, json.dumps(chart), qos=0, retain=False)
+    time.sleep(delay)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Holo and simulator test patterns")
+    parser.add_argument(
+        "--host",
+        default=os.environ.get("MQTT_HOST", "localhost"),
+        help="MQTT broker hostname",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.environ.get("MQTT_PORT", "1883")),
+        help="MQTT broker port",
+    )
+    parser.add_argument(
+        "--message",
+        default=DEFAULT_TEXT,
+        help="Text to render in the holo test sweep",
+    )
+    parser.add_argument(
+        "--delay",
+        type=float,
+        default=float(os.environ.get("CYCLE_DELAY", DEFAULT_CYCLE_DELAY)),
+        help="Delay between pattern updates",
+    )
+    parser.add_argument(
+        "--sizes",
+        nargs="+",
+        default=["small", "medium", "large"],
+        help="Text size sequence to cycle through",
+    )
+    parser.add_argument(
+        "--logo",
+        default=os.environ.get("HOLO_LOGO", "/srv/assets/logo.png"),
+        help="Path to an optional logo file",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable debug logging",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO)
+
+    logging.info("Connecting to MQTT broker at %s:%s", args.host, args.port)
+    client = connect_client(args.host, args.port)
+
+    try:
+        publish_sim_panel(client, args.delay)
+        publish_text_patterns(client, args.message, args.sizes, args.delay)
+        maybe_publish_logo(client, pathlib.Path(args.logo), args.delay)
+    finally:
+        client.loop_stop()
+        client.disconnect()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a mac-focused Firstlight bootstrap script to publish holo announcements and collect heartbeat telemetry
- add holo and simulator test-patterns helper along with a README describing usage

## Testing
- python -m py_compile agents/mac/*.py
- python agents/auto_novel_agent.py

------
https://chatgpt.com/codex/tasks/task_e_68e18f69e64c8329b22712380a7ac50b