### PR TITLE
Add Pi-Holo audio playback service and tooling

### DIFF
--- a/agent/mac/send_audio.py
+++ b/agent/mac/send_audio.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Publish Pi-Holo audio playback commands over MQTT."""
+from __future__ import annotations
+
+import argparse
+import os
+from typing import Any
+
+from agent.mac.mqtt import publish_payload
+
+
+def parse_loop(value: str) -> bool:
+    lowered = value.strip().lower()
+    if lowered in {"1", "true", "yes", "loop"}:
+        return True
+    if lowered in {"0", "false", "no", "stop"}:
+        return False
+    raise argparse.ArgumentTypeError(f"invalid loop flag: {value}")
+
+
+def clamp_volume(value: float) -> float:
+    return max(0.0, min(1.0, value))
+
+
+def build_payload(args: argparse.Namespace) -> dict[str, Any]:
+    if args.stop:
+        return {"stop": True}
+
+    payload: dict[str, Any] = {
+        "file": args.file,
+        "volume": clamp_volume(args.volume),
+    }
+    if args.loop:
+        payload["loop"] = True
+    return payload
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Send an audio command to the Pi-Holo listener")
+    parser.add_argument("file", nargs="?", help="Sound file name relative to the Pi sounds directory")
+    parser.add_argument("volume", nargs="?", type=float, default=0.8, help="Playback volume between 0 and 1")
+    parser.add_argument("loop", nargs="?", type=parse_loop, default=False, help="Loop flag (0 or 1)")
+    parser.add_argument("--topic", default=os.getenv("AUDIO_TOPIC", "holo/audio"), help="MQTT topic (default: %(default)s)")
+    parser.add_argument("--stop", action="store_true", help="Send a stop payload instead of play")
+    args = parser.parse_args()
+
+    if not args.stop and not args.file:
+        parser.error("file argument is required unless --stop is used")
+
+    payload = build_payload(args)
+    publish_payload(args.topic, payload)
+
+    if args.stop:
+        print(f"Published stop command to {args.topic}")
+    else:
+        loop_label = "looping" if args.loop else "once"
+        print(
+            f"Published {payload['file']} at volume {payload['volume']:.2f} ({loop_label}) to {args.topic}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pis/pi-holo/README.md
+++ b/pis/pi-holo/README.md
@@ -1,0 +1,55 @@
+# Pi-Holo Audio Add-on
+
+This directory contains the MQTT audio playback service for the Pi-Holo along with
+helper tooling to publish alerts from macOS workstations.
+
+## Files
+
+- `audio_player.py` — MQTT subscriber that plays audio files with `pygame.mixer`.
+- `audio.service` — systemd unit that starts the audio listener during boot.
+
+The macOS publisher lives in `agent/mac/send_audio.py`.
+
+## Installation on the Pi-Holo
+
+```sh
+scp pis/pi-holo/audio_player.py pis/pi-holo/audio.service pi@pi-holo.local:/home/pi/
+ssh pi@pi-holo.local <<'EOF'
+sudo apt update
+sudo apt install -y python3-pip
+pip install --break-system-packages pygame paho-mqtt
+mkdir -p /home/pi/sounds
+sudo mv /home/pi/audio.service /etc/systemd/system/audio.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now audio
+EOF
+```
+
+Sound files are expected inside `/home/pi/sounds`. Place `alert.wav` (or other
+OGG/WAV assets) in that directory.
+
+## Sending audio commands
+
+From a Mac that already publishes MQTT events for Pi-ops:
+
+```sh
+python agent/mac/send_audio.py alert.wav 0.8 0  # plays once at 80%
+python agent/mac/send_audio.py alert.wav 0.6 1  # loop the clip
+python agent/mac/send_audio.py --stop           # stop playback
+```
+
+The script uses the same environment variables as the other MQTT helpers:
+
+- `MQTT_HOST`, `MQTT_PORT`, `MQTT_USERNAME`, `MQTT_PASSWORD`
+- `MQTT_TLS`/`MQTT_CA_FILE` for TLS settings
+- `AUDIO_TOPIC` if you need something other than `holo/audio`
+
+Alternatively you can publish stop messages directly:
+
+```sh
+mosquitto_pub -h pi-ops.local -t holo/audio -m '{"stop":true}'
+```
+
+To integrate with Reflex automations, publish JSON payloads such as
+`{"file":"alert.wav","volume":0.9}` to the `holo/audio` topic alongside your
+existing `holo/cmd` banners.

--- a/pis/pi-holo/audio.service
+++ b/pis/pi-holo/audio.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=BlackRoad Pi-Holo audio listener
+After=network-online.target sound.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=pi
+WorkingDirectory=/home/pi
+ExecStart=/usr/bin/env python3 /home/pi/audio_player.py
+Restart=on-failure
+RestartSec=2
+Environment=AUDIO_MQTT_HOST=pi-ops.local
+Environment=AUDIO_SOUNDS_DIR=/home/pi/sounds
+
+[Install]
+WantedBy=multi-user.target

--- a/pis/pi-holo/audio_player.py
+++ b/pis/pi-holo/audio_player.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""MQTT-driven audio playback service for the Pi-Holo."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import signal
+import threading
+from pathlib import Path
+from typing import Any
+
+import pygame
+from paho.mqtt import client as mqtt
+
+
+LOGGER = logging.getLogger("pi-holo.audio")
+
+
+class MixerController:
+    """Wrapper around ``pygame.mixer`` with simple playback semantics."""
+
+    def __init__(self, sounds_dir: Path, *, default_volume: float = 0.8) -> None:
+        self.sounds_dir = sounds_dir
+        self.sounds_dir.mkdir(parents=True, exist_ok=True)
+        self.default_volume = default_volume
+        self._lock = threading.Lock()
+        self._current_file: str | None = None
+        self._init_mixer()
+
+    def _init_mixer(self) -> None:
+        try:
+            pygame.mixer.init()
+        except pygame.error as exc:  # pragma: no cover - requires Raspberry Pi audio stack
+            LOGGER.error("failed to initialise audio mixer: %s", exc)
+            raise SystemExit(2)
+
+    def play(self, filename: str, *, volume: float | None = None, loop: bool = False) -> None:
+        path = self.sounds_dir / filename
+        if not path.is_file():
+            LOGGER.warning("audio file missing: %s", path)
+            return
+
+        volume = self._clamp_volume(volume if volume is not None else self.default_volume)
+
+        with self._lock:
+            try:
+                pygame.mixer.music.load(str(path))
+            except pygame.error as exc:
+                LOGGER.error("unable to load %s: %s", path, exc)
+                return
+
+            loops = -1 if loop else 0
+            try:
+                pygame.mixer.music.set_volume(volume)
+                pygame.mixer.music.play(loops)
+            except pygame.error as exc:
+                LOGGER.error("unable to play %s: %s", path, exc)
+                return
+
+            self._current_file = filename
+            LOGGER.info(
+                "playing %s (volume=%.2f loop=%s)",
+                filename,
+                volume,
+                "on" if loop else "off",
+            )
+
+    def stop(self) -> None:
+        with self._lock:
+            if not pygame.mixer.music.get_busy():
+                return
+            pygame.mixer.music.stop()
+            LOGGER.info("stopped playback of %s", self._current_file or "<none>")
+            self._current_file = None
+
+    @staticmethod
+    def _clamp_volume(value: float) -> float:
+        return max(0.0, min(1.0, value))
+
+
+class AudioService:
+    """MQTT service that reacts to ``holo/audio`` commands."""
+
+    def __init__(self, controller: MixerController, topic: str) -> None:
+        self.controller = controller
+        self.topic = topic
+        self._client = mqtt.Client(client_id=os.getenv("AUDIO_CLIENT_ID", "pi-holo-audio"))
+        username = os.getenv("AUDIO_MQTT_USERNAME")
+        if username:
+            self._client.username_pw_set(username, password=os.getenv("AUDIO_MQTT_PASSWORD"))
+        self._client.on_connect = self._on_connect
+        self._client.on_message = self._on_message
+        self._stop = threading.Event()
+
+    def connect(self) -> None:
+        host = os.getenv("AUDIO_MQTT_HOST", "pi-ops.local")
+        port = int(os.getenv("AUDIO_MQTT_PORT", "1883"))
+        keepalive = int(os.getenv("AUDIO_MQTT_KEEPALIVE", "60"))
+        try:
+            self._client.connect(host, port=port, keepalive=keepalive)
+        except Exception as exc:  # pragma: no cover - depends on runtime network
+            LOGGER.error("failed to connect to MQTT broker %s:%s - %s", host, port, exc)
+            raise SystemExit(3)
+
+    def loop_forever(self) -> None:
+        self._client.loop_start()
+        try:
+            while not self._stop.is_set():
+                self._stop.wait(1.0)
+        except KeyboardInterrupt:
+            LOGGER.info("received interrupt, stopping")
+        finally:
+            self._client.loop_stop()
+            self._client.disconnect()
+            pygame.mixer.music.stop()
+            pygame.mixer.quit()
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    # MQTT callbacks -------------------------------------------------
+    def _on_connect(self, client: mqtt.Client, _userdata: Any, _flags: dict[str, Any], rc: int) -> None:
+        if rc != 0:
+            LOGGER.error("MQTT connection failed with rc=%s", rc)
+            return
+        LOGGER.info("connected to MQTT broker, subscribing to %s", self.topic)
+        client.subscribe(self.topic, qos=1)
+
+    def _on_message(self, _client: mqtt.Client, _userdata: Any, msg: mqtt.MQTTMessage) -> None:
+        try:
+            payload = json.loads(msg.payload.decode("utf-8"))
+        except json.JSONDecodeError:
+            LOGGER.warning("discarding non-JSON payload on %s", msg.topic)
+            return
+
+        if isinstance(payload, dict) and payload.get("stop"):
+            self.controller.stop()
+            return
+
+        if not isinstance(payload, dict) or "file" not in payload:
+            LOGGER.warning("invalid payload on %s: %s", msg.topic, payload)
+            return
+
+        filename = str(payload.get("file"))
+        volume = payload.get("volume")
+        loop_flag = payload.get("loop", False)
+        loop = bool(loop_flag)
+
+        try:
+            volume_value = float(volume) if volume is not None else None
+        except (TypeError, ValueError):
+            LOGGER.warning("invalid volume %r, using default", volume)
+            volume_value = None
+
+        self.controller.play(filename, volume=volume_value, loop=loop)
+
+
+def _setup_logging() -> None:
+    level = os.getenv("AUDIO_LOG_LEVEL", "INFO").upper()
+    logging.basicConfig(level=level, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+
+
+def main() -> int:
+    _setup_logging()
+    sounds_dir = Path(os.getenv("AUDIO_SOUNDS_DIR", "/home/pi/sounds"))
+    default_volume = float(os.getenv("AUDIO_DEFAULT_VOLUME", "0.8"))
+
+    controller = MixerController(sounds_dir, default_volume=default_volume)
+    topic = os.getenv("AUDIO_TOPIC", "holo/audio")
+    service = AudioService(controller, topic)
+    service.connect()
+
+    def _handle_signal(_signum: int, _frame: Any) -> None:
+        service.stop()
+
+    signal.signal(signal.SIGTERM, _handle_signal)
+    signal.signal(signal.SIGINT, _handle_signal)
+    service.loop_forever()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add an MQTT-driven audio playback service for Pi-Holo along with a systemd unit
- document installation and usage for the new audio listener
- provide a macOS helper script to publish audio playback and stop commands

## Testing
- python -m compileall agent/mac/send_audio.py pis/pi-holo/audio_player.py

------
https://chatgpt.com/codex/tasks/task_e_68e9589271fc8329abfa96424c18647a