### PR TITLE
feat: scaffold FeeForge billing platform

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -14,9 +14,18 @@
   "dependencies": {
     "@lucidia/ai": "^0.0.1",
     "@lucidia/core": "^0.0.1",
+    "@blackroad/policies": "workspace:*",
+    "@blackroad/integrations": "workspace:*",
+    "@blackroad/worm": "workspace:*",
+    "@blackroad/db": "workspace:*",
+    "@fastify/swagger": "^8.15.0",
+    "@fastify/swagger-ui": "^3.0.0",
+    "@fastify/type-provider-zod": "^1.2.0",
     "cors": "^2.8.5",
     "express": "^4.19.2",
-    "helmet": "^7.1.0"
+    "fastify": "^4.28.0",
+    "helmet": "^7.1.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",

--- a/apps/api/src/feeforge/server.ts
+++ b/apps/api/src/feeforge/server.ts
@@ -1,0 +1,368 @@
+import { randomUUID } from "node:crypto";
+import { promises as fs } from "node:fs";
+import { resolve } from "node:path";
+import Fastify from "fastify";
+import swagger from "@fastify/swagger";
+import swaggerUi from "@fastify/swagger-ui";
+import { ZodTypeProvider } from "@fastify/type-provider-zod";
+import { z } from "zod";
+import {
+  AccountFeePlan,
+  FeeAccrualRecord,
+  FeeSchedule,
+  computeDailyAccrual,
+  generateInArrearsInvoice,
+} from "@lucidia/core";
+import { enforceFeeCap, requireCustodyAuthorization } from "@blackroad/policies";
+import { renderInvoicePdf, submitCustodyDeduction } from "@blackroad/integrations";
+import {
+  ApiFeeForgeState,
+  appendApiWorm,
+  loadApiState,
+  saveApiState,
+  snapshotInvoice,
+  StoredInvoice,
+  InvoiceDataSnapshot,
+} from "./state.js";
+
+const MarketValueSchema = z.object({
+  accountId: z.string(),
+  marketValue: z.number(),
+  cryptoMarketValue: z.number().optional(),
+});
+
+function planToHouseholdTotal(state: ApiFeeForgeState, market: z.infer<typeof MarketValueSchema>[], plan: AccountFeePlan): number | undefined {
+  if (!plan.billingGroupId) return undefined;
+  const relatedAccounts = Object.values(state.plans)
+    .filter((p) => p.billingGroupId === plan.billingGroupId)
+    .map((p) => p.accountId);
+  return market
+    .filter((entry) => relatedAccounts.includes(entry.accountId))
+    .reduce((sum, entry) => sum + entry.marketValue + (entry.cryptoMarketValue ?? 0), 0);
+}
+
+function toInvoiceSnapshot(draft: ReturnType<typeof generateInArrearsInvoice>): InvoiceDataSnapshot {
+  return {
+    billingPeriodStart: draft.billingPeriodStart.toISOString(),
+    billingPeriodEnd: draft.billingPeriodEnd.toISOString(),
+    billingGroupId: draft.billingGroupId ?? null,
+    accountId: draft.accountId ?? null,
+    currency: draft.currency,
+    amount: draft.amount,
+    lines: draft.lines,
+    minimumAppliedUSD: draft.minimumAppliedUSD,
+  };
+}
+
+export async function buildFeeForgeServer() {
+  const server = Fastify().withTypeProvider<ZodTypeProvider>();
+  await server.register(swagger, { openapi: { info: { title: "FeeForge API", version: "0.1.0" } } });
+  await server.register(swaggerUi, {});
+
+  server.post("/feeschedules", {
+    schema: {
+      body: z.object({
+        name: z.string(),
+        status: z.enum(["Active", "Draft", "Retired"]).default("Active"),
+        spec: z.record(z.any()),
+      }),
+      response: {
+        200: z.object({ id: z.string(), name: z.string() }),
+      },
+    },
+  }, async (request, reply) => {
+    const state = await loadApiState();
+    const body = request.body;
+    const schedule: FeeSchedule = {
+      id: randomUUID(),
+      name: body.name,
+      status: body.status,
+      spec: body.spec as FeeSchedule["spec"],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    state.schedules[schedule.id] = schedule;
+    appendApiWorm(state, { type: "API_FEE_SCHEDULE", scheduleId: schedule.id });
+    await saveApiState(state);
+    return reply.send({ id: schedule.id, name: schedule.name });
+  });
+
+  server.post("/plans", {
+    schema: {
+      body: z.object({
+        accountId: z.string(),
+        feeScheduleId: z.string(),
+        billingGroupId: z.string().optional(),
+        startDate: z.string(),
+        billFrequency: z.enum(["Monthly", "Quarterly"]),
+        billMode: z.enum(["InArrears", "InAdvance"]),
+        billCurrency: z.enum(["USD", "CRYPTO_USD_EQ"]).default("USD"),
+        custodyDeductionAllowed: z.boolean().default(false),
+        performanceFeeAllowed: z.boolean().default(false),
+      }),
+      response: { 200: z.object({ id: z.string() }) },
+    },
+  }, async (request, reply) => {
+    const state = await loadApiState();
+    const schedule = state.schedules[request.body.feeScheduleId];
+    if (!schedule) {
+      return reply.status(400).send({ error: "Fee schedule not found" });
+    }
+    const plan: AccountFeePlan = {
+      id: randomUUID(),
+      accountId: request.body.accountId,
+      feeScheduleId: request.body.feeScheduleId,
+      billingGroupId: request.body.billingGroupId ?? null,
+      startDate: new Date(request.body.startDate),
+      endDate: null,
+      billFrequency: request.body.billFrequency,
+      billMode: request.body.billMode,
+      billCurrency: request.body.billCurrency,
+      custodyDeductionAllowed: request.body.custodyDeductionAllowed,
+      performanceFeeAllowed: request.body.performanceFeeAllowed,
+      createdAt: new Date(),
+    };
+    state.plans[plan.id] = plan;
+    appendApiWorm(state, { type: "API_PLAN", planId: plan.id });
+    await saveApiState(state);
+    return reply.send({ id: plan.id });
+  });
+
+  server.post("/accruals/run", {
+    schema: {
+      querystring: z.object({ asOf: z.string() }),
+      body: z.object({ market: z.array(MarketValueSchema) }),
+      response: {
+        200: z.object({ count: z.number() }),
+      },
+    },
+  }, async (request, reply) => {
+    const state = await loadApiState();
+    const asOf = new Date(request.query.asOf);
+    const accruals: FeeAccrualRecord[] = [];
+    for (const plan of Object.values(state.plans)) {
+      const schedule = state.schedules[plan.feeScheduleId];
+      if (!schedule) continue;
+      const mv = request.body.market.find((entry) => entry.accountId === plan.accountId);
+      if (!mv) continue;
+      const household = planToHouseholdTotal(state, request.body.market, plan);
+      const accrual = computeDailyAccrual({
+        plan,
+        schedule,
+        marketValue: {
+          accountId: plan.accountId,
+          asOf,
+          marketValue: mv.marketValue,
+          cryptoMarketValue: mv.cryptoMarketValue,
+        },
+        householdValue: household,
+      });
+      const capViolation = enforceFeeCap({ effectiveBps: accrual.rateBps, scheduleSpec: schedule.spec });
+      if (capViolation) {
+        state.exceptions.push({
+          id: randomUUID(),
+          accountId: plan.accountId,
+          invoiceId: null,
+          code: capViolation.code,
+          severity: capViolation.severity,
+          details: capViolation.details ?? {},
+          status: "Open",
+          createdAt: new Date(),
+          resolvedAt: null,
+        });
+      }
+      accruals.push(accrual);
+    }
+    state.accruals = state.accruals.filter(
+      (existing) => new Date(existing.asOf).toISOString() !== asOf.toISOString()
+    );
+    state.accruals.push(...accruals);
+    appendApiWorm(state, { type: "API_ACCRUAL", asOf: asOf.toISOString(), count: accruals.length });
+    await saveApiState(state);
+    return reply.send({ count: accruals.length });
+  });
+
+  server.post("/invoices/generate", {
+    schema: {
+      querystring: z.object({ period: z.string(), scope: z.string().optional() }),
+      response: { 200: z.object({ generated: z.number() }) },
+    },
+  }, async (request, reply) => {
+    const state = await loadApiState();
+    const [yearPart, quarterPart] = request.query.period.split("Q");
+    const year = Number(yearPart);
+    const quarter = Number(quarterPart);
+    if (!year || !quarter) {
+      return reply.status(400).send({ error: "Invalid period" });
+    }
+    const startMonth = (quarter - 1) * 3;
+    const start = new Date(Date.UTC(year, startMonth, 1));
+    const end = new Date(Date.UTC(year, startMonth + 3, 0));
+    const invoices: StoredInvoice[] = [];
+    for (const plan of Object.values(state.plans)) {
+      if (request.query.scope) {
+        if (request.query.scope.startsWith("household:") && plan.billingGroupId !== request.query.scope.split(":")[1]) {
+          continue;
+        }
+        if (request.query.scope.startsWith("account:") && plan.accountId !== request.query.scope.split(":")[1]) {
+          continue;
+        }
+      }
+      const schedule = state.schedules[plan.feeScheduleId];
+      if (!schedule) continue;
+      const accruals = state.accruals.filter(
+        (record) =>
+          record.planId === plan.id &&
+          new Date(record.asOf) >= start &&
+          new Date(record.asOf) <= end
+      );
+      if (accruals.length === 0) continue;
+      const draft = generateInArrearsInvoice({
+        plan,
+        schedule,
+        accruals,
+        billingPeriodStart: start,
+        billingPeriodEnd: end,
+      });
+      const snapshot = toInvoiceSnapshot(draft);
+      const invoice: StoredInvoice = {
+        id: `INV-${randomUUID()}`,
+        status: "Draft",
+        data: snapshot,
+      };
+      invoices.push(invoice);
+    }
+    state.invoices = state.invoices.filter((existing) =>
+      !invoices.some((generated) => generated.data.accountId === existing.data.accountId && generated.data.billingPeriodStart === existing.data.billingPeriodStart)
+    );
+    state.invoices.push(...invoices.map(snapshotInvoice));
+    appendApiWorm(state, { type: "API_INVOICE_GENERATED", count: invoices.length });
+    await saveApiState(state);
+    return reply.send({ generated: invoices.length });
+  });
+
+  server.post("/invoices/:id/issue", {
+    schema: {
+      params: z.object({ id: z.string() }),
+      response: { 200: z.object({ status: z.string(), evidencePath: z.string() }) },
+    },
+  }, async (request, reply) => {
+    const state = await loadApiState();
+    const invoice = state.invoices.find((item) => item.id === request.params.id);
+    if (!invoice) {
+      return reply.status(404).send({ error: "Invoice not found" });
+    }
+    const pdf = await renderInvoicePdf({
+      billingPeriodStart: new Date(invoice.data.billingPeriodStart),
+      billingPeriodEnd: new Date(invoice.data.billingPeriodEnd),
+      billingGroupId: invoice.data.billingGroupId ?? undefined,
+      accountId: invoice.data.accountId ?? undefined,
+      currency: invoice.data.currency,
+      amount: invoice.data.amount,
+      lines: invoice.data.lines as any,
+      minimumAppliedUSD: invoice.data.minimumAppliedUSD,
+    });
+    const outputDir = resolve(process.cwd(), "api-invoices");
+    await fs.mkdir(outputDir, { recursive: true });
+    const evidencePath = resolve(outputDir, pdf.filename);
+    await fs.writeFile(evidencePath, pdf.buffer);
+    invoice.status = "Issued";
+    invoice.evidencePath = evidencePath;
+    appendApiWorm(state, { type: "API_INVOICE_ISSUED", invoiceId: invoice.id, evidencePath });
+    await saveApiState(state);
+    return reply.send({ status: invoice.status, evidencePath });
+  });
+
+  server.post("/payments/record", {
+    schema: {
+      body: z.object({
+        invoiceId: z.string(),
+        method: z.enum(["CustodyDeduction", "ACH", "Wire", "Check", "Crypto"]),
+        amount: z.number(),
+        currency: z.string().default("USD"),
+      }),
+      response: { 200: z.object({ status: z.string() }) },
+    },
+  }, async (request, reply) => {
+    const state = await loadApiState();
+    const invoice = state.invoices.find((item) => item.id === request.body.invoiceId);
+    if (!invoice) {
+      return reply.status(404).send({ error: "Invoice not found" });
+    }
+    if (request.body.method === "CustodyDeduction") {
+      const plan = Object.values(state.plans).find((p) => p.accountId === invoice.data.accountId);
+      if (!plan) {
+        return reply.status(400).send({ error: "Plan not found" });
+      }
+      const violation = requireCustodyAuthorization({ plan, authorization: plan.custodyDeductionAllowed ? { planId: plan.id, granted: true } : null });
+      if (violation) {
+        return reply.status(400).send({ error: violation.message });
+      }
+      await submitCustodyDeduction({
+        plan,
+        invoiceId: invoice.id,
+        amount: request.body.amount,
+        currency: request.body.currency,
+      });
+    }
+    invoice.status = request.body.amount >= invoice.data.amount ? "Paid" : "PartiallyPaid";
+    appendApiWorm(state, { type: "API_PAYMENT", invoiceId: invoice.id, method: request.body.method });
+    await saveApiState(state);
+    return reply.send({ status: invoice.status });
+  });
+
+  server.post("/invoices/:id/reverse", {
+    schema: {
+      params: z.object({ id: z.string() }),
+      body: z.object({ reason: z.string().default("Manual reversal") }),
+      response: { 200: z.object({ status: z.string() }) },
+    },
+  }, async (request, reply) => {
+    const state = await loadApiState();
+    const invoice = state.invoices.find((item) => item.id === request.params.id);
+    if (!invoice) {
+      return reply.status(404).send({ error: "Invoice not found" });
+    }
+    invoice.status = "Draft";
+    appendApiWorm(state, { type: "API_INVOICE_REVERSED", invoiceId: invoice.id, reason: request.body.reason });
+    await saveApiState(state);
+    return reply.send({ status: invoice.status });
+  });
+
+  server.get("/exceptions", {
+    schema: {
+      querystring: z.object({ status: z.string().optional() }),
+      response: {
+        200: z.object({ exceptions: z.array(z.record(z.any())) }),
+      },
+    },
+  }, async (request, reply) => {
+    const state = await loadApiState();
+    const exceptions = state.exceptions.filter((item) =>
+      request.query.status ? item.status === request.query.status : true
+    );
+    return reply.send({ exceptions });
+  });
+
+  server.post("/exceptions/:id/resolve", {
+    schema: {
+      params: z.object({ id: z.string() }),
+      body: z.object({ action: z.enum(["Approve", "Reject", "Waive"]), note: z.string().optional() }),
+      response: { 200: z.object({ status: z.string() }) },
+    },
+  }, async (request, reply) => {
+    const state = await loadApiState();
+    const exception = state.exceptions.find((item) => item.id === request.params.id);
+    if (!exception) {
+      return reply.status(404).send({ error: "Exception not found" });
+    }
+    exception.status = request.body.action === "Approve" ? "Approved" : request.body.action === "Reject" ? "Rejected" : "Waived";
+    exception.resolvedAt = new Date();
+    appendApiWorm(state, { type: "API_EXCEPTION_RESOLVED", id: exception.id, action: request.body.action });
+    await saveApiState(state);
+    return reply.send({ status: exception.status });
+  });
+
+  return server;
+}
+

--- a/apps/api/src/feeforge/state.ts
+++ b/apps/api/src/feeforge/state.ts
@@ -1,0 +1,110 @@
+import { createHash } from "node:crypto";
+import { promises as fs } from "node:fs";
+import { resolve } from "node:path";
+import {
+  AccountFeePlan,
+  FeeAccrualRecord,
+  FeeSchedule,
+  ExceptionRecord,
+  InMemoryExceptionQueue,
+} from "@lucidia/core";
+import { WormBlock } from "@blackroad/worm";
+
+export interface InvoiceDataSnapshot {
+  billingPeriodStart: string;
+  billingPeriodEnd: string;
+  billingGroupId?: string | null;
+  accountId?: string | null;
+  currency: string;
+  amount: number;
+  lines: unknown;
+  minimumAppliedUSD?: number;
+}
+
+export interface StoredInvoice {
+  id: string;
+  status: "Draft" | "Issued" | "Paid" | "PartiallyPaid";
+  evidencePath?: string;
+  data: InvoiceDataSnapshot;
+}
+
+export interface ApiFeeForgeState {
+  schedules: Record<string, FeeSchedule>;
+  plans: Record<string, AccountFeePlan>;
+  accruals: FeeAccrualRecord[];
+  invoices: StoredInvoice[];
+  exceptions: ExceptionRecord[];
+  worm: WormBlock[];
+}
+
+const STATE_FILE = resolve(process.cwd(), ".feeforge-api-state.json");
+
+export async function loadApiState(): Promise<ApiFeeForgeState> {
+  try {
+    const raw = await fs.readFile(STATE_FILE, "utf-8");
+    const parsed = JSON.parse(raw);
+    return {
+      schedules: parsed.schedules ?? {},
+      plans: parsed.plans ?? {},
+      accruals: parsed.accruals ?? [],
+      invoices: parsed.invoices ?? [],
+      exceptions: parsed.exceptions ?? [],
+      worm: parsed.worm ?? [],
+    } satisfies ApiFeeForgeState;
+  } catch (error) {
+    return {
+      schedules: {},
+      plans: {},
+      accruals: [],
+      invoices: [],
+      exceptions: [],
+      worm: [],
+    };
+  }
+}
+
+export async function saveApiState(state: ApiFeeForgeState): Promise<void> {
+  await fs.writeFile(STATE_FILE, JSON.stringify(state, null, 2));
+}
+
+export function appendApiWorm(state: ApiFeeForgeState, payload: unknown): WormBlock {
+  const prev = state.worm[state.worm.length - 1] ?? null;
+  const prevHash = prev?.hash ?? "GENESIS";
+  const idx = prev ? prev.idx + 1 : 1;
+  const ts = new Date();
+  const hash = createHash("sha256")
+    .update(JSON.stringify({ prevHash, payload }))
+    .digest("hex");
+  const block: WormBlock = { idx, ts, payload, prevHash, hash };
+  state.worm.push(block);
+  return block;
+}
+
+export function createExceptionQueue(state: ApiFeeForgeState): InMemoryExceptionQueue {
+  const queue = new InMemoryExceptionQueue();
+  for (const exception of state.exceptions) {
+    if (exception.status === "Open") {
+      queue.enqueue({
+        code: exception.code as any,
+        severity: exception.severity,
+        message: exception.details as any,
+      });
+    }
+  }
+  return queue;
+}
+
+export function snapshotInvoice(invoice: {
+  id: string;
+  status: StoredInvoice["status"];
+  evidencePath?: string;
+  data: InvoiceDataSnapshot;
+}): StoredInvoice {
+  return {
+    id: invoice.id,
+    status: invoice.status,
+    evidencePath: invoice.evidencePath,
+    data: invoice.data,
+  };
+}
+

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "blackroad-feeforge-cli",
+  "version": "0.1.0",
+  "description": "CLI for managing FeeForge billing operations.",
+  "type": "module",
+  "bin": {
+    "blackroad-feeforge": "dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsx watch src/index.ts",
+    "clean": "rimraf dist"
+  },
+  "dependencies": {
+    "@lucidia/core": "workspace:*",
+    "@blackroad/policies": "workspace:*",
+    "@blackroad/integrations": "workspace:*",
+    "@blackroad/worm": "workspace:*",
+    "@blackroad/db": "workspace:*",
+    "commander": "^11.1.0",
+    "yaml": "^2.5.1"
+  },
+  "devDependencies": {
+    "rimraf": "^6.0.1",
+    "ts-node": "^10.9.2",
+    "tsx": "^4.15.7",
+    "typescript": "^5.4.5"
+  }
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,0 +1,325 @@
+#!/usr/bin/env node
+import { randomUUID } from "node:crypto";
+import { promises as fs } from "node:fs";
+import { resolve } from "node:path";
+import { Command } from "commander";
+import YAML from "yaml";
+import {
+  AccountFeePlan,
+  FeeAccrualRecord,
+  FeeSchedule,
+  computeDailyAccrual,
+  generateInArrearsInvoice,
+  InMemoryExceptionQueue,
+} from "@lucidia/core";
+import { enforceFeeCap, requireCustodyAuthorization } from "@blackroad/policies";
+import { renderInvoicePdf, submitCustodyDeduction } from "@blackroad/integrations";
+import { appendWorm, loadState, saveState, StoredInvoice, InvoiceDataSnapshot } from "./state.js";
+
+interface MarketValueFileEntry {
+  accountId: string;
+  marketValue: number;
+  cryptoMarketValue?: number;
+}
+
+function toSchedule(spec: unknown, name: string): FeeSchedule {
+  return {
+    id: randomUUID(),
+    name,
+    status: "Active",
+    spec: spec as FeeSchedule["spec"],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+function findScheduleByName(state: Awaited<ReturnType<typeof loadState>>, name: string): FeeSchedule | undefined {
+  return Object.values(state.schedules).find((schedule) => schedule.name === name);
+}
+
+function parseDate(input: string): Date {
+  const date = new Date(input);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`Invalid date: ${input}`);
+  }
+  return date;
+}
+
+function parseQuarter(quarter: string): { start: Date; end: Date } {
+  const match = quarter.match(/^(\d{4})Q([1-4])$/);
+  if (!match) {
+    throw new Error(`Invalid quarter format: ${quarter}`);
+  }
+  const year = Number(match[1]);
+  const q = Number(match[2]);
+  const startMonth = (q - 1) * 3;
+  const start = new Date(Date.UTC(year, startMonth, 1));
+  const end = new Date(Date.UTC(year, startMonth + 3, 0));
+  return { start, end };
+}
+
+function asInvoiceSnapshot(draft: ReturnType<typeof generateInArrearsInvoice>): InvoiceDataSnapshot {
+  return {
+    billingPeriodStart: draft.billingPeriodStart.toISOString(),
+    billingPeriodEnd: draft.billingPeriodEnd.toISOString(),
+    billingGroupId: draft.billingGroupId ?? null,
+    accountId: draft.accountId ?? null,
+    currency: draft.currency,
+    amount: draft.amount,
+    lines: draft.lines,
+    minimumAppliedUSD: draft.minimumAppliedUSD,
+  };
+}
+
+const program = new Command();
+program.name("blackroad-feeforge").description("FeeForge billing CLI");
+
+program
+  .command("schedule:create")
+  .description("Create or update a fee schedule")
+  .requiredOption("--name <name>")
+  .requiredOption("--file <path>")
+  .action(async (options) => {
+    const state = await loadState();
+    const specFile = await fs.readFile(resolve(options.file), "utf-8");
+    const spec = YAML.parse(specFile);
+    const existing = findScheduleByName(state, options.name);
+    const schedule = toSchedule(spec, options.name);
+    const scheduleId = existing ? existing.id : schedule.id;
+    state.schedules[scheduleId] = { ...schedule, id: scheduleId };
+    appendWorm(state, { type: "FEE_SCHEDULE", scheduleId, name: options.name, spec });
+    await saveState(state);
+    console.log(`Saved fee schedule ${options.name} (${scheduleId})`);
+  });
+
+program
+  .command("plan:attach")
+  .description("Attach a fee schedule to an account")
+  .requiredOption("--account <id>")
+  .requiredOption("--schedule <name>")
+  .requiredOption("--freq <freq>", "Billing frequency (Monthly|Quarterly)")
+  .requiredOption("--mode <mode>", "Billing mode (InArrears|InAdvance)")
+  .option("--group <id>")
+  .option("--custody-deduction", "Allow custody deduction")
+  .option("--performance")
+  .option("--start <date>", "Plan start date", new Date().toISOString())
+  .action(async (options) => {
+    const state = await loadState();
+    const schedule = findScheduleByName(state, options.schedule);
+    if (!schedule) {
+      throw new Error(`Fee schedule ${options.schedule} not found`);
+    }
+    const plan: AccountFeePlan = {
+      id: randomUUID(),
+      accountId: options.account,
+      feeScheduleId: schedule.id,
+      billingGroupId: options.group ?? null,
+      startDate: parseDate(options.start),
+      endDate: null,
+      billFrequency: options.freq,
+      billMode: options.mode,
+      billCurrency: "USD",
+      custodyDeductionAllowed: Boolean(options.custodyDeduction),
+      performanceFeeAllowed: Boolean(options.performance),
+      createdAt: new Date(),
+    };
+    state.plans[plan.id] = plan;
+    appendWorm(state, { type: "PLAN_ATTACHED", plan });
+    await saveState(state);
+    console.log(`Attached schedule ${options.schedule} to account ${plan.accountId} (${plan.id})`);
+  });
+
+program
+  .command("accruals:run")
+  .description("Run daily accruals for the given date")
+  .requiredOption("--as-of <date>")
+  .requiredOption("--market-file <path>", "JSON file of market values")
+  .action(async (options) => {
+    const state = await loadState();
+    const asOf = parseDate(options["asOf"] ?? options.asOf);
+    const marketRaw = await fs.readFile(resolve(options.marketFile), "utf-8");
+    const marketEntries = JSON.parse(marketRaw) as MarketValueFileEntry[];
+    const queue = new InMemoryExceptionQueue();
+    const results: FeeAccrualRecord[] = [];
+    const households = new Map<string, number>();
+    for (const plan of Object.values(state.plans)) {
+      if (!state.schedules[plan.feeScheduleId]) continue;
+      if (plan.billingGroupId) {
+        const total = marketEntries
+          .filter((entry) => entry.accountId === plan.accountId || Object.values(state.plans).some((p) => p.accountId === entry.accountId && p.billingGroupId === plan.billingGroupId))
+          .reduce((sum, entry) => sum + entry.marketValue + (entry.cryptoMarketValue ?? 0), 0);
+        households.set(plan.billingGroupId, total);
+      }
+    }
+
+    for (const plan of Object.values(state.plans)) {
+      const schedule = state.schedules[plan.feeScheduleId];
+      if (!schedule) continue;
+      const mv = marketEntries.find((entry) => entry.accountId === plan.accountId);
+      if (!mv) {
+        continue;
+      }
+      const householdValue = plan.billingGroupId ? households.get(plan.billingGroupId) : undefined;
+      const accrual = computeDailyAccrual({
+        plan,
+        schedule,
+        marketValue: {
+          accountId: plan.accountId,
+          asOf,
+          marketValue: mv.marketValue,
+          cryptoMarketValue: mv.cryptoMarketValue,
+        },
+        householdValue,
+      });
+      const capViolation = enforceFeeCap({ effectiveBps: accrual.rateBps, scheduleSpec: schedule.spec });
+      if (capViolation) {
+        queue.enqueue({
+          code: capViolation.code,
+          severity: capViolation.severity,
+          message: capViolation.message,
+          metadata: capViolation.details,
+        });
+      }
+      results.push(accrual);
+    }
+
+    state.accruals = state.accruals.filter(
+      (existing) => new Date(existing.asOf).toISOString() !== asOf.toISOString()
+    );
+    state.accruals.push(...results);
+    state.exceptions.push(...queue.listOpen());
+    appendWorm(state, { type: "ACCRUAL_RUN", asOf: asOf.toISOString(), count: results.length });
+    await saveState(state);
+    console.log(`Computed ${results.length} accruals for ${asOf.toISOString().slice(0, 10)}`);
+  });
+
+program
+  .command("invoices:generate")
+  .description("Generate invoices for a quarter")
+  .requiredOption("--period <period>", "Quarter in the form 2025Q3")
+  .option("--account <id>")
+  .option("--household <id>")
+  .action(async (options) => {
+    const state = await loadState();
+    const { start, end } = parseQuarter(options.period);
+    const invoices: StoredInvoice[] = [];
+    for (const plan of Object.values(state.plans)) {
+      if (options.account && plan.accountId !== options.account) continue;
+      if (options.household && plan.billingGroupId !== options.household) continue;
+      const schedule = state.schedules[plan.feeScheduleId];
+      if (!schedule) continue;
+      const accruals = state.accruals.filter(
+        (accrual) =>
+          accrual.planId === plan.id &&
+          new Date(accrual.asOf) >= start &&
+          new Date(accrual.asOf) <= end
+      );
+      if (accruals.length === 0) continue;
+      const draft = generateInArrearsInvoice({
+        plan,
+        schedule,
+        accruals,
+        billingPeriodStart: start,
+        billingPeriodEnd: end,
+      });
+      const snapshot = asInvoiceSnapshot(draft);
+      const id = `INV-${randomUUID()}`;
+      const stored: StoredInvoice = {
+        id,
+        status: "Draft",
+        data: snapshot,
+      };
+      invoices.push(stored);
+      appendWorm(state, { type: "INVOICE_GENERATED", invoiceId: id, period: options.period, amount: snapshot.amount });
+    }
+    state.invoices = state.invoices.filter(
+      (existing) => !invoices.some((generated) => generated.data.accountId === existing.data.accountId && generated.data.billingPeriodStart === existing.data.billingPeriodStart)
+    );
+    state.invoices.push(...invoices);
+    await saveState(state);
+    console.log(`Generated ${invoices.length} invoices for ${options.period}`);
+  });
+
+program
+  .command("invoices:issue")
+  .description("Issue an invoice and render PDF evidence")
+  .requiredOption("--id <invoiceId>")
+  .action(async (options) => {
+    const state = await loadState();
+    const invoice = state.invoices.find((item) => item.id === options.id);
+    if (!invoice) {
+      throw new Error(`Invoice ${options.id} not found`);
+    }
+    const pdf = await renderInvoicePdf({
+      billingPeriodStart: new Date(invoice.data.billingPeriodStart),
+      billingPeriodEnd: new Date(invoice.data.billingPeriodEnd),
+      billingGroupId: invoice.data.billingGroupId ?? undefined,
+      accountId: invoice.data.accountId ?? undefined,
+      currency: invoice.data.currency,
+      amount: invoice.data.amount,
+      lines: invoice.data.lines as any,
+      minimumAppliedUSD: invoice.data.minimumAppliedUSD,
+    });
+    const outputDir = resolve(process.cwd(), "invoices");
+    await fs.mkdir(outputDir, { recursive: true });
+    const filePath = resolve(outputDir, pdf.filename);
+    await fs.writeFile(filePath, pdf.buffer);
+    invoice.status = "Issued";
+    invoice.evidencePath = filePath;
+    appendWorm(state, { type: "INVOICE_ISSUED", invoiceId: invoice.id, evidencePath: filePath });
+    await saveState(state);
+    console.log(`Issued invoice ${invoice.id} -> ${filePath}`);
+  });
+
+program
+  .command("payments:record")
+  .description("Record a payment against an invoice")
+  .requiredOption("--invoice <id>")
+  .requiredOption("--method <method>")
+  .requiredOption("--amount <amount>")
+  .option("--currency <currency>", "USD")
+  .action(async (options) => {
+    const state = await loadState();
+    const invoice = state.invoices.find((item) => item.id === options.invoice);
+    if (!invoice) {
+      throw new Error(`Invoice ${options.invoice} not found`);
+    }
+    const amount = Number(options.amount);
+    if (options.method === "CustodyDeduction") {
+      const plan = Object.values(state.plans).find((p) => p.accountId === invoice.data.accountId);
+      if (!plan) throw new Error("Associated plan not found for custody deduction");
+      const violation = requireCustodyAuthorization({ plan, authorization: plan.custodyDeductionAllowed ? { planId: plan.id, granted: true } : null });
+      if (violation) {
+        appendWorm(state, { type: "PAYMENT_DENIED", invoiceId: invoice.id, violation });
+        await saveState(state);
+        throw new Error(violation.message);
+      }
+      await submitCustodyDeduction({
+        plan,
+        invoiceId: invoice.id,
+        amount,
+        currency: options.currency ?? "USD",
+      });
+    }
+    invoice.status = amount >= invoice.data.amount ? "Paid" : "PartiallyPaid";
+    appendWorm(state, { type: "PAYMENT_RECORDED", invoiceId: invoice.id, method: options.method, amount });
+    await saveState(state);
+    console.log(`Recorded ${options.method} payment for invoice ${invoice.id}`);
+  });
+
+program
+  .command("exceptions:list")
+  .description("List open compliance exceptions")
+  .action(async () => {
+    const state = await loadState();
+    const open = state.exceptions.filter((ex) => ex.status === "Open");
+    if (open.length === 0) {
+      console.log("No open exceptions");
+      return;
+    }
+    for (const exception of open) {
+      console.log(`${exception.code} [${exception.severity}] -> ${exception.message ?? exception.details}`);
+    }
+  });
+
+program.parseAsync();

--- a/apps/cli/src/state.ts
+++ b/apps/cli/src/state.ts
@@ -1,0 +1,82 @@
+import { createHash } from "node:crypto";
+import { promises as fs } from "node:fs";
+import { resolve } from "node:path";
+import {
+  AccountFeePlan,
+  FeeAccrualRecord,
+  FeeSchedule,
+  ExceptionRecord,
+} from "@lucidia/core";
+import { WormBlock } from "@blackroad/worm";
+
+export interface StoredInvoice {
+  id: string;
+  status: "Draft" | "Issued" | "Paid" | "PartiallyPaid";
+  evidencePath?: string;
+  data: InvoiceDataSnapshot;
+}
+
+export interface InvoiceDataSnapshot {
+  billingPeriodStart: string;
+  billingPeriodEnd: string;
+  billingGroupId?: string | null;
+  accountId?: string | null;
+  currency: string;
+  amount: number;
+  lines: unknown;
+  minimumAppliedUSD?: number;
+}
+
+export interface FeeForgeState {
+  schedules: Record<string, FeeSchedule>;
+  plans: Record<string, AccountFeePlan>;
+  accruals: FeeAccrualRecord[];
+  invoices: StoredInvoice[];
+  exceptions: ExceptionRecord[];
+  worm: WormBlock[];
+}
+
+const STATE_FILE = resolve(process.cwd(), ".feeforge-state.json");
+
+export async function loadState(): Promise<FeeForgeState> {
+  try {
+    const data = await fs.readFile(STATE_FILE, "utf-8");
+    const parsed = JSON.parse(data);
+    return {
+      schedules: parsed.schedules ?? {},
+      plans: parsed.plans ?? {},
+      accruals: parsed.accruals ?? [],
+      invoices: parsed.invoices ?? [],
+      exceptions: parsed.exceptions ?? [],
+      worm: parsed.worm ?? [],
+    } satisfies FeeForgeState;
+  } catch (error) {
+    return {
+      schedules: {},
+      plans: {},
+      accruals: [],
+      invoices: [],
+      exceptions: [],
+      worm: [],
+    };
+  }
+}
+
+export async function saveState(state: FeeForgeState): Promise<void> {
+  const serialized = JSON.stringify(state, null, 2);
+  await fs.writeFile(STATE_FILE, serialized, "utf-8");
+}
+
+export function appendWorm(state: FeeForgeState, payload: unknown): WormBlock {
+  const prev = state.worm[state.worm.length - 1] ?? null;
+  const prevHash = prev?.hash ?? "GENESIS";
+  const idx = prev ? prev.idx + 1 : 1;
+  const ts = new Date();
+  const hash = createHash("sha256")
+    .update(JSON.stringify({ prevHash, payload }))
+    .digest("hex");
+  const block: WormBlock = { idx, ts, payload, prevHash, hash };
+  state.worm.push(block);
+  return block;
+}
+

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "ESNext",
+    "target": "ES2022",
+    "declaration": true,
+    "declarationMap": true,
+    "moduleResolution": "Node"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist"]
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lucidia/core",
   "version": "0.0.1",
-  "description": "Core domain types, validators, and crypto helpers for Lucidia Auto-Box.",
+  "description": "Core domain types, validators, crypto helpers, and the FeeForge billing engine for BlackRoad Finance.",
   "type": "module",
   "license": "Apache-2.0",
   "main": "dist/index.js",
@@ -14,10 +14,14 @@
     "clean": "rimraf dist"
   },
   "dependencies": {
+    "decimal.js": "^10.4.3",
+    "luxon": "^3.4.4",
+    "uuid": "^9.0.1",
     "zod": "^3.23.8"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
   }
 }

--- a/packages/core/src/feeforge/accrual.ts
+++ b/packages/core/src/feeforge/accrual.ts
@@ -1,0 +1,85 @@
+import { DateTime } from "luxon";
+import { computeRate } from "./rate-calculator.js";
+import {
+  AccrualComputationInput,
+  FeeAccrualRecord,
+  FeeComponentLabel,
+} from "./types.js";
+import { annualBpsToDailyRate, decimalToNumber, toDecimal } from "./utils.js";
+
+export interface DailyAccrualOptions {
+  daysInYear?: number;
+}
+
+export function computeDailyAccrual(
+  input: AccrualComputationInput,
+  options: DailyAccrualOptions = {}
+): FeeAccrualRecord {
+  const { plan, schedule, marketValue } = input;
+  const daysInYear = options.daysInYear ?? 365;
+  const asOf = DateTime.fromJSDate(marketValue.asOf).startOf("day");
+  const start = DateTime.fromJSDate(plan.startDate).startOf("day");
+  const end = plan.endDate ? DateTime.fromJSDate(plan.endDate).startOf("day") : null;
+  if (asOf < start) {
+    return emptyAccrual(plan.accountId, plan.id, schedule.id, marketValue, []);
+  }
+  if (end && asOf > end) {
+    return emptyAccrual(plan.accountId, plan.id, schedule.id, marketValue, []);
+  }
+
+  const rateResult = computeRate({
+    plan,
+    schedule: schedule.spec,
+    marketValue,
+    householdValue: input.householdValue,
+  });
+
+  if (rateResult.baseAmount <= 0 || rateResult.effectiveBps === 0) {
+    return emptyAccrual(plan.accountId, plan.id, schedule.id, marketValue, rateResult.components);
+  }
+
+  const dailyRate = annualBpsToDailyRate(rateResult.effectiveBps, daysInYear);
+  const accrualAmount = toDecimal(rateResult.baseAmount).mul(dailyRate);
+  const amount = decimalToNumber(accrualAmount);
+
+  const components = [
+    ...rateResult.components,
+    {
+      label: "BASE_TIER" as FeeComponentLabel,
+      detail: `Daily accrual @ ${rateResult.effectiveBps.toFixed(4)}bps`,
+      amount,
+      rateBps: rateResult.effectiveBps,
+    },
+  ];
+
+  return {
+    accountId: plan.accountId,
+    asOf: marketValue.asOf,
+    baseAUM: rateResult.baseAmount,
+    rateBps: rateResult.effectiveBps,
+    amount,
+    components,
+    planId: plan.id,
+    scheduleId: schedule.id,
+  };
+}
+
+function emptyAccrual(
+  accountId: string,
+  planId: string,
+  scheduleId: string,
+  marketValue: { asOf: Date },
+  components: FeeAccrualRecord["components"],
+): FeeAccrualRecord {
+  return {
+    accountId,
+    asOf: marketValue.asOf,
+    baseAUM: 0,
+    rateBps: 0,
+    amount: 0,
+    components,
+    planId,
+    scheduleId,
+  };
+}
+

--- a/packages/core/src/feeforge/exceptions.ts
+++ b/packages/core/src/feeforge/exceptions.ts
@@ -1,0 +1,37 @@
+import { v4 as uuid } from "uuid";
+import { ExceptionDetail, ExceptionQueue, ExceptionRecord } from "./types.js";
+
+export class InMemoryExceptionQueue implements ExceptionQueue {
+  private readonly store = new Map<string, ExceptionRecord>();
+
+  enqueue(detail: ExceptionDetail): ExceptionRecord {
+    const record: ExceptionRecord = {
+      ...detail,
+      id: uuid(),
+      createdAt: new Date(),
+      resolvedAt: null,
+      status: "Open",
+    };
+    this.store.set(record.id, record);
+    return record;
+  }
+
+  resolve(id: string, status: ExceptionRecord["status"], _note?: string): ExceptionRecord {
+    const record = this.store.get(id);
+    if (!record) {
+      throw new Error(`Exception ${id} not found`);
+    }
+    const updated: ExceptionRecord = {
+      ...record,
+      status,
+      resolvedAt: new Date(),
+    };
+    this.store.set(id, updated);
+    return updated;
+  }
+
+  listOpen(): ExceptionRecord[] {
+    return Array.from(this.store.values()).filter((record) => record.status === "Open");
+  }
+}
+

--- a/packages/core/src/feeforge/index.ts
+++ b/packages/core/src/feeforge/index.ts
@@ -1,0 +1,5 @@
+export * from "./types.js";
+export * from "./rate-calculator.js";
+export * from "./accrual.js";
+export * from "./invoice.js";
+export * from "./exceptions.js";

--- a/packages/core/src/feeforge/invoice.ts
+++ b/packages/core/src/feeforge/invoice.ts
@@ -1,0 +1,95 @@
+import Decimal from "decimal.js";
+import { DateTime } from "luxon";
+import {
+  AccountFeePlan,
+  FeeAccrualRecord,
+  FeeSchedule,
+  InvoiceDraft,
+  InvoiceLine,
+  InvoiceLineComponent,
+} from "./types.js";
+import { decimalToNumber } from "./utils.js";
+
+export interface InvoiceGenerationInput {
+  plan: AccountFeePlan;
+  schedule: FeeSchedule;
+  accruals: FeeAccrualRecord[];
+  billingPeriodStart: Date;
+  billingPeriodEnd: Date;
+}
+
+export function generateInArrearsInvoice(
+  input: InvoiceGenerationInput
+): InvoiceDraft {
+  const { plan, schedule, billingPeriodStart, billingPeriodEnd } = input;
+  if (plan.billMode !== "InArrears") {
+    throw new Error("generateInArrearsInvoice only supports InArrears plans");
+  }
+  if (plan.billFrequency !== "Monthly" && plan.billFrequency !== "Quarterly") {
+    throw new Error(`Unsupported billing frequency ${plan.billFrequency}`);
+  }
+
+  const startDt = DateTime.fromJSDate(billingPeriodStart).startOf("day");
+  const endDt = DateTime.fromJSDate(billingPeriodEnd).startOf("day");
+
+  const accruals = input.accruals.filter((accrual) => {
+    const asOf = DateTime.fromJSDate(accrual.asOf).startOf("day");
+    return (asOf >= startDt && asOf <= endDt) && accrual.planId === plan.id;
+  });
+
+  const totalAccrued = accruals.reduce(
+    (sum, accrual) => sum.plus(accrual.amount),
+    new Decimal(0)
+  );
+
+  const minimum = schedule.spec.minimumUSD
+    ? new Decimal(schedule.spec.minimumUSD)
+    : new Decimal(0);
+
+  let total = totalAccrued;
+  const lines: InvoiceLine[] = [];
+  const components: InvoiceLineComponent[] = [];
+
+  if (accruals.length > 0) {
+    components.push({
+      label: "BASE_TIER",
+      amount: decimalToNumber(totalAccrued),
+      meta: {
+        days: accruals.length,
+        averageRateBps:
+          accruals.reduce((sum, accrual) => sum + accrual.rateBps, 0) /
+          accruals.length,
+      },
+    });
+  }
+
+  if (minimum.greaterThan(total)) {
+    const diff = minimum.minus(total);
+    total = minimum;
+    components.push({
+      label: "MINIMUM_ADJUSTMENT",
+      amount: decimalToNumber(diff),
+      meta: { minimumUSD: schedule.spec.minimumUSD },
+    });
+  }
+
+  lines.push({
+    accountId: plan.accountId,
+    amount: decimalToNumber(total),
+    components,
+  });
+
+  return {
+    billingPeriodStart,
+    billingPeriodEnd,
+    billingGroupId: plan.billingGroupId ?? undefined,
+    accountId: plan.accountId,
+    currency: plan.billCurrency,
+    amount: decimalToNumber(total),
+    lines,
+    minimumAppliedUSD: minimum.greaterThan(totalAccrued)
+      ? schedule.spec.minimumUSD
+      : undefined,
+  };
+}
+

--- a/packages/core/src/feeforge/rate-calculator.ts
+++ b/packages/core/src/feeforge/rate-calculator.ts
@@ -1,0 +1,183 @@
+import Decimal from "decimal.js";
+import {
+  AccountFeePlan,
+  FeeAccrualComponent,
+  FeeSpec,
+  MarketValueSlice,
+} from "./types.js";
+import { decimalToNumber, toDecimal } from "./utils.js";
+
+export interface RateComputationInput {
+  plan: AccountFeePlan;
+  schedule: FeeSpec;
+  marketValue: MarketValueSlice;
+  householdValue?: number;
+}
+
+export interface RateComputationResult {
+  baseAmount: number;
+  effectiveBps: number;
+  components: FeeAccrualComponent[];
+}
+
+function computeHouseheldValue(
+  spec: FeeSpec,
+  market: MarketValueSlice,
+  householdValue?: number
+): number {
+  if (!spec.householding.enabled) {
+    return market.marketValue;
+  }
+  if (!householdValue) {
+    return market.marketValue;
+  }
+  if (spec.householding.includeAccounts === "ALL") {
+    return householdValue;
+  }
+  if (spec.householding.includeAccounts.includes(market.accountId)) {
+    return householdValue;
+  }
+  return market.marketValue;
+}
+
+export function computeRate(input: RateComputationInput): RateComputationResult {
+  const { schedule: spec, marketValue: market } = input;
+  const components: FeeAccrualComponent[] = [];
+  const accountBase = spec.valuation.includeCrypto
+    ? market.marketValue + (market.cryptoMarketValue ?? 0)
+    : market.marketValue;
+  const pricingBaseSource = computeHouseheldValue(
+    spec,
+    market,
+    input.householdValue
+  );
+  const pricingBase = spec.valuation.includeCrypto
+    ? pricingBaseSource + (market.cryptoMarketValue ?? 0)
+    : pricingBaseSource;
+  if (pricingBase <= 0 || accountBase <= 0) {
+    return { baseAmount: 0, effectiveBps: 0, components };
+  }
+  let effectiveBps = 0;
+  switch (spec.base.method) {
+    case "AUM_TIERED": {
+      const tiers = [...(spec.base.tiers ?? [])];
+      tiers.sort((a, b) => {
+        const aUp = a.upTo ?? Number.POSITIVE_INFINITY;
+        const bUp = b.upTo ?? Number.POSITIVE_INFINITY;
+        return aUp - bUp;
+      });
+      let remaining = pricingBase;
+      let lastCut = 0;
+      let weightedRate = new Decimal(0);
+      for (const tier of tiers) {
+        const tierCap = tier.upTo ?? Number.POSITIVE_INFINITY;
+        const slice = Math.min(pricingBase, tierCap) - lastCut;
+        lastCut = Math.min(pricingBase, tierCap);
+        if (slice <= 0) {
+          continue;
+        }
+        const fraction = toDecimal(slice).div(pricingBase);
+        weightedRate = weightedRate.plus(fraction.mul(tier.rateBps));
+        const allocation = accountBase * fraction.toNumber();
+        components.push({
+          label: "BASE_TIER",
+          detail: tier.upTo ? `Tier up to ${tier.upTo}` : "Overflow tier",
+          amount: allocation,
+          rateBps: tier.rateBps,
+        });
+        remaining -= slice;
+        if (remaining <= 0) {
+          break;
+        }
+      }
+      effectiveBps = decimalToNumber(weightedRate);
+      break;
+    }
+    case "FLAT": {
+      if (!spec.base.flatAnnualUSD) {
+        throw new Error("Flat fee requires flatAnnualUSD");
+      }
+      const rate = toDecimal(spec.base.flatAnnualUSD).div(pricingBase).mul(10000);
+      effectiveBps = decimalToNumber(rate);
+      components.push({
+        label: "BASE_TIER",
+        detail: "Flat fee",
+        amount: accountBase,
+        rateBps: effectiveBps,
+      });
+      break;
+    }
+    default:
+      throw new Error(`Unsupported fee base method: ${spec.base.method}`);
+  }
+
+  let runningRate = new Decimal(effectiveBps);
+  if (spec.discounts) {
+    for (const discount of spec.discounts) {
+      const discountBps = discount.bps ?? 0;
+      if (discountBps !== 0) {
+        runningRate = runningRate.minus(discountBps);
+        components.push({
+          label: "DISCOUNT",
+          detail: discount.label,
+          amount: -accountBase * (discountBps / 10000),
+          rateBps: discountBps,
+        });
+      } else if (discount.amountUSD) {
+        const amtRate = toDecimal(discount.amountUSD).div(pricingBase).mul(10000);
+        runningRate = runningRate.minus(amtRate);
+        components.push({
+          label: "DISCOUNT",
+          detail: discount.label,
+          amount: -discount.amountUSD,
+          rateBps: decimalToNumber(amtRate),
+        });
+      }
+    }
+  }
+
+  if (spec.adders) {
+    for (const adder of spec.adders) {
+      const adderBps = adder.bps ?? 0;
+      if (adderBps !== 0) {
+        runningRate = runningRate.plus(adderBps);
+        components.push({
+          label: "ADDER",
+          detail: adder.label,
+          amount: accountBase * (adderBps / 10000),
+          rateBps: adderBps,
+        });
+      } else if (adder.amountUSD) {
+        const amtRate = toDecimal(adder.amountUSD).div(pricingBase).mul(10000);
+        runningRate = runningRate.plus(amtRate);
+        components.push({
+          label: "ADDER",
+          detail: adder.label,
+          amount: adder.amountUSD,
+          rateBps: decimalToNumber(amtRate),
+        });
+      }
+    }
+  }
+
+  let capped = runningRate;
+  if (spec.capBps !== undefined && spec.capBps !== null) {
+    if (capped.greaterThan(spec.capBps)) {
+      const beforeCap = capped;
+      capped = toDecimal(spec.capBps);
+      components.push({
+        label: "CAP_ADJUSTMENT",
+        detail: `Capped at ${spec.capBps}bps`,
+        amount: 0,
+        rateBps: decimalToNumber(beforeCap.minus(capped)),
+      });
+    }
+  }
+
+  return {
+    baseAmount: accountBase,
+    effectiveBps: decimalToNumber(capped),
+    components,
+  };
+}
+

--- a/packages/core/src/feeforge/types.ts
+++ b/packages/core/src/feeforge/types.ts
@@ -1,0 +1,198 @@
+import { DateTime } from "luxon";
+
+export type Tier = { upTo?: number; rateBps: number };
+
+export type DiscountRule = "HOUSEHOLD" | "ASSET_CLASS" | "INTRO";
+export type AdderRule = "CRYPTO" | "OPTIONS";
+
+export type FeeComponentLabel =
+  | "BASE_TIER"
+  | "DISCOUNT"
+  | "ADDER"
+  | "CAP_ADJUSTMENT"
+  | "MINIMUM_ADJUSTMENT"
+  | "REFUND"
+  | "PERFORMANCE";
+
+export interface DiscountComponent {
+  label: string;
+  rule: DiscountRule;
+  bps?: number;
+  amountUSD?: number;
+}
+
+export interface AdderComponent {
+  label: string;
+  rule: AdderRule;
+  bps?: number;
+  amountUSD?: number;
+}
+
+export type BaseMethod = "AUM_TIERED" | "FLAT" | "HOURLY" | "PROJECT";
+
+export interface PerfSpec {
+  hwm: boolean;
+  hurdleRateBps?: number;
+  crystallize: "Quarterly" | "Annually";
+}
+
+export interface FeeSpec {
+  base: {
+    method: BaseMethod;
+    tiers?: Tier[];
+    flatAnnualUSD?: number;
+  };
+  minimumUSD?: number;
+  discounts?: DiscountComponent[];
+  adders?: AdderComponent[];
+  capBps?: number;
+  allowFeeCreditsFromMF?: boolean;
+  performance?: PerfSpec | null;
+  householding: { enabled: boolean; includeAccounts: string[] | "ALL" };
+  valuation: { method: "EOD_MV"; includeCrypto: boolean; priceSource: "CustodySync" };
+}
+
+export interface FeeSchedule {
+  id: string;
+  name: string;
+  status: "Active" | "Draft" | "Retired";
+  spec: FeeSpec;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export type BillingFrequency = "Monthly" | "Quarterly";
+export type BillingMode = "InArrears" | "InAdvance";
+export type BillingCurrency = "USD" | "CRYPTO_USD_EQ";
+
+export interface AccountFeePlan {
+  id: string;
+  accountId: string;
+  feeScheduleId: string;
+  billingGroupId?: string | null;
+  startDate: Date;
+  endDate?: Date | null;
+  billFrequency: BillingFrequency;
+  billMode: BillingMode;
+  billCurrency: BillingCurrency;
+  custodyDeductionAllowed: boolean;
+  performanceFeeAllowed: boolean;
+  createdAt: Date;
+}
+
+export interface MarketValueSlice {
+  accountId: string;
+  asOf: Date;
+  householdId?: string;
+  householdTotal?: number;
+  marketValue: number;
+  cryptoMarketValue?: number;
+}
+
+export interface FeeAccrualComponent {
+  label: FeeComponentLabel;
+  detail: string;
+  amount: number;
+  rateBps?: number;
+}
+
+export interface FeeAccrualRecord {
+  accountId: string;
+  asOf: Date;
+  baseAUM: number;
+  rateBps: number;
+  amount: number;
+  components: FeeAccrualComponent[];
+  planId: string;
+  scheduleId: string;
+}
+
+export interface InvoiceLineComponent {
+  label: FeeComponentLabel;
+  amount: number;
+  meta?: Record<string, unknown>;
+}
+
+export interface InvoiceLine {
+  accountId: string;
+  amount: number;
+  components: InvoiceLineComponent[];
+}
+
+export interface InvoiceDraft {
+  billingPeriodStart: Date;
+  billingPeriodEnd: Date;
+  billingGroupId?: string | null;
+  accountId?: string | null;
+  currency: string;
+  amount: number;
+  lines: InvoiceLine[];
+  minimumAppliedUSD?: number;
+}
+
+export interface RefundInstruction {
+  accountId: string;
+  amount: number;
+  reason: string;
+}
+
+export interface PerformanceContext {
+  asOf: Date;
+  periodStart: Date;
+  highWaterMark?: number;
+  currentValue: number;
+  netDeposits?: number;
+}
+
+export interface PerformanceComputationResult {
+  eligible: boolean;
+  earnedFeeUSD: number;
+  rationale: string;
+}
+
+export interface AccrualComputationInput {
+  plan: AccountFeePlan;
+  schedule: FeeSchedule;
+  marketValue: MarketValueSlice;
+  householdValue?: number;
+  performance?: PerformanceContext;
+}
+
+export interface ProrationContext {
+  asOf: DateTime;
+  start: DateTime;
+  end?: DateTime | null;
+}
+
+export interface ExceptionDetail {
+  code:
+    | "CAP_EXCEEDED"
+    | "PERF_NOT_ELIGIBLE"
+    | "NO_AUTH"
+    | "MF_COMMISSION_REBATE"
+    | "PAYMENT_FAILED";
+  severity: number;
+  message: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ExceptionRecord extends ExceptionDetail {
+  id: string;
+  createdAt: Date;
+  resolvedAt?: Date | null;
+  status: "Open" | "Approved" | "Rejected" | "Waived";
+}
+
+export interface ExceptionQueue {
+  enqueue(detail: ExceptionDetail): ExceptionRecord;
+  resolve(id: string, status: ExceptionRecord["status"], note?: string): ExceptionRecord;
+  listOpen(): ExceptionRecord[];
+}
+
+export interface CustodyAuthorization {
+  planId: string;
+  granted: boolean;
+  artifactUri?: string;
+  grantedAt?: Date;
+}
+

--- a/packages/core/src/feeforge/utils.ts
+++ b/packages/core/src/feeforge/utils.ts
@@ -1,0 +1,42 @@
+import Decimal from "decimal.js";
+import { DateTime } from "luxon";
+import { ProrationContext } from "./types.js";
+
+Decimal.set({ precision: 28, rounding: Decimal.ROUND_HALF_UP });
+
+export const DAYS_IN_YEAR = 365;
+
+export function toDecimal(value: Decimal.Value): Decimal {
+  return new Decimal(value ?? 0);
+}
+
+export function decimalToNumber(value: Decimal): number {
+  return Number(value.toFixed(8));
+}
+
+export function annualBpsToDailyRate(bps: number, daysInYear = DAYS_IN_YEAR): Decimal {
+  return toDecimal(bps).div(10000).div(daysInYear);
+}
+
+export function prorateForPlan(context: ProrationContext): Decimal {
+  const { asOf, start, end } = context;
+  if (asOf < start) {
+    return toDecimal(0);
+  }
+  if (end && asOf > end) {
+    return toDecimal(0);
+  }
+  return toDecimal(1);
+}
+
+export function daysInPeriod(start: Date, end: Date): number {
+  const startDt = DateTime.fromJSDate(start).startOf("day");
+  const endDt = DateTime.fromJSDate(end).startOf("day");
+  const diff = endDt.diff(startDt, "days").days;
+  return Math.max(1, Math.round(diff || 0));
+}
+
+export function assertNever(value: never): never {
+  throw new Error(`Unexpected value: ${value}`);
+}
+

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./types.js";
 export * from "./validators.js";
 export * from "./crypto.js";
+export * from "./feeforge/index.js";

--- a/packages/core/tests/feeforge.test.ts
+++ b/packages/core/tests/feeforge.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+import { DateTime } from "luxon";
+import {
+  AccountFeePlan,
+  FeeSchedule,
+  computeDailyAccrual,
+  generateInArrearsInvoice,
+  InMemoryExceptionQueue,
+} from "../src/feeforge/index.js";
+
+function buildPlan(overrides: Partial<AccountFeePlan> = {}): AccountFeePlan {
+  return {
+    id: "plan-1",
+    accountId: "ACC-1",
+    feeScheduleId: "fs-1",
+    billingGroupId: null,
+    startDate: new Date("2025-01-01T00:00:00Z"),
+    endDate: null,
+    billFrequency: "Quarterly",
+    billMode: "InArrears",
+    billCurrency: "USD",
+    custodyDeductionAllowed: true,
+    performanceFeeAllowed: false,
+    createdAt: new Date("2025-01-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+function buildSchedule(overrides: Partial<FeeSchedule["spec"]> = {}): FeeSchedule {
+  return {
+    id: "fs-1",
+    name: "Core",
+    status: "Active",
+    createdAt: new Date("2025-01-01T00:00:00Z"),
+    updatedAt: new Date("2025-01-01T00:00:00Z"),
+    spec: {
+      base: {
+        method: "AUM_TIERED",
+        tiers: [
+          { upTo: 1_000_000, rateBps: 100 },
+          { upTo: 2_000_000, rateBps: 75 },
+          { rateBps: 50 },
+        ],
+      },
+      minimumUSD: 0,
+      discounts: [],
+      adders: [],
+      capBps: 300,
+      allowFeeCreditsFromMF: false,
+      performance: null,
+      householding: { enabled: false, includeAccounts: [] },
+      valuation: { method: "EOD_MV", includeCrypto: false, priceSource: "CustodySync" },
+      ...overrides,
+    },
+  };
+}
+
+describe("FeeForge engine", () => {
+  it("computes tiered blended rate and daily accrual", () => {
+    const plan = buildPlan();
+    const schedule = buildSchedule();
+    const asOf = new Date("2025-03-31T00:00:00Z");
+    const accrual = computeDailyAccrual({
+      plan,
+      schedule,
+      marketValue: {
+        accountId: plan.accountId,
+        asOf,
+        marketValue: 2_500_000,
+      },
+    });
+    expect(accrual.rateBps).toBeCloseTo(80, 3);
+    expect(accrual.amount).toBeCloseTo((2_500_000 * 0.008) / 365, 2);
+  });
+
+  it("enforces cap when adders push rate above maximum", () => {
+    const plan = buildPlan();
+    const schedule = buildSchedule({
+      adders: [{ label: "Crypto", rule: "CRYPTO", bps: 400 }],
+      capBps: 250,
+    });
+    const accrual = computeDailyAccrual({
+      plan,
+      schedule,
+      marketValue: {
+        accountId: plan.accountId,
+        asOf: new Date("2025-03-31T00:00:00Z"),
+        marketValue: 1_000_000,
+      },
+    });
+    expect(accrual.rateBps).toBe(250);
+  });
+
+  it("supports householding by using combined MV for breakpoints", () => {
+    const schedule = buildSchedule({ householding: { enabled: true, includeAccounts: "ALL" } });
+    const planA = buildPlan({ id: "plan-A", accountId: "ACC-A" });
+    const planB = buildPlan({ id: "plan-B", accountId: "ACC-B" });
+    const householdTotal = 3_000_000;
+    const accrualA = computeDailyAccrual({
+      plan: planA,
+      schedule,
+      marketValue: {
+        accountId: planA.accountId,
+        asOf: new Date("2025-03-31T00:00:00Z"),
+        marketValue: 1_000_000,
+      },
+      householdValue: householdTotal,
+    });
+    const accrualB = computeDailyAccrual({
+      plan: planB,
+      schedule,
+      marketValue: {
+        accountId: planB.accountId,
+        asOf: new Date("2025-03-31T00:00:00Z"),
+        marketValue: 2_000_000,
+      },
+      householdValue: householdTotal,
+    });
+
+    // Combined household produces 75bps blended rate (1mm*100 + 1mm*75 + 1mm*50)/3mm = 75bps
+    expect(accrualA.rateBps).toBeCloseTo(75, 3);
+    expect(accrualB.rateBps).toBeCloseTo(75, 3);
+    // Each account accrues on its own balance
+    expect(accrualA.baseAUM).toBeCloseTo(1_000_000);
+    expect(accrualB.baseAUM).toBeCloseTo(2_000_000);
+  });
+
+  it("prorates new account by skipping accruals before start", () => {
+    const plan = buildPlan({ startDate: new Date("2025-03-15T00:00:00Z") });
+    const schedule = buildSchedule();
+    const preStart = computeDailyAccrual({
+      plan,
+      schedule,
+      marketValue: {
+        accountId: plan.accountId,
+        asOf: new Date("2025-03-10T00:00:00Z"),
+        marketValue: 1_000_000,
+      },
+    });
+    expect(preStart.amount).toBe(0);
+
+    const postStart = computeDailyAccrual({
+      plan,
+      schedule,
+      marketValue: {
+        accountId: plan.accountId,
+        asOf: new Date("2025-03-20T00:00:00Z"),
+        marketValue: 1_000_000,
+      },
+    });
+    expect(postStart.amount).toBeGreaterThan(0);
+  });
+
+  it("aggregates quarterly accruals into invoices applying minimums", () => {
+    const plan = buildPlan();
+    const schedule = buildSchedule({ minimumUSD: 500 });
+    const accruals = Array.from({ length: 90 }).map((_, idx) =>
+      computeDailyAccrual({
+        plan,
+        schedule,
+        marketValue: {
+          accountId: plan.accountId,
+          asOf: DateTime.fromISO("2025-01-01", { zone: "utc" })
+            .plus({ days: idx })
+            .toJSDate(),
+          marketValue: 50_000,
+        },
+      })
+    );
+    const invoice = generateInArrearsInvoice({
+      plan,
+      schedule,
+      accruals,
+      billingPeriodStart: new Date("2025-01-01T00:00:00Z"),
+      billingPeriodEnd: new Date("2025-03-31T00:00:00Z"),
+    });
+    expect(invoice.amount).toBe(500);
+    expect(invoice.minimumAppliedUSD).toBe(500);
+  });
+
+  it("maintains exception queue lifecycle", () => {
+    const queue = new InMemoryExceptionQueue();
+    const created = queue.enqueue({
+      code: "CAP_EXCEEDED",
+      severity: 90,
+      message: "Exceeded cap",
+    });
+    expect(queue.listOpen()).toHaveLength(1);
+    const resolved = queue.resolve(created.id, "Approved", "Waived after review");
+    expect(resolved.status).toBe("Approved");
+    expect(queue.listOpen()).toHaveLength(0);
+  });
+});
+

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@blackroad/db",
+  "version": "0.1.0",
+  "description": "Prisma schema and helpers for FeeForge billing records.",
+  "type": "module",
+  "license": "Apache-2.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist", "prisma"],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "clean": "rimraf dist",
+    "prisma:generate": "prisma generate"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.18.0"
+  },
+  "devDependencies": {
+    "prisma": "^5.18.0",
+    "rimraf": "^6.0.1",
+    "typescript": "^5.4.5"
+  }
+}

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1,0 +1,109 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model FeeSchedule {
+  id        String   @id @default(cuid())
+  name      String
+  status    String
+  spec      Json
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now())
+}
+
+model BillingGroup {
+  id           String   @id @default(cuid())
+  label        String
+  householdIds String[]
+  policyKey    String?
+}
+
+model AccountFeePlan {
+  id                     String   @id @default(cuid())
+  accountId              String
+  feeScheduleId          String
+  billingGroupId         String?
+  startDate              DateTime
+  endDate                DateTime?
+  billFrequency          String
+  billMode               String
+  billCurrency           String
+  custodyDeductionAllowed Boolean
+  performanceFeeAllowed  Boolean
+  createdAt              DateTime @default(now())
+}
+
+model FeeAccrual {
+  id         String   @id @default(cuid())
+  accountId  String
+  asOf       DateTime
+  baseAUM    Decimal  @db.Decimal(38, 6)
+  rateBps    Int
+  amount     Decimal  @db.Decimal(38, 6)
+  components Json
+  source     String
+}
+
+model Invoice {
+  id                String   @id @default(cuid())
+  billingPeriodStart DateTime
+  billingPeriodEnd   DateTime
+  billingGroupId    String?
+  accountId         String?
+  status            String
+  currency          String
+  amount            Decimal  @db.Decimal(38, 6)
+  lines             Json
+  createdAt         DateTime @default(now())
+  issuedAt          DateTime?
+  paidAt            DateTime?
+  evidencePath      String?
+}
+
+model Payment {
+  id          String   @id @default(cuid())
+  invoiceId   String
+  method      String
+  amount      Decimal  @db.Decimal(38, 6)
+  currency    String
+  externalRef String?
+  postedAt    DateTime
+  status      String
+  meta        Json
+}
+
+model FeeException {
+  id        String   @id @default(cuid())
+  accountId String?
+  invoiceId String?
+  code      String
+  severity  Int
+  details   Json
+  status    String
+  createdAt DateTime @default(now())
+  resolvedAt DateTime?
+}
+
+model ErrorLedger {
+  id          String   @id @default(cuid())
+  scope       String
+  refId       String?
+  description String
+  correction  Json?
+  createdAt   DateTime @default(now())
+}
+
+model WormBlock {
+  id      String   @id @default(cuid())
+  idx     Int      @unique
+  ts      DateTime @default(now())
+  payload Json
+  prevHash String
+  hash    String
+}
+

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,0 +1,10 @@
+import { PrismaClient } from "@prisma/client";
+
+export const prisma = new PrismaClient();
+
+export async function withPrisma<T>(handler: (client: PrismaClient) => Promise<T>): Promise<T> {
+  return handler(prisma);
+}
+
+export type { PrismaClient };
+

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "ESNext",
+    "target": "ES2022",
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist"]
+}

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@blackroad/integrations",
+  "version": "0.1.0",
+  "description": "External integration stubs for FeeForge (custody, payments, pricing).",
+  "type": "module",
+  "license": "Apache-2.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "clean": "rimraf dist"
+  },
+  "dependencies": {
+    "@lucidia/core": "workspace:*",
+    "uuid": "^9.0.1"
+  },
+  "devDependencies": {
+    "rimraf": "^6.0.1",
+    "typescript": "^5.4.5"
+  }
+}

--- a/packages/integrations/src/custody.ts
+++ b/packages/integrations/src/custody.ts
@@ -1,0 +1,28 @@
+import { v4 as uuid } from "uuid";
+import { AccountFeePlan } from "@lucidia/core";
+
+export interface CustodyDeductionRequest {
+  plan: AccountFeePlan;
+  invoiceId: string;
+  amount: number;
+  currency: string;
+  evidenceUri?: string;
+}
+
+export interface CustodyDeductionReceipt {
+  id: string;
+  status: "Submitted" | "Confirmed";
+  submittedAt: Date;
+  confirmationRef?: string;
+}
+
+export async function submitCustodyDeduction(
+  request: CustodyDeductionRequest
+): Promise<CustodyDeductionReceipt> {
+  return {
+    id: uuid(),
+    status: "Submitted",
+    submittedAt: new Date(),
+  };
+}
+

--- a/packages/integrations/src/index.ts
+++ b/packages/integrations/src/index.ts
@@ -1,0 +1,4 @@
+export * from "./custody.js";
+export * from "./payments.js";
+export * from "./pricing.js";
+export * from "./pdf.js";

--- a/packages/integrations/src/payments.ts
+++ b/packages/integrations/src/payments.ts
@@ -1,0 +1,29 @@
+import { v4 as uuid } from "uuid";
+
+export type ExternalPaymentMethod = "ACH" | "Wire" | "Check" | "Crypto";
+
+export interface ExternalPaymentRequest {
+  invoiceId: string;
+  method: ExternalPaymentMethod;
+  amount: number;
+  currency: string;
+  reference?: string;
+}
+
+export interface ExternalPaymentReceipt {
+  id: string;
+  status: "Pending" | "Settled" | "Failed";
+  postedAt: Date;
+  failureReason?: string;
+}
+
+export async function recordExternalPayment(
+  request: ExternalPaymentRequest
+): Promise<ExternalPaymentReceipt> {
+  return {
+    id: uuid(),
+    status: "Settled",
+    postedAt: new Date(),
+  };
+}
+

--- a/packages/integrations/src/pdf.ts
+++ b/packages/integrations/src/pdf.ts
@@ -1,0 +1,17 @@
+import { InvoiceDraft } from "@lucidia/core";
+
+export interface PdfRenderResult {
+  buffer: Buffer;
+  contentType: string;
+  filename: string;
+}
+
+export async function renderInvoicePdf(invoice: InvoiceDraft): Promise<PdfRenderResult> {
+  const content = JSON.stringify(invoice, null, 2);
+  return {
+    buffer: Buffer.from(content, "utf-8"),
+    contentType: "application/pdf",
+    filename: `invoice-${invoice.accountId ?? invoice.billingGroupId}.pdf`,
+  };
+}
+

--- a/packages/integrations/src/pricing.ts
+++ b/packages/integrations/src/pricing.ts
@@ -1,0 +1,29 @@
+export interface PricingQuote {
+  assetId: string;
+  price: number;
+  asOf: Date;
+  currency: string;
+}
+
+export async function fetchEndOfDayPricing(assetIds: string[]): Promise<PricingQuote[]> {
+  const now = new Date();
+  return assetIds.map((assetId) => ({
+    assetId,
+    price: 1,
+    asOf: now,
+    currency: "USD",
+  }));
+}
+
+export async function convertToUsd(
+  amount: number,
+  currency: string,
+  rate?: number
+): Promise<number> {
+  if (currency === "USD") {
+    return amount;
+  }
+  const fxRate = rate ?? 1;
+  return amount * fxRate;
+}
+

--- a/packages/integrations/tsconfig.json
+++ b/packages/integrations/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "ESNext",
+    "target": "ES2022",
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist"]
+}

--- a/packages/policies/package.json
+++ b/packages/policies/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@blackroad/policies",
+  "version": "0.1.0",
+  "description": "Compliance policy checks for BlackRoad FeeForge.",
+  "type": "module",
+  "license": "Apache-2.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "clean": "rimraf dist"
+  },
+  "dependencies": {
+    "@lucidia/core": "workspace:*",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "rimraf": "^6.0.1",
+    "typescript": "^5.4.5"
+  }
+}

--- a/packages/policies/src/fees/caps.ts
+++ b/packages/policies/src/fees/caps.ts
@@ -1,0 +1,31 @@
+import { FeeSpec } from "@lucidia/core";
+import { z } from "zod";
+import { PolicyViolation } from "./types.js";
+
+const CapInput = z.object({
+  effectiveBps: z.number().nonnegative(),
+  scheduleSpec: z.custom<FeeSpec>(),
+});
+
+export function enforceFeeCap(input: {
+  effectiveBps: number;
+  scheduleSpec: FeeSpec;
+}): PolicyViolation | null {
+  const parsed = CapInput.parse(input);
+  if (parsed.scheduleSpec.capBps === undefined || parsed.scheduleSpec.capBps === null) {
+    return null;
+  }
+  if (parsed.effectiveBps <= parsed.scheduleSpec.capBps) {
+    return null;
+  }
+  return {
+    code: "CAP_EXCEEDED",
+    severity: 90,
+    message: `Effective rate ${parsed.effectiveBps}bps exceeds cap ${parsed.scheduleSpec.capBps}bps`,
+    details: {
+      effectiveBps: parsed.effectiveBps,
+      capBps: parsed.scheduleSpec.capBps,
+    },
+  };
+}
+

--- a/packages/policies/src/fees/custody.ts
+++ b/packages/policies/src/fees/custody.ts
@@ -1,0 +1,33 @@
+import { AccountFeePlan, CustodyAuthorization } from "@lucidia/core";
+import { z } from "zod";
+import { PolicyViolation } from "./types.js";
+
+const CustodyInput = z.object({
+  plan: z.custom<AccountFeePlan>(),
+  authorization: z.custom<CustodyAuthorization | null | undefined>(),
+});
+
+export function requireCustodyAuthorization(input: {
+  plan: AccountFeePlan;
+  authorization?: CustodyAuthorization | null;
+}): PolicyViolation | null {
+  const { plan, authorization } = CustodyInput.parse(input);
+  if (!plan.custodyDeductionAllowed) {
+    return {
+      code: "NO_AUTH",
+      severity: 80,
+      message: "Custody deduction requested without client authorization",
+      details: { planId: plan.id },
+    };
+  }
+  if (!authorization || !authorization.granted) {
+    return {
+      code: "NO_AUTH",
+      severity: 85,
+      message: "Custody deduction authorization artifact missing",
+      details: { planId: plan.id },
+    };
+  }
+  return null;
+}
+

--- a/packages/policies/src/fees/disclosure.ts
+++ b/packages/policies/src/fees/disclosure.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+import { PolicyViolation } from "./types.js";
+
+const DeliveryInput = z.object({
+  clientId: z.string(),
+  period: z.string(),
+  deliveries: z.array(
+    z.object({
+      document: z.enum(["ADV", "FORM_CRS", "FEE_SCHEDULE"]),
+      deliveredAt: z.date(),
+    })
+  ),
+});
+
+export function confirmDisclosureDelivery(input: {
+  clientId: string;
+  period: string;
+  deliveries: { document: "ADV" | "FORM_CRS" | "FEE_SCHEDULE"; deliveredAt: Date }[];
+}): PolicyViolation | null {
+  const parsed = DeliveryInput.parse(input);
+  const hasAdv = parsed.deliveries.some((delivery) => delivery.document === "ADV");
+  const hasCrs = parsed.deliveries.some((delivery) => delivery.document === "FORM_CRS");
+  if (hasAdv && hasCrs) {
+    return null;
+  }
+  return {
+    code: "DISCLOSURE_MISSING",
+    severity: 60,
+    message: `Missing ADV/CRS delivery evidence for ${parsed.clientId} in ${parsed.period}`,
+  };
+}
+

--- a/packages/policies/src/fees/mutualfund.ts
+++ b/packages/policies/src/fees/mutualfund.ts
@@ -1,0 +1,35 @@
+import { FeeSchedule } from "@lucidia/core";
+import { z } from "zod";
+import { PolicyViolation } from "./types.js";
+
+const CreditInput = z.object({
+  schedule: z.custom<FeeSchedule>(),
+  mode: z.enum(["FEE_CREDIT", "REBATE"]),
+  amount: z.number().positive(),
+});
+
+export function validateMutualFundCredit(input: {
+  schedule: FeeSchedule;
+  mode: "FEE_CREDIT" | "REBATE";
+  amount: number;
+}): PolicyViolation | null {
+  const parsed = CreditInput.parse(input);
+  if (parsed.mode === "REBATE") {
+    return {
+      code: "MF_COMMISSION_REBATE",
+      severity: 90,
+      message: "Mutual-fund commission rebates are prohibited",
+      details: { scheduleId: parsed.schedule.id },
+    };
+  }
+  if (!parsed.schedule.spec.allowFeeCreditsFromMF) {
+    return {
+      code: "MF_COMMISSION_REBATE",
+      severity: 70,
+      message: "Schedule does not permit mutual-fund fee credits",
+      details: { scheduleId: parsed.schedule.id },
+    };
+  }
+  return null;
+}
+

--- a/packages/policies/src/fees/performance.ts
+++ b/packages/policies/src/fees/performance.ts
@@ -1,0 +1,51 @@
+import { AccountFeePlan, FeeSchedule } from "@lucidia/core";
+import { z } from "zod";
+import { PolicyViolation } from "./types.js";
+
+const EligibilityInput = z.object({
+  plan: z.custom<AccountFeePlan>(),
+  schedule: z.custom<FeeSchedule>(),
+  eligibility: z
+    .object({
+      qualifiedPurchaser: z.boolean().optional(),
+      qualifiedClient: z.boolean().optional(),
+    })
+    .optional(),
+});
+
+export function enforcePerformanceEligibility(input: {
+  plan: AccountFeePlan;
+  schedule: FeeSchedule;
+  eligibility?: { qualifiedPurchaser?: boolean; qualifiedClient?: boolean };
+}): PolicyViolation | null {
+  const { plan, schedule, eligibility } = EligibilityInput.parse(input);
+  if (!schedule.spec.performance) {
+    return null;
+  }
+  if (!plan.performanceFeeAllowed) {
+    return {
+      code: "PERF_NOT_ELIGIBLE",
+      severity: 95,
+      message: "Performance fee blocked because plan is not eligible",
+      details: { planId: plan.id },
+    };
+  }
+  if (!eligibility) {
+    return {
+      code: "PERF_NOT_ELIGIBLE",
+      severity: 95,
+      message: "Performance fee eligibility evidence missing",
+      details: { planId: plan.id },
+    };
+  }
+  if (!eligibility.qualifiedClient && !eligibility.qualifiedPurchaser) {
+    return {
+      code: "PERF_NOT_ELIGIBLE",
+      severity: 95,
+      message: "Client fails qualified purchaser/client requirements",
+      details: { planId: plan.id },
+    };
+  }
+  return null;
+}
+

--- a/packages/policies/src/fees/types.ts
+++ b/packages/policies/src/fees/types.ts
@@ -1,0 +1,7 @@
+export interface PolicyViolation {
+  code: "CAP_EXCEEDED" | "NO_AUTH" | "PERF_NOT_ELIGIBLE" | "MF_COMMISSION_REBATE" | "DISCLOSURE_MISSING";
+  severity: number;
+  message: string;
+  details?: Record<string, unknown>;
+}
+

--- a/packages/policies/src/index.ts
+++ b/packages/policies/src/index.ts
@@ -1,0 +1,6 @@
+export * from "./fees/caps.js";
+export * from "./fees/custody.js";
+export * from "./fees/performance.js";
+export * from "./fees/mutualfund.js";
+export * from "./fees/disclosure.js";
+export * from "./fees/types.js";

--- a/packages/policies/tsconfig.json
+++ b/packages/policies/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "ESNext",
+    "target": "ES2022",
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist"]
+}

--- a/packages/worm/package.json
+++ b/packages/worm/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@blackroad/worm",
+  "version": "0.1.0",
+  "description": "Append-only WORM archive for FeeForge evidence.",
+  "type": "module",
+  "license": "Apache-2.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "clean": "rimraf dist"
+  },
+  "devDependencies": {
+    "rimraf": "^6.0.1",
+    "typescript": "^5.4.5"
+  }
+}

--- a/packages/worm/src/index.ts
+++ b/packages/worm/src/index.ts
@@ -1,0 +1,50 @@
+import { createHash } from "node:crypto";
+
+export interface WormAppendInput<T = unknown> {
+  payload: T;
+}
+
+export interface WormBlock<T = unknown> {
+  idx: number;
+  ts: Date;
+  payload: T;
+  prevHash: string;
+  hash: string;
+}
+
+export interface WormLedger<T = unknown> {
+  append(entry: WormAppendInput<T>): Promise<WormBlock<T>>;
+  tail(): WormBlock<T> | null;
+  all(): WormBlock<T>[];
+}
+
+export class InMemoryWormLedger<T = unknown> implements WormLedger<T> {
+  private blocks: WormBlock<T>[] = [];
+
+  async append(entry: WormAppendInput<T>): Promise<WormBlock<T>> {
+    const prev = this.blocks[this.blocks.length - 1] ?? null;
+    const block: WormBlock<T> = {
+      idx: prev ? prev.idx + 1 : 1,
+      ts: new Date(),
+      payload: entry.payload,
+      prevHash: prev?.hash ?? "GENESIS",
+      hash: computeHash(prev?.hash ?? "GENESIS", entry.payload),
+    };
+    this.blocks.push(block);
+    return block;
+  }
+
+  tail(): WormBlock<T> | null {
+    return this.blocks[this.blocks.length - 1] ?? null;
+  }
+
+  all(): WormBlock<T>[] {
+    return [...this.blocks];
+  }
+}
+
+function computeHash(prevHash: string, payload: unknown): string {
+  const content = JSON.stringify({ prevHash, payload });
+  return createHash("sha256").update(content).digest("hex");
+}
+

--- a/packages/worm/tsconfig.json
+++ b/packages/worm/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "ESNext",
+    "target": "ES2022",
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist"]
+}


### PR DESCRIPTION
## Summary
- add FeeForge billing engine with tiered rate math, accruals, invoicing, and exception queue under @lucidia/core
- introduce compliance policies, integration stubs, Prisma schema, and append-only WORM utility packages for FeeForge evidence
- provide CLI workflows and a Fastify API for schedules, plans, accruals, invoices, payments, and exceptions

## Testing
- `cd packages/core && npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68e19d72630c8329a3a00fd671a325a4