### PR TITLE
Add Creator lightpath onboarding mock flow

### DIFF
--- a/docs/creator-lightpath-onboarding-flow.md
+++ b/docs/creator-lightpath-onboarding-flow.md
@@ -1,0 +1,53 @@
+# Creator Lightpath Onboarding Flow (v0.1)
+
+This pack captures the three-screen onboarding loop for the Creator lightpath experience and the fastest ways to mock it with live-ish feedback.
+
+## Flow Summary
+
+- **Step 1 – Welcome:** Set the emotional hook with the promise: *"You create. We handle the rest."* Keep the copy minimal and point to the under-10-minute loop.
+- **Step 2 – Upload:** Ask for one flagship asset (video, image, or text). Show a mock RoadCoin balance underneath with copy reinforcing that it will update when the work is live.
+- **Step 3 – Live + Reward:** Mirror the live experience: surface view count, gently increasing RoadCoin earned, and a Stripe payout rehearsal. Close with the "Welcome to the first five" line once the user hits **Claim Reward**.
+
+## Screen Specs
+
+### Screen 1 – Welcome
+- **Headline:** *You create. We handle the rest.*
+- **Body copy:** "A short demo run to test upload → publish → payout. Takes under 10 minutes. You’ll see your reward appear live."
+- **Primary CTA:** `Let’s Start`
+
+### Screen 2 – Upload
+- **Prompt:** “Drop in one piece you’re proud of.”
+- **Supported types:** video / image / text (accept any file for the mock).
+- **Status bar copy:** “You’ll see this number change when your work goes live.”
+- **Primary CTA:** `Publish` (only active once a file is chosen).
+
+### Screen 3 – Live + Reward
+- **Headline:** *It’s up.*
+- **Micro-animation:** light confetti treatment when the screen loads.
+- **Tile contents:** view count, RoadCoin earned (auto-increments), Stripe payout test button.
+- **Primary CTA:** `Claim Reward`
+- **Post-CTA message:** “Welcome to the first five. You just closed the loop.”
+
+## Interaction Notes
+
+- Keep the entire loop under three clicks: Start → Publish → Claim Reward.
+- Auto-increment the view count and RoadCoin value for ~5 seconds so the user literally watches the balance change.
+- The Stripe payout test button should flip to a confirmed state and unlock the final line of copy.
+- Provide a visible balance delta so the before/after story is obvious to the user.
+
+## Rapid Mocking Toolkit
+
+| Need | Tool | Notes |
+| --- | --- | --- |
+| Static frames | **Figma** + FigJam | Drop the copy deck into Figma AI to spin up frame variants; keep the palette dark with neon gradients to match the console aesthetic. |
+| Interactive prototype (no code) | **Framer** or **Bravo Studio** | Use drop-in interactions to simulate the balance tick and confetti. Ideal for lightweight user interviews. |
+| Live coded stub | **Vite + React** (the `sites/blackroad` sandbox) | The new `CreatorLightpath` page renders the exact three-step flow with mock counters, payout rehearsal, and copy so PMs/Design can tweak directly in code. |
+| Motion polish | **LottieFiles** or **Haikei** gradients | Quick confetti or background ambient loops that can be exported to JSON/SVG and embedded later. |
+| Usability capture | **Loom** or **Fathom** | Record the first five testers completing the loop so the rest of the team can see the emotional beat land. |
+
+## Next Up
+
+1. Validate the copy and pacing with 3–5 creators — capture where they hesitate.
+2. Decide whether to gate the full dashboard until this loop is completed in production.
+3. If the response is strong, upgrade the confetti to a reusable animation and wire in real payout webhooks.
+

--- a/sites/blackroad/src/App.jsx
+++ b/sites/blackroad/src/App.jsx
@@ -73,6 +73,7 @@ const NAV_LINKS = [
   { path: "backroad", label: "Backroad" },
   { path: "agents", label: "Agents" },
   { path: "subscribe", label: "Subscribe" },
+  { path: "creator-lightpath", label: "Creator lightpath" },
   { path: "lucidia", label: "Lucidia" },
   {
     path: "math",
@@ -102,6 +103,7 @@ const LEGACY_ROUTES = [
   { path: "backroad", element: <Backroad /> },
   { path: "agents", element: <Agents /> },
   { path: "subscribe", element: <Subscribe /> },
+  { path: "creator-lightpath", element: <CreatorLightpath /> },
   { path: "lucidia", element: <Lucidia /> },
   { path: "math", element: <InfinityMath /> },
   { path: "ot", element: <OptimalTransportLab /> },
@@ -141,6 +143,7 @@ const legacyRoutes = [
   { path: "backroad", label: "Backroad", element: <Backroad /> },
   { path: "agents", label: "Agents", element: <Agents /> },
   { path: "subscribe", label: "Subscribe", element: <Subscribe /> },
+  { path: "creator-lightpath", label: "Creator lightpath", element: <CreatorLightpath /> },
   { path: "lucidia", label: "Lucidia", element: <Lucidia /> },
   { path: "math", label: "∞ Infinity Math", accent: true, element: <InfinityMath /> },
   { path: "ising", label: "Ising 2D Lab", element: <Ising2DLab /> },
@@ -172,6 +175,7 @@ const legacyRoutes = [
 ];
 import StableFluidsLab from "./pages/StableFluidsLab.jsx";
 import Subscribe from "./pages/Subscribe.jsx";
+import CreatorLightpath from "./pages/CreatorLightpath.jsx";
 import Terminal from "./pages/Terminal.jsx";
 import VorticityStreamLab from "./pages/VorticityStreamLab.jsx";
 import WaveletLab from "./pages/WaveletLab.jsx";
@@ -185,6 +189,7 @@ const PRIMARY_ROUTES = [
   { to: "/backroad", label: "Backroad", element: Backroad },
   { to: "/agents", label: "Agents", element: Agents },
   { to: "/subscribe", label: "Subscribe", element: Subscribe },
+  { to: "/creator-lightpath", label: "Creator lightpath", element: CreatorLightpath },
   { to: "/lucidia", label: "Lucidia", element: Lucidia },
   { to: "/math", label: "Infinity Math", element: InfinityMath, gradient: true },
 ];

--- a/sites/blackroad/src/pages/CreatorLightpath.jsx
+++ b/sites/blackroad/src/pages/CreatorLightpath.jsx
@@ -1,0 +1,309 @@
+import { useEffect, useMemo, useState } from "react";
+
+const FLOW_STEPS = [
+  {
+    id: 0,
+    label: "Welcome",
+    summary: "Frame the promise and set up the fast loop.",
+  },
+  {
+    id: 1,
+    label: "Upload",
+    summary: "Collect one piece and prime the mock balance.",
+  },
+  {
+    id: 2,
+    label: "Live + Reward",
+    summary: "Show the loop closing with a payout rehearsal.",
+  },
+];
+
+const CONFETTI_COLORS = ["#FF8DC7", "#FBBF24", "#6EE7B7", "#93C5FD", "#F472B6"];
+const BASE_BALANCE = 128.4;
+
+export default function CreatorLightpath() {
+  const [step, setStep] = useState(0);
+  const [fileName, setFileName] = useState("");
+  const [viewCount, setViewCount] = useState(0);
+  const [roadCoinEarned, setRoadCoinEarned] = useState(0);
+  const [payoutChecked, setPayoutChecked] = useState(false);
+  const [rewardClaimed, setRewardClaimed] = useState(false);
+
+  const confettiPieces = useMemo(
+    () =>
+      Array.from({ length: 16 }).map((_, index) => ({
+        color: CONFETTI_COLORS[index % CONFETTI_COLORS.length],
+        delay: (index % 6) * 0.18,
+      })),
+    [],
+  );
+
+  useEffect(() => {
+    if (step !== 2) {
+      setViewCount(0);
+      setRoadCoinEarned(0);
+      setPayoutChecked(false);
+      setRewardClaimed(false);
+      return undefined;
+    }
+
+    let frame = 0;
+    const viewTarget = 142;
+    const roadCoinTarget = 12.8;
+
+    const interval = window.setInterval(() => {
+      frame += 1;
+      setViewCount((prev) => (prev < viewTarget ? Math.min(viewTarget, prev + Math.ceil(Math.random() * 3)) : prev));
+      setRoadCoinEarned((prev) => {
+        if (prev >= roadCoinTarget) return prev;
+        const next = Number((prev + 0.25 + Math.random() * 0.2).toFixed(2));
+        return next > roadCoinTarget ? roadCoinTarget : next;
+      });
+
+      if (frame > 40) {
+        window.clearInterval(interval);
+      }
+    }, 260);
+
+    return () => window.clearInterval(interval);
+  }, [step]);
+
+  const moveNext = () => setStep((prev) => Math.min(prev + 1, FLOW_STEPS.length - 1));
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 text-slate-100">
+      <div className="mx-auto flex max-w-4xl flex-col gap-10 px-6 py-12">
+        <header className="flex flex-col gap-3">
+          <span className="text-xs uppercase tracking-[0.4em] text-slate-400">Creator lightpath</span>
+          <h1 className="text-3xl font-semibold text-white md:text-4xl">A three-click loop to prove the system is alive.</h1>
+          <p className="max-w-2xl text-sm text-slate-300">
+            Guide new creators through a single upload, a simulated publish, and a payout confirmation. Keep it concrete,
+            keep it under ten minutes, and let them watch their RoadCoin balance jump in real time.
+          </p>
+        </header>
+
+        <section className="rounded-2xl border border-white/5 bg-white/5 p-6 shadow-xl backdrop-blur">
+          <ProgressRail step={step} />
+
+          {step === 0 && <WelcomeScreen onNext={moveNext} />}
+          {step === 1 && <UploadScreen fileName={fileName} onFileChange={setFileName} onPublish={moveNext} />}
+          {step === 2 && (
+            <LiveRewardScreen
+              baseBalance={BASE_BALANCE}
+              confettiPieces={confettiPieces}
+              onClaim={() => setRewardClaimed(true)}
+              onPayoutTest={() => setPayoutChecked(true)}
+              payoutChecked={payoutChecked}
+              rewardClaimed={rewardClaimed}
+              roadCoinEarned={roadCoinEarned}
+              viewCount={viewCount}
+            />
+          )}
+        </section>
+
+        <footer className="grid gap-4 rounded-2xl border border-white/5 bg-slate-950/60 p-6 text-sm text-slate-300 md:grid-cols-2">
+          <div>
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-400">Loop checkpoints</h2>
+            <ul className="mt-3 space-y-2 text-sm">
+              {FLOW_STEPS.map((item) => (
+                <li key={item.id} className="flex gap-3">
+                  <span
+                    className={`mt-1 h-2.5 w-2.5 rounded-full ${step >= item.id ? "bg-emerald-400" : "bg-white/20"}`}
+                  />
+                  <div>
+                    <p className="font-medium text-white">{item.label}</p>
+                    <p className="text-xs text-slate-400">{item.summary}</p>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="rounded-xl border border-white/5 bg-black/40 p-4">
+            <p className="text-xs uppercase tracking-wide text-slate-400">Designer note</p>
+            <p className="mt-2 text-sm text-slate-200">
+              This screen set is coded inside the BlackRoad Vite + React sandbox. Clone, tweak copy, or restyle fast, then export
+              to a Figma or Framer handoff. Perfect for pairing with a live demo or usability test.
+            </p>
+          </div>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+function ProgressRail({ step }) {
+  return (
+    <div className="mb-6 flex flex-col gap-2">
+      <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-slate-400">
+        <span>Step {step + 1}</span>
+        <span>{FLOW_STEPS[step]?.label}</span>
+      </div>
+      <div className="h-1 w-full overflow-hidden rounded-full bg-white/10">
+        <div
+          className="h-full rounded-full bg-gradient-to-r from-fuchsia-400 via-sky-400 to-amber-300 transition-all duration-500"
+          style={{ width: `${((step + 1) / FLOW_STEPS.length) * 100}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function WelcomeScreen({ onNext }) {
+  return (
+    <div className="flex flex-col gap-6 rounded-2xl border border-white/10 bg-black/30 p-6">
+      <div className="space-y-2">
+        <p className="text-sm uppercase tracking-wide text-emerald-300/80">Screen 1 – Welcome</p>
+        <h2 className="text-2xl font-semibold text-white">You create. We handle the rest.</h2>
+        <p className="text-sm text-slate-300">
+          A short demo run to test upload → publish → payout. Takes under 10 minutes. You’ll see your reward appear live.
+        </p>
+      </div>
+      <button
+        className="inline-flex items-center justify-center rounded-lg bg-emerald-400 px-5 py-2 text-sm font-semibold text-slate-900 transition hover:bg-emerald-300"
+        onClick={onNext}
+      >
+        Let’s Start
+      </button>
+    </div>
+  );
+}
+
+function UploadScreen({ fileName, onFileChange, onPublish }) {
+  const handleFileChange = (event) => {
+    const file = event.target.files?.[0];
+    onFileChange(file ? file.name : "");
+  };
+
+  return (
+    <div className="flex flex-col gap-6 rounded-2xl border border-emerald-400/20 bg-black/30 p-6">
+      <div className="space-y-2">
+        <p className="text-sm uppercase tracking-wide text-emerald-300/80">Screen 2 – Upload</p>
+        <h2 className="text-xl font-semibold text-white">Drop in one piece you’re proud of.</h2>
+        <p className="text-sm text-slate-300">Supports video, image, or text.</p>
+      </div>
+
+      <label
+        className="flex min-h-[160px] cursor-pointer flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-white/20 bg-white/5 p-6 text-center text-sm text-slate-300 transition hover:border-emerald-300/60 hover:bg-white/10"
+      >
+        <span className="rounded-full bg-white/10 px-3 py-1 text-xs uppercase tracking-wide text-white/80">Upload zone</span>
+        <span className="text-base font-medium text-white/90">Drag & drop or browse</span>
+        <span className="text-xs text-slate-400">{fileName || "video / image / text"}</span>
+        <input className="hidden" type="file" onChange={handleFileChange} />
+      </label>
+
+      <div className="space-y-2 rounded-xl border border-white/10 bg-white/5 p-4">
+        <div className="flex items-center justify-between text-xs text-slate-300">
+          <span>Mock RoadCoin balance</span>
+          <span>{BASE_BALANCE.toFixed(2)} RC</span>
+        </div>
+        <div className="h-1.5 w-full overflow-hidden rounded-full bg-white/10">
+          <div className="h-full w-1/3 bg-gradient-to-r from-emerald-400 via-sky-400 to-amber-300" />
+        </div>
+        <p className="text-xs text-slate-400">You’ll see this number change when your work goes live.</p>
+      </div>
+
+      <button
+        className="inline-flex items-center justify-center self-start rounded-lg bg-emerald-400 px-5 py-2 text-sm font-semibold text-slate-900 transition hover:bg-emerald-300 disabled:cursor-not-allowed disabled:bg-white/30 disabled:text-white/60"
+        disabled={!fileName}
+        onClick={onPublish}
+      >
+        Publish
+      </button>
+    </div>
+  );
+}
+
+function LiveRewardScreen({
+  baseBalance,
+  confettiPieces,
+  onClaim,
+  onPayoutTest,
+  payoutChecked,
+  rewardClaimed,
+  roadCoinEarned,
+  viewCount,
+}) {
+  return (
+    <div className="relative overflow-hidden rounded-2xl border border-emerald-400/40 bg-black/30 p-6">
+      <div aria-hidden className="pointer-events-none absolute inset-x-6 top-0 flex justify-between text-2xl">
+        {confettiPieces.map((piece, index) => (
+          <span
+            key={index}
+            className="animate-bounce"
+            style={{ color: piece.color, animationDelay: `${piece.delay}s` }}
+          >
+            •
+          </span>
+        ))}
+      </div>
+
+      <div className="space-y-2">
+        <p className="text-sm uppercase tracking-wide text-emerald-300/80">Screen 3 – Live + Reward</p>
+        <h2 className="text-2xl font-semibold text-white">It’s up.</h2>
+        <p className="text-sm text-slate-300">Your drop is live. Watch the counters climb, then run the payout rehearsal.</p>
+      </div>
+
+      <div className="mt-6 grid gap-4 rounded-xl border border-white/10 bg-white/5 p-5 md:grid-cols-[2fr_1fr]">
+        <div className="space-y-4">
+          <div className="rounded-lg border border-white/10 bg-black/40 p-4">
+            <p className="text-xs uppercase tracking-wide text-slate-400">Live tile</p>
+            <div className="mt-2 flex flex-col gap-3 rounded-lg border border-white/10 bg-white/5 p-4">
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-semibold text-white">Featured piece</span>
+                <span className="rounded-full bg-emerald-400/20 px-3 py-1 text-xs text-emerald-200">Live</span>
+              </div>
+              <div className="grid grid-cols-2 gap-3 text-sm text-slate-200">
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-slate-400">View count</p>
+                  <p className="text-lg font-semibold text-white">{viewCount}</p>
+                </div>
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-slate-400">RoadCoin earned</p>
+                  <p className="text-lg font-semibold text-emerald-300">{roadCoinEarned.toFixed(2)} RC</p>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <button
+            className={`inline-flex items-center justify-center gap-2 rounded-lg border px-4 py-2 text-sm font-semibold transition ${
+              payoutChecked
+                ? "border-emerald-400/60 bg-emerald-400/10 text-emerald-200"
+                : "border-white/20 bg-white/5 text-white hover:border-emerald-300/60 hover:text-emerald-200"
+            }`}
+            onClick={onPayoutTest}
+            type="button"
+          >
+            <span className="h-2 w-2 rounded-full bg-emerald-300" />
+            Stripe payout test
+          </button>
+
+          {payoutChecked ? (
+            <p className="text-xs text-emerald-200">Payout confirmed in sandbox. Ready for the real run.</p>
+          ) : (
+            <p className="text-xs text-slate-400">Trigger the fake payout to complete the loop.</p>
+          )}
+        </div>
+
+        <aside className="flex flex-col justify-between gap-4 rounded-lg border border-white/10 bg-black/30 p-4">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-slate-400">Balance update</p>
+            <p className="mt-1 text-2xl font-semibold text-white">{(baseBalance + roadCoinEarned).toFixed(2)} RC</p>
+            <p className="text-xs text-slate-400">Auto-refreshing demo balance.</p>
+          </div>
+          <button
+            className="inline-flex items-center justify-center rounded-lg bg-emerald-400 px-4 py-2 text-sm font-semibold text-slate-900 transition hover:bg-emerald-300"
+            onClick={onClaim}
+            type="button"
+          >
+            Claim Reward
+          </button>
+          {rewardClaimed && (
+            <p className="text-sm font-medium text-emerald-200">Welcome to the first five. You just closed the loop.</p>
+          )}
+        </aside>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add an interactive three-step Creator Lightpath onboarding screen to the BlackRoad console
- wire the new page into the existing navigation + router so the prototype is reachable from the portal
- document the flow details and suggested rapid prototyping tools for the team

## Testing
- npm run lint *(fails: existing duplicate identifier error in App.jsx reported by ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_68ed908dfb488329a22716defb84ac74