### PR TITLE
Add blog post on AI agents and stablecoin liquidity trends

### DIFF
--- a/sites/blackroad/content/blog/ai-agents-stablecoin-liquidity.md
+++ b/sites/blackroad/content/blog/ai-agents-stablecoin-liquidity.md
@@ -1,0 +1,40 @@
+---
+title: "AI Agents, Stablecoin Liquidity, and the Reality Check"
+date: "2025-09-12"
+tags: [ai, crypto, stablecoins]
+description: "Why AI-driven liquidity routing could reshape stablecoins, and why token prices have yet to catch up."
+---
+
+The collision of artificial intelligence and crypto markets is creating a fresh
+tension between lofty expectations and what the market is willing to reward.
+Recent commentary from Paxos Labs cofounder Bhau Kotecha highlights a future
+where agentic AI programs become the dominant users of stablecoins. In that
+scenario, autonomous bots shuttle liquidity across issuers—USDT, USDC, PYUSD,
+and synthetic models—while “voting with capital” for the most efficient
+balances sheets in real time.
+
+If that automation plays out, fragmentation across stablecoin issuers stops
+being a liability and instead becomes a competitive filter. AI routers would be
+incentivized to chase the most transparent reserves, lowest slippage venues,
+and fastest settlement rails, rewarding fundamentals instead of brand inertia.
+It also reframes stablecoins as core infrastructure for machine-to-machine
+commerce: the medium that allows microtransactions, automated treasury
+rebalancing, and event-driven hedging without human intervention.
+
+Yet the market’s scorecard tells another story. AI-crypto tokens have shed more
+than half their value since 2024 despite a modest uptick in venture funding—
+about $516 million raised in the first eight months of 2025. The funding surge
+has not translated into price momentum because the promises of autonomous
+agents, on-chain AI markets, and predictive trading intelligence still outpace
+usable infrastructure. Most projects are still wrestling with costly inference,
+siloed data access, and tokenomics that struggle to retain real demand beyond
+speculation.
+
+Taken together, we are watching two timelines unfold at once. Stablecoin rails
+are mature enough that AI liquidity engines feel plausible, but the tokens
+trying to monetize the AI narrative remain stuck in the lab. Builders should
+prioritize resilient bridges between AI services and on-chain execution—
+especially standardized APIs for bots, programmatic treasury controls for
+issuers, and clearer value accrual for token holders. Until those gaps close,
+funding headlines will keep outpacing token performance, even as AI bots quietly
+become the biggest stablecoin power users behind the scenes.


### PR DESCRIPTION
## Summary
- add a new blog post covering AI agents as liquidity routers for stablecoins and the gap between hype and token performance

## Testing
- not run (content-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e2a01c77248329b89bc999c70f091b