### PR TITLE
Add Helm chart for Autopal deployment

### DIFF
--- a/autopal-helm/Chart.yaml
+++ b/autopal-helm/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: autopal
+description: Helm chart for deploying the Autopal FastAPI console with optional Redis.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/autopal-helm/templates/NOTES.txt
+++ b/autopal-helm/templates/NOTES.txt
@@ -1,0 +1,11 @@
+Thank you for installing Autopal!
+
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+  {{- range $host := .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ (index $host.paths 0).path }}
+  {{- end }}
+{{- else }}
+  export SERVICE_IP=$(kubectl get svc {{ include "autopal.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo "Visit http://$SERVICE_IP:{{ .Values.service.port }}"
+{{- end }}

--- a/autopal-helm/templates/_helpers.tpl
+++ b/autopal-helm/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{- define "autopal.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "autopal.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "autopal.labels" -}}
+app.kubernetes.io/name: {{ include "autopal.name" . }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | trunc 63 | trimSuffix "-" }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+{{- end -}}
+
+{{- define "autopal.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "autopal.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "autopal.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- if .Values.serviceAccount.name -}}
+{{- .Values.serviceAccount.name -}}
+{{- else -}}
+{{ include "autopal.fullname" . }}
+{{- end -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "autopal.breakGlassSecretName" -}}
+{{- if .Values.breakGlassSecret.existingSecretName -}}
+{{- .Values.breakGlassSecret.existingSecretName -}}
+{{- else -}}
+{{- if .Values.breakGlassSecret.name -}}
+{{- .Values.breakGlassSecret.name -}}
+{{- else -}}
+{{ printf "%s-break-glass" (include "autopal.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/autopal-helm/templates/configmap.yaml
+++ b/autopal-helm/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "autopal.fullname" . }}-config
+  labels:
+    {{- include "autopal.labels" . | nindent 4 }}
+data:
+  autopal.config.json: |
+    {{- toPrettyJson .Values.config | nindent 4 }}

--- a/autopal-helm/templates/deployment.yaml
+++ b/autopal-helm/templates/deployment.yaml
@@ -1,0 +1,91 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "autopal.fullname" . }}
+  labels:
+    {{- include "autopal.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "autopal.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "autopal.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "autopal.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: autopal
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.targetPort }}
+              protocol: TCP
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            - name: AUTOPAL_CONFIG
+              value: /config/autopal.config.json
+            {{- $useBreakGlass := and .Values.breakGlassSecret.enabled (or (and .Values.breakGlassSecret.create .Values.breakGlassSecret.value) .Values.breakGlassSecret.existingSecretName) }}
+            {{- if $useBreakGlass }}
+            - name: AUTOPAL_BREAK_GLASS_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "autopal.breakGlassSecretName" . }}
+                  key: {{ default "secret" .Values.breakGlassSecret.key }}
+            {{- end }}
+            {{- range $name, $value := .Values.env }}
+            - name: {{ $name }}
+              value: {{ tpl $value $ | quote }}
+            {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /config/autopal.config.json
+              subPath: autopal.config.json
+          {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "autopal.fullname" . }}-config
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}

--- a/autopal-helm/templates/hpa.yaml
+++ b/autopal-helm/templates/hpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "autopal.fullname" . }}
+  labels:
+    {{- include "autopal.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "autopal.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/autopal-helm/templates/ingress.yaml
+++ b/autopal-helm/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "autopal.fullname" . }}
+  labels:
+    {{- include "autopal.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "autopal.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/autopal-helm/templates/redis.yaml
+++ b/autopal-helm/templates/redis.yaml
@@ -1,0 +1,78 @@
+{{- if .Values.redis.enabled }}
+{{- $redisFullname := printf "%s-redis" (include "autopal.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- if .Values.redis.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $redisFullname }}
+  labels:
+    {{- include "autopal.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.redis.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.redis.persistence.size }}
+  {{- with .Values.redis.persistence.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}
+---
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $redisFullname }}
+  labels:
+    {{- include "autopal.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "autopal.name" . }}-redis
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "autopal.name" . }}-redis
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: redis
+          image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
+          imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
+          ports:
+            - containerPort: 6379
+              name: redis
+          {{- with .Values.redis.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          {{- if .Values.redis.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ $redisFullname }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $redisFullname }}
+  labels:
+    {{- include "autopal.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.redis.service.type }}
+  selector:
+    app.kubernetes.io/name: {{ include "autopal.name" . }}-redis
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+    - name: redis
+      port: {{ .Values.redis.service.port }}
+      targetPort: 6379
+      protocol: TCP
+{{- end }}

--- a/autopal-helm/templates/secret.yaml
+++ b/autopal-helm/templates/secret.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.breakGlassSecret.enabled .Values.breakGlassSecret.create .Values.breakGlassSecret.value }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "autopal.breakGlassSecretName" . }}
+  labels:
+    {{- include "autopal.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{ default "secret" .Values.breakGlassSecret.key }}: {{ .Values.breakGlassSecret.value | b64enc }}
+{{- end }}

--- a/autopal-helm/templates/service.yaml
+++ b/autopal-helm/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "autopal.fullname" . }}
+  labels:
+    {{- include "autopal.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "autopal.selectorLabels" . | nindent 4 }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+      name: http

--- a/autopal-helm/templates/serviceaccount.yaml
+++ b/autopal-helm/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "autopal.serviceAccountName" . }}
+  labels:
+    {{- include "autopal.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/autopal-helm/values.yaml
+++ b/autopal-helm/values.yaml
@@ -1,0 +1,98 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/example/autopal-fastapi
+  tag: "latest"
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 8080
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: autopal.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+resources: {}
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+env: {}
+
+envFrom: []
+
+extraVolumeMounts: []
+
+extraVolumes: []
+
+config:
+  global_enabled: true
+  dual_control_timeout_seconds: 900
+  endpoints:
+    "/secrets/materialize":
+      required_audience:
+        - "gha:org/repo@refs/heads/main"
+      step_up_required: true
+      dual_control_required: true
+      rate_limit:
+        limit: 5
+        window_seconds: 60
+
+breakGlassSecret:
+  enabled: false
+  create: true
+  name: ""
+  key: secret
+  value: ""
+  existingSecretName: ""
+
+redis:
+  enabled: true
+  image:
+    repository: redis
+    tag: "7.2"
+    pullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    port: 6379
+  resources: {}
+  persistence:
+    enabled: false
+    accessModes:
+      - ReadWriteOnce
+    size: 1Gi
+    storageClass: ""


### PR DESCRIPTION
## Summary
- add a Helm chart that deploys the Autopal FastAPI service with rendered configuration, service account, and probes
- wire configurable ConfigMap, optional ingress, and break-glass secret support that mirrors the existing autopal.config.json contract
- include a demo Redis deployment/service and optional HPA to align with the compose defaults

## Testing
- `helm version` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ebe8e34cc48329872c5788d7651aea