### PR TITLE
fix: ensure quarter close script fails on error

### DIFF
--- a/scripts/quarter_close.js
+++ b/scripts/quarter_close.js
@@ -28,5 +28,5 @@ async function postSlack(message) {
   console.log('Quarter close kickoff complete');
 })().catch(err => {
   console.error(err);
-  process.exit(0);
+  process.exit(1);
 });


### PR DESCRIPTION
## Summary
- ensure the quarter close automation exits with a failure code when the Slack or GitHub steps throw

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ec7df96dd08329bf7aad0888ba915a