### PR TITLE
Add company charter and operating principles

### DIFF
--- a/COMPANY_CHARTER.md
+++ b/COMPANY_CHARTER.md
@@ -1,0 +1,65 @@
+# Company Charter & Operating Principles
+
+## 1. Mission
+
+Define the company’s heartbeat — the problem we exist to solve and for whom.
+
+> We build systems that give creators financial sovereignty through transparent, on-chain coordination.
+
+## 2. Vision
+
+Paint the long horizon. What the world looks like when we’ve done our job right.
+
+> A global ecosystem where contribution, not capital, is the main currency.
+
+## 3. Guiding Principles
+
+- **Integrity > Optics** — we tell the truth, even when it’s awkward.
+- **Autonomy + Alignment** — freedom to act, anchored by shared goals.
+- **Bias for Clarity** — confusion is the enemy; we document decisions fast.
+- **Community as Co-owners** — users, contributors, and holders all share upside.
+- **Security First** — our reputation lives in the safety of our systems and funds.
+- **Iterate in Public** — transparency compounds trust.
+
+## 4. Ownership & Governance
+
+- Founders hold Class F governance tokens (super-vote 10:1) for 5 years, then convert 1:1 to standard GOV.
+- Contributors earn GOV over time through contribution proofs.
+- Investors (if any) may hold REV tokens (cash-flow rights, no votes).
+- Treasury managed by multisig committee (3-of-5) with 2-day timelock.
+- Amendments require 67% GOV + majority of Class F (if active) approval.
+
+## 5. Decision Hierarchy
+
+| Decision Type                       | Who Decides                 | Recorded Where     |
+| ----------------------------------- | --------------------------- | ------------------ |
+| Strategic (mission/charter)         | Founders + GOV vote         | Charter log        |
+| Tactical (OKRs, budgets)            | Dept leads                  | OKR tracker        |
+| Technical (architecture, releases)  | Eng RFC process             | GitHub RFCs        |
+| Tokenomics / Treasury               | Treasury Committee + GOV    | Snapshot + Ledger  |
+| Policy / Compliance                 | Legal + Approver            | Docs + Policy repo |
+
+**RACI template:**
+
+- **Responsible** → executes.
+- **Accountable** → final approval.
+- **Consulted** → gives input.
+- **Informed** → kept updated.
+
+## 6. Amendment Rules
+
+1. Proposal created → discussion in public forum.
+2. Governance vote (Snapshot / on-chain).
+3. If passed, updated charter version logged in Git with changelog entry.
+4. Previous version archived (read-only).
+5. Legal & ops verify dependencies (handbook, policies, tokenomics).
+
+---
+
+### Metadata
+
+- **Owner:** Founders / Chief of Staff
+- **Approvers:** Founders + Treasury Committee
+- **Review Cadence:** Annual or after any major governance change
+- **Status:** Draft 🧩
+- **Next Step:** Confirm mission + vision wording → publish v1.0 in root folder


### PR DESCRIPTION
## Summary
- add a root-level company charter outlining mission, vision, and guiding principles
- document ownership, governance, decision hierarchy, and amendment workflow for the charter

## Testing
- not run (documentation change)

------
https://chatgpt.com/codex/tasks/task_e_68e80545649483298a2b8533be291733