### PR TITLE
Add October 9 daily operations brief

### DIFF
--- a/status/2025-10-09.md
+++ b/status/2025-10-09.md
@@ -1,0 +1,13 @@
+# Daily Operations Brief — 2025-10-09
+
+## Infrastructure Maintenance
+- **GitHub Platform:** Status page reports all systems operational with no active incidents. Continue monitoring for Copilot-related regressions following recent fixes in US/EU regions.
+- **Cloudflare Dublin (DUB):** Magic Transit performance degradation resolved at 01:56 UTC; review telemetry for residual latency or rerouted traffic in the region.
+
+## Security Intelligence
+- **CISA KEV Catalog:** Additions on Oct 6 (seven CVEs) and Oct 7 (one CVE) highlight actively exploited vulnerabilities. Ensure patch pipeline prioritizes these entries and confirm no pending exposures remain.
+
+## Follow-Ups
+- Validate GitHub integration health and confirm Copilot-dependent workflows behave as expected post-incident.
+- Analyze Dublin ingress/egress metrics for anomalies during the 00:28–01:56 UTC window and document remediation actions if required.
+- Cross-reference CISA KEV additions against asset inventory to confirm mitigation timelines and ownership.


### PR DESCRIPTION
## Summary
- add the October 9, 2025 daily operations brief covering GitHub, Cloudflare, and CISA KEV updates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e8058841e88329b555b1f6da8f5388