### PR TITLE
Add quickstart guide for Pepper's Ghost neural rendering

### DIFF
--- a/docs/PEPPERS_GHOST_NERF_QUICKSTART.md
+++ b/docs/PEPPERS_GHOST_NERF_QUICKSTART.md
@@ -70,7 +70,10 @@ instant_ngp:
 ```
 Invoke with:
 ```bash
-ns-train instant-ngp --data ./datasets/<scene_name> --load-config configs/jetson_instant_ngp.yaml
+ns-train instant-ngp \
+  --data ./datasets/<scene_name> \
+  --config-path configs \
+  --config-name jetson_instant_ngp
 ```
 
 ## Gaussian Splatting Option


### PR DESCRIPTION
## Summary
- add a quickstart guide for capturing, training, and rendering neural assets for the Pepper's Ghost cube
- include Jetson-friendly Instant-NGP preset and gaussian splatting option notes
- document display loop tips and Lucidia scene concepts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5ffddc75c832985337aabdac0872c