### PR TITLE
Add Pepper's Ghost calibration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,10 +157,15 @@ Example:
 ```
 
 The script also understands:
-
 - "Refresh working copy and redeploy"
 - "Rebase branch and update site"
 - "Sync Salesforce -> Airtable -> Droplet"
+
+---
+
+## Visual Hardware Guides
+
+- [Pepper's Ghost Cube Calibration](docs/guides/peppers-ghost-calibration.md) — 5-minute tune-up checklist for crisp, centered holographic projections.
 
 It pulls from GitHub, triggers connector webhooks, updates a Working Copy checkout, and
 executes a remote refresh command on the droplet.

--- a/docs/guides/peppers-ghost-calibration.md
+++ b/docs/guides/peppers-ghost-calibration.md
@@ -1,0 +1,61 @@
+# Pepper's Ghost Cube Calibration Guide
+
+A tuned Pepper's Ghost pyramid delivers a crisp, floating illusion instead of a blurry ghost. Use this 5-minute calibration workflow and keep a log of your tweaks so the cube stays aligned between sessions.
+
+## 1. Level and Angle
+- Place a small bubble level (or a phone level app) on the acrylic pyramid's top to confirm it is flat.
+- Verify the pyramid tilt is roughly 45° relative to the screen. Shim with thin tape or card stock until reflections stay centered and symmetric.
+
+## 2. Centering
+- Display a high-contrast test image: a black background with a white square or crosshair centered on screen.
+- Nudge the pyramid until the reflection is perfectly centered inside the cube without clipping on any edge.
+
+## 3. Reflection Parity
+- Show four identical markers near each edge of the screen (top, bottom, left, right).
+- You should see a single, stable floating image mid-pyramid. Doubled edges mean the angle or centering is off—revisit leveling and shimming.
+
+## 4. LED Illumination
+- Start with LEDs off and set the screen brightness around 60–80% to preserve deep blacks.
+- Gradually raise LED intensity just enough to reveal the cube edges and interior. If blacks turn charcoal, dim the LEDs or choose a cooler/less saturated channel.
+
+## 5. Screen Synchronization (Multi-panel Rigs)
+- Match resolution and refresh rate across every panel (for example, 1080p @ 60 Hz).
+- If animation tears at the seams, ensure each panel receives the same frame timing and playback start—ideally clone a single player feed to all screens.
+
+## 6. Color and Contrast
+- Favor dark user interfaces (#000–#050) for backgrounds.
+- Push contrast on subjects with bright edges, subtle bloom, and minimal mid-gray areas to avoid milkiness in reflections.
+
+## 7. Anti-smudge and Stray Light Control
+- Clean inside and outside acrylic faces with a microfiber cloth; fingerprints slash contrast.
+- Block ambient light leaking from behind or beneath the screens using felt tape or black paper baffles.
+
+## Visual Quality Checklist
+- Blacks remain black (not charcoal).
+- No double images along edges.
+- The object appears centered and consistently bright while you move around the cube.
+
+## High-impact Micro-adjustments
+- 1–2° tilt refinements often eliminate double edges.
+- 2–5% LED dimming can restore true blacks.
+- 2–3 mm lateral shifts realign corners and stop clipping.
+
+## Reusable Test Content
+- **Focus card:** black screen with a 2 px white crosshair centered.
+- **Edge card:** black screen with 10 px white borders inset 5% from each edge.
+- **Motion loop:** small white dot orbiting slowly to validate sync and tearing.
+
+## Calibration Log Template
+Record each session to repeat successful setups quickly.
+
+```
+Date/Time:
+Pyramid angle: ____°
+Pyramid position: X ____ mm | Y ____ mm
+Screen: res ____ | Hz ____ | brightness ____%
+LED: preset ____ | intensity ____%
+Notes: (ghosting? washout? edge clipping?)
+Result: (✓ crisp / ~ okay / ✗ needs work)
+```
+
+> Want a targeted nudge plan? Collect the current pyramid angle, LED levels, and screen settings, then share them so an experienced operator can recommend precise adjustments (e.g., “dim LEDs 8%, rotate 1.5° clockwise, shift +3 mm Y”).


### PR DESCRIPTION
## Summary
- add a dedicated Pepper's Ghost cube calibration guide with quick setup steps and reusable test cards
- link the new guide from the README so hardware operators can find it quickly

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e2a069c0188329b6b7c0d56e5c3a48