### PR TITLE
Update workboard with latest drop status

### DIFF
--- a/AGENT_WORKBOARD.md
+++ b/AGENT_WORKBOARD.md
@@ -26,3 +26,9 @@
 
 ## Last Status Report
 <!-- Agents append latest status, error, or notifications here -->
+
+### 2025-10-04
+- Shipped governance and upgrade wiring end-to-end, including handlers, proposal examples, and CLI hooks.
+- Landed the RoadStudio pipeline MVP with deterministic renders and a golden-frame regression check.
+- Established observability baselines (OTel collectors, Prometheus/Grafana integration, exemplar stubs).
+- Next focus: auto-captioning, public API + SDKs, and tokenomics simulation unless strategic priorities shift.


### PR DESCRIPTION
## Summary
- log the recently shipped governance, RoadStudio, and observability work in the agent workboard
- capture the planned focus on auto-captioning, public API/SDKs, and the tokenomics simulation

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e1904c32dc8329a70bef995a6b9509