### PR TITLE
Add resume verification pack and runner

### DIFF
--- a/docs/verification/blackroad_resume_claims.json
+++ b/docs/verification/blackroad_resume_claims.json
@@ -92,7 +92,7 @@
       "text": "Published whitepaper with a 100-item Evidence Map; released streaming co-coding UI with agent presence and contradiction flags.",
       "evidence_ids": [1, 9, 10, 41, 48, 74],
       "files": [
-        "docs/… (whitepaper md)",
+        "docs/whitepaper.md",
         "services/lucidia_api/app/routes.py",
         "agents/auto_novel_agent.py",
         "lucidia/brain.py",
@@ -113,7 +113,9 @@
         "analytics/dbt/models/marts/ops/fct_github_issues_daily.sql",
         "tools/export_embeddings.py",
         "lucidia/roadie.py",
-        ".github/workflows/* (if present)"
+        ".github/workflows/ci.yml",
+        ".github/workflows/deploy.yml",
+        ".github/workflows/release-please.yml"
       ],
       "checks": [
         "Open dbt models; confirm normalized schema + marts.",

--- a/tools/verification/run_blackroad_claim_verifier.py
+++ b/tools/verification/run_blackroad_claim_verifier.py
@@ -39,8 +39,17 @@ If any verdict is FALSE, generate a minimal PR plan (file, snippet to add, test)
 
 def load_claims(path: Path) -> Dict[str, Any]:
     """Load the verification claims JSON file."""
-    content = path.read_text(encoding="utf-8")
-    return json.loads(content)
+    try:
+        content = path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(f"Claims file not found: {path}") from exc
+    except OSError as exc:
+        raise OSError(f"Failed to read claims file at {path}: {exc}") from exc
+
+    try:
+        return json.loads(content)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Malformed JSON in claims file {path}: {exc}") from exc
 
 
 def build_payload(claims: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- add a resume-claim verification JSON pack under docs/verification
- provide a runner script that emits the Ψ′ verification payload for Guardian automation

## Testing
- `python3 tools/verification/run_blackroad_claim_verifier.py | head`


------
https://chatgpt.com/codex/tasks/task_e_68e826d24c308329b445bc0bcb3a8b39