### PR TITLE
Add hardened Node CI automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+contact_links: []

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,13 @@
 version: 2
 updates:
   - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - npm
+  - package-ecosystem: npm
     directory: "/apps/api"
     schedule: { interval: weekly }
   - package-ecosystem: github-actions

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -19,3 +19,9 @@
 - name: status/help-wanted
   color: "5319e7"
   description: Needs attention
+- name: automerge
+  color: "0e8a16"
+  description: Auto-merge when checks succeed
+- name: no-rerun
+  color: "b60205"
+  description: Opt out of automatic reruns

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,58 @@
+name: "🤖 Auto-merge"
+
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - reopened
+      - ready_for_review
+      - converted_to_draft
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  enable:
+    if: >-
+      ${{
+        (
+          github.event.action == 'labeled'
+          && github.event.label.name == 'automerge'
+          && !github.event.pull_request.draft
+        )
+        ||
+        (
+          (github.event.action == 'synchronize' || github.event.action == 'ready_for_review' || github.event.action == 'reopened')
+          && !github.event.pull_request.draft
+          && contains(github.event.pull_request.labels.*.name, 'automerge')
+        )
+      }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pull-request-number: ${{ github.event.pull_request.number }}
+          merge-method: squash
+
+  disable:
+    if: >-
+      ${{
+        (
+          github.event.action == 'unlabeled'
+          && github.event.label
+          && github.event.label.name == 'automerge'
+        )
+        || github.event.action == 'converted_to_draft'
+      }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Disable auto-merge
+        uses: peter-evans/disable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pull-request-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/auto-rerun.yml
+++ b/.github/workflows/auto-rerun.yml
@@ -1,0 +1,67 @@
+name: "🔁 Auto rerun"
+
+on:
+  workflow_run:
+    workflows:
+      - "🧪 Node CI"
+    types:
+      - completed
+
+permissions:
+  actions: write
+  pull-requests: read
+
+jobs:
+  rerun:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate rerun eligibility
+        id: evaluate
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const run = context.payload.workflow_run;
+            const core = require('@actions/core');
+            if (run.event !== 'pull_request') {
+              core.info('Workflow is not associated with a pull request. Skipping rerun.');
+              core.setOutput('should_rerun', 'false');
+              return;
+            }
+            if ((run.run_attempt || 1) > 1) {
+              core.info(`Workflow already rerun (attempt ${run.run_attempt}). Skipping.`);
+              core.setOutput('should_rerun', 'false');
+              return;
+            }
+            const pr = run.pull_requests && run.pull_requests[0];
+            if (!pr) {
+              core.info('Unable to determine pull request context. Skipping.');
+              core.setOutput('should_rerun', 'false');
+              return;
+            }
+            const labelsResponse = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+            });
+            const hasOptOut = labelsResponse.data.some(label => label.name.toLowerCase() === 'no-rerun');
+            if (hasOptOut) {
+              core.info('no-rerun label present. Respecting opt-out.');
+              core.setOutput('should_rerun', 'false');
+              return;
+            }
+            core.info(`Queueing rerun for workflow ${run.id} on PR #${pr.number}.`);
+            core.setOutput('should_rerun', 'true');
+
+      - name: Trigger rerun
+        if: ${{ steps.evaluate.outputs.should_rerun == 'true' }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.actions.reRunWorkflowFailedJobs({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+            });

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,4 +1,4 @@
-name: lint-pr
+name: "🧪 Commitlint"
 
 on:
   pull_request:
@@ -6,6 +6,7 @@ on:
 
 jobs:
   commitlint:
+    name: "🧪 commitlint"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -1,0 +1,57 @@
+name: "🧪 Node CI"
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - '.github/workflows/node-ci.yml'
+      - '.github/workflows/node-tests.yml'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'jest.config.js'
+      - 'srv/**'
+      - 'lib/**'
+      - 'tests/**'
+      - 'app/**'
+      - 'frontend/**'
+      - 'scripts/**'
+  push:
+    branches:
+      - main
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - 'jest.config.js'
+      - 'srv/**'
+      - 'lib/**'
+      - 'tests/**'
+      - 'app/**'
+      - 'frontend/**'
+      - 'scripts/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  checks: write
+  pull-requests: read
+
+concurrency:
+  group: node-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
+
+jobs:
+  tests:
+    name: "🧪 Node tests"
+    uses: ./.github/workflows/node-tests.yml
+    secrets: inherit
+    with:
+      node-version: '20'
+      install-command: npm ci --no-audit --no-fund
+      test-command: npm test -- --ci --runInBand
+      junit-path: reports/junit.xml
+      artifact-name: node-ci-junit
+      package-manager: npm
+      cache-dependency-path: |
+        package-lock.json
+        sites/blackroad/package-lock.json
+      working-directory: .

--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -1,0 +1,111 @@
+name: Reusable Node Tests
+
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        description: Node.js version to use
+        required: false
+        default: '20'
+        type: string
+      install-command:
+        description: Command used to install dependencies
+        required: false
+        default: npm ci
+        type: string
+      test-command:
+        description: Command used to execute tests
+        required: false
+        default: npm test -- --ci
+        type: string
+      working-directory:
+        description: Directory to run commands from
+        required: false
+        default: .
+        type: string
+      junit-path:
+        description: Relative path for the junit XML output
+        required: false
+        default: reports/junit.xml
+        type: string
+      artifact-name:
+        description: Name of the uploaded artifact
+        required: false
+        default: node-test-results
+        type: string
+      package-manager:
+        description: Package manager used for caching
+        required: false
+        default: npm
+        type: string
+      cache-dependency-path:
+        description: Path(s) to dependency lockfiles for caching
+        required: false
+        default: package-lock.json
+        type: string
+      timeout-minutes:
+        description: Job timeout in minutes
+        required: false
+        default: 30
+        type: number
+      upload-artifact:
+        description: Whether to upload junit artifacts
+        required: false
+        default: true
+        type: boolean
+  workflow_dispatch:
+    inputs:
+      node-version:
+        description: Node.js version to use
+        required: false
+        default: '20'
+
+permissions:
+  contents: read
+  checks: write
+  pull-requests: read
+
+jobs:
+  tests:
+    name: Run Node tests
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    env:
+      CI: true
+      JEST_JUNIT_OUTPUT: ${{ inputs.junit-path }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: ${{ inputs.package-manager }}
+          cache-dependency-path: ${{ inputs.cache-dependency-path }}
+
+      - name: Install dependencies
+        if: ${{ inputs.install-command != '' }}
+        run: ${{ inputs.install-command }}
+
+      - name: Run tests
+        run: ${{ inputs.test-command }}
+
+      - name: Publish junit report
+        if: always()
+        uses: mikepenz/action-junit-report@v4
+        with:
+          report_paths: ${{ inputs.working-directory != '.' && format('{0}/{1}', inputs.working-directory, inputs.junit-path) || inputs.junit-path }}
+          require_tests: false
+
+      - name: Upload test artifacts
+        if: ${{ always() && inputs.upload-artifact }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: ${{ inputs.working-directory != '.' && format('{0}/{1}', inputs.working-directory, inputs.junit-path) || inputs.junit-path }}
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,4 +1,4 @@
-name: Semantic PR Title
+name: "🧠 Semantic PR Title"
 on:
   pull_request:
     types: [opened, edited, synchronize]

--- a/README_PR_AUTOMATION.md
+++ b/README_PR_AUTOMATION.md
@@ -14,6 +14,12 @@ What it does
 4.Opens a PR, applies labels, requests review, optionally enables auto-merge.
 5.Prints the PR link.
 
+### Labels that drive automation
+- `automerge` – enabling this label triggers the auto-merge workflow once required
+  checks succeed.
+- `no-rerun` – add to a pull request to opt out of automatic CI reruns after
+  the hardened Node pipeline fails.
+
 For alias- and consent-focused wrapper configuration snippets that pair with the automation prompts, see
 [`docs/WRAPPER_ALIAS_CONFIG.md`](docs/WRAPPER_ALIAS_CONFIG.md).
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,4 +4,14 @@ module.exports = {
   verbose: true,
   roots: ['<rootDir>/tests'],
   testMatch: ['**/*.test.js'],
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'reports',
+        outputName: 'junit.xml',
+      },
+    ],
+  ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,8 @@
         "nodemon": "^3.0.2",
         "prettier": "^3.3.3",
         "supertest": "^6.3.4",
-        "typescript": "^5.6.3"
+        "typescript": "^5.6.3",
+        "jest-junit": "^16.0.0"
       },
       "engines": {
         "node": ">=20"
@@ -8333,6 +8334,39 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/jest-junit": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-16.0.0.tgz",
+      "integrity": "sha512-A94mmw6NfJab4Fg/BlvVOUXzXgF0XIH6EmTgJ5NDPp4xoKq0Kr7sErb+4Xs9nZvu58pJojz5RFGpqnZYJTrRfQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "strip-ansi": "^6.0.1",
+        "uuid": "^8.3.2",
+        "xml": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/jest-junit/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "@types/node": "^20.14.9",
     "@types/node-fetch": "^2.6.11",
     "@types/react": "^18.2.64",
-    "typescript": "^5.6.3"
+    "typescript": "^5.6.3",
+    "jest-junit": "^16.0.0"
   },
   "lint-staged": {
     "*.{js,jsx,mjs,cjs,ts,tsx}": [


### PR DESCRIPTION
## Summary
- add a reusable Node test workflow and a hardened Node CI entry point with caching, junit uploads, and concurrency controls
- introduce an auto-rerun workflow with a `no-rerun` escape hatch and document the automation labels
- wire up auto-merge support, supporting labels, dependabot coverage, and jest-junit reporting

## Testing
- node -e "require('./jest.config.js'); console.log('jest config ok')"

------
https://chatgpt.com/codex/tasks/task_e_68e84186a31c83299cee0e5432afa07c