### PR TITLE
Add Phase 2 Starter Pack build plan

### DIFF
--- a/docs/phase-2-starter-pack-roadmap.md
+++ b/docs/phase-2-starter-pack-roadmap.md
@@ -1,0 +1,32 @@
+# Phase 2 Starter Pack Build Plan
+
+## Recommended Starting Point
+Focus first on shipping a **template toolkit** that codifies the workflows defined in Phase 1. Concretely, stand up reusable documents (PRDs, SOPs, governance forms, scorecards) that every team can adopt immediately. This keeps momentum from the Starter Pack launch while providing tangible assets that unlock rhythm-of-business execution.
+
+## Why Templates First?
+- **Immediate utility**: Teams can plug the templates into active projects right away, proving the value of the Starter Pack and creating quick wins.
+- **Consistent governance**: Standardized forms reinforce the owner/structure model introduced in Phase 1 and make compliance expectations explicit.
+- **Tooling clarity**: Well-formed templates make it much easier to wire automations into ClickUp, Notion, or GitHub in the next wave because required fields and lifecycle stages are already defined.
+
+## Execution Outline
+1. **Inventory required artifacts**
+   - PRD, launch brief, and release retro templates for product/engineering.
+   - SOP and runbook templates for operations and support teams.
+   - Governance forms covering change control, risk reviews, and exception handling.
+2. **Draft template v1 set**
+   - Build in Markdown/Notion-compatible syntax for portability.
+   - Embed owner roles, approval checkpoints, and linked metrics sections that map back to Phase 1 structures.
+3. **Review with department leads**
+   - Run quick alignment sessions (30–45 min) to validate required fields and stage gates.
+   - Capture feedback for iterative updates before broader rollout.
+4. **Package for distribution**
+   - Publish templates in the Starter Pack workspace with versioning notes.
+   - Provide a “How to adopt” mini-guide that references the rollout playbook from Phase 1.
+
+## Follow-On: Tool Integrations
+Once the template library is stable, wire it into execution platforms:
+- **ClickUp**: Create task templates with custom fields that mirror the document sections and automate assignment of owners.
+- **Notion**: Build synced databases for PRDs and SOPs using the Markdown drafts as seed content.
+- **GitHub**: Convert the governance forms into issue templates and workflow files to drive consistent reviews.
+
+Sequencing this way keeps the Starter Pack actionable, validates the framework with working assets, and sets up a smoother integration sprint when we hook everything into the tooling stack.


### PR DESCRIPTION
## Summary
- add documentation that recommends building the starter-pack template toolkit before wiring automations
- outline execution steps and follow-on integrations for ClickUp, Notion, and GitHub

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e8046b32fc832981279e7a21eb621b