### PR TITLE
Add security posture snapshot documentation

### DIFF
--- a/docs/security/posture-review.md
+++ b/docs/security/posture-review.md
@@ -1,0 +1,20 @@
+# Prism Console Security Posture Snapshot
+
+The current security foundations show intentional planning, but critical feedback mechanisms remain placeholders. As a result, the overall posture is only partially realized and should be treated as midway toward the desired "stellar" state.
+
+## Signals of Strength
+- **Documented policies:** A published security policy commits to maintaining the main branch, outlines responsible disclosure expectations, and notes controls such as secret scanning plus HSTS and Referrer-Policy headers.
+- **Automation hooks:** Root-level scripts support linting, formatting, Jest tests, health checks, and demo bundles, demonstrating a path toward reproducible workflows once the project stabilizes.
+
+## Risks and Gaps
+- **Low maintainer confidence:** The README acknowledges that the maintainer is "not a strong coder yet," increasing the likelihood of latent defects or unfinished features slipping into production.
+- **Synthetic health signals:** The shipped health payload is hard-coded to "OK," and the synthetic checks only emit deterministic stub data that tests simply confirm, so actual service regressions would not be detected today.
+- **Empty operational dashboards:** The Lucidia review HTML explicitly calls itself a placeholder awaiting the real engine, leaving governance teams without actionable findings.
+- **Missing backing artifacts:** Status generation expects catalog and health JSON assets that are currently absent; when they are missing, tables render from empty lists so availability reports can appear green while covering nothing.
+
+## Recommended Next Steps
+1. Replace synthetic health data with live probes and persisted metrics so `health/index.json` and the status generator reflect real service signals.
+2. Implement the promised review engine—or integrate existing security scanners—to populate the Lucidia report with substantive findings.
+3. Pair the maintainer with experienced reviewers or add stricter CI gates to counterbalance the self-reported skill gap and keep regressions out of main.
+
+Addressing these items should elevate the score toward an 8–9/10; until then, plan for additional diligence.


### PR DESCRIPTION
## Summary
- add a dedicated security posture snapshot outlining current strengths and gaps
- capture actionable next steps to replace placeholder health and review signals

## Testing
- not run (documentation change only)

------
https://chatgpt.com/codex/tasks/task_e_68ec634b80588329b68671cc568fbfd3