### PR TITLE
Add blog coverage of UK's retail crypto ETN rollout

### DIFF
--- a/sites/blackroad/content/blog/uk-retail-crypto-etns-rollout.md
+++ b/sites/blackroad/content/blog/uk-retail-crypto-etns-rollout.md
@@ -1,0 +1,39 @@
+---
+title: "UK Greenlights Retail Crypto ETNs for October 2025 Launch"
+date: "2025-10-05"
+tags: ["regulation", "markets", "crypto"]
+description: "FCA will let retail investors access crypto ETNs from October 2025, prompting brokers to prep for listings."
+---
+
+## Market snapshot
+
+- **Bitcoin (BTC):** holding above the six-figure mark as of October 5 (UTC).
+- **Ethereum (ETH):** trading in the mid-$4,500 range.
+- **Solana (SOL):** Solana status page reports no incidents today, indicating healthy network performance.
+
+## FCA unlocks retail access to crypto ETNs
+
+The UK Financial Conduct Authority confirmed that retail investors can trade crypto exchange-traded notes (cETNs) starting **8 October 2025**, provided the notes are listed on FCA-recognised UK exchanges.
+
+Key guardrails include:
+
+- The decision reverses the January 2021 retail ban on cETNs, but crypto derivatives such as futures and options remain prohibited.
+- Issuers and distributors must comply with the UK financial promotion regime and the Consumer Duty when marketing or supporting these products.
+- cETNs are not eligible for Financial Services Compensation Scheme (FSCS) protection, so investors bear the full market and operational risk.
+
+## Broker readiness
+
+UK platforms are taking varied approaches to the new allowance:
+
+- **Committed or early launch plans:** FreeTrade, Stratiphy.
+- **Reviewing or considering:** Fidelity Personal Investing, IG, Interactive Investor.
+- **Delaying or undecided:** eToro (no immediate rollout), Hargreaves Lansdown, AJ Bell (both assessing participation).
+- **Specialist access:** Saxo intends to enable crypto ETNs for UK clients on October 8, subject to conditions.
+
+Many brokers are expected to plug into existing ETNs already listed on the London Stock Exchange from issuers such as 21Shares and WisdomTree. Firms continue to weigh risk controls, operational complexity, and compliance obligations before confirming their launch timelines.
+
+## What to watch next
+
+- Expect updated product disclosures and risk warnings as brokers finalize their cETN offerings.
+- Monitor Solana’s status page and other chain health dashboards for network resilience as trading interest increases.
+- Watch for FCA supervision updates or guidance clarifying consumer protections and reporting expectations ahead of the October 2025 go-live.


### PR DESCRIPTION
## Summary
- add a new blog post covering the FCA's decision to permit retail access to crypto ETNs from October 8, 2025
- include current market context and broker readiness status updates

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e29f9bc890832990309c335e0c57fd