### PR TITLE
Ignore Python egg-info artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,10 @@ __pycache__/
 codex/runtime/
 benchmarks/
 
+# Python packaging artifacts
+*.egg-info/
+**/*.egg-info/
+
 # Lucidia artifacts
 secrets/*
 datasets/


### PR DESCRIPTION
## Summary
- add gitignore entries for Python egg-info directories to avoid committing packaging metadata

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ec6e7716b88329a9fd781899752310