### PR TITLE
Add Codex Spotlights wave II entries

### DIFF
--- a/codex/entries/013-verifiable-compute.md
+++ b/codex/entries/013-verifiable-compute.md
@@ -1,0 +1,27 @@
+# Codex 13 — Verifiable Compute — Trust the Result, Not the Box
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Aim
+Prove remote computation was executed correctly without re-running it locally.
+
+## Core
+- Model the workload as a succinct non-interactive argument of knowledge (SNARK) relation \(R(x, w)\) with constraint system \(C(x, w) = 1\).
+- Enforce soundness so that \(\Pr[\text{V accepts} \land (x, w) \notin R] \leq \text{negl}(\lambda)\).
+- Achieve verification time \(T_{\text{verify}} = \tilde{O}(|x|)\), independent of prover runtime.
+
+## Runbook
+1. Compile the workload into a circuit or other arithmetization and fix the public input \(x\).
+2. Have the prover return the output \(y\) alongside a proof \(\pi\); the verifier checks \(\pi\).
+3. Archive \((x, y, \pi, \mathsf{vk})\) into the Civilizational ECC and pin the digest on-chain or in an immutable log.
+
+## Telemetry
+- Proof size and amortized cost per proof.
+- Verification time and failure rate.
+- Prover runtime and resource consumption.
+
+## Failsafes
+- If the prover times out, fall back to redundant execution across diverse hardware targets.
+- If proof verification fails, quarantine the output and trigger incident response.
+
+**Tagline:** Believe the math, not the metal.

--- a/codex/entries/014-zero-knowledge-access.md
+++ b/codex/entries/014-zero-knowledge-access.md
@@ -1,0 +1,27 @@
+# Codex 14 — Zero-Knowledge Access — Reveal Nothing, Prove Enough
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Aim
+Grant access rights based on properties while withholding identity and sensitive attributes.
+
+## Core
+- Use zero-knowledge proofs of knowledge to show membership in policy predicates without revealing the witness: \(\text{ZKPoK}\{w : H(w) = c \wedge P(w) = 1\}\).
+- Apply group or ring signatures to provide signer anonymity with optional linkability.
+- Log nullifiers or other one-time tokens to prevent reuse without deanonymizing.
+
+## Runbook
+1. Define the policy predicate \(P\) and issue credentials that commit to \(c\).
+2. At access time, present a zero-knowledge proof that \(P(w)\) holds while revealing no personally identifiable information.
+3. Record a nullifier or serial number to detect double-spend or abuse attempts.
+
+## Telemetry
+- Proof acceptance rate and average generation time.
+- Distribution of nullifier usage and collision monitoring.
+- Credential issuance and revocation volume.
+
+## Failsafes
+- If the policy predicate drifts or becomes stale, hot-patch it and force credential refresh.
+- Escalate to step-up authentication (such as device attestation) after repeated proof failures or suspected abuse.
+
+**Tagline:** Permissions by proof, not by passport.

--- a/codex/entries/015-quantitative-information-flow.md
+++ b/codex/entries/015-quantitative-information-flow.md
@@ -1,0 +1,27 @@
+# Codex 15 — Quantitative Information Flow — Measure the Leak
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Aim
+Keep secrets secure by quantifying leakage instead of relying on intuition.
+
+## Core
+- Define information leakage through a channel \(C\) as mutual information \(\mathcal{L} = I(S; O) = H(S) - H(S \mid O)\).
+- Enforce quantitative noninterference so that \(\mathcal{L} \leq \epsilon\) for each release.
+- Use hyperproperty reasoning (2-safety) to compare pairs of runs against policy constraints.
+
+## Runbook
+1. Annotate confidential sources and observable sinks; instrument systems to estimate \(I(S; O)\).
+2. Allocate an \(\epsilon\) leakage budget per module and deny releases that exceed the cap.
+3. Apply differential privacy, padding, or channel randomization to reduce \(\mathcal{L}\).
+
+## Telemetry
+- Bits leaked per query or release and cumulative leakage versus budget.
+- Effectiveness of mitigation techniques over time.
+- Alerts raised when leakage approaches thresholds.
+
+## Failsafes
+- Trigger an emergency kill switch when leakage exceeds the budget.
+- Capture forensic snapshots and patch the offending module before re-enabling output.
+
+**Tagline:** Quantify every whisper.

--- a/codex/entries/016-supply-chain-attestation.md
+++ b/codex/entries/016-supply-chain-attestation.md
@@ -1,0 +1,27 @@
+# Codex 16 — Supply-Chain Attestation — Build Graphs That Verify Themselves
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Aim
+Ensure every artifact in the supply chain is traceable, reproducible, and cryptographically attested.
+
+## Core
+- Represent artifacts as a DAG \(G = (V, E)\) with digests \(h(v) = H(\text{content})\).
+- Apply in-toto style layouts so that each step \(s\) satisfies its predicate \(\Pi_s\).
+- Leverage measured boot with platform configuration registers \(p_i = H(p_{i-1} \parallel m_i)\) to bind runtime state.
+
+## Runbook
+1. Perform hermetic builds, generate SBOMs, and sign each supply-chain edge with a key scoped to \(\Pi_s\).
+2. During deployment, verify the path from source \(v_0\) to target \(v_*\), confirm SBOM closure, check PCR values, and validate timestamps.
+3. Deny execution if any edge is unsigned or if digests mismatch the expected lineage.
+
+## Telemetry
+- Attestation pass rate across environments.
+- Number of orphan or unreferenced artifacts.
+- SBOM coverage and freshness of signing keys.
+
+## Failsafes
+- Quarantine rollouts that fail attestation and initiate rollback to the last verified state.
+- Require manual review for any unsigned artifact before reattempting deployment.
+
+**Tagline:** Only the proven ship.

--- a/codex/entries/017-erasure-coded-resilience.md
+++ b/codex/entries/017-erasure-coded-resilience.md
@@ -1,0 +1,27 @@
+# Codex 17 — Erasure-Coded Resilience — Lose Shards, Keep Truth
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Aim
+Survive faults, sabotage, or regional failures without losing data integrity.
+
+## Core
+- Encode \(k\) source blocks into \(n\) coded blocks (Reed–Solomon) so any \(k\) suffice to recover the original data.
+- Tolerate \(f = n - k\) faults with rate \(k / n\) tailored to the threat model.
+- Use regenerating codes (MSR/MBR) to optimize repair bandwidth when restoring lost shards.
+
+## Runbook
+1. Select \((n, k)\) parameters aligned with durability and latency requirements, then geo-distribute shards.
+2. Rotate shards periodically and audit decode success under simulated failure scenarios.
+3. Pair storage with zero-knowledge audits proving shards belong to the same file lineage.
+
+## Telemetry
+- Decode success probability under sampled fault sets.
+- Time to repair missing shards and restore redundancy.
+- Entropy measurements of stored shards to detect drift or tampering.
+
+## Failsafes
+- If shard loss exceeds \(f\), trigger emergency replication and pause writes until redundancy is restored.
+- Investigate anomalous entropy or audit failures before resuming regular operations.
+
+**Tagline:** Fragment boldly, recover surely.

--- a/codex/entries/018-byzantine-agreement.md
+++ b/codex/entries/018-byzantine-agreement.md
@@ -1,0 +1,27 @@
+# Codex 18 — Byzantine Agreement — Keep Consensus Under Attack
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Aim
+Reach agreement among distributed replicas even when some behave maliciously.
+
+## Core
+- With \(3f + 1\) replicas, tolerate up to \(f\) Byzantine faults without violating safety.
+- Guarantee safety so no two honest replicas commit different values and maintain liveness under partial synchrony.
+- Target commit latency of roughly two to three rounds, as in PBFT or HotStuff families.
+
+## Runbook
+1. Size quorums at \(N = 3f + 1\), randomize leaders, and rotate keys to limit targeted attacks.
+2. Gossip using authenticated channels, checkpoint state, and maintain view-change proofs.
+3. Rate-limit clients and detect equivocation via signed message logs.
+
+## Telemetry
+- Commit rate and consensus latency.
+- Frequency of view changes and estimated fault counts.
+- Network health metrics affecting synchrony assumptions.
+
+## Failsafes
+- If liveness degrades, shrink to a smaller honest core or enter read-only mode.
+- Escalate to manual intervention when equivocation exceeds thresholds or key compromise is suspected.
+
+**Tagline:** Agreement even when the room lies.

--- a/codex/entries/019-rate-limit-calculus.md
+++ b/codex/entries/019-rate-limit-calculus.md
@@ -1,0 +1,27 @@
+# Codex 19 — Rate-Limit Calculus — Bound Blast Radius
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Aim
+Prove that no single client or tenant can overwhelm the system.
+
+## Core
+- Enforce token bucket policies with parameters \((r, b)\): admit requests only when available tokens exceed the cost.
+- Bound worst-case load over window \(T\) by \(rT + b\).
+- Compose hierarchical rate limits by enforcing the minimum allowance across multiple buckets.
+
+## Runbook
+1. Assign per-principal \((r, b)\) values based on risk class and business priority.
+2. Enforce limits locally and at edge layers while composing with upstream throttles.
+3. Measure effective demand and adjust parameters cautiously with safe step sizes.
+
+## Telemetry
+- Accepted versus dropped requests by principal.
+- Bucket occupancy distributions and refill latency.
+- Impact on tail latency and error budgets.
+
+## Failsafes
+- Clamp burst size \(b\) to a minimum when anomalies spike.
+- Shift excess load to queues or lotteries to preserve fairness under sustained attack.
+
+**Tagline:** Throttle proof before throttle panic.

--- a/codex/entries/020-side-channel-budget.md
+++ b/codex/entries/020-side-channel-budget.md
@@ -1,0 +1,27 @@
+# Codex 20 — Side-Channel Budget — Close the Acoustic/Energy Loops
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Aim
+Bound information leakage through timing, power, or electromagnetic side channels.
+
+## Core
+- Estimate channel capacity using disturbance bounds: \(C \leq \tfrac{1}{2} \log\big(1 + \tfrac{P}{N}\big)\).
+- Apply constant-time implementations, randomized blinding, and \(d\)-order masking to resist \(d - 1\) probes.
+- Inject controlled noise, power gating, and scheduling jitter to lower signal-to-noise ratios.
+
+## Runbook
+1. Classify operations by sensitivity and enforce constant-time code paths.
+2. Introduce noise and flatten power signatures with gating while adding timing jitter.
+3. Validate countermeasures using correlation power analysis (CPA) score thresholds.
+
+## Telemetry
+- CPA correlation metrics against target features.
+- Timing variance and electromagnetic signal-to-noise ratios.
+- Success rate of side-channel penetration tests.
+
+## Failsafes
+- Disable sensitive features or require HSM execution when CPA exceeds threshold \(\tau\).
+- Route workloads to hardened hardware whenever noise injections degrade functionality.
+
+**Tagline:** Silence every leak the sensors can hear.

--- a/codex/entries/021-conformal-risk-control.md
+++ b/codex/entries/021-conformal-risk-control.md
@@ -1,0 +1,27 @@
+# Codex 21 — Conformal Risk Control — Errors You Can Budget
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Aim
+Guarantee bounded error rates online without assuming a stationary data distribution.
+
+## Core
+- Define a nonconformity measure \(s(x)\) and maintain a threshold \(q_\alpha\) such that \(\Pr(s(x_{\text{new}}) \le q_\alpha) \ge 1 - \alpha\).
+- Abstain or defer decisions when \(s(x) > q_\alpha\) to keep risk within budget.
+- Continuously recalibrate thresholds on sliding windows to track drift.
+
+## Runbook
+1. Calibrate nonconformity scores over a recent window and maintain online quantiles.
+2. Gate automated actions on conformal acceptance; route abstentions to human or slower control paths.
+3. Recalibrate thresholds upon drift alarms or when error audits exceed tolerances.
+
+## Telemetry
+- Empirical error rates versus target \(\alpha\).
+- Abstain rates and downstream resolution times.
+- Calibration lag and drift detection statistics.
+
+## Failsafes
+- Increase abstention thresholds when observed error rises.
+- Require secondary model agreement or manual oversight before resuming automatic decisions.
+
+**Tagline:** Confidence with math-backed brakes.

--- a/codex/entries/022-adversarial-training-cvar.md
+++ b/codex/entries/022-adversarial-training-cvar.md
@@ -1,0 +1,27 @@
+# Codex 22 — Adversarial Training with CVaR — Robust by the Tail
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Aim
+Optimize models for worst-case performance by focusing on tail risk instead of average loss.
+
+## Core
+- Minimize conditional value at risk (CVaR) at level \(\alpha\): \(\min_\theta \ \text{CVaR}_\alpha(\ell(f_\theta(x + \delta), y))\) subject to \(\|\delta\| \le \epsilon\).
+- Generate hard examples through projected gradient descent (PGD) or expectation over transformation (EOT) loops.
+- Use randomized smoothing or Lipschitz bounds to certify robustness where feasible.
+
+## Runbook
+1. In the inner loop, create adversarial perturbations, tracking tail losses throughout training.
+2. In the outer loop, optimize parameters to minimize CVaR while enforcing a floor on clean accuracy.
+3. Certify robustness post-training and log certified radii alongside accuracy metrics.
+
+## Telemetry
+- Tail loss trajectories and CVaR estimates.
+- Gap between clean and robust accuracy.
+- Certified radii coverage across validation sets.
+
+## Failsafes
+- When tail loss exceeds budget, reduce exposure, increase regularization, or pause deployment.
+- Require human review before shipping models whose robustness certificates regress.
+
+**Tagline:** Train for the attacks you dread, not the averages you like.

--- a/codex/entries/023-session-types-ifc.md
+++ b/codex/entries/023-session-types-ifc.md
@@ -1,0 +1,27 @@
+# Codex 23 — Session Types & IFC — Make Illegal States Unrepresentable
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Aim
+Guarantee protocol correctness and data-flow integrity through type systems.
+
+## Core
+- Encode communication protocols as session types \(S\) where duality ensures endpoint compatibility.
+- Enforce information-flow control with lattice labels \(L\) so that \(a \sqsubseteq b\) implies data may flow from \(a\) to \(b\).
+- Reject programs at compile time that violate session orderings or IFC policies.
+
+## Runbook
+1. Annotate endpoints with their session types and label data using the IFC lattice.
+2. Compile the system and refuse builds that violate session progression or confidentiality rules.
+3. Deploy runtime monitors at explicit declassification points to enforce residual policies.
+
+## Telemetry
+- Compile-time rejection rates broken down by rule.
+- Runtime policy hits and declassification events.
+- Developer feedback loops on protocol evolution.
+
+## Failsafes
+- Treat any violation as a hard failure requiring explicit declassification and audit trails.
+- Freeze deployments if monitors detect unexpected flows until policy or code is adjusted.
+
+**Tagline:** Type the protocol, tame the flow.

--- a/codex/entries/024-verifiable-delay-randomness.md
+++ b/codex/entries/024-verifiable-delay-randomness.md
@@ -1,0 +1,27 @@
+# Codex 24 — Verifiable Delay & Randomness — Unbiasable Lottery
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Aim
+Produce public randomness that cannot be accelerated or forged.
+
+## Core
+- Compute verifiable delay functions (VDFs) \(y = f^{(T)}(x)\) that require sequential effort yet yield easily verifiable proofs \(\pi\).
+- Derive randomness beacons as \(R_t = H(y_t \parallel \text{context})\) for downstream use.
+- Slash or penalize invalid submissions to discourage manipulation attempts.
+
+## Runbook
+1. Seed the VDF with attested entropy and context, then compute \(y\) and proof \(\pi\).
+2. Verify \(\pi\) publicly and derive committees or lotteries from the resulting beacon \(R_t\).
+3. Archive beacons immutably and monitor for forks or divergent outputs.
+
+## Telemetry
+- Verification time and resource usage.
+- Fork rate and availability of beacon outputs.
+- Participation statistics for committees derived from the beacon.
+
+## Failsafes
+- Fall back to multi-party commit-reveal protocols when the VDF beacon fails.
+- Escalate to governance review when invalid proofs surface or delays exceed tolerances.
+
+**Tagline:** Randomness that no miner can rush.

--- a/codex/entries/025-network-coding-recovery.md
+++ b/codex/entries/025-network-coding-recovery.md
@@ -1,0 +1,27 @@
+# Codex 25 — Network Coding for Recovery — Throughput with Armor
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Aim
+Maximize goodput and accelerate recovery in the face of packet loss or jamming.
+
+## Core
+- Apply random linear network coding so transmitted packets \(y_i = \sum_j a_{ij} x_j\) carry innovative combinations.
+- Decode once the receiver collects packets whose coefficients span the unknowns (full rank).
+- Adapt redundancy rates to observed signal-to-noise ratio (SNR) and adversarial conditions.
+
+## Runbook
+1. Encode data at network edges, tuning redundancy for current loss conditions.
+2. Prioritize critical flows by allocating higher coding rates and monitor rank growth at receivers.
+3. Combine coding with path diversity to mitigate targeted interference.
+
+## Telemetry
+- Rank progression over time for each flow.
+- Goodput versus offered load and retransmission rates.
+- Loss, jam, or interference indicators across paths.
+
+## Failsafes
+- Increase redundancy or reroute traffic when rank stagnates or decoding stalls.
+- Escalate to alternate transports when multiple paths experience correlated failure.
+
+**Tagline:** Mix packets so recovery outruns loss.

--- a/codex/entries/026-safety-as-lyapunov.md
+++ b/codex/entries/026-safety-as-lyapunov.md
@@ -1,0 +1,27 @@
+# Codex 26 — Safety as Lyapunov — Prove You’ll Settle, Not Spiral
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Aim
+Design control policies that guarantee convergence toward safe states.
+
+## Core
+- Identify a Lyapunov function \(V(x) \ge 0\) such that \(\dot{V}(x) \le -\lambda V(x)\) inside the safe set.
+- Synthesize certificates via sum-of-squares (SOS) or convex relaxations when analytic proofs are hard.
+- Use \(V\) as a safety shield inside model predictive control (MPC) loops.
+
+## Runbook
+1. Select candidate Lyapunov functions and verify the decrease condition over the operating region.
+2. Integrate the Lyapunov constraint into MPC or reinforcement policies, rejecting actions that raise \(V\) excessively.
+3. Monitor \(\dot{V}\) online and adapt the controller when dynamics shift.
+
+## Telemetry
+- Estimated decay rate \(\lambda\) and convergence time.
+- Violation counts where actions were rejected by the safety filter.
+- Recovery time after disturbances or policy adjustments.
+
+## Failsafes
+- Switch to a conservative backup controller when violations repeat.
+- Require re-certification of \(V\) after major model changes or hardware swaps.
+
+**Tagline:** Stability by proof, not by hope.

--- a/codex/entries/027-provenance-dag.md
+++ b/codex/entries/027-provenance-dag.md
@@ -1,0 +1,27 @@
+# Codex 27 — Provenance DAG — Who Touched What, Provably
+
+**Fingerprint:** `23064887b1469b19fa562e8afdee5e9046bedf99aa9cd7142c35e38f91e6fef2`
+
+## Aim
+Maintain an immutable history of data and model lineage with cryptographic integrity.
+
+## Core
+- Model each transformation as a node \(v\) in a DAG with incoming edges from its inputs.
+- Hash node contents so any tampering breaks path verification.
+- Sign lineage updates and anchor digests to transparency logs for public verification.
+
+## Runbook
+1. Hash inputs, code, and environment metadata; sign and append new nodes to the provenance graph.
+2. Support impact analysis via graph reachability and automate recalls of contaminated outputs.
+3. Periodically anchor the DAG root hashes to append-only transparency or blockchain logs.
+
+## Telemetry
+- Latency of path verification queries.
+- Count of orphan nodes or unverifiable edges.
+- Time to recall or quarantine affected outputs.
+
+## Failsafes
+- Block publication of artifacts with unverifiable provenance paths.
+- Quarantine entire subtrees when signatures or hashes mismatch expectations.
+
+**Tagline:** Every lineage, logged and locked.


### PR DESCRIPTION
## Summary
- add codex entries 13-27 capturing the wave II security and systems spotlights with aims, cores, runbooks, telemetry, failsafes, and taglines

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e609cfab1083298cba3e52b7cd749e