### PR TITLE
Add October kernel monitoring notes

### DIFF
--- a/security/kernel_watch_2025-10.md
+++ b/security/kernel_watch_2025-10.md
@@ -1,0 +1,35 @@
+# Kernel and Service Monitoring Notes (2025-10-04)
+
+## Observed External Status Signals
+
+- OpenAI status dashboard currently reports the platform as fully operational, but recent history on the page shows several incidents in early October and the preceding months.
+- Cloudflare status dashboard is presently tracking partial service issues, including elevated write latency in certain regions alongside R2, D1, and cache purge impact reports.
+
+> **Reminder:** Always corroborate third-party status data with official vendor notifications or direct API telemetry before initiating incident response.
+
+## Reported Kernel Vulnerabilities to Validate
+
+The following issues have been reported publicly. Treat them as leads until vendor advisories or CVE bulletins confirm scope and mitigations.
+
+| Identifier | Component | Reported Risk Summary | Recommended Validation Steps |
+| --- | --- | --- | --- |
+| CVE-2025-39946 | Linux kernel TLS parsing | Potential overflow in `sk_buff` when parsing malformed TLS headers under low-buffer conditions. Could enable crafted-packet exploitation. | Check distribution security channels for acknowledgment. Review TLS offload configurations and ensure rate limiting / anomaly detection for TLS endpoints. |
+| CVE-2025-39932 | SUSE kernel | Listed in SUSE CVE tracker, severity not yet confirmed. | Monitor SUSE advisories and apply vendor patches once released. Confirm kernel package versions in staging and production. |
+| CVE-2025-37899 | Linux `ksmbd` subsystem | Reported use-after-free during SMB session teardown allowing remote code execution. | Disable `ksmbd` where unused. For required services, restrict exposure, enable signing, and follow vendor mitigations once validated. |
+
+## Immediate Action Items
+
+1. Subscribe to OpenAI and Cloudflare status notifications to receive incident alerts quickly.
+2. Poll distro-maintained update channels (e.g., Ubuntu USN, RHEL errata, SUSE patch finder) for kernel advisories at least daily until remediation guidance is published.
+3. Inventory systems running TLS termination or SMB services and document whether kernel-space modules (e.g., `ksmbd`) are loaded. Prioritize isolation or temporary disablement where feasible.
+4. Schedule non-production patch validation windows so patches can be deployed rapidly once released.
+5. Coordinate with detection engineering to ensure IDS/IPS signatures and telemetry cover malformed TLS traffic and anomalous SMB teardown flows.
+
+## Tracking Checklist
+
+- [ ] Confirm vendor acknowledgment for each CVE.
+- [ ] Capture patch availability dates and link to advisories.
+- [ ] Record mitigation status for TLS endpoints and SMB services.
+- [ ] Update runbooks once official fixes are applied.
+
+Document updates in `security/` should include references to authoritative advisories (NVD, vendor bulletins) once they are published.


### PR DESCRIPTION
## Summary
- add security note outlining October 2025 kernel vulnerability reports and related service status observations
- capture immediate validation and mitigation actions for TLS and SMB exposures
- include checklist for tracking vendor advisories and remediation progress

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e29ad04e9883299fe7af19cf89808e