### PR TITLE
Add blog on GenX320 event vision kit for Raspberry Pi 5

### DIFF
--- a/sites/blackroad/content/blog/raspberry-pi-genx320-event-camera.md
+++ b/sites/blackroad/content/blog/raspberry-pi-genx320-event-camera.md
@@ -1,0 +1,32 @@
+---
+title: "GenX320 Event Vision Lands on Raspberry Pi 5"
+date: "2025-10-08"
+tags: [raspberry-pi, computer-vision, hardware]
+description: "Prophesee's GenX320 Starter Kit brings neuromorphic, event-based sensing to Raspberry Pi 5 projects with low power draw and microsecond latency."
+---
+
+Neuromorphic vision hardware has finally reached maker-friendly territory. Prophesee's new GenX320 Starter Kit for Raspberry Pi 5 packages its flagship event sensor into a compact module that snaps onto the Pi's MIPI CSI-2 interface. Instead of recording full frames, the 320×320 pixel device reports asynchronous changes per pixel, enabling responsive perception at a fraction of the data and power budget of traditional image sensors.
+
+## Why it matters
+
+- **High-speed perception**: With an effective event rate comparable to ~10,000 frames per second, the GenX320 delivers motion detail that standard 60 FPS capture simply cannot match.
+- **Wide dynamic range**: Over 140 dB of dynamic range lets the sensor track motion across scenes that mix bright sunshine and deep shadows without shutter juggling.
+- **Low power and latency**: Typical draw stays under 50 mW and event latency in bright conditions drops below 150 microseconds—perfect for battery-powered drones, cobots, and safety monitors that need real-time reactions.
+
+## Starter kit hardware
+
+The kit includes a purpose-built camera board that mates with the Raspberry Pi 5 over CSI-2 (D-PHY). Prophesee bundles two lens options—an M12 lens with a 76° field of view and an ultra-wide M6 lens covering 104°—plus a mounting system sized for the Pi ecosystem. Between the mechanical flexibility and the Pi 5's upgraded CPU/GPU, builders can prototype fast-tracking robots, industrial counters, or low-light monitoring nodes without spinning custom boards.
+
+## Software and developer tooling
+
+Prophesee is pairing the hardware with an open software stack: kernel drivers, Python and C++ APIs, visualization utilities, and tools for recording and replaying event streams. That means teams can explore event-based SLAM, gesture recognition, or anomaly detection workflows directly on the Pi 5, then scale the same code to larger edge compute boxes.
+
+## Availability and next steps
+
+Starter kits are up for pre-order now through Prophesee and authorized distributors, with Raspberry Pi's official blog spotlighting the launch as a path to "see faster, smarter, and with far less power." Expect early adopters to share benchmarks over the coming weeks; in the meantime, line up a project plan:
+
+1. **Pick your application**: drones, robotic grippers, safety tripwires, and industrial IoT counters are prime beneficiaries of microsecond vision.
+2. **Prototype the pipeline**: use the replay tools to simulate edge cases, then iterate with the live camera to dial in thresholds and debouncing.
+3. **Plan for deployment**: budget power envelopes under 50 mW for sensing, and reserve CPU/GPU time on the Pi 5 for inference and control loops.
+
+Need help comparing the GenX320 to other event sensors or sketching a full system architecture? Let us know—we can dig into benchmarks, data pipelines, and integration strategies tailored to your build.


### PR DESCRIPTION
## Summary
- add a new blog post covering Prophesee's GenX320 Starter Kit for Raspberry Pi 5
- highlight sensor specs, kit hardware, developer tooling, and launch availability

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e80664f2788329b295d0f39d74b3ea