### PR TITLE
Add poisoned influence playbook and demo

### DIFF
--- a/docs/prism/Poisoned_High_Influence_Samples_Playbook.md
+++ b/docs/prism/Poisoned_High_Influence_Samples_Playbook.md
@@ -1,0 +1,123 @@
+# Playbook Episode: Poisoned High-Influence Samples
+
+## TL;DR
+- **Detect**: Identify training samples whose removal most shifts test loss; high influence + sketchy provenance = immediate quarantine.
+- **Recover**: Retrain with trimmed/CVaR/reweighted objectives, prove recovery on holdout data, and rehearse the student-agent rebuild ritual.
+
+## 1. Overview — Objective & Metric
+- **Goal**: Detect small clusters of training points that exert outsized control over model behaviour, determine whether they are tainted, and recover clean performance.
+- **Primary signal**: Approximate point influence on test loss
+  \\[ I_i \approx - \nabla_\theta L_{\text{test}}(\theta)^\top H_\theta^{-1} \nabla_\theta \ell(\theta; x_i, y_i) \\
+  where \\( H_\theta = \nabla_\theta^2 \frac{1}{n}\sum_j \ell(\theta; x_j, y_j) + \lambda I \\) (damped Hessian).
+- **Cheap proxy**: Gradient alignment filter
+  \\[ \tilde I_i = \frac{|\nabla_\theta \ell_i^\top \nabla_\theta L_{\text{test}}|}{\|\nabla_\theta \ell_i\|_2 + \epsilon} \\]
+  Use as a fast pre-filter before spending cycles on the Hessian solve.
+- **Risk score**: Combine magnitude of influence with provenance flags
+  \\[ \text{risk}_i = \text{normalize}(|I_i|) \cdot (1 + \text{prov\_flag}_i) \\]
+  where provenance flags catch unsigned uploads, abnormal timestamps, or suspicious source IPs.
+
+## 2. Detection Pipeline
+1. **Calibration holdout**: Set aside a robust mini-test set \(T\); compute \( \nabla_\theta L_T \).
+2. **Fast filter**: Evaluate \( \tilde I_i \) for all training samples; keep top \(k\%\) (default 1–5%).
+3. **Gold influence**: For candidates only, solve \( H v = \nabla_\theta L_T \) using conjugate gradient with a Hessian-vector operator. Influence estimate: \( I_i \approx -v^\top \nabla_\theta \ell_i \).
+4. **Provenance join**: Attach ingestion metadata (missing signatures, upload anomalies, geographic/IP mismatches) and compute \( \text{risk}_i \).
+5. **Flag & quarantine**: Samples with \( \text{risk}_i \) beyond thresholds (e.g., >3× median or top 0.1%) move to quarantine for manual/automated review.
+
+## 3. Roadie-Friendly Runnable Demo
+- File: [`examples/redtest4_influence_demo.py`](../../examples/redtest4_influence_demo.py)
+- What it does: trains a regularized logistic regressor on synthetic data, plants three poisoned points, and reports both proxy and Hessian-based influence scores.
+- Run locally (no external deps beyond NumPy):
+  ```bash
+  python examples/redtest4_influence_demo.py
+  ```
+- Expected outcome: the planted poisoned indices appear at the top of both proxy and gold influence rankings, illustrating the detection flow end-to-end.
+
+## 4. Mitigation Recipes
+### Immediate
+- **Quarantine** flagged samples; snapshot raw payloads and metadata.
+- **Freeze & gate** downstream models that show the largest behavioural delta.
+- **Robust retrain**:
+  - Trim top-k influential points and retrain.
+  - Swap to CVaR (tail-focused) or trimmed mean objectives.
+  - Downweight suspicious samples (0.01–0.1 × original weight) during retrain.
+- **Provenance audit**: require submission proof for each quarantined sample; lacking proof keeps it quarantined.
+
+### Longer-term
+- **Redact & replace** compromised external sources; rebuild from trusted feeds.
+- **Hardening**: enforce signed submissions, rate-limit ingestion, and pre-promote new data through influence checks.
+- **Policy drill**: codify the student-agent confirm step; every cohort must reproduce the retrain within Roadie constraints.
+
+## 5. Forensics Artifact Schema
+Capture every incident in a bundle pinned to Civilizational ECC:
+```json
+{
+  "incident_id": "rt4-20251008-0001",
+  "detected_at": "2025-10-08T15:04:05-05:00",
+  "top_flags": [
+    {"idx": 3, "influence": 125.3, "proxy": 54.2, "prov_flag": 1, "uploader": "anon-ip-203.*"}
+  ],
+  "model_hash_before": "sha3:abcd...",
+  "model_hash_after": "sha3:ef01...",
+  "actions": ["quarantine_samples", "retrain_trim", "notify_governance"],
+  "restore_plan": {"restore_seed": "model:v1.2", "deadline": "2025-10-12"},
+  "forensic_paths": ["s3://ecc/rt4/inputs.zip", "s3://ecc/rt4/model_before.pt"]
+}
+```
+Include quarantined raw samples plus a one-page seed detailing how to rebuild the dataset and recompute influence scores.
+
+## 6. Student-Agent Drill — “Quarantine → Rebuild”
+- **Crew** (3 students): detection, provenance audit, and retrain owners.
+- **Deliverables within 48 h**:
+  - Reproducible script that flags the same samples.
+  - Retrained model with test loss \(\leq 1.05\times\) the clean baseline.
+  - Plain-language one-page seed summarizing cause and fix.
+- **Checkpoints**: 6 h (detection reproducibility), 24 h (trimmed retrain prototype), 48 h (full rebuild + canary smoke tests).
+- **Rubric**: reproducibility 40%, time-to-recover 20%, explanation clarity 20%, restoration effectiveness 20%.
+
+## 7. Red-Team Scenarios
+- **Sparse high-influence**: flip labels on a handful of leverage-heavy inputs.
+- **Camouflage batches**: blend many low-influence poisons that accumulate impact.
+- **Temporal trickle**: drip similar poisons over months to dodge per-round thresholds.
+- **Collusion**: coordinate fake provenance headers and rotating upload IPs.
+Exercise each variant against the full detection & mitigation stack.
+
+## 8. Recovery Verification
+- **Test loss delta**: post-mitigation loss \(\leq 1.05\times\) baseline.
+- **Influence shrinkage**: max \(|I_i|\) drops by >90%.
+- **Stewardship metrics**: ensure externality metrics (cost/resource usage) stay stable.
+- **Provenance completeness**: \(>95\%\) of quarantined samples must present valid provenance before release.
+
+## 9. Slide-Ready Summary
+**Title**: *Poisoned Samples — Detect, Quarantine, Rebuild*
+- Influence \(\approx -\nabla L_T^\top H^{-1}\nabla \ell_i\) finds the dangerous few.
+- Cheap filter → CG Hessian-inverse → provenance → risk scoring.
+- Auto-mitigate: quarantine, trimmed/CVaR retrain, provenance audit.
+- Teach-back: student-agent 48 h rebuild drill; seed docs for 500-year recoverability.
+**Footer**: “If the model remembers the poison, the people must rehearse forgetting it.”
+
+## 10. Operational Knobs & Thresholds
+- `fast_filter_top_frac = 0.02`
+- `cg_tol = 1e-6`, `cg_maxiter = 300`
+- `quarantine_threshold = max(10 × median(|I|), absolute_cutoff)`
+- `provenance_flag = 1` when signatures missing, IP/timestamp anomalies, or small-batch repeats.
+- `retrain_mode = 'trim'` by default; switch to `'cvar'` for higher assurance.
+- `student_drill_deadline = 48h` (Roadie mode: 48 h offline).
+
+## 11. Automation Snippet
+```python
+infl, proxy, grads = influence_scores(theta, X_train, y_train, X_test, y_test)
+candidates = np.argsort(-np.abs(proxy))[: int(len(X_train) * fast_filter_top_frac)]
+# Upgrade to gold influence only for candidates
+gold_infl = {i: infl[i] for i in candidates}
+prov_flag = {i: check_provenance(i) for i in candidates}
+risk = {i: abs(gold_infl[i]) * (1 + prov_flag[i]) for i in candidates}
+quarantine = [i for i in candidates if risk[i] > quarantine_threshold]
+if quarantine:
+    snapshot_model()
+    quarantine_samples(quarantine)
+    retrain_and_compare(quarantine)
+    publish_forensic_bundle()
+```
+
+---
+This episode equips Prism operators to spot poisoned leverage points, quarantine them without panic, and prove recovery while training the next crew.

--- a/examples/redtest4_influence_demo.py
+++ b/examples/redtest4_influence_demo.py
@@ -1,0 +1,145 @@
+"""Roadie-friendly logistic regression influence demo.
+
+This script trains a small logistic regression model, plants a few poisoned
+points, and computes both proxy and Hessian-based influence scores to surface
+high-leverage samples. Runs offline with NumPy only.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from math import sqrt
+
+np.random.seed(1)
+
+
+def sigmoid(z: np.ndarray) -> np.ndarray:
+    """Numerically stable sigmoid."""
+
+    return 1.0 / (1.0 + np.exp(-z))
+
+
+def loss_and_grad(
+    theta: np.ndarray,
+    X: np.ndarray,
+    y: np.ndarray,
+    reg: float = 1e-3,
+) -> tuple[float, np.ndarray]:
+    """Compute logistic loss and gradient with L2 regularization."""
+
+    z = X.dot(theta)
+    p = sigmoid(z)
+    eps = 1e-12
+    loss = -np.mean(y * np.log(p + eps) + (1 - y) * np.log(1 - p + eps))
+    loss += 0.5 * reg * np.sum(theta * theta)
+    grad = X.T.dot(p - y) / X.shape[0] + reg * theta
+    return loss, grad
+
+
+def hv_finite(
+    theta: np.ndarray,
+    v: np.ndarray,
+    X: np.ndarray,
+    y: np.ndarray,
+    reg: float = 1e-3,
+    eps: float = 1e-5,
+) -> np.ndarray:
+    """Approximate Hessian-vector product using symmetric finite differences."""
+
+    _, g1 = loss_and_grad(theta + eps * v, X, y, reg)
+    _, g0 = loss_and_grad(theta - eps * v, X, y, reg)
+    return (g1 - g0) / (2 * eps)
+
+
+def cg_solve(
+    hv_fn,
+    b: np.ndarray,
+    tol: float = 1e-6,
+    maxiter: int = 200,
+) -> np.ndarray:
+    """Conjugate gradient solver for symmetric positive definite systems."""
+
+    x = np.zeros_like(b)
+    r = b.copy()
+    p = r.copy()
+    rsold = r.dot(r)
+    for _ in range(maxiter):
+        hp = hv_fn(p)
+        denom = p.dot(hp) + 1e-12
+        alpha = rsold / denom
+        x += alpha * p
+        r -= alpha * hp
+        rsnew = r.dot(r)
+        if sqrt(rsnew) < tol:
+            break
+        p = r + (rsnew / rsold) * p
+        rsold = rsnew
+    return x
+
+
+def influence_scores(
+    theta: np.ndarray,
+    X_train: np.ndarray,
+    y_train: np.ndarray,
+    X_test: np.ndarray,
+    y_test: np.ndarray,
+    reg: float = 1e-3,
+    top_frac: float = 0.02,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Compute influence and proxy scores for a logistic model."""
+
+    _, g_test = loss_and_grad(theta, X_test, y_test, reg)
+    hv = lambda v: hv_finite(theta, v, X_train, y_train, reg)
+    v = cg_solve(hv, g_test, tol=1e-6, maxiter=300)
+
+    n, _ = X_train.shape
+    grads = np.zeros((n, theta.size))
+    for i in range(n):
+        xi = X_train[i : i + 1]
+        yi = y_train[i : i + 1]
+        _, gi = loss_and_grad(theta, xi, yi, reg)
+        grads[i] = gi
+
+    influence = -grads.dot(v)
+    proxy = np.abs(grads.dot(g_test)) / (np.linalg.norm(grads, axis=1) + 1e-12)
+    return influence, proxy, grads
+
+
+def main() -> None:
+    n_train, n_test, d = 300, 100, 10
+    X = np.random.normal(size=(n_train + n_test, d))
+    true_theta = np.random.normal(size=(d,))
+    logits = X.dot(true_theta)
+    probs = sigmoid(logits)
+    y = (np.random.rand(len(probs)) < probs).astype(float)
+
+    # Plant a few poisoned, high-leverage points by aligning with true_theta
+    for j in range(3):
+        X[j] = true_theta * 10.0
+        y[j] = 1 - y[j]
+
+    X_train, y_train = X[:n_train], y[:n_train]
+    X_test, y_test = X[n_train:], y[n_train:]
+
+    theta = np.zeros(d)
+    lr = 0.5
+    for epoch in range(200):
+        loss, grad = loss_and_grad(theta, X_train, y_train, reg=1e-3)
+        theta -= lr * grad
+        if epoch % 50 == 0:
+            print(f"epoch {epoch:03d} loss {loss:.4f}")
+
+    influence, proxy, _ = influence_scores(
+        theta, X_train, y_train, X_test[:20], y_test[:20], reg=1e-3, top_frac=0.02
+    )
+
+    top_infl_idx = np.argsort(-np.abs(influence))[:10]
+    top_proxy_idx = np.argsort(-proxy)[:10]
+
+    print("Top influence indices:", top_infl_idx)
+    print("Influence scores:", influence[top_infl_idx])
+    print("Top proxy indices:", top_proxy_idx)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document the poisoned high-influence samples playbook with detection, mitigation, and drill guidance
- add a runnable NumPy logistic regression demo that highlights high-influence poisoned points

## Testing
- `python examples/redtest4_influence_demo.py`


------
https://chatgpt.com/codex/tasks/task_e_68e60e09877c83299c8babc9036c7828