### PR TITLE
chore: ignore python egg metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ __pycache__/
 codex/runtime/
 benchmarks/
 
+# Python build artifacts
+**/*.egg-info/
+
 # Lucidia artifacts
 secrets/*
 datasets/


### PR DESCRIPTION
## Summary
- add a repository-wide ignore rule for Python egg-info metadata directories

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ec665aeeb48329a29290c1442bc3b9