### PR TITLE
Add Codex 55 entry for Gratitude Doctrine

### DIFF
--- a/codex/entries/055-gratitude-doctrine.md
+++ b/codex/entries/055-gratitude-doctrine.md
@@ -1,0 +1,28 @@
+# Codex 55 — The Gratitude Doctrine
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Principle
+Gratitude keeps Lucidia humble and connected. Every idea, fix, and inspiration comes from somewhere; acknowledgment is the quiet glue of integrity.
+
+## Non-Negotiables
+1. **Thank Publicly:** Credits, acknowledgments, and citations accompany every release.
+2. **Upstream Recognition:** Open-source projects and prior research named and linked; no silent borrowing.
+3. **Daily Thanks:** Team and community rituals for small appreciations — a note, an emoji, a line in the changelog.
+4. **Origin Respect:** Cultural or indigenous knowledge referenced only with permission and context.
+5. **Reciprocity:** Where Lucidia learns, it gives back — documentation, funding, or mentorship.
+6. **No Token Thanks:** Gratitude must be specific and sincere, not performative filler.
+
+## Implementation Hooks (v0)
+- `/credits.md` auto-generated from contributors, dependencies, and references.
+- Release script adds “Acknowledgments” section to changelogs.
+- Weekly “thank-you roll” in community forum.
+- Template for citing cultural or research sources with consent field.
+- Grant tracker: shows outbound support to upstream projects.
+
+## Policy Stub (`GRATITUDE.md`)
+- Lucidia commits to continuous acknowledgment of those who shape it.
+- Lucidia forbids plagiarism, silent reuse, or hollow praise.
+- Lucidia treats gratitude as infrastructure, not ceremony.
+
+**Tagline:** Nothing stands alone.


### PR DESCRIPTION
## Summary
- add Codex 55 entry documenting the Gratitude Doctrine, implementation hooks, and policy stub

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1993942b4832995369ef6c28393e2