### PR TITLE
Augment resume verifier with interview validation cues

### DIFF
--- a/docs/verification/blackroad_resume_claims.json
+++ b/docs/verification/blackroad_resume_claims.json
@@ -152,7 +152,7 @@
       "text": "Published whitepaper with a 100-item Evidence Map; released streaming co-coding UI with agent presence and contradiction flags.",
       "evidence_ids": [1, 9, 10, 41, 48, 74],
       "files": [
-        "docs/… (whitepaper md)",
+        "docs/whitepaper.md",
         "services/lucidia_api/app/routes.py",
         "agents/auto_novel_agent.py",
         "lucidia/brain.py",

--- a/tools/verification/prompt_templates.py
+++ b/tools/verification/prompt_templates.py
@@ -1,0 +1,27 @@
+"""Prompt templates for the BlackRoad resume claim verifier."""
+
+RESUME_VERIFICATION_PROMPT = """Ψ′-pre (scope):
+You are the Truth Agent. Verify each resume bullet in the JSON against repo artifacts and logs.
+Return a trinary verdict per bullet: TRUE, FALSE, or NEEDS-EVIDENCE.
+Treat quantitative metrics (%, latency, grades) as NEEDS-EVIDENCE unless supported by logs/benchmarks.
+
+Method:
+1) For each bullet:
+   a) Open listed files; search for named classes/functions/routes and behaviors (e.g., DistributedMemoryPalace, /chat SSE, EstimatorQNN).
+   b) Cross-check with Evidence Map IDs to ensure the code paths exist and perform the claimed role.
+   c) If a metric is claimed, look for benchmark/ops logs (e.g., events.log, perf/*.json, CI artifacts).
+      If none found, mark NEEDS-EVIDENCE and emit a contradiction record with 'metric_missing'.
+2) Emit a table:
+   - bullet_text
+   - verdict (TRUE|FALSE|NEEDS-EVIDENCE)
+   - supporting_snippets (file:path:line ranges)
+   - contradictions[] (if any)
+   - remediation (what log/benchmark to add)
+
+Success criteria:
+- No hallucinated files.
+- Deterministic, reproducible outputs given the same repo state.
+- All metric claims either grounded by logs or downgraded to NEEDS-EVIDENCE with a remediation step.
+
+Ψ′-post (write):
+If any verdict is FALSE, generate a minimal PR plan (file, snippet to add, test) to make it TRUE."""


### PR DESCRIPTION
## Summary
- extend the BlackRoad resume claims pack with interview validation prompts that tie top bullets to concrete code and metrics checks
- update the verifier CLI to render the bullet list and associated validation guidance, while validating the new configuration structure

## Testing
- python3 tools/verification/run_blackroad_claim_verifier.py --resume-bullets
- python3 tools/verification/run_blackroad_claim_verifier.py --validate
- python3 tools/verification/run_blackroad_claim_verifier.py | head

------
https://chatgpt.com/codex/tasks/task_e_68e826d24c308329b445bc0bcb3a8b39