### PR TITLE
Add FastAPI controls app and tests for Autopal flows

### DIFF
--- a/autopal_fastapi/README.md
+++ b/autopal_fastapi/README.md
@@ -1,0 +1,26 @@
+# Autopal Controls API
+
+This mini FastAPI application models the Autopal control surfaces that power
+maintenance, step-up authentication, dual-control overrides, and rate limiting.
+
+## Features
+
+* **Maintenance switch** – `/maintenance/activate` and `/maintenance/deactivate`
+  toggle a global flag. A middleware blocks all non-allowlisted routes whenever
+  maintenance mode is active, while `/health/*` remains reachable.
+* **Step-up enforcement** – `/secrets/materialize` demands an `X-Step-Up`
+  header with the value `verified` and otherwise responds with
+  `401 step_up_required`.
+* **Dual-control overrides** – `/controls/overrides` creates an override and
+  `/controls/overrides/{id}/approve` requires two distinct subjects before the
+  request is marked as granted.
+* **Rate limiting** – `/config/rate-limit` tunes the per-identity limiter that
+  guards `/limited/ping`, making it easy to exercise rate limit behaviour in
+  tests.
+
+## Running the suite
+
+```bash
+pip install -r requirements.txt
+pytest autopal_fastapi/tests
+```

--- a/autopal_fastapi/__init__.py
+++ b/autopal_fastapi/__init__.py
@@ -1,0 +1,3 @@
+"""Autopal FastAPI application package."""
+
+from .app import app, create_app  # noqa: F401

--- a/autopal_fastapi/app.py
+++ b/autopal_fastapi/app.py
@@ -1,0 +1,171 @@
+"""FastAPI application that models the Autopal control flows."""
+
+from __future__ import annotations
+
+import time
+import uuid
+from collections import deque
+from typing import Deque, Dict, Iterable
+
+from fastapi import Depends, FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field, PositiveInt
+
+
+class Identity(BaseModel):
+    """Represents the authenticated caller."""
+
+    subject: str
+    email: str
+
+
+class RateLimitConfig(BaseModel):
+    """Configuration payload for the in-memory rate limiter."""
+
+    limit: PositiveInt = Field(..., description="Maximum number of requests allowed within the window.")
+    window_seconds: PositiveInt = Field(..., description="Window size in seconds for rate counting.")
+
+
+class RateLimiter:
+    """Simple in-memory rate limiter keyed by caller identity."""
+
+    def __init__(self, limit: int = 10, window_seconds: int = 60) -> None:
+        self.limit = limit
+        self.window_seconds = window_seconds
+        self._hits: Dict[str, Deque[float]] = {}
+
+    def configure(self, *, limit: int, window_seconds: int) -> None:
+        """Update limiter configuration and clear historical counts."""
+
+        self.limit = limit
+        self.window_seconds = window_seconds
+        self._hits.clear()
+
+    def check(self, identity: str) -> None:
+        """Raise when the caller exceeds the configured rate."""
+
+        now = time.monotonic()
+        queue = self._hits.setdefault(identity, deque())
+        boundary = now - self.window_seconds
+
+        while queue and queue[0] <= boundary:
+            queue.popleft()
+
+        if len(queue) >= self.limit:
+            raise HTTPException(status_code=429, detail="rate_limit_exceeded")
+
+        queue.append(now)
+
+
+class Override(BaseModel):
+    """Represents a dual-control override request."""
+
+    override_id: str
+    reason: str | None = None
+    approvals: list[str] = Field(default_factory=list)
+    granted: bool = False
+
+
+def _allowlisted(path: str, allowlist: Iterable[str]) -> bool:
+    return any(path.startswith(prefix) for prefix in allowlist)
+
+
+async def get_identity(_: Request) -> Identity:
+    """Default identity dependency that mimics a locked-down OIDC handler."""
+
+    raise HTTPException(status_code=401, detail="unauthenticated")
+
+
+def require_step_up(request: Request) -> None:
+    """Ensure the caller satisfied a hypothetical step-up challenge."""
+
+    if request.headers.get("x-step-up") != "verified":
+        raise HTTPException(status_code=401, detail="step_up_required")
+
+
+def create_app() -> FastAPI:
+    """Instantiate the FastAPI application with all routes and state."""
+
+    app = FastAPI(title="Autopal Controls API", version="1.0.0")
+
+    # Global state shared between requests for the lifetime of the application instance.
+    app.state.maintenance_mode = False
+    app.state.maintenance_allowlist = ("/health", "/maintenance")
+    app.state.rate_limiter = RateLimiter()
+    app.state.overrides: Dict[str, Override] = {}
+
+    @app.middleware("http")
+    async def maintenance_middleware(request: Request, call_next):  # type: ignore[override]
+        if request.app.state.maintenance_mode and not _allowlisted(
+            request.url.path, request.app.state.maintenance_allowlist
+        ):
+            return JSONResponse(status_code=503, content={"detail": "maintenance_mode"})
+
+        return await call_next(request)
+
+    @app.get("/health/live")
+    async def live() -> dict[str, str]:
+        return {"status": "live"}
+
+    @app.get("/health/ready")
+    async def ready() -> dict[str, str]:
+        return {"status": "ready"}
+
+    @app.post("/maintenance/activate")
+    async def activate_maintenance() -> dict[str, bool]:
+        app.state.maintenance_mode = True
+        return {"maintenance_mode": True}
+
+    @app.post("/maintenance/deactivate")
+    async def deactivate_maintenance() -> dict[str, bool]:
+        app.state.maintenance_mode = False
+        return {"maintenance_mode": False}
+
+    @app.post("/config/rate-limit")
+    async def configure_rate_limit(payload: RateLimitConfig) -> RateLimitConfig:
+        app.state.rate_limiter.configure(limit=payload.limit, window_seconds=payload.window_seconds)
+        return payload
+
+    @app.get("/limited/ping")
+    async def limited_ping(identity: Identity = Depends(get_identity)) -> dict[str, str]:
+        limiter: RateLimiter = app.state.rate_limiter
+        limiter.check(identity.subject)
+        return {"message": "pong", "subject": identity.subject}
+
+    @app.get("/secrets/materialize")
+    async def materialize_secret(
+        request: Request, identity: Identity = Depends(get_identity)
+    ) -> dict[str, str]:
+        require_step_up(request)
+        return {"materialized": "secret", "granted_to": identity.subject}
+
+    @app.post("/controls/overrides", status_code=201)
+    async def create_override(reason: str | None = None) -> Override:
+        override_id = str(uuid.uuid4())
+        override = Override(override_id=override_id, reason=reason)
+        app.state.overrides[override_id] = override
+        return override
+
+    @app.post("/controls/overrides/{override_id}/approve")
+    async def approve_override(
+        override_id: str, identity: Identity = Depends(get_identity)
+    ) -> Override:
+        overrides: Dict[str, Override] = app.state.overrides
+        override = overrides.get(override_id)
+        if override is None:
+            raise HTTPException(status_code=404, detail="override_not_found")
+
+        if identity.subject in override.approvals:
+            raise HTTPException(status_code=400, detail="duplicate_approval")
+
+        override.approvals.append(identity.subject)
+        if len(set(override.approvals)) >= 2:
+            override.granted = True
+
+        overrides[override_id] = override
+        return override
+
+    return app
+
+
+app = create_app()

--- a/autopal_fastapi/tests/test_app.py
+++ b/autopal_fastapi/tests/test_app.py
@@ -1,0 +1,92 @@
+import pytest
+from fastapi import Request
+from fastapi.testclient import TestClient
+
+from autopal_fastapi.app import Identity, create_app, get_identity
+
+
+@pytest.fixture
+def app():
+    test_app = create_app()
+
+    def identity_override(request: Request) -> Identity:
+        actor = request.headers.get("x-actor", "tester")
+        return Identity(subject=actor, email=f"{actor}@example.com")
+
+    test_app.dependency_overrides[get_identity] = identity_override
+    return test_app
+
+
+@pytest.fixture
+def client(app):
+    with TestClient(app) as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+def test_health_routes_operate_during_maintenance(client):
+    response = client.post("/maintenance/activate")
+    assert response.status_code == 200
+    assert response.json()["maintenance_mode"] is True
+
+    health = client.get("/health/live")
+    assert health.status_code == 200
+    assert health.json()["status"] == "live"
+
+    client.post("/maintenance/deactivate")
+
+
+def test_maintenance_blocks_non_allowlisted_routes(client):
+    client.post("/maintenance/activate")
+    response = client.get("/secrets/materialize", headers={"x-step-up": "verified"})
+    assert response.status_code == 503
+    assert response.json()["detail"] == "maintenance_mode"
+
+    client.post("/maintenance/deactivate")
+    success = client.get("/secrets/materialize", headers={"x-step-up": "verified"})
+    assert success.status_code == 200
+    assert success.json()["materialized"] == "secret"
+
+
+def test_step_up_required_until_header_present(client):
+    missing = client.get("/secrets/materialize")
+    assert missing.status_code == 401
+    assert missing.json()["detail"] == "step_up_required"
+
+    granted = client.get("/secrets/materialize", headers={"x-step-up": "verified"})
+    assert granted.status_code == 200
+    assert granted.json()["granted_to"] == "tester"
+
+
+def test_dual_control_flow_requires_distinct_approvals(client):
+    created = client.post("/controls/overrides", json={"reason": "rotate secrets"})
+    assert created.status_code == 201
+    override_id = created.json()["override_id"]
+
+    first = client.post(f"/controls/overrides/{override_id}/approve", headers={"x-actor": "alice"})
+    assert first.status_code == 200
+    assert first.json()["granted"] is False
+    assert first.json()["approvals"] == ["alice"]
+
+    duplicate = client.post(f"/controls/overrides/{override_id}/approve", headers={"x-actor": "alice"})
+    assert duplicate.status_code == 400
+
+    second = client.post(f"/controls/overrides/{override_id}/approve", headers={"x-actor": "bob"})
+    assert second.status_code == 200
+    assert second.json()["granted"] is True
+    assert set(second.json()["approvals"]) == {"alice", "bob"}
+
+
+def test_rate_limit_can_be_tightened_and_triggers_429(client):
+    configure = client.post("/config/rate-limit", json={"limit": 2, "window_seconds": 60})
+    assert configure.status_code == 200
+
+    first = client.get("/limited/ping", headers={"x-actor": "ratelimited"})
+    assert first.status_code == 200
+
+    second = client.get("/limited/ping", headers={"x-actor": "ratelimited"})
+    assert second.status_code == 200
+
+    third = client.get("/limited/ping", headers={"x-actor": "ratelimited"})
+    assert third.status_code == 429
+    assert third.json()["detail"] == "rate_limit_exceeded"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 anthropic
 boto3
 fastapi
+httpx
 matplotlib==3.9.4
 mpmath
 notion-client


### PR DESCRIPTION
## Summary
- add a focused `autopal_fastapi` package that models the maintenance switch, step-up enforcement, dual-control overrides, and a configurable rate limiter
- cover the new endpoints with a pytest suite and supporting README documentation
- add the `httpx` dependency needed by FastAPI's TestClient

## Testing
- pip install -r requirements.txt
- pytest autopal_fastapi/tests
- pytest *(fails: repo-wide suite depends on unavailable packages such as blackroad_agent, lucidia modules, and Anthropic credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68e18db3040c832995244070bb516c51