### PR TITLE
feat: generate configurable unity project archives

### DIFF
--- a/workers/unity/Dockerfile
+++ b/workers/unity/Dockerfile
@@ -1,7 +1,14 @@
 FROM node:20-alpine
 WORKDIR /app
+
+RUN apk add --no-cache zip
+
 COPY package.json ./
 RUN npm install
+
 COPY server.js ./
+COPY template ./template
+COPY README.md ./README.md
+
 EXPOSE 3000
 CMD ["node", "server.js"]

--- a/workers/unity/README.md
+++ b/workers/unity/README.md
@@ -1,8 +1,71 @@
 # Unity Exporter
 
-Stub service that writes a placeholder Unity project zip.
+Generates a ready-to-open Unity project archive from a lightweight JSON payload.
+The service copies a templated project, rewrites metadata based on the request,
+and ships a zipped folder into `downloads/` for downstream automation.
 
 - **Endpoint:** `POST /export`
-- **Output:** `downloads/unity-project.zip`
+- **Response:** JSON metadata plus the path to the generated zip
+- **Unity version:** 2022.3.18f1 (safe to upgrade in the template if required)
 
-Replace with a real Unity build pipeline when available.
+## Request shape
+
+```jsonc
+{
+  "projectName": "BlackRoad Systems Prototype",   // optional
+  "sceneName": "Launch Pad",                      // optional
+  "author": "Agent Smith",                        // optional
+  "description": "Short summary for the README.", // optional
+  "sceneGuid": "...",                             // optional 32-char hex
+  "scriptGuid": "..."                             // optional 32-char hex
+}
+```
+
+All fields are optional. Missing or empty values fall back to sensible defaults
+(`BlackRoad Sample`, `Sample Scene`, etc.).
+
+## Response payload
+
+```jsonc
+{
+  "ok": true,
+  "path": "<absolute path to downloads/<slug>.zip>",
+  "project": {
+    "name": "BlackRoad Systems Prototype",
+    "slug": "blackroad-systems-prototype",
+    "scene": {
+      "name": "Launch Pad",
+      "file": "Assets/Scenes/LaunchPad.unity",
+      "guid": "3c2f..."
+    },
+    "scriptGuid": "a451...",
+    "author": "Agent Smith",
+    "description": "Short summary for the README."
+  }
+}
+```
+
+## Template contents
+
+The template (under `./template`) includes:
+
+- `ProjectSettings/ProjectVersion.txt` pinned to Unity `2022.3.18f1`
+- `ProjectSettings/ProjectSettings.asset` with placeholder metadata
+- `Packages/manifest.json` with core dependencies only
+- `Assets/Scenes/<Scene>.unity` and matching `.meta` file wired to the supplied GUID
+- `Assets/Scripts/HelloBlackRoad.cs` plus `.meta` file, pre-attached in the scene
+- A generated README summarizing the chosen metadata for collaborators
+
+Feel free to evolve the template to match evolving project standards (URP/HDRP,
+additional packages, custom scripts, etc.).
+
+## Running locally
+
+```bash
+cd workers/unity
+npm install
+node server.js
+```
+
+Then POST to `http://localhost:3000/export` with your JSON payload. The resulting
+zip lands under `workers/unity/downloads/`.

--- a/workers/unity/server.js
+++ b/workers/unity/server.js
@@ -1,21 +1,174 @@
 import express from "express";
-import { mkdir, writeFile } from "fs/promises";
+import { cp, mkdtemp, mkdir, readdir, readFile, rename, rm, writeFile } from "fs/promises";
 import path from "path";
+import { tmpdir } from "os";
+import { randomUUID } from "crypto";
+import { spawn } from "child_process";
+import { fileURLToPath } from "url";
 
 const app = express();
-app.use(express.json());
+app.use(express.json({ limit: "1mb" }));
 
-app.post("/export", async (_req, res) => {
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const TEMPLATE_DIR = path.join(__dirname, "template");
+
+const DEFAULTS = {
+  projectName: "BlackRoad Sample",
+  sceneName: "Sample Scene",
+  author: "BlackRoad Systems",
+  description: "Generated via the BlackRoad Unity exporter."
+};
+
+app.post("/export", async (req, res) => {
+  const body = req.body ?? {};
+  const projectName = extractString(body.projectName, DEFAULTS.projectName);
+  const sceneName = extractString(body.sceneName, DEFAULTS.sceneName);
+  const author = extractString(body.author, DEFAULTS.author);
+  const description = extractString(body.description, DEFAULTS.description);
+  const projectSlug = slugify(projectName) || "blackroad-sample";
+  const sceneFile = sceneFileName(sceneName);
+  const sceneGuid = normalizeGuid(body.sceneGuid) ?? makeGuid();
+  const scriptGuid = normalizeGuid(body.scriptGuid) ?? makeGuid();
+
+  const downloadsDir = path.join(process.cwd(), "downloads");
+  const tmpRoot = await mkdtemp(path.join(tmpdir(), "unity-exporter-"));
+  const projectRoot = path.join(tmpRoot, projectSlug);
+
   try {
-    const outDir = path.join(process.cwd(), "downloads");
-    await mkdir(outDir, { recursive: true });
-    const zipPath = path.join(outDir, "unity-project.zip");
-    await writeFile(zipPath, "stub unity project");
-    res.json({ ok: true, path: zipPath });
-  } catch (e) {
-    res.status(500).json({ ok: false, error: String(e) });
+    await cp(TEMPLATE_DIR, projectRoot, { recursive: true });
+
+    if (sceneFile !== "SampleScene") {
+      await rename(
+        path.join(projectRoot, "Assets", "Scenes", "SampleScene.unity"),
+        path.join(projectRoot, "Assets", "Scenes", `${sceneFile}.unity`)
+      );
+      await rename(
+        path.join(projectRoot, "Assets", "Scenes", "SampleScene.unity.meta"),
+        path.join(projectRoot, "Assets", "Scenes", `${sceneFile}.unity.meta`)
+      );
+    }
+
+    const replacements = {
+      __PROJECT_NAME__: projectName,
+      __SCENE_NAME__: sceneName,
+      __SCENE_FILE__: sceneFile,
+      __AUTHOR__: author,
+      __DESCRIPTION__: description,
+      __SCENE_GUID__: sceneGuid,
+      __SCRIPT_GUID__: scriptGuid
+    };
+
+    await replacePlaceholders(projectRoot, replacements);
+
+    await mkdir(downloadsDir, { recursive: true });
+    const zipPath = path.join(downloadsDir, `${projectSlug}.zip`);
+    await rm(zipPath, { force: true });
+    await zipDirectory(tmpRoot, projectSlug, zipPath);
+
+    res.json({
+      ok: true,
+      path: zipPath,
+      project: {
+        name: projectName,
+        slug: projectSlug,
+        scene: {
+          name: sceneName,
+          file: `Assets/Scenes/${sceneFile}.unity`,
+          guid: sceneGuid
+        },
+        scriptGuid,
+        author,
+        description
+      }
+    });
+  } catch (error) {
+    res.status(500).json({ ok: false, error: error instanceof Error ? error.message : String(error) });
+  } finally {
+    await rm(tmpRoot, { recursive: true, force: true });
   }
 });
 
 const port = process.env.PORT || 3000;
-app.listen(port, () => console.log("unity exporter listening on", port));
+app.listen(port, () => {
+  console.log("unity exporter listening on", port);
+});
+
+function extractString(value, fallback) {
+  if (typeof value !== "string") {
+    return fallback;
+  }
+  const trimmed = value.trim();
+  return trimmed.length ? trimmed : fallback;
+}
+
+function slugify(value) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function sceneFileName(value) {
+  const parts = value
+    .split(/[^A-Za-z0-9]+/g)
+    .filter(Boolean)
+    .map(capitalize);
+  if (!parts.length) {
+    return "SampleScene";
+  }
+  return parts.join("");
+}
+
+function capitalize(segment) {
+  if (!segment) {
+    return "";
+  }
+  return segment.charAt(0).toUpperCase() + segment.slice(1);
+}
+
+function normalizeGuid(value) {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const normalized = value.replace(/[^a-fA-F0-9]/g, "").toLowerCase();
+  return normalized.length === 32 ? normalized : null;
+}
+
+function makeGuid() {
+  return randomUUID().replace(/-/g, "").toLowerCase();
+}
+
+async function replacePlaceholders(dir, replacements) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await replacePlaceholders(entryPath, replacements);
+      continue;
+    }
+
+    let content = await readFile(entryPath, "utf8");
+    let updated = content;
+    for (const [token, replacement] of Object.entries(replacements)) {
+      updated = updated.split(token).join(replacement);
+    }
+    if (updated !== content) {
+      await writeFile(entryPath, updated, "utf8");
+    }
+  }
+}
+
+async function zipDirectory(root, folderName, destination) {
+  await new Promise((resolve, reject) => {
+    const zip = spawn("zip", ["-r", destination, folderName], { cwd: root });
+    zip.on("close", (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`zip exited with code ${code}`));
+      }
+    });
+    zip.on("error", reject);
+  });
+}

--- a/workers/unity/template/Assets/Scenes/SampleScene.unity
+++ b/workers/unity/template/Assets/Scenes/SampleScene.unity
@@ -1,0 +1,228 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: __SCENE_GUID__
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_FogStartDistance: 0
+  m_FogEndDistance: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_Sun: {fileID: 0}
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+  m_UseShadowmask: 1
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &1000
+GameObject:
+  m_ObjectHideFlags: 0
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1001}
+  - component: {fileID: 1002}
+  - component: {fileID: 1003}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_IsActive: 1
+--- !u!4 &1001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!20 &1002
+Camera:
+  m_ObjectHideFlags: 0
+  m_GameObject: {fileID: 1000}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.192, g: 0.301, b: 0.475, a: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetDisplay: 0
+--- !u!81 &1003
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_GameObject: {fileID: 1000}
+  m_Enabled: 1
+--- !u!1 &1100
+GameObject:
+  m_ObjectHideFlags: 0
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1101}
+  - component: {fileID: 1102}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_IsActive: 1
+--- !u!4 &1101
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1100}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!108 &1102
+Light:
+  m_ObjectHideFlags: 0
+  m_GameObject: {fileID: 1100}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+  m_CookieSize: 10
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!1 &1200
+GameObject:
+  m_ObjectHideFlags: 0
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1201}
+  - component: {fileID: 1202}
+  m_Layer: 0
+  m_Name: __SCENE_NAME__ Anchor
+  m_TagString: Untagged
+  m_IsActive: 1
+--- !u!4 &1201
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1200}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1202
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1200}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: __SCRIPT_GUID__, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  message: "__DESCRIPTION__"

--- a/workers/unity/template/Assets/Scenes/SampleScene.unity.meta
+++ b/workers/unity/template/Assets/Scenes/SampleScene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: __SCENE_GUID__
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/template/Assets/Scripts/HelloBlackRoad.cs
+++ b/workers/unity/template/Assets/Scripts/HelloBlackRoad.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+
+namespace BlackRoad.Unity
+{
+    /// <summary>
+    /// Simple bootstrap component that logs when the sample scene starts running.
+    /// Values are substituted by the exporter so the generated scene is annotated
+    /// with useful metadata for the rest of the pipeline.
+    /// </summary>
+    public sealed class HelloBlackRoad : MonoBehaviour
+    {
+        [SerializeField]
+        [TextArea]
+        private string description = "__DESCRIPTION__";
+
+        [SerializeField]
+        private string projectName = "__PROJECT_NAME__";
+
+        [SerializeField]
+        private string author = "__AUTHOR__";
+
+        private void Start()
+        {
+            Debug.Log($"[{projectName}] Scene '{gameObject.name}' booted by {author}. {description}");
+        }
+    }
+}

--- a/workers/unity/template/Assets/Scripts/HelloBlackRoad.cs.meta
+++ b/workers/unity/template/Assets/Scripts/HelloBlackRoad.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: __SCRIPT_GUID__
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/template/Packages/manifest.json
+++ b/workers/unity/template/Packages/manifest.json
@@ -1,0 +1,14 @@
+{
+  "dependencies": {
+    "com.unity.collab-proxy": "2.0.7",
+    "com.unity.textmeshpro": "3.0.6",
+    "com.unity.timeline": "1.7.5",
+    "com.unity.test-framework": "1.1.33",
+    "com.unity.ugui": "1.0.0",
+    "com.unity.modules.ai": "1.0.0",
+    "com.unity.modules.animation": "1.0.0",
+    "com.unity.modules.audio": "1.0.0",
+    "com.unity.modules.physics": "1.0.0",
+    "com.unity.modules.unitywebrequest": "1.0.0"
+  }
+}

--- a/workers/unity/template/ProjectSettings/EditorBuildSettings.asset
+++ b/workers/unity/template/ProjectSettings/EditorBuildSettings.asset
@@ -1,0 +1,11 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1045 &1
+EditorBuildSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Scenes:
+  - enabled: 1
+    path: Assets/Scenes/__SCENE_FILE__.unity
+    guid: __SCENE_GUID__
+  m_configObjects: {}

--- a/workers/unity/template/ProjectSettings/ProjectSettings.asset
+++ b/workers/unity/template/ProjectSettings/ProjectSettings.asset
@@ -1,0 +1,39 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!129 &1
+PlayerSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 26
+  productName: __PROJECT_NAME__
+  companyName: BlackRoad Systems
+  bundleVersion: 0.1.0
+  defaultScreenWidth: 1920
+  defaultScreenHeight: 1080
+  defaultScreenWidthWeb: 960
+  defaultScreenHeightWeb: 600
+  fullscreenMode: 1
+  runInBackground: 1
+  captureSingleScreen: 0
+  muteOtherAudioSources: 0
+  forceSingleInstance: 0
+  usePlayerLog: 1
+  resizableWindow: 1
+  visibleInBackground: 1
+  allowFullScreenSwitch: 1
+  displayResolutionDialog: 1
+  useMacAppStoreValidation: 0
+  macAppStoreCategory: public.app-category.education
+  deferSystemGesturesMode: 0
+  hideHomeButton: 0
+  renderOutsideSafeArea: 1
+  defaultIsNativeResolution: 1
+  forceSRGBBlit: 1
+  useFlare: 1
+  useFog: 1
+  activeColorSpace: 1
+  scriptingRuntimeVersion: 1
+  managedStrippingLevel: 1
+  gcIncremental: 1
+  legacyClampBlendShapeWeights: 0
+  virtualRealitySupported: 0
+  scriptingDefineSymbols: {}

--- a/workers/unity/template/ProjectSettings/ProjectVersion.txt
+++ b/workers/unity/template/ProjectSettings/ProjectVersion.txt
@@ -1,0 +1,2 @@
+m_EditorVersion: 2022.3.18f1
+m_EditorVersionWithRevision: 2022.3.18f1 (f0191201bc6a)

--- a/workers/unity/template/README.md
+++ b/workers/unity/template/README.md
@@ -1,0 +1,23 @@
+# __PROJECT_NAME__
+
+Generated via the BlackRoad Unity exporter service. The template contains a
+single playable scene, starter scripts, and placeholder settings you can evolve
+into a full production project.
+
+## Quick facts
+
+- **Primary scene:** `Assets/Scenes/__SCENE_FILE__.unity`
+- **Scene display name:** __SCENE_NAME__
+- **Author:** __AUTHOR__
+- **Description:** __DESCRIPTION__
+
+## Next steps
+
+1. Open the project in Unity `2022.3.18f1` or newer.
+2. Review `ProjectSettings/ProjectSettings.asset` to align quality, build
+   targets, and scripting defines with your needs.
+3. Replace the placeholder assets and scripts with your real gameplay content.
+4. Commit the generated project into source control or feed it into automated
+   build pipelines as needed.
+
+Happy prototyping!


### PR DESCRIPTION
## Summary
- replace the stub Unity exporter endpoint with a templated project generator that personalizes metadata from the request payload
- add a reusable Unity project template (scene, script, project settings, README) that the exporter copies before zipping
- update the worker Dockerfile and documentation so the runtime bundles the template and zip tooling

## Testing
- curl -s -X POST http://localhost:3000/export -H 'Content-Type: application/json' -d '{"projectName":"Explorer","sceneName":"Forest Walk","author":"Unity Agent","description":"Prototype scene"}'

------
https://chatgpt.com/codex/tasks/task_e_68ec433dbbdc83298682a4ef78d06649