### PR TITLE
Add blog post on 2025 Nobel Prize immune tolerance discovery

### DIFF
--- a/sites/blackroad/content/blog/nobel-2025-immune-tolerance-breakthrough.md
+++ b/sites/blackroad/content/blog/nobel-2025-immune-tolerance-breakthrough.md
@@ -1,0 +1,33 @@
+---
+title: "2025 Nobel Prize Spotlights Immune System Brake Pedal"
+date: "2025-10-06"
+tags: [science, medicine, immunology]
+description: "How Sakaguchi, Brunkow, and Ramsdell decoded regulatory T cells and FOXP3 to explain immune self-control."
+---
+
+The 2025 Nobel Prize in Physiology or Medicine celebrates three scientists whose work revealed how the immune system knows when to stop. Their discovery of regulatory T cells (Tregs) and the FOXP3 gene transformed our understanding of autoimmune disease, transplant tolerance, and the delicate balance between defense and self-harm.
+
+## Regulatory T cells enter the story
+
+Back in 1995, Shimon Sakaguchi uncovered a subset of T cells that put the brakes on immune activation. These regulatory T cells, or Tregs, quietly police immune responses, halting attacks on healthy tissue before they spiral.
+
+## FOXP3 ties genetics to immune restraint
+
+Mary E. Brunkow and Fred Ramsdell then traced lethal autoimmune disease in mice to mutations in a gene they called *Foxp3*. Their translational leap was to show that human FOXP3 mutations cause IPEX syndrome, a devastating autoimmune condition. That evidence connected FOXP3 to Treg identity and function.
+
+Sakaguchi later demonstrated that FOXP3 is the master switch Tregs need both to develop and to suppress immune activity. Without it, the immune system loses its self-control circuitry.
+
+## Why this matters now
+
+Together, their work defined peripheral immune tolerance—our body’s post-thymus safety net that restrains self-reactive immune cells that escaped early selection. The concept reframed how clinicians think about autoimmunity, graft rejection, and tumor immunity.
+
+By understanding these biological brakes, researchers can now explore therapies that dial Tregs or FOXP3 activity up or down. That could mean new treatments for autoimmune disorders, precision tools to protect transplanted organs, or strategies to unleash the immune system against cancers.
+
+## Key takeaways
+
+- **Regulatory T cells** act as molecular brakes that prevent collateral damage from immune responses.
+- **FOXP3** functions as the genetic program Tregs rely on to develop and restrain inflammation.
+- **Peripheral tolerance** explains how the immune system continually avoids attacking the body’s own tissues.
+- **Therapeutic targeting** of Tregs or FOXP3 may unlock interventions for autoimmunity, transplantation, and oncology.
+
+The Nobel Committee’s choice underscores how decoding the immune system’s restraint mechanisms can open entirely new frontiers in medicine.


### PR DESCRIPTION
## Summary
- add a blog post covering the 2025 Nobel Prize in Physiology or Medicine
- highlight how regulatory T cells and FOXP3 discoveries underpin peripheral immune tolerance
- outline therapeutic implications for autoimmunity, transplantation, and oncology

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6004493988329a6fb81e08e422bcc