### PR TITLE
Add ops haptics bridge and firmware

### DIFF
--- a/README_HAPTICS.md
+++ b/README_HAPTICS.md
@@ -1,0 +1,62 @@
+# Ops Haptics Add-on
+
+This add-on pairs a small Arduino with the Pi-Ops stack to surface reflex alerts using light, sound, and vibration.
+
+## Contents
+
+| Path | Purpose |
+| --- | --- |
+| `arduino/HapticsAlert.ino` | Firmware that parses serial alert lines and drives the LED (D13), buzzer (D9), and vibration motor (D5). |
+| `pi-ops/ops_haptics_bridge.py` | Python bridge that subscribes to `ops/reflex/alert` MQTT events and forwards them to the Arduino. |
+| `pi-ops/ops_haptics_bridge.service` | systemd unit to launch the bridge on boot. |
+
+## Flash the Arduino
+
+1. Connect the Arduino to your workstation with USB.
+2. Open `arduino/HapticsAlert.ino` in the Arduino IDE.
+3. Select the correct board/port and upload at **115200 baud**.
+
+The sketch expects newline-terminated lines formatted as `kind=<kind>,dur=<ms>,int=<0-255>`.
+
+## Deploy on Pi-Ops
+
+```bash
+scp pi-ops/ops_haptics_bridge.py pi-ops/ops_haptics_bridge.service pi@pi-ops.local:/home/pi/
+ssh pi@pi-ops.local \
+  'sudo apt update && sudo apt install -y python3-pip && \
+   pip install --break-system-packages paho-mqtt pyserial && \
+   sudo mv /home/pi/ops_haptics_bridge.service /etc/systemd/system/ && \
+   sudo systemctl daemon-reload && \
+   sudo systemctl enable --now ops_haptics_bridge'
+```
+
+The service runs the bridge as the `pi` user and connects to `/dev/ttyACM0`.
+
+## Test the Loop
+
+With the bridge running, publish a test alert:
+
+```bash
+mosquitto_pub -h pi-ops.local -t ops/reflex/alert -m '{"kind":"node_lost","meta":{"dur_ms":1200,"intensity":255}}'
+mosquitto_sub -h pi-ops.local -t ops/reflex/haptic_status -v
+```
+
+The Arduino will blink the D13 LED for every alert. `temp_high` and `node_lost` also buzz on D9; `node_lost` additionally pulses the D5 motor.
+
+## Wiring Notes
+
+- **Vibration motor (D5)**: drive through an NPN transistor (2N2222/2N3904), add a ~1 kΩ base resistor and a flyback diode (1N4148/1N4007) across the motor leads.
+- **Buzzer (D9)**: for an active buzzer, add ~100 Ω in series. Piezo buzzers can be driven directly with the PWM output at low duty.
+- **Power**: use the Arduino 5 V rail for the motor only if the USB supply can provide the stall current; otherwise power the motor from an external 5 V source and share ground.
+
+## Serial Protocol Cheat Sheet
+
+Each MQTT alert is converted into a single serial line:
+
+```
+kind=<alert-kind>,dur=<duration-ms>,int=<intensity-0-255>\n
+```
+
+- `dur` is clamped to 50–5000 ms.
+- `int` is clamped to 0–255 and is used as the PWM duty cycle for the buzzer and motor.
+- Arduino responses prefixed with `ACK:` are published to `ops/reflex/haptic_status` with the `state` set to `ack`.

--- a/arduino/HapticsAlert.ino
+++ b/arduino/HapticsAlert.ino
@@ -1,0 +1,135 @@
+#include <Arduino.h>
+
+const uint8_t LED_PIN = 13;
+const uint8_t BUZZER_PIN = 9;
+const uint8_t MOTOR_PIN = 5;
+
+struct AlertPayload {
+  char kind[32];
+  uint16_t durationMs;
+  uint8_t intensity;
+};
+
+char inputBuffer[128];
+size_t bufferIndex = 0;
+
+void resetMotor() {
+  analogWrite(MOTOR_PIN, 0);
+}
+
+void blinkLed(uint16_t millisOn) {
+  digitalWrite(LED_PIN, HIGH);
+  delay(millisOn);
+  digitalWrite(LED_PIN, LOW);
+}
+
+void playBuzzer(uint16_t durationMs, uint8_t intensity, bool urgent) {
+  const uint8_t duty = constrain(intensity, 0, 255);
+  const uint16_t window = urgent ? 60 : 120;
+  unsigned long start = millis();
+  while (millis() - start < durationMs) {
+    analogWrite(BUZZER_PIN, duty);
+    delay(window);
+    analogWrite(BUZZER_PIN, 0);
+    delay(window);
+  }
+  analogWrite(BUZZER_PIN, 0);
+}
+
+void vibrateMotor(uint16_t durationMs, uint8_t intensity) {
+  const uint16_t pulseWindowMs = 120;
+  unsigned long start = millis();
+  while (millis() - start < durationMs) {
+    analogWrite(MOTOR_PIN, intensity);
+    delay(pulseWindowMs / 2);
+    resetMotor();
+    delay(pulseWindowMs / 2);
+  }
+  resetMotor();
+}
+
+void processAlert(const AlertPayload &payload) {
+  blinkLed(120);
+
+  bool isTempHigh = strcmp(payload.kind, "temp_high") == 0;
+  bool isNodeLost = strcmp(payload.kind, "node_lost") == 0;
+
+  if (isTempHigh || isNodeLost) {
+    playBuzzer(payload.durationMs, payload.intensity, isNodeLost);
+  }
+
+  if (isNodeLost) {
+    vibrateMotor(payload.durationMs, payload.intensity);
+  } else {
+    resetMotor();
+  }
+
+  Serial.print(F("ACK:"));
+  Serial.println(payload.kind);
+}
+
+bool parsePayload(const char *line, AlertPayload &payload) {
+  payload.kind[0] = '\0';
+  payload.durationMs = 500;
+  payload.intensity = 200;
+
+  char working[sizeof(inputBuffer)];
+  strncpy(working, line, sizeof(working) - 1);
+  working[sizeof(working) - 1] = '\0';
+
+  char *token = strtok(working, ",");
+  while (token != nullptr) {
+    while (*token == ' ') {
+      ++token;
+    }
+
+    if (strncmp(token, "kind=", 5) == 0) {
+      strncpy(payload.kind, token + 5, sizeof(payload.kind) - 1);
+      payload.kind[sizeof(payload.kind) - 1] = '\0';
+    } else if (strncmp(token, "dur=", 4) == 0) {
+      payload.durationMs = constrain(atoi(token + 4), 50, 5000);
+    } else if (strncmp(token, "int=", 4) == 0) {
+      payload.intensity = constrain(atoi(token + 4), 0, 255);
+    }
+
+    token = strtok(nullptr, ",");
+  }
+
+  return payload.kind[0] != '\0';
+}
+
+void setup() {
+  pinMode(LED_PIN, OUTPUT);
+  pinMode(BUZZER_PIN, OUTPUT);
+  pinMode(MOTOR_PIN, OUTPUT);
+  resetMotor();
+  digitalWrite(LED_PIN, LOW);
+
+  Serial.begin(115200);
+}
+
+void loop() {
+  while (Serial.available() > 0) {
+    char incoming = Serial.read();
+    if (incoming == '\r') {
+      continue;
+    }
+
+    if (incoming == '\n') {
+      inputBuffer[bufferIndex] = '\0';
+      bufferIndex = 0;
+
+      AlertPayload payload;
+      if (parsePayload(inputBuffer, payload)) {
+        processAlert(payload);
+      } else {
+        Serial.println(F("ERR:parse"));
+      }
+    } else if (bufferIndex < sizeof(inputBuffer) - 1) {
+      inputBuffer[bufferIndex++] = incoming;
+    } else {
+      bufferIndex = 0;
+      Serial.println(F("ERR:overflow"));
+    }
+  }
+}

--- a/pi-ops/ops_haptics_bridge.py
+++ b/pi-ops/ops_haptics_bridge.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Bridge ops/reflex alerts to the haptics Arduino over serial."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import queue
+import signal
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+import paho.mqtt.client as mqtt
+import serial
+
+DEFAULT_ALERT_TOPIC = "ops/reflex/alert"
+DEFAULT_STATUS_TOPIC = "ops/reflex/haptic_status"
+ACK_PREFIX = "ACK:"
+
+
+@dataclass
+class AlertMessage:
+    kind: str
+    duration_ms: int
+    intensity: int
+
+    @classmethod
+    def from_payload(cls, payload: dict) -> Optional["AlertMessage"]:
+        kind = payload.get("kind")
+        if not isinstance(kind, str) or not kind:
+            return None
+
+        meta = payload.get("meta") or {}
+        try:
+            duration = int(meta.get("dur_ms", 500))
+        except (TypeError, ValueError):
+            duration = 500
+        try:
+            intensity = int(meta.get("intensity", 200))
+        except (TypeError, ValueError):
+            intensity = 200
+
+        duration = max(50, min(duration, 5000))
+        intensity = max(0, min(intensity, 255))
+        return cls(kind=kind, duration_ms=duration, intensity=intensity)
+
+    def to_serial_line(self) -> str:
+        return f"kind={self.kind},dur={self.duration_ms},int={self.intensity}\n"
+
+
+class SerialReader(threading.Thread):
+    def __init__(self, ser: serial.SerialBase, status_queue: "queue.Queue[str]") -> None:
+        super().__init__(daemon=True)
+        self._ser = ser
+        self._status_queue = status_queue
+        self._running = threading.Event()
+        self._running.set()
+
+    def run(self) -> None:
+        while self._running.is_set():
+            try:
+                raw = self._ser.readline()
+            except serial.SerialException as exc:  # pragma: no cover - hardware dependent
+                logging.error("Serial read error: %s", exc)
+                time.sleep(1.0)
+                continue
+
+            if not raw:
+                continue
+
+            line = raw.decode("utf-8", errors="ignore").strip()
+            if not line:
+                continue
+
+            logging.debug("serial<= %s", line)
+            if line.startswith(ACK_PREFIX):
+                self._status_queue.put(line[len(ACK_PREFIX) :].strip())
+
+    def stop(self) -> None:
+        self._running.clear()
+
+
+class HapticsBridge:
+    def __init__(self, args: argparse.Namespace) -> None:
+        self.args = args
+        self.client = mqtt.Client()
+        self.client.enable_logger(logging.getLogger("mqtt"))
+        self.client.on_connect = self._on_connect
+        self.client.on_message = self._on_message
+        self.serial = serial.Serial(
+            args.serial_port, args.baud, timeout=1
+        )
+        self.status_queue: "queue.Queue[str]" = queue.Queue()
+        self.reader = SerialReader(self.serial, self.status_queue)
+        self._status_thread = threading.Thread(target=self._publish_status_loop, daemon=True)
+        self._stop = threading.Event()
+
+    def start(self) -> None:
+        logging.info(
+            "Connecting to MQTT broker %s:%s", self.args.mqtt_host, self.args.mqtt_port
+        )
+        self.reader.start()
+        self._status_thread.start()
+        self.client.connect(self.args.mqtt_host, self.args.mqtt_port, keepalive=30)
+        self.client.loop_start()
+
+    def wait_forever(self) -> None:
+        try:
+            while not self._stop.is_set():
+                time.sleep(0.2)
+        except KeyboardInterrupt:
+            logging.info("Stopping bridge")
+            self.stop()
+
+    def stop(self) -> None:
+        self._stop.set()
+        self.reader.stop()
+        self.reader.join(timeout=1.5)
+        self.client.loop_stop()
+        self.client.disconnect()
+        self._status_thread.join(timeout=1.5)
+        self.serial.close()
+
+    # MQTT callbacks -----------------------------------------------------
+
+    def _on_connect(self, client: mqtt.Client, userdata, flags, rc):  # type: ignore[override]
+        if rc != 0:
+            logging.error("MQTT connection failed with rc=%s", rc)
+            return
+        logging.info("Connected to MQTT, subscribing to %s", self.args.alert_topic)
+        client.subscribe(self.args.alert_topic, qos=1)
+
+    def _on_message(self, client: mqtt.Client, userdata, msg: mqtt.MQTTMessage):  # type: ignore[override]
+        try:
+            payload = json.loads(msg.payload.decode("utf-8"))
+        except json.JSONDecodeError:
+            logging.warning("Ignoring non-JSON payload on %s", msg.topic)
+            return
+
+        alert = AlertMessage.from_payload(payload)
+        if alert is None:
+            logging.warning("Payload missing required fields: %s", payload)
+            return
+
+        line = alert.to_serial_line()
+        logging.info("serial=> %s", line.strip())
+        try:
+            self.serial.write(line.encode("utf-8"))
+            self.serial.flush()
+        except serial.SerialException as exc:  # pragma: no cover - hardware dependent
+            logging.error("Serial write error: %s", exc)
+
+        status_payload = json.dumps(
+            {
+                "kind": alert.kind,
+                "state": "sent",
+                "timestamp": time.time(),
+            }
+        )
+        client.publish(self.args.status_topic, status_payload, qos=0, retain=False)
+
+    # Status publishing --------------------------------------------------
+
+    def _publish_status_loop(self) -> None:
+        while not self._stop.is_set():
+            try:
+                kind = self.status_queue.get(timeout=0.5)
+            except queue.Empty:
+                continue
+
+            payload = json.dumps(
+                {"kind": kind, "state": "ack", "timestamp": time.time()}
+            )
+            logging.info("Publishing ack for %s", kind)
+            self.client.publish(self.args.status_topic, payload, qos=0, retain=False)
+
+
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--mqtt-host", default="localhost", help="MQTT broker hostname (default: localhost)"
+    )
+    parser.add_argument(
+        "--mqtt-port", type=int, default=1883, help="MQTT broker port (default: 1883)"
+    )
+    parser.add_argument(
+        "--alert-topic", default=DEFAULT_ALERT_TOPIC, help="MQTT topic for alerts"
+    )
+    parser.add_argument(
+        "--status-topic", default=DEFAULT_STATUS_TOPIC, help="MQTT topic for acks"
+    )
+    parser.add_argument(
+        "--serial-port",
+        default="/dev/ttyACM0",
+        help="Serial device for the Arduino (default: /dev/ttyACM0)",
+    )
+    parser.add_argument(
+        "--baud", type=int, default=115200, help="Serial baud rate (default: 115200)"
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        help="Logging level (DEBUG, INFO, WARNING, ERROR)",
+    )
+    return parser.parse_args(argv)
+
+
+def configure_logging(level: str) -> None:
+    logging.basicConfig(
+        level=getattr(logging, level.upper(), logging.INFO),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = parse_args(argv)
+    configure_logging(args.log_level)
+
+    bridge = HapticsBridge(args)
+
+    def _signal_handler(signum, frame):
+        logging.info("Received signal %s, shutting down", signum)
+        bridge.stop()
+
+    signal.signal(signal.SIGTERM, _signal_handler)
+    signal.signal(signal.SIGINT, _signal_handler)
+
+    bridge.start()
+    bridge.wait_forever()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pi-ops/ops_haptics_bridge.service
+++ b/pi-ops/ops_haptics_bridge.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Blackroad Ops Haptics Bridge
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=pi
+Group=pi
+WorkingDirectory=/home/pi
+Environment=PYTHONUNBUFFERED=1
+ExecStart=/usr/bin/python3 /home/pi/ops_haptics_bridge.py --mqtt-host=localhost --serial-port=/dev/ttyACM0
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add an Arduino sketch that drives the alert LED, buzzer, and vibration motor via a tiny serial protocol
- add a Pi-Ops MQTT-to-serial bridge script plus a systemd unit for automatic startup
- document wiring, flashing, deployment, and test commands for the haptics add-on

## Testing
- python -m compileall pi-ops/ops_haptics_bridge.py

------
https://chatgpt.com/codex/tasks/task_e_68ebe8bca43c83298982ed391e89b9cc