### PR TITLE
Add ops haptics bridge and Arduino controller

### DIFF
--- a/README_HAPTICS.md
+++ b/README_HAPTICS.md
@@ -1,0 +1,70 @@
+# Ops Haptics Add-On
+
+This package provides a simple haptics stack that reacts to alerts on the `ops/reflex/alert` topic and drives an Arduino-based buzzer and vibration motor assembly.
+
+## Contents
+
+| Path | Description |
+| ---- | ----------- |
+| `arduino/HapticsAlert.ino` | Arduino sketch that listens for serial commands and drives the LED, buzzer, and vibration motor. |
+| `pi-ops/ops_haptics_bridge.py` | Python bridge that connects MQTT alerts to the Arduino over USB serial. |
+| `systemd/ops_haptics_bridge.service` | Systemd service unit to run the bridge on boot. |
+
+## Hardware wiring
+
+* **Microcontroller:** Arduino Uno (or compatible) connected over USB to the Pi-Ops host.
+* **LED:** Uses the onboard `D13` LED to flash for each alert.
+* **Buzzer:** Connect an active buzzer to `D9` (PWM). Add a ~100 Ω series resistor when using an active buzzer, or drive a passive piezo directly via PWM at modest duty cycle.
+* **Vibration motor:** Connect a coin vibration motor to `D5` through an NPN transistor (e.g., 2N2222). Place a 1 kΩ resistor between `D5` and the transistor base, and a flyback diode (1N4148/1N4007) across the motor leads (cathode to +5 V) to protect against voltage spikes.
+* **Power:** Use the Arduino’s 5 V rail for both buzzer and motor. Ensure the USB port or external supply can provide the required current.
+
+## Arduino deployment
+
+1. Open `arduino/HapticsAlert.ino` in the Arduino IDE or the CLI.
+2. Select the target board and port, and flash at `115200` baud.
+3. After reset, the sketch prints `READY` once the serial port is up.
+
+## Pi-Ops bridge installation
+
+```bash
+scp pi-ops/ops_haptics_bridge.py pi-ops/ops_haptics_bridge.service pi@pi-ops.local:/home/pi/
+ssh pi@pi-ops.local \
+  'sudo apt update && \
+   sudo apt install -y python3-pip && \
+   pip install --break-system-packages paho-mqtt pyserial && \
+   sudo mv /home/pi/ops_haptics_bridge.service /etc/systemd/system/ && \
+   sudo systemctl daemon-reload && \
+   sudo systemctl enable --now ops_haptics_bridge'
+```
+
+The bridge listens to `ops/reflex/alert`, forwards events to `/dev/ttyACM0`, and publishes acknowledgements to `ops/reflex/haptic_status`.
+
+## Testing
+
+With the Arduino connected and the service running, publish a sample alert and confirm the acknowledgement stream:
+
+```bash
+mosquitto_pub -h pi-ops.local -t ops/reflex/alert -m '{"kind":"node_lost","meta":{"dur_ms":1200,"intensity":255}}'
+mosquitto_sub -h pi-ops.local -t ops/reflex/haptic_status -v
+```
+
+You should observe:
+
+* The Arduino LED flashing for at least 200 ms.
+* The buzzer sounding for `temp_high` and `node_lost` alerts.
+* The vibration motor pulsing for `node_lost` alerts.
+* An MQTT status message confirming the alert delivery (or reporting any parsing/serial errors).
+
+## Serial protocol
+
+The bridge sends newline-terminated ASCII lines:
+
+```
+ALERT <kind> <duration_ms> <intensity>
+```
+
+* `<kind>` matches the alert kind from MQTT (e.g., `node_lost`, `temp_high`).
+* `<duration_ms>` is the duration to run the effect.
+* `<intensity>` maps to the PWM duty cycle (0–255).
+
+The Arduino responds with either `ACK <kind>` after playing the haptic pattern or `ERR <reason>` if the command is malformed.

--- a/arduino/HapticsAlert.ino
+++ b/arduino/HapticsAlert.ino
@@ -1,0 +1,142 @@
+#include <Arduino.h>
+
+const uint8_t LED_PIN = LED_BUILTIN;
+const uint8_t BUZZER_PIN = 9;
+const uint8_t MOTOR_PIN = 5;
+
+const unsigned long MOTOR_PULSE_MS = 150;
+const unsigned long MOTOR_PAUSE_MS = 120;
+const unsigned long LED_MIN_MS = 200;
+
+char inputBuffer[96];
+size_t inputIndex = 0;
+
+void processLine(char *line);
+void handleAlert(const char *kind, unsigned long durationMs, uint8_t intensity);
+
+void setup() {
+  pinMode(LED_PIN, OUTPUT);
+  pinMode(BUZZER_PIN, OUTPUT);
+  pinMode(MOTOR_PIN, OUTPUT);
+
+  digitalWrite(LED_PIN, LOW);
+  analogWrite(BUZZER_PIN, 0);
+  analogWrite(MOTOR_PIN, 0);
+
+  Serial.begin(115200);
+  while (!Serial) {
+    ;
+  }
+  Serial.println(F("READY"));
+}
+
+void loop() {
+  while (Serial.available() > 0) {
+    char c = Serial.read();
+
+    if (c == '\r') {
+      continue;
+    }
+
+    if (c == '\n') {
+      inputBuffer[inputIndex] = '\0';
+      if (inputIndex > 0) {
+        processLine(inputBuffer);
+      }
+      inputIndex = 0;
+    } else if (inputIndex < sizeof(inputBuffer) - 1) {
+      inputBuffer[inputIndex++] = c;
+    } else {
+      // Buffer overflow, reset.
+      inputIndex = 0;
+      Serial.println(F("ERR overflow"));
+    }
+  }
+}
+
+void processLine(char *line) {
+  char *command = strtok(line, " ");
+  if (command == nullptr) {
+    return;
+  }
+
+  if (strcmp(command, "ALERT") != 0) {
+    Serial.println(F("ERR bad_cmd"));
+    return;
+  }
+
+  char *kind = strtok(nullptr, " ");
+  char *durationToken = strtok(nullptr, " ");
+  char *intensityToken = strtok(nullptr, " ");
+
+  if (kind == nullptr) {
+    Serial.println(F("ERR no_kind"));
+    return;
+  }
+
+  unsigned long durationMs = 500;
+  if (durationToken != nullptr) {
+    durationMs = strtoul(durationToken, nullptr, 10);
+    if (durationMs == 0) {
+      durationMs = 200;
+    }
+  }
+
+  long rawIntensity = 255;
+  if (intensityToken != nullptr) {
+    rawIntensity = strtol(intensityToken, nullptr, 10);
+  }
+
+  if (rawIntensity < 0) {
+    rawIntensity = 0;
+  }
+  if (rawIntensity > 255) {
+    rawIntensity = 255;
+  }
+
+  handleAlert(kind, durationMs, static_cast<uint8_t>(rawIntensity));
+  Serial.print(F("ACK "));
+  Serial.println(kind);
+}
+
+void handleAlert(const char *kind, unsigned long durationMs, uint8_t intensity) {
+  const bool buzzerActive = (strcmp(kind, "temp_high") == 0) || (strcmp(kind, "node_lost") == 0);
+  const bool motorActive = (strcmp(kind, "node_lost") == 0);
+
+  unsigned long start = millis();
+  unsigned long ledEnd = start + max(durationMs, LED_MIN_MS);
+
+  digitalWrite(LED_PIN, HIGH);
+
+  if (buzzerActive) {
+    analogWrite(BUZZER_PIN, intensity);
+  } else {
+    analogWrite(BUZZER_PIN, 0);
+  }
+
+  analogWrite(MOTOR_PIN, 0);
+  unsigned long lastToggle = millis();
+  bool motorOn = false;
+
+  while (millis() - start < durationMs) {
+    if (motorActive) {
+      unsigned long now = millis();
+      unsigned long interval = motorOn ? MOTOR_PULSE_MS : MOTOR_PAUSE_MS;
+      if (now - lastToggle >= interval) {
+        motorOn = !motorOn;
+        analogWrite(MOTOR_PIN, motorOn ? intensity : 0);
+        lastToggle = now;
+      }
+    }
+    delay(10);
+  }
+
+  analogWrite(BUZZER_PIN, 0);
+  analogWrite(MOTOR_PIN, 0);
+
+  while (millis() < ledEnd) {
+    delay(10);
+  }
+
+  digitalWrite(LED_PIN, LOW);
+}

--- a/pi-ops/ops_haptics_bridge.py
+++ b/pi-ops/ops_haptics_bridge.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""MQTT to serial bridge for the ops haptics controller."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import signal
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+import paho.mqtt.client as mqtt
+import serial
+
+LOG_FORMAT = "%(asctime)s %(levelname)s %(name)s: %(message)s"
+LOGGER = logging.getLogger("ops_haptics_bridge")
+
+
+@dataclass
+class Alert:
+    kind: str
+    duration_ms: int
+    intensity: int
+
+    @classmethod
+    def from_payload(cls, payload: str) -> "Alert":
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSON payload: {exc}") from exc
+
+        if not isinstance(data, dict):
+            raise ValueError("Payload must be a JSON object")
+
+        kind = data.get("kind")
+        if not isinstance(kind, str) or not kind:
+            raise ValueError("Alert kind must be a non-empty string")
+
+        meta = data.get("meta") or {}
+        if not isinstance(meta, dict):
+            raise ValueError("meta must be a JSON object when provided")
+
+        duration = meta.get("dur_ms", 500)
+        intensity = meta.get("intensity", 255)
+
+        try:
+            duration_ms = max(0, int(duration))
+        except (TypeError, ValueError) as exc:
+            raise ValueError("dur_ms must be an integer") from exc
+
+        try:
+            intensity_value = int(intensity)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("intensity must be an integer") from exc
+
+        intensity_value = max(0, min(255, intensity_value))
+
+        return cls(kind=kind, duration_ms=duration_ms, intensity=intensity_value)
+
+    def serialize(self) -> str:
+        return f"ALERT {self.kind} {self.duration_ms} {self.intensity}\n"
+
+
+class SerialBridge:
+    def __init__(self, port: str, baudrate: int, timeout: float) -> None:
+        self.serial = serial.Serial(port, baudrate=baudrate, timeout=timeout)
+        self.lock = threading.Lock()
+
+    def send_alert(self, alert: Alert) -> str:
+        line = alert.serialize().encode("ascii")
+        with self.lock:
+            LOGGER.debug("Sending line to serial: %s", line)
+            self.serial.write(line)
+            self.serial.flush()
+            return self.read_ack(timeout=2.0)
+
+    def read_ack(self, timeout: float) -> str:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            chunk = self.serial.readline()
+            if chunk:
+                try:
+                    text = chunk.decode("utf-8", errors="replace").strip()
+                except UnicodeDecodeError:
+                    continue
+                if text:
+                    LOGGER.debug("Received line from serial: %s", text)
+                    return text
+            time.sleep(0.05)
+        return ""
+
+    def close(self) -> None:
+        try:
+            self.serial.close()
+        except serial.SerialException:
+            pass
+
+
+class BridgeApplication:
+    def __init__(
+        self,
+        mqtt_host: str,
+        mqtt_port: int,
+        serial_port: str,
+        serial_baud: int,
+        mqtt_alert_topic: str,
+        mqtt_status_topic: str,
+    ) -> None:
+        self.mqtt_host = mqtt_host
+        self.mqtt_port = mqtt_port
+        self.serial_port = serial_port
+        self.serial_baud = serial_baud
+        self.mqtt_alert_topic = mqtt_alert_topic
+        self.mqtt_status_topic = mqtt_status_topic
+
+        self.bridge: Optional[SerialBridge] = None
+        self.client = mqtt.Client()
+        self.client.on_connect = self._on_connect
+        self.client.on_message = self._on_message
+        self.client.on_disconnect = self._on_disconnect
+
+        self.running = True
+
+    def start(self) -> None:
+        LOGGER.info("Opening serial port %s @ %s", self.serial_port, self.serial_baud)
+        self.bridge = SerialBridge(self.serial_port, self.serial_baud, timeout=0.1)
+
+        LOGGER.info("Connecting to MQTT broker %s:%s", self.mqtt_host, self.mqtt_port)
+        self.client.connect(self.mqtt_host, self.mqtt_port, keepalive=30)
+        self.client.loop_start()
+
+        while self.running:
+            time.sleep(0.2)
+
+    def stop(self) -> None:
+        LOGGER.info("Stopping bridge")
+        self.running = False
+        self.client.loop_stop()
+        self.client.disconnect()
+        if self.bridge:
+            self.bridge.close()
+
+    # MQTT callbacks -----------------------------------------------------
+    def _on_connect(self, client: mqtt.Client, _userdata, _flags, rc: int) -> None:
+        if rc != 0:
+            LOGGER.error("MQTT connection failed with code %s", rc)
+            return
+        LOGGER.info("Connected to MQTT, subscribing to %s", self.mqtt_alert_topic)
+        client.subscribe(self.mqtt_alert_topic)
+
+    def _on_disconnect(self, _client: mqtt.Client, _userdata, rc: int) -> None:
+        if rc != 0:
+            LOGGER.warning("Unexpected MQTT disconnection (code %s)", rc)
+
+    def _on_message(self, _client: mqtt.Client, _userdata, msg: mqtt.MQTTMessage) -> None:
+        payload_text = msg.payload.decode("utf-8", errors="replace")
+        LOGGER.info("Received alert payload: %s", payload_text)
+        try:
+            alert = Alert.from_payload(payload_text)
+        except ValueError as exc:
+            LOGGER.error("Failed to parse alert payload: %s", exc)
+            self._publish_status({
+                "status": "error",
+                "error": str(exc),
+                "raw": payload_text,
+            })
+            return
+
+        if self.bridge is None:
+            LOGGER.error("Serial bridge is not ready")
+            self._publish_status({
+                "status": "error",
+                "error": "serial_not_ready",
+                "kind": alert.kind,
+            })
+            return
+
+        ack = self.bridge.send_alert(alert)
+        status = {
+            "status": "ok" if ack.startswith("ACK") else "timeout",
+            "kind": alert.kind,
+            "ack": ack,
+            "duration_ms": alert.duration_ms,
+            "intensity": alert.intensity,
+        }
+        LOGGER.info("Publishing status: %s", status)
+        self._publish_status(status)
+
+    def _publish_status(self, payload_dict: dict) -> None:
+        try:
+            payload = json.dumps(payload_dict)
+        except (TypeError, ValueError) as exc:
+            LOGGER.error("Could not encode status payload: %s", exc)
+            return
+        self.client.publish(self.mqtt_status_topic, payload)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Bridge ops alerts to haptics controller")
+    parser.add_argument("--mqtt-host", default="localhost")
+    parser.add_argument("--mqtt-port", type=int, default=1883)
+    parser.add_argument("--mqtt-alert-topic", default="ops/reflex/alert")
+    parser.add_argument("--mqtt-status-topic", default="ops/reflex/haptic_status")
+    parser.add_argument("--serial-port", default="/dev/ttyACM0")
+    parser.add_argument("--serial-baud", type=int, default=115200)
+    parser.add_argument("--log-level", default="INFO")
+    return parser.parse_args(argv)
+
+
+def configure_logging(level: str) -> None:
+    logging.basicConfig(level=getattr(logging, level.upper(), logging.INFO), format=LOG_FORMAT)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    configure_logging(args.log_level)
+
+    app = BridgeApplication(
+        mqtt_host=args.mqtt_host,
+        mqtt_port=args.mqtt_port,
+        serial_port=args.serial_port,
+        serial_baud=args.serial_baud,
+        mqtt_alert_topic=args.mqtt_alert_topic,
+        mqtt_status_topic=args.mqtt_status_topic,
+    )
+
+    def handle_signal(signum, _frame):
+        LOGGER.info("Received signal %s, shutting down", signum)
+        app.stop()
+
+    signal.signal(signal.SIGTERM, handle_signal)
+    signal.signal(signal.SIGINT, handle_signal)
+
+    try:
+        app.start()
+    except serial.SerialException as exc:
+        LOGGER.error("Serial error: %s", exc)
+        return 1
+    finally:
+        app.stop()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/systemd/ops_haptics_bridge.service
+++ b/systemd/ops_haptics_bridge.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=BlackRoad Ops Haptics Bridge
+After=network.target
+StartLimitIntervalSec=30
+StartLimitBurst=3
+
+[Service]
+Type=simple
+WorkingDirectory=/home/pi
+ExecStart=/usr/bin/env python3 /home/pi/ops_haptics_bridge.py --mqtt-host localhost
+Restart=on-failure
+RestartSec=5
+User=pi
+Group=pi
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add an Arduino sketch that drives LED, buzzer, and vibration motor based on serial alerts
- provide an MQTT-to-serial bridge plus systemd unit to run it on Pi-Ops
- document wiring, deployment, and testing steps for the haptics add-on

## Testing
- python3 -m py_compile pi-ops/ops_haptics_bridge.py

------
https://chatgpt.com/codex/tasks/task_e_68eaaa20d65c8329a12be29bbdf554bc