### PR TITLE
Add portal one-button runner and utilities

### DIFF
--- a/portal/README.md
+++ b/portal/README.md
@@ -21,10 +21,17 @@ sudo apt-get install qrencode zbar-tools tor
 
 | Script | Purpose |
 | --- | --- |
+| `portal-env` | Check the runtime environment and required dependencies. |
+| `portal-run` | Execute the one-button workflow (proof → health → checklist). |
+| `portal-selftest` | Run a quick smoke test that builds a PSBT and verifies signing flow without broadcasting. |
+| `portal-help` | Display a help index of the major Portal commands and workflows. |
 | `psbt-to-qr <file.psbt> [out.png]` | Encode a (signed or unsigned) PSBT into a QR image. Files larger than ~2500 base64 characters are split into numbered parts. |
 | `qr-to-psbt <out.psbt> <img1.png> [img2.png ...]` | Reconstruct a PSBT from one or more QR images scanned on an offline machine. |
 | `portal-static [addr:port]` | Serve `reports/health.html` over HTTP on localhost. Used internally by the Tor helper. |
 | `portal-health-tor` | Print the Tor onion URL for the health page and launch the local static server on `127.0.0.1:8088`. |
+| `psbt-fake-sign <label>` | Clone `<label>.psbt` to `<label>.signed.psbt` for offline signer simulations and automated tests. |
+
+The new `portal-env` helper checks that `bitcoin-cli`, `jq`, and `python3` are available and that `configs/raw.descriptor` is populated. `portal-run` chains a descriptor proof, the health report generator, and the checklist builder for a single-command operations sweep. `portal-selftest` performs a key-safe smoke test that exercises PSBT creation and verification using the `psbt-fake-sign` shim, while `portal-help` prints a concise index of the most common workflows.
 
 ### PSBT via QR workflow
 

--- a/portal/bin/portal-env
+++ b/portal/bin/portal-env
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEFAULT_ROOT="/home/pi/portal"
+ROOT="${PORTAL_ROOT:-$DEFAULT_ROOT}"
+ROOT="${ROOT%/}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ ! -d "$ROOT" ]]; then
+  ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+fi
+
+ok=1
+require() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "missing: $cmd" >&2
+    ok=0
+  fi
+}
+
+echo "== portal env check =="
+require bitcoin-cli
+require jq
+require python3
+if [[ ! -s "$ROOT/configs/raw.descriptor" ]]; then
+  echo "missing: $ROOT/configs/raw.descriptor" >&2
+  ok=0
+fi
+
+echo "optional (nice to have): litecoin-cli, curl (for ETH RPC), qrencode, zbarimg, gum/whiptail, tor, caddy"
+
+if (( ok )); then
+  exit 0
+else
+  exit 1
+fi

--- a/portal/bin/portal-help
+++ b/portal/bin/portal-help
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cat <<'TXT'
+Portal Help (key-safe; no seeds/private keys)
+
+Core:
+  portal-env                 Check required tools & files
+  portal-run                 One-button: proof → health → checklist
+  portal-tui                 Menu UI (if installed)
+  portal                     CLI (proof, psbt:new, verify, broadcast, policy, utxo freeze)
+
+Proofs:
+  portal proof /path/raw.descriptor
+  ltc-proof                  (fill configs/ltc.raw.descriptor)
+  eth-proof                  (fill configs/eth.json)
+
+PSBT (air-gap):
+  portal psbt:new <label> <outputs.json> <feerate>
+  psbt-to-qr /path/to.psbt            # encode for offline signer
+  qr-to-psbt  out.psbt IMG*.png
+  portal psbt:verify <label>.signed.psbt
+  CONFIRM_BROADCAST=1 portal psbt:broadcast <label>.signed.psbt
+
+Policy:
+  portal policy:request <request.json>
+  portal-build-from-request <request.json>
+  portal policy:collect <label> <sigfile>
+  portal policy:status <label>
+
+Health/Reports/Prices:
+  price set btc <number>    # offline price store
+  portal-health             # ${PORTAL_ROOT:-/home/pi/portal}/reports/health.html
+  portal-health-tor         # onion (read-only)
+  portal-checklist          # ops checklist HTML
+
+Backups:
+  portal-backup  [/home/pi/portal.backup.tgz]
+  portal-restore <backup.tgz>
+
+Tests:
+  portal-test               # policy gate test (earlier prompt)
+  portal-selftest           # smoke test; no broadcast
+
+Security rules:
+  - No private keys here. Signing is offline.
+  - No broadcast without CONFIRM_BROADCAST=1.
+TXT

--- a/portal/bin/portal-run
+++ b/portal/bin/portal-run
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEFAULT_ROOT="/home/pi/portal"
+ROOT="${PORTAL_ROOT:-$DEFAULT_ROOT}"
+ROOT="${ROOT%/}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ ! -d "$ROOT" ]]; then
+  ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+fi
+
+DESC_FILE="$ROOT/configs/raw.descriptor"
+
+"$ROOT/bin/portal-env" || { echo "fix env first"; exit 2; }
+
+if [[ ! -f "$ROOT/bin/portal" ]]; then
+  echo "missing portal CLI at $ROOT/bin/portal" >&2
+  exit 3
+fi
+
+OUT="$("$ROOT/bin/portal" proof "$DESC_FILE" | sed -e 's/^BALANCE: //')"
+BAL="$(echo "$OUT" | awk '{print $1}')"
+echo "BTC balance: ${BAL:-unknown}"
+
+if [[ -n "${PRICE_BTC:-}" && -x "$ROOT/bin/price" ]]; then
+  "$ROOT/bin/price" set btc "$PRICE_BTC" >/dev/null || true
+fi
+
+if [[ -x "$ROOT/bin/portal-health" ]]; then
+  "$ROOT/bin/portal-health" >/dev/null
+fi
+if [[ -x "$ROOT/bin/portal-checklist" ]]; then
+  "$ROOT/bin/portal-checklist" >/dev/null
+fi
+
+echo "Health:     $ROOT/reports/health.html"
+echo "Checklist:  $ROOT/reports/ops-checklist.html"

--- a/portal/bin/portal-selftest
+++ b/portal/bin/portal-selftest
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEFAULT_ROOT="/home/pi/portal"
+ROOT="${PORTAL_ROOT:-$DEFAULT_ROOT}"
+ROOT="${ROOT%/}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ ! -d "$ROOT" ]]; then
+  ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+fi
+
+LOG_DIR="$ROOT/logs"
+mkdir -p "$LOG_DIR"
+LOG="$LOG_DIR/selftest.$(date -u +%Y%m%d%H%M%S).log"
+
+{
+  echo "== selftest start =="
+  "$ROOT/bin/portal-env"
+  LABEL="selftest_$$"
+  OUT_JSON="$ROOT/configs/$LABEL.outputs.json"
+  echo '[{"address":"tb1qexampledestxxxxxxxxxxxxxxxxxxxxxxxxxxxx","amount_btc":"0.00001000"}]' > "$OUT_JSON"
+  "$ROOT/bin/portal" psbt:new "$LABEL" "$OUT_JSON" 2
+  if [[ -s "$ROOT/psbts/$LABEL.psbt" ]]; then
+    echo "PSBT created"
+  else
+    echo "expected PSBT at $ROOT/psbts/$LABEL.psbt" >&2
+    exit 10
+  fi
+  "$ROOT/bin/psbt-fake-sign" "$LABEL"
+  "$ROOT/bin/portal" psbt:verify "$ROOT/psbts/$LABEL.signed.psbt"
+  echo "verify ok; broadcast remains gated"
+  rm -f "$OUT_JSON" \
+        "$ROOT/psbts/$LABEL.psbt" \
+        "$ROOT/psbts/$LABEL.psbt.sha256" \
+        "$ROOT/psbts/$LABEL.meta.json" \
+        "$ROOT/psbts/$LABEL.signed.psbt" \
+        "$ROOT/psbts/$LABEL.verified.json"
+  echo "== selftest ok =="
+} | tee "$LOG"
+
+echo "LOG: $LOG"

--- a/portal/bin/psbt-fake-sign
+++ b/portal/bin/psbt-fake-sign
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEFAULT_ROOT="/home/pi/portal"
+ROOT="${PORTAL_ROOT:-$DEFAULT_ROOT}"
+ROOT="${ROOT%/}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ ! -d "$ROOT" ]]; then
+  ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+fi
+
+LABEL="${1:-}"
+if [[ -z "$LABEL" ]]; then
+  echo "usage: psbt-fake-sign <label>" >&2
+  exit 1
+fi
+
+IN="$ROOT/psbts/$LABEL.psbt"
+OUT="$ROOT/psbts/$LABEL.signed.psbt"
+
+if [[ ! -f "$IN" ]]; then
+  echo "missing PSBT: $IN" >&2
+  exit 2
+fi
+
+cp "$IN" "$OUT"
+echo "Fake-signed PSBT -> $OUT"


### PR DESCRIPTION
## Summary
- add a portal-env helper that verifies required binaries and descriptor configuration
- introduce a one-button portal-run workflow plus a key-safe portal-selftest and psbt-fake-sign shim
- document the new helpers and bundle a portal-help index for quick operator guidance

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e859b22544832999da9d94efe3ed79