### PR TITLE
Add hash-chained auditing to Prism SSE events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ yarn-debug.log*
 pr_autopilot.log
 pnpm-debug.log*
 blackroad_deploy.log
+prism/logs/
 
 # OS
 .DS_Store

--- a/apps/prismweb/src/components/prism/Console.tsx
+++ b/apps/prismweb/src/components/prism/Console.tsx
@@ -14,16 +14,23 @@ const Console: React.FC<{ client: Client }> = ({ client }) => {
   useEffect(() => {
     if (!runId) return;
     const es = new EventSource('/events');
+    const extract = (message: MessageEvent): any => {
+      const parsed = JSON.parse(message.data);
+      if (parsed && typeof parsed === 'object' && 'data' in parsed) {
+        return (parsed as any).data;
+      }
+      return parsed;
+    };
     es.addEventListener('run.out', (e) => {
-      const data = JSON.parse((e as MessageEvent).data);
+      const data = extract(e as MessageEvent);
       if (data.runId === runId) setLines((l) => [...l, data.chunk]);
     });
     es.addEventListener('run.err', (e) => {
-      const data = JSON.parse((e as MessageEvent).data);
+      const data = extract(e as MessageEvent);
       if (data.runId === runId) setLines((l) => [...l, data.chunk]);
     });
     es.addEventListener('run.end', (e) => {
-      const data = JSON.parse((e as MessageEvent).data);
+      const data = extract(e as MessageEvent);
       if (data.runId === runId) {
         setStatus(data.exitCode === 0 ? 'ok' : data.exitCode === null ? 'cancelled' : 'error');
         es.close();

--- a/apps/prismweb/test/console.test.tsx
+++ b/apps/prismweb/test/console.test.tsx
@@ -7,7 +7,18 @@ class MockEventSource {
   listeners: Record<string, Function[]> = {};
   constructor(url: string) { MockEventSource.last = this; }
   addEventListener(type: string, cb: any) { (this.listeners[type] ||= []).push(cb); }
-  emit(type: string, data: any) { (this.listeners[type] || []).forEach((cb) => cb({ data: JSON.stringify(data) })); }
+  emit(type: string, data: any) {
+    const envelope = {
+      id: 'evt',
+      kind: type,
+      data,
+      index: 0,
+      ts: new Date().toISOString(),
+      prevHash: 'GENESIS',
+      hash: 'hash',
+    };
+    (this.listeners[type] || []).forEach((cb) => cb({ data: JSON.stringify(envelope) }));
+  }
   close() {}
 }
 (globalThis as any).EventSource = MockEventSource as any;


### PR DESCRIPTION
## Summary
- add a hash-chained event envelope for Prism SSE traffic and persist the append-only log for tamper evidence
- surface the new envelope structure to clients while keeping the console view backwards compatible
- adjust the console test harness and ignore generated Prism log artifacts

## Testing
- pnpm --dir prism/server test
- pnpm --dir apps/prismweb test

------
https://chatgpt.com/codex/tasks/task_e_68e5ff9343488329871370ea85b583cb