### PR TITLE
Add developer impact brief on GitHub AI pivot

### DIFF
--- a/analysis/github_ai_pivot_developer_impact.md
+++ b/analysis/github_ai_pivot_developer_impact.md
@@ -1,0 +1,38 @@
+# Microsoft GitHub AI Pivot: Developer Impact Assessment
+
+## Context Snapshot
+- Microsoft plans to transform GitHub into a deeply integrated AI development hub that serves as the "central nervous system" for coding workflows.
+- Strategic focus areas include richer GitHub Actions automations, tighter analytics, and expanded security/compliance guardrails bundled with AI tooling.
+- Aligning GitHub more explicitly with Azure services is expected, alongside internal mandates to accelerate Copilot-driven productivity metrics.
+- Competitive pressure from Cursor, Anthropic's Claude Code, and other AI-first IDEs is accelerating Microsoft's roadmap pace.
+
+## Developer Upside
+1. **Unified workflow surface** – Consolidated telemetry, deployment, and policy hooks inside GitHub reduce context-switching between repos, CI, and compliance dashboards.
+2. **Stronger automation primitives** – Native AI-aware GitHub Actions and guardrails can shorten review cycles and automate repetitive remediation tasks.
+3. **Improved discovery in VS Code** – New Copilot embedding models promise materially better in-editor semantic search with smaller indexes and faster retrieval.
+4. **Specialized AI models** – Copilot-SWE is tuned for editing/refactoring flows, which can improve iterative development and legacy modernization.
+
+## Trade-offs and Risks
+1. **Platform lock-in** – Deeper Azure coupling may increase switching costs for teams running heterogeneous cloud stacks.
+2. **Governance overhead** – Expanded analytics and compliance hooks can feel heavy-handed if not configurable per team or repo.
+3. **AI dependency** – Over-optimizing for Copilot-native workflows might erode manual expertise and create brittle spots when models drift.
+4. **Cost visibility** – Expect renewed emphasis on Copilot usage targets; budget owners will need clearer ROI tracking for subscriptions and compute.
+
+## Operational Gotchas
+- **Migration planning**: Teams on self-hosted runners or alternative CI/CD systems should map feature parity before committing to GitHub-first automation.
+- **Data residency**: Verify how new analytics and AI features handle data localization, especially for regulated industries.
+- **Security posture**: Tighter integration means broader blast radius; revisit secrets management and least-privilege policies as GitHub links deeper into Azure.
+- **Change management**: Developer enablement teams will need training programs to keep pace with evolving Copilot capabilities and telemetry dashboards.
+
+## Competitive Posture vs Cursor & Claude Code
+- **Cursor** excels at iterative AI pair-programming in-editor, but lacks GitHub's native CI/compliance surface. Microsoft's strategy is to bundle end-to-end governance.
+- **Claude Code** emphasizes natural-language reasoning and long-context assistance; GitHub's counter is telemetry + automation depth rather than raw context length.
+- **Differentiator**: GitHub is betting on being the orchestration layer for code-to-cloud workflows, while rivals remain IDE-centric assistants.
+
+## Recommended Developer Actions
+1. **Audit workflows** – Inventory current CI/CD, analytics, and compliance touchpoints to gauge benefit from GitHub-native replacements.
+2. **Pilot Copilot search** – Enable the new embeddings in VS Code Insiders to benchmark retrieval quality against existing search tools.
+3. **Set guardrails** – Define policy boundaries (security, cost, privacy) before adopting Microsoft-managed automations.
+4. **Monitor roadmap** – Track upcoming VS Code releases and Azure integration announcements to anticipate mandatory shifts.
+
+_Last updated: 2025-09-26_


### PR DESCRIPTION
## Summary
- add a developer-focused briefing on Microsoft's push to deepen GitHub's AI integrations
- outline pros, risks, operational considerations, and competitive context versus Cursor and Claude Code

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68ebdb8ff6ec8329865ae6ff487ab37e