### PR TITLE
Enable CODEx comment fixes to auto-merge pull requests

### DIFF
--- a/agents/pr_autopilot.py
+++ b/agents/pr_autopilot.py
@@ -75,28 +75,74 @@ class AutomatedPullRequestManager:
         payload = {"reviewers": [self.default_reviewer]}
         requests.post(url, json=payload, headers=headers, timeout=10)
 
-    def handle_trigger(self, phrase: str) -> None:
+    def handle_trigger(
+        self,
+        phrase: str,
+        pr_number: Optional[int] = None,
+        branch_name: Optional[str] = None,
+    ) -> None:
         """Respond to CODEx trigger phrases and run the matching action."""
+
         phrase_lower = phrase.lower()
+
         if "fix comments" in phrase_lower:
-            self.apply_comment_fixes()
+            self.apply_comment_fixes(pr_number=pr_number, branch_name=branch_name)
         elif "summarize" in phrase_lower:
             self.log("Summarizing PR (placeholder)")
+        elif "merge" in phrase_lower and pr_number is not None:
+            self.enable_auto_merge(pr_number)
         elif "merge" in phrase_lower:
-            self.log("Merging PR (placeholder)")
+            self.log("Merge trigger received but no PR number supplied; skipping.")
 
-    def apply_comment_fixes(self) -> None:
+    def apply_comment_fixes(
+        self,
+        pr_number: Optional[int] = None,
+        branch_name: Optional[str] = None,
+    ) -> None:
         """Execute the CODEx comment fixer script to update code comments."""
+
         repo_root = Path(__file__).resolve().parents[1]
+
+        if branch_name:
+            try:
+                subprocess.run(
+                    ["git", "checkout", branch_name],
+                    check=True,
+                    cwd=repo_root,
+                )
+            except (OSError, subprocess.CalledProcessError) as exc:
+                self.log(f"Unable to checkout branch {branch_name!r}: {exc}")
+                return
+
         try:
             subprocess.run(
-                ["node", ".github/tools/codex-apply.js", ".github/prompts/codex-fix-comments.md"],
+                [
+                    "node",
+                    ".github/tools/codex-apply.js",
+                    ".github/prompts/codex-fix-comments.md",
+                ],
                 check=True,
                 cwd=repo_root,
             )
             self.log("Applied comment fixes")
         except (OSError, subprocess.CalledProcessError) as exc:
             self.log(f"Failed to apply comment fixes: {exc}")
+            return
+
+        if branch_name and self._has_uncommitted_changes(repo_root):
+            if not self._commit_with_message(
+                repo_root,
+                branch_name,
+                "chore: apply codex comment fixes",
+            ):
+                return
+
+        if pr_number is not None:
+            self._comment_on_pr(pr_number, "Comment fixes applied :sparkles:")
+
+        if branch_name and pr_number is not None:
+            self.auto_enhance_pull_request(pr_number, branch_name)
+            self.enable_auto_merge(pr_number)
 
     def log(self, message: str) -> None:
         """Write a message to the log file."""
@@ -179,6 +225,29 @@ class AutomatedPullRequestManager:
             self.log(f"Failed to commit/push auto-fix iteration {iteration}: {exc}")
             return False
 
+    def _commit_with_message(
+        self, repo_root: Path, branch_name: str, message: str
+    ) -> bool:
+        try:
+            subprocess.run(["git", "add", "-A"], cwd=repo_root, check=True)
+            if not self._has_uncommitted_changes(repo_root):
+                self.log("No changes detected after applying fixes; nothing to commit.")
+                return False
+            subprocess.run(
+                ["git", "commit", "-m", message],
+                cwd=repo_root,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "push", "origin", branch_name],
+                cwd=repo_root,
+                check=True,
+            )
+            return True
+        except subprocess.CalledProcessError as exc:
+            self.log(f"Failed to commit/push comment fixes: {exc}")
+            return False
+
     def _comment_on_pr(self, pr_number: int, message: str) -> None:
         if not self.token:
             self.log("Skipping PR comment because no token is configured.")
@@ -199,6 +268,59 @@ class AutomatedPullRequestManager:
             response.raise_for_status()
         except requests.RequestException as exc:
             self.log(f"Failed to post auto-fix comment to PR #{pr_number}: {exc}")
+
+    def enable_auto_merge(self, pr_number: int, merge_method: str = "SQUASH") -> None:
+        """Enable GitHub auto-merge for the given pull request."""
+
+        if not self.token:
+            self.log("Skipping auto-merge enablement because no token is configured.")
+            return
+
+        node_id = self._get_pr_node_id(pr_number)
+        if not node_id:
+            self.log(f"Unable to determine node id for PR #{pr_number}; cannot enable auto-merge.")
+            return
+
+        method = merge_method.upper()
+        query = (
+            "mutation($pr:ID!,$method:PullRequestMergeMethod!)"
+            "{ enablePullRequestAutoMerge("
+            "input:{pullRequestId:$pr, mergeMethod:$method})"
+            "{ clientMutationId }}"
+        )
+        payload = {"query": query, "variables": {"pr": node_id, "method": method}}
+        headers = {
+            "Authorization": f"token {self.token}",
+            "Accept": "application/vnd.github+json",
+        }
+        try:
+            response = requests.post(
+                "https://api.github.com/graphql",
+                json=payload,
+                headers=headers,
+                timeout=10,
+            )
+            response.raise_for_status()
+            self.log(f"Enabled auto-merge for PR #{pr_number}")
+        except requests.RequestException as exc:
+            self.log(f"Failed to enable auto-merge for PR #{pr_number}: {exc}")
+
+    def _get_pr_node_id(self, pr_number: int) -> Optional[str]:
+        if not self.token:
+            return None
+
+        url = f"https://api.github.com/repos/{self.repo}/pulls/{pr_number}"
+        headers = {
+            "Authorization": f"token {self.token}",
+            "Accept": "application/vnd.github+json",
+        }
+        try:
+            response = requests.get(url, headers=headers, timeout=10)
+            response.raise_for_status()
+            return response.json().get("node_id")
+        except requests.RequestException as exc:
+            self.log(f"Failed to fetch PR #{pr_number} metadata: {exc}")
+            return None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- update the PR autopilot to accept PR numbers and branch names when handling @codex triggers
- automatically commit and push comment fixes before running iterative auto-fix passes
- enable GitHub auto-merge after fixes or explicit merge commands when credentials are available

## Testing
- python -m py_compile *.py
- python auto_novel_agent.py

------
https://chatgpt.com/codex/tasks/task_e_68e198ae0f848329964d0311157a8e66