### PR TITLE
docs: add manifests for staging and preview environments

### DIFF
--- a/docs/devx/preview-environments.md
+++ b/docs/devx/preview-environments.md
@@ -1,6 +1,6 @@
 # Pull Request Preview Environments
 
-Preview environments are provisioned per pull request using ECS Fargate. The Terraform module under `modules/preview-env` creates an application load balancer, task definition, ECS service, and Route53 alias record (`pr-###.dev.blackroad.io`).
+Preview environments are provisioned per pull request using ECS Fargate. The Terraform module under `modules/preview-env` creates an application load balancer, task definition, ECS service, and Route53 alias record (`pr-###.dev.blackroad.io`). See [`environments/preview.yml`](../../environments/preview.yml) for the canonical manifest that release tooling and ChatOps reference.
 
 ## GitHub Action flow
 

--- a/docs/preview-environments.md
+++ b/docs/preview-environments.md
@@ -1,6 +1,6 @@
 # Preview Environments on ECS + ALB
 
-This repository now provisions short-lived preview environments for every pull request. The automation uses GitHub Actions with the AWS CLI to provision the ECS/Fargate service, ALB listener rule, target group, and Route53 DNS records, then tears everything back down when the PR closes.
+This repository now provisions short-lived preview environments for every pull request. The automation uses GitHub Actions with the AWS CLI to provision the ECS/Fargate service, ALB listener rule, target group, and Route53 DNS records, then tears everything back down when the PR closes. Operational details and required secrets live in [`environments/preview.yml`](../environments/preview.yml).
 
 ## Required repository configuration
 

--- a/environments/preview.yml
+++ b/environments/preview.yml
@@ -1,0 +1,37 @@
+name: preview
+host_pattern: https://pr-<pr>.dev.blackroad.io
+status: active
+kind: ephemeral
+provisioning:
+  workflow: .github/workflows/preview.yml
+  module: infra/preview-env
+  terraform_workspace: preview
+  description: >-
+    Every pull request builds a container image, registers an ECS task definition, and wires the
+    load balancer + Route53 alias under `pr-<number>.dev.blackroad.io`. Closing the PR tears the
+    stack back down automatically.
+reviewers:
+  - blackboxprogramming
+operations:
+  secrets:
+    - PREVIEW_ENV_AWS_ROLE
+    - PREVIEW_ENV_ECR_REGISTRY
+    - PREVIEW_ENV_ECR_REPOSITORY
+    - PREVIEW_ENV_TF_STATE_BUCKET
+    - PREVIEW_ENV_TF_LOCK_TABLE
+    - PREVIEW_ENV_CLUSTER_ARN
+    - PREVIEW_ENV_EXECUTION_ROLE_ARN
+    - PREVIEW_ENV_TASK_ROLE_ARN
+    - PREVIEW_ENV_PRIVATE_SUBNET_IDS
+    - PREVIEW_ENV_PUBLIC_SUBNET_IDS
+    - PREVIEW_ENV_VPC_ID
+    - PREVIEW_ENV_HOSTED_ZONE_ID
+    - PREVIEW_ENV_VARS_JSON
+    - PREVIEW_ENV_SECRETS_JSON
+    - SLACK_BOT_TOKEN
+    - SLACK_PREVIEW_CHANNEL
+  health_checks:
+    - https://pr-<pr>.dev.blackroad.io/healthz/ui
+notes:
+  - Use `PR=<number> make deploy` from `infra/preview-env` for manual smoke tests when debugging the workflow.
+  - Listener rule priorities default to `5000 + PR % 4000`; adjust if the ALB approaches the priority limit.

--- a/environments/production.yml
+++ b/environments/production.yml
@@ -2,3 +2,21 @@ name: production
 url: https://blackroad.io
 reviewers:
   - blackboxprogramming
+status: active
+kind: customer-facing
+chatops:
+  command: "/deploy blackroad pages"
+  workflow: .github/workflows/_backup_132_deploy-blackroad.yml
+  branch: main
+deploy:
+  description: >-
+    Main branch merges rebuild `sites/blackroad` and publish the artifact to GitHub Pages.
+    Optional providers (Vercel, Cloudflare, Netlify) are available through the channel workflow
+    for rollbacks or parallel canary deployments.
+verification:
+  checklist:
+    - curl -s https://blackroad.io/healthz
+    - curl -s -o /dev/null -w '%{http_code}' https://blackroad.io/relay | grep 403
+    - curl -s -H 'X-BlackRoad-Key: $BLACKROAD_KEY' https://blackroad.io/api/projects
+notes:
+  - Use the channel workflow when you need to target canary, beta, or prod providers beyond GitHub Pages.

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -1,0 +1,21 @@
+name: staging
+url: https://staging.blackroad.io
+reviewers:
+  - blackboxprogramming
+status: planned
+kind: persistent
+chatops:
+  command: "/deploy blackroad staging"
+  workflow: .github/workflows/_backup_132_deploy-blackroad-staging.yml
+  branch: staging
+deploy:
+  description: >-
+    GitHub Actions builds `sites/blackroad` from the `staging` branch and publishes it to the
+    GitHub Pages staging environment for QA sign-off before production pushes.
+verification:
+  checklist:
+    - Confirm the GitHub Pages environment named "staging" is green before approving.
+    - Once DNS is wired, curl https://staging.blackroad.io/healthz and confirm HTTP 200.
+notes:
+  - DNS for `staging.blackroad.io` has not been delegated yet; rely on the Pages preview URL until the cutover completes.
+  - Feature flags and config overrides should be staged here before `main` merges trigger production deploys.


### PR DESCRIPTION
## Summary
- add structured manifests for production, staging, and preview environments so release automation has a canonical source
- update the preview environment runbooks to link to the new manifest for operators

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ec73388c1883299c22f55554ba9d58