### PR TITLE
Add blog coverage of Discord support breach risk

### DIFF
--- a/sites/blackroad/content/blog/discord-support-breach-honeypot-risk.md
+++ b/sites/blackroad/content/blog/discord-support-breach-honeypot-risk.md
@@ -1,0 +1,33 @@
+---
+title: "Discord Support Breach Shows Third-Party Honeypot Risk"
+date: "2025-10-05"
+tags: [security, incident-response, third-party-risk]
+description: "Key lessons from Discord's October 2025 support breach and why outsourced customer service portals attract attackers."
+---
+
+## What happened
+
+Discord disclosed that attackers compromised a third-party customer support provider on October 3, 2025. The adversaries used the foothold to exfiltrate records tied to users who had contacted Discord Customer Support or Trust & Safety and then attempted to extort the company. The breach did not touch Discord's core production systems, but it exposed sensitive case files held by the vendor.
+
+The affected dataset included names, email addresses, contact information, IP addresses, conversation histories with support agents, limited billing metadata (such as payment type and the last four digits of a card), and a small number of government ID images uploaded for age appeals. Discord emphasized that the attackers did **not** obtain full payment card numbers, passwords, authentication tokens, or any messages outside of the support workflow.
+
+## Immediate response
+
+Discord revoked the vendor's access, launched an internal and forensic investigation, notified law enforcement, and began emailing impacted users. The company promised that anyone whose government-issued ID was accessed would receive explicit notice.
+
+Users who have recently interacted with Discord support should monitor their inboxes (including spam folders) for official notices. Expect phishing attempts that spoof the disclosure—treat any unexpected request for credentials, payment, or new "verification" uploads as hostile until verified through Discord's published channels.
+
+## Why outsourced support is a prime target
+
+Third-party ticketing platforms collect rich metadata that adversaries can weaponize for social engineering, credential harvesting, or account takeover. Because these systems centralize identity documents, dispute narratives, and contact methods, they act as honeypots with a higher return on compromise than typical user databases. Media reports suggested the breached vendor operated a Zendesk instance, underscoring the systemic risk of managed support desks.
+
+Security teams should treat external support providers as critical infrastructure: enforce least-privilege data scopes, monitor access with independent logging, require rapid offboarding controls, and simulate vendor compromise during tabletop exercises. Age-verification pipelines deserve special scrutiny, since they often store highly sensitive documents for a narrow use case.
+
+## Actions to take now
+
+- **Review exposure**: If you submitted tickets—especially age verification appeals—assume that metadata could be exposed until Discord confirms otherwise.
+- **Harden comms**: Rotate any shared secrets sent through support threads and revoke delegated access granted during troubleshooting.
+- **Detect phishing**: Deploy targeted detections for Discord-themed lures, especially among community moderators and staff with elevated privileges.
+- **Re-assess vendors**: Inventory every third-party platform that handles support or trust & safety data and validate that contractual, technical, and monitoring controls match their sensitivity.
+
+Outsourcing customer support can accelerate operations, but only if organizations continuously audit the security posture of the partners that now hold their most sensitive user conversations.


### PR DESCRIPTION
## Summary
- add a blog post detailing Discord's October 2025 customer support breach and the third-party honeypot risks it highlights

## Testing
- npm run build *(fails: existing syntax error in sites/blackroad/src/pages/AutoDiffLab.jsx unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a0b0a8fc8329a696fdfd203308d5