### PR TITLE
Add Trial 4 red-team episode for poisoned high-influence samples

### DIFF
--- a/resilience/playbooks/redteam/trial4_poisoned_high_influence.md
+++ b/resilience/playbooks/redteam/trial4_poisoned_high_influence.md
@@ -1,0 +1,92 @@
+# Trial 4 Playbook Episode — Poisoned High-Influence Samples
+
+## Episode Overview
+- **Aim**: Surface and neutralise a small cadre of poisoned, high-influence samples that can distort model behaviour while global training loss still trends downward.
+- **Attack vector**: The adversary introduces a handful of records with extreme leverage and manipulated labels into the training stream. They collude across rounds to stay below coarse anomaly detectors.
+- **Roadie posture**: Toggle Roadie mode to cut sample counts in half, shrink perturbations, and keep the rehearsal viable on an air-gapped field kit.
+
+## Operational Run Script
+- **Location**: `resilience/playbooks/redteam/trial4_poisoned_high_influence.py`
+- **Invocation**: `python resilience/playbooks/redteam/trial4_poisoned_high_influence.py --ridge 1e-3 --cooks-threshold 12 --top-k 3`
+- **Roadie invocation**: add `--roadie` (and optionally `--json` for log-friendly output).
+- **Expected behaviour**:
+  - `cooks_ratio` (max-to-median Cook's distance) exceeds the detection threshold when poisoned points are present.
+  - Mitigation by removing the top `k` influential samples drives `mitigation_effect` positive and `mse_after < mse_before`.
+  - Ground-truth `poison_indices` remain within the flagged set for validation purposes.
+
+### Math signature
+- Cook's distance `D_i = \frac{r_i^2}{p \cdot \text{MSE}} \cdot \frac{h_{ii}}{(1-h_{ii})^2}` spikes for the poisoned points because both the leverage term `h_{ii}` and squared residual `r_i^2` are large.
+- Detection metric: `\text{ratio} = \max_i D_i / \text{median}_i D_i` with alert threshold `K = 12` (tunable per deployment).
+
+### Detection wiring
+- Prism metric: `influence.max_to_median`
+- Alert rule: trigger when the ratio stays above threshold for three consecutive samples (3 Hz default) or instantly if `ratio > 20`.
+- Dashboard surfaces:
+  - **Blow-Up Meter**: add `influence_ratio` as a sub-component contributing to the red zone when > 12.
+  - **Red-Team Console**: exposes `trial4_poisoned` with play/step/abort controls and log streaming of Cook's distance ranks.
+  - **Roadie Toggle**: reduces sample count and thresholds for offline rehearsal.
+
+### Mitigation play
+1. **Immediate**: quarantine the flagged samples (auto-drop top `k` by Cook's distance) and retrain the ridge model to stabilise loss.
+2. **Sustaining**: require provenance attestation for the quarantined records, launch CVaR-weighted retraining, and audit the data ingestion channel for provenance gaps.
+3. **Governance**: emit alerts to custodianship log, rotate committee responsible for data approvals, and record the event for Long Constitution review.
+
+## Forensic Checklist (Altar-Grade)
+1. Snapshot model weights, optimiser state, and data shards involved in the round.
+2. Hash and store the quarantined records plus their provenance metadata (source, signature, ingestion timestamp).
+3. Export the Cook's distance vector, leverage scores, residuals, and mitigation effect.
+4. Capture upstream pipeline logs (ingest, schema validation, signer ID) for ±30 minutes around detection.
+5. Generate the forensic bundle JSON:
+   ```json
+   {
+     "trial_id": "redtest4_influence",
+     "timestamp": "<ISO8601>",
+     "inputs_hash": "<sha256>",
+     "provenance_tag": "<tag>",
+     "metrics": {
+       "cooks_ratio": 18.7,
+       "max_cooks": 0.92,
+       "median_cooks": 0.05
+     },
+     "actions": [
+       "quarantined_top3_influence",
+       "triggered_cvar_retrain",
+       "escalated_custodianship"
+     ],
+     "artifacts": [
+       "model:trial4-pre.tar.gz",
+       "model:trial4-post.tar.gz",
+       "data:trial4-quarantine.parquet"
+     ],
+     "roadie": false
+   }
+   ```
+6. Anchor the bundle into the Civilizational ECC ledger and replicate to the write-once archive.
+7. File an incident note referencing the custodianship and DP burn dashboards.
+
+## Student-Agent Drill
+1. **Briefing** (5 min): Explain Cook's distance, leverage, and why tiny poisoned sets can dominate updates.
+2. **Hands-on** (15 min): Run the script twice — once with default parameters, once after modifying `--top-k` to 1 — and compare mitigation effectiveness.
+3. **Reverse Engineering** (10 min): Students craft an alternative poisoning by editing the generator to tweak `label_shift`; rerun detection to ensure the ratio still fires.
+4. **Defense Write-Up** (10 min): Document how they'd integrate provenance checks and influence capping into the data acceptance pipeline.
+5. **Reflection** (5 min): Share how the Blow-Up Meter and Privacy Burn Rate panels help differentiate data poisoning from privacy drain incidents.
+
+Roadie variant trims timing so the entire session fits in a 30-minute on-device drill; instructors copy resulting JSON outputs onto the write-once USB for after-action review.
+
+## Slide-Ready Summary (4-Up)
+1. **Threat Snapshot**: poisoned high-influence points silently bend the model despite low training loss; watch `influence.max_to_median`.
+2. **Detection & Panels**: Blow-Up Meter turns amber, Red-Team Console logs flagged indices, provenance panel shows suspicious gaps.
+3. **Mitigation Flow**: quarantine + CVaR retrain → provenance audit → custodianship escalation, with Roadie support for offline rehearsals.
+4. **Key Lesson**: influence analytics must ride alongside privacy/accounting metrics to catch slow, high-impact poisoning before it cascades.
+
+## Orchestration Hooks
+- Auto-schedule trial 4 in the red-team rotation weekly; Roadie kits run monthly.
+- Telemetry sampling stays at 1 Hz; extend to 5 Hz during live incidents for finer granularity.
+- Ensure the Red-Team Console attaches the forensic bundle reference to every run log entry.
+
+## Supporting Artifacts
+- **Script**: `resilience/playbooks/redteam/trial4_poisoned_high_influence.py`
+- **Dashboard panels**: Totalization Policy, Blow-Up Meter, Privacy Burn Rate, Provenance Integrity, Percolation Alarm, Red-Team Console, Roadie Mode Toggle.
+- **Runbook references**: Align with steps 1–10 of the incident response quick runbook (contain → archive).
+
+Ready to detonate Trial 4. The apprentices learn how subtle poisoning hides in plain sight, and Prism proves it can catch the catastrophe before it compounds.

--- a/resilience/playbooks/redteam/trial4_poisoned_high_influence.py
+++ b/resilience/playbooks/redteam/trial4_poisoned_high_influence.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Red-team trial 4: poisoned high-influence samples simulation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from typing import Dict, List
+
+import numpy as np
+
+
+@dataclass
+class TrialResult:
+    """Structured output for the poisoned high-influence trial."""
+
+    ridge: float
+    cooks_ratio: float
+    cooks_threshold: float
+    flagged: bool
+    max_cooks: float
+    median_cooks: float
+    high_influence_indices: List[int]
+    mitigation_effect: float
+    mse_before: float
+    mse_after: float
+    poison_indices: List[int]
+
+    def to_dict(self) -> Dict[str, float | bool | List[int]]:
+        """Convert the dataclass into a serialisable dictionary."""
+
+        return {
+            "ridge": self.ridge,
+            "cooks_ratio": self.cooks_ratio,
+            "cooks_threshold": self.cooks_threshold,
+            "flagged": self.flagged,
+            "max_cooks": self.max_cooks,
+            "median_cooks": self.median_cooks,
+            "high_influence_indices": self.high_influence_indices,
+            "mitigation_effect": self.mitigation_effect,
+            "mse_before": self.mse_before,
+            "mse_after": self.mse_after,
+            "poison_indices": self.poison_indices,
+        }
+
+
+def generate_dataset(seed: int, roadie: bool) -> Dict[str, np.ndarray]:
+    """Generate a regression dataset with poisoned high-influence samples."""
+
+    rng = np.random.default_rng(seed)
+    n_clean = 120 if not roadie else 48
+    n_poison = 6 if not roadie else 3
+    n_features = 3
+
+    w_true = np.array([0.5, -1.2, 2.0])
+
+    x_clean = rng.normal(0.0, 1.0, size=(n_clean, n_features))
+    noise = rng.normal(0.0, 0.3, size=n_clean)
+    y_clean = x_clean @ w_true + noise
+
+    x_poison = rng.normal(0.0, 1.0, size=(n_poison, n_features))
+    leverage_boost = 12.0 if not roadie else 7.5
+    x_poison[:, 0] += leverage_boost
+    label_shift = 15.0 if not roadie else 10.0
+    y_poison = x_poison @ w_true + rng.normal(0.0, 0.05, size=n_poison) + label_shift
+
+    x = np.vstack([x_clean, x_poison])
+    y = np.concatenate([y_clean, y_poison])
+
+    # Keep track of indices for poisoned points to assist with forensics.
+    poison_indices = list(range(n_clean, n_clean + n_poison))
+
+    return {"x": x, "y": y, "poison_indices": poison_indices}
+
+
+def add_bias(x: np.ndarray) -> np.ndarray:
+    """Append a bias column to the design matrix."""
+
+    bias = np.ones((x.shape[0], 1))
+    return np.hstack([bias, x])
+
+
+def fit_ridge_regression(x: np.ndarray, y: np.ndarray, ridge: float) -> np.ndarray:
+    """Fit ridge regression using the closed-form solution."""
+
+    xtx = x.T @ x
+    identity = np.eye(xtx.shape[0])
+    weights = np.linalg.solve(xtx + ridge * identity, x.T @ y)
+    return weights
+
+
+def cooks_distance(x: np.ndarray, y: np.ndarray, weights: np.ndarray) -> Dict[str, np.ndarray]:
+    """Compute Cook's distance for each sample."""
+
+    y_hat = x @ weights
+    residuals = y - y_hat
+    n_samples, n_params = x.shape
+
+    mse = np.sum(residuals**2) / (n_samples - n_params)
+    xtx_inv = np.linalg.inv(x.T @ x)
+    hat_diag = np.einsum("ij,jk,ik->i", x, xtx_inv, x)
+    stability = np.clip(1.0 - hat_diag, 1e-6, None)
+
+    cooks = (residuals**2 / (n_params * mse)) * (hat_diag / (stability**2))
+    return {"cooks": cooks, "mse": mse, "residuals": residuals}
+
+
+def evaluate_trial(
+    ridge: float,
+    cooks_threshold: float,
+    seed: int,
+    roadie: bool,
+    top_k: int,
+) -> TrialResult:
+    """Run the poisoned high-influence detection and mitigation sequence."""
+
+    dataset = generate_dataset(seed=seed, roadie=roadie)
+    x_raw = dataset["x"]
+    y = dataset["y"]
+    poison_indices = dataset["poison_indices"]
+
+    x = add_bias(x_raw)
+    weights = fit_ridge_regression(x, y, ridge=ridge)
+    cooks_data = cooks_distance(x, y, weights)
+    cooks_values = cooks_data["cooks"]
+
+    max_cooks = float(np.max(cooks_values))
+    median_cooks = float(np.median(cooks_values))
+    ratio = max_cooks / (median_cooks + 1e-12)
+    flagged = ratio > cooks_threshold
+
+    top_indices = np.argsort(cooks_values)[-top_k:][::-1]
+    mitigation_mask = np.ones(x.shape[0], dtype=bool)
+    mitigation_mask[top_indices] = False
+    x_mitigated = x[mitigation_mask]
+    y_mitigated = y[mitigation_mask]
+
+    mitigated_weights = fit_ridge_regression(x_mitigated, y_mitigated, ridge=ridge)
+    mse_before = float(cooks_data["mse"])
+    mse_after = float(np.sum((y_mitigated - x_mitigated @ mitigated_weights) ** 2) /
+                     (x_mitigated.shape[0] - x_mitigated.shape[1]))
+
+    mitigation_effect = (mse_before - mse_after) / (mse_before + 1e-12)
+
+    return TrialResult(
+        ridge=ridge,
+        cooks_ratio=float(ratio),
+        cooks_threshold=cooks_threshold,
+        flagged=flagged,
+        max_cooks=max_cooks,
+        median_cooks=median_cooks,
+        high_influence_indices=[int(i) for i in top_indices],
+        mitigation_effect=float(mitigation_effect),
+        mse_before=mse_before,
+        mse_after=mse_after,
+        poison_indices=[int(i) for i in poison_indices],
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+
+    parser = argparse.ArgumentParser(
+        description="Run the red-team poisoned high-influence samples trial.",
+    )
+    parser.add_argument("--ridge", type=float, default=1e-3, help="Ridge regularisation strength.")
+    parser.add_argument(
+        "--cooks-threshold",
+        type=float,
+        default=12.0,
+        help="Ratio threshold of max Cook's distance to median for flagging.",
+    )
+    parser.add_argument("--seed", type=int, default=7, help="Random seed for reproducibility.")
+    parser.add_argument(
+        "--roadie",
+        action="store_true",
+        help="Run in Roadie mode with fewer samples and smaller perturbations.",
+    )
+    parser.add_argument(
+        "--top-k",
+        type=int,
+        default=3,
+        help="Number of high-influence samples to remove during mitigation.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output results as JSON for ingestion by dashboards or logs.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Entry point for running the trial."""
+
+    args = parse_args()
+    result = evaluate_trial(
+        ridge=args.ridge,
+        cooks_threshold=args.cooks_threshold,
+        seed=args.seed,
+        roadie=args.roadie,
+        top_k=args.top_k,
+    )
+
+    if args.json:
+        print(json.dumps(result.to_dict(), indent=2))
+    else:
+        print("Trial 4 — Poisoned High-Influence Samples")
+        print(f"ridge={result.ridge:.3e}  ratio={result.cooks_ratio:.2f}  "
+              f"threshold={result.cooks_threshold:.2f}  flagged={result.flagged}")
+        print(f"max_cooks={result.max_cooks:.3f} median_cooks={result.median_cooks:.3f}")
+        print(f"high_influence_indices={result.high_influence_indices}")
+        print(f"mitigation_effect={result.mitigation_effect:.2%}  "
+              f"mse_before={result.mse_before:.4f}  mse_after={result.mse_after:.4f}")
+        print("poison_indices (ground truth)",
+              result.poison_indices if not args.json else "hidden")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a detailed playbook episode for the Trial 4 poisoned high-influence attack
- provide a runnable simulation script that surfaces Cook's distance ratios and mitigation impact

## Testing
- python resilience/playbooks/redteam/trial4_poisoned_high_influence.py
- python resilience/playbooks/redteam/trial4_poisoned_high_influence.py --roadie

------
https://chatgpt.com/codex/tasks/task_e_68e60d3bf3348329bd34f2102063ca20