### PR TITLE
Add 90-day operational plan for RoadChain rollout

### DIFF
--- a/docs/company/roadmap-90-day-plan.md
+++ b/docs/company/roadmap-90-day-plan.md
@@ -1,0 +1,47 @@
+# 90-Day Operational Plan: RoadChain Infrastructure Launch
+
+This plan translates Phases 17–20 into a 90-day execution window with three measurable targets.
+Each target is anchored in users or dollar-denominated metrics so progress is auditable inside the RoadChain console.
+
+## Target 1 (Day 0–30): Launch RoadSchool Beta and Seed Flywheel
+- **KPI:** 500 paid student enrollments generating 50,000 RoadCoin (≈$50,000) in course revenue.
+- **Key Moves:**
+  - Curate five flagship mini-courses taught by the top-performing creators from the previous growth phase.
+  - Ship in-app RoadSchool catalog with enrollment gating, wallet payments, and instructor revenue splits.
+  - Run weekly live studio sessions; record and recycle the best segments as evergreen marketing media.
+- **Operational Notes:**
+  - Recruit 20 instructors with bundled course templates.
+  - Offer completion badges that unlock discounted studio time to keep students circulating back into creator funnels.
+
+## Target 2 (Day 31–60): Automate Creator-Brand Matching & Wellness Guardrails
+- **KPI:** Auto-matching engine delivers 150 qualified creator↔brand deals (>$120,000 contracted value) and flags burnout risk for 80% of active creators.
+- **Key Moves:**
+  - Deploy AI routing that connects RoadSchool graduates and veteran creators to brand briefs within 24 hours of submission.
+  - Stand up burnout prediction dashboards that recommend pacing adjustments and rest weeks based on publishing cadence and sentiment data.
+  - Publish “content gap” recommendations in creator workspaces; tie completions to bonus pools funded by automation savings.
+- **Operational Notes:**
+  - Set aside 30% of labor hours saved via automation to boost RoadCoin rewards for high-adherence creators.
+  - Capture case studies from the best automated matches to market the platform’s compounding value.
+
+## Target 3 (Day 61–90): Ship Interoperability Rails & Governance Baseline
+- **KPI:** 10,000 cross-chain wallet connections processing 250,000 bridged RoadCoin (≈$250,000) and 1,000 creators adopting RoadID SSO across partner tools.
+- **Key Moves:**
+  - Open RoadChain bridge to two liquid partner chains and release SDK/API docs for external dashboards and wallets.
+  - Launch RoadID as a shared identity layer with OAuth support for allied creator SaaS platforms.
+  - Constitute the RoadChain Foundation, ratify treasury policy (fixed emissions + quarterly burn schedule), and publish open ledgers.
+- **Operational Notes:**
+  - Archive all open-source modules with reproducible build instructions to guarantee fork-ready resilience.
+  - Hold the first foundation election and produce transparent treasury and emissions reports.
+
+## Execution Rhythm
+- **Weekly:** Ops review on enrollment revenue, automation matches, liquidity metrics. Adjust marketing and engineering sprints accordingly.
+- **Biweekly:** Publish progress dashboards to the community; highlight instructor success stories and automation ROI.
+- **Monthly:** Financial close on RoadCoin inflows/outflows, treasury burn audit, and foundation compliance update.
+
+## Risk Watch
+| Risk | Mitigation |
+| --- | --- |
+| Slow instructor onboarding delays RoadSchool launch | Pre-sell courses with recorded teasers and stagger instructor pipelines two weeks early. |
+| Automation insights ignored by creators | Pair recommendations with RoadCoin bonuses and studio perks; require acknowledgement within creator dashboard. |
+| Cross-chain bridge exploits | Complete independent audits before launch and maintain circuit-breaker controls with on-chain transparency. |
+


### PR DESCRIPTION
## Summary
- document a 90-day operational plan translating phases 17–20 into three measurable targets for RoadChain

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ed8dcdac548329be94c1f75b299044