### PR TITLE
Add company charter template

### DIFF
--- a/governance/company_charter.md
+++ b/governance/company_charter.md
@@ -1,0 +1,46 @@
+# Company Charter & Operating Principles
+
+This charter defines the foundational intent and operating guardrails for the company. It is organized into six core blocks designed to stay concise and actionable.
+
+## 1. Mission — Why We Exist
+- **Purpose statement:** _Placeholder for the core reason the company exists._
+- **Primary stakeholders:** _Placeholder for the people or systems we serve._
+- **Impact focus:** _Placeholder for the primary outcomes or value delivered._
+
+## 2. Vision — The Long-Term Change We Seek
+- **Future state narrative:** _Placeholder describing the world we aim to help create._
+- **Time horizon:** _Placeholder outlining the expected timeframe for realizing the vision._
+- **Strategic anchors:**
+  - _Anchor 1 placeholder_
+  - _Anchor 2 placeholder_
+  - _Anchor 3 placeholder_
+
+## 3. Guiding Principles — How We Behave When No One's Watching
+- **Principle 1:** _Placeholder for a non-negotiable behavior._
+- **Principle 2:** _Placeholder for a second behavior or norm._
+- **Principle 3:** _Placeholder for a third behavior or norm._
+- **Accountability:** _Placeholder for how adherence is reinforced._
+
+## 4. Ownership & Governance — Rights and Control
+- **Ownership structure:** _Placeholder describing equity or membership model._
+- **Governance bodies:**
+  - **Board / Council:** _Placeholder for composition and responsibilities._
+  - **Executive leadership:** _Placeholder for delegated authority._
+  - **Advisory roles:** _Placeholder for any advisory groups._
+- **Control transitions:** _Placeholder for rules on how control may shift over time._
+
+## 5. Decision Hierarchy — From Idea to Record
+- **Idea intake:** _Placeholder for how proposals are captured._
+- **Evaluation process:** _Placeholder for review criteria and forums._
+- **Approval authority:** _Placeholder mapping decision rights by type or scale._
+- **Documentation & record-keeping:** _Placeholder for where decisions are logged and how they are communicated._
+
+## 6. Amendment Rules — Evolving the Charter
+- **Eligibility to propose changes:** _Placeholder describing who can submit amendments._
+- **Review cadence:** _Placeholder for how often the charter is reviewed._
+- **Voting or consent requirements:** _Placeholder for thresholds needed to ratify changes._
+- **Version control & communication:** _Placeholder for how updates are recorded and rolled out._
+
+---
+
+_Use this template as the baseline. Replace placeholders with concrete language, dates, structures, and names to finalize the charter. Maintain clarity and brevity so the document stays actionable._


### PR DESCRIPTION
## Summary
- add a Company Charter & Operating Principles template outlining six foundational blocks
- provide placeholders for mission, vision, principles, governance, decision hierarchy, and amendment rules
- include guidance text to help fill in each section clearly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e804b015dc8329a853df42e2b1a06e