### PR TITLE
Ignore Python egg-info artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ cmd/slack/slack
 repos/
 runtime/
 __pycache__/
+**/*.egg-info/
 codex/runtime/
 benchmarks/
 


### PR DESCRIPTION
## Summary
- add a glob to ignore Python egg-info metadata directories

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68ec6c75cb408329963c776946f3c631