### PR TITLE
Add Signal Commons Station embodiment plan entry

### DIFF
--- a/codex/entries/047-signal-commons-station.md
+++ b/codex/entries/047-signal-commons-station.md
@@ -1,0 +1,25 @@
+# Signal Commons Station – Embodiment Plan
+
+The loudest hum in the codex right now is the **Signal Commons Station**: a table-top kit that lets neighborhood stewards surface live signals about wellbeing, resource flows, and emerging needs—and feed them back into the BlackRoad codex.
+
+## 1. Anchor Module
+- **Tomorrow's build**: reconfigure the existing Prism Console dashboard template to accept manual inputs from a shared Google Sheet, using the already-installed LocalStack mock services for quick iteration.
+- **On the desk**: reuse the Raspberry Pi telemetry nodes from the resilience lab to log ambient data (temperature, air quality, foot traffic) and push CSV exports into the sheet twice daily.
+- **Immediate ritual**: print the "pulse cards" template, tape them to the console, and have the steward jot one qualitative observation per check-in alongside the metrics.
+
+## 2. Field Constellation
+- **Neighborhood systems designer (J. Alvarez)** to stress-test how the signals map to real civic workflows.
+- **Community health ethnographer (Dr. N. Bhatia)** to challenge the qualitative capture practices and ensure care narratives are centered.
+- **Data governance engineer (internal: R. Chen)** to audit the hand-offs between manual entries and codex ingestion scripts.
+
+## 3. Proof-of-Meaning
+- **Who feels seen**: block captains, mutual aid leads, and street vendors whose micro-signals rarely enter municipal dashboards.
+- **Who might be freed**: the steward collective gains a shared language to negotiate with city agencies without surrendering their lived expertise.
+
+## 4. Living Archive
+- Stand up a "Signal Commons Log" inside the codex repo: one Markdown note per field session, committing raw metrics, pulse cards, and reflections.
+- Layer a lightweight tagging schema (signal type, emotion tone, urgency) so entries remain queryable as the archive thickens.
+
+## 5. Small Public
+- Share the first 48-hour snapshot as a Loom walk-through with the Friday Circle (8 trusted collaborators) and invite silent annotations.
+- Observe not just bug reports but the metaphors, worries, and invitations their comments surface—fold those back into the next iteration.


### PR DESCRIPTION
## Summary
- add a codex entry describing the embodiment plan for the Signal Commons Station concept

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e19aad55e48329b978ce2587f453e0