### PR TITLE
chore: ignore Python egg-info artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ dist/
 artifacts.sha256
 public/artifacts.sha256
 
+# Python
+**/*.egg-info/
+*.egg-info
+
 # Local data
 srv/blackroad-api/blackroad.db
 _trash/


### PR DESCRIPTION
## Summary
- add gitignore entries to drop Python egg-info directories and files from version control
- clean up the previously generated torchquantum egg-info metadata

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ec68fc17bc8329b10ce0ed5740ddd9