### PR TITLE
Fix run lifecycle cleanup to prevent leaks

### DIFF
--- a/prism/server/test/run.test.ts
+++ b/prism/server/test/run.test.ts
@@ -1,25 +1,31 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import supertest from 'supertest';
 import { buildServer, bus } from '../src/index.js';
 import fs from 'fs';
 
 describe('run and approvals', () => {
+  afterEach(() => {
+    delete process.env.PRISM_RUN_ALLOW;
+  });
+
   it('emits run events', async () => {
     process.env.PRISM_RUN_ALLOW = 'node';
     const app = buildServer();
     await app.listen({ port: 0 });
     const events: string[] = [];
-    bus.on('event', (e: any) => {
+    const handler = (e: any) => {
       if (e.kind === 'run.start') events.push('start');
       if (e.kind === 'run.out' && e.data.chunk.trim() === 'hello') events.push('out');
       if (e.kind === 'run.end') events.push('end');
-    });
+    };
+    bus.on('event', handler);
     await supertest(app.server)
       .post('/run')
       .send({ projectId: 'p', sessionId: 's', cmd: "node -e \"console.log('hello')\"" })
       .expect(200);
     await new Promise((r) => setTimeout(r, 500));
     await app.close();
+    bus.off('event', handler);
     expect(events).toEqual(['start', 'out', 'end']);
   });
 
@@ -28,18 +34,44 @@ describe('run and approvals', () => {
     const app = buildServer();
     await app.listen({ port: 0 });
     const events: string[] = [];
-    bus.on('event', (e: any) => {
+    const handler = (e: any) => {
       if (e.kind === 'run.start') events.push('start');
       if (e.kind === 'run.out' && e.data.chunk.trim() === 'hi') events.push('out');
       if (e.kind === 'run.end') events.push('end');
-    });
+    };
+    bus.on('event', handler);
     await supertest(app.server)
       .post('/run')
       .send({ projectId: 'p', sessionId: 's', cmd: 'node -e "console.log(\\"hi\\")"' })
       .expect(200);
     await new Promise((r) => setTimeout(r, 500));
     await app.close();
+    bus.off('event', handler);
     expect(events).toEqual(['start', 'out', 'end']);
+  });
+
+  it('emits completion when a command cannot be spawned', async () => {
+    process.env.PRISM_RUN_ALLOW = 'definitely-not-real';
+    const app = buildServer();
+    await app.listen({ port: 0 });
+    const events: any[] = [];
+    const handler = (e: any) => {
+      if (e.kind === 'run.err' || e.kind === 'run.end') {
+        events.push(e);
+      }
+    };
+    bus.on('event', handler);
+    await supertest(app.server)
+      .post('/run')
+      .send({ projectId: 'p', sessionId: 's', cmd: 'definitely-not-real --flag' })
+      .expect(200);
+    await new Promise((r) => setTimeout(r, 500));
+    bus.off('event', handler);
+    await app.close();
+    const endEvent = events.find((e) => e.kind === 'run.end');
+    expect(endEvent).toBeDefined();
+    expect(endEvent!.data.status).toBe('error');
+    expect(endEvent!.data.error).toBeDefined();
   });
 
   it('requires approval for diffs when policy is review', async () => {
@@ -58,6 +90,7 @@ describe('run and approvals', () => {
     await supertest(app.server).post(`/approvals/${approvalId}/approve`).send({});
     const content = fs.readFileSync('prism/work/test.txt', 'utf8').trim();
     expect(content).toBe('hello');
+    fs.rmSync('prism/work', { recursive: true, force: true });
     await app.close();
   });
 });


### PR DESCRIPTION
## Summary
- track spawned processes separately and finalize runs to avoid retaining child handles
- prune stored run and approval history and drop approval payloads after decisions to cap memory usage
- extend run tests for spawn failures, clean up fixtures, and remove lingering event listeners

## Testing
- cd prism/server && npm test

------
https://chatgpt.com/codex/tasks/task_e_68e747b0914083298547d50f11ddf1a9