### PR TITLE
Add macOS guidance to Pi↔Droplet connectivity checklist

### DIFF
--- a/docs/pi/pi-droplet-connectivity-checklist.md
+++ b/docs/pi/pi-droplet-connectivity-checklist.md
@@ -4,13 +4,15 @@ Use this runbook when you need to confirm that a Raspberry Pi on your LAN can re
 
 > **Safety first:** Only run commands you understand. Redact private data before sharing outputs outside your environment.
 
-> **macOS note:** The commands in this runbook target Linux systems (your Pi and the droplet). If you are collecting evidence from a
-> macOS workstation, substitute the appropriate tooling—e.g., use `ifconfig` / `netstat -an` / `lsof -i` instead of `ip` / `ss`,
-> and `log show --predicate 'process == "sshd"' --last 10m` for recent SSH events because `systemctl` and `journalctl` are not
-> available. Administrative SSH service management on macOS is handled through `sudo launchctl load -w`
-> `/System/Library/LaunchDaemons/ssh.plist` (enable) and `sudo launchctl unload -w ...` (disable). When you need to inspect or
-> restart the DigitalOcean droplet itself, SSH into the droplet first—run the droplet-side commands there rather than on your
-> laptop.
+> **macOS note:** This runbook targets Linux utilities on the Pi and droplet. When you collect evidence from a macOS workstation,
+> adjust the tooling accordingly:
+> - Substitute `ifconfig`, `netstat -an`, or `lsof -i` for `ip`, `ss`, or other Linux network commands. For SSH audit logs, run
+>   `log show --predicate 'process == "sshd"' --last 10m` because `systemctl` and `journalctl` are unavailable on macOS.
+> - Manage the local SSH daemon with `sudo launchctl load -w /System/Library/LaunchDaemons/ssh.plist` (enable) or
+>   `sudo launchctl unload -w /System/Library/LaunchDaemons/ssh.plist` (disable). `sudo systemsetup -getremotelogin` confirms
+>   whether Remote Login is currently enabled.
+> - When droplet-side checks are required, open an SSH session first (for example, `ssh your_droplet_user@<droplet-ip>`) and run
+>   the droplet commands inside that shell instead of executing them directly from macOS.
 
 ## 1. Baseline checks on the Pi
 Perform these steps from a terminal on the Pi (directly or over LAN SSH).


### PR DESCRIPTION
## Summary
- clarify that the connectivity runbook assumes Linux utilities and add macOS-friendly substitutes
- remind operators to connect to the droplet before executing droplet-side commands from macOS

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68ebfe4b63bc8329b5e86b1d1bc9724b