### PR TITLE
Add architecture RFC template

### DIFF
--- a/engineering/rfcs/architecture-rfc-template.md
+++ b/engineering/rfcs/architecture-rfc-template.md
@@ -1,0 +1,114 @@
+# Architecture RFC Template
+
+## 1. Header & Metadata
+
+- **RFC ID:** ENG-RFC-####
+- **Title:**
+- **Author:**
+- **Reviewers:** Eng Lead, Security Lead, Product
+- **Status:** Draft / Under Review / Approved / Implemented / Deprecated
+- **Date:**
+- **Links:** Related PRDs, tickets, diagrams
+
+---
+
+## 2. Context & Summary 🪄
+
+- **Problem Statement:** What’s broken or missing?
+- **Goal:** Why this change exists.
+- **Scope:** Define what systems and services are affected.
+- **Assumptions:** List known truths or constraints.
+
+---
+
+## 3. Current State ⚙️
+
+Describe how it works now (attach diagrams as needed).
+
+- Architecture diagram or flow
+- Key components and interfaces
+- Pain points and limits (performance, cost, maintainability)
+
+---
+
+## 4. Proposed Design 🧩
+
+- **Overview:** Brief of the new architecture.
+- **Components:** Core modules, APIs, data stores, dependencies.
+- **Interactions:** Sequence or flow diagrams.
+- **Data Model:** Tables, schemas, contract structs.
+- **Security:** AuthN/AuthZ flow, data protection, key handling.
+- **Performance:** Expected throughput, latency, scalability.
+
+**Implementation Notes**
+
+- **Language/Framework:**
+- **Libraries/SDKs:**
+- **Deployment Model:** container / serverless / on-chain / hybrid
+- **Observability:** logs, metrics, alerts
+
+---
+
+## 5. Alternatives Considered 🔄
+
+| Option | Pros | Cons | Reason Rejected |
+| --- | --- | --- | --- |
+| Option A | Simple, fast | Not scalable | Not future-proof |
+| Option B | Modular | Higher cost | Complexity |
+
+---
+
+## 6. Impact & Risks ⚠️
+
+- **Impact Areas:** Performance, security, dev velocity, user experience.
+
+| Risk | Severity | Mitigation |
+| --- | --- | --- |
+| Latency spikes | High | Caching layer |
+| Integration break | Medium | Contract versioning |
+| Data loss | High | Backup + migration plan |
+
+- **Backward Compatibility:** How to avoid breaking existing systems.
+
+---
+
+## 7. Implementation Plan 🚧
+
+| Phase | Task | Owner | ETA | Status |
+| --- | --- | --- | --- | --- |
+| P1 | Build prototype | Eng |  | 🟡 |
+| P2 | Review + testing | Security |  | 🟢 |
+| P3 | Deploy + monitor | DevOps |  | ⏳ |
+
+- **Testing Strategy:** unit, integration, load, on-chain simulation.
+- **Rollback Plan:** steps to revert if needed.
+
+---
+
+## 8. Decision Record 🏁
+
+- **Final Decision:** Accepted / Rejected / Deferred
+- **Approved by:**
+- **Date:**
+- **Changelog:**
+  - v1.0: Drafted
+  - v1.1: Security Review Added
+  - v1.2: Final Approval
+
+---
+
+## 9. Governance & Storage 🔐
+
+- RFCs live in `/engineering/rfcs/` (Git).
+- Each merged RFC = decision artifact.
+- Immutable index updated automatically on merge.
+
+---
+
+**Metadata**
+
+- **Owner:** Engineering Lead
+- **Approvers:** CTO / Product Council
+- **Review Cadence:** As needed per major change
+- **Status:** Template Ready ⚙️
+- **Next Step:** Use for next major system design (Token Treasury v1)


### PR DESCRIPTION
## Summary
- add an architecture RFC template under engineering/rfcs to guide future design proposals

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e83157a2008329849c176ddc4ae51d