### PR TITLE
docs: add .NET SDK setup guidance for Microsoft Agent Framework

### DIFF
--- a/docs/ai/microsoft-agent-framework.md
+++ b/docs/ai/microsoft-agent-framework.md
@@ -11,3 +11,40 @@ Microsoft Agent Framework is an open-source SDK and runtime that unifies previou
 
 ## Getting Started
 Developers can begin by experimenting locally with Python or .NET agents, then use the built-in interoperability features to connect additional services or tools. When ready for production, the same projects can be moved into Azure AI Foundry for managed hosting and monitoring.
+
+### Install the .NET SDK (8.0 or later)
+Microsoft Agent Framework ships first-class .NET samples that rely on the modern SDK toolchain. Install the latest long-term support release (currently **8.0.x**) and verify that the CLI is on your path:
+
+```bash
+# macOS
+brew install --cask dotnet-sdk
+
+# Ubuntu / Debian
+wget https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb
+sudo dpkg -i packages-microsoft-prod.deb
+sudo apt-get update && sudo apt-get install -y dotnet-sdk-8.0
+
+# Windows (PowerShell)
+winget install Microsoft.DotNet.SDK.8
+```
+
+Confirm the installation before running any samples:
+
+```bash
+dotnet --info
+dotnet --list-sdks
+```
+
+If Visual Studio Code or Visual Studio prompts for an SDK download, accept the installer—this places the runtime in `~/Library/dotnet` on macOS (as shown in the on-screen workflow) and automatically wires up shell integration.
+
+### Create your first agent project
+With the SDK installed, create a new console application and reference the Microsoft Agent Framework NuGet package:
+
+```bash
+dotnet new console -n AgentQuickstart
+cd AgentQuickstart
+dotnet add package Microsoft.Agent.Framework --prerelease
+dotnet run
+```
+
+You can now connect the .NET agent to Python peers through A2A or MCP adapters, iterate locally, and publish to Azure AI Foundry when production-ready.


### PR DESCRIPTION
## Summary
- document the supported .NET SDK installation paths for macOS, Linux, and Windows
- add quick verification commands and a starter console app workflow for Microsoft Agent Framework samples

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7f98fa01883298bad0e80deea9f21