### PR TITLE
Add reflex runtime for Lucidia event hooks

### DIFF
--- a/lucidia/reflex/__init__.py
+++ b/lucidia/reflex/__init__.py
@@ -1,0 +1,9 @@
+"""Lightweight reflex runtime for Lucidia.
+
+This package exposes the shared reflex bus instance and helpers for
+registering background reactions to edge events.
+"""
+
+from .core import BUS, start, ReflexBus
+
+__all__ = ["BUS", "start", "ReflexBus"]

--- a/lucidia/reflex/core.py
+++ b/lucidia/reflex/core.py
@@ -1,0 +1,147 @@
+"""Core runtime for Lucidia reflexes.
+
+The runtime offers a single in-process bus that small reflex handlers can
+subscribe to.  Watchers emit topic/payload pairs into the bus and the
+runtime dispatches them on a background thread so the emitters stay
+non-blocking.
+
+The runtime respects the ``LUCIDIA_REFLEX_OFF`` environment variable as an
+emergency kill switch.  When the variable is set to ``"1"`` no handlers are
+invoked, though events are still logged for observability.
+
+Events are logged as JSON lines.  The output path defaults to the value of
+``LUCIDIA_REFLEX_LOG`` if provided, otherwise the log is sent to stdout.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List
+import json
+import os
+import queue
+import threading
+import time
+import logging
+from pathlib import Path
+
+
+class ReflexBus:
+    """A tiny publish/subscribe bus for reflex handlers."""
+
+    def __init__(self, *, disabled: bool | None = None) -> None:
+        env_disabled = os.environ.get("LUCIDIA_REFLEX_OFF", "0") == "1"
+        self._enabled = not (disabled if disabled is not None else env_disabled)
+        self._routes: Dict[str, List[Callable[[Any], None]]] = {}
+        self._q: "queue.Queue[tuple[str, Any]]" = queue.Queue()
+        self._thread: threading.Thread | None = None
+        self._lock = threading.Lock()
+        self._logger = self._configure_logger()
+
+    # ------------------------------------------------------------------
+    def _configure_logger(self) -> logging.Logger:
+        logger = logging.getLogger("lucidia.reflex")
+        logger.setLevel(logging.INFO)
+
+        if logger.handlers:
+            return logger
+
+        log_path = os.environ.get("LUCIDIA_REFLEX_LOG")
+        handler: logging.Handler
+        if log_path:
+            try:
+                path = Path(log_path)
+                path.parent.mkdir(parents=True, exist_ok=True)
+                handler = logging.FileHandler(path)
+            except OSError:
+                handler = logging.StreamHandler()
+        else:
+            handler = logging.StreamHandler()
+
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        logger.addHandler(handler)
+        return logger
+
+    # ------------------------------------------------------------------
+    @property
+    def enabled(self) -> bool:
+        """Return whether the bus will dispatch events to handlers."""
+
+        return self._enabled
+
+    # ------------------------------------------------------------------
+    def enable(self) -> None:
+        self._enabled = True
+
+    # ------------------------------------------------------------------
+    def disable(self) -> None:
+        self._enabled = False
+
+    # ------------------------------------------------------------------
+    def on(self, topic: str, fn: Callable[[Any], None]) -> Callable[[Any], None]:
+        """Register a reflex handler for a topic."""
+
+        self._routes.setdefault(topic, []).append(fn)
+        return fn
+
+    # ------------------------------------------------------------------
+    def emit(self, topic: str, payload: Any) -> None:
+        """Publish an event to the bus."""
+
+        entry = {
+            "ts": time.time(),
+            "topic": topic,
+            "payload": payload,
+        }
+        try:
+            self._logger.info(json.dumps(entry, default=str))
+        except Exception:
+            # Logging must never break reflex flow.
+            pass
+
+        if not self._enabled:
+            return
+
+        self._q.put((topic, payload))
+
+    # ------------------------------------------------------------------
+    def start(self) -> None:
+        """Ensure the dispatcher thread is running."""
+
+        if not self._enabled:
+            return
+
+        with self._lock:
+            if self._thread and self._thread.is_alive():
+                return
+            self._thread = threading.Thread(target=self.run_forever, daemon=True)
+            self._thread.start()
+
+    # ------------------------------------------------------------------
+    def run_forever(self) -> None:
+        """Dispatch events to registered handlers."""
+
+        while True:
+            topic, payload = self._q.get()
+            for fn in list(self._routes.get(topic, [])):
+                try:
+                    fn(payload)
+                except Exception as exc:  # pragma: no cover - guardrail
+                    err_entry = {
+                        "ts": time.time(),
+                        "topic": topic,
+                        "error": str(exc),
+                    }
+                    try:
+                        self._logger.info(json.dumps(err_entry, default=str))
+                    except Exception:
+                        pass
+
+
+BUS = ReflexBus()
+
+
+def start() -> None:
+    """Public helper to spin up the reflex dispatcher."""
+
+    BUS.start()
+

--- a/lucidia/reflex/gpio_reflex.py
+++ b/lucidia/reflex/gpio_reflex.py
@@ -1,0 +1,57 @@
+"""Example reflex wiring for Raspberry Pi GPIO events."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+try:  # pragma: no cover - optional hardware dependency
+    import RPi.GPIO as GPIO
+except ImportError:  # pragma: no cover - optional hardware dependency
+    GPIO = None
+
+from lucidia.reflex.core import BUS, start
+
+LED = 18
+INPUT = 17
+
+
+def setup() -> None:
+    """Prepare GPIO pins for input edge watching."""
+
+    if GPIO is None:
+        return
+    GPIO.setmode(GPIO.BCM)
+    GPIO.setup(LED, GPIO.OUT)
+    GPIO.setup(INPUT, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+
+
+@BUS.on("gpio:edge")
+def blink(_: Any) -> None:
+    if GPIO is None:
+        return
+    GPIO.output(LED, True)
+    time.sleep(0.1)
+    GPIO.output(LED, False)
+
+
+def watch(poll_interval: float = 0.02) -> None:
+    """Poll the GPIO pin and emit events on changes."""
+
+    if GPIO is None or not BUS.enabled:
+        return
+
+    last = GPIO.input(INPUT)
+    while True:
+        cur = GPIO.input(INPUT)
+        if cur != last:
+            BUS.emit("gpio:edge", {"pin": INPUT, "state": cur})
+            last = cur
+        time.sleep(poll_interval)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual wiring
+    setup()
+    start()
+    watch()
+

--- a/lucidia/reflex/log_reflex.py
+++ b/lucidia/reflex/log_reflex.py
@@ -1,0 +1,38 @@
+"""Job log reflex example."""
+
+from __future__ import annotations
+
+import re
+import time
+from typing import Any
+
+from lucidia.reflex.core import BUS, start
+
+ERROR_RE = re.compile(r"\bERROR\b")
+
+
+@BUS.on("joblog:line")
+def on_line(evt: Any) -> None:
+    line = evt.get("line", "")
+    if ERROR_RE.search(line):
+        print("[reflex] tagged ERROR:", line.strip())
+
+
+def tail(path: str = "/srv/blackroad/logs/agent.log", poll_interval: float = 0.1) -> None:
+    if not BUS.enabled:
+        return
+
+    with open(path, "r", encoding="utf-8") as f:
+        f.seek(0, 2)
+        while True:
+            line = f.readline()
+            if not line:
+                time.sleep(poll_interval)
+                continue
+            BUS.emit("joblog:line", {"line": line})
+
+
+if __name__ == "__main__":  # pragma: no cover - manual wiring
+    start()
+    tail()
+

--- a/lucidia/reflex/wallet_reflex.py
+++ b/lucidia/reflex/wallet_reflex.py
@@ -1,0 +1,36 @@
+"""Wallet webhook reflex example."""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import os
+import subprocess
+from typing import Any, Dict
+
+from lucidia.reflex.core import BUS, start
+
+WALLET_LOG = os.environ.get("LUCIDIA_WALLET_LOG", "/var/log/lucidia/wallet-events.log")
+
+
+@BUS.on("wallet:credit")
+def on_credit(evt: Dict[str, Any]) -> None:
+    os.makedirs(os.path.dirname(WALLET_LOG), exist_ok=True)
+    record = {"at": _dt.datetime.utcnow().isoformat() + "Z", **evt}
+    with open(WALLET_LOG, "a", encoding="utf-8") as f:
+        f.write(json.dumps(record) + "\n")
+    try:
+        subprocess.Popen(["paplay", "/usr/share/sounds/freedesktop/stereo/complete.oga"])
+    except Exception:
+        pass
+
+
+def http_wallet_webhook(data: Dict[str, Any]) -> None:
+    if data.get("delta_sats", 0) > 0:
+        BUS.emit("wallet:credit", data)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual wiring
+    start()
+    http_wallet_webhook({"txid": "abc", "delta_sats": 12345})
+


### PR DESCRIPTION
## Summary
- add a lightweight reflex bus with JSON logging and kill switch support
- provide GPIO, wallet, and log reflex examples that emit and react to bus events

## Testing
- python -m compileall lucidia/reflex

------
https://chatgpt.com/codex/tasks/task_e_68e5ffc77cc483299cc5a7bcc447e956