### PR TITLE
Add automated reruns for backend tests

### DIFF
--- a/.github/workflows/tests-auto-rerun.yml
+++ b/.github/workflows/tests-auto-rerun.yml
@@ -1,0 +1,66 @@
+name: Auto Re-run Backend Tests
+
+on:
+  workflow_run:
+    workflows:
+      - Backend Tests
+    types:
+      - completed
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  rerun:
+    name: Queue re-run on failure
+    runs-on: ubuntu-latest
+    if: >-
+      ${{ github.event.workflow_run.conclusion == 'failure' ||
+          github.event.workflow_run.conclusion == 'timed_out' }}
+    steps:
+      - name: Evaluate run status
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const run = context.payload.workflow_run;
+            const { owner, repo } = context.repo;
+            const maxAttempts = 3;
+
+            if (run.event !== 'pull_request') {
+              core.info(`Run ${run.id} originated from ${run.event}; skipping auto re-run.`);
+              return;
+            }
+
+            if (run.run_attempt >= maxAttempts) {
+              core.info(`Run attempt ${run.run_attempt} reached max of ${maxAttempts}; not re-running.`);
+              return;
+            }
+
+            const prInfo = run.pull_requests && run.pull_requests[0];
+            if (!prInfo) {
+              core.info(`Run ${run.id} has no associated pull request; skipping.`);
+              return;
+            }
+
+            const prNumber = prInfo.number;
+            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+
+            if (pr.state !== 'open') {
+              core.info(`PR #${prNumber} is not open (state=${pr.state}); skipping.`);
+              return;
+            }
+
+            if (pr.merged) {
+              core.info(`PR #${prNumber} is already merged; skipping.`);
+              return;
+            }
+
+            core.info(`Triggering re-run for Backend Tests (run id ${run.id}) on PR #${prNumber}.`);
+            await github.request('POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun', {
+              owner,
+              repo,
+              run_id: run.id,
+            });
+            core.notice(`Queued automatic re-run attempt ${run.run_attempt + 1} for PR #${prNumber}.`);

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,6 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
       - run: npm install
       - run: npm test


### PR DESCRIPTION
## Summary
- align the backend test workflow with the repository's Node.js 20 runtime requirement
- add an automation workflow that re-triggers the backend tests when a pull-request run fails, up to three attempts

## Testing
- `npm install --no-progress` *(fails: 503 Service Unavailable from verdaccio.internal)*

------
https://chatgpt.com/codex/tasks/task_e_68e8033b4a348329a7b0d321095a512b