### PR TITLE
Remove torchquantum self dependency from vendored requirements

### DIFF
--- a/envs/quantum/src/torchquantum/requirements.txt
+++ b/envs/quantum/src/torchquantum/requirements.txt
@@ -19,6 +19,5 @@ tensorflow>=2.4.1
 torch>=1.8.0
 torchdiffeq>=0.2.3
 torchpack>=0.3.0
-torchquantum>=0.1
 torchvision>=0.9.0.dev20210130
 tqdm>=4.56.0


### PR DESCRIPTION
## Summary
- remove the torchquantum self-dependency from the vendored requirements so the editable install is the sole provider

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ec5f75310c83299172498c544e850d