### PR TITLE
Add hiring pack for founding agentic systems engineer

### DIFF
--- a/docs/company/README.md
+++ b/docs/company/README.md
@@ -4,3 +4,4 @@ This directory collects corporate and planning documents for BlackRoad.
 
 - [Implementation Plan for Enterprise Tool Integrations](implementation-plan.md)
 - [BlackRoad Trademark Pack](trademark-pack.md)
+- [BlackRoad Hiring Pack — Founding Agentic Systems Engineer](hiring-pack.md)

--- a/docs/company/hiring-pack.md
+++ b/docs/company/hiring-pack.md
@@ -1,0 +1,141 @@
+# BlackRoad Hiring Pack — Founding Agentic Systems Engineer
+
+The hiring pack keeps every interaction with candidates consistent, transparent, and aligned with BlackRoad's utility-first RoadCoin (RC) philosophy and bias-aware processes. Use each section as the single source of truth when kicking off a search, running interviews, or preparing an offer.
+
+---
+
+## 1. Job Description (JD)
+
+**Role Summary**
+
+BlackRoad is hiring a Founding Agentic Systems Engineer to harden the Prism Console, scale symbolic-English automation, and ensure reliability for operators who depend on real-time insights. You will architect and ship agentic workflows that respect compliance guardrails, maintain verifiable change logs, and surface health metrics that reduce on-call noise.
+
+**What You'll Tackle**
+
+- Design and implement resilient services for the Prism Console (routing, audit trails, onboarding flows, data ingestion, and human-in-the-loop review).
+- Extend Lucidia/Prism automation loops with verifiable policies, RoadCoin issuance hooks, and service-level health indicators.
+- Own instrumentation that tracks contradiction counts, SLO compliance, and real-time latency thresholds.
+- Partner with product, compliance, and ops to encode regulatory policy (state filings, Vault token practices, onboarding guardrails) directly into workflows.
+- Lead incident reviews and author runbooks that convert lessons into observable, testable guardrails.
+
+**What Success Looks Like (6–12 Months)**
+
+- Prism Console uptime consistently clears its SLO while regression gates stay green.
+- Audit-ready change logs and RoadCoin reward hooks exist for every automated workflow, with RoadCoin issuance tied to verifiable contribution checkpoints.
+- Deployment, rollback, and onboarding playbooks are codified, version-controlled, and demonstrably used by operators.
+- The engineer mentors new hires, raises signal during interviews, and documents technical context in Symbolic English for downstream agents.
+
+**Minimum Qualifications**
+
+- 6+ years building production systems (TypeScript/Node, Python, or Rust) with verifiable deployment pipelines.
+- Experience implementing secure automation (OIDC, Vault, scoped tokens) and running post-incident reviews that ship fixes.
+- Comfort translating regulatory or policy requirements into code and documentation.
+- Track record of bias-aware interviewing and mentorship.
+
+**Preferred Experience**
+
+- Prior work on agent orchestration, symbolic reasoning, or high-signal observability platforms.
+- Familiarity with RoadCoin or similar contribution-token frameworks.
+- Experience hardening SOC 2 / state regulatory controls for fintech or agentic platforms.
+
+**How We Work**
+
+- Remote-first with anchored collaboration windows around UTC-8 to UTC-5.
+- Async-first rituals documented in the Prism knowledge base and Symbolic English runbooks.
+- Contribution tokens (RC) recognize useful work alongside salary and equity; RC is utility-centric and tracked with verification gates.
+
+---
+
+## 2. Interview Scorecard
+
+**Instructions**
+
+- Use this scorecard for every candidate. Capture evidence-based notes, not opinions. Call out when bias mitigation steps were applied.
+- Rating scale: 4 (Strong Yes), 3 (Yes), 2 (No), 1 (Strong No). Default to "No Decision" if signal is insufficient.
+- Note explicit follow-up items and RC-aligned opportunities (e.g., what contributions merit RC grants).
+
+| Dimension | What Good Looks Like | Bias Mitigation Prompts | Rating (1-4) | Evidence & Notes |
+| --- | --- | --- | --- | --- |
+| **Systems Architecture** | Designs reliable, observable services with clear failure isolation, secure token handling, and regression gates. | Ask for recent example; probe for team context to avoid bias toward solo hero narratives. |  |  |
+| **Agentic Automation** | Demonstrates ability to encode policies in automation loops, describing guardrails, audits, and RoadCoin issuance triggers. | Consider cross-industry experience; avoid weighting only fintech backgrounds. |  |  |
+| **Security & Compliance** | Shows working knowledge of Vault/OIDC, least privilege, and regulatory alignment (state filings, SOC practices). | Use structured follow-up ("What controls ensured compliance?") to avoid assumptions based on employer brand. |  |  |
+| **Collaboration & Documentation** | Communicates in structured, Symbolic English-style narratives; documents decisions and runbooks. | Check for collaboration styles across time zones; discount charisma vs. substance. |  |  |
+| **Values & Equity Alignment** | Embraces RC as a utility token tied to verifiable contributions, supports transparent rewards, and models inclusive behavior. | Invite candidates to share examples of fair recognition; ensure space for nontraditional paths. |  |  |
+| **Overall Recommendation** | Summarize hire/no-hire decision, outstanding risks, and suggested RC grant band. | Triangulate with other interviewers; flag if more signal is required. |  |  |
+
+---
+
+## 3. Offer Letter Template
+
+```
+Subject: Your Offer to Join BlackRoad as Founding Agentic Systems Engineer
+
+Hi <Candidate Name>,
+
+Thank you for spending time with the BlackRoad team. We’re excited to invite you to join us as a Founding Agentic Systems Engineer, reporting to <Hiring Manager>.
+
+Compensation & Ownership
+- Base Salary: $<Amount> USD (paid semi-monthly).
+- Equity: <Number> stock options in BlackRoad Inc., subject to Board approval, a 4-year vesting schedule, and a 1-year cliff.
+- RoadCoin (RC): Initial grant of <Amount> RC, issued upon start. RC recognizes verifiable contributions (ship-ready code, regression gates cleared, documentation delivered) and remains a utility token — not a speculative asset. Additional RC awards follow contribution checkpoints defined in our RoadCoin policy.
+- Benefits: Comprehensive health coverage, paid time off (flexible, minimum 15 days), and equipment stipend.
+
+How We Work
+- Remote-first team with collaboration anchors in UTC-8 to UTC-5.
+- Documentation-driven rituals; every deployment and incident is logged with Symbolic English narratives.
+- Bias-aware recruiting and promotion processes; we expect every teammate to uphold these standards.
+
+Your Start
+- Target Start Date: <Date>.
+- Location: Remote (with periodic in-person working sessions as needed).
+- This offer is contingent on reference checks and standard employment verifications.
+
+Please confirm acceptance by <Expiration Date> by replying to this email. Once accepted, we’ll send onboarding details, equipment logistics, and RC wallet activation steps.
+
+We’re thrilled at the possibility of building BlackRoad’s next chapter together.
+
+With care,
+<Your Name>
+<Title>
+BlackRoad Inc.
+```
+
+---
+
+## 4. Hiring Workflow Checklist
+
+**Request & Planning**
+
+- [ ] Role intake with hiring manager: confirm scope, success metrics, budget, RC grant bands, and timeline.
+- [ ] Update headcount tracker and finance approvals; log req in the hiring pipeline.
+- [ ] Publish JD via internal announcement and external channels (site, curated communities, referrals).
+- [ ] Brief interview panel on scorecard dimensions, bias mitigation reminders, and RC philosophy refresh.
+
+**Sourcing & Screening**
+
+- [ ] Calibrate sourcing strategy: inbound triage, targeted outreach, partnerships, and community events.
+- [ ] Conduct structured recruiter screen (role motivation, salary/equity expectations, RC readiness).
+- [ ] Send candidate prep pack (mission primer, Prism overview, RC utility explainer, interview logistics).
+
+**Interviews**
+
+- [ ] Panelists capture evidence-based notes in the shared scorecard; recruiting monitors completion.
+- [ ] Run daily debrief syncs when candidates are in process; address bias call-outs immediately.
+- [ ] Collect work sample or technical exercise aligned with actual deliverables (e.g., designing an automation guardrail).
+- [ ] Hiring manager compiles final decision doc referencing JD success metrics and RC contribution opportunities.
+
+**Offer & Close**
+
+- [ ] Calibrate offer band using compensation benchmarks and RC grant guidelines.
+- [ ] Prepare offer letter template with personalized comp details and send for leadership approval.
+- [ ] Deliver offer live (video/phone), then follow with written letter; answer RC, equity, and benefits questions.
+- [ ] Track candidate decision date; run closing plan (team meet-and-greets, roadmap deep dives, AMA).
+
+**Onboarding**
+
+- [ ] Kick off pre-start onboarding: equipment order, access requests, RC wallet provisioning, HRIS setup.
+- [ ] Publish onboarding itinerary (week-by-week goals, mentors, key systems) in Prism knowledge base.
+- [ ] Schedule compliance and security briefings (Vault usage, token issuance, regulatory posture).
+- [ ] 30/60/90-day check-ins with hiring manager; ensure RC contribution checkpoints are clear and logged.
+
+This pack is version-controlled — update it whenever processes or policies change to keep every candidate experience consistent and fair.


### PR DESCRIPTION
## Summary
- add a version-controlled hiring pack for the founding agentic systems engineer role covering JD, scorecard, offer template, and workflow checklist
- link the hiring pack from the company documentation index for visibility

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e85922aa0083299e4fafb4d4c09cf9