### PR TITLE
Enable Playwright smoke tests for Blackroad site

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,3 +14,23 @@ jobs:
           node -e "const fs=require('fs');const p='package.json';const j=JSON.parse(fs.readFileSync(p,'utf8'));j.scripts=j.scripts||{};j.scripts.test=j.scripts.test||'echo \"No tests specified\" && exit 0';fs.writeFileSync(p, JSON.stringify(j,null,2));"
       - run: npm ci --omit=optional || npm i --package-lock-only
       - run: npm test
+  site-playwright:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sites/blackroad
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: sites/blackroad/package-lock.json
+      - name: Install dependencies
+        run: npm ci --omit=optional || npm i --package-lock-only
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+      - name: Run Playwright tests
+        run: npm test
+        env:
+          CI: "true"

--- a/sites/blackroad/README.md
+++ b/sites/blackroad/README.md
@@ -18,6 +18,11 @@ npm run build   # outputs to sites/blackroad/dist
 
 npm run preview # http://localhost:5174
 
+## Testing
+
+npm test           # runs Playwright smoke + regression suite (starts local dev server automatically)
+npm run e2e        # alias for the same Playwright test runner
+
 ## Deployment
 
 GitHub Pages builds and deploys `dist` on every push to `main` via `.github/workflows/site-build.yml`.

--- a/sites/blackroad/package-lock.json
+++ b/sites/blackroad/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.3.1",
       "dependencies": {
         "react": "^19.1.1",
-        "react-dom": "^18.3.1",
+        "react-dom": "^19.1.1",
         "react-rnd": "10.5.2",
         "react-router-dom": "7.8.2",
         "recharts": "^2.11.0"
@@ -19,7 +19,7 @@
         "@playwright/test": "^1.47.0",
         "@size-limit/file": "^11.1.5",
         "@types/react": "^19.1.12",
-        "@types/react-dom": "^18.3.7",
+        "@types/react-dom": "^19.1.5",
         "@typescript-eslint/eslint-plugin": "^8.4.0",
         "@typescript-eslint/parser": "^8.4.0",
         "@vitejs/plugin-react": "5.0.2",
@@ -1359,9 +1359,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.1.12",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.12.tgz",
-      "integrity": "sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==",
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.0.tgz",
+      "integrity": "sha512-1LOH8xovvsKsCBq1wnT4ntDUdCJKmnEakhsuoUSy6ExlHCkGP2hqnatagYTgFk6oeL0VU31u7SNjunPN+GchtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1369,13 +1369,13 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.0.tgz",
+      "integrity": "sha512-brtBs0MnE9SMx7px208g39lRmC5uHZs96caOJfTjFcYSLHNamvaSMfJNagChVNkup2SdtOxKX1FDBkRSJe1ZAg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^18.0.0"
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3846,25 +3846,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.1.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
-      "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
+      "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
+      "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.2.0"
       }
     },
     "node_modules/react-draggable": {
@@ -4152,13 +4151,10 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/section-matter": {
       "version": "1.0.0",

--- a/sites/blackroad/package.json
+++ b/sites/blackroad/package.json
@@ -11,12 +11,12 @@
     "preview": "vite preview",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx || true",
     "format": "prettier -w .",
-    "test": "echo \"(add Playwright later)\"",
-    "e2e": "playwright test || true"
+    "test": "playwright test",
+    "e2e": "playwright test"
   },
   "dependencies": {
     "react": "^19.1.1",
-    "react-dom": "^18.3.1",
+    "react-dom": "^19.1.1",
     "react-rnd": "10.5.2",
     "react-router-dom": "7.8.2",
     "recharts": "^2.11.0"
@@ -26,7 +26,7 @@
     "@playwright/test": "^1.47.0",
     "@size-limit/file": "^11.1.5",
     "@types/react": "^19.1.12",
-    "@types/react-dom": "^18.3.7",
+    "@types/react-dom": "^19.1.5",
     "@typescript-eslint/eslint-plugin": "^8.4.0",
     "@typescript-eslint/parser": "^8.4.0",
     "@vitejs/plugin-react": "5.0.2",

--- a/sites/blackroad/playwright.config.ts
+++ b/sites/blackroad/playwright.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from "@playwright/test";
+
+const host = process.env.E2E_HOST ?? "127.0.0.1";
+const port = Number(process.env.E2E_PORT ?? 5173);
+const baseURL = process.env.E2E_BASE ?? `http://${host}:${port}`;
+
+if (!process.env.E2E_BASE) {
+  process.env.E2E_BASE = baseURL;
+}
+
+export default defineConfig({
+  testDir: "tests",
+  retries: process.env.CI ? 1 : 0,
+  use: {
+    baseURL,
+    trace: "retain-on-failure",
+  },
+  webServer: {
+    command: `npm run dev -- --host ${host} --port ${port}`,
+    url: baseURL,
+    timeout: 120_000,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/sites/blackroad/src/pages/AutoDiffLab.jsx
+++ b/sites/blackroad/src/pages/AutoDiffLab.jsx
@@ -44,7 +44,7 @@ export default function AutoDiffLab(){
       <h2 className="text-xl font-semibold">Automatic Differentiation — Dual & Finite Diff</h2>
       <div className="grid" style={{gridTemplateColumns:'1fr 320px', gap:16}}>
         <Panel title="Function">
-          <p className="text-sm opacity-80">f(x) = e^{\{sin x\}} + x^3 − 2 log x</p>
+          <p className="text-sm opacity-80">f(x) = e^{sin x} + x^3 − 2 log x</p>
           <p className="text-sm">x = <b>{x.toFixed(6)}</b></p>
           <p className="text-sm">f(x) = <b>{dual.y.toFixed(6)}</b></p>
           <p className="text-sm">f′(x) via dual = <b>{dual.dy.toFixed(6)}</b></p>

--- a/sites/blackroad/tests/blog-hello-world.spec.ts
+++ b/sites/blackroad/tests/blog-hello-world.spec.ts
@@ -1,8 +1,7 @@
 import { test, expect } from "@playwright/test";
-const base = process.env.E2E_BASE || "http://127.0.0.1:5173";
 
 test("blog post hello world is accessible", async ({ page }) => {
-  await page.goto(base + "/blog/hello-world.html");
+  await page.goto("/blog/hello-world.html");
   await expect(page.getByRole("heading", { name: /Hello World/i })).toBeVisible();
   await expect(page.getByText(/Welcome to Hello World on BlackRoad.io./i)).toBeVisible();
 });

--- a/sites/blackroad/tests/e2e.spec.ts
+++ b/sites/blackroad/tests/e2e.spec.ts
@@ -1,5 +1,4 @@
 import { test, expect } from '@playwright/test';
-const base = process.env.E2E_BASE || 'http://127.0.0.1:4178';
 const routes = [
   '/',
   '/docs',
@@ -17,7 +16,7 @@ const routes = [
 
 for (const r of routes) {
   test(`route ${r} renders`, async ({ page }) => {
-    await page.goto(base + r);
+    await page.goto(r);
     await expect(page)
       .toHaveTitle(/blackroad/i, { timeout: 30000 })
       .catch(() => {}); // title may be minimal

--- a/sites/blackroad/tests/home.smoke.spec.ts
+++ b/sites/blackroad/tests/home.smoke.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("home smoke", () => {
+  test("shows desktop launchers and opens API agent", async ({ page }) => {
+    await page.goto("/");
+
+    const apiLauncher = page.getByRole("button", { name: "API" });
+    const llmLauncher = page.getByRole("button", { name: "LLM" });
+
+    await expect(apiLauncher).toBeVisible();
+    await expect(llmLauncher).toBeVisible();
+
+    await apiLauncher.click();
+
+    await expect(page.getByText(/API Agent/i)).toBeVisible();
+    await expect(page.getByRole("button", { name: /Run health probe/i })).toBeVisible();
+  });
+});

--- a/sites/blackroad/tests/home.spec.ts
+++ b/sites/blackroad/tests/home.spec.ts
@@ -1,8 +1,7 @@
 import { test, expect } from "@playwright/test";
-const base = process.env.E2E_BASE || "http://127.0.0.1:5173";
 
 test("home renders new landing hero", async ({ page }) => {
-  await page.goto(base + "/");
+  await page.goto("/");
   await expect(page.getByRole("heading", { name: /Welcome to Blackroad/i })).toBeVisible();
   await expect(page.getByRole("link", { name: /Enter Portal/i })).toBeVisible();
   // status widget should eventually resolve
@@ -10,12 +9,12 @@ test("home renders new landing hero", async ({ page }) => {
 });
 
 test("status page fetches /api/health.json", async ({ page }) => {
-  await page.goto(base + "/status");
+  await page.goto("/status");
   await expect(page.getByText(/Status/i)).toBeVisible();
 });
 
 test("portal index lists cards", async ({ page }) => {
-  await page.goto(base + "/portal");
+  await page.goto("/portal");
   await expect(page.getByText(/Roadbook/i)).toBeVisible();
   await expect(page.getByText(/Roadview/i)).toBeVisible();
   await expect(page.getByText(/Lucidia/i)).toBeVisible();

--- a/sites/blackroad/tests/roadview.spec.ts
+++ b/sites/blackroad/tests/roadview.spec.ts
@@ -1,8 +1,7 @@
 import { test, expect } from "@playwright/test";
-const base = process.env.E2E_BASE || "http://127.0.0.1:5173";
 
 test("team dropdown filters items", async ({ page }) => {
-  await page.goto(base + "/roadview");
+  await page.goto("/roadview");
   await expect(page.getByRole("heading", { name: /RoadView/i })).toBeVisible();
   await page.selectOption(page.getByRole("combobox", { name: "Team" }), "alpha");
   await expect(page.getByText("Quest Engine")).toBeVisible();

--- a/sites/blackroad/tests/run-e2e-from-sitemap.js
+++ b/sites/blackroad/tests/run-e2e-from-sitemap.js
@@ -6,7 +6,7 @@
 const fs = require('fs'); const path = require('path')
 const { test, expect, chromium } = require('@playwright/test') // via pw test runner API
 ;(async () => {
-  const base = process.env.E2E_BASE || 'http://127.0.0.1:4178'
+  const base = process.env.E2E_BASE || 'http://127.0.0.1:5173'
   const distMap = path.join(process.cwd(), 'dist', 'sitemap.xml')
   let urls = []
   if (fs.existsSync(distMap)) {


### PR DESCRIPTION
## Summary
- replace the Blackroad site test entrypoints with Playwright and add a project config that boots Vite during test runs
- add a desktop smoke test and normalize existing specs to work with the configured base URL while fixing an AutoDiffLab string escape
- document the new workflow and hook the Playwright suite into CI alongside dependency updates needed for installation

## Testing
- npm --prefix sites/blackroad test *(fails: host lacks Playwright system dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c4634a0083298f0572f8794d40c7