### PR TITLE
Add PagerDuty ↔ Jira incident automation

### DIFF
--- a/apps/portals/app/api/pd/audit/route.ts
+++ b/apps/portals/app/api/pd/audit/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+import { IncidentAuditRecord, listRecentAudit } from '../../../../lib/incident-audit';
+
+export async function GET() {
+  try {
+    const records = await listRecentAudit();
+    return NextResponse.json({ ok: true, records });
+  } catch (error) {
+    console.error('Failed to list incident audit', error);
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+export type { IncidentAuditRecord };

--- a/apps/portals/app/api/pd/bulk/route.ts
+++ b/apps/portals/app/api/pd/bulk/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { addPagerDutyNote } from '../../../../lib/pagerduty';
+import { jiraBrowseUrl, jiraCreateIssue } from '../../../../lib/jira';
+import { insertIncidentAudit } from '../../../../lib/incident-audit';
+
+interface BulkSweepRequest {
+  pdIncidentId: string;
+  pdUrl: string;
+  systems: string[];
+  tasksMarkdown: string;
+  actorEmail?: string;
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const { pdIncidentId, pdUrl, systems, tasksMarkdown = '', actorEmail } =
+      (await req.json()) as BulkSweepRequest;
+
+    if (!pdIncidentId || !pdUrl || !Array.isArray(systems) || systems.length === 0) {
+      return NextResponse.json(
+        { error: 'pdIncidentId, pdUrl, and systems are required' },
+        { status: 400 },
+      );
+    }
+
+    const summary = `Risk sweep: ${systems.length} systems yellow`;
+    const description = [
+      `Systems:\n${systems.map(s => `- ${s}`).join('\n')}`,
+      `Tasks:\n${tasksMarkdown}`,
+      `PD: ${pdUrl}`,
+      process.env.RUNBOOK_URL ? `Runbook: ${process.env.RUNBOOK_URL}` : null,
+    ]
+      .filter(Boolean)
+      .join('\n\n');
+
+    const issue = await jiraCreateIssue({
+      summary,
+      description,
+      labels: ['risk-sweep', 'pagerduty'],
+    });
+
+    await insertIncidentAudit({
+      actorEmail,
+      action: 'bulk',
+      pdIncidentId,
+      pdUrl,
+      jiraKey: issue.key,
+      payloadHash: null,
+      openedAt: new Date(),
+    });
+
+    try {
+      await addPagerDutyNote(pdIncidentId, `Jira: ${jiraBrowseUrl(issue.key)}`);
+    } catch (noteError) {
+      console.error('Failed to add sweep Jira note', noteError);
+    }
+
+    return NextResponse.json({
+      ok: true,
+      pagerDuty: {
+        id: pdIncidentId,
+        url: pdUrl,
+      },
+      jira: {
+        key: issue.key,
+        url: jiraBrowseUrl(issue.key),
+      },
+    });
+  } catch (error) {
+    console.error('PagerDuty bulk sweep failed', error);
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/apps/portals/app/api/pd/create/route.ts
+++ b/apps/portals/app/api/pd/create/route.ts
@@ -1,0 +1,124 @@
+import crypto from 'crypto';
+import { NextRequest, NextResponse } from 'next/server';
+import { addPagerDutyNote, createPagerDutyIncident } from '../../../../lib/pagerduty';
+import { jiraBrowseUrl, jiraCreateIssue } from '../../../../lib/jira';
+import {
+  findRecentCreateForSystem,
+  insertIncidentAudit,
+} from '../../../../lib/incident-audit';
+
+interface CreatePagerDutyRequest {
+  title: string;
+  bodyMd: string;
+  systemKey: string;
+  serviceId: string;
+  urgency?: 'high' | 'low';
+  escalationPolicyId?: string;
+  actorEmail?: string;
+  runbookUrls?: string[];
+  labels?: string[];
+}
+
+function sanitizeSummary(title: string) {
+  return title.replace(/^\[.*?\]\s*/, '').trim();
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const payload = (await req.json()) as CreatePagerDutyRequest;
+    const {
+      title,
+      bodyMd,
+      systemKey,
+      serviceId,
+      urgency = 'high',
+      escalationPolicyId,
+      actorEmail,
+      runbookUrls = [],
+      labels = [],
+    } = payload;
+
+    if (!title || !bodyMd || !systemKey || !serviceId) {
+      return NextResponse.json(
+        { error: 'title, bodyMd, systemKey, and serviceId are required' },
+        { status: 400 },
+      );
+    }
+
+    const recent = await findRecentCreateForSystem(systemKey);
+    if (recent) {
+      return NextResponse.json(
+        {
+          error: 'Incident already opened for this system within the last five minutes',
+        },
+        { status: 429 },
+      );
+    }
+
+    const pagerDutyIncident = await createPagerDutyIncident({
+      title,
+      body: bodyMd,
+      serviceId,
+      urgency,
+      escalationPolicyId,
+      runbookUrls,
+    });
+
+    const jiraSummary = sanitizeSummary(title);
+    const jiraDescriptionParts = [bodyMd.trim(), `PD: ${pagerDutyIncident.html_url}`];
+    if (runbookUrls.length > 0) {
+      jiraDescriptionParts.push(`Runbooks:\n${runbookUrls.join('\n')}`);
+    }
+    const jiraDescription = jiraDescriptionParts.join('\n\n');
+
+    const allLabels = Array.from(new Set(['incident', 'pagerduty', systemKey, ...labels]));
+
+    const issue = await jiraCreateIssue({
+      summary: jiraSummary,
+      description: jiraDescription,
+      labels: allLabels,
+    });
+
+    const payloadHash = crypto
+      .createHash('sha256')
+      .update(JSON.stringify({ title, bodyMd, systemKey, serviceId }))
+      .digest('hex');
+
+    await insertIncidentAudit({
+      actorEmail,
+      systemKey,
+      action: 'create',
+      pdIncidentId: pagerDutyIncident.id,
+      pdUrl: pagerDutyIncident.html_url,
+      jiraKey: issue.key,
+      payloadHash,
+      openedAt: new Date(),
+    });
+
+    try {
+      await addPagerDutyNote(
+        pagerDutyIncident.id,
+        `Jira: ${jiraBrowseUrl(issue.key)}`,
+      );
+    } catch (noteError) {
+      console.error('Failed to add PagerDuty note for Jira link', noteError);
+    }
+
+    return NextResponse.json({
+      ok: true,
+      pagerDuty: {
+        id: pagerDutyIncident.id,
+        url: pagerDutyIncident.html_url,
+      },
+      jira: {
+        key: issue.key,
+        url: jiraBrowseUrl(issue.key),
+      },
+      systemKey,
+    });
+  } catch (error) {
+    console.error('PagerDuty create failed', error);
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/apps/portals/app/api/pd/resolve/route.ts
+++ b/apps/portals/app/api/pd/resolve/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { addPagerDutyNote, resolvePagerDutyIncident } from '../../../../lib/pagerduty';
+import { jiraBrowseUrl, jiraResolve } from '../../../../lib/jira';
+import { getAuditByPagerDutyId, insertIncidentAudit } from '../../../../lib/incident-audit';
+
+interface ResolvePagerDutyRequest {
+  incidentId: string;
+  resolution?: string;
+  postmortemUrl?: string;
+  actorEmail?: string;
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const { incidentId, resolution, postmortemUrl, actorEmail } =
+      (await req.json()) as ResolvePagerDutyRequest;
+
+    if (!incidentId) {
+      return NextResponse.json({ error: 'incidentId is required' }, { status: 400 });
+    }
+
+    const resolutionText = resolution?.trim() || 'Resolved via Ops Portal';
+    const pagerDutyIncident = await resolvePagerDutyIncident(incidentId, resolutionText);
+
+    const auditRow = await getAuditByPagerDutyId(incidentId);
+    if (auditRow?.jira_key) {
+      const comment = postmortemUrl
+        ? `Post-mortem: ${postmortemUrl}`
+        : 'Resolved via Ops Portal';
+      await jiraResolve(auditRow.jira_key, 'Fixed', comment);
+    }
+
+    if (postmortemUrl) {
+      try {
+        await addPagerDutyNote(incidentId, `Post-mortem: ${postmortemUrl}`);
+      } catch (noteError) {
+        console.error('Failed to add PagerDuty post-mortem note', noteError);
+      }
+    }
+
+    await insertIncidentAudit({
+      actorEmail,
+      systemKey: auditRow?.system_key ?? undefined,
+      action: 'resolve',
+      pdIncidentId: incidentId,
+      pdUrl: pagerDutyIncident.html_url,
+      jiraKey: auditRow?.jira_key ?? undefined,
+      resolvedAt: new Date(),
+    });
+
+    return NextResponse.json({
+      ok: true,
+      incidentId,
+      pagerDuty: {
+        id: pagerDutyIncident.id,
+        url: pagerDutyIncident.html_url,
+      },
+      jira: auditRow?.jira_key
+        ? {
+            key: auditRow.jira_key,
+            url: jiraBrowseUrl(auditRow.jira_key),
+          }
+        : null,
+    });
+  } catch (error) {
+    console.error('PagerDuty resolve failed', error);
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/apps/portals/app/ops/incidents/page.tsx
+++ b/apps/portals/app/ops/incidents/page.tsx
@@ -1,0 +1,687 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Card } from '../../../components/ui/card';
+import type { IncidentAuditRecord } from '../../../api/pd/audit/route';
+
+interface PagerDutyCreateResponse {
+  ok: boolean;
+  pagerDuty?: { id: string; url: string };
+  jira?: { key: string; url: string } | null;
+  error?: string;
+  systemKey?: string;
+}
+
+interface PagerDutyResolveResponse {
+  ok: boolean;
+  incidentId?: string;
+  pagerDuty?: { id: string; url: string };
+  jira?: { key: string; url: string } | null;
+  error?: string;
+}
+
+interface PagerDutyBulkResponse {
+  ok: boolean;
+  pagerDuty?: { id: string; url: string };
+  jira?: { key: string; url: string };
+  error?: string;
+}
+
+type GroupedIncident = {
+  pdIncidentId: string;
+  latestAction: IncidentAuditRecord['action'];
+  jiraKey: string | null;
+  pdUrl: string | null;
+  systemKey: string | null;
+  openedAt: string | null;
+  resolvedAt: string | null;
+  events: IncidentAuditRecord[];
+};
+
+type ActionLinks = {
+  pd?: { id: string; url: string };
+  jira?: { key: string; url: string };
+};
+
+interface ActionState {
+  loading: boolean;
+  message: string | null;
+  error: string | null;
+  links?: ActionLinks;
+}
+
+const jiraBase = process.env.NEXT_PUBLIC_JIRA_BASE ?? process.env.NEXT_PUBLIC_JIRA_URL ?? 'https://yourdomain.atlassian.net';
+
+function groupByIncident(records: IncidentAuditRecord[]): GroupedIncident[] {
+  const map = new Map<string, GroupedIncident>();
+  for (const record of records) {
+    const id = record.pd_incident_id ?? `audit-${record.id}`;
+    const existing = map.get(id);
+    if (!existing) {
+      map.set(id, {
+        pdIncidentId: record.pd_incident_id ?? '',
+        latestAction: record.action,
+        jiraKey: record.jira_key,
+        pdUrl: record.pd_url,
+        systemKey: record.system_key,
+        openedAt: record.opened_at,
+        resolvedAt: record.resolved_at,
+        events: [record],
+      });
+    } else {
+      existing.events.push(record);
+      if (record.time > existing.events[0].time) {
+        existing.latestAction = record.action;
+        existing.jiraKey = record.jira_key;
+        existing.pdUrl = record.pd_url;
+        existing.systemKey = record.system_key;
+        existing.openedAt = record.opened_at ?? existing.openedAt;
+        existing.resolvedAt = record.resolved_at ?? existing.resolvedAt;
+      }
+    }
+  }
+  return Array.from(map.values()).sort((a, b) => {
+    const aTime = a.events[0]?.time ?? '';
+    const bTime = b.events[0]?.time ?? '';
+    return bTime.localeCompare(aTime);
+  });
+}
+
+function formatDate(value: string | null) {
+  if (!value) return '—';
+  try {
+    return new Date(value).toLocaleString();
+  } catch {
+    return value;
+  }
+}
+
+export default function OpsIncidentsPage() {
+  const [records, setRecords] = useState<IncidentAuditRecord[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [createState, setCreateState] = useState<ActionState>({
+    loading: false,
+    message: null,
+    error: null,
+  });
+
+  const [resolveState, setResolveState] = useState<ActionState>({
+    loading: false,
+    message: null,
+    error: null,
+  });
+
+  const [bulkState, setBulkState] = useState<ActionState>({
+    loading: false,
+    message: null,
+    error: null,
+  });
+
+  const loadAudit = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/pd/audit', { cache: 'no-store' });
+      const body = await res.json();
+      if (!res.ok || !body.ok) {
+        throw new Error(body.error || 'Failed to load audit records');
+      }
+      setRecords(Array.isArray(body.records) ? body.records : []);
+      setError(null);
+    } catch (err) {
+      console.error(err);
+      setError(err instanceof Error ? err.message : 'Unable to load audit records');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadAudit();
+  }, [loadAudit]);
+
+  const incidents = useMemo(() => groupByIncident(records), [records]);
+
+  async function handleCreate(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const form = event.currentTarget;
+    const data = new FormData(form);
+    const runbookValue = data.get('runbookUrls');
+    const runbooks = typeof runbookValue === 'string'
+      ? runbookValue
+          .split('\n')
+          .map(line => line.trim())
+          .filter(Boolean)
+      : [];
+
+    const labelValue = data.get('labels');
+    const labels = typeof labelValue === 'string'
+      ? labelValue
+          .split(',')
+          .map(label => label.trim())
+          .filter(Boolean)
+      : [];
+
+    setCreateState({ loading: true, message: null, error: null });
+    try {
+      const res = await fetch('/api/pd/create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: String(data.get('title') ?? ''),
+          bodyMd: String(data.get('bodyMd') ?? ''),
+          systemKey: String(data.get('systemKey') ?? ''),
+          serviceId: String(data.get('serviceId') ?? ''),
+          urgency: String(data.get('urgency') ?? 'high'),
+          escalationPolicyId: data.get('escalationPolicyId')
+            ? String(data.get('escalationPolicyId'))
+            : undefined,
+          runbookUrls: runbooks,
+          labels,
+        }),
+      });
+      const body = (await res.json()) as PagerDutyCreateResponse;
+      if (!res.ok || !body.ok) {
+        throw new Error(body.error || 'Unable to create incident');
+      }
+      setCreateState({
+        loading: false,
+        message: 'PagerDuty and Jira created successfully.',
+        error: null,
+        links: {
+          pd: body.pagerDuty,
+          jira: body.jira ?? undefined,
+        },
+      });
+      form.reset();
+      await loadAudit();
+    } catch (err) {
+      setCreateState({
+        loading: false,
+        message: null,
+        error: err instanceof Error ? err.message : 'Unable to create incident',
+      });
+    }
+  }
+
+  async function handleResolve(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const form = event.currentTarget;
+    const data = new FormData(form);
+    const incidentId = String(data.get('incidentId') ?? '');
+    const resolution = data.get('resolution');
+    const postmortem = data.get('postmortemUrl');
+
+    setResolveState({ loading: true, message: null, error: null });
+    try {
+      const res = await fetch('/api/pd/resolve', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          incidentId,
+          resolution: resolution ? String(resolution) : undefined,
+          postmortemUrl: postmortem ? String(postmortem) : undefined,
+        }),
+      });
+      const body = (await res.json()) as PagerDutyResolveResponse;
+      if (!res.ok || !body.ok) {
+        throw new Error(body.error || 'Unable to resolve incident');
+      }
+      setResolveState({
+        loading: false,
+        message: 'Incident resolved.',
+        error: null,
+        links: {
+          pd: body.pagerDuty,
+          jira: body.jira ?? undefined,
+        },
+      });
+      form.reset();
+      await loadAudit();
+    } catch (err) {
+      setResolveState({
+        loading: false,
+        message: null,
+        error: err instanceof Error ? err.message : 'Unable to resolve incident',
+      });
+    }
+  }
+
+  async function handleBulk(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const form = event.currentTarget;
+    const data = new FormData(form);
+    const systemsValue = data.get('systems');
+    const systems = typeof systemsValue === 'string'
+      ? systemsValue
+          .split('\n')
+          .map(line => line.trim())
+          .filter(Boolean)
+      : [];
+    const tasks = data.get('tasksMarkdown');
+
+    setBulkState({ loading: true, message: null, error: null });
+    try {
+      const res = await fetch('/api/pd/bulk', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          pdIncidentId: String(data.get('pdIncidentId') ?? ''),
+          pdUrl: String(data.get('pdUrl') ?? ''),
+          systems,
+          tasksMarkdown: tasks ? String(tasks) : '',
+        }),
+      });
+      const body = (await res.json()) as PagerDutyBulkResponse;
+      if (!res.ok || !body.ok) {
+        throw new Error(body.error || 'Unable to create sweep coordination ticket');
+      }
+      setBulkState({
+        loading: false,
+        message: 'Sweep coordination ticket created.',
+        error: null,
+        links: {
+          pd: body.pagerDuty,
+          jira: body.jira,
+        },
+      });
+      form.reset();
+      await loadAudit();
+    } catch (err) {
+      setBulkState({
+        loading: false,
+        message: null,
+        error: err instanceof Error ? err.message : 'Unable to create sweep coordination ticket',
+      });
+    }
+  }
+
+  return (
+    <main className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-6 py-10">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold text-white">Incident automation</h1>
+        <p className="text-sm text-slate-400">
+          Creating or resolving PagerDuty incidents now mirrors the state in Jira automatically.
+          We keep the Ops audit trail tidy and show cross-links on every card.
+        </p>
+      </header>
+
+      <section className="grid gap-6 md:grid-cols-2">
+        <Card className="space-y-4 border border-slate-800 p-6">
+          <h2 className="text-lg font-semibold text-white">Open PagerDuty incident</h2>
+          <form className="space-y-3 text-sm" onSubmit={handleCreate}>
+            <div>
+              <label className="mb-1 block text-slate-300" htmlFor="title">
+                Title
+              </label>
+              <input
+                id="title"
+                name="title"
+                required
+                className="w-full rounded border border-slate-700 bg-slate-900 px-3 py-2 text-white"
+                placeholder="[DB] Latency spike"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-slate-300" htmlFor="bodyMd">
+                Body (Markdown)
+              </label>
+              <textarea
+                id="bodyMd"
+                name="bodyMd"
+                required
+                className="h-32 w-full rounded border border-slate-700 bg-slate-900 px-3 py-2 text-white"
+                placeholder="Runbook notes, impact, responders"
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="mb-1 block text-slate-300" htmlFor="systemKey">
+                  System key
+                </label>
+                <input
+                  id="systemKey"
+                  name="systemKey"
+                  required
+                  className="w-full rounded border border-slate-700 bg-slate-900 px-3 py-2 text-white"
+                  placeholder="payments-api"
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-slate-300" htmlFor="serviceId">
+                  PagerDuty service ID
+                </label>
+                <input
+                  id="serviceId"
+                  name="serviceId"
+                  required
+                  className="w-full rounded border border-slate-700 bg-slate-900 px-3 py-2 text-white"
+                  placeholder="PXXXX"
+                />
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="mb-1 block text-slate-300" htmlFor="urgency">
+                  Urgency
+                </label>
+                <select
+                  id="urgency"
+                  name="urgency"
+                  className="w-full rounded border border-slate-700 bg-slate-900 px-3 py-2 text-white"
+                  defaultValue="high"
+                >
+                  <option value="high">High</option>
+                  <option value="low">Low</option>
+                </select>
+              </div>
+              <div>
+                <label className="mb-1 block text-slate-300" htmlFor="escalationPolicyId">
+                  Escalation policy (optional)
+                </label>
+                <input
+                  id="escalationPolicyId"
+                  name="escalationPolicyId"
+                  className="w-full rounded border border-slate-700 bg-slate-900 px-3 py-2 text-white"
+                  placeholder="PEXXXXX"
+                />
+              </div>
+            </div>
+            <div>
+              <label className="mb-1 block text-slate-300" htmlFor="runbookUrls">
+                Runbook URLs (one per line)
+              </label>
+              <textarea
+                id="runbookUrls"
+                name="runbookUrls"
+                className="h-20 w-full rounded border border-slate-700 bg-slate-900 px-3 py-2 text-white"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-slate-300" htmlFor="labels">
+                Extra Jira labels (comma separated)
+              </label>
+              <input
+                id="labels"
+                name="labels"
+                className="w-full rounded border border-slate-700 bg-slate-900 px-3 py-2 text-white"
+              />
+            </div>
+            <button
+              type="submit"
+              className="w-full rounded bg-indigo-500 px-4 py-2 font-medium text-white transition hover:bg-indigo-400"
+              disabled={createState.loading}
+            >
+              {createState.loading ? 'Creating…' : 'Create PD + Jira'}
+            </button>
+            {createState.message && <p className="text-sm text-emerald-400">{createState.message}</p>}
+            {createState.links && (
+              <div className="flex flex-wrap gap-2 text-xs">
+                {createState.links.pd && (
+                  <a
+                    href={createState.links.pd.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="rounded bg-slate-700/50 px-2 py-1 font-semibold text-slate-200"
+                  >
+                    PagerDuty {createState.links.pd.id}
+                  </a>
+                )}
+                {createState.links.jira && (
+                  <a
+                    href={createState.links.jira.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="rounded bg-indigo-500/10 px-2 py-1 font-semibold text-indigo-300 ring-1 ring-inset ring-indigo-500/40"
+                  >
+                    Jira {createState.links.jira.key}
+                  </a>
+                )}
+              </div>
+            )}
+            {createState.error && <p className="text-sm text-rose-400">{createState.error}</p>}
+          </form>
+        </Card>
+
+        <Card className="space-y-6 border border-slate-800 p-6">
+          <div className="space-y-4">
+            <h2 className="text-lg font-semibold text-white">Resolve incident</h2>
+            <form className="space-y-3 text-sm" onSubmit={handleResolve}>
+              <div>
+                <label className="mb-1 block text-slate-300" htmlFor="incidentId">
+                  PagerDuty incident ID
+                </label>
+                <input
+                  id="incidentId"
+                  name="incidentId"
+                  required
+                  className="w-full rounded border border-slate-700 bg-slate-900 px-3 py-2 text-white"
+                  placeholder="PIXXXX"
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-slate-300" htmlFor="resolution">
+                  Resolution summary
+                </label>
+                <input
+                  id="resolution"
+                  name="resolution"
+                  className="w-full rounded border border-slate-700 bg-slate-900 px-3 py-2 text-white"
+                  placeholder="Mitigated by scaling read replicas"
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-slate-300" htmlFor="postmortemUrl">
+                  Post-mortem URL (optional)
+                </label>
+                <input
+                  id="postmortemUrl"
+                  name="postmortemUrl"
+                  className="w-full rounded border border-slate-700 bg-slate-900 px-3 py-2 text-white"
+                  placeholder="https://docs.google.com/..."
+                />
+              </div>
+              <button
+                type="submit"
+                className="w-full rounded bg-emerald-500 px-4 py-2 font-medium text-white transition hover:bg-emerald-400"
+                disabled={resolveState.loading}
+              >
+                {resolveState.loading ? 'Resolving…' : 'Resolve PD + Jira'}
+              </button>
+              {resolveState.message && <p className="text-sm text-emerald-400">{resolveState.message}</p>}
+              {resolveState.links && (
+                <div className="flex flex-wrap gap-2 text-xs">
+                  {resolveState.links.pd && (
+                    <a
+                      href={resolveState.links.pd.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="rounded bg-slate-700/50 px-2 py-1 font-semibold text-slate-200"
+                    >
+                      PagerDuty {resolveState.links.pd.id}
+                    </a>
+                  )}
+                  {resolveState.links.jira && (
+                    <a
+                      href={resolveState.links.jira.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="rounded bg-indigo-500/10 px-2 py-1 font-semibold text-indigo-300 ring-1 ring-inset ring-indigo-500/40"
+                    >
+                      Jira {resolveState.links.jira.key}
+                    </a>
+                  )}
+                </div>
+              )}
+              {resolveState.error && <p className="text-sm text-rose-400">{resolveState.error}</p>}
+            </form>
+          </div>
+
+          <div className="space-y-4 border-t border-slate-800 pt-4">
+            <h2 className="text-lg font-semibold text-white">Risk sweep coordination</h2>
+            <form className="space-y-3 text-sm" onSubmit={handleBulk}>
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="mb-1 block text-slate-300" htmlFor="pdIncidentId">
+                    PagerDuty incident ID
+                  </label>
+                  <input
+                    id="pdIncidentId"
+                    name="pdIncidentId"
+                    required
+                    className="w-full rounded border border-slate-700 bg-slate-900 px-3 py-2 text-white"
+                  />
+                </div>
+                <div>
+                  <label className="mb-1 block text-slate-300" htmlFor="pdUrl">
+                    PagerDuty link
+                  </label>
+                  <input
+                    id="pdUrl"
+                    name="pdUrl"
+                    required
+                    className="w-full rounded border border-slate-700 bg-slate-900 px-3 py-2 text-white"
+                    placeholder="https://..."
+                  />
+                </div>
+              </div>
+              <div>
+                <label className="mb-1 block text-slate-300" htmlFor="systems">
+                  Systems (one per line)
+                </label>
+                <textarea
+                  id="systems"
+                  name="systems"
+                  required
+                  className="h-20 w-full rounded border border-slate-700 bg-slate-900 px-3 py-2 text-white"
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-slate-300" htmlFor="tasksMarkdown">
+                  Checklist / tasks
+                </label>
+                <textarea
+                  id="tasksMarkdown"
+                  name="tasksMarkdown"
+                  className="h-24 w-full rounded border border-slate-700 bg-slate-900 px-3 py-2 text-white"
+                  placeholder="- Verify failover scripts\n- Confirm comms sent"
+                />
+              </div>
+              <button
+                type="submit"
+                className="w-full rounded bg-amber-500 px-4 py-2 font-medium text-white transition hover:bg-amber-400"
+                disabled={bulkState.loading}
+              >
+                {bulkState.loading ? 'Creating…' : 'Create Jira coordination issue'}
+              </button>
+              {bulkState.message && <p className="text-sm text-emerald-400">{bulkState.message}</p>}
+              {bulkState.links && (
+                <div className="flex flex-wrap gap-2 text-xs">
+                  {bulkState.links.pd && (
+                    <a
+                      href={bulkState.links.pd.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="rounded bg-slate-700/50 px-2 py-1 font-semibold text-slate-200"
+                    >
+                      PagerDuty {bulkState.links.pd.id}
+                    </a>
+                  )}
+                  {bulkState.links.jira && (
+                    <a
+                      href={bulkState.links.jira.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="rounded bg-indigo-500/10 px-2 py-1 font-semibold text-indigo-300 ring-1 ring-inset ring-indigo-500/40"
+                    >
+                      Jira {bulkState.links.jira.key}
+                    </a>
+                  )}
+                </div>
+              )}
+              {bulkState.error && <p className="text-sm text-rose-400">{bulkState.error}</p>}
+            </form>
+          </div>
+        </Card>
+      </section>
+
+      <section className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-white">Latest activity</h2>
+          <button
+            type="button"
+            onClick={loadAudit}
+            className="rounded border border-slate-700 px-3 py-1 text-sm text-slate-300 transition hover:border-slate-500"
+            disabled={loading}
+          >
+            {loading ? 'Refreshing…' : 'Refresh'}
+          </button>
+        </div>
+        {error && <p className="text-sm text-rose-400">{error}</p>}
+        {incidents.length === 0 && !loading && (
+          <p className="text-sm text-slate-400">No incidents logged yet.</p>
+        )}
+        <div className="grid gap-4 md:grid-cols-2">
+          {incidents.map(incident => (
+            <Card
+              key={String(incident.pdIncidentId || incident.events[0]?.id)}
+              className="space-y-3 border border-slate-800 p-5"
+            >
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm font-semibold text-white">
+                    {incident.systemKey || 'Unmapped system'}
+                  </p>
+                  <p className="text-xs text-slate-400">{incident.pdIncidentId || 'Audit event'}</p>
+                </div>
+                <div className="flex items-center gap-2">
+                  {incident.jiraKey && (
+                    <a
+                      href={`${jiraBase.replace(/\/$/, '')}/browse/${incident.jiraKey}`}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="rounded-full bg-indigo-500/10 px-3 py-1 text-xs font-semibold text-indigo-300 ring-1 ring-inset ring-indigo-500/40"
+                    >
+                      Jira {incident.jiraKey}
+                    </a>
+                  )}
+                  {incident.pdUrl && (
+                    <a
+                      href={incident.pdUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="rounded-full bg-slate-700/40 px-3 py-1 text-xs font-semibold text-slate-200"
+                    >
+                      PagerDuty
+                    </a>
+                  )}
+                </div>
+              </div>
+              <div className="grid grid-cols-2 gap-2 text-xs text-slate-400">
+                <div>
+                  <span className="text-slate-500">Opened:</span>{' '}
+                  {formatDate(incident.openedAt ?? incident.events.at(-1)?.time ?? null)}
+                </div>
+                <div>
+                  <span className="text-slate-500">Resolved:</span>{' '}
+                  {formatDate(incident.resolvedAt)}
+                </div>
+              </div>
+              <ul className="space-y-1 text-xs text-slate-400">
+                {incident.events.map(event => (
+                  <li key={event.id} className="flex items-center gap-2">
+                    <span className="rounded bg-slate-800 px-2 py-0.5 text-[10px] uppercase tracking-wide text-slate-300">
+                      {event.action}
+                    </span>
+                    <span>{formatDate(event.time)}</span>
+                  </li>
+                ))}
+              </ul>
+            </Card>
+          ))}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/portals/app/page.tsx
+++ b/apps/portals/app/page.tsx
@@ -12,6 +12,7 @@ const portals = [
   { name: "Lucidia", href: "/portal" },
   { name: "Codex", href: "/codex" },
   { name: "Prism Sources", href: "/prism/sources" },
+  { name: "Ops Incidents", href: "/ops/incidents" },
 ];
 
 export default function HomePage() {

--- a/apps/portals/lib/incident-audit.ts
+++ b/apps/portals/lib/incident-audit.ts
@@ -1,0 +1,120 @@
+import { sql } from '@vercel/postgres';
+
+export type IncidentAuditAction = 'create' | 'resolve' | 'bulk';
+
+export interface IncidentAuditRecord {
+  id: number;
+  time: string;
+  actor_email: string | null;
+  system_key: string | null;
+  action: IncidentAuditAction;
+  pd_incident_id: string | null;
+  pd_url: string | null;
+  jira_key: string | null;
+  payload_hash: string | null;
+  opened_at: string | null;
+  resolved_at: string | null;
+}
+
+export interface InsertIncidentAuditParams {
+  actorEmail?: string;
+  systemKey?: string;
+  action: IncidentAuditAction;
+  pdIncidentId?: string;
+  pdUrl?: string;
+  jiraKey?: string;
+  payloadHash?: string;
+  openedAt?: Date;
+  resolvedAt?: Date;
+}
+
+let ensured = false;
+
+async function ensureAuditTable() {
+  if (ensured) return;
+  await sql`
+    CREATE TABLE IF NOT EXISTS ops_incident_audit (
+      id SERIAL PRIMARY KEY,
+      time TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      actor_email TEXT,
+      system_key TEXT,
+      action TEXT CHECK (action IN ('create', 'resolve', 'bulk')),
+      pd_incident_id TEXT,
+      pd_url TEXT,
+      jira_key TEXT,
+      payload_hash TEXT,
+      opened_at TIMESTAMPTZ,
+      resolved_at TIMESTAMPTZ
+    )
+  `;
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_ops_incident_audit_system_action_time
+      ON ops_incident_audit (system_key, action, time DESC)
+  `;
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_ops_incident_audit_pd_id
+      ON ops_incident_audit (pd_incident_id)
+  `;
+  ensured = true;
+}
+
+export async function insertIncidentAudit(params: InsertIncidentAuditParams) {
+  await ensureAuditTable();
+  const {
+    actorEmail,
+    systemKey,
+    action,
+    pdIncidentId,
+    pdUrl,
+    jiraKey,
+    payloadHash,
+    openedAt,
+    resolvedAt,
+  } = params;
+
+  await sql`
+    INSERT INTO ops_incident_audit
+      (actor_email, system_key, action, pd_incident_id, pd_url, jira_key, payload_hash, opened_at, resolved_at)
+    VALUES
+      (${actorEmail ?? null}, ${systemKey ?? null}, ${action}, ${pdIncidentId ?? null},
+       ${pdUrl ?? null}, ${jiraKey ?? null}, ${payloadHash ?? null},
+       ${openedAt ?? null}, ${resolvedAt ?? null})
+  `;
+}
+
+export async function findRecentCreateForSystem(systemKey: string, lookbackMinutes = 5) {
+  await ensureAuditTable();
+  const result = await sql<IncidentAuditRecord>`
+    SELECT *
+    FROM ops_incident_audit
+    WHERE system_key = ${systemKey}
+      AND action = 'create'
+      AND time >= NOW() - INTERVAL '${lookbackMinutes} minutes'
+    ORDER BY time DESC
+    LIMIT 1
+  `;
+  return result.rows[0];
+}
+
+export async function getAuditByPagerDutyId(pdIncidentId: string) {
+  await ensureAuditTable();
+  const result = await sql<IncidentAuditRecord>`
+    SELECT *
+    FROM ops_incident_audit
+    WHERE pd_incident_id = ${pdIncidentId}
+    ORDER BY time DESC
+    LIMIT 1
+  `;
+  return result.rows[0];
+}
+
+export async function listRecentAudit(limit = 50) {
+  await ensureAuditTable();
+  const result = await sql<IncidentAuditRecord>`
+    SELECT *
+    FROM ops_incident_audit
+    ORDER BY time DESC
+    LIMIT ${limit}
+  `;
+  return result.rows;
+}

--- a/apps/portals/lib/jira.ts
+++ b/apps/portals/lib/jira.ts
@@ -1,0 +1,159 @@
+const JIRA_API_VERSION = '3';
+
+type JiraPriority = 'Highest' | 'High' | 'Medium' | 'Low';
+
+type JiraDocumentNode = {
+  type: string;
+  [key: string]: unknown;
+};
+
+export interface JiraCreateIssueParams {
+  summary: string;
+  description: string;
+  labels?: string[];
+  priority?: JiraPriority;
+}
+
+interface JiraCreateIssueResponse {
+  id: string;
+  key: string;
+  self: string;
+}
+
+function buildAuthHeader() {
+  const user = process.env.JIRA_USER;
+  const token = process.env.JIRA_API_TOKEN;
+  if (!user || !token) {
+    throw new Error('Jira credentials are not configured');
+  }
+  const auth = Buffer.from(`${user}:${token}`).toString('base64');
+  return `Basic ${auth}`;
+}
+
+function jiraBaseUrl() {
+  const base = process.env.JIRA_BASE;
+  if (!base) {
+    throw new Error('JIRA_BASE is not configured');
+  }
+  return base.replace(/\/$/, '');
+}
+
+function toAtlassianDoc(text: string): JiraDocumentNode {
+  return {
+    type: 'doc',
+    version: 1,
+    content: [
+      {
+        type: 'paragraph',
+        content: [
+          {
+            type: 'text',
+            text,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+export async function jiraCreateIssue({
+  summary,
+  description,
+  labels = [],
+  priority = 'High',
+}: JiraCreateIssueParams): Promise<JiraCreateIssueResponse> {
+  const authHeader = buildAuthHeader();
+  const base = jiraBaseUrl();
+  const projectKey = process.env.JIRA_PROJECT_KEY;
+  const issueType = process.env.JIRA_INCIDENT_TYPE || 'Incident';
+  if (!projectKey) {
+    throw new Error('JIRA_PROJECT_KEY is not configured');
+  }
+
+  const response = await fetch(`${base}/rest/api/${JIRA_API_VERSION}/issue`, {
+    method: 'POST',
+    headers: {
+      Authorization: authHeader,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      fields: {
+        project: { key: projectKey },
+        issuetype: { name: issueType },
+        summary,
+        labels,
+        priority: { name: priority },
+        description: toAtlassianDoc(description),
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(`Failed to create Jira issue: ${message}`);
+  }
+
+  return (await response.json()) as JiraCreateIssueResponse;
+}
+
+export async function jiraComment(issueKey: string, body: string): Promise<void> {
+  const authHeader = buildAuthHeader();
+  const base = jiraBaseUrl();
+
+  const response = await fetch(`${base}/rest/api/${JIRA_API_VERSION}/issue/${issueKey}/comment`, {
+    method: 'POST',
+    headers: {
+      Authorization: authHeader,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      body: toAtlassianDoc(body),
+    }),
+  });
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(`Failed to add Jira comment: ${message}`);
+  }
+}
+
+export async function jiraResolve(
+  issueKey: string,
+  resolutionName = 'Fixed',
+  comment?: string,
+): Promise<void> {
+  const authHeader = buildAuthHeader();
+  const base = jiraBaseUrl();
+  const transitionId = process.env.JIRA_TRANSITION_RESOLVE;
+
+  if (!transitionId) {
+    throw new Error('JIRA_TRANSITION_RESOLVE is not configured');
+  }
+
+  if (comment) {
+    await jiraComment(issueKey, comment);
+  }
+
+  const response = await fetch(`${base}/rest/api/${JIRA_API_VERSION}/issue/${issueKey}/transitions`, {
+    method: 'POST',
+    headers: {
+      Authorization: authHeader,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      transition: { id: transitionId },
+      fields: {
+        resolution: { name: resolutionName },
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(`Failed to resolve Jira issue: ${message}`);
+  }
+}
+
+export function jiraBrowseUrl(issueKey: string): string {
+  return `${jiraBaseUrl()}/browse/${issueKey}`;
+}

--- a/apps/portals/lib/pagerduty.ts
+++ b/apps/portals/lib/pagerduty.ts
@@ -1,0 +1,119 @@
+const PAGERDUTY_API_BASE = 'https://api.pagerduty.com';
+
+export interface CreatePagerDutyIncidentParams {
+  title: string;
+  serviceId: string;
+  urgency?: 'high' | 'low';
+  body: string;
+  escalationPolicyId?: string;
+  runbookUrls?: string[];
+}
+
+export interface PagerDutyIncident {
+  id: string;
+  html_url: string;
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is not configured`);
+  }
+  return value;
+}
+
+function baseHeaders() {
+  return {
+    Authorization: `Token token=${requireEnv('PD_API_TOKEN')}`,
+    Accept: 'application/vnd.pagerduty+json;version=2',
+    'Content-Type': 'application/json',
+    From: requireEnv('PD_FROM_EMAIL'),
+  } as Record<string, string>;
+}
+
+export async function createPagerDutyIncident(
+  params: CreatePagerDutyIncidentParams,
+): Promise<PagerDutyIncident> {
+  const { title, serviceId, urgency = 'high', body, escalationPolicyId, runbookUrls = [] } = params;
+
+  const incidentBody = [body.trim(), ...runbookUrls.map(url => `Runbook: ${url}`)]
+    .filter(Boolean)
+    .join('\n\n');
+
+  const payload = {
+    incident: {
+      type: 'incident',
+      title,
+      service: {
+        id: serviceId,
+        type: 'service_reference',
+      },
+      urgency,
+      body: {
+        type: 'incident_body',
+        details: incidentBody,
+      },
+    } as Record<string, unknown>,
+  };
+
+  if (escalationPolicyId) {
+    payload.incident.escalation_policy = {
+      id: escalationPolicyId,
+      type: 'escalation_policy_reference',
+    };
+  }
+
+  const response = await fetch(`${PAGERDUTY_API_BASE}/incidents`, {
+    method: 'POST',
+    headers: baseHeaders(),
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(`Failed to create PagerDuty incident: ${message}`);
+  }
+
+  const json = (await response.json()) as { incident: PagerDutyIncident };
+  return json.incident;
+}
+
+export async function resolvePagerDutyIncident(
+  incidentId: string,
+  resolution: string,
+): Promise<PagerDutyIncident> {
+  const response = await fetch(`${PAGERDUTY_API_BASE}/incidents/${incidentId}`, {
+    method: 'PUT',
+    headers: baseHeaders(),
+    body: JSON.stringify({
+      incident: {
+        type: 'incident_reference',
+        status: 'resolved',
+        resolution,
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(`Failed to resolve PagerDuty incident: ${message}`);
+  }
+
+  const json = (await response.json()) as { incident: PagerDutyIncident };
+  return json.incident;
+}
+
+export async function addPagerDutyNote(incidentId: string, content: string): Promise<void> {
+  const response = await fetch(`${PAGERDUTY_API_BASE}/incidents/${incidentId}/notes`, {
+    method: 'POST',
+    headers: baseHeaders(),
+    body: JSON.stringify({
+      note: { content },
+    }),
+  });
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(`Failed to add PagerDuty note: ${message}`);
+  }
+}

--- a/apps/portals/package-lock.json
+++ b/apps/portals/package-lock.json
@@ -15,6 +15,7 @@
         "@copilotkit/react-ui": "latest",
         "@copilotkit/runtime": "latest",
         "@radix-ui/react-icons": "1.3.0",
+        "@vercel/postgres": "^0.8.0",
         "ai": "latest",
         "gray-matter": "^4.0.3",
         "marked": "^10.0.0",
@@ -2861,6 +2862,15 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@neondatabase/serverless": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-0.7.2.tgz",
+      "integrity": "sha512-wU3WA2uTyNO7wjPs3Mg0G01jztAxUxzd9/mskMmtPwPTjf7JKWi9AW5/puOGXLxmZ9PVgRFeBVRVYq5nBPhsCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pg": "8.6.6"
+      }
+    },
     "node_modules/@next/env": {
       "version": "14.2.3",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.3.tgz",
@@ -4157,6 +4167,17 @@
         "form-data": "^4.0.4"
       }
     },
+    "node_modules/@types/pg": {
+      "version": "8.6.6",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.6.tgz",
+      "integrity": "sha512-O2xNmXebtwVekJDD+02udOncjVcMZQuTEQEMpKJ0ZRf5E7/9JJX3izhKUcUifBkyKpljyUM6BTgy2trmviKlpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -4623,6 +4644,21 @@
       "dependencies": {
         "@0no-co/graphql.web": "^1.0.13",
         "wonka": "^6.3.2"
+      }
+    },
+    "node_modules/@vercel/postgres": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@vercel/postgres/-/postgres-0.8.0.tgz",
+      "integrity": "sha512-/QUV9ExwaNdKooRjOQqvrKNVnRvsaXeukPNI5DB1ovUTesglfR/fparw7ngo1KUWWKIVpEj2TRrA+ObRHRdaLg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@neondatabase/serverless": "0.7.2",
+        "bufferutil": "4.0.8",
+        "utf-8-validate": "6.0.3",
+        "ws": "8.14.2"
+      },
+      "engines": {
+        "node": ">=14.6"
       }
     },
     "node_modules/@whatwg-node/disposablestack": {
@@ -5375,6 +5411,19 @@
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/bufferutil": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.8.tgz",
+      "integrity": "sha512-4T53u4PdgsXqKaIctwF8ifXlRTTmEPJ8iEPWFdGZvcf7sbwYo6FKFEX9eNNAnzFZ7EzJAQ3CJeOtCRA4rDp7Pw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
     },
     "node_modules/busboy": {
       "version": "1.6.0",
@@ -11072,6 +11121,17 @@
         "node": ">= 6.13.0"
       }
     },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.21",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.21.tgz",
@@ -11546,6 +11606,37 @@
         "node": ">=8"
       }
     },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -11818,6 +11909,45 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -14856,6 +14986,19 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/utf-8-validate": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-6.0.3.tgz",
+      "integrity": "sha512-uIuGf9TWQ/y+0Lp+KGZCMuJWc3N9BHA+l/UmHd/oUHwJJDeysyTRxNQVkbzsIWfGFbRe3OcgML/i0mvVRPOyDA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -15335,6 +15478,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/apps/portals/package.json
+++ b/apps/portals/package.json
@@ -13,6 +13,7 @@
     "@copilotkit/react-ui": "latest",
     "@copilotkit/runtime": "latest",
     "@radix-ui/react-icons": "1.3.0",
+    "@vercel/postgres": "^0.8.0",
     "next": "14.2.3",
     "openai": "latest",
     "react": "18.2.0",


### PR DESCRIPTION
## Summary
- add Jira helper utilities, PagerDuty client, and incident audit persistence for syncing records
- extend PagerDuty create/resolve/bulk API routes to open/transition Jira issues and record cross-links
- introduce an Ops Incidents UI with Jira badges and PD/Jira links, and surface the page in the portal menu

## Testing
- npm install --prefix apps/portals --legacy-peer-deps
- npm run lint --prefix apps/portals *(fails: dependency resolution conflict between eslint-config-next@14.2.3 and eslint@9.9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68e8620d88c083299a3210aae98fb036