### PR TITLE
Add logistic loop toolkit for iterative math build workflow

### DIFF
--- a/docs/iterative_math_build_loop.md
+++ b/docs/iterative_math_build_loop.md
@@ -1,0 +1,61 @@
+# Iterative Math-Build Loop Field Notes
+
+This note packages Blocks 43–46 into a repeatable workflow you can apply inside
+our lab notebooks, electronics bench, or field experiments.
+
+## Block 43 — Iterative Loop Recipe
+
+1. **Seed** – Start from a compact pattern.  The companion module
+   `lucidia_math_lab/iterative_math_build.py` uses the logistic function as the
+   seed because it readily produces bifurcations.
+2. **Three translations** – Capture quick analogies that keep the idea moving:
+   - *Physics*: logistic energy flow in a constrained ecosystem.
+   - *Code*: a self-referential feedback loop with gain control.
+   - *Hardware*: a biased transistor oscillator that compresses amplitude.
+3. **Build a toy** – Simulate the loop and log the pulse levels.  The
+   `capture_snapshot` helper stores the run with timestamped tags so you can
+   archive the trace next to oscilloscope photos.
+4. **Measure & rename** – Swap theory-heavy names for behaviour-first labels
+   (`population → pulse_level`, `r → gain`) to emphasise the observed dynamics.
+5. **Archive & fork** – Persist the exported snapshot string together with lab
+   notes.  Next session, fork by perturbing the gain or seed level and repeat.
+
+## Block 44 — Forever Math Drills
+
+- **Euler Day** – Reinterpret `e^{i\pi} + 1 = 0` in a new medium; logistic loop
+  sweep plots provide the "graphics" variant out of the box.
+- **Symmetry Poker** – While reviewing snapshots, permute concepts (energy,
+  entropy, time, information, identity) and log invariants that survive the
+  translation.
+- **Dimensional Alchemy** – Convert the gain/seed units to expose emergent
+  constants (e.g., growth per cycle vs. per second once hardware enters).
+- **Negative Practice** – Intentionally choose unstable gains to surface which
+  assumptions the toy violates.
+
+## Block 45 — Open Build Tracks
+
+- **Track A (Quantum/Optical)** – Use the logistic module as the control layer
+  for photon coincidence experiments; gain sweeps map to phase plate tuning.
+- **Track B (Analog Computation)** – Expand the loop into a four-node lattice,
+  treat each snapshot as a potential surface sample, and search for spontaneous
+  mode locking.
+- **Track C (Algorithmic Matter)** – Translate the logistic update rules into a
+  cellular automaton and run on GPU to hunt for self-healing tilings.
+
+## Block 46 — Sustaining Equation
+
+Keep curiosity alive by balancing recognition, prediction, and certainty:
+
+\[
+\text{Curiosity} = \frac{\text{Pattern Recognition}}{\text{Prediction}} - \text{Certainty}.
+\]
+
+Adjust the logistic loop parameters accordingly—unstable gains reduce certainty
+when boredom hits, while short sweeps and smaller gains restore prediction when
+things feel overwhelming.
+
+## Next Drop Preference
+
+Select **option (b)** next: a tangible analog computing upgrade with the full
+schematic and component values for a four-node Hamiltonian lattice.  It aligns
+with Track B and dovetails with the gain-sweep snapshots documented here.

--- a/lucidia_math_lab/iterative_math_build.py
+++ b/lucidia_math_lab/iterative_math_build.py
@@ -1,0 +1,156 @@
+"""Utilities that capture the "Iterative Math-Build Loop" workflow.
+
+This module turns a simple mathematical seed—the logistic map—into a tiny
+experiment that can be iterated forever.  The workflow mirrors Block 43:
+
+Step 1 (Seed)
+    Use the logistic function :math:`x_{n+1} = r x_n (1 - x_n)` as the pattern.
+
+Step 2 (Three translations)
+    Physics
+        Population dynamics where energy input (sunlight, nutrients) is limited.
+    Code
+        A feedback loop that maps the state into itself with a tunable gain.
+    Hardware
+        A single-transistor logistic oscillator driven by a biasing envelope.
+
+Step 3 (Build a toy)
+    Simulate the logistic loop over a configurable number of pulses.
+
+Step 4 (Measure & rename)
+    Rename raw variables once we observe their behaviour: ``population`` becomes
+    ``pulse_level`` and ``r`` becomes ``gain`` to match the oscillation view.
+
+Step 5 (Archive & fork)
+    Export snapshots that carry timestamped tags ready for storage.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from statistics import fmean
+from typing import Iterable, List
+
+
+@dataclass(frozen=True)
+class LoopSnapshot:
+    """Stores a measured sequence from the logistic loop.
+
+    Attributes
+    ----------
+    tag:
+        Timestamped identifier that makes it easy to fork future experiments.
+    gain:
+        The effective amplification factor observed during the run.
+    pulse_levels:
+        Measured levels after each iteration of the loop.
+    phase_drift:
+        The final-step change, useful for spotting bifurcations.
+    mean_level:
+        Average pulse level over the capture window.
+    """
+
+    tag: str
+    gain: float
+    pulse_levels: List[float]
+    phase_drift: float
+    mean_level: float
+
+
+def iterate_logistic_loop(*, gain: float, seed_level: float, pulses: int) -> List[float]:
+    """Run the logistic map for the requested number of pulses.
+
+    Parameters
+    ----------
+    gain:
+        Feedback intensity of the loop (commonly ``r`` in the logistic map).
+    seed_level:
+        Initial pulse level.  Must be in ``(0, 1)`` for the canonical map.
+    pulses:
+        Number of iterations to execute.
+
+    Returns
+    -------
+    list of float
+        Observed pulse levels after each iteration.
+    """
+
+    if pulses <= 0:
+        raise ValueError("pulses must be positive")
+    if not 0.0 < seed_level < 1.0:
+        raise ValueError("seed_level must be strictly between 0 and 1")
+
+    level = seed_level
+    pulse_levels: List[float] = []
+    for _ in range(pulses):
+        level = gain * level * (1.0 - level)
+        pulse_levels.append(level)
+    return pulse_levels
+
+
+def capture_snapshot(
+    *,
+    gain: float = 3.72,
+    seed_level: float = 0.21,
+    pulses: int = 128,
+    tag_prefix: str = "symmetry_break",
+) -> LoopSnapshot:
+    """Simulate the loop and bundle the measurement in a :class:`LoopSnapshot`.
+
+    The timestamp embedded into ``tag`` makes it trivial to archive runs and
+    reference them the next time the "Next!" impulse hits.
+    """
+
+    pulse_levels = iterate_logistic_loop(gain=gain, seed_level=seed_level, pulses=pulses)
+    phase_drift = pulse_levels[-1] - pulse_levels[-2]
+    mean_level = fmean(pulse_levels)
+    timestamp = datetime.now(timezone.utc).strftime("%Y_%m_%dT%H%M%SZ")
+    tag = f"{tag_prefix}_{timestamp}"
+    return LoopSnapshot(
+        tag=tag,
+        gain=gain,
+        pulse_levels=pulse_levels,
+        phase_drift=phase_drift,
+        mean_level=mean_level,
+    )
+
+
+def export_snapshot(snapshot: LoopSnapshot) -> str:
+    """Serialise a snapshot into a minimal archival string.
+
+    The format favours human parsing (CSV-like) so it can be dropped into a
+    notebook, pasted into a README, or stored alongside lab photos.
+    """
+
+    header = "tag,gain,mean_level,phase_drift,pulse_levels"
+    levels = " ".join(f"{level:.6f}" for level in snapshot.pulse_levels)
+    body = f"{snapshot.tag},{snapshot.gain:.6f},{snapshot.mean_level:.6f},{snapshot.phase_drift:.6f},{levels}"
+    return f"{header}\n{body}\n"
+
+
+def sweep_gains(
+    *,
+    gains: Iterable[float],
+    seed_level: float,
+    pulses: int,
+) -> List[LoopSnapshot]:
+    """Generate snapshots for a sequence of gains.
+
+    This helper makes it easy to scan for bifurcations and immediately archive
+    the most interesting regimes.
+    """
+
+    return [
+        capture_snapshot(gain=gain, seed_level=seed_level, pulses=pulses, tag_prefix=f"gain_{gain:.3f}")
+        for gain in gains
+    ]
+
+
+__all__ = [
+    "LoopSnapshot",
+    "capture_snapshot",
+    "export_snapshot",
+    "iterate_logistic_loop",
+    "sweep_gains",
+]


### PR DESCRIPTION
## Summary
- add a logistic-map powered helper module for iterating the math-build loop
- document how Blocks 43–46 map into the new workflow and request the analog computing upgrade next

## Testing
- `pytest lucidia_math_lab` *(fails: no tests found in directory)*

------
https://chatgpt.com/codex/tasks/task_e_68e8615d471c832995fe84c2e5aba386