### PR TITLE
Add summary of Caltech neutral-atom array breakthrough

### DIFF
--- a/docs/neutral_atom_array_breakthrough.md
+++ b/docs/neutral_atom_array_breakthrough.md
@@ -1,0 +1,37 @@
+# Caltech Neutral-Atom Tweezer Array Breakthrough
+
+## Overview
+- **Platform**: Neutral cesium atoms confined in a two-dimensional optical-tweezer array with roughly 12,000 trap sites and 6,100 occupied qubits.
+- **Core achievements**: Record-setting hyperfine coherence (~12.6 s), room-temperature trapping lifetime approaching 23 minutes, and large-scale, high-fidelity atom transport across hundreds of micrometers.
+- **Strategic significance**: Simultaneous advances in scale, coherence, and controllability position neutral-atom hardware as a front-runner for fault-tolerant architectures that can leverage mid-circuit reconfiguration.
+
+## Key Technical Enablers
+1. **Scalable optical engineering**
+   - Dual-stage tweezer generation provides spare trap capacity, enabling defect reloading and rearrangement without sacrificing array density.
+   - Active intensity and phase stabilization maintains uniform trap depths across the ~12k lattice, suppressing differential light shifts that limit coherence.
+2. **Enhanced atomic state control**
+   - Raman sideband cooling prepares atoms deep in the motional ground state, extending coherence and increasing transport fidelity.
+   - Microwave dressing and spin-echo sequences counteract magnetic-field noise, pushing hyperfine coherence beyond prior neutral-atom records.
+3. **Reliable atom logistics**
+   - Fast steerable tweezers relocate atoms with ~99.95% success, supporting defect healing, routing, and modular layout changes.
+   - Buffered trap sites offer "parking spots" during reconfiguration, reducing collision risk and maintaining array regularity.
+
+## Comparison with Other Platforms
+- **Ion traps** retain exceptional single- and two-qubit fidelities but struggle to exceed a few hundred qubits per module; the Caltech array’s 6k-qubit scale narrows this gap while preserving long coherence.
+- **Superconducting qubits** excel in gate speed and integrated control electronics, yet coherence times (~100 μs) and cryogenic infrastructure remain limiting; neutral atoms deliver orders-of-magnitude longer coherence at room temperature.
+- **Photonic systems** promise natural networking but currently lack deterministic entangling operations; neutral atoms now demonstrate competitive reconfigurability with deterministic atomic resources.
+
+## Outstanding Challenges
+1. **Entangling operations at scale**
+   - Demonstrations of Rydberg-mediated entanglement exist, but extending high-fidelity multi-qubit gates across thousands of sites remains unproven.
+2. **Error correction integration**
+   - Logical qubits will require synchronized transport, mid-circuit measurement, and real-time feedback—capabilities still under active development.
+3. **Control-system complexity**
+   - Scaling optical hardware to tens of thousands of qubits increases thermal load, alignment demands, and crosstalk management challenges.
+4. **System modularity and networking**
+   - Building larger quantum processors will hinge on photonic interconnects or shuttling between modules; interface performance is still uncertain.
+
+## Outlook
+- Near-term milestones likely include multi-thousand-qubit entanglement demonstrations, logical qubit prototypes using transport-enabled layouts, and hybrid classical control stacks optimized for large arrays.
+- Competitive pressure from ions, superconductors, and photonics will drive specialization; neutral atoms may emerge as a versatile, reconfigurable backbone paired with photonic links or cryogenic modules.
+- Continued progress in laser stability, vacuum engineering, and automated calibration should convert the current experimental achievement into a platform capable of fault-tolerant quantum computation experiments within the decade.


### PR DESCRIPTION
## Summary
- add a technical briefing describing the Caltech 6,100-qubit neutral-atom optical tweezer array
- outline key enablers, comparisons to other qubit platforms, outstanding challenges, and near-term outlook

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e95424696c83299e3ff8b3833e6b4c