### PR TITLE
chore: convert ollama bridge server to esm module

### DIFF
--- a/srv/ollama-bridge/package.json
+++ b/srv/ollama-bridge/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "ollama-bridge",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "dependencies": {
+    "express": "^4.19.2"
+  }
+}

--- a/srv/ollama-bridge/server.js
+++ b/srv/ollama-bridge/server.js
@@ -1,7 +1,7 @@
-const express = require('express');
-const os = require('os');
-const fs = require('fs');
-const crypto = require('crypto');
+import express from 'express';
+import os from 'os';
+import fs from 'fs';
+import crypto from 'crypto';
 
 const app = express();
 app.use(express.json({limit: '1mb'}));
@@ -189,4 +189,4 @@ app.listen(PORT, ()=>{
   console.log(`ollama-bridge listening on ${PORT}`);
 });
 
-module.exports = app;
+export default app;


### PR DESCRIPTION
## Summary
- declare the ollama bridge service as an ES module package
- update the bridge server to use ESM imports/exports to match the package type

## Testing
- node --check srv/ollama-bridge/server.js

------
https://chatgpt.com/codex/tasks/task_e_68ec5a8f72c08329b04c7d018163c967