### PR TITLE
Add blog post on October ETF inflows

### DIFF
--- a/sites/blackroad/content/blog/bitcoin-ether-etf-flood-oct-2025.md
+++ b/sites/blackroad/content/blog/bitcoin-ether-etf-flood-oct-2025.md
@@ -1,0 +1,22 @@
+---
+title: 'ETF Demand Goes Vertical as Bitcoin and Ether Hover Near Highs'
+date: '2025-10-09'
+tags: [markets, crypto, bitcoin, ethereum, etf]
+description: 'U.S. spot Bitcoin ETFs pulled in ~$876 m while ether products added $400 m+, and BlackRock’s IBIT is closing in on $100 b AUM.'
+---
+
+## Key Takeaways
+- U.S. spot Bitcoin ETFs drew roughly $876 million in net inflows on 8 October, underscoring relentless demand even with price near records.
+- Ether ETF creations topped $400 million the same session, signaling multi-asset participation rather than a single-asset chase.
+- BlackRock’s IBIT is approaching $100 billion in assets with more than 700,000 BTC, cementing a 56% share of U.S. spot ETF holdings.
+
+## Flow Snapshot
+The 8 October tape delivered one of the strongest single-day surges since launch. Bitcoin funds absorbed ~$876 million of fresh capital while ether vehicles added over $400 million. That mix shows allocators are deploying across the stack, not just hiding in the perceived safety of BTC. The flows landed as both assets sat just below all-time highs, reinforcing that this is not a dip-buying scramble but an ongoing asset-allocation shift.
+
+## IBIT’s Dominance
+IBIT now sits near $97.4 billion AUM and controls more than 700,000 BTC. With a roughly 56% share of U.S. spot ETF holdings, the fund has become the structural benchmark for institutional crypto exposure. Its growth rate matters: every creation basket tightens available liquid supply, keeping exchange balances lean and offering a persistent tailwind during otherwise sluggish sessions.
+
+## Structural Implications
+The combination of cross-asset inflows and IBIT’s scale points to demand that is anchored in allocation mandates rather than speculative swings. Structural buying keeps volatility compressed on pullbacks and raises the bar for any bearish narrative to gain traction. Watch how flows behave into upcoming macro catalysts—if they stay elevated, dips could remain shallow and altcoin rotation may accelerate as investors seek beta beyond the majors.
+
+Stay mindful of positioning, but respect that the ETF bid is rewriting crypto market microstructure in real time.


### PR DESCRIPTION
## Summary
- add a new blog post covering the October 8 surge in bitcoin and ether ETF inflows
- highlight IBIT's approach toward $100 billion in assets and its market share
- outline why the sustained ETF demand signals structural support for crypto markets

## Testing
- not run (content change only)


------
https://chatgpt.com/codex/tasks/task_e_68e805c221fc8329bba784de4f9864b2