### PR TITLE
docs: clarify repo scan network access guidance

### DIFF
--- a/analysis/repo_scan_capabilities.md
+++ b/analysis/repo_scan_capabilities.md
@@ -1,0 +1,13 @@
+# Repo Scan Capabilities
+
+## Environment Access
+
+- **File system**: Full read access to the repository, including hidden files, unless explicitly restricted by task instructions.
+- **Remote network access**: Outbound HTTP/HTTPS requests to the public internet are enabled for repo scan tasks. Private networks and endpoints behind firewalls may still be unreachable, and long-lived connections are not guaranteed.
+- **Process execution**: Standard shell commands and tooling available in the container can be executed, subject to resource and permission limits.
+
+## Usage Notes
+
+- Prefer lightweight search tools such as `rg` over recursive `ls`/`grep` when exploring large repositories.
+- Obey any scoped instructions defined in `AGENTS.md` files before modifying content.
+- Document any limitations encountered during a scan so that future operators understand the environment constraints.


### PR DESCRIPTION
## Summary
- add a repo scan capabilities reference for the analysis workspace
- note that remote network access is enabled while still highlighting environment limits

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e744b6d4d48329a2f086484cd0a821