### PR TITLE
Add Autopal break-glass emergency access

### DIFF
--- a/autopal.config.json
+++ b/autopal.config.json
@@ -1,0 +1,23 @@
+{
+  "feature_flags": {
+    "global_enabled": true,
+    "require_step_up": true
+  },
+  "break_glass": {
+    "enabled": true,
+    "alg": "HS256",
+    "hmac_secret_env": "AUTOPAL_BREAK_GLASS_SECRET",
+    "ttl_seconds": 600,
+    "allowlist_endpoints": [
+      "POST /secrets/materialize",
+      "POST /fossil/override",
+      "POST /approvals/{rid}/approve"
+    ],
+    "allowed_subjects": ["ops-oncall", "sre-lead"]
+  },
+  "audit": {
+    "enabled": true,
+    "sink": "stdout",
+    "redact_values": true
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ pydantic
 pyarrow==16.1.0
 pre-commit==4.3.0
 psutil
+PyJWT
 PyYAML==6.0.2
 python-dotenv
 qiskit-aer==0.17.1

--- a/services/autopal/__init__.py
+++ b/services/autopal/__init__.py
@@ -1,0 +1,5 @@
+"""Autopal emergency access service package."""
+
+from .app import app
+
+__all__ = ["app"]

--- a/services/autopal/app.py
+++ b/services/autopal/app.py
@@ -1,0 +1,73 @@
+"""Autopal emergency FastAPI application."""
+
+from __future__ import annotations
+
+from fastapi import Depends, FastAPI
+from fastapi.responses import JSONResponse
+
+from .audit import AuditLogger
+from .breakglass import BreakGlassContext, BreakGlassGate
+from .config import config_loader
+from .guard import AccessGuard
+from .schemas import (
+    ApprovalRequest,
+    FossilOverrideRequest,
+    MaterializeRequest,
+    OperationResponse,
+)
+
+app = FastAPI(title="Autopal Emergency Console", version="0.1.0", docs_url=None)
+
+audit_logger = AuditLogger()
+break_glass_gate = BreakGlassGate(audit_logger)
+access_guard = AccessGuard(config_loader, break_glass_gate, audit_logger)
+
+
+@app.middleware("http")
+async def enforce_break_glass_allowlist(request, call_next):
+    """Reject break-glass headers on endpoints outside of the allowlist."""
+
+    token = request.headers.get(BreakGlassGate.HEADER)
+    if not token:
+        return await call_next(request)
+    config = config_loader.get()
+    method = request.method.upper()
+    path = request.url.path
+    if not break_glass_gate.is_allowlisted(method, path, config.break_glass):
+        return JSONResponse(status_code=403, content={"detail": "Break-glass not permitted for this endpoint"})
+    return await call_next(request)
+
+
+@app.get("/healthz")
+async def healthcheck() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.post("/secrets/materialize", response_model=OperationResponse)
+async def materialize_secret(
+    payload: MaterializeRequest,
+    context: BreakGlassContext | None = Depends(access_guard),
+) -> OperationResponse:
+    return OperationResponse.from_context("materialized", payload.reason, context)
+
+
+@app.post("/fossil/override", response_model=OperationResponse)
+async def override_fossil(
+    payload: FossilOverrideRequest,
+    context: BreakGlassContext | None = Depends(access_guard),
+) -> OperationResponse:
+    detail = f"override requested by {payload.requested_by}"
+    return OperationResponse.from_context("override_submitted", detail, context)
+
+
+@app.post("/approvals/{rid}/approve", response_model=OperationResponse)
+async def approve_request(
+    rid: str,
+    payload: ApprovalRequest,
+    context: BreakGlassContext | None = Depends(access_guard),
+) -> OperationResponse:
+    detail = f"approval for {rid} by {payload.actor}"
+    return OperationResponse.from_context("approved", detail, context)
+
+
+__all__ = ["app"]

--- a/services/autopal/audit.py
+++ b/services/autopal/audit.py
@@ -1,0 +1,51 @@
+"""JSON audit logging utilities for Autopal."""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from .config import AuditConfig
+
+
+@dataclass
+class AuditRecord:
+    """Structured representation of an audit event."""
+
+    event: str
+    ts: int
+    payload: dict[str, Any]
+
+    def to_json(self) -> str:
+        return json.dumps({"ts": self.ts, "event": self.event, **self.payload}, default=str, separators=(",", ":"))
+
+
+class AuditLogger:
+    """Emit compact JSON audit events."""
+
+    def __init__(self, writer: Callable[[str], None] | None = None) -> None:
+        self._writer = writer or (lambda msg: print(msg, file=sys.stdout, flush=True))
+
+    def log(self, config: AuditConfig, event: str, **context: Any) -> None:
+        """Log an event when auditing is enabled."""
+
+        if not config.enabled:
+            return
+        payload = {key: self._maybe_redact(key, value, config) for key, value in context.items()}
+        record = AuditRecord(event=event, ts=int(time.time()), payload=payload)
+        self._writer(record.to_json())
+
+    @staticmethod
+    def _maybe_redact(key: str, value: Any, config: AuditConfig) -> Any:
+        if not config.redact_values:
+            return value
+        lowered = key.lower()
+        if any(token in lowered for token in ("token", "secret", "authorization", "password")):
+            return "<redacted>"
+        return value
+
+
+__all__ = ["AuditLogger", "AuditRecord"]

--- a/services/autopal/breakglass.py
+++ b/services/autopal/breakglass.py
@@ -1,0 +1,133 @@
+"""Break-glass admission checks."""
+
+from __future__ import annotations
+
+import os
+import re
+import time
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Any
+
+import jwt
+from fastapi import HTTPException, Request, status
+from jwt import InvalidTokenError
+
+from .audit import AuditLogger
+from .config import AppConfig, BreakGlassConfig
+
+
+@dataclass
+class BreakGlassContext:
+    """Context returned when a break-glass token is accepted."""
+
+    subject: str
+    issued_at: int
+    expires_at: int
+    endpoint: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "subject": self.subject,
+            "issued_at": self.issued_at,
+            "expires_at": self.expires_at,
+            "endpoint": self.endpoint,
+        }
+
+
+class BreakGlassGate:
+    """Validate break-glass headers and emit audit events."""
+
+    HEADER = "X-Break-Glass"
+
+    def __init__(self, audit_logger: AuditLogger) -> None:
+        self._audit = audit_logger
+
+    def evaluate(
+        self,
+        request: Request,
+        method: str,
+        path: str,
+        route_template: str,
+        config: AppConfig,
+    ) -> BreakGlassContext | None:
+        token = request.headers.get(self.HEADER)
+        if not token:
+            return None
+
+        cfg = config.break_glass
+        if not cfg.enabled:
+            raise HTTPException(status.HTTP_403_FORBIDDEN, "Break-glass is disabled")
+        if not self._is_allowlisted(method, path, cfg):
+            raise HTTPException(status.HTTP_403_FORBIDDEN, "Break-glass not permitted for this endpoint")
+
+        secret = os.getenv(cfg.hmac_secret_env)
+        if not secret:
+            raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, "Break-glass secret is not configured")
+
+        try:
+            claims = jwt.decode(
+                token,
+                secret,
+                algorithms=[cfg.alg],
+                options={"require": ["sub", "iat", "exp"]},
+            )
+        except InvalidTokenError as exc:  # pragma: no cover - PyJWT raises numerous subclasses
+            raise HTTPException(status.HTTP_403_FORBIDDEN, "Invalid break-glass token") from exc
+
+        subject = str(claims.get("sub"))
+        if subject not in cfg.allowed_subjects:
+            raise HTTPException(status.HTTP_403_FORBIDDEN, "Subject not authorised for break-glass")
+
+        try:
+            issued_at = int(claims.get("iat"))
+            expires_at = int(claims.get("exp"))
+        except (TypeError, ValueError) as exc:
+            raise HTTPException(status.HTTP_403_FORBIDDEN, "Invalid break-glass token timing claims") from exc
+
+        now = int(time.time())
+        if expires_at <= issued_at or expires_at <= now:
+            raise HTTPException(status.HTTP_403_FORBIDDEN, "Break-glass token expired")
+        if (expires_at - issued_at) > cfg.ttl_seconds:
+            raise HTTPException(status.HTTP_403_FORBIDDEN, "Break-glass token exceeds permitted TTL")
+
+        context = BreakGlassContext(
+            subject=subject,
+            issued_at=issued_at,
+            expires_at=expires_at,
+            endpoint=route_template,
+        )
+        self._audit.log(
+            config.audit,
+            "break_glass.accepted",
+            sub=subject,
+            iat=issued_at,
+            exp=expires_at,
+            endpoint=route_template,
+        )
+        return context
+
+    def _is_allowlisted(self, method: str, path: str, cfg: BreakGlassConfig) -> bool:
+        method_upper = method.upper()
+        for entry in cfg.allowlist_endpoints:
+            entry_method, entry_path = entry.split(" ", 1)
+            if entry_method.upper() != method_upper:
+                continue
+            pattern = self._compiled_pattern(entry_path)
+            if pattern.fullmatch(path):
+                return True
+        return False
+
+    def is_allowlisted(self, method: str, path: str, cfg: BreakGlassConfig) -> bool:
+        """Public wrapper around the allowlist matcher."""
+
+        return self._is_allowlisted(method, path, cfg)
+
+    @staticmethod
+    @lru_cache(maxsize=64)
+    def _compiled_pattern(template: str) -> re.Pattern[str]:
+        regex = re.sub(r"\{[^/]+\}", "[^/]+", template)
+        return re.compile(f"^{regex}$")
+
+
+__all__ = ["BreakGlassContext", "BreakGlassGate"]

--- a/services/autopal/config.py
+++ b/services/autopal/config.py
@@ -1,0 +1,126 @@
+"""Configuration loader for the Autopal emergency access service."""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from threading import Lock
+from typing import Literal
+
+from pydantic import BaseModel, Field, validator
+
+
+class FeatureFlags(BaseModel):
+    """Runtime switches that gate Autopal behaviour."""
+
+    global_enabled: bool = Field(True, description="When false, normal traffic is blocked without break-glass")
+    require_step_up: bool = Field(
+        True,
+        description="When true, the X-Step-Up-Approved header is required for sensitive endpoints.",
+    )
+
+
+class BreakGlassConfig(BaseModel):
+    """Settings governing break-glass JWT admission."""
+
+    enabled: bool = True
+    alg: str = Field("HS256", description="JWT signing algorithm")
+    hmac_secret_env: str = Field(
+        "AUTOPAL_BREAK_GLASS_SECRET",
+        description="Environment variable containing the HMAC secret",
+    )
+    ttl_seconds: int = Field(600, gt=0, description="Maximum allowed lifetime for break-glass tokens")
+    allowlist_endpoints: list[str] = Field(default_factory=list)
+    allowed_subjects: list[str] = Field(default_factory=list)
+
+    @validator("allowlist_endpoints", each_item=True)
+    def _validate_allowlist_entry(cls, value: str) -> str:  # noqa: D401
+        """Ensure allowlist entries follow the "METHOD /path" format."""
+
+        if " " not in value:
+            raise ValueError("allowlist entries must be of form 'METHOD /path'")
+        method, path = value.split(" ", 1)
+        if not method or not path.startswith("/"):
+            raise ValueError("allowlist entries must include an HTTP verb and absolute path")
+        return f"{method.upper()} {path}"
+
+    @validator("allowed_subjects", each_item=True)
+    def _strip_subject(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("allowed subjects cannot be empty")
+        return cleaned
+
+
+class AuditConfig(BaseModel):
+    """Audit emission configuration."""
+
+    enabled: bool = True
+    sink: Literal["stdout"] = "stdout"
+    redact_values: bool = True
+
+
+class AppConfig(BaseModel):
+    """Top-level configuration object."""
+
+    feature_flags: FeatureFlags = Field(default_factory=FeatureFlags)
+    break_glass: BreakGlassConfig
+    audit: AuditConfig = Field(default_factory=AuditConfig)
+
+
+@dataclass
+class _CachedConfig:
+    signature: tuple[int, int] | None
+    config: AppConfig | None
+
+
+class ConfigLoader:
+    """Load Autopal configuration with lightweight change detection."""
+
+    def __init__(self, path: str | os.PathLike[str] | None = None) -> None:
+        default_path = Path.cwd() / "autopal.config.json"
+        resolved_path = Path(path or os.getenv("AUTOPAL_CONFIG_PATH") or default_path)
+        self._path = resolved_path
+        self._cache = _CachedConfig(signature=None, config=None)
+        self._lock = Lock()
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def get(self) -> AppConfig:
+        """Return the current configuration, reloading if the file changed."""
+
+        try:
+            stat_result = self._path.stat()
+        except FileNotFoundError as exc:  # pragma: no cover - defensive guard
+            raise RuntimeError(f"Autopal config not found at {self._path}") from exc
+
+        signature = (stat_result.st_mtime_ns, stat_result.st_size)
+        with self._lock:
+            if self._cache.signature != signature or self._cache.config is None:
+                self._cache = _CachedConfig(signature=signature, config=self._load())
+            # Return a deepcopy so request handlers can't mutate shared config
+            return copy.deepcopy(self._cache.config)
+
+    def _load(self) -> AppConfig:
+        data = json.loads(self._path.read_text())
+        model_validate = getattr(AppConfig, "model_validate", None)
+        if callable(model_validate):
+            return model_validate(data)
+        return AppConfig.parse_obj(data)  # type: ignore[attr-defined]
+
+
+config_loader = ConfigLoader()
+
+__all__ = [
+    "AppConfig",
+    "AuditConfig",
+    "BreakGlassConfig",
+    "ConfigLoader",
+    "FeatureFlags",
+    "config_loader",
+]

--- a/services/autopal/guard.py
+++ b/services/autopal/guard.py
@@ -1,0 +1,40 @@
+"""Request guard that applies maintenance, step-up, and break-glass logic."""
+
+from fastapi import HTTPException, Request, status
+
+from .audit import AuditLogger
+from .breakglass import BreakGlassContext, BreakGlassGate
+from .config import ConfigLoader
+
+
+class AccessGuard:
+    """FastAPI dependency enforcing Autopal access requirements."""
+
+    def __init__(self, loader: ConfigLoader, gate: BreakGlassGate, audit_logger: AuditLogger) -> None:
+        self._loader = loader
+        self._gate = gate
+        self._audit = audit_logger
+
+    async def __call__(self, request: Request) -> BreakGlassContext | None:
+        config = self._loader.get()
+        route = request.scope.get("route")
+        route_template = route.path if route else request.url.path
+        method = request.method.upper()
+        path = request.url.path
+
+        context = self._gate.evaluate(request, method, path, route_template, config)
+        if not config.feature_flags.global_enabled and context is None:
+            caller = request.client.host if request.client else None
+            self._audit.log(config.audit, "maintenance.block", endpoint=route_template, caller=caller)
+            raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, "Autopal is in maintenance mode")
+
+        if config.feature_flags.require_step_up:
+            approved = str(request.headers.get("X-Step-Up-Approved", "")).lower()
+            if approved not in {"true", "1", "yes"}:
+                self._audit.log(config.audit, "step_up.required", endpoint=route_template)
+                raise HTTPException(status.HTTP_428_PRECONDITION_REQUIRED, "Step-up approval required")
+
+        return context
+
+
+__all__ = ["AccessGuard"]

--- a/services/autopal/schemas.py
+++ b/services/autopal/schemas.py
@@ -1,0 +1,43 @@
+"""Pydantic schemas for Autopal endpoints."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from .breakglass import BreakGlassContext
+
+
+class MaterializeRequest(BaseModel):
+    secret_id: str = Field(..., description="Identifier of the secret to materialize")
+    reason: str | None = Field(None, description="Optional justification for the request")
+
+
+class FossilOverrideRequest(BaseModel):
+    fossil_id: str = Field(..., description="Fossil job identifier")
+    requested_by: str = Field(..., description="Requester issuing the override")
+
+
+class ApprovalRequest(BaseModel):
+    actor: str = Field(..., description="Person or service approving the request")
+    notes: str | None = Field(None, description="Optional approval notes")
+
+
+class OperationResponse(BaseModel):
+    status: str
+    detail: str | None = None
+    break_glass: dict[str, object] | None = Field(
+        default=None,
+        description="Context describing the accepted break-glass token, if any.",
+    )
+
+    @classmethod
+    def from_context(cls, status: str, detail: str | None, context: BreakGlassContext | None) -> "OperationResponse":
+        return cls(status=status, detail=detail, break_glass=context.as_dict() if context else None)
+
+
+__all__ = [
+    "ApprovalRequest",
+    "FossilOverrideRequest",
+    "MaterializeRequest",
+    "OperationResponse",
+]

--- a/tests/test_autopal_break_glass.py
+++ b/tests/test_autopal_break_glass.py
@@ -1,0 +1,186 @@
+"""Tests for the Autopal break-glass and maintenance guard."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+
+DEFAULT_CONFIG: dict[str, Any] = {
+    "feature_flags": {"global_enabled": True, "require_step_up": True},
+    "break_glass": {
+        "enabled": True,
+        "alg": "HS256",
+        "hmac_secret_env": "AUTOPAL_BREAK_GLASS_SECRET",
+        "ttl_seconds": 600,
+        "allowlist_endpoints": [
+            "POST /secrets/materialize",
+            "POST /fossil/override",
+            "POST /approvals/{rid}/approve",
+        ],
+        "allowed_subjects": ["ops-oncall", "sre-lead"],
+    },
+    "audit": {"enabled": True, "sink": "stdout", "redact_values": True},
+}
+
+
+@pytest.fixture
+def autopal_app(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Callable[[dict[str, Any] | None], tuple[TestClient, Path]]:
+    """Factory returning a configured Autopal TestClient."""
+
+    def factory(overrides: dict[str, Any] | None = None) -> tuple[TestClient, Path]:
+        config = json.loads(json.dumps(DEFAULT_CONFIG))
+        if overrides:
+            merge_dict(config, overrides)
+
+        config_path = tmp_path / "autopal.config.json"
+        config_path.write_text(json.dumps(config))
+
+        monkeypatch.setenv("AUTOPAL_CONFIG_PATH", str(config_path))
+        monkeypatch.setenv("AUTOPAL_BREAK_GLASS_SECRET", "dev-secret")
+
+        for module_name in list(sys.modules.keys()):
+            if module_name.startswith("services.autopal"):
+                sys.modules.pop(module_name)
+
+        module = importlib.import_module("services.autopal.app")
+        client = TestClient(module.app)
+        return client, config_path
+
+    return factory
+
+
+def merge_dict(dest: dict[str, Any], src: dict[str, Any]) -> None:
+    for key, value in src.items():
+        if isinstance(value, dict) and isinstance(dest.get(key), dict):
+            merge_dict(dest[key], value)
+        else:
+            dest[key] = value
+
+
+def merge_copy(base: dict[str, Any], overrides: dict[str, Any]) -> dict[str, Any]:
+    merged = json.loads(json.dumps(base))
+    merge_dict(merged, overrides)
+    return merged
+
+
+def mint_token(subject: str, ttl: int) -> str:
+    now = int(time.time())
+    payload = {"sub": subject, "iat": now, "exp": now + ttl}
+    return jwt.encode(payload, key="dev-secret", algorithm="HS256")
+
+
+def test_requires_step_up_header(
+    autopal_app: Callable[[dict[str, Any] | None], tuple[TestClient, Path]]
+) -> None:
+    client, _ = autopal_app(None)
+    response = client.post("/secrets/materialize", json={"secret_id": "alpha"})
+    assert response.status_code == 428
+
+
+def test_break_glass_allows_maintenance_override(
+    autopal_app: Callable[[dict[str, Any] | None], tuple[TestClient, Path]]
+) -> None:
+    client, config_path = autopal_app(None)
+    disable_global = {"feature_flags": {"global_enabled": False}}
+    config_path.write_text(json.dumps(merge_copy(DEFAULT_CONFIG, disable_global)))
+
+    response_blocked = client.post(
+        "/secrets/materialize",
+        json={"secret_id": "alpha"},
+        headers={"X-Step-Up-Approved": "true"},
+    )
+    assert response_blocked.status_code == 503
+
+    token = mint_token("ops-oncall", ttl=300)
+    response = client.post(
+        "/secrets/materialize",
+        json={"secret_id": "alpha"},
+        headers={
+            "X-Step-Up-Approved": "true",
+            "X-Break-Glass": token,
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["status"] == "materialized"
+
+
+def test_break_glass_rejected_on_non_allowlisted_route(
+    autopal_app: Callable[[dict[str, Any] | None], tuple[TestClient, Path]]
+) -> None:
+    client, _ = autopal_app(None)
+    token = mint_token("ops-oncall", ttl=60)
+    response = client.get("/healthz", headers={"X-Break-Glass": token})
+    assert response.status_code == 403
+
+
+def test_break_glass_ttl_enforced(
+    autopal_app: Callable[[dict[str, Any] | None], tuple[TestClient, Path]]
+) -> None:
+    overrides = {"break_glass": {"ttl_seconds": 60}}
+    client, _ = autopal_app(overrides)
+    now = int(time.time())
+    long_token = jwt.encode(
+        {"sub": "ops-oncall", "iat": now, "exp": now + 3600},
+        key="dev-secret",
+        algorithm="HS256",
+    )
+    response = client.post(
+        "/secrets/materialize",
+        json={"secret_id": "alpha"},
+        headers={
+            "X-Step-Up-Approved": "true",
+            "X-Break-Glass": long_token,
+        },
+    )
+    assert response.status_code == 403
+
+    short_token = mint_token("ops-oncall", ttl=30)
+    response_ok = client.post(
+        "/secrets/materialize",
+        json={"secret_id": "alpha"},
+        headers={
+            "X-Step-Up-Approved": "true",
+            "X-Break-Glass": short_token,
+        },
+    )
+    assert response_ok.status_code == 200
+
+
+def test_break_glass_subject_allowlist(
+    autopal_app: Callable[[dict[str, Any] | None], tuple[TestClient, Path]]
+) -> None:
+    client, _ = autopal_app(None)
+    token = mint_token("random-user", ttl=60)
+    response = client.post(
+        "/secrets/materialize",
+        json={"secret_id": "alpha"},
+        headers={
+            "X-Step-Up-Approved": "true",
+            "X-Break-Glass": token,
+        },
+    )
+    assert response.status_code == 403
+
+
+def test_step_up_allows_request(
+    autopal_app: Callable[[dict[str, Any] | None], tuple[TestClient, Path]]
+) -> None:
+    client, _ = autopal_app(None)
+    response = client.post(
+        "/secrets/materialize",
+        json={"secret_id": "alpha"},
+        headers={"X-Step-Up-Approved": "true"},
+    )
+    assert response.status_code == 200
+    assert response.json()["status"] == "materialized"


### PR DESCRIPTION
## Summary
- add an Autopal FastAPI service with guarded materialize, fossil override, and approval endpoints plus break-glass middleware
- introduce JSON audit logging, JWT validation, and dynamic config loading for break-glass and step-up policies
- cover the new access paths with targeted pytest coverage and document runtime configuration defaults

## Testing
- pytest tests/test_autopal_break_glass.py

------
https://chatgpt.com/codex/tasks/task_e_68e192a924f8832991e732d76e6cc768