### PR TITLE
Fix portal Tor hidden service access check

### DIFF
--- a/portal/bin/portal-health-tor
+++ b/portal/bin/portal-health-tor
@@ -2,8 +2,14 @@
 set -euo pipefail
 ROOT="/home/pi/portal"
 HS="/var/lib/tor/portal-health/hostname"
-[ -s "$HS" ] || { echo "Tor hidden service not ready. Check 'systemctl status tor'." >&2; exit 2; }
-ONION="$(sudo cat "$HS")"
+if ! sudo test -s "$HS"; then
+  echo "Tor hidden service not ready. Check 'systemctl status tor'." >&2
+  exit 2
+fi
+if ! ONION="$(sudo cat "$HS")"; then
+  echo "Unable to read Tor hidden service hostname. Check 'sudo systemctl status tor'." >&2
+  exit 3
+fi
 echo "Onion address: http://$ONION/"
 echo "Starting local static server on 127.0.0.1:8088..."
 exec "$ROOT/bin/portal-static" 127.0.0.1:8088


### PR DESCRIPTION
## Summary
- ensure the Tor health helper checks the hidden service hostname using sudo privileges
- add explicit error messaging when reading the hostname fails

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e612afda248329bf6f620220f0b08b