### PR TITLE
Add PR preview container workflows

### DIFF
--- a/.github/workflows/preview-containers-cleanup.yml
+++ b/.github/workflows/preview-containers-cleanup.yml
@@ -1,0 +1,26 @@
+name: Cleanup Preview Containers
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  cleanup:
+    name: Remove Preview Image Tag
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Delete PR preview tag
+        uses: actions/delete-package-versions@v5
+        with:
+          owner: ${{ github.repository_owner }}
+          package-name: ${{ github.event.repository.name }}
+          package-type: container
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag-pattern: pr-${{ github.event.number }}-*
+          min-versions-to-keep: 0
+          delete-only-untagged-versions: false

--- a/.github/workflows/preview-containers.yml
+++ b/.github/workflows/preview-containers.yml
@@ -1,0 +1,146 @@
+name: PR Preview Containers
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+  packages: write
+  pull-requests: write
+  security-events: write
+
+jobs:
+  metadata:
+    name: Prepare metadata
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    outputs:
+      image: ${{ steps.metadata.outputs.image }}
+      tag-suffix: ${{ steps.metadata.outputs.tag_suffix }}
+      image-ref: ${{ steps.metadata.outputs.image_ref }}
+      short-sha: ${{ steps.metadata.outputs.short_sha }}
+    steps:
+      - name: Compute image metadata
+        id: metadata
+        env:
+          REPO: ${{ github.event.repository.name }}
+          OWNER: ${{ github.repository_owner }}
+          PR_NUMBER: ${{ github.event.number }}
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          SHORT_SHA="${PR_SHA:0:7}"
+          IMAGE="ghcr.io/${OWNER}/${REPO}"
+          TAG_SUFFIX="pr-${PR_NUMBER}-${SHORT_SHA}"
+
+          echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+          echo "tag_suffix=${TAG_SUFFIX}" >> "$GITHUB_OUTPUT"
+          echo "image_ref=${IMAGE}:${TAG_SUFFIX}" >> "$GITHUB_OUTPUT"
+
+  build-image:
+    name: Build & Push Preview Image
+    needs: metadata
+    if: needs.metadata.result == 'success'
+    uses: ./.github/workflows/reusable-docker-preview-build.yml
+    with:
+      image: ${{ needs.metadata.outputs.image }}
+      tag: ${{ needs.metadata.outputs['tag-suffix'] }}
+    secrets: inherit
+
+  sbom:
+    name: Generate SBOM
+    runs-on: ubuntu-latest
+    needs: [metadata, build-image]
+    if: needs.build-image.result == 'success'
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate SBOM with Syft
+        uses: anchore/syft-action@v1
+        with:
+          image: ${{ needs.metadata.outputs['image-ref'] }}@${{ needs.build-image.outputs.digest }}
+          output-file: sbom-pr-${{ github.event.number }}.spdx.json
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-${{ github.event.number }}-sbom
+          path: sbom-pr-${{ github.event.number }}.spdx.json
+          if-no-files-found: error
+
+  grype-scan:
+    name: Vulnerability Scan
+    runs-on: ubuntu-latest
+    needs: [metadata, build-image]
+    if: needs.build-image.result == 'success'
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Scan image with Grype
+        id: grype
+        uses: anchore/grype-action@v1
+        with:
+          image: ${{ needs.metadata.outputs['image-ref'] }}@${{ needs.build-image.outputs.digest }}
+          fail-build: false
+          output: sarif
+
+      - name: Upload SARIF to Code Scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ steps.grype.outputs.sarif }}
+
+  comment:
+    name: Post Preview Instructions
+    runs-on: ubuntu-latest
+    needs:
+      - metadata
+      - build-image
+      - sbom
+      - grype-scan
+    if: needs.build-image.result == 'success'
+    steps:
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- codex-preview-containers -->';
+            const tag = `${{ needs.metadata.outputs['image-ref'] }}`;
+            const digest = `${{ needs.build-image.outputs.digest }}`;
+            const pr = context.issue.number;
+
+            const lines = [
+              marker,
+              '### Preview Container',
+              `• Image: \`${tag}\``,
+              `• Digest: \`${digest}\``,
+              '',
+              '```bash',
+              `docker pull ${tag}`,
+              `docker run --rm ${tag}`,
+              '```',
+              '',
+              `SBOM is available as the \`pr-${pr}-sbom\` workflow artifact.`
+            ];
+            const body = lines.join('\n');
+
+            const { owner, repo } = context.repo;
+            const comments = await github.rest.issues.listComments({ owner, repo, issue_number: pr, per_page: 100 });
+            const existing = comments.data.find(comment => comment.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: pr, body });
+            }
+

--- a/.github/workflows/reusable-docker-preview-build.yml
+++ b/.github/workflows/reusable-docker-preview-build.yml
@@ -1,0 +1,128 @@
+name: Reusable Docker Preview Build
+
+on:
+  workflow_call:
+    inputs:
+      image:
+        description: 'Fully qualified image name (e.g., ghcr.io/org/repo)'
+        required: true
+        type: string
+      tag:
+        description: 'Tag suffix to append to the image (e.g., pr-123)'
+        required: true
+        type: string
+      extra-tags:
+        description: 'Optional newline-separated list of additional tag suffixes'
+        required: false
+        type: string
+      context:
+        description: 'Build context path'
+        required: false
+        type: string
+        default: .
+      file:
+        description: 'Dockerfile path relative to the repository root'
+        required: false
+        type: string
+        default: ./Dockerfile
+      build-args:
+        description: 'Optional multiline string of build args (KEY=VALUE)'
+        required: false
+        type: string
+      labels:
+        description: 'Optional multiline string of image labels'
+        required: false
+        type: string
+
+    secrets:
+      registry-username:
+        description: 'Optional registry username. Defaults to github.actor when omitted.'
+        required: false
+      registry-password:
+        description: 'Optional registry password/token. Defaults to secrets.GITHUB_TOKEN when omitted.'
+        required: false
+
+    outputs:
+      image-ref:
+        description: 'Primary image reference that was published'
+        value: ${{ jobs.build.outputs.image-ref }}
+      digest:
+        description: 'Digest produced by the build'
+        value: ${{ jobs.build.outputs.digest }}
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    name: Build container image
+    runs-on: ubuntu-latest
+    outputs:
+      image-ref: ${{ steps.meta.outputs.primary-tag }}
+      digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.registry-username || github.actor }}
+          password: ${{ secrets.registry-password || secrets.GITHUB_TOKEN }}
+
+      - name: Prepare image metadata
+        id: meta
+        env:
+          IMAGE: ${{ inputs.image }}
+          TAG: ${{ inputs.tag }}
+          EXTRA: ${{ inputs['extra-tags'] }}
+        run: |
+          PRIMARY_TAG="${IMAGE}:${TAG}"
+          echo "primary-tag=${PRIMARY_TAG}" >> "$GITHUB_OUTPUT"
+
+          if [ -n "${EXTRA}" ]; then
+            mapfile -t EXTRA_LINES <<'EOF_INPUT'
+${EXTRA}
+EOF_INPUT
+            TAG_LIST=()
+            for suffix in "${EXTRA_LINES[@]}"; do
+              if [ -n "$suffix" ]; then
+                TAG_LIST+=("${IMAGE}:${suffix}")
+              fi
+            done
+            if [ "${#TAG_LIST[@]}" -gt 0 ]; then
+              printf '%s\n' "${TAG_LIST[@]}" > tags.txt
+              {
+                echo "additional-tags<<EOF"
+                cat tags.txt
+                echo "EOF"
+              } >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
+          echo "::group::Image tags"
+          echo "${PRIMARY_TAG}"
+          if [ -f tags.txt ]; then
+            cat tags.txt
+          fi
+          echo "::endgroup::"
+
+      - name: Build and push image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.file }}
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.primary-tag }}
+            ${{ steps.meta.outputs.additional-tags || '' }}
+          provenance: false
+          sbom: false
+          labels: ${{ inputs.labels }}
+          build-args: ${{ inputs['build-args'] }}


### PR DESCRIPTION
## Summary
- add a PR workflow that builds and pushes a GHCR preview image, generates an SBOM, runs a Grype scan, and comments with pull instructions
- add a cleanup workflow that removes the PR preview tag from GHCR after the pull request closes
- add a reusable Docker build workflow to standardize preview image builds

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e855289b908329b0a56ba69efd1d21