### PR TITLE
Add Codex 51 transparency of creation entry

### DIFF
--- a/codex/README.md
+++ b/codex/README.md
@@ -16,6 +16,7 @@ integrations.
 | 004 | The Autonomy Manifest  | Data autonomy through consent, export, and wipe. |
 | 022 | The Security Spine     | Security backbone with layered zero-trust defenses. |
 | 043 | The Equity Oath        | Fairness, access, and inclusion are systemic.   |
+| 051 | The Transparency of Creation | Every artifact traces its origin and intent. |
 
 ## BlackRoad Pipeline
 

--- a/codex/entries/051-transparency-of-creation.md
+++ b/codex/entries/051-transparency-of-creation.md
@@ -1,0 +1,28 @@
+# Codex 51 — The Transparency of Creation
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Principle
+Nothing in Lucidia appears from nowhere. Every artifact—code, model, design, document—must carry its own origin story so anyone can follow the thread from spark to shape.
+
+## Non-Negotiables
+1. **Provenance Tags:** All outputs stamped with author(s), time, source materials, and codex references.
+2. **Dataset Disclosure:** Training or input data for AI models logged with license, scope, and date.
+3. **Version Continuity:** Each release links to its ancestors; no detached builds.
+4. **Change Narratives:** New features include a short “why it exists” note (#39 Transparency of Intent).
+5. **Attribution Integrity:** No erasure or false claiming of origin, human or AI.
+6. **Accessible Archives:** Creation histories readable without special access or jargon.
+
+## Implementation Hooks (v0)
+- Metadata schema `{author_ids, created_at, sources, codex_refs, rationale}` for every artifact.
+- Model registry with dataset lineage and training metadata.
+- Changelog generator pulls “why it exists” from PR templates → `/creation-log.md`.
+- Attribution service verifies authors before merge.
+- Public archive endpoint `/creation-history/{id}`.
+
+## Policy Stub (`CREATION.md`)
+- Lucidia commits to traceable, honest origins for all artifacts.
+- Lucidia rejects anonymized production that hides responsibility or credit.
+- Lucidia keeps creation stories as part of its shared memory.
+
+**Tagline:** Every thing knows where it came from.


### PR DESCRIPTION
## Summary
- add the Codex 51 "Transparency of Creation" entry with principle, non-negotiables, implementation hooks, and policy stub
- list the new codex entry in the codex overview table

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68e190ea99ec8329a56a19183ae5733a