### PR TITLE
Update devcontainer base image tag

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/base:ubuntu-22.04
+FROM mcr.microsoft.com/devcontainers/base:jammy
 
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y \


### PR DESCRIPTION
## Summary
- update the devcontainer Dockerfile to use the supported `mcr.microsoft.com/devcontainers/base:jammy` tag

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ec04133c9c8329bde2c513af8435eb