### PR TITLE
Add RoadChain docker compose stack - bind node RPC interfaces

### DIFF
--- a/compose/roadchain.yml
+++ b/compose/roadchain.yml
@@ -6,7 +6,7 @@ services:
     image: ghcr.io/roadchain/node:latest   # replace with your node image
     container_name: roadchain-node
     restart: unless-stopped
-    command: ["--network=testnet", "--http", "--http-port=8545", "--ws", "--ws-port=8546"]
+    command: ["--network=testnet", "--http", "--http-port=8545", "--http.addr=0.0.0.0", "--ws", "--ws-port=8546", "--ws.addr=0.0.0.0"]
     ports:
       - "8545:8545"   # HTTP RPC
       - "8546:8546"   # WebSocket


### PR DESCRIPTION
## Summary
- add a modular docker compose definition for the RoadChain node, wallet, and dashboard stack
- document usage instructions for the new compose bundle
- bind the RoadChain node HTTP/WS interfaces to the container network so dependent services can connect

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e6129c6e188329bea0a34f95f4bf0b