### PR TITLE
feat(env): add staging and preview manifests

### DIFF
--- a/environments/preview.yml
+++ b/environments/preview.yml
@@ -1,0 +1,62 @@
+name: preview
+branch: pr/*
+description: >-
+  Ephemeral ECS/Fargate environments spun up per pull request for validation and
+  stakeholder review.
+url_template: https://pr-<pr-number>.dev.blackroad.io
+reviewers:
+  - devx-team
+  - platform-ops
+deploy_targets:
+  - surface: application
+    provider: aws_ecs
+    cluster_variable: ECS_CLUSTER
+    service_family: prism-console-preview
+    container:
+      image_repository_variable: ECR_REPO
+      port_variable: CONTAINER_PORT
+    load_balancer:
+      arn_variable: ALB_ARN
+      https_listener_variable: HTTPS_LISTENER_ARN
+      host_template: pr-<pr-number>.dev.blackroad.io
+    route53:
+      hosted_zone_variable: HOSTED_ZONE_ID
+      dns_name_variable: ALB_DNS
+    iam:
+      execution_role_variable: TASK_EXECUTION_ROLE_ARN
+      task_role_variable: TASK_ROLE_ARN
+    network:
+      vpc_variable: VPC_ID
+      subnet_variable: SUBNETS
+      security_group_variable: SERVICE_SG
+workflow: .github/workflows/preview.yml
+lifecycle:
+  create_on: [opened, reopened, synchronize]
+  destroy_on: [closed]
+inputs:
+  required_repository_variables:
+    - AWS_REGION
+    - ECS_CLUSTER
+    - VPC_ID
+    - SUBNETS
+    - SERVICE_SG
+    - ALB_ARN
+    - HTTPS_LISTENER_ARN
+    - ALB_ZONE_ID
+    - ALB_DNS
+    - HOSTED_ZONE_ID
+    - CONTAINER_PORT
+    - ECR_REPO
+    - TASK_EXECUTION_ROLE_ARN
+    - TASK_ROLE_ARN
+  required_secrets:
+    - AWS_ROLE_TO_ASSUME
+notifications:
+  slack_channel: #eng
+  pr_comment: true
+smoke_tests:
+  - curl -fsS $PREVIEW_URL/health
+notes:
+  - >-
+    Workflow provisions target groups, listener rules, Route53 alias records,
+    and the ECS service, then tears them down when the PR closes.

--- a/environments/production.yml
+++ b/environments/production.yml
@@ -1,4 +1,68 @@
 name: production
-url: https://blackroad.io
+branch: main
+description: >-
+  Primary customer-facing deployment served from blackroad.io with the marketing
+  surface, application, and API footprint.
+urls:
+  marketing: https://blackroad.io
+  app: https://app.blackroad.io
+  api: https://api.blackroad.io
+  status: https://status.blackroad.io
 reviewers:
   - blackboxprogramming
+  - platform-ops
+  - security-reviewers
+deploy_targets:
+  - surface: marketing-site
+    provider: cloudflare_pages
+    artifact_path: sites/blackroad
+    workflow: .github/workflows/pages-landing.yml
+    notes: >-
+      BuildBlackRoadSiteAgent builds the static site and WebsiteBot deploys it to
+      Cloudflare Pages.
+  - surface: customer-app
+    provider: fly_io
+    app: blackroad-app
+    release_channel: stable
+    regions: [iad, ord]
+    workflow: .github/workflows/canary.yml
+    secrets:
+      - FLY_API_TOKEN
+  - surface: api
+    provider: aws_ecs
+    cluster: blackroad-prod
+    service: prism-console-api
+    workflow: .github/workflows/_backup_132_deploy.yml
+    container:
+      port: 4010
+      healthcheck: /api/llm/health
+    load_balancer:
+      host: api.blackroad.io
+      https_listener_secret: AWS_PROD_HTTPS_LISTENER_ARN
+    iam:
+      deploy_role_secret: AWS_PROD_DEPLOY_ROLE
+observability:
+  grafana: https://blackroad.io/monitoring
+  alerting_channel: https://blackroad.io/monitoring
+  healthchecks:
+    - https://blackroad.io/healthz
+    - https://blackroad.io/api/llm/health
+runbooks:
+  - DEPLOYMENT.md
+  - RUNBOOK.md
+  - ROLLBACK.md
+approvals:
+  change_windows:
+    - name: weekly_release
+      schedule: Tuesday 02:00-05:00 UTC
+  required_roles:
+    - platform
+    - security
+backups:
+  schedule: "0 3 * * *"
+  script: /usr/local/bin/blackroad-backup-sqlite.sh
+  location: /var/backups/blackroad/sqlite/
+notes:
+  - >-
+    Use the autopal dual-approval environment access workflow before making
+    production changes.

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -1,0 +1,59 @@
+name: staging
+branch: staging
+description: >-
+  Pre-production stack that mirrors production for integration testing, release
+  rehearsals, and data verification before a mainline cutover.
+urls:
+  primary: https://staging.blackroad.io
+  preview_route: https://staging.blackroad.io/prism
+reviewers:
+  - platform-ops
+  - qa-team
+  - security-reviewers
+deploy_targets:
+  - surface: marketing-site
+    provider: cloudflare_pages
+    artifact_path: sites/blackroad
+    workflow: .github/workflows/pages-stage.yml
+  - surface: customer-app
+    provider: fly_io
+    app: blackroad-app-staging
+    release_channel: staging
+    regions: [iad]
+    workflow: .github/workflows/canary.yml
+    secrets:
+      - FLY_STAGING_API_TOKEN
+  - surface: api
+    provider: aws_ecs
+    cluster: blackroad-staging
+    service: prism-console-api-staging
+    workflow: .github/workflows/_backup_132_deploy.yml
+    container:
+      port: 4010
+      healthcheck: /api/llm/health
+    load_balancer:
+      host: api.staging.blackroad.io
+      https_listener_secret: AWS_STAGING_HTTPS_LISTENER_ARN
+    iam:
+      deploy_role_secret: AWS_STAGING_DEPLOY_ROLE
+qa:
+  regression_suite:
+    command: make test ENV=staging
+    location: tools/lucidia-autotester
+  smoke_tests:
+    - curl -fsS https://staging.blackroad.io/healthz
+    - curl -fsS https://api.staging.blackroad.io/api/llm/health
+approvals:
+  required_roles:
+    - platform
+    - qa
+  change_windows:
+    - name: daily-promotion
+      schedule: 16:00-18:00 UTC
+observability:
+  grafana: https://blackroad.io/monitoring
+  notes: Mirrors production dashboards with staging data source wiring.
+notes:
+  - >-
+    Exercise the autopal environment access workflow for staging when dual
+    control is required.


### PR DESCRIPTION
## Summary
- expand the production environment manifest with deployment targets, observability hooks, approvals, and backups
- add staging environment metadata covering deploy surfaces and QA entry points
- define a preview environment manifest that captures the ECS/Fargate wiring and workflow requirements for PR previews

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ec6ac9503c8329b65262f8a891e2be