### PR TITLE
Add daily PD↔Jira smoke job and Ops smoke status tile

### DIFF
--- a/.github/workflows/smoke-daily.yml
+++ b/.github/workflows/smoke-daily.yml
@@ -1,0 +1,233 @@
+name: Daily PD↔Jira Smoke
+
+on:
+  schedule:
+    # 14:00 UTC is 08:00 America/Chicago (CST/CDT auto-handled by changing this when clocks move)
+    - cron: "0 14 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  BASE_URL: ${{ vars.OPSPORTAL_BASE_URL }}
+  ACTOR_EMAIL: ${{ vars.SMOKE_ACTOR_EMAIL }}
+  SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_SMOKE }}
+  PD_EVENTS_URL: https://events.pagerduty.com/v2/enqueue
+  PD_ROUTING_KEY: ${{ secrets.PD_ROUTING_KEY_SMOKE }}
+  JIRA_BASE: ${{ vars.NEXT_PUBLIC_JIRA_BASE }}
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - name: Open PD (sandbox) via Ops API
+        id: open
+        run: |
+          set -euo pipefail
+
+          curl_retry() {
+            local attempt=1
+            local max_attempts=2
+            local exit_code=0
+            while [ "$attempt" -le "$max_attempts" ]; do
+              if output=$(curl --max-time 25 -sS --fail-with-body "$@"); then
+                printf '%s' "$output"
+                return 0
+              fi
+              exit_code=$?
+              if [ "$attempt" -lt "$max_attempts" ]; then
+                sleep 3
+              fi
+              attempt=$((attempt + 1))
+            done
+            return "$exit_code"
+          }
+
+          BODY='{"systemKey":"sandbox","overrideUrgency":"low"}'
+          RES=$(curl_retry -X POST "$BASE_URL/api/pd/create?sandbox=1" \
+            -H "Content-Type: application/json" \
+            -H "x-user-email: $ACTOR_EMAIL" \
+            --data "$BODY")
+          echo "$RES"
+          URL=$(echo "$RES" | jq -r '.url // ""')
+          if [ -z "$URL" ]; then
+            echo "PagerDuty URL missing in response" >&2
+            exit 1
+          fi
+          echo "pd_url=$URL" >> "$GITHUB_OUTPUT"
+
+      - name: Wait briefly (allow linkage propagation)
+        run: sleep 10
+
+      - name: Fetch risk snapshot & Jira linkage
+        id: link
+        run: |
+          set -euo pipefail
+
+          curl_retry() {
+            local attempt=1
+            local max_attempts=2
+            local exit_code=0
+            while [ "$attempt" -le "$max_attempts" ]; do
+              if output=$(curl --max-time 25 -sS --fail-with-body "$@"); then
+                printf '%s' "$output"
+                return 0
+              fi
+              exit_code=$?
+              if [ "$attempt" -lt "$max_attempts" ]; then
+                sleep 3
+              fi
+              attempt=$((attempt + 1))
+            done
+            return "$exit_code"
+          }
+
+          SNAP=$(curl_retry "$BASE_URL/api/scorecard/risk?sandbox=1")
+          echo "$SNAP"
+          JIRA=$(echo "$SNAP" | jq -r '.systems[] | select(.key=="sandbox") | .jiraKey // ""' || echo "")
+          echo "jira_key=$JIRA" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve PD (attach PM link) via Ops API
+        id: resolve
+        run: |
+          set -euo pipefail
+
+          curl_retry() {
+            local attempt=1
+            local max_attempts=2
+            local exit_code=0
+            while [ "$attempt" -le "$max_attempts" ]; do
+              if output=$(curl --max-time 25 -sS --fail-with-body "$@"); then
+                printf '%s' "$output"
+                return 0
+              fi
+              exit_code=$?
+              if [ "$attempt" -lt "$max_attempts" ]; then
+                sleep 3
+              fi
+              attempt=$((attempt + 1))
+            done
+            return "$exit_code"
+          }
+
+          PM="https://notion.so/.../sandbox-daily-$(date +%F)"
+          BODY=$(jq -n --arg pm "$PM" '{incidentId:"infer",postmortemUrl:$pm}')
+          RES=$(curl_retry -X POST "$BASE_URL/api/pd/resolve?sandbox=1" \
+            -H "Content-Type: application/json" \
+            -H "x-user-email: $ACTOR_EMAIL" \
+            --data "$BODY")
+          echo "$RES"
+
+      - name: Post Slack ✅
+        if: success()
+        run: |
+          set -euo pipefail
+
+          curl_retry() {
+            local attempt=1
+            local max_attempts=2
+            local exit_code=0
+            while [ "$attempt" -le "$max_attempts" ]; do
+              if output=$(curl --max-time 25 -sS --fail-with-body "$@"); then
+                printf '%s' "$output"
+                return 0
+              fi
+              exit_code=$?
+              if [ "$attempt" -lt "$max_attempts" ]; then
+                sleep 3
+              fi
+              attempt=$((attempt + 1))
+            done
+            return "$exit_code"
+          }
+
+          PD_URL="${{ steps.open.outputs.pd_url }}"
+          JIRA_KEY="${{ steps.link.outputs.jira_key }}"
+          TRIMMED_BASE="${JIRA_BASE%/}"
+
+          JIRA_LINE="• Jira: N/A"
+          if [ -n "$JIRA_KEY" ] && [ -n "$TRIMMED_BASE" ]; then
+            JIRA_LINE="• Jira: ${TRIMMED_BASE}/browse/$JIRA_KEY"
+          elif [ -n "$JIRA_KEY" ]; then
+            JIRA_LINE="• Jira: $JIRA_KEY"
+          else
+            JIRA_LINE="• Jira: Pending (link not yet available)"
+          fi
+
+          MSG="✅ Daily smoke passed\n• PD: ${PD_URL:-N/A}\n$JIRA_LINE"
+          if [ -z "$JIRA_KEY" ]; then
+            MSG="${MSG}\n⚠️ Jira linkage pending — no page triggered."
+          fi
+
+          PAYLOAD=$(jq -n --arg text "$MSG" '{text:$text}')
+          curl_retry -X POST "$SLACK_WEBHOOK" -H "Content-Type: application/json" --data "$PAYLOAD" >/dev/null
+
+      - name: Post Slack ❌ + Page PagerDuty
+        if: failure()
+        run: |
+          set -euo pipefail
+
+          curl_retry() {
+            local attempt=1
+            local max_attempts=2
+            local exit_code=0
+            while [ "$attempt" -le "$max_attempts" ]; do
+              if output=$(curl --max-time 25 -sS --fail-with-body "$@"); then
+                printf '%s' "$output"
+                return 0
+              fi
+              exit_code=$?
+              if [ "$attempt" -lt "$max_attempts" ]; then
+                sleep 3
+              fi
+              attempt=$((attempt + 1))
+            done
+            return "$exit_code"
+          }
+
+          MSG="❌ Daily smoke FAILED — check Ops Portal logs"
+          PAYLOAD=$(jq -n --arg text "$MSG" '{text:$text}')
+          curl_retry -X POST "$SLACK_WEBHOOK" -H "Content-Type: application/json" --data "$PAYLOAD" >/dev/null
+
+          PD_PAYLOAD=$(jq -n \
+            --arg routing_key "$PD_ROUTING_KEY" \
+            '{routing_key:$routing_key,event_action:"trigger",payload:{summary:"Daily PD↔Jira smoke failed",severity:"error",source:"ops-portal"}}')
+          curl_retry -X POST "$PD_EVENTS_URL" -H "Content-Type: application/json" --data "$PD_PAYLOAD" >/dev/null
+
+      - name: Callback status (store)
+        if: always()
+        run: |
+          set -euo pipefail
+
+          curl_retry() {
+            local attempt=1
+            local max_attempts=2
+            local exit_code=0
+            while [ "$attempt" -le "$max_attempts" ]; do
+              if output=$(curl --max-time 25 -sS --fail-with-body "$@"); then
+                printf '%s' "$output"
+                return 0
+              fi
+              exit_code=$?
+              if [ "$attempt" -lt "$max_attempts" ]; then
+                sleep 3
+              fi
+              attempt=$((attempt + 1))
+            done
+            return "$exit_code"
+          }
+
+          PD_URL="${{ steps.open.outputs.pd_url }}"
+          JIRA_KEY="${{ steps.link.outputs.jira_key }}"
+
+          PAYLOAD=$(jq -n \
+            --argjson ok ${{ job.status == 'success' }} \
+            --arg at "$(date -Iseconds)" \
+            --arg pd "${PD_URL:-}" \
+            --arg jira "${JIRA_KEY:-}" \
+            '{ok:$ok,at:$at,pd:$pd,jira:$jira}')
+
+          curl_retry -X POST "$BASE_URL/api/smoke/status" -H "Content-Type: application/json" --data "$PAYLOAD" >/dev/null || true

--- a/app/api/smoke/status/route.ts
+++ b/app/api/smoke/status/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+
+type SmokeStatus = {
+  ok: boolean;
+  at: string;
+  pd?: string;
+  jira?: string;
+};
+
+const defaultStatus = (): SmokeStatus => ({
+  ok: true,
+  at: new Date().toISOString(),
+  pd: "",
+  jira: "",
+});
+
+export async function GET() {
+  const status = (globalThis as { __SMOKE__?: SmokeStatus }).__SMOKE__;
+  return NextResponse.json(status ?? defaultStatus());
+}
+
+export async function POST(request: Request) {
+  const body = await request.json();
+  const payload: SmokeStatus = {
+    ok: Boolean(body?.ok),
+    at: typeof body?.at === "string" ? body.at : new Date().toISOString(),
+    pd: typeof body?.pd === "string" ? body.pd : "",
+    jira: typeof body?.jira === "string" ? body.jira : "",
+  };
+
+  (globalThis as { __SMOKE__?: SmokeStatus }).__SMOKE__ = payload;
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/ops/components/SmokeStatusTile.tsx
+++ b/app/ops/components/SmokeStatusTile.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import useSWR from "swr";
+import { useMemo, type CSSProperties } from "react";
+
+type SmokeStatus = {
+  ok: boolean;
+  at?: string;
+  pd?: string;
+  jira?: string;
+};
+
+const fetcher = async (url: string): Promise<SmokeStatus> => {
+  const response = await fetch(url, { cache: "no-store" });
+  if (!response.ok) {
+    throw new Error("Failed to fetch smoke status");
+  }
+  return response.json();
+};
+
+const jiraBase =
+  process.env.NEXT_PUBLIC_JIRA_BASE ??
+  process.env.NEXT_PUBLIC_JIRA_URL ??
+  "";
+
+const boxStyle: CSSProperties = {
+  border: "1px solid #e5e7eb",
+  borderRadius: "0.75rem",
+  padding: "1rem 1.25rem",
+  backgroundColor: "#ffffff",
+  boxShadow: "0 5px 15px rgba(15, 23, 42, 0.05)",
+  minWidth: "240px",
+  maxWidth: "320px",
+};
+
+const titleStyle: CSSProperties = {
+  fontSize: "0.95rem",
+  fontWeight: 600,
+  marginBottom: "0.5rem",
+};
+
+const labelStyle: CSSProperties = {
+  fontSize: "0.9rem",
+  marginBottom: "0.25rem",
+};
+
+const metaStyle: CSSProperties = {
+  fontSize: "0.8rem",
+  color: "#64748b",
+};
+
+export default function SmokeStatusTile() {
+  const { data, error } = useSWR<SmokeStatus>("/api/smoke/status", fetcher, {
+    refreshInterval: 60_000,
+  });
+
+  const status = data ?? { ok: true };
+
+  const displayTime = useMemo(() => {
+    if (!status.at) {
+      return "—";
+    }
+    const date = new Date(status.at);
+    if (Number.isNaN(date.getTime())) {
+      return status.at;
+    }
+    return date.toLocaleString();
+  }, [status.at]);
+
+  const pdLink = status.pd ? status.pd : "";
+  const jiraLink = useMemo(() => {
+    if (!status.jira) {
+      return "";
+    }
+    if (jiraBase) {
+      const base = jiraBase.endsWith("/") ? jiraBase.slice(0, -1) : jiraBase;
+      return `${base}/browse/${status.jira}`;
+    }
+    return status.jira;
+  }, [status.jira]);
+
+  const lines: string[] = [];
+  if (!status.ok) {
+    lines.push("❌ Last run failed — check PagerDuty + logs");
+  } else if (!status.jira) {
+    lines.push("⚠️ Jira linkage pending — no page was sent");
+  }
+  if (error) {
+    lines.push("⚠️ Unable to refresh status");
+  }
+
+  return (
+    <section style={boxStyle}>
+      <div style={titleStyle}>Daily Smoke</div>
+      <div style={labelStyle}>Status: {status.ok ? "✅ Pass" : "❌ Fail"}</div>
+      <div style={labelStyle}>When: {displayTime}</div>
+      <div style={metaStyle}>Updates every minute</div>
+      {pdLink && (
+        <div style={labelStyle}>
+          <a href={pdLink} target="_blank" rel="noreferrer">
+            PagerDuty
+          </a>
+        </div>
+      )}
+      {jiraLink && (
+        <div style={labelStyle}>
+          <a href={jiraLink} target="_blank" rel="noreferrer">
+            Jira
+          </a>
+        </div>
+      )}
+      {lines.length > 0 && (
+        <div style={{ ...metaStyle, marginTop: "0.5rem", whiteSpace: "pre-line" }}>
+          {lines.join("\n")}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/app/ops/page.tsx
+++ b/app/ops/page.tsx
@@ -1,4 +1,5 @@
 import Heatmap from "./components/Heatmap";
+import SmokeStatusTile from "./components/SmokeStatusTile";
 import { getRiskSnapshot } from "@/lib/ops/risk";
 import { getRecentIncidentEvents } from "@/lib/ops/db";
 
@@ -13,6 +14,9 @@ export default async function OpsPage() {
       <header style={{ display: "flex", alignItems: "center", gap: "1rem", marginBottom: "1.5rem" }}>
         <h1 style={{ fontSize: "1.75rem", fontWeight: 600 }}>Ops Heatmap</h1>
       </header>
+      <section style={{ marginBottom: "1.5rem" }}>
+        <SmokeStatusTile />
+      </section>
       <Heatmap initialSystems={snapshot.systems} initialAudit={audit} generatedAt={snapshot.generatedAt} />
     </main>
   );


### PR DESCRIPTION
## Summary
- add a scheduled Daily PD↔Jira Smoke workflow with retry/timeouts, Slack + PagerDuty notifications, and status callback
- expose a temporary /api/smoke/status endpoint to store and return the most recent smoke run result
- show a live-updating smoke status tile on the Ops page that links to PagerDuty and Jira when available

## Testing
- npm run lint *(fails: Cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68e9562c0a608329807fc474b353a4da