### PR TITLE
Add PagerDuty ops workflow automation

### DIFF
--- a/app/api/pd/audit/route.ts
+++ b/app/api/pd/audit/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getRecentIncidentEvents } from "@/lib/ops/db";
+import { requireOpsAccess } from "@/lib/ops/auth";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  try {
+    requireOpsAccess(req);
+    const events = getRecentIncidentEvents(10);
+    return NextResponse.json({ events });
+  } catch (err: any) {
+    if (String(err?.message || err) === "forbidden") {
+      return NextResponse.json({ error: "forbidden" }, { status: 403 });
+    }
+    return NextResponse.json(
+      { error: "server_error", details: String(err?.message || err) },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/pd/bulk/route.ts
+++ b/app/api/pd/bulk/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireOpsAccess } from "@/lib/ops/auth";
+import { getRiskSnapshot } from "@/lib/ops/risk";
+import { getBulkThreshold } from "@/lib/ops/config";
+import { createPagerDutyIncident } from "@/lib/ops/pagerduty";
+import { getLastCreateForSystem, getOpenIncidentForSystem } from "@/lib/ops/db";
+
+const BULK_SYSTEM_KEY = "bulk";
+const FIVE_MINUTES = 5 * 60 * 1000;
+
+export async function POST(req: NextRequest) {
+  try {
+    const { email } = requireOpsAccess(req);
+    const snapshot = getRiskSnapshot();
+    const yellow = snapshot.systems.filter((s) => s.color === "yellow");
+    const threshold = getBulkThreshold();
+
+    if (yellow.length < threshold) {
+      return NextResponse.json({ ok: false, reason: "threshold_not_met", count: yellow.length });
+    }
+
+    const open = getOpenIncidentForSystem(BULK_SYSTEM_KEY);
+    if (open?.pdIncidentId && open.url) {
+      return NextResponse.json({
+        ok: true,
+        dedup: true,
+        incidentId: open.pdIncidentId,
+        url: open.url,
+      });
+    }
+
+    const last = getLastCreateForSystem(BULK_SYSTEM_KEY);
+    if (last?.createdAt) {
+      const lastTs = Date.parse(last.createdAt);
+      if (!Number.isNaN(lastTs) && Date.now() - lastTs < FIVE_MINUTES) {
+        return NextResponse.json(
+          { error: "already_opened_recently", retryAt: new Date(lastTs + FIVE_MINUTES).toISOString() },
+          { status: 409 }
+        );
+      }
+    }
+
+    const tasks = yellow
+      .map((s) => `- ${s.name}: ${s.action} (risk ${s.risk.toFixed(2)})`)
+      .join("\n");
+
+    const details = `Multiple medium risks detected:\n${tasks}`;
+
+    const result = await createPagerDutyIncident({
+      systemKey: BULK_SYSTEM_KEY,
+      title: `Risk sweep: ${yellow.length} yellow systems`,
+      details,
+      actorEmail: email,
+      metadata: {
+        bulk: true,
+        systems: yellow.map((s) => s.key),
+        threshold,
+      },
+    });
+
+    return NextResponse.json({ ok: true, incidentId: result.incidentId, url: result.url });
+  } catch (err: any) {
+    const message = String(err?.message || err);
+    if (message === "forbidden") {
+      return NextResponse.json({ error: "forbidden" }, { status: 403 });
+    }
+    if (message === "pd_env_missing") {
+      return NextResponse.json({ error: "pd_env_missing" }, { status: 500 });
+    }
+    if (message.startsWith("pd_error")) {
+      return NextResponse.json({ error: "pd_error", details: message }, { status: 502 });
+    }
+    if (message.startsWith("pd_config_missing")) {
+      return NextResponse.json({ error: "pd_config_missing" }, { status: 400 });
+    }
+    return NextResponse.json({ error: "server_error", details: message }, { status: 500 });
+  }
+}

--- a/app/api/pd/create/route.ts
+++ b/app/api/pd/create/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireOpsAccess } from "@/lib/ops/auth";
+import { getLastCreateForSystem, getOpenIncidentForSystem } from "@/lib/ops/db";
+import { createPagerDutyIncident } from "@/lib/ops/pagerduty";
+import { getRunbookUrl } from "@/lib/ops/config";
+
+const FIVE_MINUTES = 5 * 60 * 1000;
+
+export async function POST(req: NextRequest) {
+  try {
+    const { email } = requireOpsAccess(req);
+    const body = await req.json();
+    const { systemKey, title, details, overrideUrgency, metadata } = body || {};
+
+    if (!systemKey || typeof systemKey !== "string") {
+      return NextResponse.json({ error: "invalid_system" }, { status: 400 });
+    }
+
+    if (!title || typeof title !== "string") {
+      return NextResponse.json({ error: "invalid_title" }, { status: 400 });
+    }
+
+    const existing = getOpenIncidentForSystem(systemKey);
+    if (existing?.pdIncidentId && existing.url) {
+      return NextResponse.json({
+        ok: true,
+        dedup: true,
+        url: existing.url,
+        incidentId: existing.pdIncidentId,
+        openedAt: existing.createdAt,
+      });
+    }
+
+    const lastCreate = getLastCreateForSystem(systemKey);
+    if (lastCreate?.createdAt) {
+      const lastTs = Date.parse(lastCreate.createdAt);
+      if (!Number.isNaN(lastTs) && Date.now() - lastTs < FIVE_MINUTES) {
+        const retryAt = new Date(lastTs + FIVE_MINUTES).toISOString();
+        return NextResponse.json(
+          { error: "already_opened_recently", retryAt },
+          { status: 409 }
+        );
+      }
+    }
+
+    const result = await createPagerDutyIncident({
+      systemKey,
+      title,
+      details,
+      overrideUrgency,
+      actorEmail: email,
+      metadata: {
+        ...((metadata && typeof metadata === "object") ? metadata : {}),
+        source: "ops_portal",
+        runbook: getRunbookUrl(systemKey) || undefined,
+      },
+    });
+
+    return NextResponse.json({ ok: true, incidentId: result.incidentId, url: result.url });
+  } catch (err: any) {
+    const message = String(err?.message || err);
+    if (message === "forbidden") {
+      return NextResponse.json({ error: "forbidden" }, { status: 403 });
+    }
+    if (message === "pd_env_missing") {
+      return NextResponse.json({ error: "pd_env_missing" }, { status: 500 });
+    }
+    if (message.startsWith("pd_config_missing")) {
+      return NextResponse.json({ error: "pd_config_missing" }, { status: 400 });
+    }
+    if (message.startsWith("pd_error")) {
+      return NextResponse.json({ error: "pd_error", details: message }, { status: 502 });
+    }
+    return NextResponse.json({ error: "server_error", details: message }, { status: 500 });
+  }
+}

--- a/app/api/pd/resolve/route.ts
+++ b/app/api/pd/resolve/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireOpsAccess } from "@/lib/ops/auth";
+import { resolvePagerDutyIncident } from "@/lib/ops/pagerduty";
+import { postSlackMessage } from "@/lib/ops/slack";
+
+export async function POST(req: NextRequest) {
+  try {
+    const { email } = requireOpsAccess(req);
+    const { incidentId, postmortemUrl } = await req.json();
+    if (!incidentId || typeof incidentId !== "string") {
+      return NextResponse.json({ error: "invalid_incident" }, { status: 400 });
+    }
+
+    await resolvePagerDutyIncident({ incidentId, actorEmail: email, postmortemUrl });
+
+    await postSlackMessage(`✅ PD incident resolved: ${incidentId}\n${postmortemUrl || ""}`);
+
+    return NextResponse.json({ ok: true });
+  } catch (err: any) {
+    const message = String(err?.message || err);
+    if (message === "forbidden") {
+      return NextResponse.json({ error: "forbidden" }, { status: 403 });
+    }
+    if (message.startsWith("pd_error")) {
+      return NextResponse.json({ error: "pd_error", details: message }, { status: 502 });
+    }
+    if (message === "pd_env_missing") {
+      return NextResponse.json({ error: "pd_env_missing" }, { status: 500 });
+    }
+    return NextResponse.json({ error: "server_error", details: message }, { status: 500 });
+  }
+}

--- a/app/api/scorecard/risk/route.ts
+++ b/app/api/scorecard/risk/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { getRiskSnapshot } from "@/lib/ops/risk";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    const snapshot = getRiskSnapshot();
+    return NextResponse.json({ systems: snapshot.systems, generatedAt: snapshot.generatedAt });
+  } catch (err: any) {
+    return NextResponse.json(
+      { error: "server_error", details: String(err?.message || err) },
+      { status: 500 }
+    );
+  }
+}

--- a/app/ops/components/Heatmap.tsx
+++ b/app/ops/components/Heatmap.tsx
@@ -1,0 +1,338 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import type { CSSProperties } from "react";
+import type { RiskSystem } from "@/lib/ops/risk";
+import type { IncidentAuditRecord } from "@/lib/ops/db";
+
+interface Props {
+  initialSystems: RiskSystem[];
+  initialAudit: IncidentAuditRecord[];
+  generatedAt: string;
+}
+
+interface OpsUser {
+  email: string;
+  groups: string;
+}
+
+const STORAGE_KEY = "ops-portal-user";
+
+export default function Heatmap({ initialSystems, initialAudit, generatedAt }: Props) {
+  const [systems, setSystems] = useState(initialSystems);
+  const [audit, setAudit] = useState(initialAudit);
+  const [user, setUser] = useState<OpsUser | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        if (parsed?.email) {
+          setUser(parsed);
+        }
+      }
+    } catch (err) {
+      console.warn("failed to load ops user", err);
+    }
+  }, []);
+
+  const hasOpsAccess = useMemo(() => Boolean(user?.email && user?.groups), [user]);
+
+  function withUserHeaders(headers: Record<string, string> = {}) {
+    const next: Record<string, string> = { ...headers };
+    if (user?.email) next["x-user-email"] = user.email;
+    if (user?.groups) next["x-user-groups"] = user.groups;
+    return next;
+  }
+
+  async function refresh() {
+    setLoading(true);
+    setError(null);
+    try {
+      const [riskRes, auditRes] = await Promise.all([
+        fetch("/api/scorecard/risk"),
+        hasOpsAccess
+          ? fetch("/api/pd/audit", { headers: withUserHeaders() })
+          : Promise.resolve(new Response(JSON.stringify({ events: [] })))
+      ]);
+
+      if (!riskRes.ok) {
+        throw new Error(`risk_fetch_${riskRes.status}`);
+      }
+      const riskData = await riskRes.json();
+      setSystems(Array.isArray(riskData.systems) ? riskData.systems : []);
+
+      if (auditRes.ok) {
+        const auditData = await auditRes.json();
+        if (Array.isArray(auditData.events)) {
+          setAudit(auditData.events);
+        }
+      }
+    } catch (err: any) {
+      setError(String(err?.message || err));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleResolve(system: RiskSystem) {
+    if (!hasOpsAccess || !system.pdIncidentId) {
+      return;
+    }
+    const postmortemUrl = window.prompt("Post-mortem URL (optional):") || "";
+    setMessage(null);
+    setError(null);
+    try {
+      const res = await fetch("/api/pd/resolve", {
+        method: "POST",
+        headers: withUserHeaders({ "Content-Type": "application/json" }),
+        body: JSON.stringify({ incidentId: system.pdIncidentId, postmortemUrl }),
+      });
+      const data = await res.json();
+      if (!res.ok || !data.ok) {
+        throw new Error(data?.details || data?.error || "pd_resolve_failed");
+      }
+      setMessage(`Resolved PD incident ${system.pdIncidentId}`);
+      await refresh();
+    } catch (err: any) {
+      setError(String(err?.message || err));
+    }
+  }
+
+  async function handleCreate(system: RiskSystem) {
+    if (!hasOpsAccess) return;
+    setMessage(null);
+    setError(null);
+    try {
+      const payload = {
+        systemKey: system.key,
+        title: `${system.name}: ${system.action}`,
+        details: `Risk score ${system.risk.toFixed(2)}\nOwner: ${system.owner || "n/a"}`,
+      };
+      const res = await fetch("/api/pd/create", {
+        method: "POST",
+        headers: withUserHeaders({ "Content-Type": "application/json" }),
+        body: JSON.stringify(payload),
+      });
+      const data = await res.json();
+      if (res.status === 409) {
+        throw new Error(data?.error || "already_opened_recently");
+      }
+      if (!res.ok) {
+        throw new Error(data?.details || data?.error || "pd_create_failed");
+      }
+      if (data?.dedup) {
+        setMessage(`Reusing PD incident ${data.incidentId}`);
+      } else {
+        setMessage(`Created PD incident ${data.incidentId}`);
+      }
+      await refresh();
+    } catch (err: any) {
+      setError(String(err?.message || err));
+    }
+  }
+
+  async function handleBulk() {
+    if (!hasOpsAccess) return;
+    setMessage(null);
+    setError(null);
+    try {
+      const res = await fetch("/api/pd/bulk", {
+        method: "POST",
+        headers: withUserHeaders({ "Content-Type": "application/json" }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        if (data?.reason === "threshold_not_met") {
+          setMessage("Threshold not met for sweep");
+          return;
+        }
+        throw new Error(data?.details || data?.error || "pd_bulk_failed");
+      }
+      if (data?.dedup) {
+        setMessage(`Reusing sweep PD incident ${data.incidentId}`);
+      } else {
+        setMessage(`Opened sweep PD incident ${data.incidentId}`);
+      }
+      await refresh();
+    } catch (err: any) {
+      setError(String(err?.message || err));
+    }
+  }
+
+  function updateUser(next: OpsUser) {
+    setUser(next);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+    }
+  }
+
+  return (
+    <section style={{ display: "grid", gridTemplateColumns: "2fr 1fr", gap: "2rem" }}>
+      <div>
+        <div style={{ display: "flex", alignItems: "center", gap: "1rem", marginBottom: "1rem" }}>
+          <UserForm value={user} onChange={updateUser} />
+          <button onClick={refresh} disabled={loading} style={buttonStyle}>
+            {loading ? "Refreshing…" : "Refresh"}
+          </button>
+          <button
+            onClick={handleBulk}
+            disabled={!hasOpsAccess || loading}
+            style={{ ...buttonStyle, backgroundColor: "#f59e0b", color: "#0f172a" }}
+          >
+            Open PD Sweep
+          </button>
+          <span style={{ fontSize: "0.85rem", color: "#64748b" }}>
+            Snapshot: {new Date(generatedAt).toLocaleString()}
+          </span>
+        </div>
+        {message && <p style={{ color: "#16a34a", marginBottom: "0.75rem" }}>{message}</p>}
+        {error && <p style={{ color: "#f87171", marginBottom: "0.75rem" }}>{error}</p>}
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(260px, 1fr))", gap: "1rem" }}>
+          {systems.map((system) => (
+            <article key={system.key} style={{
+              borderRadius: "12px",
+              padding: "1rem",
+              background: cardColor(system.color),
+              color: "#0f172a",
+              boxShadow: "0 8px 16px rgba(15, 23, 42, 0.15)",
+            }}>
+              <header style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                <div>
+                  <h2 style={{ margin: 0, fontSize: "1.1rem", fontWeight: 600 }}>{system.name}</h2>
+                  <p style={{ margin: 0, fontSize: "0.85rem" }}>Risk {system.risk.toFixed(2)}</p>
+                </div>
+                <span style={{ fontSize: "0.75rem", fontWeight: 500 }}>{system.color.toUpperCase()}</span>
+              </header>
+              <p style={{ marginTop: "0.75rem", fontSize: "0.9rem" }}>{system.action}</p>
+              {system.owner && (
+                <p style={{ marginTop: "0.25rem", fontSize: "0.8rem", color: "#1e293b" }}>Owner: {system.owner}</p>
+              )}
+              {system.pdIncidentId ? (
+                <p style={{ marginTop: "0.5rem", fontSize: "0.8rem" }}>
+                  PD: <a href={system.pdUrl || "#"} target="_blank" rel="noreferrer">{system.pdIncidentId}</a>
+                  {system.openedAt && (
+                    <span style={{ marginLeft: "0.25rem", color: "#475569" }}>
+                      (opened {new Date(system.openedAt).toLocaleString()})
+                    </span>
+                  )}
+                </p>
+              ) : (
+                <p style={{ marginTop: "0.5rem", fontSize: "0.8rem", color: "#475569" }}>No open PD incident</p>
+              )}
+              <div style={{ marginTop: "0.75rem", display: "flex", gap: "0.5rem", flexWrap: "wrap" }}>
+                <button
+                  onClick={() => handleCreate(system)}
+                  disabled={!hasOpsAccess || loading}
+                  style={{ ...buttonStyle, backgroundColor: "#2563eb", color: "white" }}
+                >
+                  Open PD
+                </button>
+                {system.color === "red" && system.pdIncidentId && (
+                  <button
+                    onClick={() => handleResolve(system)}
+                    disabled={!hasOpsAccess || loading}
+                    style={{ ...buttonStyle, backgroundColor: "#22c55e", color: "#0f172a" }}
+                  >
+                    Resolve PD
+                  </button>
+                )}
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+      <aside>
+        <h3 style={{ fontSize: "1.1rem", fontWeight: 600, marginBottom: "0.75rem" }}>Recent PD ops</h3>
+        <div style={{ borderRadius: "12px", border: "1px solid #cbd5f5", padding: "0.75rem", maxHeight: "28rem", overflowY: "auto" }}>
+          {audit.length === 0 && <p style={{ fontSize: "0.85rem", color: "#64748b" }}>No recent actions.</p>}
+          {audit.map((event) => (
+            <div key={event.id} style={{ marginBottom: "0.75rem" }}>
+              <div style={{ fontSize: "0.8rem", color: "#475569" }}>
+                {new Date(event.createdAt).toLocaleString()} · {event.actorEmail}
+              </div>
+              <div style={{ fontSize: "0.9rem", fontWeight: 500 }}>
+                {event.action.toUpperCase()} {event.systemKey ? `(${event.systemKey})` : ""}
+              </div>
+              {event.pdIncidentId && (
+                <div style={{ fontSize: "0.8rem" }}>PD: {event.pdIncidentId}</div>
+              )}
+            </div>
+          ))}
+        </div>
+      </aside>
+    </section>
+  );
+}
+
+function cardColor(color: RiskSystem["color"]): string {
+  switch (color) {
+    case "red":
+      return "#fee2e2";
+    case "yellow":
+      return "#fef3c7";
+    default:
+      return "#dcfce7";
+  }
+}
+
+function UserForm({ value, onChange }: { value: OpsUser | null; onChange: (next: OpsUser) => void }) {
+  const [local, setLocal] = useState<OpsUser>({ email: value?.email || "", groups: value?.groups || "Ops" });
+
+  useEffect(() => {
+    setLocal({ email: value?.email || "", groups: value?.groups || "Ops" });
+  }, [value?.email, value?.groups]);
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        onChange(local);
+      }}
+      style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}
+    >
+      <input
+        type="email"
+        required
+        placeholder="ops@blackroadinc.us"
+        value={local.email}
+        onChange={(e) => setLocal((prev) => ({ ...prev, email: e.target.value }))}
+        style={inputStyle}
+      />
+      <input
+        type="text"
+        required
+        placeholder="Ops,Security"
+        value={local.groups}
+        onChange={(e) => setLocal((prev) => ({ ...prev, groups: e.target.value }))}
+        style={inputStyle}
+      />
+      <button type="submit" style={buttonStyle}>
+        Save
+      </button>
+    </form>
+  );
+}
+
+const buttonStyle: CSSProperties = {
+  padding: "0.5rem 0.9rem",
+  borderRadius: "9999px",
+  border: "none",
+  cursor: "pointer",
+  fontSize: "0.85rem",
+  fontWeight: 600,
+  backgroundColor: "#e2e8f0",
+  color: "#0f172a",
+};
+
+const inputStyle: CSSProperties = {
+  padding: "0.45rem 0.75rem",
+  borderRadius: "8px",
+  border: "1px solid #cbd5f5",
+  fontSize: "0.85rem",
+};

--- a/app/ops/page.tsx
+++ b/app/ops/page.tsx
@@ -1,0 +1,19 @@
+import Heatmap from "./components/Heatmap";
+import { getRiskSnapshot } from "@/lib/ops/risk";
+import { getRecentIncidentEvents } from "@/lib/ops/db";
+
+export const dynamic = "force-dynamic";
+
+export default async function OpsPage() {
+  const snapshot = getRiskSnapshot();
+  const audit = getRecentIncidentEvents(10);
+
+  return (
+    <main style={{ padding: "2rem", fontFamily: "Inter, sans-serif" }}>
+      <header style={{ display: "flex", alignItems: "center", gap: "1rem", marginBottom: "1.5rem" }}>
+        <h1 style={{ fontSize: "1.75rem", fontWeight: 600 }}>Ops Heatmap</h1>
+      </header>
+      <Heatmap initialSystems={snapshot.systems} initialAudit={audit} generatedAt={snapshot.generatedAt} />
+    </main>
+  );
+}

--- a/asana/pd_workflow.csv
+++ b/asana/pd_workflow.csv
@@ -1,0 +1,6 @@
+Task Name,Description,Assignee Email,Section,Due Date
+PD auto-assign map,Add per-system assignees + EP + urgency config.,amundsonalexa@gmail.com,Today,2025-10-31
+Resolve endpoint,/api/pd/resolve to close incidents with post-mortem link.,amundsonalexa@gmail.com,Today,2025-10-31
+Bulk PD sweep,/api/pd/bulk to open coordination incident when ≥3 yellow.,amundsonalexa@gmail.com,Today,2025-10-31
+Throttle & dedupe,Server-side limit + open-incident reuse per system.,amundsonalexa@gmail.com,Today,2025-10-31
+Audit & UI,Show PD status on cards; list last 10 PD ops on /ops.,amundsonalexa@gmail.com,Today,2025-10-31

--- a/config/pagerduty.json
+++ b/config/pagerduty.json
@@ -1,0 +1,34 @@
+{
+  "systems": {
+    "default": {
+      "serviceId": "PD_SERVICE_DEFAULT",
+      "escalationPolicyId": "EP_DEFAULT",
+      "assignees": [],
+      "urgency": "low"
+    },
+    "api": {
+      "serviceId": "PD_SERVICE_API",
+      "escalationPolicyId": "EP_API",
+      "assignees": ["PDU123", "PDU456"],
+      "urgency": "high"
+    },
+    "ui": {
+      "serviceId": "PD_SERVICE_UI",
+      "escalationPolicyId": "EP_UI",
+      "assignees": ["PDU789"],
+      "urgency": "low"
+    },
+    "bulk": {
+      "serviceId": "PD_SERVICE_API",
+      "escalationPolicyId": "EP_API",
+      "assignees": ["PDU123"],
+      "urgency": "high"
+    }
+  },
+  "runbooks": {
+    "api": "https://notion.so/.../API-Incident-Runbook",
+    "ui": "https://notion.so/.../UI-Incident-Runbook",
+    "ingest-gh": "https://notion.so/.../Ingest-GitHub-Runbook",
+    "bulk": "https://notion.so/.../Ops-Risk-Sweep"
+  }
+}

--- a/data/ops/risk-snapshot.json
+++ b/data/ops/risk-snapshot.json
@@ -1,0 +1,37 @@
+{
+  "generatedAt": "2025-02-01T00:00:00Z",
+  "systems": [
+    {
+      "key": "api",
+      "name": "Public API",
+      "color": "red",
+      "risk": 0.92,
+      "action": "Rate-limit spikes impacting checkout",
+      "owner": "Ops"
+    },
+    {
+      "key": "ui",
+      "name": "Web UI",
+      "color": "yellow",
+      "risk": 0.66,
+      "action": "Audit stale feature flags",
+      "owner": "Ops"
+    },
+    {
+      "key": "ingest-gh",
+      "name": "GitHub Ingest",
+      "color": "yellow",
+      "risk": 0.61,
+      "action": "Requeue stalled repo syncs",
+      "owner": "Data Platform"
+    },
+    {
+      "key": "billing",
+      "name": "Billing",
+      "color": "green",
+      "risk": 0.21,
+      "action": "Continue monitoring nightly jobs",
+      "owner": "FinOps"
+    }
+  ]
+}

--- a/db/migrations/202503010000_ops_pd.sql
+++ b/db/migrations/202503010000_ops_pd.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS ops_incident_audit (
+  id TEXT PRIMARY KEY,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  actor_email TEXT NOT NULL,
+  action TEXT NOT NULL CHECK (action IN ('create','resolve','bulk')),
+  system_key TEXT,
+  pd_incident_id TEXT,
+  url TEXT,
+  payload_hash TEXT,
+  details TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_ops_incident_system_created_at
+  ON ops_incident_audit(system_key, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_ops_incident_pd_created_at
+  ON ops_incident_audit(pd_incident_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_ops_incident_action_created_at
+  ON ops_incident_audit(action, created_at DESC);

--- a/docs/pd-workflow-slack.md
+++ b/docs/pd-workflow-slack.md
@@ -1,0 +1,14 @@
+# PagerDuty workflow rollout blurbs
+
+## #releases
+
+PD workflow complete:
+- Red card → Create PD with auto-assignees & runbook
+- Resolve PD from the Heatmap (adds post-mortem link)
+- “PD Sweep” opens one coordination incident if multiple yellows
+- Spam guard prevents duplicate incidents
+
+## #security
+
+PD API token stays in SSM; endpoints are Ops/Sec only and audited.
+Auto-assign maps by system; tweak assignees/urgency in config.

--- a/lib/ops/auth.ts
+++ b/lib/ops/auth.ts
@@ -1,0 +1,37 @@
+import { NextRequest } from "next/server";
+
+export interface OpsContext {
+  email: string;
+  groups: string[];
+}
+
+const allowedGroups = new Set(["ops", "security"]);
+
+function parseGroups(header: string | null): string[] {
+  if (!header) return [];
+  return header
+    .split(",")
+    .map((g) => g.trim())
+    .filter(Boolean);
+}
+
+export function requireOpsAccess(req: NextRequest): OpsContext {
+  const email = (req.headers.get("x-user-email") || "").trim();
+  const groups = parseGroups(req.headers.get("x-user-groups"));
+  const normalized = groups.map((g) => g.toLowerCase());
+  const hasGroup = normalized.some((g) => allowedGroups.has(g));
+
+  const domainOk = email.endsWith("@blackroadinc.us");
+
+  const devBypass =
+    process.env.NODE_ENV !== "production" && process.env.PD_DEV_BYPASS === "1";
+
+  if ((hasGroup && domainOk) || devBypass) {
+    return {
+      email: email || process.env.PD_DEV_EMAIL || "ops@blackroadinc.us",
+      groups,
+    };
+  }
+
+  throw new Error("forbidden");
+}

--- a/lib/ops/config.ts
+++ b/lib/ops/config.ts
@@ -1,0 +1,85 @@
+import fs from "fs";
+import path from "path";
+
+type Urgency = "high" | "low";
+
+export interface SystemPagerDutyConfig {
+  serviceId: string;
+  escalationPolicyId?: string;
+  assignees?: string[];
+  urgency?: Urgency;
+}
+
+export interface PagerDutyConfig {
+  systems: Record<string, SystemPagerDutyConfig>;
+  runbooks?: Record<string, string>;
+}
+
+let cachedConfig: PagerDutyConfig | null = null;
+
+function readConfigFromEnv(): PagerDutyConfig | null {
+  const raw = process.env.PD_SYSTEM_MAP;
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    if (typeof parsed === "object" && parsed) {
+      const { systems = {}, runbooks = {} } = parsed as PagerDutyConfig;
+      return { systems, runbooks };
+    }
+  } catch (err) {
+    console.error("[pd] failed to parse PD_SYSTEM_MAP env", err);
+  }
+  return null;
+}
+
+function readConfigFromFile(): PagerDutyConfig {
+  const explicit = process.env.PD_CONFIG_PATH;
+  const candidates = [
+    explicit,
+    path.join(process.cwd(), "config", "pagerduty.json"),
+  ].filter((p): p is string => Boolean(p));
+
+  for (const file of candidates) {
+    try {
+      const raw = fs.readFileSync(file, "utf-8");
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === "object") {
+        const { systems = {}, runbooks = {} } = parsed as PagerDutyConfig;
+        return { systems, runbooks };
+      }
+    } catch (err) {
+      // try next candidate
+    }
+  }
+
+  return { systems: {}, runbooks: {} };
+}
+
+export function loadPagerDutyConfig(): PagerDutyConfig {
+  if (!cachedConfig) {
+    cachedConfig = readConfigFromEnv() ?? readConfigFromFile();
+  }
+  return cachedConfig;
+}
+
+export function getSystemPagerDutyConfig(systemKey: string): SystemPagerDutyConfig | undefined {
+  const cfg = loadPagerDutyConfig();
+  return cfg.systems[systemKey] ?? cfg.systems["default"];
+}
+
+export function getRunbookUrl(systemKey: string): string | undefined {
+  const cfg = loadPagerDutyConfig();
+  const map = cfg.runbooks ?? {};
+  return map[systemKey] ?? map["default"] ?? process.env.RUNBOOK_URL;
+}
+
+export function getBulkThreshold(): number {
+  const raw = process.env.PD_BULK_THRESHOLD;
+  const parsed = raw ? Number.parseInt(raw, 10) : NaN;
+  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  return 3;
+}
+
+export function resetPagerDutyConfigCache(): void {
+  cachedConfig = null;
+}

--- a/lib/ops/db.ts
+++ b/lib/ops/db.ts
@@ -1,0 +1,171 @@
+import fs from "fs";
+import path from "path";
+import Database from "better-sqlite3";
+import { randomUUID } from "crypto";
+
+export type IncidentAction = "create" | "resolve" | "bulk";
+
+export interface IncidentAuditRecord {
+  id: string;
+  createdAt: string;
+  actorEmail: string;
+  action: IncidentAction;
+  systemKey: string | null;
+  pdIncidentId: string | null;
+  url: string | null;
+  payloadHash: string | null;
+  details: string | null;
+}
+
+const defaultDbPath = process.env.DB_PATH || "/srv/blackroad-api/blackroad.db";
+const dbPath = process.env.PD_DB_PATH || defaultDbPath;
+
+fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+
+const db = new Database(dbPath);
+
+db.pragma("journal_mode = WAL");
+db.pragma("foreign_keys = ON");
+
+db.exec(`
+  CREATE TABLE IF NOT EXISTS ops_incident_audit (
+    id TEXT PRIMARY KEY,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    actor_email TEXT NOT NULL,
+    action TEXT NOT NULL CHECK (action IN ('create','resolve','bulk')),
+    system_key TEXT,
+    pd_incident_id TEXT,
+    url TEXT,
+    payload_hash TEXT,
+    details TEXT
+  );
+`);
+
+db.exec(`
+  CREATE INDEX IF NOT EXISTS idx_ops_incident_system_created_at
+    ON ops_incident_audit(system_key, created_at DESC);
+`);
+
+db.exec(`
+  CREATE INDEX IF NOT EXISTS idx_ops_incident_pd_created_at
+    ON ops_incident_audit(pd_incident_id, created_at DESC);
+`);
+
+db.exec(`
+  CREATE INDEX IF NOT EXISTS idx_ops_incident_action_created_at
+    ON ops_incident_audit(action, created_at DESC);
+`);
+
+const insertStmt = db.prepare(
+  `INSERT INTO ops_incident_audit (
+      id, actor_email, action, system_key, pd_incident_id, url, payload_hash, details
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+);
+
+const recentStmt = db.prepare(
+  `SELECT id, created_at, actor_email, action, system_key, pd_incident_id, url, payload_hash, details
+   FROM ops_incident_audit
+   ORDER BY datetime(created_at) DESC
+   LIMIT ?`
+);
+
+const lastCreateStmt = db.prepare(
+  `SELECT id, created_at, actor_email, action, system_key, pd_incident_id, url, payload_hash, details
+   FROM ops_incident_audit
+   WHERE system_key = ?
+     AND action IN ('create','bulk')
+   ORDER BY datetime(created_at) DESC
+   LIMIT 1`
+);
+
+const openIncidentStmt = db.prepare(
+  `SELECT base.id, base.created_at, base.actor_email, base.action, base.system_key,
+          base.pd_incident_id, base.url, base.payload_hash, base.details
+   FROM ops_incident_audit base
+   WHERE base.system_key = ?
+     AND base.action IN ('create','bulk')
+     AND NOT EXISTS (
+       SELECT 1 FROM ops_incident_audit r
+       WHERE r.pd_incident_id = base.pd_incident_id
+         AND r.action = 'resolve'
+         AND datetime(r.created_at) >= datetime(base.created_at)
+     )
+   ORDER BY datetime(base.created_at) DESC
+   LIMIT 1`
+);
+
+const findSystemByIncidentStmt = db.prepare(
+  `SELECT system_key
+   FROM ops_incident_audit
+   WHERE pd_incident_id = ?
+     AND action IN ('create','bulk')
+   ORDER BY datetime(created_at) DESC
+   LIMIT 1`
+);
+
+export function logIncidentEvent(args: {
+  actorEmail: string;
+  action: IncidentAction;
+  systemKey?: string | null;
+  pdIncidentId?: string | null;
+  url?: string | null;
+  payloadHash?: string | null;
+  details?: string | null;
+}): IncidentAuditRecord {
+  const id = randomUUID();
+  const {
+    actorEmail,
+    action,
+    systemKey = null,
+    pdIncidentId = null,
+    url = null,
+    payloadHash = null,
+    details = null,
+  } = args;
+  insertStmt.run(id, actorEmail, action, systemKey, pdIncidentId, url, payloadHash, details);
+  return {
+    id,
+    createdAt: new Date().toISOString(),
+    actorEmail,
+    action,
+    systemKey,
+    pdIncidentId,
+    url,
+    payloadHash,
+    details,
+  };
+}
+
+export function getRecentIncidentEvents(limit = 10): IncidentAuditRecord[] {
+  const rows = recentStmt.all(limit);
+  return rows.map(mapRow);
+}
+
+export function getLastCreateForSystem(systemKey: string): IncidentAuditRecord | null {
+  const row = lastCreateStmt.get(systemKey);
+  return row ? mapRow(row) : null;
+}
+
+export function getOpenIncidentForSystem(systemKey: string): IncidentAuditRecord | null {
+  const row = openIncidentStmt.get(systemKey);
+  return row ? mapRow(row) : null;
+}
+
+export function getSystemForIncidentId(pdIncidentId: string): string | null {
+  const row = findSystemByIncidentStmt.get(pdIncidentId);
+  return row?.system_key ?? null;
+}
+
+function mapRow(row: any): IncidentAuditRecord {
+  return {
+    id: row.id,
+    createdAt: row.created_at,
+    actorEmail: row.actor_email,
+    action: row.action,
+    systemKey: row.system_key ?? null,
+    pdIncidentId: row.pd_incident_id ?? null,
+    url: row.url ?? null,
+    payloadHash: row.payload_hash ?? null,
+    details: row.details ?? null,
+  };
+}

--- a/lib/ops/hash.ts
+++ b/lib/ops/hash.ts
@@ -1,0 +1,6 @@
+import { createHash } from "crypto";
+
+export function hashPayload(input: unknown): string {
+  const json = typeof input === "string" ? input : JSON.stringify(input ?? {});
+  return createHash("sha256").update(json).digest("hex");
+}

--- a/lib/ops/pagerduty.ts
+++ b/lib/ops/pagerduty.ts
@@ -1,0 +1,152 @@
+import { getRunbookUrl, getSystemPagerDutyConfig } from "./config";
+import { hashPayload } from "./hash";
+import { getSystemForIncidentId, logIncidentEvent } from "./db";
+
+interface BaseIncidentInput {
+  systemKey: string;
+  title: string;
+  details?: string;
+  overrideUrgency?: "low" | "high";
+  actorEmail: string;
+  metadata?: Record<string, unknown>;
+}
+
+interface CreateIncidentResult {
+  incidentId: string;
+  url: string;
+  payloadHash: string;
+}
+
+function ensurePagerDutyEnv(): { token: string; from: string } {
+  const token = process.env.PD_API_TOKEN;
+  const from = process.env.PD_FROM_EMAIL;
+  if (!token || !from) {
+    throw new Error("pd_env_missing");
+  }
+  return { token, from };
+}
+
+export async function createPagerDutyIncident(input: BaseIncidentInput): Promise<CreateIncidentResult> {
+  const { systemKey, title, details = "", overrideUrgency, actorEmail, metadata } = input;
+  const cfg = getSystemPagerDutyConfig(systemKey);
+  if (!cfg) {
+    throw new Error(`pd_config_missing:${systemKey}`);
+  }
+
+  const runbook = getRunbookUrl(systemKey);
+  const baseDetails = [details.trim(), runbook ? `Runbook: ${runbook}` : null]
+    .filter(Boolean)
+    .join("\n\n");
+
+  const incident: Record<string, any> = {
+    type: "incident",
+    title,
+    service: { id: cfg.serviceId, type: "service_reference" },
+    body: {
+      type: "incident_body",
+      details: baseDetails || "Triggered via Ops Portal",
+    },
+  };
+
+  if (cfg.escalationPolicyId) {
+    incident.escalation_policy = {
+      id: cfg.escalationPolicyId,
+      type: "escalation_policy_reference",
+    };
+  }
+
+  if (cfg.assignees?.length) {
+    incident.assignments = cfg.assignees.map((id) => ({
+      assignee: { id, type: "user_reference" },
+    }));
+  }
+
+  const urgency = overrideUrgency || cfg.urgency;
+  if (urgency) {
+    incident.urgency = urgency;
+  }
+
+  const payload = { incident };
+  const payloadHash = hashPayload(payload);
+  const { token, from } = ensurePagerDutyEnv();
+
+  const res = await fetch("https://api.pagerduty.com/incidents", {
+    method: "POST",
+    headers: {
+      Authorization: `Token token=${token}`,
+      "Content-Type": "application/json",
+      Accept: "application/vnd.pagerduty+json;version=2",
+      From: from,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`pd_error:${res.status}:${text}`);
+  }
+
+  const data = await res.json();
+  const incidentId = data?.incident?.id;
+  const url = data?.incident?.html_url;
+  if (!incidentId || !url) {
+    throw new Error("pd_response_unexpected");
+  }
+
+  logIncidentEvent({
+    actorEmail,
+    action: metadata?.bulk ? "bulk" : "create",
+    systemKey,
+    pdIncidentId: incidentId,
+    url,
+    payloadHash,
+    details: metadata && Object.keys(metadata).length ? JSON.stringify(metadata) : null,
+  });
+
+  return { incidentId, url, payloadHash };
+}
+
+export async function resolvePagerDutyIncident(params: {
+  incidentId: string;
+  actorEmail: string;
+  postmortemUrl?: string;
+}): Promise<void> {
+  const { token, from } = ensurePagerDutyEnv();
+  const { incidentId, actorEmail, postmortemUrl } = params;
+
+  const body = {
+    incident: {
+      type: "incident",
+      status: "resolved",
+      resolution: postmortemUrl
+        ? `See post-mortem: ${postmortemUrl}`
+        : "Resolved via Ops Portal",
+    },
+  };
+
+  const res = await fetch(`https://api.pagerduty.com/incidents/${incidentId}`, {
+    method: "PUT",
+    headers: {
+      Authorization: `Token token=${token}`,
+      "Content-Type": "application/json",
+      Accept: "application/vnd.pagerduty+json;version=2",
+      From: from,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`pd_error:${res.status}:${text}`);
+  }
+
+  const systemKey = getSystemForIncidentId(incidentId);
+
+  logIncidentEvent({
+    actorEmail,
+    action: "resolve",
+    systemKey,
+    pdIncidentId: incidentId,
+    details: postmortemUrl ? JSON.stringify({ postmortemUrl }) : null,
+  });
+}

--- a/lib/ops/risk.ts
+++ b/lib/ops/risk.ts
@@ -1,0 +1,54 @@
+import fs from "fs";
+import path from "path";
+import { getOpenIncidentForSystem } from "./db";
+
+export interface RiskSystem {
+  key: string;
+  name: string;
+  color: "red" | "yellow" | "green";
+  risk: number;
+  action: string;
+  owner?: string;
+  pdIncidentId?: string | null;
+  pdUrl?: string | null;
+  openedAt?: string | null;
+}
+
+export interface RiskSnapshot {
+  generatedAt: string;
+  systems: RiskSystem[];
+}
+
+const defaultSnapshotPath = process.env.RISK_SNAPSHOT_PATH
+  || path.join(process.cwd(), "data", "ops", "risk-snapshot.json");
+
+function readSnapshotFile(): RiskSnapshot {
+  try {
+    const raw = fs.readFileSync(defaultSnapshotPath, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object") {
+      return parsed as RiskSnapshot;
+    }
+  } catch (err) {
+    console.warn("[pd] using fallback risk snapshot", err);
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    systems: [],
+  };
+}
+
+export function getRiskSnapshot(): RiskSnapshot {
+  const snapshot = readSnapshotFile();
+  const augmented = snapshot.systems.map((system) => {
+    const open = getOpenIncidentForSystem(system.key);
+    return {
+      ...system,
+      pdIncidentId: open?.pdIncidentId ?? null,
+      pdUrl: open?.url ?? null,
+      openedAt: open?.createdAt ?? null,
+    };
+  });
+  return { ...snapshot, systems: augmented };
+}

--- a/lib/ops/slack.ts
+++ b/lib/ops/slack.ts
@@ -1,0 +1,13 @@
+export async function postSlackMessage(text: string): Promise<void> {
+  const url = process.env.SLACK_WEBHOOK;
+  if (!url) return;
+  try {
+    await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text }),
+    });
+  } catch (err) {
+    console.error("[pd] failed to post slack message", err);
+  }
+}


### PR DESCRIPTION
## Summary
- add PagerDuty config, runbook map, and risk snapshot wiring for ops systems
- expose PD create/resolve/bulk/audit APIs with spam guards and audit logging
- build Ops heatmap UI actions plus supporting Asana tasks and Slack comms notes

## Testing
- npm run lint *(fails: Cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68e85a36909c8329bf334a762d1762cb