### PR TITLE
fix: stabilize torchquantum gate wrapper

### DIFF
--- a/lucidia/quantum_engine/models.py
+++ b/lucidia/quantum_engine/models.py
@@ -22,7 +22,11 @@ class PQCClassifier(nn.Module):
         self.rx0(qdev, wires=0)
         self.ry0(qdev, wires=1)
         self.rz0(qdev, wires=2)
-        logits = self.measure(qdev).reshape(bsz, 2, 2).sum(-1)
+        measurements = self.measure(qdev)
+        if measurements.shape[1] < 4:
+            pad = 4 - measurements.shape[1]
+            measurements = F.pad(measurements, (0, pad))
+        logits = measurements[:, :4].reshape(bsz, 2, 2).sum(-1)
         return F.log_softmax(logits, dim=1)
 
 


### PR DESCRIPTION
## Summary
- ensure the torchquantum stub builds proper complex gate matrices and updates expectation math
- pad the PQC classifier logits so smaller wire counts reshape cleanly

## Testing
- pytest tests/test_quantum_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68ec66ddc4848329a5b954eda54c1aa7