### PR TITLE
Add budget and runway model template

### DIFF
--- a/finance/model/budget_runway_model.md
+++ b/finance/model/budget_runway_model.md
@@ -1,0 +1,150 @@
+# Budget & Runway Model
+
+## 1️⃣ Header & Metadata
+
+- **Model ID:** FIN-BUD-####
+- **Version:** _TBD_
+- **Owner:** Finance Lead
+- **Approvers:** CEO / Treasury Committee
+- **Effective Period:** FY20XX
+- **Last Updated:** _TBD_
+- **Status:** Draft / Active / Archived
+- **Links:** Live spreadsheet · AOP · OKRs · Forecasts
+
+---
+
+## 2️⃣ Summary Sheet 📊
+
+**Purpose:** Provide a one-glance snapshot of company health.
+
+| Metric | Value | Notes |
+| --- | --- | --- |
+| Monthly Burn | $ |  |
+| Cash on Hand | $ |  |
+| Runway | X months | Calculated automatically |
+| ARR | $ |  |
+| Target Runway | 18–24 months |  |
+| Treasury Split (Fiat/Crypto) | 70% / 30% |  |
+
+**Formula:**
+
+```
+Runway = Cash on Hand / Monthly Net Burn
+```
+
+---
+
+## 3️⃣ Revenue Forecast 💰
+
+| Stream | Description | Pricing | Growth Rate | FY Target | Owner |
+| --- | --- | --- | --- | --- | --- |
+| SaaS Fees | Product subscriptions | $X/mo | 10%/qtr |  | PM |
+| Protocol Fees | On-chain transactions | 0.5% | 20%/qtr |  | Treasury |
+| Grants | External funding |  |  |  | Finance |
+
+**Assumptions:** List adoption rates, churn expectations, pricing model changes, and other factors underpinning the forecast.
+
+---
+
+## 4️⃣ Expense Forecast 🧾
+
+### Headcount Costs
+
+| Role | Count | Monthly Cost | Annual Cost |
+| --- | --- | --- | --- |
+| Engineering | 10 | $ | $ |
+| Marketing | 3 | $ | $ |
+| Ops/Admin | 2 | $ | $ |
+| Contractors |  | $ | $ |
+
+### Operational Costs
+
+| Category | Vendor/Tool | Monthly | Annual | Notes |
+| --- | --- | --- | --- | --- |
+| Cloud | AWS | $ | $ |  |
+| Legal | Outside Counsel | $ | $ |  |
+| Security | Audits | $ | $ |  |
+| Community | Events, Grants | $ | $ |  |
+
+### Token Grants (if applicable)
+
+| Program | Allocation | Vesting | Monthly Unlock | Notes |
+| --- | --- | --- | --- | --- |
+| Contributor Rewards | 10M UTIL | 4 years |  |  |
+| Liquidity Incentives | 20M UTIL | 18 months |  |  |
+
+---
+
+## 5️⃣ Scenario Planning 📈
+
+| Scenario | Assumptions | Runway | Outcome |
+| --- | --- | --- | --- |
+| Base | Expected growth, stable costs | 20 mo | Sustainable |
+| Conservative | -20% revenue, +10% cost | 15 mo | Cut optional spend |
+| Aggressive | +30% growth investment | 12 mo | Need new funding |
+
+**Visualization:** Plot Runway vs Time with months on the X-axis and cash balance on the Y-axis.
+
+---
+
+## 6️⃣ Cash Flow Statement 💳
+
+| Month | Inflows | Outflows | Net Burn | Cumulative Cash |
+| --- | --- | --- | --- | --- |
+| Jan | $ | $ | $ | $ |
+| Feb | $ | $ | $ | $ |
+| Mar | $ | $ | $ | $ |
+
+**Key Formula:**
+
+```
+Net Burn = Total Outflows - Total Inflows
+```
+
+---
+
+## 7️⃣ Runway Dashboard 🧮
+
+Embed or link to live charts:
+
+- Burn Rate (line chart)
+- Cash Remaining (bar chart)
+- Runway Months (auto-calculated)
+
+Integrate with the finance sheet or a Dune dashboard for on-chain tracking, where applicable.
+
+---
+
+## 8️⃣ Governance & Controls 🏛️
+
+- All budget changes >10% require Treasury Committee approval.
+- Reforecast quarterly alongside the OKR cycle.
+- Reconcile fiat and crypto treasury balances monthly.
+- Flag major variances (>15%) in the Executive Review.
+
+---
+
+## 9️⃣ Review & Audit 🔍
+
+| Review Type | Frequency | Owner |
+| --- | --- | --- |
+| Finance Review | Monthly | CFO |
+| Audit | Annual | External CPA |
+| Treasury Health Check | Quarterly | Treasury Committee |
+
+**Checklist:**
+
+- Validate formulas.
+- Update actuals.
+- Sync to AOP.
+- Confirm exchange rates (for crypto).
+
+---
+
+## Metadata
+
+- **Owner:** Finance Lead
+- **Approvers:** CFO / Treasury Committee
+- **Review Cadence:** Quarterly
+- **Status:** Template Ready 💸
+- **Next Step:** Create live sheet integration and dashboards for burn tracking.


### PR DESCRIPTION
## Summary
- add a finance budget and runway model template covering metadata, forecasts, and governance checkpoints

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e85470a8e88329b3693ad094d5dde7