### PR TITLE
Add manifests for staging and preview environments

### DIFF
--- a/.github/environments/preview.yml
+++ b/.github/environments/preview.yml
@@ -1,0 +1,1 @@
+url: https://pr-<pr-number>.dev.blackroad.io

--- a/.github/environments/staging.yml
+++ b/.github/environments/staging.yml
@@ -1,0 +1,1 @@
+url: https://staging.blackroad.io

--- a/environments/preview.yml
+++ b/environments/preview.yml
@@ -1,0 +1,4 @@
+name: preview
+url: https://pr-<pr-number>.dev.blackroad.io
+reviewers:
+  - blackboxprogramming

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -1,0 +1,4 @@
+name: staging
+url: https://staging.blackroad.io
+reviewers:
+  - blackboxprogramming


### PR DESCRIPTION
## Summary
- add YAML manifests for the staging and preview environments with reviewer metadata to match production
- register the staging and preview environment URLs under `.github/environments` so GitHub deploy gates are preconfigured

## Testing
- not run (YAML changes only)


------
https://chatgpt.com/codex/tasks/task_e_68ec677d666c832995057da4abb54b0a