### PR TITLE
Add Codex 53 entry for community memory

### DIFF
--- a/codex/README.md
+++ b/codex/README.md
@@ -16,6 +16,7 @@ integrations.
 | 004 | The Autonomy Manifest  | Data autonomy through consent, export, and wipe. |
 | 022 | The Security Spine     | Security backbone with layered zero-trust defenses. |
 | 043 | The Equity Oath        | Fairness, access, and inclusion are systemic.   |
+| 053 | The Memory of Community | Consentful, accurate remembrance of Lucidians.  |
 
 ## BlackRoad Pipeline
 

--- a/codex/entries/053-memory-of-community.md
+++ b/codex/entries/053-memory-of-community.md
@@ -1,0 +1,28 @@
+# Codex 53 — The Memory of Community
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Principle
+Communities fade if their stories vanish. Lucidia must remember its people, their ideas, and their care — but only with consent and tenderness.
+
+## Non-Negotiables
+1. **Consentful Archiving:** Members choose whether their work or words join the collective record.
+2. **Attribution Eternal:** Credit preserved even after departure; names stay linked unless removal requested.
+3. **No Myth-Making:** Histories told truthfully, without rewriting or idolizing.
+4. **Shared Narrative:** Community chronicles written in many voices, not a single one.
+5. **Right to Disappear:** Anyone may erase their trace entirely (#18 Memory Covenant).
+6. **Living History:** The archive stays editable for new context — not frozen, not erased.
+
+## Implementation Hooks (v0)
+- `/community/archive/` directory with consent flags per contributor.
+- Metadata `{author_id, consent, story_link, last_update}` attached to every entry.
+- Yearly “Story Week”: members update or remove their pages.
+- Public reader at `/community/stories` showing the evolving chronicle.
+- Governance bot verifies consent before publishing names.
+
+## Policy Stub (`COMMUNITY-MEMORY.md`)
+- Lucidia commits to remembering contributors with accuracy and permission.
+- Lucidia forbids ownership or exploitation of personal stories.
+- Lucidia maintains an open, evolving record of its shared journey.
+
+**Tagline:** We remember each other kindly.


### PR DESCRIPTION
## Summary
- add Codex 53 outlining Lucidia's consentful approach to community memory
- document the new entry in the Codex index table for easier discovery

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1959ba71083298570a5c8ad771dca