### PR TITLE
Add AutoPal FastAPI stack with mock OIDC issuer and Redis

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 anthropic
 boto3
 fastapi
+PyJWT[crypto]
+cryptography
 matplotlib==3.9.4
 mpmath
 notion-client
@@ -15,6 +17,7 @@ python-dotenv
 qiskit-aer==0.17.1
 qiskit-machine-learning==0.7.2
 requests==2.32.4
+redis
 streamlit==1.48.1
 torch
 uvicorn

--- a/services/autopal/Dockerfile
+++ b/services/autopal/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
+WORKDIR /app
+
+COPY requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/services/autopal/README.md
+++ b/services/autopal/README.md
@@ -1,0 +1,10 @@
+# AutoPal FastAPI Service
+
+This directory contains the FastAPI implementation for the AutoPal materialization service.
+It exposes a single `POST /secrets/materialize` endpoint that validates OpenID Connect
+ID tokens, enforces step-up headers, and applies per-subject rate limits.
+
+The service supports both in-process and Redis-backed rate limiting. When the
+`REDIS_URL` environment variable is present the Redis backend is used, otherwise
+an in-memory fallback is applied. Default OIDC settings target the local mock
+issuer defined in the docker-compose stack under `stack/autopal-fastapi`.

--- a/services/autopal/app/__init__.py
+++ b/services/autopal/app/__init__.py
@@ -1,0 +1,1 @@
+"""AutoPal FastAPI service package."""

--- a/services/autopal/app/__main__.py
+++ b/services/autopal/app/__main__.py
@@ -1,0 +1,20 @@
+"""Entry-point helper for running the AutoPal service locally."""
+
+from __future__ import annotations
+
+import uvicorn
+
+from .config import settings
+
+
+def main() -> None:
+    uvicorn.run(
+        "app.main:app",
+        host=settings.app_host,
+        port=settings.app_port,
+        factory=False,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/services/autopal/app/auth.py
+++ b/services/autopal/app/auth.py
@@ -1,0 +1,64 @@
+"""OIDC token validation helpers for the AutoPal service."""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any, Dict
+
+import jwt
+from jwt import PyJWKClient
+
+from .config import settings
+
+
+class TokenVerificationError(RuntimeError):
+    """Raised when a presented token fails validation."""
+
+
+class TokenVerifier:
+    """Validate JWTs issued by the configured OIDC issuer."""
+
+    def __init__(self, jwks_url: str, cache_ttl: int) -> None:
+        self._jwks_client = PyJWKClient(jwks_url)
+        self._cache_ttl = cache_ttl
+        self._last_refresh = 0.0
+        self._lock = threading.Lock()
+
+    def _maybe_refresh(self) -> None:
+        now = time.monotonic()
+        if now - self._last_refresh < self._cache_ttl:
+            return
+        with self._lock:
+            if now - self._last_refresh < self._cache_ttl:
+                return
+            # PyJWKClient caches per-kid automatically; a dummy call forces refresh.
+            self._jwks_client.clear_cache()
+            self._last_refresh = now
+
+    def verify(self, token: str, audience: str) -> Dict[str, Any]:
+        try:
+            self._maybe_refresh()
+            signing_key = self._jwks_client.get_signing_key_from_jwt(token)
+            claims = jwt.decode(
+                token,
+                signing_key.key,
+                algorithms=["RS256"],
+                audience=audience,
+                issuer=settings.oidc_issuer.rstrip("/"),
+            )
+        except Exception as exc:  # noqa: BLE001 - bubble up as service error
+            raise TokenVerificationError(str(exc)) from exc
+        return claims
+
+
+_verifier: TokenVerifier | None = None
+
+
+def get_token_verifier() -> TokenVerifier:
+    """Return a singleton verifier bound to the configured settings."""
+
+    global _verifier
+    if _verifier is None:
+        _verifier = TokenVerifier(settings.oidc_jwks_url, settings.cache_jwks_ttl)
+    return _verifier

--- a/services/autopal/app/config.py
+++ b/services/autopal/app/config.py
@@ -1,0 +1,85 @@
+"""Configuration helpers for the AutoPal FastAPI service."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from typing import Optional
+
+
+def _env(key: str, default: Optional[str] = None) -> Optional[str]:
+    value = os.getenv(key)
+    if value is None:
+        return default
+    value = value.strip()
+    return value or default
+
+
+def _normalize_issuer(value: str) -> str:
+    value = value.strip()
+    if not value.endswith("/"):
+        value = f"{value}/"
+    return value
+
+
+@dataclass(slots=True)
+class Settings:
+    """Runtime configuration for the AutoPal service."""
+
+    oidc_issuer: str
+    oidc_jwks_url: str
+    redis_url: Optional[str]
+    rate_limit_requests: int
+    rate_limit_window_seconds: int
+    step_up_header: str
+    audience_header: str
+    cache_jwks_ttl: int
+    app_host: str
+    app_port: int
+
+
+DEFAULT_ISSUER = _normalize_issuer(
+    _env("OIDC_ISSUER", "http://localhost:8081/") or "http://localhost:8081/"
+)
+DEFAULT_JWKS_URL = _env(
+    "OIDC_JWKS_URL", f"{DEFAULT_ISSUER.rstrip('/')}/.well-known/jwks.json"
+) or "http://localhost:8081/.well-known/jwks.json"
+
+
+def load_settings() -> Settings:
+    """Load settings from environment variables."""
+
+    issuer = _env("OIDC_ISSUER", DEFAULT_ISSUER)
+    if not issuer:
+        raise RuntimeError("OIDC_ISSUER must be provided")
+    issuer = _normalize_issuer(issuer)
+
+    jwks_url = _env("OIDC_JWKS_URL", DEFAULT_JWKS_URL)
+    if not jwks_url:
+        raise RuntimeError("OIDC_JWKS_URL must be provided")
+
+    redis_url = _env("REDIS_URL")
+
+    rate_limit_requests = int(_env("RATE_LIMIT_REQUESTS", "5") or 5)
+    rate_limit_window_seconds = int(_env("RATE_LIMIT_WINDOW_SECONDS", "60") or 60)
+    step_up_header = _env("STEP_UP_HEADER", "X-Step-Up-Approved") or "X-Step-Up-Approved"
+    audience_header = _env("AUDIENCE_HEADER", "X-Audience") or "X-Audience"
+    cache_jwks_ttl = int(_env("JWKS_CACHE_SECONDS", "300") or 300)
+    app_host = _env("UVICORN_HOST", "0.0.0.0") or "0.0.0.0"
+    app_port = int(_env("UVICORN_PORT", "8080") or 8080)
+
+    return Settings(
+        oidc_issuer=issuer,
+        oidc_jwks_url=jwks_url,
+        redis_url=redis_url,
+        rate_limit_requests=rate_limit_requests,
+        rate_limit_window_seconds=rate_limit_window_seconds,
+        step_up_header=step_up_header,
+        audience_header=audience_header,
+        cache_jwks_ttl=cache_jwks_ttl,
+        app_host=app_host,
+        app_port=app_port,
+    )
+
+
+settings = load_settings()

--- a/services/autopal/app/main.py
+++ b/services/autopal/app/main.py
@@ -1,0 +1,98 @@
+"""FastAPI application exposing the AutoPal secret materialization flow."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+from fastapi import Depends, FastAPI, Header, HTTPException, status
+from fastapi.responses import JSONResponse
+
+from .auth import TokenVerificationError, get_token_verifier
+from .config import settings
+from .ratelimit import InMemoryRateLimitBackend, RateLimitExceeded, RateLimiter
+
+try:
+    from .ratelimit_redis import create_redis_backend
+except RuntimeError:
+    create_redis_backend = None  # type: ignore[assignment]
+
+
+def _build_rate_limiter() -> RateLimiter:
+    if settings.redis_url and create_redis_backend is not None:
+        backend = create_redis_backend(settings.redis_url)
+    else:
+        backend = InMemoryRateLimitBackend()
+    return RateLimiter(
+        limit=settings.rate_limit_requests,
+        window_seconds=settings.rate_limit_window_seconds,
+        backend=backend,
+    )
+
+
+app = FastAPI(title="AutoPal", version="1.0.0")
+_rate_limiter = _build_rate_limiter()
+
+
+async def verify_request(
+    authorization: str = Header(..., alias="Authorization"),
+    audience: str = Header(..., alias=settings.audience_header),
+) -> Tuple[Dict[str, Any], str]:
+    if not authorization.lower().startswith("bearer "):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid_token")
+    token = authorization.split(" ", 1)[1].strip()
+    if not token:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid_token")
+    verifier = get_token_verifier()
+    try:
+        claims = verifier.verify(token, audience)
+    except TokenVerificationError as exc:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid_token") from exc
+    return claims, audience
+
+
+@app.get("/healthz")
+async def healthcheck() -> Dict[str, str]:
+    """Lightweight readiness probe."""
+
+    return {"status": "ok"}
+
+
+@app.post("/secrets/materialize")
+async def materialize_secret(
+    token_ctx: Tuple[Dict[str, Any], str] = Depends(verify_request),
+    step_up_approved: str | None = Header(None, alias=settings.step_up_header),
+) -> JSONResponse:
+    claims, audience = token_ctx
+    subject = claims.get("sub")
+    if not subject:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="missing_subject")
+
+    key = f"{subject}::{audience}"
+    try:
+        await _rate_limiter.check(key)
+    except RateLimitExceeded as exc:
+        headers = {"Retry-After": str(exc.retry_after)}
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="rate_limit_exceeded",
+            headers=headers,
+        ) from exc
+
+    if not step_up_approved or step_up_approved.lower() != "true":
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="step_up_required")
+
+    payload = {
+        "subject": subject,
+        "audience": audience,
+        "materialized": True,
+        "secrets": {
+            "api_token": "mock-secret-token",
+            "ttl_seconds": settings.rate_limit_window_seconds,
+        },
+    }
+    return JSONResponse(payload)
+
+
+@app.on_event("shutdown")
+async def shutdown_event() -> None:
+    await _rate_limiter.close()

--- a/services/autopal/app/ratelimit.py
+++ b/services/autopal/app/ratelimit.py
@@ -1,0 +1,66 @@
+"""Rate limiting primitives for the AutoPal service."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+from typing import Protocol, Tuple
+
+
+class RateLimitBackend(Protocol):
+    """Protocol implemented by rate-limit storage backends."""
+
+    async def increment(self, key: str, window_seconds: int) -> Tuple[int, int]:
+        """Increment the request counter and return the new count and TTL in seconds."""
+
+    async def close(self) -> None:
+        """Release any backend resources."""
+
+
+class RateLimitExceeded(Exception):
+    """Raised when a caller exceeds the configured rate limit."""
+
+    def __init__(self, retry_after: int) -> None:
+        super().__init__("Rate limit exceeded")
+        self.retry_after = max(1, retry_after)
+
+
+@dataclass(slots=True)
+class RateLimiter:
+    """Apply rate limiting to per-subject keys."""
+
+    limit: int
+    window_seconds: int
+    backend: RateLimitBackend
+
+    async def check(self, key: str) -> None:
+        count, ttl = await self.backend.increment(key, self.window_seconds)
+        if count > self.limit:
+            raise RateLimitExceeded(ttl or self.window_seconds)
+
+    async def close(self) -> None:
+        await self.backend.close()
+
+
+class InMemoryRateLimitBackend:
+    """Simple in-process sliding window counter."""
+
+    def __init__(self) -> None:
+        self._entries: dict[str, tuple[int, float]] = {}
+        self._lock = asyncio.Lock()
+
+    async def increment(self, key: str, window_seconds: int) -> Tuple[int, int]:
+        async with self._lock:
+            now = time.monotonic()
+            count, expires_at = self._entries.get(key, (0, 0.0))
+            if now >= expires_at:
+                count = 0
+                expires_at = now + window_seconds
+            count += 1
+            self._entries[key] = (count, expires_at)
+            ttl = max(0, int(round(expires_at - now)))
+            return count, ttl
+
+    async def close(self) -> None:
+        self._entries.clear()

--- a/services/autopal/app/ratelimit_redis.py
+++ b/services/autopal/app/ratelimit_redis.py
@@ -1,0 +1,42 @@
+"""Redis-backed rate limiting for AutoPal."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+try:
+    import redis.asyncio as redis  # type: ignore
+except ModuleNotFoundError as exc:  # pragma: no cover - handled at runtime
+    raise RuntimeError(
+        "redis-py is required for the Redis rate limit backend"
+    ) from exc
+
+from .ratelimit import RateLimitBackend
+
+
+class RedisRateLimitBackend(RateLimitBackend):
+    """Redis implementation for distributed rate limiting."""
+
+    def __init__(self, url: str) -> None:
+        self._client = redis.from_url(url, decode_responses=True)
+
+    async def increment(self, key: str, window_seconds: int) -> Tuple[int, int]:
+        count = await self._client.incr(key)
+        if count == 1:
+            await self._client.expire(key, window_seconds)
+            ttl = window_seconds
+        else:
+            ttl = await self._client.ttl(key)
+            if ttl < 0:
+                await self._client.expire(key, window_seconds)
+                ttl = window_seconds
+        return count, max(0, ttl)
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+
+def create_redis_backend(url: str) -> RedisRateLimitBackend:
+    """Factory helper used by the service wiring."""
+
+    return RedisRateLimitBackend(url)

--- a/services/autopal/requirements.txt
+++ b/services/autopal/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.110.0
+uvicorn[standard]==0.27.1
+PyJWT[crypto]==2.8.0
+redis==5.0.3
+requests==2.32.3

--- a/services/mock-issuer/Dockerfile
+++ b/services/mock-issuer/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
+WORKDIR /app
+
+COPY requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8081"]

--- a/services/mock-issuer/README.md
+++ b/services/mock-issuer/README.md
@@ -1,0 +1,11 @@
+# Mock OIDC Issuer
+
+This FastAPI service generates ephemeral RSA keys at startup and exposes a minimal
+OpenID Connect surface suitable for local development:
+
+- `/.well-known/openid-configuration`
+- `/.well-known/jwks.json`
+- `/token` for minting ID tokens
+- `/healthz` for readiness checks
+
+Use the `/token` endpoint to mint short-lived ID tokens for the AutoPal stack.

--- a/services/mock-issuer/app/__init__.py
+++ b/services/mock-issuer/app/__init__.py
@@ -1,0 +1,1 @@
+"""Mock OIDC issuer used for local AutoPal development."""

--- a/services/mock-issuer/app/main.py
+++ b/services/mock-issuer/app/main.py
@@ -1,0 +1,108 @@
+"""Minimal mock OIDC issuer for local development."""
+
+from __future__ import annotations
+
+import os
+import time
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict
+from uuid import uuid4
+
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+import jwt
+
+
+def _b64(value: int) -> str:
+    return jwt.utils.base64url_encode(value.to_bytes((value.bit_length() + 7) // 8, "big")).decode()
+
+
+def _build_private_key() -> RSAPrivateKey:
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+class TokenRequest(BaseModel):
+    sub: str = Field(..., description="Subject claim")
+    aud: str = Field(..., description="Audience claim")
+    exp: int = Field(..., description="Expiry in seconds or absolute timestamp")
+
+
+app = FastAPI(title="Mock OIDC Issuer", version="0.1.0")
+_private_key = _build_private_key()
+_kid = os.getenv("MOCK_ISSUER_KID", uuid4().hex)
+
+
+def _issuer_url() -> str:
+    base = os.getenv("MOCK_ISSUER_URL", "http://mock-issuer:8081/").strip()
+    if not base.endswith("/"):
+        base = f"{base}/"
+    return base
+
+
+def _jwks() -> Dict[str, Any]:
+    public_numbers = _private_key.public_key().public_numbers()
+    return {
+        "keys": [
+            {
+                "kty": "RSA",
+                "use": "sig",
+                "alg": "RS256",
+                "kid": _kid,
+                "n": _b64(public_numbers.n),
+                "e": _b64(public_numbers.e),
+            }
+        ]
+    }
+
+
+@app.get("/.well-known/openid-configuration")
+async def configuration() -> Dict[str, Any]:
+    issuer = _issuer_url()
+    return {
+        "issuer": issuer.rstrip("/"),
+        "jwks_uri": f"{issuer.rstrip('/')}/.well-known/jwks.json",
+        "token_endpoint": f"{issuer.rstrip('/')}/token",
+        "id_token_signing_alg_values_supported": ["RS256"],
+    }
+
+
+@app.get("/.well-known/jwks.json")
+async def jwks() -> Dict[str, Any]:
+    return _jwks()
+
+
+@app.get("/healthz")
+async def healthz() -> Dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.post("/token")
+async def mint_token(request: TokenRequest) -> Dict[str, str]:
+    now = datetime.now(timezone.utc)
+    if request.exp > 1_000_000_000:
+        expires_at = datetime.fromtimestamp(request.exp, tz=timezone.utc)
+    else:
+        expires_at = now + timedelta(seconds=request.exp)
+
+    if expires_at <= now:
+        raise HTTPException(status_code=400, detail="exp must be in the future")
+
+    payload = {
+        "iss": _issuer_url().rstrip("/"),
+        "sub": request.sub,
+        "aud": request.aud,
+        "iat": int(time.time()),
+        "nbf": int(time.time()),
+        "exp": int(expires_at.timestamp()),
+    }
+
+    token = jwt.encode(
+        payload,
+        _private_key,
+        algorithm="RS256",
+        headers={"kid": _kid},
+    )
+    return {"id_token": token}

--- a/services/mock-issuer/requirements.txt
+++ b/services/mock-issuer/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.110.0
+uvicorn[standard]==0.27.1
+PyJWT[crypto]==2.8.0
+cryptography==42.0.7
+pydantic==2.7.1

--- a/stack/autopal-fastapi/README.md
+++ b/stack/autopal-fastapi/README.md
@@ -1,0 +1,41 @@
+# AutoPal FastAPI Stack
+
+This docker-compose stack launches the AutoPal API, a mock OIDC issuer, and Redis
+for distributed rate limiting.
+
+## Services
+
+| Service       | Port | Description |
+| ------------- | ---- | ----------- |
+| `autopal`     | 8080 | FastAPI AutoPal materialization service |
+| `mock-issuer` | 8081 | FastAPI mock OIDC issuer with JWKS + token minting |
+| `redis`       | 6379 | Backing store for shared rate limits |
+
+## Usage
+
+```bash
+docker compose up --build
+```
+
+Once the stack is running:
+
+```bash
+ID=$(curl -s -X POST http://localhost:8081/token \
+  -H 'Content-Type: application/json' \
+  -d '{"sub":"alice","aud":"gha:org/repo@refs/heads/main","exp":3600}' | jq -r .id_token)
+
+# First call without step-up should 401
+curl -i -X POST http://localhost:8080/secrets/materialize \
+  -H "Authorization: Bearer $ID" \
+  -H "X-Audience: gha:org/repo@refs/heads/main"
+
+# Add step-up header to succeed
+curl -i -X POST http://localhost:8080/secrets/materialize \
+  -H "Authorization: Bearer $ID" \
+  -H "X-Audience: gha:org/repo@refs/heads/main" \
+  -H "X-Step-Up-Approved: true"
+```
+
+The Redis-backed limiter tracks requests per subject and audience. When the
+configured burst is exceeded the API returns `429 Too Many Requests` with a
+`Retry-After` header indicating when the bucket refills.

--- a/stack/autopal-fastapi/docker-compose.yml
+++ b/stack/autopal-fastapi/docker-compose.yml
@@ -1,0 +1,37 @@
+version: "3.9"
+
+services:
+  autopal:
+    build:
+      context: ../../services/autopal
+    environment:
+      UVICORN_HOST: 0.0.0.0
+      UVICORN_PORT: "8080"
+      OIDC_ISSUER: http://mock-issuer:8081/
+      OIDC_JWKS_URL: http://mock-issuer:8081/.well-known/jwks.json
+      REDIS_URL: redis://redis:6379/0
+      RATE_LIMIT_REQUESTS: "5"
+      RATE_LIMIT_WINDOW_SECONDS: "60"
+    ports:
+      - "8080:8080"
+    depends_on:
+      - mock-issuer
+      - redis
+
+  mock-issuer:
+    build:
+      context: ../../services/mock-issuer
+    environment:
+      MOCK_ISSUER_URL: http://mock-issuer:8081/
+    ports:
+      - "8081:8081"
+
+  redis:
+    image: redis:7.2-alpine
+    command: ["redis-server", "--save", "", "--appendonly", "no"]
+    ports:
+      - "6379:6379"
+
+networks:
+  default:
+    name: autopal-stack


### PR DESCRIPTION
## Summary
- add an AutoPal FastAPI service that validates OIDC tokens, enforces step-up headers, and supports Redis-backed rate limits with in-memory fallback
- introduce a mock OIDC issuer microservice for local development and document usage alongside the new stack README
- provide a docker-compose stack that runs AutoPal, the mock issuer, and Redis together and add necessary JWT/Redis dependencies

## Testing
- python -m compileall services/autopal/app services/mock-issuer/app

------
https://chatgpt.com/codex/tasks/task_e_68e190bca44c8329bd7972269d2daa7b