### PR TITLE
docs: capture deployment-focused next initiative

### DIFF
--- a/AGENT_WORKBOARD.md
+++ b/AGENT_WORKBOARD.md
@@ -1,5 +1,13 @@
 # Agent Workboard
 
+## Next Initiative
+
+- **Focus**: Environments & deploys — wire real infrastructure targets into the existing automation surface.
+- **Objectives**:
+  - Define environment manifests for staging, preview, and production footprints.
+  - Hook CI/CD outputs into managed deploy targets (start with Fly.io and AWS ECS) via reusable workflows.
+  - Extend release runbooks with rollback/forward procedures and policy gates for infra changes.
+
 ## To Do
 - [ ] Deploy site (`WebsiteBot`)
 - [ ] Build site (`BuildBlackRoadSiteAgent`)
@@ -26,6 +34,10 @@
 
 ## Last Status Report
 <!-- Agents append latest status, error, or notifications here -->
+
+### 2025-10-05
+- Reconciled "next" track selection: prioritizing deployment integrations so shipping work can land on managed infra with the current automation stack.
+- Drafted objectives covering environment manifests, multi-target deploy hooks, and infra-aware release guardrails to guide upcoming branch work.
 
 ### 2025-10-04
 - Shipped governance and upgrade wiring end-to-end, including handlers, proposal examples, and CLI hooks.


### PR DESCRIPTION
## Summary
- document the deployment-focused next initiative with concrete objectives
- record a status update noting the focus shift toward infrastructure integrations

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e8599ed90083299f0a8030fa9ad176