### PR TITLE
Add live scorecard API and dashboard

### DIFF
--- a/app/api/scorecard/route.ts
+++ b/app/api/scorecard/route.ts
@@ -1,0 +1,365 @@
+import { NextResponse } from 'next/server';
+import {
+  CloudWatchClient,
+  GetMetricStatisticsCommand,
+  type Dimension
+} from '@aws-sdk/client-cloudwatch';
+
+export const runtime = 'nodejs';
+export const revalidate = 0;
+
+const region =
+  process.env.SCORECARD_AWS_REGION || process.env.AWS_REGION || 'us-west-2';
+
+const cloudWatch = new CloudWatchClient({ region });
+
+const fifteenMinutes = 15 * 60 * 1000;
+
+async function getMetric({
+  namespace,
+  metricName,
+  dimensions,
+  statistic,
+  extendedStatistic,
+  period = 60
+}: {
+  namespace: string;
+  metricName: string;
+  dimensions: Dimension[];
+  statistic?: 'Average' | 'Sum' | 'Minimum' | 'Maximum';
+  extendedStatistic?: string;
+  period?: number;
+}): Promise<number | null> {
+  const now = new Date();
+  const start = new Date(now.getTime() - fifteenMinutes);
+
+  try {
+    const command = new GetMetricStatisticsCommand({
+      Namespace: namespace,
+      MetricName: metricName,
+      Dimensions: dimensions,
+      StartTime: start,
+      EndTime: now,
+      Period: period,
+      ...(statistic ? { Statistics: [statistic] } : {}),
+      ...(extendedStatistic ? { ExtendedStatistics: [extendedStatistic] } : {})
+    });
+
+    const response = await cloudWatch.send(command);
+    const datapoints = [...(response.Datapoints ?? [])].sort(
+      (a, b) =>
+        (a.Timestamp?.getTime() ?? 0) - (b.Timestamp?.getTime() ?? 0)
+    );
+
+    const latest = datapoints.at(-1);
+    if (!latest) {
+      return null;
+    }
+
+    if (extendedStatistic) {
+      const extended = latest.ExtendedStatistics ?? {};
+      const value =
+        extended[extendedStatistic] ?? extended[extendedStatistic.toLowerCase()];
+      return typeof value === 'number' ? value : null;
+    }
+
+    if (!statistic) {
+      return null;
+    }
+
+    const value = (latest as Record<string, unknown>)[statistic];
+    return typeof value === 'number' ? value : null;
+  } catch (error) {
+    console.error('scorecard: metric fetch failed', {
+      namespace,
+      metricName,
+      error
+    });
+    return null;
+  }
+}
+
+function safePercent(value: number | null, fractionDigits = 2): number | null {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return null;
+  }
+  const rounded = Number(value.toFixed(fractionDigits));
+  return Number.isFinite(rounded) ? rounded : null;
+}
+
+async function getHealthMetrics() {
+  const albDimensionValue =
+    process.env.SCORECARD_ALB_SUFFIX || process.env.ALB_SUFFIX;
+  if (!albDimensionValue) {
+    return {
+      uptime: null,
+      latencyP95: null,
+      errorRate: null,
+      requestCount: null,
+      errorCount: null,
+      wafBlocked: null
+    };
+  }
+
+  const dimensions: Dimension[] = [
+    { Name: 'LoadBalancer', Value: albDimensionValue }
+  ];
+
+  const wafAcl = process.env.SCORECARD_WAF_ACL || process.env.WAF_WEB_ACL;
+
+  const wafPromise = wafAcl
+    ? getMetric({
+        namespace: 'AWS/WAFV2',
+        metricName: 'BlockedRequests',
+        dimensions: [{ Name: 'WebACL', Value: wafAcl }],
+        statistic: 'Sum'
+      })
+    : Promise.resolve(null);
+
+  const [requestCount, elb5xx, target5xx, latencyP95, wafBlocked] =
+    await Promise.all([
+      getMetric({
+        namespace: 'AWS/ApplicationELB',
+        metricName: 'RequestCount',
+        dimensions,
+        statistic: 'Sum'
+      }),
+      getMetric({
+        namespace: 'AWS/ApplicationELB',
+        metricName: 'HTTPCode_ELB_5XX_Count',
+        dimensions,
+        statistic: 'Sum'
+      }),
+      getMetric({
+        namespace: 'AWS/ApplicationELB',
+        metricName: 'HTTPCode_Target_5XX_Count',
+        dimensions,
+        statistic: 'Sum'
+      }),
+      getMetric({
+        namespace: 'AWS/ApplicationELB',
+        metricName: 'TargetResponseTime',
+        dimensions,
+        extendedStatistic: 'p95'
+      }),
+      wafPromise
+    ]);
+
+  const hasErrorMetric =
+    typeof elb5xx === 'number' || typeof target5xx === 'number';
+  const errorCount = hasErrorMetric ? (elb5xx ?? 0) + (target5xx ?? 0) : null;
+  const errorRate =
+    typeof errorCount === 'number' && requestCount && requestCount > 0
+      ? (errorCount / requestCount) * 100
+      : null;
+  const uptime =
+    typeof errorRate === 'number' ? Math.max(0, 100 - errorRate) : null;
+
+  return {
+    uptime: safePercent(uptime),
+    latencyP95: latencyP95 ?? null,
+    errorRate: safePercent(errorRate),
+    requestCount: requestCount ?? null,
+    errorCount,
+    wafBlocked: wafBlocked ?? null
+  };
+}
+
+async function githubRequest(path: string) {
+  const token = process.env.SCORECARD_GITHUB_TOKEN || process.env.GITHUB_TOKEN;
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github+json'
+  };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  const res = await fetch(`https://api.github.com${path}`, {
+    headers,
+    next: { revalidate: 0 }
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`GitHub request failed: ${res.status} ${text}`);
+  }
+  return res.json();
+}
+
+async function getVelocityMetrics() {
+  const repo = process.env.SCORECARD_GITHUB_REPO;
+  if (!repo) {
+    return {
+      deploysMonth: null,
+      changeSuccess: null,
+      lastDeployAt: null
+    };
+  }
+
+  const [owner, name] = repo.split('/');
+  if (!owner || !name) {
+    throw new Error('SCORECARD_GITHUB_REPO must be in the form owner/name');
+  }
+
+  const since = new Date();
+  since.setDate(1);
+  since.setHours(0, 0, 0, 0);
+
+  try {
+    const releases = await githubRequest(
+      `/repos/${owner}/${name}/releases?per_page=100`
+    );
+    const deploysThisMonth = Array.isArray(releases)
+      ? releases.filter((release: any) => {
+          const created = release?.created_at
+            ? new Date(release.created_at)
+            : null;
+          return created ? created >= since : false;
+        })
+      : [];
+
+    const workflowFilter = process.env.SCORECARD_DEPLOY_WORKFLOW;
+    const workflows = await githubRequest(
+      `/repos/${owner}/${name}/actions/runs?per_page=100`
+    );
+    const workflowRuns = Array.isArray(workflows?.workflow_runs)
+      ? workflows.workflow_runs
+      : [];
+
+    const relevantRuns = workflowRuns.filter((run: any) => {
+      const created = run?.created_at ? new Date(run.created_at) : null;
+      if (!created || created < since) {
+        return false;
+      }
+      if (workflowFilter) {
+        return run?.name === workflowFilter;
+      }
+      return run?.event === 'deployment' || run?.conclusion === 'success';
+    });
+
+    const total = relevantRuns.length;
+    const successes = relevantRuns.filter(
+      (run: any) => run?.conclusion === 'success'
+    ).length;
+
+    const latestDeploy = deploysThisMonth
+      .map((release: any) => release?.created_at)
+      .filter(Boolean)
+      .sort()
+      .at(-1);
+
+    return {
+      deploysMonth: deploysThisMonth.length,
+      changeSuccess: total > 0 ? safePercent((successes / total) * 100) : null,
+      lastDeployAt: latestDeploy ?? null
+    };
+  } catch (error) {
+    console.error('scorecard: velocity metrics failed', error);
+    return {
+      deploysMonth: null,
+      changeSuccess: null,
+      lastDeployAt: null
+    };
+  }
+}
+
+async function getSecurityMetrics() {
+  const incidentRepo = process.env.SCORECARD_INCIDENT_REPO;
+  const incidentLabel = process.env.SCORECARD_INCIDENT_LABEL || 'incident';
+  let incidents: number | null = null;
+  try {
+    if (incidentRepo) {
+      const query = encodeURIComponent(
+        `repo:${incidentRepo} state:open label:"${incidentLabel}"`
+      );
+      const data = await githubRequest(`/search/issues?q=${query}`);
+      incidents = typeof data?.total_count === 'number' ? data.total_count : null;
+    }
+  } catch (error) {
+    console.error('scorecard: incident lookup failed', error);
+    incidents = null;
+  }
+
+  const academyFeed = process.env.SCORECARD_ACADEMY_FEED;
+  let academyCoverage: number | null = null;
+  if (academyFeed) {
+    try {
+      const res = await fetch(academyFeed, { next: { revalidate: 0 } });
+      if (res.ok) {
+        const data = await res.json();
+        const coverage = data?.coverage ?? data?.academyCoverage;
+        academyCoverage =
+          typeof coverage === 'number' ? safePercent(coverage, 1) : null;
+      }
+    } catch (error) {
+      console.error('scorecard: academy feed failed', error);
+    }
+  }
+
+  const evidenceFeed = process.env.SCORECARD_EVIDENCE_FEED;
+  let openFindings: number | null = null;
+  if (evidenceFeed) {
+    try {
+      const res = await fetch(evidenceFeed, { next: { revalidate: 0 } });
+      if (res.ok) {
+        const data = await res.json();
+        const findings = data?.openFindings ?? data?.open_controls;
+        openFindings =
+          typeof findings === 'number' ? Math.max(0, findings) : null;
+      }
+    } catch (error) {
+      console.error('scorecard: evidence feed failed', error);
+    }
+  }
+
+  return {
+    alerts: null,
+    openFindings,
+    incidents,
+    academyCoverage
+  };
+}
+
+async function getSpend() {
+  const feed = process.env.COST_FEED || process.env.SCORECARD_COST_FEED;
+  if (!feed) {
+    return { monthToDate: null, forecast: null };
+  }
+
+  try {
+    const res = await fetch(feed, { next: { revalidate: 0 } });
+    if (!res.ok) {
+      throw new Error(`cost feed failed: ${res.status}`);
+    }
+    const data = await res.json();
+    const month = data?.month ?? data?.monthToDate ?? data?.actual;
+    const forecast = data?.forecast ?? data?.projected;
+    return {
+      monthToDate: typeof month === 'number' ? month : null,
+      forecast: typeof forecast === 'number' ? forecast : null
+    };
+  } catch (error) {
+    console.error('scorecard: cost feed failed', error);
+    return { monthToDate: null, forecast: null };
+  }
+}
+
+export async function GET() {
+  const [health, velocity, security, spend] = await Promise.all([
+    getHealthMetrics(),
+    getVelocityMetrics(),
+    getSecurityMetrics(),
+    getSpend()
+  ]);
+
+  const alerts =
+    typeof health.wafBlocked === 'number'
+      ? Math.max(0, Math.round(health.wafBlocked))
+      : security.alerts;
+
+  return NextResponse.json({
+    updated: new Date().toISOString(),
+    health,
+    security: { ...security, alerts },
+    velocity,
+    spend
+  });
+}

--- a/app/scorecard/page.tsx
+++ b/app/scorecard/page.tsx
@@ -1,0 +1,321 @@
+'use client';
+
+import useSWR from 'swr';
+import { Activity, ShieldCheck, Timer, Wallet } from 'lucide-react';
+import { useMemo } from 'react';
+import type { ReactNode } from 'react';
+
+type Severity = 'green' | 'yellow' | 'red' | 'neutral';
+
+type ScorecardResponse = {
+  updated: string;
+  health: {
+    uptime: number | null;
+    latencyP95: number | null;
+    errorRate: number | null;
+    requestCount: number | null;
+    errorCount: number | null;
+    wafBlocked: number | null;
+  };
+  security: {
+    alerts: number | null;
+    openFindings: number | null;
+    incidents: number | null;
+    academyCoverage: number | null;
+  };
+  velocity: {
+    deploysMonth: number | null;
+    changeSuccess: number | null;
+    lastDeployAt: string | null;
+  };
+  spend: {
+    monthToDate: number | null;
+    forecast: number | null;
+  };
+};
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+const severityColors: Record<Severity, string> = {
+  green: 'bg-green-50 border-green-200',
+  yellow: 'bg-yellow-50 border-yellow-200',
+  red: 'bg-red-50 border-red-200',
+  neutral: 'bg-slate-50 border-slate-200'
+};
+
+const numberFormatter = new Intl.NumberFormat('en-US', {
+  maximumFractionDigits: 0
+});
+
+const currencyFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  maximumFractionDigits: 0
+});
+
+function classifyHigh(value: number | null, thresholds: { green: number; yellow: number }): Severity {
+  if (typeof value !== 'number') return 'neutral';
+  if (value >= thresholds.green) return 'green';
+  if (value >= thresholds.yellow) return 'yellow';
+  return 'red';
+}
+
+function classifyLow(value: number | null, thresholds: { green: number; yellow: number }): Severity {
+  if (typeof value !== 'number') return 'neutral';
+  if (value <= thresholds.green) return 'green';
+  if (value <= thresholds.yellow) return 'yellow';
+  return 'red';
+}
+
+function combineSeverity(values: Severity[]): Severity {
+  if (values.includes('red')) return 'red';
+  if (values.includes('yellow')) return 'yellow';
+  if (values.includes('green')) return 'green';
+  return 'neutral';
+}
+
+function formatPercent(value: number | null, digits = 1) {
+  if (typeof value !== 'number') return '—';
+  return `${value.toFixed(digits)}%`;
+}
+
+function formatMs(seconds: number | null) {
+  if (typeof seconds !== 'number') return '—';
+  return `${Math.round(seconds * 1000)} ms`;
+}
+
+function formatNumber(value: number | null) {
+  if (typeof value !== 'number') return '—';
+  return numberFormatter.format(value);
+}
+
+function formatCurrency(value: number | null) {
+  if (typeof value !== 'number') return '—';
+  return currencyFormatter.format(value);
+}
+
+function formatDate(value: string | null) {
+  if (!value) return '—';
+  const dt = new Date(value);
+  if (Number.isNaN(dt.getTime())) return '—';
+  return dt.toLocaleString();
+}
+
+type CardProps = {
+  title: string;
+  icon: ReactNode;
+  severity: Severity;
+  children: ReactNode;
+};
+
+function Card({ title, icon, severity, children }: CardProps) {
+  return (
+    <section
+      className={`border rounded-2xl p-6 shadow-sm flex flex-col gap-4 transition-colors ${severityColors[severity]}`}
+    >
+      <header className="flex items-center gap-3">
+        <div className="h-10 w-10 rounded-full bg-white/70 flex items-center justify-center text-slate-700">
+          {icon}
+        </div>
+        <h2 className="text-lg font-semibold text-slate-900">{title}</h2>
+      </header>
+      <div className="space-y-3 text-slate-800 text-sm">{children}</div>
+    </section>
+  );
+}
+
+type MetricProps = {
+  label: string;
+  value: ReactNode;
+  helper?: ReactNode;
+};
+
+function Metric({ label, value, helper }: MetricProps) {
+  return (
+    <div className="flex items-start justify-between gap-3">
+      <div>
+        <div className="text-xs uppercase tracking-wide text-slate-500">{label}</div>
+        {helper && <div className="text-xs text-slate-500 mt-1">{helper}</div>}
+      </div>
+      <div className="text-base font-semibold text-slate-900">{value}</div>
+    </div>
+  );
+}
+
+export default function ScorecardPage() {
+  const { data, error } = useSWR<ScorecardResponse>('/api/scorecard', fetcher, {
+    refreshInterval: 120_000,
+    revalidateOnFocus: false
+  });
+
+  const computed = useMemo(() => {
+    if (!data) {
+      return null;
+    }
+
+    const healthSeverity = combineSeverity([
+      classifyHigh(data.health.uptime, { green: 99.9, yellow: 99 }),
+      classifyLow(data.health.latencyP95, { green: 1, yellow: 1.5 }),
+      classifyLow(data.health.errorRate, { green: 0.5, yellow: 1 })
+    ]);
+
+    const changeSeverity = classifyHigh(data.velocity.changeSuccess, {
+      green: 98,
+      yellow: 95
+    });
+
+    const securitySeverity = combineSeverity([
+      classifyLow(data.security.alerts, { green: 0, yellow: 10 }),
+      classifyLow(data.security.openFindings, { green: 0, yellow: 5 }),
+      classifyLow(data.security.incidents, { green: 0, yellow: 1 }),
+      classifyHigh(data.security.academyCoverage, { green: 90, yellow: 80 })
+    ]);
+
+    const spendVariance =
+      typeof data.spend.monthToDate === 'number' &&
+      typeof data.spend.forecast === 'number' &&
+      data.spend.forecast > 0
+        ? (data.spend.monthToDate / data.spend.forecast) * 100
+        : null;
+
+    const spendSeverity = classifyLow(spendVariance, { green: 100, yellow: 110 });
+
+    return {
+      healthSeverity,
+      changeSeverity,
+      securitySeverity,
+      spendSeverity,
+      spendVariance
+    };
+  }, [data]);
+
+  return (
+    <main className="min-h-screen bg-slate-100">
+      <div className="mx-auto flex max-w-6xl flex-col gap-6 px-6 py-10">
+        <header className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold text-slate-900">BlackRoad Scorecard</h1>
+            <p className="text-sm text-slate-600">
+              Health, security, velocity, and spend in one glance.
+            </p>
+          </div>
+          <div className="text-xs text-slate-500">
+            {data && `Updated ${new Date(data.updated).toLocaleString()}`}
+          </div>
+        </header>
+
+        {error && (
+          <div className="rounded-lg border border-red-300 bg-red-50 p-4 text-sm text-red-700">
+            Unable to load scorecard data. Please check the data feeds.
+          </div>
+        )}
+
+        {!data && !error && (
+          <div className="rounded-lg border border-slate-200 bg-white p-6 text-center text-sm text-slate-600">
+            Loading live metrics…
+          </div>
+        )}
+
+        {data && computed && (
+          <div className="grid gap-6 md:grid-cols-2">
+            <Card
+              title="Health"
+              icon={<Activity className="h-5 w-5" />}
+              severity={computed.healthSeverity}
+            >
+              <Metric label="Uptime" value={formatPercent(data.health.uptime, 2)} />
+              <Metric
+                label="Latency p95"
+                value={formatMs(data.health.latencyP95)}
+                helper="Last 15 minutes"
+              />
+              <Metric
+                label="Error rate"
+                value={formatPercent(data.health.errorRate, 2)}
+                helper={`5xx count: ${formatNumber(data.health.errorCount)}`}
+              />
+              <Metric
+                label="Request volume"
+                value={formatNumber(data.health.requestCount)}
+                helper="Last 15 minutes"
+              />
+            </Card>
+
+            <Card
+              title="Security"
+              icon={<ShieldCheck className="h-5 w-5" />}
+              severity={computed.securitySeverity}
+            >
+              <Metric
+                label="WAF alerts"
+                value={formatNumber(data.security.alerts)}
+                helper="Blocked requests (15m)"
+              />
+              <Metric
+                label="Open findings"
+                value={formatNumber(data.security.openFindings)}
+                helper="Evidence pack"
+              />
+              <Metric
+                label="Open incidents"
+                value={formatNumber(data.security.incidents)}
+                helper="cstate"
+              />
+              <Metric
+                label="Academy coverage"
+                value={formatPercent(data.security.academyCoverage, 1)}
+                helper="PeopleOps"
+              />
+            </Card>
+
+            <Card
+              title="Velocity"
+              icon={<Timer className="h-5 w-5" />}
+              severity={computed.changeSeverity}
+            >
+              <Metric
+                label="Deploys this month"
+                value={formatNumber(data.velocity.deploysMonth)}
+                helper={
+                  data.velocity.lastDeployAt
+                    ? `Last deploy ${formatDate(data.velocity.lastDeployAt)}`
+                    : undefined
+                }
+              />
+              <Metric
+                label="Change success"
+                value={formatPercent(data.velocity.changeSuccess, 2)}
+                helper="Workflow success rate"
+              />
+            </Card>
+
+            <Card
+              title="Spend"
+              icon={<Wallet className="h-5 w-5" />}
+              severity={computed.spendSeverity}
+            >
+              <Metric
+                label="Month-to-date"
+                value={formatCurrency(data.spend.monthToDate)}
+              />
+              <Metric label="Forecast" value={formatCurrency(data.spend.forecast)} />
+              <Metric
+                label="vs forecast"
+                value={
+                  computed.spendVariance !== null
+                    ? formatPercent(computed.spendVariance, 1)
+                    : '—'
+                }
+                helper="Target ≤ 100%"
+              />
+            </Card>
+          </div>
+        )}
+
+        <footer className="text-xs text-slate-500">
+          Auto-refreshing every 2 minutes. Configure feeds via SCORECARD_* env vars.
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "node": ">=20"
   },
   "dependencies": {
+    "@aws-sdk/client-cloudwatch": "^3.632.0",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
     "bcrypt": "^5.1.1",
@@ -49,7 +50,9 @@
     "react-dom": "^18.2.0",
     "stripe": "^12.18.0",
     "ethers": "^6.10.0",
-    "yaml": "^2.3.4"
+    "yaml": "^2.3.4",
+    "lucide-react": "^0.460.0",
+    "swr": "^2.2.4"
   },
   "devDependencies": {
     "nodemon": "^3.0.2",


### PR DESCRIPTION
## Summary
- add a /api/scorecard route that pulls CloudWatch metrics plus external feeds with defensive fallbacks
- build the /scorecard page with auto-refreshing metric cards and severity-based styling
- include dependencies for the AWS CloudWatch SDK, SWR data fetching, and Lucide icons

## Testing
- not run (npm install blocked by private Verdaccio registry returning 503)


------
https://chatgpt.com/codex/tasks/task_e_68e8549c4ee0832987cf2a4a9fb6d4a1