### PR TITLE
Add staging and preview environment manifests

### DIFF
--- a/README-OPS.md
+++ b/README-OPS.md
@@ -36,5 +36,11 @@ sudo systemctl enable --now br-cleanup-nightly.timer
 
 An optional sudoers snippet is in `etc/sudoers.d/br-cleanup`.
 
+## Environment manifests
+
+- `environments/production.yml` documents the GitHub Environment that drives the main deploy workflow.
+- `environments/staging.yml` captures pre-production checks (smoke tests and Slack alerts) used before promoting builds.
+- `environments/preview.yml` maps the per-PR AWS ECS Fargate previews under `dev.blackroad.io` managed by Terraform.
+
 
 _Last updated on 2025-09-11_

--- a/environments/preview.yml
+++ b/environments/preview.yml
@@ -1,0 +1,28 @@
+name: preview
+url: https://pr-<number>.dev.blackroad.io
+reviewers:
+  - blackboxprogramming
+description: >-
+  Ephemeral per-pull-request environment built on AWS ECS Fargate via Terraform.
+workflows:
+  - .github/workflows/preview-env.yml
+infrastructure:
+  provider: aws-ecs-fargate
+  region: us-east-1
+  domain: dev.blackroad.io
+  terraform_directory: infra/preview-env
+  image_registry_secret: PREVIEW_ENV_ECR_REGISTRY
+  cluster_secret: PREVIEW_ENV_CLUSTER_ARN
+  task_role_secret: PREVIEW_ENV_TASK_ROLE_ARN
+  execution_role_secret: PREVIEW_ENV_EXECUTION_ROLE_ARN
+  subnet_secrets:
+    private: PREVIEW_ENV_PRIVATE_SUBNET_IDS
+    public: PREVIEW_ENV_PUBLIC_SUBNET_IDS
+  vpc_secret: PREVIEW_ENV_VPC_ID
+  state_backend_bucket_secret: PREVIEW_ENV_TF_STATE_BUCKET
+  state_lock_table_secret: PREVIEW_ENV_TF_LOCK_TABLE
+  environment_variables_secret: PREVIEW_ENV_VARS_JSON
+  secrets_payload: PREVIEW_ENV_SECRETS_JSON
+  teardown_on_close: true
+notifications:
+  slack_channel_secret: SLACK_PREVIEW_CHANNEL

--- a/environments/production.yml
+++ b/environments/production.yml
@@ -2,3 +2,7 @@ name: production
 url: https://blackroad.io
 reviewers:
   - blackboxprogramming
+description: >-
+  Primary customer-facing deployment managed by the CI & Deploy to Droplet workflow.
+workflows:
+  - .github/workflows/deploy.yml

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -1,0 +1,12 @@
+name: staging
+url: https://staging.blackroad.io
+reviewers:
+  - blackboxprogramming
+description: >-
+  Pre-production environment used for regression checks before promoting releases.
+workflows:
+  - .github/workflows/_backup_132_lucidia-ci.yml
+checks:
+  - npm run test:smoke -- --baseUrl=https://staging.blackroad.io
+notifications:
+  slack_channel: "#deployments"


### PR DESCRIPTION
## Summary
- add dedicated manifests for the production, staging, and preview environments
- capture the AWS ECS preview automation details and staging smoke checks for quick reference
- point ops documentation at the new manifests for deploy coordination

## Testing
- not run (docs and configuration only)


------
https://chatgpt.com/codex/tasks/task_e_68ec61e1c8648329810a0770954519cc