### PR TITLE
Ignore Python egg metadata artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ runtime/
 __pycache__/
 codex/runtime/
 benchmarks/
+*.egg-info/
 
 # Lucidia artifacts
 secrets/*


### PR DESCRIPTION
## Summary
- add a .gitignore pattern to exclude generated Python *.egg-info directories
- remove the previously generated torchquantum.egg-info metadata from the working tree

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ec6901aa4c83299aa7e781d02e612b