### PR TITLE
Add YAML scene runner tooling for Mac demos

### DIFF
--- a/agent/mac/menu_launcher.py
+++ b/agent/mac/menu_launcher.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Menu bar launcher for running YAML scenes on macOS."""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+try:  # pragma: no cover - import-time path fix for direct execution
+    if __package__ in {None, ""}:  # type: ignore[name-defined]
+        THIS_FILE = Path(__file__).resolve()
+        PROJECT_ROOT = THIS_FILE.parents[2]
+        if str(PROJECT_ROOT) not in sys.path:
+            sys.path.insert(0, str(PROJECT_ROOT))
+        from agent.mac.scene_models import SceneValidationError, load_scene
+    else:
+        from agent.mac.scene_models import SceneValidationError, load_scene
+except ImportError as exc:  # pragma: no cover - runtime import guard
+    raise SystemExit(f"Unable to import scene utilities: {exc}") from exc
+
+try:  # pragma: no cover - optional dependency for macOS menu bar apps
+    import rumps
+except ImportError:  # pragma: no cover - optional dependency for macOS menu bar apps
+    rumps = None  # type: ignore
+
+
+if rumps is not None:  # pragma: no cover - only defined when dependency is present
+
+    class SceneMenuApp(rumps.App):  # type: ignore[misc]
+        """Menu bar application that triggers scene playback."""
+
+        def __init__(self, scenes: Dict[str, Path], runner: Path) -> None:
+            super().__init__("Scenes")
+            self._runner = runner
+            items = []
+            for title, path in sorted(scenes.items()):
+                items.append(rumps.MenuItem(title, callback=self._make_callback(path)))
+            if items:
+                items.append(rumps.separator)
+            items.append(rumps.MenuItem("Quit", callback=self._quit))
+            self.menu = items
+
+        def _make_callback(self, scene_path: Path):  # type: ignore[override]
+            def _callback(_):
+                rumps.notification("Scene", scene_path.name, "Running…")
+                subprocess.Popen([sys.executable, str(self._runner), str(scene_path)])
+
+            return _callback
+
+        def _quit(self, _):  # type: ignore[override]
+            rumps.quit_application()
+
+
+def _discover_scenes(paths: List[Path]) -> Dict[str, Path]:
+    scenes: Dict[str, Path] = {}
+    for path in paths:
+        if path.is_dir():
+            for candidate in sorted(path.glob("*.yaml")):
+                _register_scene(candidate, scenes)
+        else:
+            _register_scene(path, scenes)
+    return scenes
+
+
+def _register_scene(path: Path, scenes: Dict[str, Path]) -> None:
+    try:
+        scene = load_scene(path)
+    except SceneValidationError as exc:
+        raise SystemExit(f"Invalid scene '{path}': {exc}") from exc
+    title = scene.name
+    suffix = 1
+    while title in scenes:
+        suffix += 1
+        title = f"{scene.name} ({suffix})"
+    scenes[title] = path
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="macOS menu bar launcher for scenes")
+    parser.add_argument(
+        "paths",
+        nargs="+",
+        type=Path,
+        help="Scene files or directories to expose in the menu",
+    )
+    parser.add_argument(
+        "--runner",
+        type=Path,
+        default=Path(__file__).with_name("scene_runner.py"),
+        help="Path to scene_runner.py (defaults to sibling script)",
+    )
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    if rumps is None:  # pragma: no cover - optional dependency guard
+        raise SystemExit(
+            "The 'rumps' package is required for the menu bar app. Install it via `pip install rumps`."
+        )
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    scenes = _discover_scenes([path.expanduser() for path in args.paths])
+    if not scenes:
+        raise SystemExit("No valid scenes found")
+    runner = args.runner.expanduser()
+    if not runner.exists():
+        raise SystemExit(f"Scene runner not found at {runner}")
+    app = SceneMenuApp(scenes, runner)
+    app.run()
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    raise SystemExit(main())

--- a/agent/mac/scene_models.py
+++ b/agent/mac/scene_models.py
@@ -1,0 +1,181 @@
+"""Shared utilities for YAML-driven scene playback."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+try:  # pragma: no cover - dependency availability handled at runtime
+    import yaml  # type: ignore
+except ImportError:  # pragma: no cover - dependency availability handled at runtime
+    yaml = None  # type: ignore
+
+try:  # pragma: no cover - dependency availability handled at runtime
+    from jsonschema import Draft7Validator
+except ImportError:  # pragma: no cover - dependency availability handled at runtime
+    Draft7Validator = None  # type: ignore
+
+
+class SceneValidationError(RuntimeError):
+    """Raised when a scene definition cannot be parsed or validated."""
+
+
+@dataclass(frozen=True)
+class SceneStep:
+    """A single MQTT publication within a scene."""
+
+    index: int
+    topic: str
+    payload: Dict[str, Any]
+    delay: float = 0.0
+    wait: float = 0.0
+    label: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class Scene:
+    """In-memory representation of a scene file."""
+
+    path: Path
+    name: str
+    description: Optional[str]
+    steps: List[SceneStep]
+
+
+SCENE_SCHEMA: Dict[str, Any] = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "required": ["name", "steps"],
+    "properties": {
+        "name": {"type": "string", "minLength": 1},
+        "description": {"type": "string"},
+        "defaults": {
+            "type": "object",
+            "properties": {
+                "topic": {"type": "string", "minLength": 1},
+                "delay": {"type": "number", "minimum": 0},
+                "wait": {"type": "number", "minimum": 0},
+                "payload": {"type": "object"},
+            },
+            "additionalProperties": False,
+        },
+        "steps": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "object",
+                "required": ["payload"],
+                "properties": {
+                    "label": {"type": "string"},
+                    "topic": {"type": "string", "minLength": 1},
+                    "payload": {"type": "object"},
+                    "delay": {"type": "number", "minimum": 0},
+                    "wait": {"type": "number", "minimum": 0},
+                },
+                "additionalProperties": False,
+            },
+        },
+    },
+    "additionalProperties": False,
+}
+
+
+def _ensure_yaml() -> None:
+    if yaml is None:  # pragma: no cover - environment specific
+        raise SceneValidationError(
+            "PyYAML is required to load scene files. Install it via `pip install pyyaml`."
+        )
+
+
+def _ensure_jsonschema() -> None:
+    if Draft7Validator is None:  # pragma: no cover - environment specific
+        raise SceneValidationError(
+            "jsonschema is required to validate scene files. Install it via `pip install jsonschema`."
+        )
+
+
+def _load_raw_yaml(path: Path) -> Dict[str, Any]:
+    _ensure_yaml()
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:  # pragma: no cover - simple filesystem errors
+        raise SceneValidationError(f"Scene file not found: {path}") from exc
+    except yaml.YAMLError as exc:  # type: ignore[attr-defined]
+        raise SceneValidationError(f"Invalid YAML in {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise SceneValidationError(f"Scene file must contain a mapping at the top level: {path}")
+    return data
+
+
+def validate_scene_document(document: Dict[str, Any], *, path: Optional[Path] = None) -> None:
+    """Validate a scene document against the schema."""
+
+    _ensure_jsonschema()
+    validator = Draft7Validator(SCENE_SCHEMA)  # type: ignore[operator]
+    errors = sorted(validator.iter_errors(document), key=lambda err: err.path)
+    if errors:
+        location = f" in {path}" if path else ""
+        messages = "; ".join(error.message for error in errors)
+        raise SceneValidationError(f"Scene validation failed{location}: {messages}")
+
+
+def _coerce_non_negative(value: Any, *, field: str, default: float = 0.0) -> float:
+    if value is None:
+        return float(default)
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as exc:
+        raise SceneValidationError(f"Scene step field '{field}' must be numeric") from exc
+    if number < 0:
+        raise SceneValidationError(f"Scene step field '{field}' must be >= 0")
+    return number
+
+
+def load_scene(path: Path) -> Scene:
+    """Load and validate a scene file into an executable representation."""
+
+    document = _load_raw_yaml(path)
+    validate_scene_document(document, path=path)
+
+    defaults = document.get("defaults", {})
+    default_topic = defaults.get("topic")
+    default_delay = _coerce_non_negative(defaults.get("delay"), field="defaults.delay", default=0.0)
+    default_wait = _coerce_non_negative(defaults.get("wait"), field="defaults.wait", default=0.0)
+    default_payload = defaults.get("payload") if isinstance(defaults.get("payload"), dict) else None
+
+    steps: List[SceneStep] = []
+    for index, raw_step in enumerate(document["steps"], start=1):
+        topic = raw_step.get("topic", default_topic)
+        if not topic:
+            raise SceneValidationError(
+                f"Step {index} in {path} is missing a topic and no default was provided"
+            )
+        payload = raw_step.get("payload")
+        if not isinstance(payload, dict):
+            raise SceneValidationError(
+                f"Step {index} in {path} must define a payload object"
+            )
+        if default_payload:
+            merged_payload = dict(default_payload)
+            merged_payload.update(payload)
+            payload = merged_payload
+        delay = _coerce_non_negative(raw_step.get("delay"), field="delay", default=default_delay)
+        wait = _coerce_non_negative(raw_step.get("wait"), field="wait", default=default_wait)
+        label = raw_step.get("label") if raw_step.get("label") else None
+        steps.append(
+            SceneStep(
+                index=index,
+                topic=str(topic),
+                payload=payload,
+                delay=delay,
+                wait=wait,
+                label=label,
+            )
+        )
+
+    return Scene(
+        path=path,
+        name=str(document.get("name", path.stem)),
+        description=document.get("description"),
+        steps=steps,
+    )

--- a/agent/mac/scene_runner.py
+++ b/agent/mac/scene_runner.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Execute YAML-defined MQTT scenes from the Mac agent."""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Iterable, Optional
+
+try:  # pragma: no cover - import-time path fix for direct execution
+    if __package__ in {None, ""}:  # type: ignore[name-defined]
+        THIS_FILE = Path(__file__).resolve()
+        PROJECT_ROOT = THIS_FILE.parents[2]
+        if str(PROJECT_ROOT) not in sys.path:
+            sys.path.insert(0, str(PROJECT_ROOT))
+        from agent.mac.mqtt import publish_payload
+        from agent.mac.scene_models import Scene, SceneStep, SceneValidationError, load_scene
+    else:
+        from agent.mac.mqtt import publish_payload
+        from agent.mac.scene_models import Scene, SceneStep, SceneValidationError, load_scene
+except ImportError as exc:  # pragma: no cover - runtime import guard
+    raise SystemExit(f"Unable to import MQTT helpers: {exc}") from exc
+
+
+def _format_step(step: SceneStep) -> str:
+    label = f" – {step.label}" if step.label else ""
+    delay = f", delay={step.delay:.2f}s" if step.delay else ""
+    wait = f", wait={step.wait:.2f}s" if step.wait else ""
+    return f"Step {step.index}: topic='{step.topic}'{label}{delay}{wait}"
+
+
+def _publish_step(step: SceneStep, *, dry_run: bool) -> None:
+    envelope = {"topic": step.topic, "payload": step.payload}
+    if dry_run:
+        print(f"[dry-run] {_format_step(step)}")
+        print(json.dumps(envelope, indent=2, ensure_ascii=False))
+        return
+    print(f"Publishing {_format_step(step)}")
+    publish_payload(step.topic, step.payload)
+
+
+def _play_scene(scene: Scene, *, dry_run: bool) -> None:
+    for step in scene.steps:
+        if step.delay:
+            time.sleep(step.delay)
+        _publish_step(step, dry_run=dry_run)
+        if step.wait:
+            time.sleep(step.wait)
+
+
+def _seconds_until_minute(minute: int) -> float:
+    now = dt.datetime.now()
+    next_run = now.replace(second=0, microsecond=0)
+    if now.minute >= minute:
+        next_run += dt.timedelta(hours=1)
+    next_run = next_run.replace(minute=minute)
+    return max((next_run - now).total_seconds(), 0.0)
+
+
+def _run_with_hourly_schedule(scene: Scene, *, minute: int, dry_run: bool, run_now: bool) -> None:
+    if run_now:
+        print(f"Running '{scene.name}' immediately before entering hourly schedule")
+        _play_scene(scene, dry_run=dry_run)
+    while True:
+        sleep_for = _seconds_until_minute(minute)
+        if sleep_for:
+            target = dt.datetime.now() + dt.timedelta(seconds=sleep_for)
+            print(f"Waiting {sleep_for:.1f}s for next run at {target.strftime('%H:%M:%S')}")
+            time.sleep(sleep_for)
+        print(f"Starting scheduled run for '{scene.name}' at {dt.datetime.now().isoformat(timespec='seconds')}")
+        _play_scene(scene, dry_run=dry_run)
+
+
+def _run_with_repeat(scene: Scene, *, interval: float, dry_run: bool) -> None:
+    while True:
+        start = time.monotonic()
+        _play_scene(scene, dry_run=dry_run)
+        elapsed = time.monotonic() - start
+        sleep_for = max(interval - elapsed, 0.0)
+        if sleep_for:
+            print(f"Sleeping {sleep_for:.2f}s before repeating scene")
+            time.sleep(sleep_for)
+
+
+def run_scene(
+    path: Path,
+    *,
+    dry_run: bool = False,
+    repeat: Optional[float] = None,
+    hourly_minute: Optional[int] = None,
+    run_now: bool = False,
+) -> None:
+    """Load and execute a scene using the requested scheduling mode."""
+
+    scene = load_scene(path)
+    print(f"Loaded scene '{scene.name}' from {path} with {len(scene.steps)} steps")
+
+    if repeat is not None and hourly_minute is not None:
+        raise SceneValidationError("Choose either --repeat or --hourly-minute, not both")
+
+    if hourly_minute is not None:
+        _run_with_hourly_schedule(scene, minute=hourly_minute, dry_run=dry_run, run_now=run_now)
+        return
+
+    _play_scene(scene, dry_run=dry_run)
+
+    if repeat is not None:
+        if repeat <= 0:
+            raise SceneValidationError("Repeat interval must be greater than zero")
+        print(f"Entering repeat loop every {repeat:.2f}s")
+        _run_with_repeat(scene, interval=repeat, dry_run=dry_run)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Play a YAML-defined MQTT scene")
+    parser.add_argument("scene", type=Path, help="Path to the YAML scene file")
+    parser.add_argument("--dry", action="store_true", help="Print envelopes instead of publishing")
+    parser.add_argument(
+        "--repeat",
+        type=float,
+        help="Repeat the scene every N seconds (cannot be combined with --hourly-minute)",
+    )
+    parser.add_argument(
+        "--hourly-minute",
+        type=int,
+        choices=range(60),
+        help="Run the scene when the system clock reaches this minute each hour",
+    )
+    parser.add_argument(
+        "--run-now",
+        action="store_true",
+        help="Execute the scene immediately before starting the hourly schedule",
+    )
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        run_scene(
+            args.scene,
+            dry_run=args.dry,
+            repeat=args.repeat,
+            hourly_minute=args.hourly_minute,
+            run_now=args.run_now,
+        )
+    except SceneValidationError as exc:
+        parser.error(str(exc))
+    except KeyboardInterrupt:
+        print("\nInterrupted")
+        return 130
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    raise SystemExit(main())

--- a/agent/mac/validate_scene.py
+++ b/agent/mac/validate_scene.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Validate YAML scene definitions."""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Iterable
+
+try:  # pragma: no cover - import-time path fix for direct execution
+    if __package__ in {None, ""}:  # type: ignore[name-defined]
+        THIS_FILE = Path(__file__).resolve()
+        PROJECT_ROOT = THIS_FILE.parents[2]
+        if str(PROJECT_ROOT) not in sys.path:
+            sys.path.insert(0, str(PROJECT_ROOT))
+        from agent.mac.scene_models import SceneValidationError, load_scene
+    else:
+        from agent.mac.scene_models import SceneValidationError, load_scene
+except ImportError as exc:  # pragma: no cover - runtime import guard
+    raise SystemExit(f"Unable to import scene utilities: {exc}") from exc
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Validate YAML scene definitions")
+    parser.add_argument("scenes", nargs="+", type=Path, help="Scene file(s) to validate")
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    status = 0
+    for scene_path in args.scenes:
+        try:
+            scene = load_scene(scene_path)
+        except SceneValidationError as exc:
+            status = 1
+            print(f"[FAIL] {scene_path}: {exc}")
+            continue
+        print(f"[ OK ] {scene_path} — '{scene.name}' with {len(scene.steps)} step(s)")
+    return status
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    raise SystemExit(main())

--- a/scenes/alert_demo.yaml
+++ b/scenes/alert_demo.yaml
@@ -1,0 +1,42 @@
+name: Alert Demo
+description: Simulated critical alert flow for demos and testing.
+defaults:
+  wait: 1.0
+steps:
+  - label: Pre-alert banner
+    topic: sim/panel
+    payload:
+      panel_id: status
+      duration_ms: 4000
+      accent: "#F97316"
+      lines:
+        - text: Monitoring active
+          icon: activity
+        - text: Awaiting telemetry
+  - label: Raise hologram alert
+    topic: holo/text
+    delay: 0.5
+    payload:
+      text: "⚠  Network anomaly detected"
+      duration_ms: 4500
+      size: 60
+      effect: pulse
+  - label: Panel escalation
+    topic: sim/panel
+    wait: 3.0
+    payload:
+      panel_id: status
+      duration_ms: 6000
+      accent: "#DC2626"
+      lines:
+        - text: ALERT · Response team paged
+          icon: alert
+        - text: Containment protocol running
+  - label: Resolution message
+    topic: holo/text
+    wait: 4.0
+    payload:
+      text: "Incident resolved"
+      duration_ms: 3800
+      size: 52
+      effect: fade-out

--- a/scenes/boot_demo.yaml
+++ b/scenes/boot_demo.yaml
@@ -1,0 +1,29 @@
+name: Boot Demo
+description: Warm-up script for the Pi-Holo and Pi-Sim pairing.
+defaults:
+  topic: holo/text
+  wait: 1.25
+steps:
+  - label: Title card
+    payload:
+      text: "BlackRoad Systems"
+      duration_ms: 3200
+      size: 72
+      effect: fade-in
+  - label: Bring systems online
+    payload:
+      text: "Initializing subsystems"
+      duration_ms: 2600
+      size: 56
+      effect: scan
+  - label: Status banner
+    topic: sim/panel
+    wait: 2.0
+    payload:
+      panel_id: status
+      duration_ms: 6000
+      accent: "#16A34A"
+      lines:
+        - text: Boot complete
+          icon: check
+        - text: All services nominal

--- a/scenes/camera_intro.yaml
+++ b/scenes/camera_intro.yaml
@@ -1,0 +1,30 @@
+name: Camera Intro
+description: Lower-third and panel sequence to introduce a live camera feed.
+defaults:
+  wait: 1.0
+steps:
+  - label: Panel warmup
+    topic: sim/panel
+    payload:
+      panel_id: camera
+      duration_ms: 5000
+      accent: "#0EA5E9"
+      lines:
+        - text: Camera feed online
+          icon: camera
+        - text: Route A · Secure
+  - label: Lower third
+    topic: holo/text
+    payload:
+      text: "Live from the Atrium"
+      duration_ms: 5200
+      size: 58
+      effect: ribbon
+  - label: Subject callout
+    topic: holo/text
+    wait: 2.5
+    payload:
+      text: "Focus: Operator 01"
+      duration_ms: 4800
+      size: 48
+      effect: scan


### PR DESCRIPTION
## Summary
- add a reusable scene model helper with jsonschema validation for YAML-driven MQTT shows
- provide a CLI scene runner with dry-run, repeat, and hourly scheduling options plus a macOS menu bar launcher
- check in sample boot, camera intro, and alert scenes for quick demos

## Testing
- `python -m py_compile agent/mac/*.py`
- `python agent/mac/validate_scene.py scenes/boot_demo.yaml scenes/camera_intro.yaml scenes/alert_demo.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68ebebb87af08329be3b60f2cc90a4bd