### PR TITLE
Add staging and preview environment manifests

### DIFF
--- a/environments/README.md
+++ b/environments/README.md
@@ -1,0 +1,19 @@
+# Environment manifests
+
+Each file in this directory captures the reviewers and routing details for one deployment footprint. Automation can load these YML documents to determine who to ping for approvals and which hostnames map to the environment.
+
+## Fields
+
+- `name`: Short identifier for the environment.
+- `url`: Canonical hostname that represents the environment (used for status pings and dashboards).
+- `url_template` (optional): Template for ephemeral endpoints, used by preview environments that spin up per PR (`<number>` is replaced with the pull request number).
+- `reviewers`: Default GitHub handles or teams who should review releases hitting the environment.
+- `notes`: Free-form context about infrastructure targets or routing.
+
+## Current environments
+
+- `production.yml` — Public site at https://blackroad.io
+- `staging.yml` — Release-candidate staging stack on Fly.io + AWS ECS
+- `preview.yml` — Ephemeral per-PR preview routed through AWS ALB and Route53 under `*.dev.blackroad.io`
+
+Extend these files with additional metadata (e.g., deploy workflows, health checks) as automation matures.

--- a/environments/preview.yml
+++ b/environments/preview.yml
@@ -1,0 +1,9 @@
+name: preview
+url: https://dev.blackroad.io
+url_template: https://pr-<number>.dev.blackroad.io
+reviewers:
+  - blackboxprogramming
+  - devx-duty
+notes:
+  - Ephemeral environment spun up per pull request via .github/workflows/preview.yml.
+  - Routes traffic through AWS ALB with per-PR listener rules.

--- a/environments/production.yml
+++ b/environments/production.yml
@@ -2,3 +2,5 @@ name: production
 url: https://blackroad.io
 reviewers:
   - blackboxprogramming
+notes:
+  - Public site served via GitHub Pages; API and relay live on AWS ECS.

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -1,0 +1,8 @@
+name: staging
+url: https://staging.blackroad.io
+reviewers:
+  - blackboxprogramming
+  - platform-duty
+notes:
+  - Primary integration environment for release candidates.
+  - Deploys via Fly.io for the web tier and AWS ECS for APIs.


### PR DESCRIPTION
## Summary
- add dedicated manifests for staging and preview environments alongside production
- describe manifest schema and usage in a new README for the environments directory
- document preview URL template and reviewer defaults for each footprint

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68ec5f67c3bc8329a6c562d384bcdd79