### PR TITLE
feat: add exception duplicate guard and slack card

### DIFF
--- a/opt/blackroad/api/__init__.py
+++ b/opt/blackroad/api/__init__.py
@@ -1,5 +1,7 @@
 from fastapi import APIRouter
 from .astro_meteoroid import router as astro_meteoroid_router
+from .exceptions import router as exceptions_router
 
 api_router = APIRouter()
 api_router.include_router(astro_meteoroid_router)
+api_router.include_router(exceptions_router)

--- a/opt/blackroad/api/exceptions.py
+++ b/opt/blackroad/api/exceptions.py
@@ -1,0 +1,191 @@
+"""FastAPI endpoints for policy exceptions."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+import requests
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
+
+from policy.exceptions import (
+    approval_card,
+    approve_exception,
+    create_exception,
+    deny_exception,
+    ensure_schema,
+    get_exception,
+    load_rule,
+    prepend_duplicate_notice,
+)
+
+router = APIRouter(prefix="/exceptions", tags=["exceptions"])
+
+
+def _connect() -> sqlite3.Connection:
+    dsn = os.getenv("EXCEPTIONS_DB_PATH", "exceptions.db")
+    uri = dsn.startswith("file:")
+    conn = sqlite3.connect(dsn, check_same_thread=False, uri=uri)
+    conn.row_factory = sqlite3.Row
+    ensure_schema(conn)
+    return conn
+
+
+_CONN = _connect()
+
+
+class ExceptionCreate(BaseModel):
+    rule_id: str
+    org_id: str
+    subject_type: str
+    subject_id: str
+    reason: str
+    requested_by: str
+    valid_until: Optional[datetime] = None
+
+
+class ExceptionResponse(BaseModel):
+    id: str
+    status: str
+    duplicate: bool
+    valid_until: Optional[str]
+
+
+@router.post("/", response_model=ExceptionResponse)
+async def create_exception_endpoint(payload: ExceptionCreate) -> Dict[str, Any]:
+    record, duplicate = create_exception(
+        _CONN,
+        rule_id=payload.rule_id,
+        org_id=payload.org_id,
+        subject_type=payload.subject_type,
+        subject_id=payload.subject_id,
+        reason=payload.reason,
+        requested_by=payload.requested_by,
+        valid_until=payload.valid_until,
+    )
+    if not record:
+        raise HTTPException(status_code=500, detail="failed to persist exception")
+
+    card = approval_card(
+        payload.rule_id,
+        payload.org_id,
+        payload.subject_type,
+        payload.subject_id,
+        payload.reason,
+        record.get("valid_until"),
+        record["id"],
+        payload.requested_by,
+    )
+    if duplicate:
+        prepend_duplicate_notice(card)
+    _post_slack(card)
+
+    return {
+        "id": record["id"],
+        "status": record["status"],
+        "duplicate": duplicate,
+        "valid_until": record.get("valid_until"),
+    }
+
+
+@router.get("/{exc_id}")
+async def get_exception_endpoint(exc_id: str) -> Dict[str, Any]:
+    record = get_exception(_CONN, exc_id)
+    if not record:
+        raise HTTPException(status_code=404, detail="not_found")
+    return record
+
+
+def _parse_datetime(value: str | None) -> Optional[datetime]:
+    if not value:
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    return datetime.fromisoformat(text)
+
+
+@router.post("/{exc_id}/approve")
+async def approve_endpoint(exc_id: str, request: Request) -> Dict[str, Any]:
+    form = await request.form()
+    actor = form.get("actor")
+    valid_until = _parse_datetime(form.get("valid_until"))
+    record = approve_exception(
+        _CONN,
+        exc_id,
+        actor=actor,
+        valid_until=valid_until,
+        slack_user_id=form.get("slack_user_id"),
+        message_ts=form.get("message_ts"),
+        button=form.get("button"),
+    )
+    if not record:
+        raise HTTPException(status_code=404, detail="not_found")
+    _post_owner_update(record, "approved")
+    return record
+
+
+@router.post("/{exc_id}/deny")
+async def deny_endpoint(exc_id: str, request: Request) -> Dict[str, Any]:
+    form = await request.form()
+    actor = form.get("actor")
+    record = deny_exception(
+        _CONN,
+        exc_id,
+        actor=actor,
+        reason=form.get("reason"),
+        slack_user_id=form.get("slack_user_id"),
+        message_ts=form.get("message_ts"),
+        button=form.get("button"),
+    )
+    if not record:
+        raise HTTPException(status_code=404, detail="not_found")
+    _post_owner_update(record, "denied")
+    return record
+
+
+def _post_slack(card: Dict[str, Any]) -> None:
+    token = os.getenv("SLACK_BOT_TOKEN")
+    channel = os.getenv("SECOPS_CHANNEL")
+    if not token or not channel:
+        return
+    body = dict(card)
+    body["channel"] = channel
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json; charset=utf-8",
+    }
+    try:
+        resp = requests.post("https://slack.com/api/chat.postMessage", json=body, headers=headers, timeout=5)
+        resp.raise_for_status()
+    except Exception:  # pragma: no cover - network best effort
+        pass
+
+
+def _post_owner_update(record: Dict[str, Any], decision: str) -> None:
+    token = os.getenv("SLACK_BOT_TOKEN")
+    channel = os.getenv("SECOPS_CHANNEL")
+    if not token or not channel:
+        return
+    try:
+        spec = load_rule(record["rule_id"])
+    except KeyError:  # pragma: no cover - defensive
+        return
+    owners = ", ".join(spec.owners) if spec.owners else "owners"
+    text = (
+        f":bell: Exception `{record['id']}` for rule `{record['rule_id']}` was {decision}"
+        f" by *{record.get('decided_by') or 'unknown'}*."
+        f" Notifying {owners}."
+    )
+    body = {"channel": channel, "text": text}
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json; charset=utf-8",
+    }
+    try:
+        requests.post("https://slack.com/api/chat.postMessage", json=body, headers=headers, timeout=5)
+    except Exception:  # pragma: no cover - best effort
+        pass

--- a/policy/exceptions/__init__.py
+++ b/policy/exceptions/__init__.py
@@ -1,0 +1,32 @@
+"""Policy exception helpers for duplicate detection and Slack flows."""
+
+from .db import (
+    ensure_schema,
+    create_exception,
+    get_exception,
+    approve_exception,
+    deny_exception,
+)
+from .slack import (
+    approval_card,
+    prepend_duplicate_notice,
+    encode_ctx,
+    format_owners_line,
+)
+from .responses import build_policy_violation_error
+from .specs import RuleSpec, load_rule
+
+__all__ = [
+    "ensure_schema",
+    "create_exception",
+    "get_exception",
+    "approve_exception",
+    "deny_exception",
+    "approval_card",
+    "prepend_duplicate_notice",
+    "encode_ctx",
+    "format_owners_line",
+    "build_policy_violation_error",
+    "RuleSpec",
+    "load_rule",
+]

--- a/policy/exceptions/db.py
+++ b/policy/exceptions/db.py
@@ -1,0 +1,321 @@
+"""SQLite helpers for policy exceptions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import json
+import sqlite3
+import uuid
+from typing import Any, Dict, Optional, Tuple
+
+OPEN_STATUSES = ("pending", "approved")
+
+
+@dataclass
+class ExceptionRecord:
+    """Row representation returned by helpers."""
+
+    id: str
+    rule_id: str
+    org_id: str
+    subject_type: str
+    subject_id: str
+    status: str
+    reason: str | None
+    requested_by: str | None
+    valid_until: str | None
+    decided_by: str | None
+    decided_at: str | None
+    created_at: str
+    updated_at: str
+
+    @classmethod
+    def from_row(cls, row: sqlite3.Row) -> "ExceptionRecord":
+        return cls(
+            id=row["id"],
+            rule_id=row["rule_id"],
+            org_id=row["org_id"],
+            subject_type=row["subject_type"],
+            subject_id=row["subject_id"],
+            status=row["status"],
+            reason=row["reason"],
+            requested_by=row["requested_by"],
+            valid_until=row["valid_until"],
+            decided_by=row["decided_by"],
+            decided_at=row["decided_at"],
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "rule_id": self.rule_id,
+            "org_id": self.org_id,
+            "subject_type": self.subject_type,
+            "subject_id": self.subject_id,
+            "status": self.status,
+            "reason": self.reason,
+            "requested_by": self.requested_by,
+            "valid_until": self.valid_until,
+            "decided_by": self.decided_by,
+            "decided_at": self.decided_at,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+
+
+def ensure_schema(conn: sqlite3.Connection) -> None:
+    """Create the ``exceptions`` tables and triggers if missing."""
+
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS exceptions (
+            id TEXT PRIMARY KEY,
+            rule_id TEXT NOT NULL,
+            org_id TEXT NOT NULL,
+            subject_type TEXT NOT NULL,
+            subject_id TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'pending',
+            reason TEXT,
+            requested_by TEXT,
+            valid_until TEXT,
+            decided_by TEXT,
+            decided_at TEXT,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_exceptions_lookup
+            ON exceptions (rule_id, org_id, subject_type, subject_id);
+
+        CREATE TRIGGER IF NOT EXISTS exceptions_no_dupe
+        BEFORE INSERT ON exceptions
+        FOR EACH ROW
+        BEGIN
+          SELECT
+            CASE
+              WHEN EXISTS (
+                SELECT 1 FROM exceptions
+                WHERE rule_id = NEW.rule_id
+                  AND org_id = NEW.org_id
+                  AND subject_type = NEW.subject_type
+                  AND subject_id = NEW.subject_id
+                  AND status IN ('pending', 'approved')
+              )
+              THEN RAISE(ABORT, 'duplicate open exception')
+            END;
+        END;
+
+        CREATE TABLE IF NOT EXISTS exception_audit (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            exception_id TEXT NOT NULL,
+            event TEXT NOT NULL,
+            actor TEXT,
+            slack_user_id TEXT,
+            message_ts TEXT,
+            details TEXT,
+            created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_exception_audit_exception
+            ON exception_audit (exception_id);
+        """
+    )
+    conn.commit()
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _to_iso(value: Optional[datetime]) -> Optional[str]:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _row_to_record(row: sqlite3.Row | None) -> Optional[ExceptionRecord]:
+    if row is None:
+        return None
+    return ExceptionRecord.from_row(row)
+
+
+def get_exception(conn: sqlite3.Connection, exc_id: str) -> Optional[Dict[str, Any]]:
+    row = conn.execute(
+        "SELECT * FROM exceptions WHERE id = ?",
+        (exc_id,),
+    ).fetchone()
+    record = _row_to_record(row)
+    return record.to_dict() if record else None
+
+
+def _fetch_existing(
+    conn: sqlite3.Connection,
+    rule_id: str,
+    org_id: str,
+    subject_type: str,
+    subject_id: str,
+) -> Optional[ExceptionRecord]:
+    row = conn.execute(
+        """
+        SELECT * FROM exceptions
+        WHERE rule_id = ? AND org_id = ? AND subject_type = ? AND subject_id = ?
+          AND status IN ('pending', 'approved')
+        ORDER BY datetime(updated_at) DESC
+        LIMIT 1
+        """,
+        (rule_id, org_id, subject_type, subject_id),
+    ).fetchone()
+    return _row_to_record(row)
+
+
+def create_exception(
+    conn: sqlite3.Connection,
+    *,
+    rule_id: str,
+    org_id: str,
+    subject_type: str,
+    subject_id: str,
+    reason: str | None = None,
+    requested_by: str | None = None,
+    valid_until: Optional[datetime] = None,
+) -> Tuple[Dict[str, Any], bool]:
+    """Insert an exception row and return (record, duplicate)."""
+
+    exc_id = uuid.uuid4().hex
+    now = _utc_now()
+    valid_until_iso = _to_iso(valid_until)
+    try:
+        conn.execute(
+            """
+            INSERT INTO exceptions (
+                id, rule_id, org_id, subject_type, subject_id,
+                status, reason, requested_by, valid_until, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?, ?)
+            """,
+            (
+                exc_id,
+                rule_id,
+                org_id,
+                subject_type,
+                subject_id,
+                reason,
+                requested_by,
+                valid_until_iso,
+                now,
+                now,
+            ),
+        )
+        conn.commit()
+        record = get_exception(conn, exc_id)
+        return record or {}, False
+    except sqlite3.IntegrityError as exc:
+        conn.rollback()
+        if "duplicate open exception" not in str(exc).lower():
+            raise
+        existing = _fetch_existing(conn, rule_id, org_id, subject_type, subject_id)
+        if not existing:
+            raise
+        return existing.to_dict(), True
+
+
+def _log_audit(
+    conn: sqlite3.Connection,
+    *,
+    exception_id: str,
+    event: str,
+    actor: str | None = None,
+    slack_user_id: str | None = None,
+    message_ts: str | None = None,
+    details: Optional[Dict[str, Any]] = None,
+) -> None:
+    payload = json.dumps(details or {}, separators=(",", ":"))
+    conn.execute(
+        """
+        INSERT INTO exception_audit (
+            exception_id, event, actor, slack_user_id, message_ts, details
+        ) VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (exception_id, event, actor, slack_user_id, message_ts, payload),
+    )
+
+
+def approve_exception(
+    conn: sqlite3.Connection,
+    exc_id: str,
+    *,
+    actor: str | None = None,
+    valid_until: Optional[datetime] = None,
+    slack_user_id: str | None = None,
+    message_ts: str | None = None,
+    button: str | None = None,
+) -> Optional[Dict[str, Any]]:
+    valid_until_iso = _to_iso(valid_until)
+    stamp = _utc_now()
+    conn.execute(
+        """
+        UPDATE exceptions
+        SET status = 'approved',
+            valid_until = COALESCE(?, valid_until),
+            decided_by = ?,
+            decided_at = ?,
+            updated_at = ?
+        WHERE id = ?
+        """,
+        (valid_until_iso, actor, stamp, stamp, exc_id),
+    )
+    record = get_exception(conn, exc_id)
+    if record:
+        _log_audit(
+            conn,
+            exception_id=exc_id,
+            event="approve",
+            actor=actor,
+            slack_user_id=slack_user_id,
+            message_ts=message_ts,
+            details={"button": button, "valid_until": valid_until_iso},
+        )
+        conn.commit()
+    return record
+
+
+def deny_exception(
+    conn: sqlite3.Connection,
+    exc_id: str,
+    *,
+    actor: str | None = None,
+    reason: str | None = None,
+    slack_user_id: str | None = None,
+    message_ts: str | None = None,
+    button: str | None = None,
+) -> Optional[Dict[str, Any]]:
+    stamp = _utc_now()
+    conn.execute(
+        """
+        UPDATE exceptions
+        SET status = 'denied',
+            decided_by = ?,
+            decided_at = ?,
+            reason = COALESCE(?, reason),
+            updated_at = ?
+        WHERE id = ?
+        """,
+        (actor, stamp, reason, stamp, exc_id),
+    )
+    record = get_exception(conn, exc_id)
+    if record:
+        _log_audit(
+            conn,
+            exception_id=exc_id,
+            event="deny",
+            actor=actor,
+            slack_user_id=slack_user_id,
+            message_ts=message_ts,
+            details={"button": button, "reason": reason},
+        )
+        conn.commit()
+    return record

--- a/policy/exceptions/responses.py
+++ b/policy/exceptions/responses.py
@@ -1,0 +1,44 @@
+"""Helpers for shaping policy violation responses."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from .specs import RuleSpec, load_rule
+
+
+def _escape_reason(reason: str) -> str:
+    return reason.replace("\"", "\\\"")
+
+
+def build_policy_violation_error(
+    *,
+    rule_id: str,
+    reason: str,
+    message: str,
+    subject_type: str,
+    subject_id: str,
+    org_id: str,
+) -> Dict[str, object]:
+    """Construct a rich error payload with exception hint metadata."""
+
+    spec: RuleSpec = load_rule(rule_id)
+    hint_reason = _escape_reason(reason)
+    hint = (
+        f"/exception rule={rule_id} "
+        f"subject={subject_type}:{subject_id} org={org_id} "
+        f'reason="{hint_reason}"'
+    )
+    owners = list(spec.owners)
+    payload: Dict[str, object] = {
+        "error": {
+            "code": "policy_violation",
+            "rule_id": rule_id,
+            "reason": reason,
+            "message": message,
+            "docs_url": spec.docs_url,
+            "owners": owners,
+            "request_exception_hint": hint,
+        }
+    }
+    return payload

--- a/policy/exceptions/slack.py
+++ b/policy/exceptions/slack.py
@@ -1,0 +1,120 @@
+"""Slack card helpers for approval flows."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Iterable
+
+from .specs import RuleSpec, load_rule
+
+
+def format_owners_line(owners: Iterable[str]) -> str:
+    owners = [owner for owner in (o.strip() for o in owners) if owner]
+    if not owners:
+        return "*Owners:* _unassigned_"
+    return "*Owners:* " + ", ".join(owners)
+
+
+def section(text: str) -> dict[str, Any]:
+    return {
+        "type": "section",
+        "text": {"type": "mrkdwn", "text": text},
+    }
+
+
+def button(label: str, style: str, action_id: str, value: str) -> dict[str, Any]:
+    return {
+        "type": "button",
+        "text": {"type": "plain_text", "text": label},
+        "style": style,
+        "action_id": action_id,
+        "value": value,
+    }
+
+
+def encode_ctx(exc_id: str, rule: str, org: str, subject_type: str, subject_id: str, hours: str) -> str:
+    payload = {
+        "exc_id": exc_id,
+        "rule_id": rule,
+        "org_id": org,
+        "subject_type": subject_type,
+        "subject_id": subject_id,
+        "hours": hours,
+    }
+    return json.dumps(payload)
+
+
+def _fallback(value: str | None, default: str) -> str:
+    value = (value or "").strip()
+    return value if value else default
+
+
+def approval_card(
+    rule_id: str,
+    org_id: str,
+    subject_type: str,
+    subject_id: str,
+    reason: str,
+    until: str | None,
+    exc_id: str,
+    requested_by: str,
+) -> dict[str, Any]:
+    spec: RuleSpec = load_rule(rule_id)
+    owners_line = format_owners_line(spec.owners)
+    header = {
+        "type": "header",
+        "text": {"type": "plain_text", "text": "Exception request"},
+    }
+    kvs = (
+        f"*Rule:* `{rule_id}`\n"
+        f"*Subject:* `{subject_type}:{subject_id}`\n"
+        f"*Org:* `{org_id}`\n"
+        f"*Until:* `{_fallback(until, '(none)')}`\n"
+        f"*Requested by:* `{requested_by}`"
+    )
+    section_top = section(kvs)
+    section_reason = section(f"*Reason:*\n{reason}")
+    context_elements = [
+        {"type": "mrkdwn", "text": owners_line},
+    ]
+    if spec.docs_url:
+        context_elements.append({"type": "mrkdwn", "text": f"<{spec.docs_url}|Docs>"})
+    context_elements.append({"type": "mrkdwn", "text": f"*ID:* `{exc_id}`"})
+    context = {"type": "context", "elements": context_elements}
+    actions = {
+        "type": "actions",
+        "elements": [
+            button(
+                "Approve 24h",
+                "primary",
+                "approve",
+                encode_ctx(exc_id, rule_id, org_id, subject_type, subject_id, "24"),
+            ),
+            button(
+                "Approve 72h",
+                "primary",
+                "approve72",
+                encode_ctx(exc_id, rule_id, org_id, subject_type, subject_id, "72"),
+            ),
+            button(
+                "Deny",
+                "danger",
+                "deny",
+                encode_ctx(exc_id, rule_id, org_id, subject_type, subject_id, ""),
+            ),
+        ],
+    }
+    return {
+        "blocks": [header, section_top, section_reason, context, actions],
+    }
+
+
+def prepend_duplicate_notice(card: dict[str, Any]) -> None:
+    """Insert a warning section when a duplicate was encountered."""
+
+    warning = section(":warning: Existing open exception found; re-using it.")
+    blocks = card.get("blocks")
+    if isinstance(blocks, list):
+        card["blocks"] = [warning, *blocks]
+    else:  # pragma: no cover - defensive
+        card["blocks"] = [warning]

--- a/policy/exceptions/specs.py
+++ b/policy/exceptions/specs.py
@@ -1,0 +1,62 @@
+"""Rule specification loader used by the exception service."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict, Iterable
+
+import yaml
+
+
+@dataclass(frozen=True)
+class RuleSpec:
+    """Metadata surfaced alongside policy violations."""
+
+    rule_id: str
+    name: str
+    owners: tuple[str, ...]
+    docs_url: str | None
+
+
+def _rules_dir() -> Path:
+    return Path(__file__).resolve().parents[2] / "rules"
+
+
+@lru_cache()
+def _load_all() -> Dict[str, RuleSpec]:
+    specs: Dict[str, RuleSpec] = {}
+    for path in sorted(_rules_dir().glob("*.yaml")):
+        payload = yaml.safe_load(path.read_text())
+        if not isinstance(payload, dict):
+            continue
+        rule_id = str(payload.get("id", "")).strip()
+        if not rule_id:
+            continue
+        name = str(payload.get("name") or rule_id)
+        owners = tuple(str(owner).strip() for owner in payload.get("owners", []) if str(owner).strip())
+        docs_url = payload.get("docs_url")
+        if docs_url is not None:
+            docs_url = str(docs_url)
+        specs[rule_id] = RuleSpec(rule_id, name, owners, docs_url)
+    return specs
+
+
+def all_specs() -> Iterable[RuleSpec]:
+    """Return all loaded rule specs."""
+
+    return _load_all().values()
+
+
+def load_rule(rule_id: str) -> RuleSpec:
+    """Lookup ``rule_id`` returning a :class:`RuleSpec`.
+
+    Raises ``KeyError`` if the rule cannot be located.
+    """
+
+    specs = _load_all()
+    try:
+        return specs[rule_id]
+    except KeyError as exc:  # pragma: no cover - sanity guard
+        raise KeyError(f"unknown rule_id: {rule_id}") from exc

--- a/policy/rules_engine/rule.py
+++ b/policy/rules_engine/rule.py
@@ -49,6 +49,9 @@ class Rule:
         severity = payload.get("severity", "low")
         block_on_error = bool(payload.get("block_on_error", False))
         metadata = dict(payload.get("metadata", {}))
+        for key in ("name", "owners", "docs_url"):
+            if key in payload and key not in metadata:
+                metadata[key] = payload[key]
         return cls(rule_id, expr, mode=mode, severity=severity, block_on_error=block_on_error, metadata=metadata)
 
     def evaluate(self, event: Mapping[str, Any], ctx: EvaluationContext) -> RuleEvaluationResult:
@@ -58,10 +61,28 @@ class Rule:
             outcome = bool(self._evaluator.evaluate(event, ctx))
         except Exception as exc:
             details = ctx.to_details()
-            details.setdefault("rule", {"id": self.id, "mode": self.mode.value, "severity": self.severity})
+            rule_details = details.setdefault(
+                "rule", {"id": self.id, "mode": self.mode.value, "severity": self.severity}
+            )
+            if isinstance(self.metadata, dict):
+                if "name" in self.metadata:
+                    rule_details.setdefault("name", self.metadata["name"])
+                if "owners" in self.metadata:
+                    rule_details.setdefault("owners", self.metadata["owners"])
+                if "docs_url" in self.metadata:
+                    rule_details.setdefault("docs_url", self.metadata["docs_url"])
             return RuleEvaluationResult(False, details, error=exc)
         details = ctx.to_details()
-        details.setdefault("rule", {"id": self.id, "mode": self.mode.value, "severity": self.severity})
+        rule_details = details.setdefault(
+            "rule", {"id": self.id, "mode": self.mode.value, "severity": self.severity}
+        )
+        if isinstance(self.metadata, dict):
+            if "name" in self.metadata:
+                rule_details.setdefault("name", self.metadata["name"])
+            if "owners" in self.metadata:
+                rule_details.setdefault("owners", self.metadata["owners"])
+            if "docs_url" in self.metadata:
+                rule_details.setdefault("docs_url", self.metadata["docs_url"])
         return RuleEvaluationResult(outcome, details)
 
 

--- a/rules/consent_friction_spike.yaml
+++ b/rules/consent_friction_spike.yaml
@@ -1,6 +1,11 @@
 id: CONSENT_FRICTION_SPIKE
+name: Consent friction spike monitor
 mode: observe
 severity: medium
+owners:
+  - "@trust-safety"
+  - "ts@company.com"
+docs_url: https://your.docs/policies/consent_friction_spike
 metadata:
   description: Detect consent-required deny spikes to reduce operator load.
 expr: rate(deny_reason == "consent_required", "15m") > 0.15

--- a/rules/mirror_class_limit.yaml
+++ b/rules/mirror_class_limit.yaml
@@ -1,7 +1,12 @@
 id: MIRROR_CLASS_LIMIT
+name: Mirror classification guardrail
 mode: enforce
 severity: high
 block_on_error: true
+owners:
+  - "@oncall-security"
+  - "security@company.com"
+docs_url: https://your.docs/policies/mirror_class_limit
 metadata:
   runbook: docs/runbooks/mirror_class_limit.md
   summary: Block mirrors on restricted or secret repositories.

--- a/rules/multi_provider_single_role.yaml
+++ b/rules/multi_provider_single_role.yaml
@@ -1,7 +1,12 @@
 id: MULTI_PROVIDER_SINGLE_ROLE
+name: Multi-provider fan-out limiter
 mode: enforce
 severity: medium
 block_on_error: true
+owners:
+  - "@secops-automation"
+  - "automation@company.com"
+docs_url: https://your.docs/policies/multi_provider_single_role
 metadata:
   product: Mirror Guard
   description: Block low-privilege users from fanning out mirrors across providers.

--- a/rules/policy_drift_regression.yaml
+++ b/rules/policy_drift_regression.yaml
@@ -1,6 +1,11 @@
 id: POLICY_DRIFT_REGRESSION
+name: Policy drift regression detector
 mode: observe
 severity: medium
+owners:
+  - "@policy-engineering"
+  - "policy@company.com"
+docs_url: https://your.docs/policies/policy_drift_regression
 metadata:
   product: Mirror Guard
   description: Compare deny rate to baseline after recent policy change.

--- a/rules/secret_expiry_cluster.yaml
+++ b/rules/secret_expiry_cluster.yaml
@@ -1,6 +1,11 @@
 id: SECRET_EXPIRY_CLUSTER
+name: Secret expiry clustering
 mode: observe
 severity: high
+owners:
+  - "@platform-secrets"
+  - "secrets@company.com"
+docs_url: https://your.docs/policies/secret_expiry_cluster
 metadata:
   product: Secret Hygiene
   description: Cluster secret-expired errors to trigger automated rotation.

--- a/tests/test_exceptions_db.py
+++ b/tests/test_exceptions_db.py
@@ -1,0 +1,87 @@
+from datetime import datetime, timedelta, timezone
+import sqlite3
+
+from policy.exceptions import (
+    approve_exception,
+    create_exception,
+    deny_exception,
+    ensure_schema,
+    get_exception,
+)
+
+
+def _conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    ensure_schema(conn)
+    return conn
+
+
+def test_duplicate_exception_returns_existing_id():
+    conn = _conn()
+    first, dup = create_exception(
+        conn,
+        rule_id="MIRROR_CLASS_LIMIT",
+        org_id="acme",
+        subject_type="repo",
+        subject_id="acme/web",
+        reason="Need to sync overnight",
+        requested_by="alice",
+    )
+    assert dup is False
+    second, dup2 = create_exception(
+        conn,
+        rule_id="MIRROR_CLASS_LIMIT",
+        org_id="acme",
+        subject_type="repo",
+        subject_id="acme/web",
+        reason="retry",
+        requested_by="alice",
+    )
+    assert dup2 is True
+    assert second["id"] == first["id"]
+
+
+def test_approve_and_deny_update_status():
+    conn = _conn()
+    record, _ = create_exception(
+        conn,
+        rule_id="MIRROR_CLASS_LIMIT",
+        org_id="acme",
+        subject_type="repo",
+        subject_id="acme/api",
+        reason="Investigating",
+        requested_by="bob",
+    )
+    exc_id = record["id"]
+    until = datetime.now(timezone.utc) + timedelta(hours=24)
+    approved = approve_exception(
+        conn,
+        exc_id,
+        actor="approver",
+        valid_until=until,
+        slack_user_id="U123",
+        message_ts="1700000000.0",
+        button="approve24",
+    )
+    assert approved is not None
+    assert approved["status"] == "approved"
+    assert approved["decided_by"] == "approver"
+    assert approved["valid_until"] is not None
+
+    denied = deny_exception(
+        conn,
+        exc_id,
+        actor="approver",
+        reason="expired",
+        slack_user_id="U123",
+        message_ts="1700000001.0",
+        button="deny",
+    )
+    assert denied is not None
+    assert denied["status"] == "denied"
+    assert denied["reason"] == "expired"
+
+    final = get_exception(conn, exc_id)
+    assert final is not None
+    assert final["status"] == "denied"

--- a/tests/test_exceptions_slack.py
+++ b/tests/test_exceptions_slack.py
@@ -1,0 +1,40 @@
+from policy.exceptions.slack import approval_card, prepend_duplicate_notice
+
+
+def test_approval_card_includes_metadata():
+    card = approval_card(
+        rule_id="MIRROR_CLASS_LIMIT",
+        org_id="acme",
+        subject_type="repo",
+        subject_id="acme/web",
+        reason="Urgent hotfix",
+        until="2025-02-01T00:00:00Z",
+        exc_id="exc123",
+        requested_by="alice",
+    )
+    blocks = card["blocks"]
+    assert blocks[0]["text"]["text"] == "Exception request"
+    context = blocks[3]
+    elements = context["elements"]
+    owners_entry = elements[0]["text"]
+    assert owners_entry.startswith("*Owners:* ")
+    docs_entry = next(e for e in elements if "Docs" in e.get("text", ""))
+    assert "mirror_class_limit" in docs_entry["text"]
+    id_entry = next(e for e in elements if "*ID:*" in e.get("text", ""))
+    assert "exc123" in id_entry["text"]
+
+
+def test_prepend_duplicate_notice_adds_warning_block():
+    card = approval_card(
+        rule_id="MIRROR_CLASS_LIMIT",
+        org_id="acme",
+        subject_type="repo",
+        subject_id="acme/web",
+        reason="duplicate",
+        until=None,
+        exc_id="exc123",
+        requested_by="alice",
+    )
+    prepend_duplicate_notice(card)
+    first_block = card["blocks"][0]
+    assert first_block["text"]["text"].startswith(":warning:")

--- a/tests/test_policy_violation_response.py
+++ b/tests/test_policy_violation_response.py
@@ -1,0 +1,20 @@
+from policy.exceptions.responses import build_policy_violation_error
+
+
+def test_policy_violation_payload_contains_hint_and_metadata():
+    payload = build_policy_violation_error(
+        rule_id="MIRROR_CLASS_LIMIT",
+        reason="classification_block",
+        message="Mirroring blocked for non-public repository.",
+        subject_type="repo",
+        subject_id="acme/web",
+        org_id="acme",
+    )
+    error = payload["error"]
+    assert error["rule_id"] == "MIRROR_CLASS_LIMIT"
+    assert error["docs_url"].endswith("mirror_class_limit")
+    assert error["owners"]
+    hint = error["request_exception_hint"]
+    assert hint.startswith("/exception rule=MIRROR_CLASS_LIMIT")
+    assert "subject=repo:acme/web" in hint
+    assert 'reason="classification_block"' in hint


### PR DESCRIPTION
## Summary
- add FastAPI endpoints for exception requests with duplicate detection, Slack notifications, and approval actions
- factor shared exception helpers for SQLite persistence, Slack cards, and policy violation responses
- enrich rule definitions with owner and docs metadata and cover flows with new unit tests

## Testing
- `pytest` *(fails: requires optional dependencies such as blackroad_agent, torch, sympy, matplotlib, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68e1932cbae483299c5b7c7f2e8f6d60