### PR TITLE
Add mentorship learning pulse template

### DIFF
--- a/docs/enablement-template-library.md
+++ b/docs/enablement-template-library.md
@@ -1,0 +1,60 @@
+# Enablement Template Library
+
+## Template #7 — 🧠 Learning Loop & Mentorship Pulse
+
+- **Use:** personal development, pair-learning, post-project reflections.
+- **Goal:** capture progress, surface blockers early, and normalize asking for help.
+
+### 🧾 Header
+- **HASH ID:** `(MENTOR-2025-W40)`
+- **Mentee:** `@__`  
+  **Mentor/Coach:** `@__`
+- **Period:** `–`
+- **Focus Area:** technical | leadership | ops | well-being
+- **Pulse:** `🟢🟢⚪️⚪️⚪️ → 🟢🟢🟢🟢🟢✅`
+
+### 🌱 Stage 1 — Check-In
+- Energy level this week 🔋 (1-5)
+- What felt easy?
+- What felt hard or confusing?
+- What help did you ask for (or wish you had)?
+- Any boundaries slipping (too many hours, too few breaks)?
+
+> 🟡 **If stuck:** write “I don’t know yet — need a hand with ___” and tag your mentor.
+
+### 🧭 Stage 2 — Learning Highlights
+
+| Skill/Topic | Action Taken | Result | Confidence (⚪-🟢) |
+| --- | --- | --- | --- |
+| Example: Kubernetes secrets mgmt | Read docs + deployed demo | Works locally | 🟡 |
+|  |  |  |  |
+
+### 💬 Stage 3 — Feedback Exchange
+- **Mentee → Mentor:** What support or style helps most?
+- **Mentor → Mentee:** What growth moment stood out?
+- **Both:** One thing to try next cycle.
+
+### 🪴 Stage 4 — Next Steps
+1. New goal or experiment for next week.
+2. Resource (link/book/course/person).
+3. Follow-up checkpoint date.
+
+### 📘 Stage 5 — Document and Share
+- Notes synced to ClickUp / Notion Learning Hub.
+- Key takeaways posted in `#learning-feed` (or private DM if sensitive).
+- Mentor updates progress meter `🟢`.
+
+### 🪶 Automation Hooks
+- **ClickUp:** recurring task “Learning Pulse” → auto-create subtasks (Check-In, Highlights, Feedback).
+- **Slack:** `/pulse-learning` → posts lightweight template into 1-on-1 thread.
+- **GitHub:** comment trigger `/retro-learn` on PR → generates mini reflection checklist.
+
+### ✅ Completion Criteria
+- Reflection logged and shared.
+- New goal + mentor sync scheduled.
+- At least one “I don’t know yet” captured and resolved.
+- Pulse `🟢🟢🟢🟢🟢✅`.
+
+---
+
+**Next slot:** Template #8 — 💬 Team Retro & Psych Safety Pulse (the group version that keeps transparency and morale tight).

--- a/docs/enablement.md
+++ b/docs/enablement.md
@@ -9,3 +9,7 @@ This module provides a lightweight LMS for offline use:
 - Event calendar and feedback collection
 
 Use the CLI via `python -m cli.console` with commands beginning with `learn:`.
+
+## Template Library
+
+- [Template #7 — 🧠 Learning Loop & Mentorship Pulse](enablement-template-library.md)


### PR DESCRIPTION
## Summary
- add a documentation entry for Template #7 — Learning Loop & Mentorship Pulse in the enablement library
- link the enablement hub overview to the new template reference

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e853c9c3ac832981c59b430f3b18b9