### PR TITLE
Add standard SOP template outline

### DIFF
--- a/docs/SOP_TEMPLATE.md
+++ b/docs/SOP_TEMPLATE.md
@@ -1,0 +1,51 @@
+# Standard Operating Procedure (SOP) Template
+
+> Use this template to document repeatable processes with enough detail that another team member can execute them without additional context. Replace the bracketed guidance in each section with process-specific information.
+
+## 1. Purpose & Scope
+- **Purpose:** [Summarize why this SOP exists and the problem it solves.]
+- **Scope:** [Define the start and end boundaries of the process, including systems, teams, or geographies covered.]
+- **Out of Scope:** [List responsibilities or scenarios explicitly excluded from this SOP.]
+
+## 2. Roles & Responsibilities
+| Role | Responsibilities | Backup / Escalation |
+| --- | --- | --- |
+| [Role name] | [Key duties performed in this process.] | [Backup owner or escalation path.] |
+| [Add rows as needed] | | |
+
+## 3. Procedure Steps
+1. **[Step name]** — [Detailed description of the action, including tooling and required approvals.]
+2. **[Step name]** — [Include decision points, screenshots, or checklists to remove ambiguity.]
+3. **[Step name]** — [Continue numbering until the process completes.]
+
+> Tip: Use sub-bullets to capture conditional branches or troubleshooting notes.
+
+## 4. Inputs & Outputs
+- **Required Inputs:**
+  - [Data, forms, systems access, or triggers needed before the process starts.]
+- **Outputs / Deliverables:**
+  - [Artifacts, notifications, updated systems, or status changes produced by the process.]
+
+## 5. Risks & Controls
+| Risk | Impact | Preventive Controls | Detective Controls |
+| --- | --- | --- | --- |
+| [Describe potential failure point.] | [Explain the consequence.] | [Document the control that reduces likelihood.] | [Document the control that flags issues quickly.] |
+
+## 6. Metrics & SLAs
+- **Key Metrics:**
+  - [Primary KPIs (e.g., turnaround time, error rate).]
+- **Service Level Agreements:**
+  - [Targets or thresholds (e.g., respond within 4 business hours).]
+- **Reporting Cadence:**
+  - [How often metrics are reviewed and by whom.]
+
+## 7. References
+- [Link to related policies, playbooks, templates, diagrams, or regulatory requirements.]
+- [Include ticket queues, dashboards, or source data locations.]
+
+---
+
+### Change Log
+| Date | Version | Author | Description |
+| --- | --- | --- | --- |
+| [YYYY-MM-DD] | [v1.0] | [Name] | [Summary of updates.] |


### PR DESCRIPTION
## Summary
- add a reusable SOP template outlining purpose, roles, procedure, inputs, risks, metrics, and references
- include change log section so teams can track revisions

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e842793c788329b5de9c01fb9ee8b3