### PR TITLE
Harden CI workflows with reruns and reusable testing

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -1,0 +1,63 @@
+name: Run Tests
+
+description: >-
+  Configure a language runtime, optionally install dependencies, and execute the
+  provided test command.
+
+inputs:
+  language:
+    description: Primary language runtime to configure (e.g. node, python).
+    required: true
+  version:
+    description: Version of the runtime to install.
+    required: true
+  test_command:
+    description: Command used to execute the test suite.
+    required: true
+  working-directory:
+    description: Directory where commands should run.
+    required: false
+    default: .
+  install-command:
+    description: Optional command to install dependencies before running tests.
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Node.js
+      if: inputs.language == 'node'
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.version }}
+        cache: npm
+        cache-dependency-path: |
+          **/package-lock.json
+          **/npm-shrinkwrap.json
+          **/package.json
+    - name: Setup Python
+      if: inputs.language == 'python'
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.version }}
+        cache: 'pip'
+        cache-dependency-path: |
+          **/requirements*.txt
+          **/pyproject.toml
+          **/setup.cfg
+    - name: Runtime not explicitly handled
+      if: inputs.language != 'node' && inputs.language != 'python'
+      shell: bash
+      run: echo "::notice::No explicit runtime setup for '${{ inputs.language }}'."
+    - name: Install dependencies
+      if: inputs.install-command != ''
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: ${{ inputs.install-command }}
+    - name: Run tests
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        CI: true
+      run: ${{ inputs.test_command }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,47 @@
 name: ci
-on: [push, pull_request]
+
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
-    timeout-minutes: 10
+    if: >-
+      !(
+        github.event_name == 'push' &&
+        contains(github.event.head_commit.message, '[skip ci]')
+      ) &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with: { python-version: '3.11' }
-      - run: python -m pip install -U pip pytest jsonschema
-      - run: pytest -q
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+      - name: Install test dependencies
+        run: python -m pip install -U pip pytest jsonschema
+      - name: Run pytest
+        run: pytest -q --junitxml=junit-pytests.xml
+      - name: Publish test results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          files: |
+            **/junit-*.xml
       - name: Determinism smoke
         run: |
           python -m pip install .
@@ -24,15 +56,31 @@ jobs:
         run: bash scripts/hash_artifacts.sh || true
 
   build-test:
-    timeout-minutes: 10
+    if: >-
+      !(
+        github.event_name == 'push' &&
+        contains(github.event.head_commit.message, '[skip ci]')
+      ) &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with: { node-version: '20' }
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: |
+            apps/api/package-lock.json
       - run: npm ci --prefix apps/api
       - run: npm run build --prefix apps/api
       - run: npm test --prefix apps/api --if-present
+      - name: Publish test results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          files: |
+            apps/api/**/junit-*.xml
       - name: Upload API dist
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/prism-ci.yml
+++ b/.github/workflows/prism-ci.yml
@@ -6,26 +6,55 @@ on:
       - 'prism/**'
       - '.github/workflows/prism-ci.yml'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'prism/**'
       - '.github/workflows/prism-ci.yml'
 
+permissions:
+  contents: read
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
+    if: >-
+      !(
+        github.event_name == 'push' &&
+        contains(github.event.head_commit.message, '[skip ci]')
+      ) &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+    timeout-minutes: 45
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: npm
+          cache-dependency-path: |
+            prism/server/package-lock.json
       - run: npm --prefix prism/server ci
       - run: npm --prefix prism/server run lint
       - run: npm --prefix prism/server test -- --coverage
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements-dev.txt
+            requirements.txt
       - run: pip install -r requirements-dev.txt
-      - run: pytest tests/prism
+      - run: pytest --junitxml=junit-prism-python.xml tests/prism
+      - name: Publish test results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          files: |
+            **/junit-*.xml
       - uses: codecov/codecov-action@v4
         with:
           files: prism/server/coverage/coverage-final.json

--- a/.github/workflows/rerun-failed-jobs.yml
+++ b/.github/workflows/rerun-failed-jobs.yml
@@ -1,0 +1,30 @@
+name: "🔁 Auto Re-run Failed Jobs (max 3)"
+
+on:
+  workflow_run:
+    types: [completed]
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: write
+
+jobs:
+  rerun-failed:
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'failure' &&
+      contains(github.event.workflow_run.name, 'CI') &&
+      github.event.workflow_run.run_attempt < 3 &&
+      !contains(github.event.workflow_run.head_branch, 'no-rerun')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const runId = context.payload.workflow_run.id;
+            await github.request('POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun-failed-jobs', {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: runId,
+            });

--- a/.github/workflows/test-reusable.yml
+++ b/.github/workflows/test-reusable.yml
@@ -1,0 +1,41 @@
+name: "🧩 Reusable Test"
+
+on:
+  workflow_call:
+    inputs:
+      language:
+        required: true
+        type: string
+      version:
+        required: true
+        type: string
+      test:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests
+        uses: ./.github/actions/run-tests
+        with:
+          language: ${{ inputs.language }}
+          version: ${{ inputs.version }}
+          test_command: ${{ inputs.test }}
+      - name: Publish test results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          files: |
+            **/junit-*.xml


### PR DESCRIPTION
## Summary
- add a workflow that automatically re-runs failed CI jobs up to three attempts while allowing `no-rerun` opt-outs
- harden existing CI pipelines with concurrency controls, caching, junit publishing, and skip/draft guards
- introduce a reusable test workflow and composite action to standardize runtime setup across repositories

## Testing
- not run (workflow updates only)


------
https://chatgpt.com/codex/tasks/task_e_68e830c32990832998d1f814ef778cf9