### PR TITLE
Align react-dom with React 19

### DIFF
--- a/sites/blackroad/package-lock.json
+++ b/sites/blackroad/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.3.1",
       "dependencies": {
         "react": "^19.1.1",
-        "react-dom": "^18.3.1",
+        "react-dom": "^19.1.1",
         "react-rnd": "10.5.2",
         "react-router-dom": "7.8.2",
         "recharts": "^2.11.0"
@@ -19,7 +19,7 @@
         "@playwright/test": "^1.47.0",
         "@size-limit/file": "^11.1.5",
         "@types/react": "^19.1.12",
-        "@types/react-dom": "^18.3.7",
+        "@types/react-dom": "^19.2.0",
         "@typescript-eslint/eslint-plugin": "^8.4.0",
         "@typescript-eslint/parser": "^8.4.0",
         "@vitejs/plugin-react": "5.0.2",
@@ -1359,9 +1359,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.1.12",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.12.tgz",
-      "integrity": "sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==",
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.0.tgz",
+      "integrity": "sha512-1LOH8xovvsKsCBq1wnT4ntDUdCJKmnEakhsuoUSy6ExlHCkGP2hqnatagYTgFk6oeL0VU31u7SNjunPN+GchtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1369,13 +1369,13 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.0.tgz",
+      "integrity": "sha512-brtBs0MnE9SMx7px208g39lRmC5uHZs96caOJfTjFcYSLHNamvaSMfJNagChVNkup2SdtOxKX1FDBkRSJe1ZAg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^18.0.0"
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3846,25 +3846,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.1.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
-      "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
+      "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
+      "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.2.0"
       }
     },
     "node_modules/react-draggable": {
@@ -4152,13 +4151,10 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/section-matter": {
       "version": "1.0.0",

--- a/sites/blackroad/package.json
+++ b/sites/blackroad/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "react": "^19.1.1",
-    "react-dom": "^18.3.1",
+    "react-dom": "^19.1.1",
     "react-rnd": "10.5.2",
     "react-router-dom": "7.8.2",
     "recharts": "^2.11.0"
@@ -26,7 +26,7 @@
     "@playwright/test": "^1.47.0",
     "@size-limit/file": "^11.1.5",
     "@types/react": "^19.1.12",
-    "@types/react-dom": "^18.3.7",
+    "@types/react-dom": "^19.2.0",
     "@typescript-eslint/eslint-plugin": "^8.4.0",
     "@typescript-eslint/parser": "^8.4.0",
     "@vitejs/plugin-react": "5.0.2",

--- a/sites/blackroad/src/pages/AutoDiffLab.jsx
+++ b/sites/blackroad/src/pages/AutoDiffLab.jsx
@@ -44,7 +44,7 @@ export default function AutoDiffLab(){
       <h2 className="text-xl font-semibold">Automatic Differentiation — Dual & Finite Diff</h2>
       <div className="grid" style={{gridTemplateColumns:'1fr 320px', gap:16}}>
         <Panel title="Function">
-          <p className="text-sm opacity-80">f(x) = e^{\{sin x\}} + x^3 − 2 log x</p>
+          <p className="text-sm opacity-80">{"f(x) = e^{{sin x}} + x^3 − 2 log x"}</p>
           <p className="text-sm">x = <b>{x.toFixed(6)}</b></p>
           <p className="text-sm">f(x) = <b>{dual.y.toFixed(6)}</b></p>
           <p className="text-sm">f′(x) via dual = <b>{dual.dy.toFixed(6)}</b></p>


### PR DESCRIPTION
## Summary
- align the blackroad site react-dom dependency and types to match React 19.1.1
- refresh package-lock.json by reinstalling dependencies
- adjust the AutoDiffLab function label so the production build succeeds under the new tooling

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2c4615fd0832982f398999c9abb82