### PR TITLE
Add risk heatmap drilldowns and automation feeds

### DIFF
--- a/apps/portals/app/api/scorecard/risk/notify/route.ts
+++ b/apps/portals/app/api/scorecard/risk/notify/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+import { loadRiskScorecard } from "../service";
+
+export const dynamic = "force-dynamic";
+
+function formatLine(name: string, color: string, risk: number, action: string) {
+  const colorUpper = color.toUpperCase();
+  return `• ${name} — ${colorUpper} (risk ${risk.toFixed(2)}): ${action}`;
+}
+
+export async function POST() {
+  const webhook = process.env.SLACK_WEBHOOK;
+  if (!webhook) {
+    return NextResponse.json({ ok: false, error: "SLACK_WEBHOOK not configured" }, { status: 500 });
+  }
+
+  const payload = await loadRiskScorecard();
+  const top3 = payload.systems.slice(0, 3).map((system) => formatLine(system.name, system.color, system.risk, system.action));
+  const body = {
+    text: `Risk Heatmap – Top 3\n${top3.join("\n")}`,
+  };
+
+  const response = await fetch(webhook, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    return NextResponse.json({ ok: false, error: `Slack webhook failed (${response.status})` }, { status: 502 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/apps/portals/app/api/scorecard/risk/route.ts
+++ b/apps/portals/app/api/scorecard/risk/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+import { loadRiskScorecard } from "./service";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const payload = await loadRiskScorecard();
+  return NextResponse.json(payload);
+}

--- a/apps/portals/app/api/scorecard/risk/service.ts
+++ b/apps/portals/app/api/scorecard/risk/service.ts
@@ -1,0 +1,309 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export type RiskSystem = {
+  key: string;
+  name: string;
+  risk: number;
+  burn: number;
+  findings: number;
+  cost: number;
+  color: "red" | "yellow" | "green";
+  action: string;
+  links: {
+    g?: string;
+    s?: string;
+    c?: string;
+  };
+};
+
+export type RiskPayload = {
+  systems: RiskSystem[];
+  updatedAt: string;
+  stale: boolean;
+};
+
+type ReliabilityMap = Record<string, number>;
+type SecurityMap = Record<string, number>;
+type CostMap = Record<string, { actual?: number; forecast?: number }>;
+
+type RiskCache = {
+  payload: RiskPayload | null;
+};
+
+const globalState = globalThis as typeof globalThis & {
+  __riskScorecardCache?: RiskCache;
+};
+
+function getCache(): RiskCache {
+  if (!globalState.__riskScorecardCache) {
+    globalState.__riskScorecardCache = { payload: null };
+  }
+  return globalState.__riskScorecardCache;
+}
+
+const SYSTEM_CONFIG: { key: string; name: string; action: string }[] = [
+  { key: "api", name: "Public API", action: "Throttle retry storm + ship circuit breaker patch." },
+  { key: "ui", name: "Web UI", action: "Prioritize checkout latency fix; rerun lighthouse after deploy." },
+  { key: "ingest-gh", name: "Ingest – GitHub", action: "Clear stuck runner + requeue repo sync backlog." },
+  { key: "ingest-lin", name: "Ingest – Linear", action: "Re-auth OAuth token; backfill last 48h issues." },
+  { key: "ingest-str", name: "Ingest – Stripe", action: "Validate webhook secret rotation + replay missing events." },
+  { key: "infra", name: "Core Infra", action: "Drain noisy node pool; finish kernel patch rollout." },
+  { key: "data", name: "Data Platform", action: "Refresh dbt freshness tests + unblock nightly pipeline." },
+];
+
+const DEFAULT_BURN: ReliabilityMap = {
+  api: 1.2,
+  ui: 0.6,
+  "ingest-gh": 1.4,
+  "ingest-lin": 0.5,
+  "ingest-str": 0.8,
+  infra: 0.4,
+  data: 0.7,
+};
+
+const LINK_MAP: Record<string, { g?: string; s?: string; c?: string }> = {
+  api: {
+    g: process.env.GRAFANA_PANEL_API,
+    s: process.env.SECHUB_LINK_API,
+    c: process.env.COSTEXPLORER_LINK_API,
+  },
+  ui: {
+    g: process.env.GRAFANA_PANEL_UI,
+    s: process.env.SECHUB_LINK_UI,
+    c: process.env.COSTEXPLORER_LINK_UI,
+  },
+  "ingest-gh": {
+    g: process.env.GRAFANA_PANEL_GH,
+    s: process.env.SECHUB_LINK_GH,
+    c: process.env.COSTEXPLORER_LINK_GH,
+  },
+  "ingest-lin": {
+    g: process.env.GRAFANA_PANEL_LIN,
+    s: process.env.SECHUB_LINK_LIN,
+    c: process.env.COSTEXPLORER_LINK_LIN,
+  },
+  "ingest-str": {
+    g: process.env.GRAFANA_PANEL_STR,
+    s: process.env.SECHUB_LINK_STR,
+    c: process.env.COSTEXPLORER_LINK_STR,
+  },
+  infra: {
+    g: process.env.GRAFANA_PANEL_INFRA,
+    s: process.env.SECHUB_LINK_INFRA,
+    c: process.env.COSTEXPLORER_LINK_INFRA,
+  },
+  data: {
+    g: process.env.GRAFANA_PANEL_DATA,
+    s: process.env.SECHUB_LINK_DATA,
+    c: process.env.COSTEXPLORER_LINK_DATA,
+  },
+};
+
+function clamp(value: number, min: number, max: number) {
+  if (Number.isNaN(value)) return min;
+  return Math.min(max, Math.max(min, value));
+}
+
+function round(value: number, decimals: number) {
+  const factor = 10 ** decimals;
+  return Math.round(value * factor) / factor;
+}
+
+async function loadJson(source: string | undefined, fallback: string): Promise<any | null> {
+  const target = source && source.trim().length > 0 ? source.trim() : fallback;
+  if (!target) return null;
+
+  if (target.startsWith("http://") || target.startsWith("https://")) {
+    const response = await fetch(target, { cache: "no-store" });
+    if (!response.ok) {
+      throw new Error(`Failed to fetch ${target}: ${response.status}`);
+    }
+    return response.json();
+  }
+
+  const resolved = path.resolve(target);
+  if (!fs.existsSync(resolved)) {
+    return null;
+  }
+  const raw = fs.readFileSync(resolved, "utf-8");
+  if (!raw.trim()) return null;
+  return JSON.parse(raw);
+}
+
+function parseReliability(data: any): ReliabilityMap {
+  if (!data || typeof data !== "object") return {};
+  if (Array.isArray(data)) {
+    return data.reduce<ReliabilityMap>((acc, entry) => {
+      const key = typeof entry?.key === "string" ? entry.key : entry?.system;
+      const burn = Number(entry?.burn ?? entry?.value);
+      if (key) acc[key] = burn;
+      return acc;
+    }, {});
+  }
+  return Object.entries(data).reduce<ReliabilityMap>((acc, [key, value]) => {
+    acc[key] = Number(value);
+    return acc;
+  }, {});
+}
+
+function parseSecurity(data: any): SecurityMap {
+  if (!data || typeof data !== "object") return {};
+  if (Array.isArray(data)) {
+    return data.reduce<SecurityMap>((acc, entry) => {
+      const key = typeof entry?.key === "string" ? entry.key : entry?.system;
+      const count = Number(entry?.count ?? entry?.value ?? entry?.findings ?? 0);
+      if (key) acc[key] = count;
+      return acc;
+    }, {});
+  }
+  return Object.entries(data).reduce<SecurityMap>((acc, [key, value]) => {
+    acc[key] = Number((value as any)?.count ?? value);
+    return acc;
+  }, {});
+}
+
+function parseCost(data: any): CostMap {
+  const result: CostMap = {};
+  if (!data || typeof data !== "object") return result;
+  if (Array.isArray(data)) {
+    for (const entry of data) {
+      const key = typeof entry?.key === "string" ? entry.key : entry?.system;
+      if (!key) continue;
+      const actual = Number(entry?.actual ?? entry?.cost ?? entry?.value ?? 0);
+      const forecast = Number(entry?.forecast ?? entry?.plan ?? entry?.target ?? 0);
+      result[key] = { actual, forecast };
+    }
+    return result;
+  }
+  for (const [key, value] of Object.entries(data)) {
+    const val = value as any;
+    result[key] = {
+      actual: Number(val?.actual ?? val?.cost ?? val?.value ?? 0),
+      forecast: Number(val?.forecast ?? val?.plan ?? val?.target ?? val?.budget ?? 0),
+    };
+  }
+  return result;
+}
+
+function computeCostDelta(entry: { actual?: number; forecast?: number } | undefined) {
+  if (!entry) return 0;
+  const actual = Number(entry.actual ?? 0);
+  const forecast = Number(entry.forecast ?? 0);
+  if (forecast <= 0) {
+    return clamp(actual > 0 ? 1 : 0, 0, 1);
+  }
+  const over = (actual - forecast) / forecast;
+  return clamp(over <= 0 ? 0 : over, 0, 1);
+}
+
+function computeRiskScore(burn: number, findings: number, cost: number) {
+  const score = burn * 0.5 + findings * 0.3 + cost * 0.2;
+  return clamp(score, 0, 2);
+}
+
+function toColor(score: number): RiskSystem["color"] {
+  if (score >= 1.2) return "red";
+  if (score >= 0.7) return "yellow";
+  return "green";
+}
+
+function buildLinks(key: string) {
+  const entry = LINK_MAP[key] || {};
+  const links: { g?: string; s?: string; c?: string } = {};
+  if (entry.g) links.g = entry.g;
+  if (entry.s) links.s = entry.s;
+  if (entry.c) links.c = entry.c;
+  return links;
+}
+
+export async function loadRiskScorecard(): Promise<RiskPayload> {
+  const cache = getCache();
+  const reliabilitySource = process.env.RISK_BURN_FEED_URL ?? process.env.RISK_BURN_SOURCE;
+  const securitySource = process.env.SECURITY_FEED_URL ?? process.env.SECURITY_FEED_SOURCE;
+  const costSource = process.env.COST_FEED_URL ?? process.env.COST_FEED_SOURCE;
+
+  let reliabilityMap: ReliabilityMap = {};
+  let reliabilityFailed = false;
+
+  if (reliabilitySource) {
+    try {
+      const rawReliability = await loadJson(reliabilitySource, "portal/reports/risk_burn.json");
+      if (rawReliability) {
+        reliabilityMap = parseReliability(rawReliability);
+      }
+    } catch (error) {
+      reliabilityFailed = true;
+      console.error("[risk-scorecard] reliability feed error", error);
+    }
+  }
+
+  if (!Object.keys(reliabilityMap).length) {
+    reliabilityMap = { ...DEFAULT_BURN };
+  }
+
+  let securityMap: SecurityMap = {};
+  if (securitySource) {
+    try {
+      const rawSecurity = await loadJson(securitySource, "portal/reports/security_feed.json");
+      if (rawSecurity) securityMap = parseSecurity(rawSecurity);
+    } catch (error) {
+      console.error("[risk-scorecard] security feed error", error);
+    }
+  } else {
+    const fallback = await loadJson(undefined, "portal/reports/security_feed.json");
+    if (fallback) securityMap = parseSecurity(fallback);
+  }
+
+  let costMap: CostMap = {};
+  if (costSource) {
+    try {
+      const rawCost = await loadJson(costSource, "portal/reports/cost_feed.json");
+      if (rawCost) costMap = parseCost(rawCost);
+    } catch (error) {
+      console.error("[risk-scorecard] cost feed error", error);
+    }
+  } else {
+    const fallback = await loadJson(undefined, "portal/reports/cost_feed.json");
+    if (fallback) costMap = parseCost(fallback);
+  }
+
+  const now = new Date();
+  const systems: RiskSystem[] = SYSTEM_CONFIG.map((config) => {
+    const burnRaw = reliabilityMap[config.key] ?? DEFAULT_BURN[config.key] ?? 0;
+    const burn = round(clamp(Number(burnRaw) || 0, 0, 2), 2);
+    const findingsRaw = securityMap[config.key] ?? 0;
+    const findings = round(clamp(Number(findingsRaw) || 0, 0, 2), 2);
+    const costDelta = round(computeCostDelta(costMap[config.key]), 2);
+    const risk = round(computeRiskScore(burn, findings, costDelta), 2);
+    const color = toColor(risk);
+
+    return {
+      key: config.key,
+      name: config.name,
+      burn,
+      findings,
+      cost: costDelta,
+      risk,
+      color,
+      action: config.action,
+      links: buildLinks(config.key),
+    };
+  }).sort((a, b) => b.risk - a.risk || a.name.localeCompare(b.name));
+
+  const payload: RiskPayload = {
+    systems,
+    updatedAt: now.toISOString(),
+    stale: reliabilityFailed,
+  };
+
+  if (reliabilityFailed && cache.payload) {
+    return { ...cache.payload, stale: true };
+  }
+
+  if (!reliabilityFailed || !cache.payload) {
+    cache.payload = payload;
+  }
+
+  return payload;
+}

--- a/apps/portals/app/page.tsx
+++ b/apps/portals/app/page.tsx
@@ -12,6 +12,7 @@ const portals = [
   { name: "Lucidia", href: "/portal" },
   { name: "Codex", href: "/codex" },
   { name: "Prism Sources", href: "/prism/sources" },
+  { name: "Risk Heatmap", href: "/scorecard/risk" },
 ];
 
 export default function HomePage() {

--- a/apps/portals/app/scorecard/risk/page.tsx
+++ b/apps/portals/app/scorecard/risk/page.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Topbar } from "../../../components/ui/topbar";
+import { Card } from "../../../components/ui/card";
+
+type RiskSystem = {
+  key: string;
+  name: string;
+  risk: number;
+  burn: number;
+  findings: number;
+  cost: number;
+  color: "red" | "yellow" | "green";
+  action: string;
+  links?: {
+    g?: string;
+    s?: string;
+    c?: string;
+  };
+};
+
+type RiskPayload = {
+  systems: RiskSystem[];
+  updatedAt: string;
+  stale?: boolean;
+};
+
+type FilterValue = "all" | "red" | "yellow" | "green";
+
+type StatusMessage = {
+  kind: "success" | "error";
+  text: string;
+};
+
+function colorClass(color: RiskSystem["color"]) {
+  switch (color) {
+    case "red":
+      return "border-rose-500/60 bg-rose-500/10";
+    case "yellow":
+      return "border-amber-500/60 bg-amber-500/10";
+    default:
+      return "border-emerald-500/60 bg-emerald-500/10";
+  }
+}
+
+function metric(value: number) {
+  if (Number.isNaN(value)) return "—";
+  return value.toFixed(2);
+}
+
+export default function RiskHeatmapPage() {
+  const [payload, setPayload] = useState<RiskPayload | null>(null);
+  const [only, setOnly] = useState<FilterValue>("all");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<StatusMessage | null>(null);
+
+  const load = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/scorecard/risk", { cache: "no-store" });
+      if (!res.ok) {
+        throw new Error(`Request failed (${res.status})`);
+      }
+      const body: RiskPayload = await res.json();
+      setPayload(body);
+    } catch (err) {
+      console.error(err);
+      setError("Unable to load risk scorecard right now.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const systems = useMemo(() => {
+    if (!payload) return [] as RiskSystem[];
+    const filtered = payload.systems.filter((system) => only === "all" || system.color === only);
+    return filtered;
+  }, [payload, only]);
+
+  const exportCsv = () => {
+    if (!systems.length) return;
+    const rows = systems.map((system) =>
+      [system.name, system.risk, system.burn, system.findings, system.cost, system.color, system.action.replace(/\n/g, " ")].join(","),
+    );
+    const csv = ["name,risk,burn,findings,cost,color,action", ...rows].join("\n");
+    const blob = new Blob([csv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `risk-${new Date().toISOString().slice(0, 10)}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const subscribe = async () => {
+    setMessage(null);
+    try {
+      const res = await fetch("/api/scorecard/risk/notify", { method: "POST" });
+      if (!res.ok) {
+        throw new Error(`Notify failed (${res.status})`);
+      }
+      setMessage({ kind: "success", text: "Digest sent to #exec." });
+    } catch (err) {
+      console.error(err);
+      setMessage({ kind: "error", text: "Unable to send Slack digest." });
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <Topbar title="Risk Heatmap" />
+      <main className="flex-1 space-y-6 bg-slate-950/80 px-4 py-6">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold text-white">Risk Heatmap</h1>
+            <p className="text-sm text-slate-400">Map reliability, security, and cost pressure by system.</p>
+            {payload?.stale && (
+              <span className="mt-2 inline-flex items-center rounded-full border border-amber-500/50 bg-amber-500/10 px-2 py-0.5 text-xs text-amber-200">
+                Stale – showing last good CloudWatch snapshot
+              </span>
+            )}
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <select
+              value={only}
+              onChange={(event) => setOnly(event.target.value as FilterValue)}
+              className="border border-slate-700 bg-slate-900 px-2 py-1 text-sm text-slate-100"
+            >
+              <option value="all">All</option>
+              <option value="red">Red</option>
+              <option value="yellow">Yellow</option>
+              <option value="green">Green</option>
+            </select>
+            <button
+              type="button"
+              onClick={exportCsv}
+              className="rounded bg-slate-800 px-2 py-1 text-xs text-slate-100 transition hover:bg-slate-700"
+            >
+              Export CSV
+            </button>
+            <button
+              type="button"
+              onClick={subscribe}
+              className="rounded bg-slate-800 px-2 py-1 text-xs text-slate-100 transition hover:bg-slate-700"
+            >
+              Send to #exec
+            </button>
+          </div>
+        </div>
+
+        {message && (
+          <div
+            className={`rounded border px-3 py-2 text-xs ${
+              message.kind === "success"
+                ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-200"
+                : "border-rose-500/40 bg-rose-500/10 text-rose-200"
+            }`}
+          >
+            {message.text}
+          </div>
+        )}
+
+        {error && (
+          <div className="rounded border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-sm text-rose-200">{error}</div>
+        )}
+
+        {loading && !error && <div className="text-sm text-slate-400">Loading…</div>}
+
+        {!loading && !error && (
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {systems.map((system) => (
+              <Card key={system.key} className={`border ${colorClass(system.color)} p-4 text-sm text-slate-100`}>
+                <div className="flex items-start justify-between">
+                  <div>
+                    <div className="text-base font-semibold text-white">{system.name}</div>
+                    <div className="text-xs uppercase tracking-wide text-slate-400">Risk {metric(system.risk)}</div>
+                  </div>
+                </div>
+                <div className="mt-3 space-y-1 text-xs text-slate-300">
+                  <div title="Error-budget burn vs 99.9% SLO, last 24h">Burn {metric(system.burn)}</div>
+                  <div title="Open critical/high issues normalized (0..2)">Find {metric(system.findings)}</div>
+                  <div title="Over forecast (0..1)">Cost {metric(system.cost)}</div>
+                </div>
+                <p className="mt-3 text-xs text-slate-200">{system.action}</p>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  {system.links?.g && (
+                    <a
+                      href={system.links.g}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="rounded bg-slate-100 px-2 py-1 text-xs font-medium text-slate-900"
+                    >
+                      Grafana
+                    </a>
+                  )}
+                  {system.links?.s && (
+                    <a
+                      href={system.links.s}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="rounded bg-slate-100 px-2 py-1 text-xs font-medium text-slate-900"
+                    >
+                      SecHub
+                    </a>
+                  )}
+                  {system.links?.c && (
+                    <a
+                      href={system.links.c}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="rounded bg-slate-100 px-2 py-1 text-xs font-medium text-slate-900"
+                    >
+                      Cost
+                    </a>
+                  )}
+                </div>
+              </Card>
+            ))}
+            {!systems.length && (
+              <div className="text-sm text-slate-400">No systems match this filter.</div>
+            )}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/asana-risk-heatmap.csv
+++ b/asana-risk-heatmap.csv
@@ -1,0 +1,6 @@
+Task Name,Description,Assignee Email,Section,Due Date
+Add deep links,"Env/JSON for Grafana, Security Hub, Cost per system; wire into API.",amundsonalexa@gmail.com,Today,2025-10-31
+UI drilldowns,"Buttons + tooltips + filters + CSV export on /scorecard/risk.",amundsonalexa@gmail.com,Today,2025-10-31
+Slack digest endpoint,"/api/scorecard/risk/notify posts Top 3 to #exec.",amundsonalexa@gmail.com,Today,2025-10-31
+Security feed job,"Nightly Security Hub/Snyk rollup → JSON.",amundsonalexa@gmail.com,This Week,2025-11-01
+Cost feed job,"Daily Cost Explorer rollup → JSON.",amundsonalexa@gmail.com,This Week,2025-11-01

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -1,11 +1,18 @@
 # Environment Variables
 
-| Name              | Description                                  | Default                                                                | Scope   |
-| ----------------- | -------------------------------------------- | ---------------------------------------------------------------------- | ------- |
-| `OPENAI_API_KEY`  | API key for OpenAI integrations              | _none_                                                                 | runtime |
-| `DATABASE_URL`    | Postgres connection string                   | `postgres://user:pass@db:5432/prism` <!-- pragma: allowlist secret --> | server  |
-| `S3_BUCKET`       | S3 bucket for artifacts                      | `prism-artifacts`                                                      | server  |
-| `PRISM_RUN_ALLOW` | Comma list of allowed executables for `/run` | `node`                                                                 | server  |
+| Name                  | Description                                                  | Default                                      | Scope   |
+| --------------------- | ------------------------------------------------------------ | -------------------------------------------- | ------- |
+| `OPENAI_API_KEY`      | API key for OpenAI integrations                              | _none_                                       | runtime |
+| `DATABASE_URL`        | Postgres connection string                                   | `postgres://user:pass@db:5432/prism` <!-- pragma: allowlist secret --> | server  |
+| `S3_BUCKET`           | S3 bucket for artifacts                                      | `prism-artifacts`                            | server  |
+| `PRISM_RUN_ALLOW`     | Comma list of allowed executables for `/run`                 | `node`                                       | server  |
+| `GRAFANA_PANEL_*`     | Grafana panel deep link per system key (e.g., `GRAFANA_PANEL_API`) | _none_                                       | portal  |
+| `SECHUB_LINK_*`       | AWS Security Hub deep link per system key                    | _none_                                       | portal  |
+| `COSTEXPLORER_LINK_*` | AWS Cost Explorer link per system key                        | _none_                                       | portal  |
+| `RISK_BURN_FEED_URL`  | Reliability burn feed (CloudWatch JSON or cached file)       | `portal/reports/risk_burn.json`              | portal  |
+| `SECURITY_FEED_URL`   | Security findings feed JSON (critical/high counts by system) | `portal/reports/security_feed.json`          | portal  |
+| `COST_FEED_URL`       | Cost feed JSON (actual vs. forecast by system)               | `portal/reports/cost_feed.json`              | portal  |
+| `SLACK_WEBHOOK`       | Incoming webhook for #exec digest                            | _none_                                       | portal  |
 
 Store secrets in a manager such as HashiCorp Vault or Doppler; avoid committing
 plain-text secrets. Populate values locally via `.env` and in production through

--- a/ops/next_push/slack_posts.md
+++ b/ops/next_push/slack_posts.md
@@ -52,3 +52,17 @@ Webhook optional for near-real-time freshness.
 
 GitHub PATs stored only as SSM SecureString refs; no plaintext DB storage.
 Upgrade path to GitHub App is prepped; rotates tokens automatically.
+
+## #exec — Risk heatmap drilldowns
+
+Risk Heatmap now clicks through:
+- “Grafana / SecHub / Cost” buttons on each system
+- Export CSV + quick Slack “Top 3 risks” digest
+Bookmark: app.blackroadinc.us/scorecard/risk
+
+## #eng — Grafana + findings wiring
+
+Red cards link straight to the exact Grafana panel and findings list.
+If a link feels off, ping here and we’ll fix the mapping JSON.
+
+Want me to wire PD “Create Incident” directly from a red card (one click opens a templated incident)?

--- a/portal/reports/cost_feed.json
+++ b/portal/reports/cost_feed.json
@@ -1,0 +1,9 @@
+{
+  "api": { "actual": 1320.5, "forecast": 1500 },
+  "ui": { "actual": 220.1, "forecast": 250 },
+  "ingest-gh": { "actual": 410.2, "forecast": 380 },
+  "ingest-lin": { "actual": 120.0, "forecast": 140 },
+  "ingest-str": { "actual": 305.5, "forecast": 290 },
+  "infra": { "actual": 980.0, "forecast": 950 },
+  "data": { "actual": 640.8, "forecast": 620 }
+}

--- a/portal/reports/risk_burn.json
+++ b/portal/reports/risk_burn.json
@@ -1,0 +1,9 @@
+{
+  "api": 1.3,
+  "ui": 0.5,
+  "ingest-gh": 1.5,
+  "ingest-lin": 0.6,
+  "ingest-str": 0.9,
+  "infra": 0.4,
+  "data": 0.8
+}

--- a/portal/reports/security_feed.json
+++ b/portal/reports/security_feed.json
@@ -1,0 +1,9 @@
+{
+  "api": 2,
+  "ui": 0,
+  "ingest-gh": 1,
+  "ingest-lin": 0,
+  "ingest-str": 1,
+  "infra": 0,
+  "data": 0
+}

--- a/scripts/portal/cost_feed.ts
+++ b/scripts/portal/cost_feed.ts
@@ -1,0 +1,114 @@
+import fs from "fs";
+import path from "path";
+
+type CostRecord = {
+  Keys?: string[];
+  Metrics?: Record<string, { Amount?: string; Unit?: string }>;
+  system?: string;
+  actual?: number;
+  forecast?: number;
+  value?: number;
+};
+
+type ForecastRecord = {
+  MeanValue?: string;
+  PredictionIntervalLowerBound?: string;
+  PredictionIntervalUpperBound?: string;
+};
+
+const SOURCE = process.env.COST_FEED_SOURCE ?? "portal/logs/cost_explorer.json";
+const FORECAST_SOURCE = process.env.COST_FORECAST_SOURCE ?? "portal/logs/cost_explorer_forecast.json";
+const OUTPUT = process.env.COST_FEED_OUTPUT ?? "portal/reports/cost_feed.json";
+
+function ensureDir(filePath: string) {
+  const dir = path.dirname(filePath);
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function readJson(filePath: string) {
+  if (!fs.existsSync(filePath)) return null;
+  const raw = fs.readFileSync(filePath, "utf-8");
+  if (!raw.trim()) return null;
+  return JSON.parse(raw);
+}
+
+function normalizeKey(raw: string | undefined) {
+  if (!raw) return "unknown";
+  const parts = raw.split("$");
+  return parts[parts.length - 1].toLowerCase();
+}
+
+function accumulate(records: CostRecord[] | undefined | null) {
+  const map = new Map<string, number>();
+  if (!records) return map;
+  for (const record of records) {
+    if (record.system) {
+      map.set(record.system, (map.get(record.system) ?? 0) + Number(record.actual ?? record.value ?? 0));
+      continue;
+    }
+    const key = normalizeKey(record.Keys?.[0]);
+    const amount = Number(record.Metrics?.AmortizedCost?.Amount ?? record.Metrics?.UnblendedCost?.Amount ?? record.value ?? 0);
+    map.set(key, (map.get(key) ?? 0) + amount);
+  }
+  return map;
+}
+
+function accumulateForecast(records: ForecastRecord[] | undefined | null) {
+  const map = new Map<string, number>();
+  if (!records) return map;
+  for (const record of records) {
+    const value = Number(record.MeanValue ?? 0);
+    if (Number.isFinite(value)) {
+      map.set("forecast", (map.get("forecast") ?? 0) + value);
+    }
+  }
+  return map;
+}
+
+function main() {
+  const actualSource = readJson(SOURCE);
+  const forecastSource = readJson(FORECAST_SOURCE);
+
+  const actualGroups: CostRecord[] | undefined = actualSource?.ResultsByTime?.flatMap((entry: any) => entry.Groups) ?? actualSource?.groups;
+  const forecastGroups: ForecastRecord[] | undefined = forecastSource?.ForecastResultsByTime ?? forecastSource?.forecast;
+
+  const actualMap = accumulate(actualGroups ?? actualSource);
+  const forecastMap = new Map<string, number>();
+
+  if (Array.isArray(actualSource)) {
+    for (const entry of actualSource as CostRecord[]) {
+      if (entry.system) {
+        forecastMap.set(entry.system, Number(entry.forecast ?? 0));
+      }
+    }
+  }
+
+  if (!forecastMap.size) {
+    const forecastTotal = accumulateForecast(forecastGroups);
+    const totalActual = Array.from(actualMap.values()).reduce((acc, value) => acc + value, 0);
+    if (forecastTotal.size && totalActual > 0) {
+      const totalForecast = forecastTotal.get("forecast") ?? 0;
+      const ratio = totalForecast / totalActual;
+      for (const [key, value] of actualMap.entries()) {
+        forecastMap.set(key, value * ratio);
+      }
+    }
+  }
+
+  const result: Record<string, { actual: number; forecast: number }> = {};
+  for (const [key, value] of actualMap.entries()) {
+    const forecast = forecastMap.get(key) ?? 0;
+    result[key] = {
+      actual: Number(value.toFixed(2)),
+      forecast: Number(forecast.toFixed(2)),
+    };
+  }
+
+  ensureDir(OUTPUT);
+  fs.writeFileSync(OUTPUT, JSON.stringify(result, null, 2));
+  console.log(`cost feed written to ${OUTPUT}`);
+}
+
+if (require.main === module) {
+  main();
+}

--- a/scripts/portal/security_feed.ts
+++ b/scripts/portal/security_feed.ts
@@ -1,0 +1,77 @@
+import fs from "fs";
+import path from "path";
+
+const SOURCE = process.env.SECURITY_FEED_SOURCE ?? "portal/logs/securityhub_findings.jsonl";
+const OUTPUT = process.env.SECURITY_FEED_OUTPUT ?? "portal/reports/security_feed.json";
+
+function ensureDir(filePath: string) {
+  const dir = path.dirname(filePath);
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+type Finding = {
+  severity?: string;
+  Severity?: { Label?: string };
+  ProductFields?: Record<string, unknown>;
+  Resources?: Array<{ Tags?: Record<string, string> }>;
+  [key: string]: unknown;
+};
+
+function resolveSystem(finding: Finding) {
+  const fromField = (finding.ProductFields?.System ?? finding.ProductFields?.system ?? finding["system"]) as string | undefined;
+  if (fromField && typeof fromField === "string") return fromField.toLowerCase();
+  const resource = finding.Resources?.find((item) => item?.Tags && typeof item.Tags.system === "string");
+  if (resource) {
+    return resource.Tags!.system.toLowerCase();
+  }
+  return "unknown";
+}
+
+function resolveSeverity(finding: Finding) {
+  const raw =
+    (typeof finding.severity === "string" && finding.severity) ||
+    (finding.Severity?.Label as string | undefined) ||
+    (finding["SeverityLabel"] as string | undefined);
+  return raw ? raw.toUpperCase() : "";
+}
+
+function readFindings(): Finding[] {
+  if (!fs.existsSync(SOURCE)) {
+    return [];
+  }
+  const text = fs.readFileSync(SOURCE, "utf-8");
+  if (!text.trim()) return [];
+  return text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      try {
+        return JSON.parse(line) as Finding;
+      } catch (error) {
+        console.warn(`[security-feed] unable to parse line: ${line}`);
+        return null;
+      }
+    })
+    .filter((value): value is Finding => Boolean(value));
+}
+
+function main() {
+  const findings = readFindings();
+  const counts: Record<string, number> = {};
+
+  for (const finding of findings) {
+    const severity = resolveSeverity(finding);
+    if (severity !== "CRITICAL" && severity !== "HIGH") continue;
+    const system = resolveSystem(finding);
+    counts[system] = (counts[system] ?? 0) + 1;
+  }
+
+  ensureDir(OUTPUT);
+  fs.writeFileSync(OUTPUT, JSON.stringify(counts, null, 2));
+  console.log(`security feed written to ${OUTPUT}`);
+}
+
+if (require.main === module) {
+  main();
+}


### PR DESCRIPTION
## Summary
- add a risk scorecard service and notify endpoint that attach deep links, clamp metrics, and cache the last healthy payload
- build the /scorecard/risk UI with filters, CSV export, link buttons, tooltips, and a Slack digest trigger
- script nightly security and daily cost feeds, seed example outputs, document env variables, and capture follow-up comms/tasks

## Testing
- npm --prefix apps/portals run lint *(fails: local Next.js binary not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e8577d2a0883299cbe1c614bebfaf1