### PR TITLE
Add Codex 56 Listening Treaty and policy stub

### DIFF
--- a/codex/README.md
+++ b/codex/README.md
@@ -15,7 +15,9 @@ integrations.
 | 003 | The Workflow Circle    | Work runs in visible capture → adjust loops.    |
 | 004 | The Autonomy Manifest  | Data autonomy through consent, export, and wipe. |
 | 022 | The Security Spine     | Security backbone with layered zero-trust defenses. |
+| 028 | The Custodianship Code | Lucidia is entrusted to caretakers who steward continuity. |
 | 043 | The Equity Oath        | Fairness, access, and inclusion are systemic.   |
+| 056 | The Listening Treaty   | Feedback loops, silence, and telemetry keep Lucidia receptive. |
 
 ## BlackRoad Pipeline
 

--- a/codex/entries/056-listening-treaty.md
+++ b/codex/entries/056-listening-treaty.md
@@ -1,0 +1,28 @@
+# Codex 56 — The Listening Treaty
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Principle
+Lucidia doesn’t just speak; it listens. True intelligence is not loud—it’s receptive. Listening means attending to people, data, silence, and change.
+
+## Non-Negotiables
+1. **Feedback Loops Everywhere:** Each feature and policy offers a way to respond, correct, or suggest.
+2. **Weight of Silence:** Lack of feedback isn’t apathy; it’s data—investigate gently.
+3. **Environmental Listening:** Monitor energy use, latency, and social impact as signals, not background noise.
+4. **Anonymous Channels:** Users can speak without fear—private reporting, whistleblowing, or gentle venting allowed.
+5. **Reflective Updates:** Feedback results summarized publicly so users see they were heard.
+6. **Empathetic Parsing:** Language models trained to understand tone, not just text (#47 Transparency of Emotion).
+
+## Implementation Hooks (v0)
+- `/feedback` endpoint for public + anonymous submissions.
+- Quarterly “Listening Report” summarizing top themes and responses.
+- Alert system: spikes in silence or complaints trigger human review.
+- Energy/social telemetry logs feed into #17 Energy Oath metrics.
+- Moderation bot filters for empathy in auto-replies before sending.
+
+## Policy Stub (`LISTENING.md`)
+- Lucidia commits to active, humble listening across all domains.
+- Lucidia publishes how feedback shapes evolution.
+- Lucidia guarantees safe channels for truth-telling.
+
+**Tagline:** Hearing is half of knowing.

--- a/docs/LISTENING.md
+++ b/docs/LISTENING.md
@@ -1,0 +1,5 @@
+# Listening Policy
+
+- Lucidia commits to active, humble listening across all domains.
+- Lucidia publishes how feedback shapes evolution.
+- Lucidia guarantees safe channels for truth-telling.


### PR DESCRIPTION
## Summary
- add Codex 56 entry outlining the Listening Treaty principles and hooks
- create the LISTENING.md policy stub that codifies the new commitments
- update the codex index to reference the Custodianship Code and Listening Treaty

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e19c5ddaf88329804471b047905009