### PR TITLE
Add RoadChain docker compose stack

### DIFF
--- a/compose/roadchain.yml
+++ b/compose/roadchain.yml
@@ -1,0 +1,63 @@
+version: "3.9"
+
+name: roadchain
+services:
+  node:
+    image: ghcr.io/roadchain/node:latest   # replace with your node image
+    container_name: roadchain-node
+    restart: unless-stopped
+    command: ["--network=testnet", "--http", "--http-port=8545", "--ws", "--ws-port=8546"]
+    ports:
+      - "8545:8545"   # HTTP RPC
+      - "8546:8546"   # WebSocket
+      - "30303:30303/tcp"
+      - "30303:30303/udp"
+    environment:
+      - NODE_ENV=production
+    volumes:
+      - node_data:/var/lib/roadchain
+    healthcheck:
+      test: ["CMD", "sh", "-c", "nc -z localhost 8545"]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+
+  wallet:
+    image: ghcr.io/roadchain/wallet:latest # replace with your wallet svc image
+    container_name: roadchain-wallet
+    restart: unless-stopped
+    depends_on:
+      node:
+        condition: service_healthy
+    environment:
+      - RPC_HTTP_URL=http://node:8545
+      - NETWORK=testnet
+      # - WALLET_MNEMONIC=change-me   # prefer secrets in .env or Docker secrets
+    ports:
+      - "8081:8080"   # wallet API exposed to host
+    healthcheck:
+      test: ["CMD", "sh", "-c", "wget -qO- http://localhost:8080/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+
+  dashboard:
+    image: ghcr.io/roadchain/dashboard:latest  # replace with your UI image
+    container_name: roadchain-dashboard
+    restart: unless-stopped
+    depends_on:
+      wallet:
+        condition: service_healthy
+    environment:
+      - WALLET_API_URL=http://wallet:8080
+      - RPC_HTTP_URL=http://node:8545
+    ports:
+      - "3000:3000"   # web UI
+    healthcheck:
+      test: ["CMD", "sh", "-c", "wget -qO- http://localhost:3000/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+
+volumes:
+  node_data:

--- a/docs/roadchain-stack-compose.md
+++ b/docs/roadchain-stack-compose.md
@@ -1,0 +1,18 @@
+# RoadChain Compose Stack
+
+This compose bundle launches the core RoadChain stack with three lightweight services that share a network and persistent volume:
+
+- **Blockchain node** – exposes HTTP and WebSocket JSON-RPC endpoints and persists chain data on the `node_data` volume.
+- **Wallet facade** – bridges application traffic to the node and waits for the node health check before starting.
+- **Dashboard UI** – depends on the wallet service and surfaces a simple health probe.
+
+The definition lives at [`compose/roadchain.yml`](../compose/roadchain.yml) and uses a project name of `roadchain` so it does not collide with other compose environments.
+
+## Usage
+
+1. Adjust the `image` fields to point at the container images for your deployment (e.g., RoadChain mainnet vs. testnet).
+2. Store any sensitive values (mnemonics, API tokens) in a colocated `.env` file and reference them with `${VAR}`.
+3. Start the stack with `docker compose -f compose/roadchain.yml up -d`.
+4. Inspect health by hitting `http://localhost:3000/health` (dashboard), `http://localhost:8081/health` (wallet), or the node RPC at `http://localhost:8545`.
+
+All services include sensible health checks and will restart automatically if they fail. The shared `node_data` volume keeps blockchain data across container restarts.


### PR DESCRIPTION
## Summary
- add a modular docker compose definition for the RoadChain node, wallet, and dashboard stack
- document usage instructions for the new compose bundle

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2a03d54388329b7ea35687ffb5d92