### PR TITLE
docs: document pi-ops bridge deployment

### DIFF
--- a/data/admin/devices.json
+++ b/data/admin/devices.json
@@ -43,5 +43,16 @@
     "compliant": true,
     "notes": "Main HDMI display driven by Jetson",
     "lastSeen": 1759012961427
+  },
+  {
+    "deviceId": "pi-ops",
+    "owner": "ops",
+    "platform": "raspberry-pi-4",
+    "role": "bridge_host",
+    "attached": true,
+    "encrypted": true,
+    "compliant": true,
+    "notes": "Ops Pi running broker, dashboard, and lucidia bridge",
+    "lastSeen": 1759012961427
   }
 ]

--- a/docs/DEVICES.md
+++ b/docs/DEVICES.md
@@ -5,6 +5,7 @@ The device registry is stored in [`data/admin/devices.json`](../data/admin/devic
 | Device ID     | Hardware          | Role               | Owner | Attached | Notes |
 | ------------- | ----------------- | ------------------ | ----- | -------- | ----- |
 | `pi-01`       | Raspberry Pi 5    | Emotion LED agent  | Ops   | ✅       | Hosts the LED ring and the local operator console account.
+| `pi-ops`      | Raspberry Pi 4    | Bridge / broker    | Ops   | ✅       | Runs the MQTT broker, dashboard, and lucidia bridge stub.
 | `jetson-01`   | Jetson Orin Nano  | LLM / display GPU  | ML    | ✅       | Drives the main HDMI panel and coordinates inference jobs.
 | `display-mini`| Pi SPI display    | Status panel       | Ops   | ✅       | 2.8" SPI panel wired into `pi-01` for mini status readouts.
 | `display-main`| HDMI monitor      | Primary display    | Ops   | ✅       | Main wall display connected to `jetson-01`.

--- a/docs/pi-ops-bridge.md
+++ b/docs/pi-ops-bridge.md
@@ -1,0 +1,51 @@
+# Pi-Ops lucidia bridge deployment
+
+Pi-Ops already hosts the MQTT broker and the local dashboard, so it is the
+natural home for the lucidia edge bridge. The bridge can run headless on the Pi
+without the Jetson being present; when the Jetson is offline the process simply
+logs the traffic it would forward.
+
+## Service layout
+
+- **Unit name:** `lucidia-bridge.service`
+- **Binary:** `/opt/lucidia/bin/lucidia-sim-bridge`
+- **Working directory:** `/opt/lucidia`
+- **Log location:** `/var/log/lucidia/bridge.log`
+- **Socket:** `ipc:///var/run/lucidia_bridge.sock`
+
+## Installation steps
+
+1. Copy the compiled bridge binary to Pi-Ops:
+   ```sh
+   scp target/release/lucidia-sim-bridge pi-ops:/opt/lucidia/bin/
+   ssh pi-ops 'sudo chown root:root /opt/lucidia/bin/lucidia-sim-bridge && sudo chmod 0755 /opt/lucidia/bin/lucidia-sim-bridge'
+   ```
+2. Install the systemd unit:
+   ```sh
+   scp ops/systemd/lucidia-bridge.service pi-ops:/etc/systemd/system/
+   ssh pi-ops 'sudo systemctl daemon-reload && sudo systemctl enable --now lucidia-bridge.service'
+   ```
+3. Confirm the process starts and idles cleanly when the Jetson is offline:
+   ```sh
+   ssh pi-ops 'sudo systemctl status lucidia-bridge.service'
+   ssh pi-ops 'sudo journalctl -u lucidia-bridge.service -n 50'
+   ```
+
+The default unit starts the bridge with `SIM_WRITE_ENABLED=false`, so command
+traffic is read-only. Toggle the environment variable to `true` in the unit if
+you need to forward commands to the Jetson-side Trick/cFS stack.
+
+## Operational notes
+
+- Keep Pi-Ops on the same wired VLAN as the Jetson to minimize IPC latency.
+- The broker, dashboard, and bridge all watch `/var/run/lucidia_bridge.sock`; a
+  tmpfiles.d rule ensures the socket directory exists at boot.
+- Add Pi-Ops to the device inventory (see `data/admin/devices.json`) so the UI
+  reflects the bridge host status.
+- When staging updates, restart the bridge after the MQTT broker to avoid stale
+  subscriptions:
+  ```sh
+  ssh pi-ops 'sudo systemctl restart mosquitto && sudo systemctl restart lucidia-bridge'
+  ```
+
+_Last updated on 2025-09-11_

--- a/ops/systemd/lucidia-bridge.service
+++ b/ops/systemd/lucidia-bridge.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Lucidia edge bridge (Pi-Ops)
+After=network-online.target mosquitto.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=root
+Group=root
+WorkingDirectory=/opt/lucidia
+ExecStart=/opt/lucidia/bin/lucidia-sim-bridge
+Environment=SIM_WRITE_ENABLED=false
+Restart=on-failure
+RestartSec=5s
+StandardOutput=append:/var/log/lucidia/bridge.log
+StandardError=append:/var/log/lucidia/bridge.log
+RuntimeDirectory=lucidia_bridge
+RuntimeDirectoryMode=0755
+
+[Install]
+WantedBy=multi-user.target

--- a/ops/systemd/tmpfiles.d/lucidia-bridge.conf
+++ b/ops/systemd/tmpfiles.d/lucidia-bridge.conf
@@ -1,0 +1,1 @@
+d /var/run/lucidia_bridge 0755 root root -


### PR DESCRIPTION
## Summary
- add Pi-Ops to the device inventory and registry for bridge hosting
- document how to deploy and operate the lucidia bridge service on Pi-Ops
- ship supporting systemd and tmpfiles definitions for the bridge unit

## Testing
- jq . data/admin/devices.json

------
https://chatgpt.com/codex/tasks/task_e_68e19cfe157083299eecc8523b115141