### PR TITLE
chore: harden ci workflows

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -1,0 +1,29 @@
+name: Run Tests
+inputs:
+  language:
+    description: "Language/runtime to configure"
+    required: true
+  version:
+    description: "Runtime version"
+    required: true
+  test_command:
+    description: "Command used to execute tests"
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Setup Node.js
+      if: ${{ inputs.language == 'node' }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.version }}
+        cache: npm
+    - name: Setup Python
+      if: ${{ inputs.language == 'python' }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.version }}
+        cache: pip
+    - name: Run tests
+      shell: bash
+      run: ${{ inputs.test_command }}

--- a/.github/workflows/auto-rerun-failed.yml
+++ b/.github/workflows/auto-rerun-failed.yml
@@ -1,0 +1,29 @@
+name: "🔁 Auto Re-run Failed Jobs (max 3)"
+on:
+  workflow_run:
+    types: [completed]
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: write
+
+jobs:
+  rerun-failed:
+    if: |
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'failure' &&
+      contains(github.event.workflow_run.name, 'CI') &&
+      github.event.workflow_run.run_attempt < 3 &&
+      !contains(github.event.workflow_run.head_branch, 'no-rerun')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const runId = context.payload.workflow_run.id
+            await github.request('POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun-failed-jobs', {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: runId
+            })

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,37 @@
 name: ci
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  checks: write
+
 jobs:
   build:
-    timeout-minutes: 10
+    if: |
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
+      !contains(github.event.head_commit.message, '[skip ci]') &&
+      !contains(format('{0}', github.event.pull_request.title), '[skip ci]')
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with: { python-version: '3.11' }
+        with:
+          python-version: '3.11'
+          cache: 'pip'
       - run: python -m pip install -U pip pytest jsonschema
-      - run: pytest -q
+      - name: Run pytest
+        run: |
+          mkdir -p artifacts/test-results
+          pytest -q --junitxml=artifacts/test-results/junit-python.xml
       - name: Determinism smoke
         run: |
           python -m pip install .
@@ -22,14 +44,26 @@ jobs:
         run: python scripts/validate_contracts.py
       - name: Artifacts hash
         run: bash scripts/hash_artifacts.sh || true
+      - name: Publish test results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          files: |
+            artifacts/test-results/junit-python.xml
 
   build-test:
-    timeout-minutes: 10
+    if: |
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
+      !contains(github.event.head_commit.message, '[skip ci]') &&
+      !contains(format('{0}', github.event.pull_request.title), '[skip ci]')
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with: { node-version: '20' }
+        with:
+          node-version: '20'
+          cache: npm
       - run: npm ci --prefix apps/api
       - run: npm run build --prefix apps/api
       - run: npm test --prefix apps/api --if-present

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -1,18 +1,35 @@
 name: Test CI
 on:
-  pull_request:
   push:
     branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   unit-integration:
+    if: |
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
+      !contains(github.event.head_commit.message, '[skip ci]') &&
+      !contains(format('{0}', github.event.pull_request.title), '[skip ci]')
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with: { node-version: '20' }
+        with:
+          node-version: '20'
+          cache: npm
       - run: npm ci --prefix apps/api
       - run: npm run test:ci --prefix apps/api
       - name: Upload coverage
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: coverage

--- a/.github/workflows/test-reusable.yml
+++ b/.github/workflows/test-reusable.yml
@@ -1,0 +1,27 @@
+name: "🧩 Reusable Test"
+on:
+  workflow_call:
+    inputs:
+      language:
+        required: true
+        type: string
+      version:
+        required: true
+        type: string
+      test:
+        required: true
+        type: string
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/run-tests
+        with:
+          language: ${{ inputs.language }}
+          version: ${{ inputs.version }}
+          test_command: ${{ inputs.test }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,24 @@
 name: Tests
-on: { pull_request: {}, push: { branches: [ main ] } }
-permissions: { contents: read }
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 jobs:
   test:
+    if: |
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
+      !contains(github.event.head_commit.message, '[skip ci]') &&
+      !contains(format('{0}', github.event.pull_request.title), '[skip ci]')
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -15,7 +30,12 @@ jobs:
       - run: npm ci --omit=optional || npm i --package-lock-only
       - run: npm test
   site-playwright:
+    if: |
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
+      !contains(github.event.head_commit.message, '[skip ci]') &&
+      !contains(format('{0}', github.event.pull_request.title), '[skip ci]')
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     defaults:
       run:
         working-directory: sites/blackroad


### PR DESCRIPTION
## Summary
- add workflow to automatically rerun failed CI jobs up to three times while honoring a no-rerun branch convention
- tighten existing CI entrypoints with concurrency guards, draft/[skip ci] filters, cache usage, and junit publishing
- introduce a reusable test workflow with a companion composite action for language-aware setup

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e8312771808329880e9f6a77f35635