### PR TITLE
chore: ignore python egg metadata artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ publicssh.sh
 dist/
 .cache/
 .env
+*.egg-info/
+*.egg-info
 !tools/tools-adapter/.env
 artifacts.sha256
 public/artifacts.sha256


### PR DESCRIPTION
## Summary
- add gitignore patterns to exclude Python egg metadata directories and files

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ec6d35b0d08329a6c87d1069556814