### PR TITLE
Add hardened language CI workflow templates

### DIFF
--- a/.github/workflows/language-dotnet8-test.yml
+++ b/.github/workflows/language-dotnet8-test.yml
@@ -1,0 +1,68 @@
+name: .NET 8 • Test
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: .NET 8 • Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+          cache: true
+
+      - name: Restore dependencies
+        id: restore
+        run: |
+          if ! find . \( -name '*.sln' -o -name '*.csproj' \) -print -quit | grep -q .; then
+            echo "No .NET project detected. Skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          dotnet restore
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Run tests
+        if: ${{ steps.restore.outputs.skip != 'true' }}
+        run: |
+          mkdir -p reports/trx
+          dotnet test \
+            --no-build \
+            --logger "trx;LogFileName=test-results.trx" \
+            --results-directory reports/trx
+
+      - name: Convert TRX to JUnit
+        if: always()
+        run: |
+          if find reports/trx -maxdepth 1 -name '*.trx' -print -quit >/dev/null 2>&1; then
+            dotnet tool install --global trx2junit --version 1.5.0 || dotnet tool update --global trx2junit --version 1.5.0
+            export PATH="$PATH:$HOME/.dotnet/tools"
+            mkdir -p reports/junit
+            trx2junit reports/trx/*.trx --output reports/junit
+          else
+            echo "No TRX report found to convert."
+          fi
+
+      - name: Upload .NET artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dotnet8-test-reports
+          path: reports
+          if-no-files-found: ignore

--- a/.github/workflows/language-go122-test.yml
+++ b/.github/workflows/language-go122-test.yml
@@ -1,0 +1,58 @@
+name: Go 1.22 • Test
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Go 1.22 • Race Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache: true
+
+      - name: Cache Go build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Run go test (race)
+        env:
+          CGO_ENABLED: 1
+        run: |
+          if ! find . -name '*.go' -not -path './vendor/*' -print -quit | grep -q .; then
+            echo "No Go files found. Skipping."
+            exit 0
+          fi
+          mkdir -p reports/logs
+          set -o pipefail
+          go test -race -count=1 -json ./... | tee reports/logs/go-test.json
+
+      - name: Upload test log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: go122-test-log
+          path: reports
+          if-no-files-found: ignore

--- a/.github/workflows/language-java17-gradle.yml
+++ b/.github/workflows/language-java17-gradle.yml
@@ -1,0 +1,57 @@
+name: Java 17 • Gradle
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Java 17 • Gradle
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          cache-read-only: false
+
+      - name: Run Gradle tests
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+        run: |
+          if [ ! -f build.gradle ] && [ ! -f build.gradle.kts ]; then
+            echo "No Gradle build file found. Skipping."
+            exit 0
+          fi
+          if [ -x ./gradlew ]; then
+            ./gradlew test --console=plain --stacktrace
+          else
+            gradle test --console=plain --stacktrace
+          fi
+
+      - name: Upload JUnit XML on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: java17-gradle-reports
+          path: |
+            **/build/test-results/test/*.xml
+            **/build/reports/tests/test
+          if-no-files-found: ignore

--- a/.github/workflows/language-java17-maven.yml
+++ b/.github/workflows/language-java17-maven.yml
@@ -1,0 +1,47 @@
+name: Java 17 • Maven
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Java 17 • Maven
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+
+      - name: Build & test
+        run: |
+          if [ ! -f pom.xml ]; then
+            echo "No Maven project found. Skipping."
+            exit 0
+          fi
+          mvn -B -U test
+
+      - name: Publish JUnit results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: java17-maven-reports
+          path: |
+            **/target/surefire-reports/*.xml
+            **/target/failsafe-reports/*.xml
+          if-no-files-found: ignore

--- a/.github/workflows/language-node20-jest.yml
+++ b/.github/workflows/language-node20-jest.yml
@@ -1,0 +1,72 @@
+name: Node 20 • Jest
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Node 20 • Jest
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        id: deps
+        run: |
+          if [ ! -f package.json ]; then
+            echo "No package.json detected. Skipping installation and tests."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ -f pnpm-lock.yaml ]; then
+            corepack enable
+            corepack prepare pnpm@latest --activate
+            pnpm install --frozen-lockfile
+          elif [ -f yarn.lock ]; then
+            corepack enable
+            yarn install --frozen-lockfile
+          elif [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
+            npm ci
+          else
+            npm install
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Run Jest
+        if: ${{ steps.deps.outputs.skip != 'true' }}
+        env:
+          JEST_JUNIT_OUTPUT_DIR: reports/junit
+          JEST_JUNIT_OUTPUT_NAME: jest.xml
+        run: |
+          mkdir -p reports/junit
+          if npm run | grep -q " test"; then
+            npm test -- --ci --reporters=default --reporters=jest-junit
+          else
+            npx --yes jest --ci --reporters=default --reporters=jest-junit
+          fi
+
+      - name: Upload reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: node20-jest-reports
+          path: reports
+          if-no-files-found: ignore

--- a/.github/workflows/language-php83-phpunit.yml
+++ b/.github/workflows/language-php83-phpunit.yml
@@ -1,0 +1,72 @@
+name: PHP 8.3 • PHPUnit
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: PHP 8.3 • PHPUnit
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+          tools: composer
+
+      - name: Cache Composer
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.composer/cache/files
+            ~/.cache/composer
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        id: install-deps
+        run: |
+          if [ ! -f composer.json ]; then
+            echo "No composer.json found. Skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          composer install --no-interaction --no-progress --prefer-dist
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Run PHPUnit
+        if: ${{ steps.install-deps.outputs.skip != 'true' }}
+        run: |
+          mkdir -p reports/junit
+          if [ -f vendor/bin/phpunit ]; then
+            vendor/bin/phpunit --log-junit reports/junit/phpunit.xml
+          else
+            if ! command -v phpunit >/dev/null 2>&1; then
+              composer global require phpunit/phpunit --quiet
+              export PATH="$HOME/.composer/vendor/bin:$PATH"
+            fi
+            phpunit --log-junit reports/junit/phpunit.xml
+          fi
+
+      - name: Upload PHPUnit artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: php83-phpunit-reports
+          path: reports
+          if-no-files-found: ignore

--- a/.github/workflows/language-python312-pytest.yml
+++ b/.github/workflows/language-python312-pytest.yml
@@ -1,0 +1,70 @@
+name: Python 3.12 • Pytest
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Python 3.12 • Pytest
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements*.txt
+            pyproject.toml
+            setup.cfg
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then
+            pip install -r requirements.txt
+          elif ls requirements-*.txt >/dev/null 2>&1; then
+            for file in requirements-*.txt; do
+              pip install -r "$file"
+            done
+          elif [ -f pyproject.toml ]; then
+            pip install .
+          else
+            echo "No Python dependencies detected."
+          fi
+          pip install pytest pytest-cov
+
+      - name: Run pytest
+        run: |
+          if [ ! -f pytest.ini ] && [ ! -f pyproject.toml ] && \
+             ! find . -maxdepth 1 -type d \( -name tests -o -name test \) -print -quit | grep -q .; then
+            echo "No pytest configuration or tests found. Skipping."
+            exit 0
+          fi
+          mkdir -p reports/junit
+          pytest \
+            --maxfail=1 \
+            --disable-warnings \
+            --junitxml=reports/junit/pytest.xml \
+            -o junit_family=xunit2
+
+      - name: Upload reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: python312-pytest-reports
+          path: reports
+          if-no-files-found: ignore

--- a/.github/workflows/language-ruby33-rspec.yml
+++ b/.github/workflows/language-ruby33-rspec.yml
@@ -1,0 +1,71 @@
+name: Ruby 3.3 • RSpec
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Ruby 3.3 • RSpec
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Run RSpec
+        shell: bash
+        run: |
+          HAS_BUNDLE=0
+          if find . -maxdepth 1 \( -name 'Gemfile' -o -name '*.gemspec' \) -print -quit | grep -q .; then
+            HAS_BUNDLE=1
+          fi
+
+          if [ "$HAS_BUNDLE" -eq 0 ] && ! command -v rspec >/dev/null 2>&1; then
+            echo "No Ruby project detected. Skipping."
+            exit 0
+          fi
+
+          mkdir -p reports/junit
+
+          if [ "$HAS_BUNDLE" -eq 1 ]; then
+            RSPEC_CMD="bundle exec rspec"
+            RUBY_CMD="bundle exec ruby"
+          else
+            RSPEC_CMD="rspec"
+            RUBY_CMD="ruby"
+          fi
+
+          if ! $RUBY_CMD -e "begin; require 'rspec'; rescue LoadError; exit 1; end" >/dev/null 2>&1; then
+            echo "RSpec gem not available. Skipping."
+            exit 0
+          fi
+
+          if $RUBY_CMD -e "begin; require 'rspec_junit_formatter'; rescue LoadError; exit 1; end" >/dev/null 2>&1; then
+            $RSPEC_CMD --format progress --format RspecJunitFormatter --out reports/junit/rspec.xml
+          else
+            echo "rspec_junit_formatter not found; running without junit formatter."
+            $RSPEC_CMD --format documentation
+          fi
+
+      - name: Upload RSpec artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruby33-rspec-reports
+          path: reports
+          if-no-files-found: ignore

--- a/.github/workflows/language-rust-stable.yml
+++ b/.github/workflows/language-rust-stable.yml
@@ -1,0 +1,48 @@
+name: Rust Stable • Cargo Test
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Rust Stable • Cargo Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: true
+
+      - name: Run cargo test
+        run: |
+          if [ ! -f Cargo.toml ]; then
+            echo "No Cargo.toml found. Skipping."
+            exit 0
+          fi
+          mkdir -p reports/logs
+          set -o pipefail
+          cargo test --all-features --all-targets -- --nocapture | tee reports/logs/cargo-test.log
+
+      - name: Upload cargo logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rust-stable-test-log
+          path: reports
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- add a Node 20 + Jest workflow with cache-aware installs, junit output, and failure artifacts
- add Python, Go, and Rust workflows that cache dependencies, gate on project discovery, and publish logs on failure
- add Java (Maven/Gradle), PHP, Ruby, and .NET workflows with junit/TRX outputs and concurrency guards

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e854364bf08329b45b9407419919f1