### PR TITLE
Add MQTT heartbeat publishers for Pi fleet

### DIFF
--- a/heartbeat/heartbeat.py
+++ b/heartbeat/heartbeat.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Publish periodic device heartbeats with system metrics to MQTT."""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import signal
+import socket
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, Optional
+from urllib.parse import urlparse
+
+import psutil
+from paho.mqtt import client as mqtt
+
+
+LOGGER = logging.getLogger("heartbeat")
+
+
+@dataclass
+class MQTTConfig:
+    host: str
+    port: int
+    scheme: str
+    username: Optional[str] = None
+    password: Optional[str] = None
+    use_tls: bool = False
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        raise SystemExit(f"Invalid float for {name}: {raw!r}")
+
+
+def parse_mqtt_url(url: str) -> MQTTConfig:
+    if "://" not in url:
+        url = f"mqtt://{url}"
+
+    parsed = urlparse(url)
+    if not parsed.hostname:
+        raise SystemExit(f"MQTT URL must include a host: {url!r}")
+
+    scheme = parsed.scheme or "mqtt"
+    tls_schemes = {"mqtts", "ssl", "tls"}
+    default_port = 8883 if scheme in tls_schemes else 1883
+
+    username = parsed.username
+    password = parsed.password
+
+    return MQTTConfig(
+        host=parsed.hostname,
+        port=parsed.port or default_port,
+        scheme=scheme,
+        username=username,
+        password=password,
+        use_tls=scheme in tls_schemes,
+    )
+
+
+def build_client(config: MQTTConfig, client_id: str) -> mqtt.Client:
+    client = mqtt.Client(client_id=client_id, clean_session=True)
+    client.enable_logger(logging.getLogger("paho.mqtt.client"))
+
+    if config.username:
+        client.username_pw_set(config.username, config.password)
+
+    if config.use_tls:
+        ca_file = os.environ.get("MQTT_CA_FILE")
+        cert_file = os.environ.get("MQTT_CERT_FILE")
+        key_file = os.environ.get("MQTT_KEY_FILE")
+        client.tls_set(ca_certs=ca_file, certfile=cert_file, keyfile=key_file)
+        if os.environ.get("MQTT_TLS_INSECURE", "").lower() in {"1", "true", "yes"}:
+            client.tls_insecure_set(True)
+
+    keepalive = int(os.environ.get("MQTT_KEEPALIVE", "60"))
+    client.reconnect_delay_set(min_delay=1, max_delay=30)
+
+    def _on_connect(_client: mqtt.Client, _userdata: Any, _flags: Dict[str, Any], rc: int) -> None:
+        if rc == 0:
+            LOGGER.info("Connected to MQTT broker %s:%s", config.host, config.port)
+        else:
+            LOGGER.error("Failed to connect to MQTT broker (code %s)", rc)
+
+    def _on_disconnect(_client: mqtt.Client, _userdata: Any, rc: int) -> None:
+        if rc != 0:
+            LOGGER.warning("Unexpected MQTT disconnection (code %s)", rc)
+
+    client.on_connect = _on_connect
+    client.on_disconnect = _on_disconnect
+
+    try:
+        client.connect(config.host, config.port, keepalive=keepalive)
+    except Exception as exc:  # pragma: no cover - connectivity errors are runtime specific
+        raise SystemExit(f"Unable to connect to MQTT broker at {config.host}:{config.port} ({exc})")
+
+    return client
+
+
+def collect_temperatures() -> Dict[str, Iterable[Dict[str, Optional[float]]]]:
+    temps: Dict[str, Iterable[Dict[str, Optional[float]]]] = {}
+    try:
+        sensor_map = psutil.sensors_temperatures()
+    except (AttributeError, NotImplementedError):
+        return temps
+
+    for label, entries in sensor_map.items():
+        temps[label] = [
+            {
+                "label": entry.label or None,
+                "current": entry.current,
+                "high": entry.high,
+                "critical": entry.critical,
+            }
+            for entry in entries
+        ]
+    return temps
+
+
+def collect_metrics(hostname: str) -> Dict[str, Any]:
+    virtual_mem = psutil.virtual_memory()
+    swap = psutil.swap_memory()
+    disk = psutil.disk_usage("/")
+    net = psutil.net_io_counters()
+
+    cpu_freq = psutil.cpu_freq()
+    try:
+        load_avg = os.getloadavg()
+    except (OSError, AttributeError):
+        load_avg = None
+
+    metrics: Dict[str, Any] = {
+        "hostname": hostname,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "uptime_seconds": int(time.time() - psutil.boot_time()),
+        "cpu": {
+            "percent": psutil.cpu_percent(interval=None),
+            "count_logical": psutil.cpu_count(logical=True),
+            "count_physical": psutil.cpu_count(logical=False),
+            "frequency": {
+                "current": cpu_freq.current if cpu_freq else None,
+                "min": cpu_freq.min if cpu_freq else None,
+                "max": cpu_freq.max if cpu_freq else None,
+            },
+            "load_average": load_avg,
+        },
+        "memory": {
+            "total": virtual_mem.total,
+            "available": virtual_mem.available,
+            "used": virtual_mem.used,
+            "percent": virtual_mem.percent,
+            "swap_total": swap.total,
+            "swap_used": swap.used,
+            "swap_percent": swap.percent,
+        },
+        "disk": {
+            "path": "/",
+            "total": disk.total,
+            "used": disk.used,
+            "free": disk.free,
+            "percent": disk.percent,
+        },
+        "network": {
+            "bytes_sent": net.bytes_sent,
+            "bytes_recv": net.bytes_recv,
+            "packets_sent": net.packets_sent,
+            "packets_recv": net.packets_recv,
+        },
+        "process_count": len(psutil.pids()),
+        "temperatures": collect_temperatures(),
+    }
+
+    return metrics
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--mqtt-url",
+        default=os.environ.get("MQTT_URL", "mqtt://localhost:1883"),
+        help="MQTT broker URL (e.g. mqtt://host:1883)",
+    )
+    parser.add_argument(
+        "--topic-prefix",
+        default=os.environ.get("MQTT_TOPIC_PREFIX", "system/heartbeat"),
+        help="Topic prefix to publish under",
+    )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=_env_float("INTERVAL", 10.0),
+        help="Publish interval in seconds",
+    )
+    parser.add_argument(
+        "--hostname",
+        default=os.environ.get("HEARTBEAT_HOSTNAME") or socket.gethostname(),
+        help="Override the hostname included in the payload",
+    )
+    parser.add_argument(
+        "--log-level",
+        default=os.environ.get("LOG_LEVEL", "INFO"),
+        help="Logging level",
+    )
+    return parser.parse_args()
+
+
+def configure_logging(level: str) -> None:
+    logging.basicConfig(
+        level=getattr(logging, level.upper(), logging.INFO),
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+
+
+def main() -> None:
+    args = parse_args()
+    configure_logging(args.log_level)
+
+    if args.interval <= 0:
+        raise SystemExit("Interval must be greater than zero")
+
+    mqtt_config = parse_mqtt_url(args.mqtt_url)
+    client_id = f"heartbeat-{args.hostname}"
+    client = build_client(mqtt_config, client_id)
+
+    topic_prefix = args.topic_prefix.rstrip("/")
+    topic = f"{topic_prefix}/{args.hostname}"
+    LOGGER.info("Publishing heartbeats to %s every %ss", topic, args.interval)
+
+    should_run = True
+
+    def _signal_handler(signum: int, _frame: Any) -> None:
+        nonlocal should_run
+        LOGGER.info("Received signal %s, shutting down", signum)
+        should_run = False
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        signal.signal(sig, _signal_handler)
+
+    client.loop_start()
+
+    try:
+        psutil.cpu_percent(interval=None)  # Prime the CPU percent sampler
+        while should_run:
+            payload = collect_metrics(args.hostname)
+            message = json.dumps(payload)
+            result = client.publish(topic, payload=message, qos=0, retain=False)
+            if result.rc != mqtt.MQTT_ERR_SUCCESS:
+                LOGGER.error("Failed to publish heartbeat (rc=%s)", result.rc)
+            else:
+                LOGGER.debug("Published heartbeat payload: %s", message)
+            time.sleep(args.interval)
+    finally:
+        client.loop_stop()
+        client.disconnect()
+        LOGGER.info("Heartbeat publisher stopped")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(0)

--- a/heartbeat/heartbeat.service
+++ b/heartbeat/heartbeat.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Heartbeat telemetry publisher
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=pi
+WorkingDirectory=/home/pi/heartbeat
+Environment=MQTT_URL=mqtt://pi-ops.local
+ExecStart=/home/pi/heartbeat/run.sh
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/heartbeat/heartbeat.sh
+++ b/heartbeat/heartbeat.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MQTT_URL=${MQTT_URL:-mqtt://localhost:1883}
+MQTT_TOPIC_PREFIX=${MQTT_TOPIC_PREFIX:-system/heartbeat}
+INTERVAL=${INTERVAL:-10}
+HOSTNAME=${HEARTBEAT_HOSTNAME:-$(hostname)}
+LOG_LEVEL=${LOG_LEVEL:-info}
+
+parse_url() {
+  local url="$1"
+  local scheme hostport credentials host port
+
+  if [[ "$url" != *"://"* ]]; then
+    url="mqtt://$url"
+  fi
+
+  scheme="${url%%://*}"
+  remainder="${url#*://}"
+
+  if [[ "$remainder" == *"@"* ]]; then
+    credentials="${remainder%@*}"
+    hostport="${remainder#*@}"
+  else
+    credentials=""
+    hostport="$remainder"
+  fi
+
+  if [[ "$credentials" == *":"* ]]; then
+    MQTT_USER="${credentials%%:*}"
+    MQTT_PASS="${credentials#*:}"
+  elif [[ -n "$credentials" ]]; then
+    MQTT_USER="$credentials"
+    MQTT_PASS=""
+  else
+    MQTT_USER=""
+    MQTT_PASS=""
+  fi
+
+  if [[ "$hostport" == *":"* ]]; then
+    host="${hostport%%:*}"
+    port="${hostport#*:}"
+  else
+    host="$hostport"
+    if [[ "$scheme" == "mqtts" || "$scheme" == "ssl" || "$scheme" == "tls" ]]; then
+      port="8883"
+    else
+      port="1883"
+    fi
+  fi
+
+  MQTT_SCHEME="$scheme"
+  MQTT_HOST="$host"
+  MQTT_PORT="$port"
+}
+
+parse_url "$MQTT_URL"
+
+MOSQ_ARGS=("-h" "$MQTT_HOST" "-p" "$MQTT_PORT")
+if [[ -n "${MQTT_USER}" ]]; then
+  MOSQ_ARGS+=("-u" "$MQTT_USER")
+fi
+if [[ -n "${MQTT_PASS}" ]]; then
+  MOSQ_ARGS+=("-P" "$MQTT_PASS")
+fi
+if [[ "$MQTT_SCHEME" == "mqtts" || "$MQTT_SCHEME" == "ssl" || "$MQTT_SCHEME" == "tls" ]]; then
+  MOSQ_ARGS+=("--tls")
+fi
+
+TOPIC="${MQTT_TOPIC_PREFIX%/}/$HOSTNAME"
+
+log() {
+  local level="$1"; shift
+  local now
+  now="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  if [[ "$level" == "debug" && "$LOG_LEVEL" != "debug" ]]; then
+    return
+  fi
+  echo "$now [$level] $*" >&2
+}
+
+read_mem_percent() {
+  awk '
+    /MemTotal/ { total=$2 }
+    /MemAvailable/ { available=$2 }
+    END {
+      if (total > 0) {
+        printf "%.2f", (total-available)/total*100
+      } else {
+        print "0"
+      }
+    }
+  ' /proc/meminfo
+}
+
+read_disk_percent() {
+  df --output=pcent / | tail -n 1 | tr -dc '0-9.'
+}
+
+read_temp_c() {
+  local thermal="/sys/class/thermal/thermal_zone0/temp"
+  if [[ -f "$thermal" ]]; then
+    awk '{ printf "%.2f", $1/1000 }' "$thermal"
+  fi
+}
+
+publish_once() {
+  local timestamp uptime load1 load5 load15 mem_percent disk_percent temp_c process_count payload
+
+  timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  uptime="$(awk '{print $1}' /proc/uptime)"
+  read load1 load5 load15 _ < /proc/loadavg
+  mem_percent="$(read_mem_percent)"
+  disk_percent="$(read_disk_percent)"
+  temp_c="$(read_temp_c || true)"
+  process_count="$(ps ax | wc -l)"
+
+  payload=$(cat <<JSON
+{
+  "hostname": "${HOSTNAME}",
+  "timestamp": "${timestamp}",
+  "uptime_seconds": ${uptime},
+  "cpu": {
+    "load_average": [${load1}, ${load5}, ${load15}]
+  },
+  "memory_percent": ${mem_percent},
+  "disk_percent": ${disk_percent:-0},
+  "process_count": ${process_count},
+  "temperature_c": ${temp_c:-null}
+}
+JSON
+)
+
+  mosquitto_pub "${MOSQ_ARGS[@]}" -t "$TOPIC" -m "$payload"
+  log info "Published heartbeat: $payload"
+}
+
+trap 'log info "Exiting"; exit 0' SIGINT SIGTERM
+
+while true; do
+  publish_once || log error "Failed to publish heartbeat"
+  sleep "$INTERVAL"
+done

--- a/heartbeat/requirements.txt
+++ b/heartbeat/requirements.txt
@@ -1,0 +1,2 @@
+paho-mqtt>=1.6.1
+psutil>=5.9.0

--- a/heartbeat/run.sh
+++ b/heartbeat/run.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENV_DIR="${VENV_DIR:-$SCRIPT_DIR/.venv}"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+
+if [[ ! -d "$VENV_DIR" ]]; then
+  echo "[heartbeat] creating virtual environment at $VENV_DIR"
+  "$PYTHON_BIN" -m venv "$VENV_DIR"
+fi
+
+# shellcheck disable=SC1090
+source "$VENV_DIR/bin/activate"
+
+pip install --upgrade pip >/dev/null
+pip install --quiet --requirement "$SCRIPT_DIR/requirements.txt"
+
+echo "[heartbeat] starting publisher"
+exec "$VENV_DIR/bin/python" "$SCRIPT_DIR/heartbeat.py" "$@"


### PR DESCRIPTION
## Summary
- add a Python heartbeat publisher that reports detailed system metrics to MQTT
- provide a lightweight Bash heartbeat script for mosquitto_pub only nodes
- bundle helper scripts, dependencies, and a systemd unit for easier installs

## Testing
- python3 -m compileall heartbeat/heartbeat.py

------
https://chatgpt.com/codex/tasks/task_e_68e9574d81f8832993c415b278adbb1b