### PR TITLE
Add portal safety endpoints and automation

### DIFF
--- a/portal/bin/descriptor-doctor-run
+++ b/portal/bin/descriptor-doctor-run
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CONFIG="$ROOT/configs/doctor.desc.list"
+DOCTOR="$ROOT/bin/descriptor-doctor"
+
+if [[ ! -x "$DOCTOR" ]]; then
+  echo "missing descriptor-doctor at $DOCTOR" >&2
+  exit 1
+fi
+
+if [[ ! -f "$CONFIG" ]]; then
+  echo "missing descriptor list: $CONFIG" >&2
+  exit 1
+fi
+
+status=0
+ran=0
+while IFS= read -r raw || [[ -n "$raw" ]]; do
+  line="$(printf '%s' "$raw" | tr -d '\r' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+  [[ -z "$line" ]] && continue
+  [[ "$line" =~ ^# ]] && continue
+  ran=1
+  candidate="$line"
+  if [[ -f "$candidate" ]]; then
+    arg="$candidate"
+  elif [[ -f "$ROOT/$candidate" ]]; then
+    arg="$ROOT/$candidate"
+  elif [[ -f "$ROOT/configs/$candidate" ]]; then
+    arg="$ROOT/configs/$candidate"
+  else
+    arg="$candidate"
+  fi
+  if ! "$DOCTOR" "$arg"; then
+    status=1
+  fi
+done < "$CONFIG"
+
+if [[ $ran -eq 0 ]]; then
+  echo "no descriptors in $CONFIG" >&2
+  exit 2
+fi
+
+exit $status

--- a/portal/bin/portal
+++ b/portal/bin/portal
@@ -193,6 +193,10 @@ case "$CMD" in
       echo "Refuse: set CONFIRM_BROADCAST=1 to allow broadcast" >&2
       exit 2
     fi
+    if [[ -f "$ROOT/configs/BROADCAST_DISABLED" ]]; then
+      echo "Panic: broadcasting disabled" >&2
+      exit 9
+    fi
     local file="$1"
     local fin txid
     fin=$(bitcoin-cli finalizepsbt "$(cat "$file")" true)

--- a/portal/bin/portal-help
+++ b/portal/bin/portal-help
@@ -45,4 +45,15 @@ Tests:
 Security rules:
   - No private keys here. Signing is offline.
   - No broadcast without CONFIRM_BROADCAST=1.
+
+Extras:
+  proof-verify <proof.json>    # show sha256, bytes, tip, timestamp
+  portal-weekly                # run weekly backup now (cron handles on Sundays)
+  portal-panic                 # emergency: disable broadcast, freeze UTXOs, stop REST
+  portal-unpanic               # clear panic flag and restart REST shim
+REST (localhost):
+  token: cat /home/pi/portal/configs/api.token
+  curl -H "Authorization: Bearer $(cat /home/pi/portal/configs/api.token)" http://127.0.0.1:8787/balances
+  curl -H "Authorization: Bearer $(cat /home/pi/portal/configs/api.token)" http://127.0.0.1:8787/proof
+  curl -H "Authorization: Bearer $(cat /home/pi/portal/configs/api.token)" http://127.0.0.1:8787/doctor
 TXT

--- a/portal/bin/portal-panic
+++ b/portal/bin/portal-panic
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+FLAG="$ROOT/configs/BROADCAST_DISABLED"
+PORTAL_BIN="$ROOT/bin/portal"
+WALLET="watchonly_main"
+
+echo "== PANIC MODE =="
+
+touch "$FLAG"
+echo "BROADCAST_DISABLED set" >&2
+
+if [[ -x "$PORTAL_BIN" ]] && ! grep -q 'BROADCAST_DISABLED' "$PORTAL_BIN"; then
+  cp "$PORTAL_BIN" "$PORTAL_BIN.bak.$(date -u +%s)"
+  sed -i "/psbt:broadcast)/a\\
+    if [[ -f \"$ROOT/configs/BROADCAST_DISABLED\" ]]; then echo \"Panic: broadcasting disabled\" >&2; exit 9; fi" "$PORTAL_BIN"
+fi
+
+if command -v bitcoin-cli >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
+  if bitcoin-cli -rpcwallet="$WALLET" getwalletinfo >/dev/null 2>&1; then
+    UTXO_JSON="$(bitcoin-cli -rpcwallet="$WALLET" listunspent | jq -c '[.[] | {txid:.txid, vout:.vout}]')"
+    if [[ "$UTXO_JSON" != "[]" ]]; then
+      bitcoin-cli -rpcwallet="$WALLET" lockunspent false "$UTXO_JSON" >/dev/null || true
+    fi
+  fi
+fi
+
+sudo systemctl stop portal-rest 2>/dev/null || true
+
+echo "PANIC engaged. To revert: rm $FLAG && restore portal from backup if needed."

--- a/portal/bin/portal-rest
+++ b/portal/bin/portal-rest
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
-import os
+import base64
 import json
+import os
 import subprocess
+from glob import glob
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from urllib.parse import urlparse
 
@@ -9,7 +11,10 @@ ROOT = "/home/pi/portal"
 HOST, PORT = "127.0.0.1", 8787
 TOKEN_PATH = os.path.join(ROOT, "configs", "api.token")
 if not os.path.exists(TOKEN_PATH):
-    raise SystemExit(f"missing token file: {TOKEN_PATH}")
+    os.makedirs(os.path.dirname(TOKEN_PATH), exist_ok=True)
+    token_bytes = base64.b64encode(os.urandom(24)).decode("ascii")
+    with open(TOKEN_PATH, "w", encoding="utf-8") as fh:
+        fh.write(token_bytes)
 with open(TOKEN_PATH, "r", encoding="utf-8") as fh:
     TOKEN = fh.read().strip()
 ENABLE_PSBT_API = os.environ.get("ENABLE_PSBT_API", "0") == "1"
@@ -34,6 +39,25 @@ class Handler(BaseHTTPRequestHandler):
         auth = self.headers.get("Authorization", "")
         return auth == f"Bearer {TOKEN}"
 
+    def _load_json_field(self, path, selector=None):
+        if not os.path.exists(path):
+            return None
+        try:
+            with open(path, "r", encoding="utf-8") as fp:
+                data = json.load(fp)
+        except Exception:  # pylint: disable=broad-except
+            return None
+        if not selector:
+            return data
+        for key in selector.split("."):
+            if isinstance(data, dict):
+                data = data.get(key)
+            else:
+                return None
+            if data is None:
+                return None
+        return data
+
     def do_GET(self):
         if not self._authed():
             return json_response(self, 401, {"error": "unauthorized"})
@@ -41,29 +65,24 @@ class Handler(BaseHTTPRequestHandler):
         if parsed.path == "/health":
             btc = os.path.join(ROOT, "proofs", "aura-proof.json")
             ltc = os.path.join(ROOT, "proofs", "ltc-proof.json")
-
-            def load_amount(path, keypath):
-                if not os.path.exists(path):
-                    return None
-                try:
-                    with open(path, "r", encoding="utf-8") as fp:
-                        data = json.load(fp)
-                    for key in keypath.split("."):
-                        if isinstance(data, dict):
-                            data = data.get(key)
-                        else:
-                            data = None
-                        if data is None:
-                            break
-                    return data
-                except Exception:
-                    return None
-
             res = {
-                "btc": load_amount(btc, "scantxoutset.total_amount"),
-                "ltc": load_amount(ltc, "scantxoutset.total_amount"),
+                "btc": self._load_json_field(btc, "scantxoutset.total_amount"),
+                "ltc": self._load_json_field(ltc, "scantxoutset.total_amount"),
             }
             return json_response(self, 200, res)
+        if parsed.path == "/balances":
+            btc = os.path.join(ROOT, "proofs", "aura-proof.json")
+            ltc = os.path.join(ROOT, "proofs", "ltc-proof.json")
+            eth_path = os.path.join(ROOT, "proofs", "eth_balance.json")
+            balances = {
+                "btc": self._load_json_field(btc, "scantxoutset.total_amount"),
+                "ltc": self._load_json_field(ltc, "scantxoutset.total_amount"),
+                "eth": None,
+            }
+            eth_payload = self._load_json_field(eth_path)
+            if isinstance(eth_payload, dict):
+                balances["eth"] = eth_payload.get("eth")
+            return json_response(self, 200, balances)
         if parsed.path == "/proof":
             rc, _out, err = run([os.path.join(ROOT, "bin", "portal"), "proof", os.path.join(ROOT, "configs", "raw.descriptor")])
             if rc != 0:
@@ -73,6 +92,24 @@ class Handler(BaseHTTPRequestHandler):
                     return json_response(self, 200, json.load(fh))
             except Exception as exc:  # pylint: disable=broad-except
                 return json_response(self, 500, {"error": str(exc)})
+        if parsed.path == "/doctor":
+            rc, _out, err = run([os.path.join(ROOT, "bin", "descriptor-doctor-run")])
+            if rc != 0:
+                detail = err.strip() or _out.strip()
+                return json_response(self, 500, {"error": "doctor failed", "stderr": detail})
+            try:
+                pattern = os.path.join(ROOT, "proofs", "doctor-*.json")
+                latest = max(glob(pattern), key=os.path.getmtime)
+            except ValueError:
+                return json_response(self, 500, {"error": "no doctor proofs found"})
+            except Exception as exc:  # pylint: disable=broad-except
+                return json_response(self, 500, {"error": str(exc)})
+            try:
+                with open(latest, "r", encoding="utf-8") as fh:
+                    payload = json.load(fh)
+            except Exception as exc:  # pylint: disable=broad-except
+                return json_response(self, 500, {"error": str(exc)})
+            return json_response(self, 200, payload)
         return json_response(self, 404, {"error": "not found"})
 
     def do_POST(self):

--- a/portal/bin/portal-unpanic
+++ b/portal/bin/portal-unpanic
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+FLAG="$ROOT/configs/BROADCAST_DISABLED"
+
+rm -f "$FLAG"
+sudo systemctl restart portal-rest 2>/dev/null || true
+echo "Panic flag cleared. Review wallet locks separately with 'bitcoin-cli -rpcwallet=watchonly_main listlockunspent'."

--- a/portal/bin/portal-weekly
+++ b/portal/bin/portal-weekly
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+BACKUP_DIR="$ROOT/backups"
+BACKUP_BIN="$ROOT/bin/portal-backup"
+
+if [[ ! -x "$BACKUP_BIN" ]]; then
+  echo "missing portal-backup at $BACKUP_BIN" >&2
+  exit 1
+fi
+
+mkdir -p "$BACKUP_DIR"
+STAMP="$(date -u +%Y%m%d)"
+DEST="$BACKUP_DIR/portal.${STAMP}.tgz"
+
+"$BACKUP_BIN" "$DEST"
+
+ls -1t "$BACKUP_DIR"/portal.*.tgz 2>/dev/null | sed -n '9,$p' | xargs -r rm -f
+
+echo "BACKUP: $DEST"

--- a/portal/bin/proof-verify
+++ b/portal/bin/proof-verify
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PROOF="${1:-$ROOT/proofs/aura-proof.json}"
+
+if [[ ! -s "$PROOF" ]]; then
+  echo "missing proof" >&2
+  exit 2
+fi
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "$1 is required" >&2
+    exit 1
+  fi
+}
+
+require_cmd jq
+require_cmd sha256sum
+
+SUM="$(sha256sum "$PROOF" | awk '{print $1}')"
+SIZE="$(wc -c < "$PROOF" | tr -d ' ')"
+TIP="$(jq -r '.tip // .scantxoutset.height // empty' "$PROOF" 2>/dev/null || true)"
+
+jq -n \
+  --arg file "$PROOF" \
+  --arg sha256 "$SUM" \
+  --arg size "$SIZE" \
+  --arg tip "$TIP" \
+  '{
+    file: $file,
+    sha256: $sha256,
+    bytes: ($size | tonumber),
+    tip: (if ($tip | length) == 0 then null else (try ($tip | tonumber) catch $tip) end),
+    utc: (now | todate)
+  }'


### PR DESCRIPTION
## Summary
- extend the portal REST shim with auto-generated API tokens, balance reporting, and a doctor endpoint backed by a descriptor doctor runner
- add operational helpers for proof verification, weekly backups, and panic/unpanic workflows with help documentation updates
- gate PSBT broadcasts on a panic flag to disable broadcasts when the emergency brake is engaged

## Testing
- python3 -m py_compile portal/bin/portal-rest
- for f in portal/bin/descriptor-doctor-run portal/bin/portal-weekly portal/bin/portal-panic portal/bin/portal-unpanic portal/bin/proof-verify; do bash -n "$f"; done
- for f in portal/bin/portal-panic; do bash -n "$f"; done

------
https://chatgpt.com/codex/tasks/task_e_68e9576c84508329a5e8139617f5ab2d