### PR TITLE
Provide top resume bullet output

### DIFF
--- a/docs/verification/blackroad_resume_claims.json
+++ b/docs/verification/blackroad_resume_claims.json
@@ -1,8 +1,8 @@
 {
   "entity": "BlackRoad Inc. — Founder & Lead Architect",
   "top_resume_bullets": [
-    "Architected Lucidia, a symbolic multi-agent AI core integrating Qwen, Llama, Mistral, and Grok through local Ollama orchestration to cut external API dependency ~40% and compute overhead ~30%.",
-    "Engineered a Guardian–Roadie–Contradiction–Quantum–IDE agent mesh with stateful memory and contradiction logging that boosted peer-to-peer inference efficiency ~45% and reduced workflow solve times ~55%.",
+    "Architected Lucidia, a symbolic multi-agent AI core integrating Qwen, Llama, Mistral, and Grok through local Ollama orchestration, reducing external API dependency by ~40% and compute overhead by ~30%.",
+    "Engineered a Guardian-Roadie-Contradiction-Quantum-IDE agent mesh with stateful memory and contradiction logging that boosted peer-to-peer inference efficiency ~45% and reduced workflow solve times ~55%.",
     "Developed Codex Ψ′ trinary true/false/needs-evidence guards that deterministically gate LLM pre/post outputs and lowered hallucination-adjacent failures ~40% in production tasks.",
     "Integrated Qiskit + PyTorch TorchConnector quantum ML pipelines and functional-VAE modules, delivering Sampler/Estimator QNN tooling for physics-informed learning.",
     "Implemented local-first NGINX, Express/Socket.IO, SQLite, Docker, and systemd infrastructure with health/readiness endpoints, p95 < 500 ms SLOs, error budgets, nightly backups, and A+ TLS hardening."

--- a/tools/verification/run_blackroad_claim_verifier.py
+++ b/tools/verification/run_blackroad_claim_verifier.py
@@ -82,7 +82,19 @@ def main() -> None:
     if args.resume_bullets:
         bullets = claims.get("top_resume_bullets")
         if not bullets:
-            raise SystemExit("No top_resume_bullets section found in claims JSON.")
+            raise SystemExit(
+                "No 'top_resume_bullets' section found in claims JSON.\n"
+                "Please ensure your claims file includes a 'top_resume_bullets' key with a list of resume bullets.\n"
+                "Example structure:\n"
+                '{\n'
+                '  "top_resume_bullets": [\n'
+                '    "Built distributed memory palace for multi-agent chat",\n'
+                '    "Reduced latency by 30% via async SSE routes",\n'
+                '    "Benchmarked QNN estimator on CI artifacts"\n'
+                '  ],\n'
+                '  ...\n'
+                '}\n'
+            )
         rendered = format_resume_bullets(bullets)
         if args.output is None:
             print(rendered)


### PR DESCRIPTION
## Summary
- add a curated top_resume_bullets section to the BlackRoad resume verification pack
- extend the verification runner with a --resume-bullets flag that prints the five headline bullets

## Testing
- `python3 tools/verification/run_blackroad_claim_verifier.py --resume-bullets`
- `python3 tools/verification/run_blackroad_claim_verifier.py | head`


------
https://chatgpt.com/codex/tasks/task_e_68e826d24c308329b445bc0bcb3a8b39