### PR TITLE
Add audit artifact signing and validation pipeline

### DIFF
--- a/audits/engine.py
+++ b/audits/engine.py
@@ -1,9 +1,10 @@
+import argparse
 import datetime
 import hashlib
 import json
 import subprocess
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
 
 import yaml
 
@@ -48,13 +49,93 @@ def run_checks(defs: Dict[str, Any]) -> List[Dict[str, Any]]:
     return results
 
 
+def load_jsonl_events(path: Optional[Path]) -> List[Dict[str, Any]]:
+    events: List[Dict[str, Any]] = []
+    if not path:
+        return events
+    if not path.exists():
+        return events
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                events.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return events
+
+
+def build_audit_events(
+    report: Dict[str, Any], maintenance_events: Sequence[Dict[str, Any]]
+) -> Iterable[Dict[str, Any]]:
+    timestamp = report.get("timestamp")
+    checks: Sequence[Dict[str, Any]] = report.get("checks", [])
+    for check in checks:
+        yield {
+            "event": "audit.check",
+            "timestamp": timestamp,
+            "name": check.get("name"),
+            "passed": check.get("passed"),
+            "evidence_hash": check.get("evidence_hash"),
+        }
+
+    total = len(checks)
+    passing = sum(1 for c in checks if c.get("passed"))
+    yield {
+        "event": "audit.summary",
+        "timestamp": timestamp,
+        "lucidia_trigger": report.get("lucidia_trigger"),
+        "total_checks": total,
+        "passed_checks": passing,
+        "failed_checks": total - passing,
+    }
+
+    for event in maintenance_events:
+        normalized = dict(event)
+        normalized.setdefault("event", normalized.get("type", "maintenance.unknown"))
+        yield normalized
+
+
+def write_jsonl(events: Iterable[Dict[str, Any]], path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        for event in events:
+            f.write(json.dumps(event))
+            f.write("\n")
+    return path
+
+
 def lucidia_trigger(results: List[Dict[str, Any]]) -> str:
     if any(not r["passed"] for r in results):
         return "spiral"
     return "anchor"
 
 
-def main() -> Path:
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run audit checks and emit reports")
+    parser.add_argument(
+        "--report-dir",
+        type=Path,
+        default=REPORT_DIR,
+        help="Directory where the JSON audit report will be written.",
+    )
+    parser.add_argument(
+        "--jsonl",
+        type=Path,
+        help="Optional path to emit audit events as JSON lines.",
+    )
+    parser.add_argument(
+        "--maintenance-log",
+        type=Path,
+        help="Optional maintenance events JSONL to append into the audit stream.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> Tuple[Path, Optional[Path]]:
+    args = parse_args(argv)
     defs = load_definitions()
     results = run_checks(defs)
     report = {
@@ -64,13 +145,21 @@ def main() -> Path:
     }
     serialized = json.dumps(report, indent=2)
     report["signature"] = hashlib.sha256(serialized.encode()).hexdigest()
-    REPORT_DIR.mkdir(exist_ok=True)
-    report_path = REPORT_DIR / f"{report['timestamp']}.json"
+    args.report_dir.mkdir(parents=True, exist_ok=True)
+    report_path = args.report_dir / f"{report['timestamp']}.json"
     with open(report_path, "w", encoding="utf-8") as f:
         json.dump(report, f, indent=2)
-    return report_path
+    jsonl_path: Optional[Path] = None
+    if args.jsonl:
+        maintenance_events = load_jsonl_events(args.maintenance_log)
+        events = build_audit_events(report, maintenance_events)
+        jsonl_path = write_jsonl(events, args.jsonl)
+    return report_path, jsonl_path
 
 
 if __name__ == "__main__":
-    path = main()
-    print(f"Audit report written to {path}")
+    report_path, jsonl_path = main()
+    message = f"Audit report written to {report_path}"
+    if jsonl_path:
+        message += f"; JSONL stream at {jsonl_path}"
+    print(message)

--- a/audits/fixtures/maintenance_events.jsonl
+++ b/audits/fixtures/maintenance_events.jsonl
@@ -1,0 +1,2 @@
+{"timestamp": "2024-05-01T03:15:00Z", "event": "maintenance.block", "system": "prism-console", "reason": "security patch window", "duration_minutes": 45}
+{"timestamp": "2024-05-11T18:42:00Z", "event": "maintenance.window", "system": "prism-console", "duration_minutes": 30}

--- a/audits/validator.py
+++ b/audits/validator.py
@@ -1,0 +1,59 @@
+"""Audit log validation helpers for CI pipelines."""
+
+import argparse
+import json
+from pathlib import Path
+from typing import Iterable, Iterator, Optional
+
+
+def load_events(path: Path) -> Iterator[dict]:
+    with open(path, "r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            yield json.loads(line)
+
+
+def maintenance_block_count(events: Iterable[dict]) -> int:
+    return sum(1 for event in events if event.get("event") == "maintenance.block")
+
+
+def parse_args(argv: Optional[Iterable[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate audit JSONL streams")
+    parser.add_argument("--audit-log", type=Path, required=True, help="Path to the audit JSONL file")
+    parser.add_argument(
+        "--max-maintenance-blocks",
+        type=int,
+        default=2,
+        help="Maximum allowed maintenance.block events before failing the build.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    args = parse_args(argv)
+    if not args.audit_log.exists():
+        raise FileNotFoundError(f"Audit log {args.audit_log} does not exist")
+
+    events = list(load_events(args.audit_log))
+    blocks = maintenance_block_count(events)
+
+    if blocks > args.max_maintenance_blocks:
+        print(
+            "::error::maintenance.block threshold exceeded",
+            f"count={blocks}",
+            f"threshold={args.max_maintenance_blocks}",
+        )
+        return 1
+
+    print(
+        "::notice::maintenance.block threshold ok",
+        f"count={blocks}",
+        f"threshold={args.max_maintenance_blocks}",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pipelines/build.yml
+++ b/pipelines/build.yml
@@ -7,10 +7,22 @@ pipeline:
     image: python:3.11-slim
     commands:
       - echo test
+  audit_log:
+    image: python:3.11-slim
+    commands:
+      - pip install --no-cache-dir pyyaml
+      - mkdir -p audit-artifacts
+      - python audits/engine.py --report-dir audit-artifacts/reports --jsonl audit-artifacts/audit-log.jsonl --maintenance-log audits/fixtures/maintenance_events.jsonl
+  audit_validator:
+    image: python:3.11-slim
+    commands:
+      - python audits/validator.py --audit-log audit-artifacts/audit-log.jsonl --max-maintenance-blocks 2
   build:
     image: docker:24
     commands:
       - echo build image
+      - mkdir -p artifacts/image
+      - echo "${IMAGE_DIGEST:-sha256:$(date +%s)}" > artifacts/image/digest.txt
   sign:
     image: alpine:3.19
     commands:
@@ -19,3 +31,24 @@ pipeline:
     image: docker:24
     commands:
       - echo push to registry
+  audit_sign:
+    image: alpine:3.19
+    commands:
+      - apk add --no-cache minisign
+      - : "${MINISIGN_SECRET_KEY?MINISIGN_SECRET_KEY environment variable must be set}"
+      - : "${MINISIGN_PUBLIC_KEY?MINISIGN_PUBLIC_KEY environment variable must be set}"
+      - mkdir -p audit-artifacts
+      - printf '%s\n' "$MINISIGN_SECRET_KEY" > minisign.key
+      - printf '%s\n' "$MINISIGN_PUBLIC_KEY" > audit-artifacts/minisign.pub
+      - minisign -Sm audit-artifacts/audit-log.jsonl -s minisign.key -x audit-artifacts/audit-log.jsonl.minisig
+      - rm minisign.key
+  audit_artifacts:
+    image: alpine:3.19
+    commands:
+      - mkdir -p artifacts/audit
+      - cp audit-artifacts/audit-log.jsonl artifacts/audit/
+      - cp audit-artifacts/audit-log.jsonl.minisig artifacts/audit/
+      - cp audit-artifacts/minisign.pub artifacts/audit/
+      - cp artifacts/image/digest.txt artifacts/audit/image-digest.txt
+      - tar -czf artifacts/audit/github-audit-bundle.tgz -C artifacts/audit .
+      - echo "::notice::upload-artifact name=audit-logs::artifacts/audit/github-audit-bundle.tgz"


### PR DESCRIPTION
## Summary
- extend the audit engine so it can emit a JSONL stream that includes maintenance events alongside the detailed report
- add a validator utility and new CI stages that fail when maintenance.block activity exceeds the allowed threshold
- sign the audit log with minisign and bundle the JSONL, signature, public key, and image digest for GitHub artifact upload

## Testing
- python audits/engine.py --report-dir audit-artifacts/reports --jsonl audit-artifacts/audit-log.jsonl --maintenance-log audits/fixtures/maintenance_events.jsonl
- python audits/validator.py --audit-log audit-artifacts/audit-log.jsonl --max-maintenance-blocks 2
- python -m compileall audits

------
https://chatgpt.com/codex/tasks/task_e_68e19cd225008329b8d5a4579a7e84d8