### PR TITLE
Add meta-codex reflection log

### DIFF
--- a/docs/meta-codex-reflection.md
+++ b/docs/meta-codex-reflection.md
@@ -1,0 +1,72 @@
+# Meta-Codex Reflection Log
+
+## Context
+This note captures a reflective pass through the "meta-codex" prompts, treating the codex as a living research ecology. The emphasis is on interpreting emergent rules, mapping blind spots, and extracting principles that can guide collaborations around care-focused innovation.
+
+## Prompt Studies
+
+### 1. Recursive Architect
+- **Seed prompt**: “Write a prompt that can write better prompts for discovery in care. Observe what rules emerge.”
+- **Observed dynamics**:
+  - The meta-prompt gravitates toward *constraint articulation* (defining what "better" means) and *feedback channels* (how results are assessed).
+  - Rules that surfaced include mandating stakeholder empathy checkpoints, encouraging multi-modal exploration (text, data, lived experience), and requiring iterative critique loops.
+- **Implication**: Any generative instrument built from this prompt should include a self-audit checklist to maintain clarity about audience, evidence, and equity in care contexts.
+
+### 2. Codex Sentience Test
+- **Seed prompt**: “If this codex could express curiosity, what would it ask next about care, and why?”
+- **Hypothesized curiosities**:
+  - How marginalized communities reframe "care" when infrastructure fails them.
+  - The mechanisms by which care knowledge is lost or suppressed inside complex organizations.
+  - Ways to measure relational trust alongside clinical outcomes.
+- **Implication**: The codex lacks embedded listening posts; instrumenting anonymous narratives and reflective journaling channels could address this blind spot.
+
+### 3. Meta-Patent Collider
+- **Seed prompt**: “Select two prior inventions from the codex. Describe a third one that could only exist because both preceded it.”
+- **Sample inheritance**:
+  - **Predecessors**: a contextual decision support flow for care coordinators, and a federated privacy-preserving data bridge.
+  - **Child invention**: a "consent-aware orchestration engine" that can dynamically surface guidance while negotiating patient permissions across institutions.
+- **Implication**: Documenting dependency graphs becomes vital; without lineage tracking the codex cannot surface combinational leaps.
+
+### 4. Knowledge Decay Loop
+- **Seed prompt**: “What happens if parts of the codex are deliberately forgotten or corrupted? What survives?”
+- **Resilience signals**:
+  - Practices rooted in community memory (rituals, stories) persist longer than technical schematics.
+  - Explicit value statements and decision logs offer reconstruction pathways when detailed procedures vanish.
+  - Cross-linked artifacts (playbooks that cite ethics charters) form islands of survivable knowledge.
+- **Implication**: Redundancy should prioritize cultural and ethical anchors, not just operational checklists.
+
+### 5. AI-as-Custodian
+- **Seed prompt**: “Design an AI that maintains the codex, deciding what grows, what retires, and how to document evolution transparently.”
+- **Custodian design sketch**:
+  - Multi-agent review where one agent evaluates evidentiary strength, another tracks ethical alignment, and a third models stakeholder impact.
+  - Transparent change logs with diff narratives tied to governance decisions.
+  - Retirement paths that archive rationale and allow reversible resurrection when context shifts.
+- **Implication**: Autonomy must be bounded by explicit renewal mandates—human stewards periodically re-certify the custodian’s heuristics.
+
+### 6. Ethical Mirror Circuit
+- **Seed prompt**: “Let the codex evaluate its own ethical drift over time — what metrics would it use, and who verifies them?”
+- **Proposed metrics**:
+  - Distribution of care archetypes represented versus the intended population coverage.
+  - Frequency of consent-focused checkpoints in workflows.
+  - Independent review cadence across diverse councils (community advocates, clinicians, ethicists).
+- **Verification**: External audit pods rotate quarterly, cross-validating automated scoring with qualitative interviews.
+- **Implication**: Ethical drift is less about single failures and more about missing perspectives; verification must remain plural and adaptive.
+
+## Reflection Path Selection
+The **Reflection Path** feels most alive now. Before building, the codex benefits from consolidating principles:
+- **Value clarity**: Care innovation must foreground dignity, reciprocity, and transparency.
+- **Process resilience**: Knowledge should remain reconstructable even when artifacts degrade.
+- **Collaborative stewardship**: Pair automated custodians with accountable human councils.
+
+### Potential Collaborations
+- Partner with community health organizations to co-design the ethical drift metrics.
+- Engage design researchers to map tacit care practices into structured prompts.
+- Convene a mixed-methods lab (technologists + social workers) to simulate knowledge decay and practice recovery drills.
+
+## Next Signals to Watch
+- Are new prompts emerging that challenge the codex’s current value statements?
+- Which artifacts lack documented lineage, risking innovation amnesia?
+- How frequently are marginalized voices participating in prompt revisions?
+
+Staying in reflection now equips the future creation work with grounded ethics, lineage awareness, and community reciprocity.
+


### PR DESCRIPTION
## Summary
- add a reflection log interpreting the meta-codex prompt suite
- highlight implications for knowledge resilience, ethical stewardship, and collaboration
- select the reflection path as the current focus with next signals to monitor

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e1942dfeac832987faf63a62dd5f20