### PR TITLE
Document monetization strategy focus areas

### DIFF
--- a/docs/monetization-strategy.md
+++ b/docs/monetization-strategy.md
@@ -1,0 +1,41 @@
+# BlackRoad Monetization Strategy
+
+## Context
+BlackRoad couples infrastructure primitives (BlackRoad, Codex, Lucidia, Copilot) with creative tooling (video generation, co-chatting, code and game builders) and the RoadCoin currency. The platform needs a revenue system that compounds instead of fragmenting into unrelated side projects.
+
+## Monetization Arcs
+
+### 1. Creator Yield Layer
+- Free tier publishes to the BlackRoad portal with platform branding, ads, or sponsor placements.
+- Pro tier (creators, studios, brands) pays to remove branding, unlock higher render budgets, and access premium animation / motion template libraries.
+- RoadCoin marketplace takes a 10–15% fee on asset packs, music, motion systems, and plugins created by the community.
+- Drives steady creator-based income and keeps the marketplace circulating RoadCoin without external ad dependencies.
+
+### 2. Workflow Automation SaaS
+- Package co-chatting and coding agents as automation studios for AI workflows.
+- Meter pricing by GPU-minutes, automation seats, and integrations.
+- Offer analytics dashboards, collaboration spaces, and custom branding as add-ons.
+- Builds predictable MRR, deepens operational maturity, and leverages existing agent infrastructure.
+
+### 3. RoadCoin Loyalty Loop
+- Reward creators with RoadCoin for engagement thresholds (views, completions, remix usage).
+- Spend RoadCoin to promote content, unlock compute credits, or boost distribution.
+- Allow staking RoadCoin into shared ad / sponsor pools to earn revenue shares, anchoring the token to platform output instead of speculation.
+
+### 4. Service-Backed Funding
+- Launch "BlackRoad Studio" white-label retainers for agencies needing branded content or bespoke agent workflows.
+- Charge a baseline monthly fee plus metered compute usage.
+- Generates early cash flow and creates case studies that feed back into product improvements.
+
+### 5. Media and IP Rights
+- Curate top creator output into themed channels, compilations, and learning collections.
+- License premium bundles to partner platforms or educational publishers.
+- Share royalties back via RoadChain to reinforce the creator economy loop.
+
+## Strategic North Star
+Prioritize **steady subscription and services income** in the near term (Workflow Automation SaaS + Service-Backed Funding). These arcs:
+- Produce reliable cash flow to scale infrastructure and support creators.
+- Validate enterprise-grade operations before expanding the token economy.
+- Keep RoadCoin utility tightly coupled to real usage rather than speculation.
+
+Once subscription revenue underwrites platform stability, layer in the creator yield and loyalty loops to unlock the full economy without risking fragmentation.


### PR DESCRIPTION
## Summary
- add a monetization strategy brief that aligns infrastructure, creator tools, and RoadCoin utility
- emphasize subscription-first revenue sequencing before expanding the token economy

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ed8cfc8a788329b68e281dbf5db504