### PR TITLE
Ignore Python egg-info artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ runtime/
 __pycache__/
 codex/runtime/
 benchmarks/
+*.egg-info/
+
 
 # Lucidia artifacts
 secrets/*


### PR DESCRIPTION
## Summary
- add a gitignore rule for Python egg-info metadata directories so build artifacts stay untracked

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68ec6685d4208329ac6fbff3206b37a0