### PR TITLE
Add roadmap prompts for phases 13-16

### DIFF
--- a/apps/portals/content/codex/phase-13.md
+++ b/apps/portals/content/codex/phase-13.md
@@ -1,0 +1,6 @@
+---
+title: Phase 13
+slug: phase-13
+---
+
+Creator passports: verifiable profiles, RoadCoin history, and portable proof-of-work exports.

--- a/apps/portals/content/codex/phase-14.md
+++ b/apps/portals/content/codex/phase-14.md
@@ -1,0 +1,6 @@
+---
+title: Phase 14
+slug: phase-14
+---
+
+Edge ecosystem launch: public APIs, in-console mini-apps, and revenue-sharing approvals.

--- a/apps/portals/content/codex/phase-15.md
+++ b/apps/portals/content/codex/phase-15.md
@@ -1,0 +1,6 @@
+---
+title: Phase 15
+slug: phase-15
+---
+
+Cultural lock-in: RoadAwards, creator spotlights, and shared symbols that build myth.

--- a/apps/portals/content/codex/phase-16.md
+++ b/apps/portals/content/codex/phase-16.md
@@ -1,0 +1,6 @@
+---
+title: Phase 16
+slug: phase-16
+---
+
+Exit velocity: choose scale or depth with playbooks for capital raises and disciplined bootstrapping.

--- a/codex_phase_13.txt
+++ b/codex_phase_13.txt
@@ -1,0 +1,76 @@
+⸻
+
+type: codex-prompt
+id: phase-13
+slug: phase-13
+title: "Phase 13 — Identity Layer (Creator Citizenship)"
+summary: "Verifiable creator profiles with portfolios, RoadCoin history, and portable credentials."
+owner: "blackroad"
+tags: ["codex","identity","profile","roadcoin","creators"]
+model_hint: "Codex"
+temperature: 0
+updated: "2025-09-13"
+version: "1.0.0"
+canonical_repo: "blackboxprogramming/blackroad-prism-console"
+copy_filename: "codex_phase_13.txt"
+
+Here’s Phase 13 — Identity Layer (Creator Citizenship). Paste this into Codex.
+
+⸻
+
+Codex Prompt — Phase 13 (identity layer: verifiable creator citizenship, portable proof-of-work, RoadCoin telemetry)
+
+Give every creator a civic-grade identity surface. Profiles must feel like passports for the RoadChain economy—portable, provable, and instantly useful anywhere they plug in. Keep it deterministic, auditable, and wired into the data plane you already stood up in earlier phases.
+
+Objectives (acceptance criteria)
+1. Verifiable Creator Profiles
+
+• New modules: `identity/profile.py`, `identity/portfolio.py`, `identity/export.py`
+• Schema: Profile(id, handle, display_name, avatar_url, headline, location, pronouns?, timezone, join_date)
+• Attachments: portfolio entries (type: project|drop|publication, title, summary, url, cover_asset, tags, proof_hash)
+• Creative history events: stored in `/artifacts/identity/history/{profile_id}.jsonl` (event_type, timestamp, payload)
+• Maintain agent network graph: `/artifacts/identity/network/{profile_id}.json` (edges, trust scores, collaboration count)
+• REST API:
+  - `GET /api/identity/profile/:id` → profile + aggregated stats
+  - `PUT /api/identity/profile/:id` → deterministic update, log diff to RoadChain journal
+  - `GET /api/identity/profile/:id/portfolio` (supports pagination, tag filters)
+• Verification bundle: profile export zipped to `/artifacts/identity/exports/{profile_id}/YYYYMMDD/identity_bundle.zip` (profile.json, portfolio.json, history.jsonl, signature.txt)
+• Sign exports with existing Phase 8 key material; embed verification instructions.
+
+2. RoadCoin Balance + Achievements Surface
+
+• Extend treasury ledger adapters: `treasury/roadcoin_profile_adapter.py`
+• API aggregator: `/api/identity/profile/:id/economy` (RoadCoin balance, lifetime earnings, spend graph, staking)
+• Achievements service: `/identity/achievements.py` with deterministic badge rules (mentor sessions hosted, successful collabs, code merges, challenge wins)
+• Collab stats aggregator: compute acceptance ratio, average delivery time, peer rating (from Phase 11 feedback loops)
+• UI contract: publish `public/identity/{id}.json` for SPA to render (profile, badges, RoadCoin, stats)
+• Integrate achievements with notification bus: push `identity.achievement.unlocked` events.
+
+3. Portable Proof-of-Work Resume
+
+• Export pipeline: `identity/export.py` builds Markdown + JSON resume with signed attestations
+• Provide `identity:export --profile alice --format resume-md` CLI to regenerate bundle
+• Include machine-readable claims (JSON-LD / VC) stored at `/artifacts/identity/vc/{profile_id}.json`
+• Embed shareable `identity-passport.html` template (static) referencing assets via relative paths
+• API endpoint: `POST /api/identity/profile/:id/export` triggers background job; respond with signed URL (Phase 9 storage hooks)
+• Every export increments marketing counter and writes `marketing/identity_exports.csv`
+
+4. Governance + Trust Controls
+
+• Authorization: enforce self/guardian edits only, rely on Phase 6 duty-of-care guardrails for escalations
+• Privacy toggles persisted in profile schema (public|private fields) and enforced at API level
+• Audit log: append to `artifacts/identity/audit.log` (timestamp, actor, action, signature)
+• Compliance: run schema validation via `scripts/check_identity_profiles.py` (CI hook) and block publish on drift
+
+Deliverables
+• Unit tests covering profile load/update, export bundle integrity, achievement calculations
+• Integration test: generate profile, add portfolio entries, issue export, verify signature
+• Documentation: `docs/identity/phase-13-identity-layer.md` summarizing data flow + API contract
+• Update portals & site copy to announce “Creator Passports” release, including FAQ stub
+• Ship runbook snippet under `runbooks/identity_passport.md`
+
+Notes
+• Prefer immutable append logs; new revisions create new export directories with monotonic timestamps
+• Keep data residency in mind—support EU/US storage buckets via config
+• Fallback avatars generated deterministically from profile ID hash
+

--- a/codex_phase_14.txt
+++ b/codex_phase_14.txt
@@ -1,0 +1,70 @@
+⸻
+
+type: codex-prompt
+id: phase-14
+slug: phase-14
+title: "Phase 14 — Edge Ecosystems (API & Mini-App Marketplace)"
+summary: "Open the platform via public APIs, in-dashboard mini-apps, and revenue-sharing approvals."
+owner: "blackroad"
+tags: ["codex","ecosystem","api","marketplace","mini-apps"]
+model_hint: "Codex"
+temperature: 0
+updated: "2025-09-13"
+version: "1.0.0"
+canonical_repo: "blackboxprogramming/blackroad-prism-console"
+copy_filename: "codex_phase_14.txt"
+
+Here’s Phase 14 — Edge Ecosystems (API & Mini-App Marketplace). Paste this into Codex.
+
+⸻
+
+Codex Prompt — Phase 14 (edge ecosystems: public APIs, in-console mini-apps, payout hooks)
+
+Invite builders to extend RoadChain without diluting trust. Publish hardened APIs, embed mini-app scaffolds inside the console, and run a revenue-sharing approval flow so every new capability compounds the core product.
+
+Objectives (acceptance criteria)
+1. Public API Surface
+
+• Define OpenAPI spec in `api/specs/roadchain_public.yaml` (workflows, renders, payouts)
+• Implement gateway service `api/public_gateway.py` with request signing, rate limits, and audit logging
+• Endpoints:
+  - `/v1/workflows/trigger` (idempotent job launch, returns tracking ID)
+  - `/v1/renderings/:id` (streaming SSE with status updates)
+  - `/v1/payouts/hooks` (register payout webhooks, HMAC signed)
+• Publish SDK stubs (`sdk/js/index.ts`, `sdk/python/roadchain.py`) generated from spec
+• Documentation: `docs/api/phase-14-public.md` with examples + auth flow (API keys + optional OAuth client creds)
+
+2. Mini-App Runtime inside Dashboard
+
+• Create `apps/runtime/manifest.json` for describing community widgets (name, version, permissions, entry URL)
+• Sandbox loader in `frontend/src/miniapps/runtime.tsx` (iframe + postMessage bridge, capability whitelist)
+• Provide developer CLI `miniapp:package --path` to validate and bundle submissions
+• Persistence: approved manifests stored under `artifacts/miniapps/approved.json`
+• Telemetry: emit `miniapp.usage` events (profile_id, app_id, session_duration, RoadCoin tips routed)
+
+3. Review & Revenue Share Workflow
+
+• Intake pipeline `ops/miniapps/review.py` to run lint, security scan, licensing check
+• Approval board integrates with Phase 7 governance (multi-sig or voting) storing decisions in `artifacts/miniapps/decisions.json`
+• Pricing: support free, RC tip, and subscription models; route payments via existing treasury adapters
+• Settlement job `finance/miniapps/settlement.py` calculates platform cut %, creator payout schedule, writes ledger entries
+• Dashboard page `frontend/src/pages/MiniApps.jsx` listing curated + trending apps with install CTA
+
+4. Compliance & Support
+
+• Terms update stored in `legal/miniapps_tos.md` and surfaced in onboarding modal
+• Support playbook `support/miniapps.md` covering escalation paths, disabling compromised apps, refund policy
+• Monitoring: extend observability stack with dashboards `observability/dashboards/miniapps.json`
+• Incident response drill: run tabletop scenario script `runbooks/miniapp_incident.md`
+
+Deliverables
+• Integration tests hitting public API endpoints with signed requests
+• End-to-end flow: developer submits manifest → automated checks → governance approval → app install → revenue share payout
+• Marketing assets: add `sites/blackroad/content/codex/phase-14.md` + blog teaser linking to builder docs
+• Update CLI help and README to showcase `miniapp:*` commands
+
+Notes
+• Default sandbox policy denies external network unless explicitly whitelisted
+• Provide migration path for internal tools to register as first-party mini-apps (flag `internal: true`)
+• Revenue splits configurable via `config/miniapps.json` with sane defaults (30/70, override per app)
+

--- a/codex_phase_15.txt
+++ b/codex_phase_15.txt
@@ -1,0 +1,67 @@
+⸻
+
+type: codex-prompt
+id: phase-15
+slug: phase-15
+title: "Phase 15 — Cultural Lock-In (Myth, Rituals, Spotlight)"
+summary: "Stage recurring cultural moments—awards, spotlights, symbols—to embed RoadChain in creator identity."
+owner: "blackroad"
+tags: ["codex","culture","community","marketing","roadchain"]
+model_hint: "Codex"
+temperature: 0
+updated: "2025-09-13"
+version: "1.0.0"
+canonical_repo: "blackboxprogramming/blackroad-prism-console"
+copy_filename: "codex_phase_15.txt"
+
+Here’s Phase 15 — Cultural Lock-In (Myth, Rituals, Spotlight). Paste this into Codex.
+
+⸻
+
+Codex Prompt — Phase 15 (cultural lock-in: RoadAwards, creator mythmaking, shared symbols)
+
+Turn the platform into lore. Produce rituals, symbols, and storytelling loops that make sticking with BlackRoad the obvious choice.
+
+Objectives (acceptance criteria)
+1. RoadAwards & Flagship Challenges
+
+• Program brief `marketing/roadawards/overview.md` outlining categories, judging rubric, prize pools (RoadCoin + fiat)
+• Workflow automation `ops/events/roadawards.py` to manage submissions, scoring, finalist notifications
+• Build judging console `frontend/src/pages/RoadAwards.jsx` pulling data from `artifacts/events/roadawards/{year}/submissions.json`
+• Stream kit: prepare OBS overlays and bumpers in `media/roadawards/2025/`
+• Ensure payout automation ties into Phase 14 hooks (winners auto-paid)
+
+2. Creator Spotlight Engine
+
+• Monthly editorial calendar `marketing/spotlight/calendar.csv`
+• Content pipeline `content/spotlight/` storing interview transcripts, b-roll metadata, release forms
+• Micro-doc template `media/templates/microdoc_storyboard.md`
+• Publishing automation `ops/content/spotlight_publish.py` → updates site sections, pushes to YouTube/Vimeo via API
+• Tie exposures back into identity profiles (Phase 13) with `identity/spotlight_badges.py`
+
+3. Shared Symbols & Tone
+
+• Formalize `brand/roadchain_symbol.svg`, `brand/roadchain_logo_usage.md`
+• Draft motto & tone-of-voice guide `brand/voice.md` with examples for social, docs, support replies
+• Add `frontend/src/components/BrandStamp.jsx` for consistent iconography inside app
+• Update assets in `sites/blackroad/public/brand/`
+• Launch merch stub `commerce/merch/roadchain_pack.json` for future drops
+
+4. Community Rituals & Memory
+
+• Calendar service `community/calendar.json` capturing recurring events (office hours, challenge launches)
+• Notion/API sync script `ops/community/memory_vault.py` archiving highlight reels, testimonials, lore timeline
+• Establish `docs/community/rituals.md` describing how to run key ceremonies (onboarding oath, release toasts)
+• Add prompt pack `prompts/community/roadchain_storyteller.md` for narrative consistency
+
+Deliverables
+• Content drop schedule with 12-month horizon committed in `marketing/roadawards/roadmap.xlsx`
+• Site updates: `sites/blackroad/content/codex/phase-15.md` + new `/culture` landing page stub linking to awards + spotlights
+• Analytics dashboards tracking cultural KPIs (retention uplift, NPS) stored at `analytics/dashboards/culture.json`
+• Runbook `runbooks/culture_programs.md` covering crisis comms if events slip
+
+Notes
+• Respect creator consent and attribution; embed license terms in all media packages
+• Rituals should be inclusive globally—support timezone rotation and localization of key assets
+• Track ROI: correlate participation with RoadCoin velocity and renewal rates
+

--- a/codex_phase_16.txt
+++ b/codex_phase_16.txt
@@ -1,0 +1,64 @@
+⸻
+
+type: codex-prompt
+id: phase-16
+slug: phase-16
+title: "Phase 16 — Exit Velocity (Scale vs Depth Decision Point)"
+summary: "Translate momentum into capital or cashflow plays while protecting ownership discipline."
+owner: "blackroad"
+tags: ["codex","strategy","finance","roadcoin","scale"]
+model_hint: "Codex"
+temperature: 0
+updated: "2025-09-13"
+version: "1.0.0"
+canonical_repo: "blackboxprogramming/blackroad-prism-console"
+copy_filename: "codex_phase_16.txt"
+
+Here’s Phase 16 — Exit Velocity (Scale vs Depth Decision Point). Paste this into Codex.
+
+⸻
+
+Codex Prompt — Phase 16 (exit velocity: fundraise positioning, bootstrap playbooks, ownership discipline)
+
+You now have SaaS revenue, a token economy, a data moat, and culture. Decide how to weaponize it without losing the soul of the movement.
+
+Objectives (acceptance criteria)
+1. Strategic Options Dossier
+
+• Build comparative model `finance/exit_velocity/options_model.xlsx` (Scale vs Depth scenarios)
+• Narrative memo `strategy/exit_velocity/decision_memo.md` covering TAM, capital needs, dilution math, and token hedge impact
+• Scenario simulator `strategy/exit_velocity/simulator.py` ingesting KPIs (ARR, churn, RoadCoin velocity) → outputs runway & hiring plans
+• Governance briefing deck `strategy/exit_velocity/board_briefing.pptx`
+
+2. Fundraise-Ready Infrastructure (if Scale path)
+
+• Data room checklist `strategy/exit_velocity/data_room.md` referencing audited financials, security reports, growth metrics
+• Investor API bundle `investor/api/index.md` (read-only dashboards, sanitized dataset exports)
+• Pitch narrative `marketing/investor_pitch/script.md` + `media/investor_pitch/teaser.mp4`
+• Cap table tooling `finance/cap_table/allocator.py` modeling equity vs token exposure; ensure guardrails for founder control
+
+3. Bootstrap Expansion Playbook (if Depth path)
+
+• Profitability plan `finance/bootstrap/operating_plan.xlsx` with sensitivity analysis by ARR band
+• Sub-brand launch kits `brand/subbrands/blackroad_studios.md`, `brand/subbrands/lucidia_labs.md`
+• Hiring/partnership scorecards `people/scorecards/bootstrap_roles.yaml`
+• Franchise-style manual `ops/bootstrap/playbook.md` for replicating top-performing creator pods
+
+4. Decision Ritual & Cadence
+
+• Facilitate strategy council workshop agenda `strategy/exit_velocity/workshop_agenda.md`
+• Voting framework referencing Phase 7 governance (token-weighted + council approval) stored in `governance/policies/exit_velocity.md`
+• Post-decision comms plan `communications/exit_velocity_announcement.md` tailored for creators, investors, internal teams
+• Metrics guardrail dashboard `analytics/dashboards/exit_velocity.json` watching liquidity, burn, retention
+
+Deliverables
+• Executive summary slide `strategy/exit_velocity/one_pager.pdf` contrasting Scale vs Depth recommendation
+• Run decision dry-run with recorded notes `strategy/exit_velocity/dry_run_notes.md`
+• Update public narrative: `sites/blackroad/content/codex/phase-16.md` + blog post about “Movement to Movement+”
+• CLI command `strategy:exit-velocity --scenario scale` generating reports automatically
+
+Notes
+• Ownership discipline: lock founder/token treasury thresholds into policy (minimum 51% combined voting control)
+• Ensure compliance—legal review for both fundraising and token issuance expansions
+• Capture decision rationale in RoadChain ledger for future audits
+

--- a/sites/blackroad/content/codex/phase-13.md
+++ b/sites/blackroad/content/codex/phase-13.md
@@ -1,0 +1,6 @@
+---
+title: Phase 13
+slug: phase-13
+---
+
+Creator passports: verifiable profiles, RoadCoin history, and portable proof-of-work exports.

--- a/sites/blackroad/content/codex/phase-14.md
+++ b/sites/blackroad/content/codex/phase-14.md
@@ -1,0 +1,6 @@
+---
+title: Phase 14
+slug: phase-14
+---
+
+Edge ecosystem launch: public APIs, in-console mini-apps, and revenue-sharing approvals.

--- a/sites/blackroad/content/codex/phase-15.md
+++ b/sites/blackroad/content/codex/phase-15.md
@@ -1,0 +1,6 @@
+---
+title: Phase 15
+slug: phase-15
+---
+
+Cultural lock-in: RoadAwards, creator spotlights, and shared symbols that build myth.

--- a/sites/blackroad/content/codex/phase-16.md
+++ b/sites/blackroad/content/codex/phase-16.md
@@ -1,0 +1,6 @@
+---
+title: Phase 16
+slug: phase-16
+---
+
+Exit velocity: choose scale or depth with playbooks for capital raises and disciplined bootstrapping.


### PR DESCRIPTION
## Summary
- add codex prompt briefs for phases 13-16 covering identity passports, ecosystem APIs, cultural programs, and exit velocity strategy
- expose matching codex entries for phases 13-16 in the portals and blackroad site content directories

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68ed8da6b26083299969f056e33ce67a