### PR TITLE
Document GitHub credential hardening procedures

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -8,12 +8,12 @@ This standard operating procedure applies to all repositories under the BlackRoa
 - **Sunset classic PATs.** Existing classic tokens must be replaced with fine-grained equivalents unless a feature gap prevents the migration. Document the exception and track it in the token inventory.
 
 ## 2. Organization Controls
-- Enable mandatory approval for fine-grained PATs requesting organization access (Org Settings → Personal access tokens → Fine-grained → Require approval).
+- Enable mandatory approval for fine-grained PATs requesting organization access. Navigate to your organization settings, open the personal access tokens section, and require approval for fine-grained tokens. Confirm the exact labels against the current GitHub documentation.
 - Block or strictly restrict classic PAT issuance at the organization level and enforce maximum token lifetimes.
 - Review pending token approval requests weekly; reject scopes that exceed documented needs.
 
 ## 3. Secret Scanning Push Protection
-- Enable secret scanning with push protection at the organization level (Settings → Code security → Secret scanning → Enable push protection).
+- Enable secret scanning with push protection at the organization level. Follow the Code security settings in the organization dashboard and confirm the latest UI labels in GitHub's documentation when enabling push protection.
 - Require contributors to remediate flagged secrets or provide policy-justified bypass notes captured in the audit log.
 
 ## 4. Workflow Guidance

--- a/security/github-permission-matrix.md
+++ b/security/github-permission-matrix.md
@@ -5,7 +5,7 @@ This matrix documents least-privilege access for the three automation agents cur
 | Agent | Purpose | Preferred Auth | Repository Scope | Permissions |
 | --- | --- | --- | --- | --- |
 | Cadillac | Synchronize product documentation and open pull requests with content updates. | `GITHUB_TOKEN` when running via GitHub Actions; otherwise a fine-grained PAT dedicated to the target repo. | Specific documentation repos only (e.g., `blackroad/blackroad-docs`). Issue one token per repo when external. | `Contents: Read & Write`, `Metadata: Read`. No administrative scopes. |
-| Lucidia | Execute analytics workflows that require reading data snapshots and opening analysis reports. | `GITHUB_TOKEN` within org workflows; per-repo fine-grained PAT for external scheduling service. | Analytics repos requiring report updates (e.g., `blackroad/analytics-*`). Separate tokens per repo to avoid cross-repo access. | `Contents: Read & Write`, `Issues: Read` (for posting findings), `Metadata: Read`. |
+| Lucidia | Execute analytics workflows that require reading data snapshots and opening analysis reports. | `GITHUB_TOKEN` within org workflows; per-repo fine-grained PAT for external scheduling service. | Analytics repos requiring report updates (e.g., `blackroad/analytics-*`). Separate tokens per repo to avoid cross-repo access. | `Contents: Read & Write`, `Issues: Read & Write` (to publish findings), `Metadata: Read`. |
 | Codex | Code-quality bot that reads source, leaves review comments, and occasionally opens fix branches. | Repository `GITHUB_TOKEN` for CI-based reviews; fine-grained PAT only if the bot runs off-platform. | Target application repo only. | `Contents: Read & Write`, `Pull requests: Read & Write`, `Metadata: Read`. |
 
 ## Operational Notes


### PR DESCRIPTION
## Summary
- add a GitHub access hardening SOP to `.github/SECURITY.md`
- document fine-grained PAT requirements for Cadillac, Lucidia, and Codex agents

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e80597d9588329b1262132fc6de297