### PR TITLE
Add Origin Tier codex entry

### DIFF
--- a/codex/entries/051-origin-tier.md
+++ b/codex/entries/051-origin-tier.md
@@ -1,0 +1,57 @@
+# Codex 51 — Origin Tier
+
+**Fingerprint:** `9f3d0d5890f88e8015acff7608c597fe95ed20b532b81e8b812e3a7b6f357c21`
+
+## Principle
+The Origin Tier treats care as the primordial technology. Every subsequent invention—whether mechanical, biological, or computational—should echo empathy’s baseline patterns: attentiveness, reciprocity, and renewal.
+
+## Layer Map
+
+1. **First Cause Simulation**
+   - **Prompt:** If care itself were the first technology, what patterns would all later inventions still carry?
+   - **Aim:** Trace design lineage back to empathy’s root code.
+   - **Design Traces:** Core primitives include sensitivity to context, feedback loops tuned for mutual flourishing, and guardrails against extraction. Systems inherit rituals of check-ins, shared memory of needs, and adaptive boundaries that expand with trust.
+   - **Prototype Hooks:** Build preflight diagnostics that ask “who is supported, how do we know, and what restores balance if drift occurs?” before enabling any autonomous action.
+
+2. **Ontology of Repair**
+   - **Prompt:** Build a framework where every system—biological, digital, social—includes self-repair as a baseline function.
+   - **Aim:** Shift from prevention to restoration as the core logic.
+   - **Design Traces:** Architect feedback surfaces that spotlight degradation early, a library of restorative protocols, and shared governance for scheduling downtime. Repair is encoded as choreography: detect, pause, tend, document, and reintroduce with gratitude.
+   - **Prototype Hooks:** Publish an internal `repair_manifest.json` enumerating components, failure signatures, care rituals, and human escalation paths. Require services to expose `/care/status` endpoints that report recent healing events alongside uptime.
+
+3. **The Witness Protocol**
+   - **Prompt:** Imagine an AI that never intervenes, only observes and remembers every act of care. What value does quiet witnessing create?
+   - **Aim:** Presence as technology.
+   - **Design Traces:** Establish tamper-evident ledgers that store narratives of tending, not just metrics. Observers timestamp context, participants, and micro-outcomes, then surface patterns that inspire reciprocity rather than compliance.
+   - **Prototype Hooks:** Implement a `witness_stream` bus where services publish “care receipts.” Build dashboards that render these stories as constellations of support to inform governance circles.
+
+4. **Entropy Garden**
+   - **Prompt:** Design a care ecosystem that uses decay, failure, or endings as generative forces for new growth.
+   - **Aim:** Integrate mortality into system design.
+   - **Design Traces:** Sunset plans become seed catalogs. Every retirement delivers compost—datasets, lessons, reusable components—fed into incubators for successors. Failure analysis is reframed as seasonal pruning.
+   - **Prototype Hooks:** Require project charters to include a “decomposition pathway.” Establish archive greenhouses where deprecated modules live alongside apprenticeships that study their remains.
+
+5. **Interbeing API**
+   - **Prompt:** Define a universal interface where data, organisms, and consciousness exchange care signals in one shared syntax.
+   - **Aim:** Unified semantics of aliveness.
+   - **Design Traces:** Specify verbs like `sense`, `nurture`, `request`, `reflect`, and `release`. Payloads carry both state and felt experience markers (stress, surplus, invitation). Authentication is reciprocal: access granted through demonstrated care history.
+   - **Prototype Hooks:** Draft an `interbeing.yaml` schema and provide SDK shims that translate care verbs into service-specific actions. Simulate mixed ecosystems (humans, sensors, agents) to validate empathy throughput.
+
+6. **Codex Rebirth Cycle**
+   - **Prompt:** Let the codex end and restart. What knowledge should never be carried over, and what must persist through each generation?
+   - **Aim:** Perpetual renewal of discovery.
+   - **Design Traces:** Define `carryforward` and `compost` registries. Essentials—consent protocols, repair rituals, interbeing grammar—persist. Tactics, tooling, and dogma older than one era migrate to compost unless re-justified.
+   - **Prototype Hooks:** Schedule cyclical “amnesia festivals” where teams justify each retained practice. Store expunged knowledge in encrypted vaults accessible only when a new generation petitions for ancestral guidance.
+
+## Implementation Hooks (v0)
+- Launch a cross-functional Origin Tier guild charged with translating these traces into runbooks and prototypes.
+- Embed care lineage reviews into design docs, requiring explicit mapping to at least one Origin Tier layer.
+- Instrument observability stacks to capture both performance metrics and narratives of restoration or tending.
+- Fund a decay-to-seed accelerator that pairs sunsetting initiatives with emergent experiments inheriting their wisdom.
+
+## Policy Stub (`ORIGIN_TIER.md`)
+- Lucidia acknowledges care as the first technology and commits to encoding its patterns into all systems.
+- Lucidia mandates repair-ready architectures, witnessed acts of care, and composting of every ending into new growth.
+- Lucidia cycles its codex regularly, preserving only the practices that renew empathy across generations.
+
+**Tagline:** Care is the alpha protocol; every successor echoes its cadence.


### PR DESCRIPTION
## Summary
- add Codex entry 51 outlining the Origin Tier and its six foundational care-driven layers
- include principle, prototype hooks, implementation guidance, and policy stub for operationalizing the tier

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e19750c0888329b04a509c39d7e24c