### PR TITLE
Add /ops portal dashboard and supporting APIs

### DIFF
--- a/app/api/ops/[action]/route.ts
+++ b/app/api/ops/[action]/route.ts
@@ -1,0 +1,107 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+
+const ACTION_ENDPOINTS: Record<string, string | undefined> = {
+  "go-no-go": process.env.OPS_ACTION_GO_NO_GO_URL ?? process.env.GO_NO_GO_URL,
+  ladder: process.env.OPS_ACTION_LADDER_URL ?? process.env.CANARY_LADDER_URL,
+  rollback: process.env.OPS_ACTION_ROLLBACK_URL ?? process.env.ROLLBACK_URL
+};
+
+const OPS_ENVIRONMENT = process.env.OPERATIONS_ENVIRONMENT ?? process.env.NODE_ENV ?? "production";
+const SLACK_WEBHOOK = process.env.SLACK_WEBHOOK ?? process.env.OPS_SLACK_WEBHOOK;
+const GITHUB_TOKEN = process.env.OPS_GITHUB_TOKEN ?? process.env.GITHUB_TOKEN;
+
+async function sendSlackNotification(action: string, actor: string) {
+  if (!SLACK_WEBHOOK) return;
+  try {
+    await fetch(SLACK_WEBHOOK, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ text: `Ops action: ${actor} triggered ${action} on ${OPS_ENVIRONMENT}` })
+    });
+  } catch (error) {
+    console.warn("[ops] failed to send slack notification", error);
+  }
+}
+
+export async function POST(request: NextRequest, { params }: { params: { action: string } }) {
+  const action = params.action;
+  const endpoint = ACTION_ENDPOINTS[action];
+
+  if (!endpoint) {
+    return NextResponse.json({ error: `Action '${action}' is not configured.` }, { status: 501 });
+  }
+
+  const actor =
+    request.headers.get("x-ops-user") ??
+    request.headers.get("x-forwarded-email") ??
+    request.headers.get("x-user-email") ??
+    request.headers.get("x-github-actor") ??
+    "ops-portal";
+
+  let upstreamBody: string | undefined;
+  const contentType = request.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    try {
+      const raw = await request.text();
+      upstreamBody = raw && raw.length ? raw : undefined;
+    } catch (error) {
+      console.warn("[ops] failed to read request body", error);
+    }
+  }
+
+  if (!upstreamBody) {
+    upstreamBody = JSON.stringify({ action, actor, environment: OPS_ENVIRONMENT });
+  }
+
+  const headers: Record<string, string> = {
+    "content-type": "application/json"
+  };
+
+  if (GITHUB_TOKEN) {
+    headers.Authorization = `Bearer ${GITHUB_TOKEN}`;
+    headers.Accept = "application/vnd.github+json";
+  }
+
+  let upstreamResponse: Response;
+  try {
+    upstreamResponse = await fetch(endpoint, {
+      method: "POST",
+      headers,
+      body: upstreamBody
+    });
+  } catch (error) {
+    console.error(`[ops] action ${action} failed to reach upstream`, error);
+    return NextResponse.json({ error: `Failed to reach upstream for ${action}` }, { status: 502 });
+  }
+
+  let responseBody: any = null;
+  const responseText = await upstreamResponse.text();
+  try {
+    responseBody = responseText ? JSON.parse(responseText) : null;
+  } catch {
+    responseBody = responseText || null;
+  }
+
+  if (upstreamResponse.ok) {
+    await sendSlackNotification(action, actor);
+  }
+
+  return NextResponse.json(
+    {
+      ok: upstreamResponse.ok,
+      status: upstreamResponse.status,
+      upstream: responseBody ?? undefined
+    },
+    { status: upstreamResponse.ok ? 200 : upstreamResponse.status }
+  );
+}
+
+export async function GET(_: NextRequest, { params }: { params: { action: string } }) {
+  const action = params.action;
+  if (!Object.prototype.hasOwnProperty.call(ACTION_ENDPOINTS, action)) {
+    return NextResponse.json({ error: `Action '${action}' is not supported.` }, { status: 404 });
+  }
+  return NextResponse.json({ action, configured: Boolean(ACTION_ENDPOINTS[action]) });
+}

--- a/app/api/ops/flags/route.ts
+++ b/app/api/ops/flags/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+
+const FLAGS_ENDPOINT =
+  process.env.OPS_FLAGS_ENDPOINT ?? process.env.FLAGS_ENDPOINT ?? process.env.BR_FLAGS_URL ?? undefined;
+
+interface FlagsDocument {
+  version?: string;
+  features?: Record<string, unknown>;
+}
+
+async function fetchFlags(url: string | undefined): Promise<FlagsDocument | undefined> {
+  if (!url) return undefined;
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5000);
+    const res = await fetch(url, { cache: "no-store", signal: controller.signal });
+    clearTimeout(timeout);
+    if (!res.ok) {
+      return undefined;
+    }
+    return (await res.json()) as FlagsDocument;
+  } catch (error) {
+    console.warn(`[ops] unable to fetch flags from ${url}:`, error);
+    return undefined;
+  }
+}
+
+export async function GET() {
+  const doc = await fetchFlags(FLAGS_ENDPOINT);
+  const payload: FlagsDocument = {
+    version: doc?.version ?? process.env.FLAGS_VERSION ?? "unknown",
+    features: doc?.features ?? {}
+  };
+  return NextResponse.json(payload);
+}

--- a/app/api/ops/incidents/route.ts
+++ b/app/api/ops/incidents/route.ts
@@ -1,0 +1,126 @@
+import { NextResponse } from "next/server";
+import { promises as fs } from "fs";
+import path from "path";
+
+export const runtime = "nodejs";
+
+interface IncidentEntry {
+  title: string;
+  file: string;
+  opened_at?: string;
+  status?: string;
+}
+
+const INCIDENTS_DIR = process.env.OPS_INCIDENTS_PATH ?? path.resolve(process.cwd(), "../br-status-site/content/issues");
+const INCIDENTS_URL = process.env.OPS_INCIDENTS_URL ?? "https://status.blackroad.io/content/issues/index.json";
+
+function parseFrontMatter(content: string): Partial<IncidentEntry> {
+  const title = content.match(/^title:\s*(.+)$/m)?.[1]?.trim();
+  const status = content.match(/^status:\s*(.+)$/m)?.[1]?.trim();
+  const opened =
+    content.match(/^(?:opened_at|date|created_at):\s*(.+)$/m)?.[1]?.trim() ??
+    content.match(/^timestamp:\s*(.+)$/m)?.[1]?.trim();
+  return {
+    title,
+    status,
+    opened_at: opened ? new Date(opened).toISOString() : undefined
+  };
+}
+
+async function readFromFilesystem(dir: string): Promise<IncidentEntry[]> {
+  try {
+    const stat = await fs.stat(dir);
+    if (!stat.isDirectory()) {
+      return [];
+    }
+  } catch (error: any) {
+    if (error?.code === "ENOENT") {
+      return [];
+    }
+    console.warn("[ops] unable to read incidents directory", error);
+    return [];
+  }
+
+  const entries = await fs.readdir(dir);
+  const incidents: IncidentEntry[] = [];
+  const now = Date.now();
+  const cutoff = now - 24 * 60 * 60 * 1000;
+
+  await Promise.all(
+    entries
+      .filter((file) => file.endsWith(".md"))
+      .map(async (file) => {
+        const fullPath = path.join(dir, file);
+        try {
+          const [content, meta] = await Promise.all([fs.readFile(fullPath, "utf8"), fs.stat(fullPath)]);
+          const frontMatter = parseFrontMatter(content);
+          const openedAt = frontMatter.opened_at ?? meta.mtime.toISOString();
+          if (new Date(openedAt).getTime() < cutoff) {
+            return;
+          }
+          incidents.push({
+            title: frontMatter.title ?? file.replace(/\.md$/, ""),
+            file,
+            opened_at: openedAt,
+            status: frontMatter.status
+          });
+        } catch (error) {
+          console.warn(`[ops] failed to read incident ${file}`, error);
+        }
+      })
+  );
+
+  incidents.sort((a, b) => {
+    const aTime = a.opened_at ? new Date(a.opened_at).getTime() : 0;
+    const bTime = b.opened_at ? new Date(b.opened_at).getTime() : 0;
+    return bTime - aTime;
+  });
+
+  return incidents.slice(0, 10);
+}
+
+async function readFromRemote(url: string | undefined): Promise<IncidentEntry[]> {
+  if (!url) return [];
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5000);
+    const res = await fetch(url, { cache: "no-store", signal: controller.signal });
+    clearTimeout(timeout);
+    if (!res.ok) {
+      return [];
+    }
+    const data = (await res.json()) as IncidentEntry[];
+    if (!Array.isArray(data)) {
+      return [];
+    }
+    return data.slice(0, 10);
+  } catch (error) {
+    console.warn(`[ops] unable to fetch incidents from ${url}:`, error);
+    return [];
+  }
+}
+
+export async function GET() {
+  const [localIncidents, remoteIncidents] = await Promise.all([
+    readFromFilesystem(INCIDENTS_DIR),
+    readFromRemote(INCIDENTS_URL)
+  ]);
+
+  const merged = [...localIncidents];
+  if (remoteIncidents.length) {
+    const existing = new Set(merged.map((item) => item.file));
+    for (const incident of remoteIncidents) {
+      if (!existing.has(incident.file)) {
+        merged.push(incident);
+      }
+    }
+  }
+
+  merged.sort((a, b) => {
+    const aTime = a.opened_at ? new Date(a.opened_at).getTime() : 0;
+    const bTime = b.opened_at ? new Date(b.opened_at).getTime() : 0;
+    return bTime - aTime;
+  });
+
+  return NextResponse.json(merged.slice(0, 10));
+}

--- a/app/api/ops/status/route.ts
+++ b/app/api/ops/status/route.ts
@@ -1,0 +1,112 @@
+import { NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+
+const DEFAULT_STATUS_BASE = process.env.BR_API_GATEWAY_URL ?? process.env.OPS_STATUS_BASE;
+const STATUS_ENDPOINT =
+  process.env.OPS_STATUS_ENDPOINT ?? (DEFAULT_STATUS_BASE ? `${DEFAULT_STATUS_BASE.replace(/\/$/, "")}/v1/status` : undefined);
+const VERSION_ENDPOINT =
+  process.env.OPS_VERSION_ENDPOINT ?? (DEFAULT_STATUS_BASE ? `${DEFAULT_STATUS_BASE.replace(/\/$/, "")}/v1/version` : undefined);
+const UI_HEALTH_ENDPOINT =
+  process.env.OPS_UI_HEALTH_URL ?? process.env.APP_HEALTH_URL ?? "https://app.blackroad.io/healthz/ui";
+
+interface UpstreamStatus {
+  version?: string;
+  tag?: string;
+  version_tag?: string;
+  canary_percent?: number | string;
+  by?: string;
+  deployed_by?: string;
+  ui_ok?: boolean;
+  fivexx?: number | string;
+  p95?: number | string;
+  burn_rate_fast?: number | string;
+  burn_rate_slow?: number | string;
+  environment?: string;
+  updated_at?: string;
+  permissions?: {
+    canOperate?: boolean;
+    readOnly?: boolean;
+    reason?: string;
+  };
+}
+
+function toNumber(value: unknown, fallback = 0): number {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Number.parseFloat(value);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+  return fallback;
+}
+
+async function fetchJson(url: string | undefined): Promise<UpstreamStatus | undefined> {
+  if (!url) return undefined;
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5000);
+    const res = await fetch(url, { cache: "no-store", signal: controller.signal });
+    clearTimeout(timeout);
+    if (!res.ok) {
+      return undefined;
+    }
+    return (await res.json()) as UpstreamStatus;
+  } catch (error) {
+    console.warn(`[ops] unable to fetch ${url}:`, error);
+    return undefined;
+  }
+}
+
+async function probeHealth(url: string | undefined): Promise<boolean> {
+  if (!url) return false;
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5000);
+    const res = await fetch(url, { cache: "no-store", signal: controller.signal });
+    clearTimeout(timeout);
+    return res.ok;
+  } catch (error) {
+    console.warn(`[ops] health probe failed for ${url}:`, error);
+    return false;
+  }
+}
+
+export async function GET() {
+  const [statusDoc, versionDoc] = await Promise.all([fetchJson(STATUS_ENDPOINT), fetchJson(VERSION_ENDPOINT)]);
+
+  const versionFromStatus = statusDoc?.version ?? statusDoc?.tag ?? statusDoc?.version_tag;
+  const version =
+    versionFromStatus ?? versionDoc?.version ?? process.env.RELEASE_TAG ?? process.env.NEXT_PUBLIC_RELEASE ?? "dev";
+
+  const canaryPercent =
+    statusDoc?.canary_percent ?? versionDoc?.canary_percent ?? process.env.CANARY_PCT ?? process.env.NEXT_PUBLIC_CANARY_PCT;
+
+  const uiOk =
+    typeof statusDoc?.ui_ok === "boolean" ? statusDoc.ui_ok : await probeHealth(statusDoc ? undefined : UI_HEALTH_ENDPOINT);
+
+  const permissionsSource = statusDoc?.permissions;
+  const isReadOnlyEnv = String(process.env.OPS_READ_ONLY ?? "").toLowerCase() === "true";
+  const canOperate = permissionsSource?.canOperate ?? !permissionsSource?.readOnly ?? !isReadOnlyEnv;
+
+  const payload = {
+    version,
+    version_tag: versionDoc?.version ?? statusDoc?.version_tag,
+    canary_percent: toNumber(canaryPercent, Number(process.env.CANARY_PCT ?? 0)),
+    by: statusDoc?.by ?? statusDoc?.deployed_by ?? process.env.LAST_DEPLOYER ?? "unknown",
+    ui_ok: uiOk,
+    fivexx: toNumber(statusDoc?.fivexx, 0),
+    p95: toNumber(statusDoc?.p95, 0),
+    burn_rate_fast: toNumber(statusDoc?.burn_rate_fast, 0),
+    burn_rate_slow: toNumber(statusDoc?.burn_rate_slow, 0),
+    environment: statusDoc?.environment ?? process.env.OPERATIONS_ENVIRONMENT ?? process.env.NODE_ENV ?? "production",
+    updated_at: statusDoc?.updated_at ?? new Date().toISOString(),
+    permissions: {
+      canOperate,
+      reason: permissionsSource?.reason ?? (canOperate ? undefined : "Read only mode enabled")
+    }
+  };
+
+  return NextResponse.json(payload);
+}

--- a/app/ops/page.tsx
+++ b/app/ops/page.tsx
@@ -1,0 +1,287 @@
+'use client';
+
+import useSWR from 'swr';
+import { type ReactNode, useMemo, useState } from 'react';
+
+const fetcher = (url: string) =>
+  fetch(url).then((r) => {
+    if (!r.ok) {
+      throw new Error(`Request failed: ${r.status}`);
+    }
+    return r.json();
+  });
+
+type StatusResponse = {
+  version?: string;
+  version_tag?: string;
+  canary_percent?: number;
+  by?: string;
+  ui_ok?: boolean;
+  fivexx?: number;
+  p95?: number;
+  burn_rate_fast?: number;
+  burn_rate_slow?: number;
+  updated_at?: string;
+  environment?: string;
+  permissions?: {
+    canOperate: boolean;
+    reason?: string;
+  };
+};
+
+type FlagsResponse = {
+  version?: string;
+  features?: Record<string, unknown>;
+};
+
+type Incident = {
+  title: string;
+  file: string;
+  opened_at?: string;
+  status?: string;
+};
+
+type IncidentsResponse = Incident[];
+
+const Box = ({
+  title,
+  children
+}: {
+  title: string;
+  children: ReactNode;
+}) => (
+  <div className="flex h-full flex-col gap-2 rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+    <div className="flex items-center justify-between gap-2">
+      <h2 className="text-lg font-semibold text-slate-900">{title}</h2>
+    </div>
+    <div className="text-sm text-slate-700">{children}</div>
+  </div>
+);
+
+function Stat({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex items-center justify-between gap-2 rounded-lg bg-slate-50 px-3 py-2 text-sm">
+      <span className="font-medium text-slate-600">{label}</span>
+      <span className="font-semibold text-slate-900">{value}</span>
+    </div>
+  );
+}
+
+function BurnGauge({
+  label,
+  value
+}: {
+  label: string;
+  value: number | undefined;
+}) {
+  const pct = Math.max(0, Math.min(100, Math.round((value ?? 0) * 100)));
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-wide text-slate-500">
+        <span>{label}</span>
+        <span>{pct}%</span>
+      </div>
+      <div className="h-2 rounded-full bg-slate-200">
+        <div
+          className="h-full rounded-full bg-amber-500 transition-[width] duration-300"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default function Ops() {
+  const { data: status, error: statusError, isLoading: statusLoading, mutate: refreshStatus } = useSWR<StatusResponse>(
+    '/api/ops/status',
+    fetcher,
+    { refreshInterval: 30000 }
+  );
+  const { data: flags, error: flagsError, isLoading: flagsLoading } = useSWR<FlagsResponse>(
+    '/api/ops/flags',
+    fetcher,
+    { refreshInterval: 60000 }
+  );
+  const { data: incidents, error: incidentsError, isLoading: incidentsLoading, mutate: refreshIncidents } =
+    useSWR<IncidentsResponse>('/api/ops/incidents', fetcher, { refreshInterval: 60000 });
+  const [busyAction, setBusyAction] = useState<string | null>(null);
+
+  const readOnly = status?.permissions ? !status.permissions.canOperate : false;
+  const readOnlyReason = status?.permissions?.reason;
+
+  const deployMeta = useMemo(() => {
+    const versionLabel = status?.version_tag ?? status?.version ?? 'unknown';
+    return {
+      version: versionLabel,
+      canary: typeof status?.canary_percent === 'number' ? `${status.canary_percent}%` : '0%',
+      operator: status?.by ?? 'unknown',
+      environment: status?.environment ?? 'production'
+    };
+  }, [status]);
+
+  async function trigger(path: string) {
+    if (readOnly) return;
+    try {
+      setBusyAction(path);
+      const res = await fetch(`/api/ops/${path}`, { method: 'POST' });
+      if (!res.ok) {
+        const message = await res.text();
+        throw new Error(message || `Action ${path} failed`);
+      }
+      await Promise.all([refreshStatus(), refreshIncidents()]);
+    } catch (err) {
+      console.error(err);
+      alert(err instanceof Error ? err.message : 'Unable to trigger action');
+    } finally {
+      setBusyAction(null);
+    }
+  }
+
+  const features = useMemo(() => {
+    if (!flags?.features) return [] as Array<[string, unknown]>;
+    return Object.entries(flags.features).sort(([a], [b]) => a.localeCompare(b));
+  }, [flags]);
+
+  const incidentsList = useMemo(() => {
+    if (!incidents?.length) return [] as Incident[];
+    return incidents;
+  }, [incidents]);
+
+  return (
+    <main className="min-h-screen bg-slate-100 p-4">
+      <div className="mx-auto grid max-w-6xl gap-4 md:grid-cols-2 xl:grid-cols-3">
+        <div className="md:col-span-1 xl:col-span-1">
+          <Box title="Deploy">
+            <div className="space-y-2">
+              {statusLoading ? (
+                <div className="text-sm text-slate-500">Loading status…</div>
+              ) : statusError ? (
+                <div className="text-sm text-red-600">Unable to load deploy status.</div>
+              ) : (
+                <div className="space-y-2">
+                  <Stat label="Version" value={deployMeta.version} />
+                  <Stat label="Canary" value={deployMeta.canary} />
+                  <Stat label="Last deployer" value={deployMeta.operator} />
+                  <Stat label="Environment" value={deployMeta.environment} />
+                  {status?.updated_at && (
+                    <Stat label="Updated" value={new Date(status.updated_at).toLocaleString()} />
+                  )}
+                </div>
+              )}
+              <div className="mt-3 flex flex-wrap gap-2">
+                {['go-no-go', 'ladder', 'rollback'].map((action) => (
+                  <button
+                    key={action}
+                    disabled={readOnly || busyAction !== null}
+                    onClick={() => trigger(action)}
+                    className={`btn flex-1 whitespace-nowrap px-3 py-2 text-sm font-semibold ${
+                      readOnly ? 'cursor-not-allowed opacity-60' : ''
+                    }`}
+                  >
+                    {busyAction === action ? 'Working…' : action.replace('-', ' ')}
+                  </button>
+                ))}
+              </div>
+              {readOnly && (
+                <p className="text-xs text-amber-600">
+                  Operator controls disabled{readOnlyReason ? `: ${readOnlyReason}` : ''}.
+                </p>
+              )}
+            </div>
+          </Box>
+        </div>
+
+        <div className="md:col-span-1 xl:col-span-1">
+          <Box title="Health">
+            {statusLoading ? (
+              <div className="text-sm text-slate-500">Loading health…</div>
+            ) : statusError ? (
+              <div className="text-sm text-red-600">Unable to load health metrics.</div>
+            ) : (
+              <div className="space-y-2">
+                <Stat label="UI" value={status?.ui_ok ? '✅ up' : '❌ down'} />
+                <Stat label="5xx (5m)" value={status?.fivexx ?? 0} />
+                <Stat label="p95 latency (ms)" value={status?.p95 ?? 0} />
+              </div>
+            )}
+          </Box>
+        </div>
+
+        <div className="md:col-span-1 xl:col-span-1">
+          <Box title="Burn Rate">
+            {statusLoading ? (
+              <div className="text-sm text-slate-500">Loading burn rate…</div>
+            ) : statusError ? (
+              <div className="text-sm text-red-600">Unable to load burn rate.</div>
+            ) : (
+              <div className="space-y-3">
+                <BurnGauge label="Fast" value={status?.burn_rate_fast} />
+                <BurnGauge label="Slow" value={status?.burn_rate_slow} />
+              </div>
+            )}
+          </Box>
+        </div>
+
+        <div className="md:col-span-2 xl:col-span-1">
+          <Box title="Flags">
+            {flagsLoading ? (
+              <div className="text-sm text-slate-500">Loading flags…</div>
+            ) : flagsError ? (
+              <div className="text-sm text-red-600">Unable to load feature flags.</div>
+            ) : features.length ? (
+              <div className="divide-y divide-slate-200 rounded-lg border border-slate-200">
+                {features.map(([key, value]) => (
+                  <div key={key} className="flex items-center justify-between gap-4 px-3 py-2 text-xs">
+                    <span className="font-semibold text-slate-600">{key}</span>
+                    <span className="font-mono text-slate-800">{JSON.stringify(value)}</span>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="text-sm text-slate-500">No feature flags configured.</div>
+            )}
+            {flags?.version && (
+              <p className="pt-2 text-xs text-slate-500">Version: {flags.version}</p>
+            )}
+          </Box>
+        </div>
+
+        <div className="md:col-span-2 xl:col-span-1">
+          <Box title="Incidents (24h)">
+            {incidentsLoading ? (
+              <div className="text-sm text-slate-500">Checking incidents…</div>
+            ) : incidentsError ? (
+              <div className="text-sm text-red-600">Unable to load incidents.</div>
+            ) : incidentsList.length ? (
+              <div className="space-y-2">
+                {incidentsList.map((incident) => (
+                  <div
+                    key={incident.file}
+                    className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-xs shadow-inner"
+                  >
+                    <div className="font-semibold text-slate-800">{incident.title}</div>
+                    <div className="text-slate-500">
+                      {incident.status ? `${incident.status} • ` : ''}
+                      {incident.opened_at ? new Date(incident.opened_at).toLocaleString() : incident.file}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="text-sm text-slate-500">No active incidents in the last 24 hours.</div>
+            )}
+            <div className="pt-2 text-right">
+              <button
+                className="btn px-3 py-2 text-xs font-semibold"
+                onClick={() => refreshIncidents()}
+                disabled={incidentsLoading}
+              >
+                Refresh
+              </button>
+            </div>
+          </Box>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "socket.io": "^4.7.5",
+        "swr": "^2.2.5",
         "stripe": "^12.18.0",
         "systeminformation": "^5.25.11",
         "uuid": "^9.0.1",
@@ -7585,6 +7586,19 @@
         }
       }
     },
+    "node_modules/swr": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.5.tgz",
+      "integrity": "sha512-QtxqyclFeAsxEUeZIYmsaQ0UjimSq1RZ9Un7I68/0ClKK/U3LoyQunwkQfJZr2fc22DfIXLNDc2wFyTEikCUpg==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1",
+        "use-sync-external-store": "1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/superagent": {
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
@@ -7974,6 +7988,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "morgan": "^1.10.0",
     "next": "^14.2.5",
     "socket.io": "^4.7.5",
+    "swr": "^2.2.5",
     "systeminformation": "^5.25.11",
     "uuid": "^9.0.1",
     "better-sqlite3": "^9.4.3",


### PR DESCRIPTION
## Summary
- add a client-side /ops dashboard surface with live deploy, health, burn rate, flags, and incident panels
- expose server routes for status, flags, incidents, and action triggers that proxy upstream services and Slack notifications
- include the swr dependency to power polling data fetches on the dashboard

## Testing
- npm run lint *(fails: requires @eslint/js which is not currently installed)*

------
https://chatgpt.com/codex/tasks/task_e_68e830d7b0448329ad4d8f020b51f2bf