### PR TITLE
Add starter issues and PR drafts for Cadillac Loop

### DIFF
--- a/.github/ISSUE_TEMPLATE/chore-tracking-slack-hook.md
+++ b/.github/ISSUE_TEMPLATE/chore-tracking-slack-hook.md
@@ -1,0 +1,18 @@
+---
+name: "chore: tracking + Slack hook"
+about: "Add analytics coverage and Slack loop summaries"
+title: "chore: tracking + Slack hook"
+labels: ["type/chore", "status/planned"]
+assignees: []
+---
+
+## Problem
+No visibility on key loop events.
+
+## Solution
+Emit analytics events for onboarding, upload, and payout milestones. Post a summary to `#cadillac-loop` via the existing webhook.
+
+## Notes
+- Reuse the copy defined in `docs/prism/SlackPosts_v0_1.md`.
+- Coordinate with analytics to ensure event naming conventions stay consistent.
+- Capture retries or failures for the Slack notifier.

--- a/.github/ISSUE_TEMPLATE/feat-creator-upload-gallery.md
+++ b/.github/ISSUE_TEMPLATE/feat-creator-upload-gallery.md
@@ -1,0 +1,18 @@
+---
+name: "feat: creator upload + gallery"
+about: "Implement the upload → publish → gallery loop for testers"
+title: "feat: creator upload + gallery"
+labels: ["type/feature", "status/planned"]
+assignees: ["Copilot", "Cecilia"]
+---
+
+## Problem
+No visible upload → publish → gallery flow for testers.
+
+## Solution
+Add upload form, gallery view, and mock balance ticker. Wire the flow to `/api/v1/uploads` and ensure optimistic UI during submission.
+
+## Notes
+- Assign @Copilot for API coverage and @Cecilia for UI polish.
+- Surface a mock RoadCoin balance ticker that updates with gallery views.
+- Confirm the new endpoints are reflected in integration docs.

--- a/.github/ISSUE_TEMPLATE/feat-onboarding-shell.md
+++ b/.github/ISSUE_TEMPLATE/feat-onboarding-shell.md
@@ -1,0 +1,18 @@
+---
+name: "feat: onboarding shell"
+about: "Track the onboarding welcome + checklist shell implementation"
+title: "feat: onboarding shell"
+labels: ["type/feature", "status/planned"]
+assignees: ["Lucidia"]
+---
+
+## Problem
+New creators need a guided first-run: welcome screen → checklist → dashboard stub.
+
+## Solution
+Add pages under `apps/web/app/prism/(onboarding)` with progress tracking and analytics events (`PRISM Checklist Completed`).
+
+## Notes
+- Use doc copy from `prism-onboarding-ux.md`.
+- Assign @Lucidia for UX review.
+- Ensure analytics hooks conform to Cadillac Loop dashboards.

--- a/.github/ISSUE_TEMPLATE/feat-test-payout-flow.md
+++ b/.github/ISSUE_TEMPLATE/feat-test-payout-flow.md
@@ -1,0 +1,18 @@
+---
+name: "feat: test payout flow"
+about: "Wire Stripe test payouts and Slack notifications"
+title: "feat: test payout flow"
+labels: ["type/feature", "status/planned"]
+assignees: []
+---
+
+## Problem
+Creators can’t complete the payout loop.
+
+## Solution
+Integrate Stripe test mode and trigger a `$5` payout when the balance reaches at least 5. Emit a Slack “First Payout” message on success.
+
+## Notes
+- Use the finance test account secret `STRIPE_TEST_KEY`.
+- Confirm payout receipts appear in the test dashboard.
+- Align Slack messaging with Cadillac Loop copy.

--- a/.github/ISSUE_TEMPLATE/meta-friday-retro.md
+++ b/.github/ISSUE_TEMPLATE/meta-friday-retro.md
@@ -1,0 +1,21 @@
+---
+name: "meta: friday retro"
+about: "Automate the weekly Friday Retro ritual"
+title: "meta: friday retro"
+labels: ["type/meta", "status/planned"]
+assignees: []
+---
+
+## Problem
+Team has no weekly reflection ritual.
+
+## Solution
+Automate creation of a “Friday Retro” issue every Friday at 16:00 with the checklist:
+- What worked?
+- What drained time?
+- What to cut?
+
+## Notes
+- Tie the automation to Asana and auto-move the task to Done after close.
+- Confirm timezone alignment for the cron trigger.
+- Document the automation in the ops runbook.

--- a/.github/PULL_REQUEST_TEMPLATE/feat-creator-upload-gallery.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feat-creator-upload-gallery.md
@@ -1,0 +1,19 @@
+---
+name: "🧰 feat: creator upload + gallery"
+about: "Adds upload, publish, and gallery flow for creators"
+title: "🧰 feat: creator upload + gallery"
+labels:
+  - "type/feature"
+  - "status/ready-for-review"
+---
+
+## Summary
+- Adds minimal upload form, gallery listing, and mock RoadCoin balance counter.
+
+## Testing
+- Upload → file appears in gallery.
+- Balance increases 0.01 per view.
+- Refresh does not return 404.
+
+## Linked Issues
+Closes #2

--- a/.github/PULL_REQUEST_TEMPLATE/feat-onboarding-shell.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feat-onboarding-shell.md
@@ -1,0 +1,20 @@
+---
+name: "✨ feat: onboarding shell"
+about: "Implements the Cadillac Loop onboarding welcome + checklist flow"
+title: "✨ feat: onboarding shell"
+labels:
+  - "type/feature"
+  - "status/ready-for-review"
+---
+
+## Summary
+- Implements welcome + checklist flow for Cadillac Loop v0.1.
+- Routes: `/prism/(onboarding)/welcome`, `/checklist`, `/dashboard`.
+
+## Testing
+- Run `pnpm dev` → visit `/prism`.
+- Verify checklist progress bar fills.
+- Confirm analytics event `PRISM Checklist Completed` fires.
+
+## Linked Issues
+Closes #1

--- a/.github/PULL_REQUEST_TEMPLATE/feat-test-payout-flow.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feat-test-payout-flow.md
@@ -1,0 +1,19 @@
+---
+name: "💸 feat: test payout flow"
+about: "Completes the payout loop with Stripe test mode integration"
+title: "💸 feat: test payout flow"
+labels:
+  - "type/feature"
+  - "status/ready-for-review"
+---
+
+## Summary
+- Completes payout loop with Stripe test mode integration and Slack alert.
+
+## Testing
+- Balance ≥ 5 → click “Claim Reward”.
+- Stripe test payment executes successfully.
+- Slack `#cadillac-loop` receives confirmation.
+
+## Linked Issues
+Closes #3


### PR DESCRIPTION
## Summary
- add dedicated issue templates for onboarding, upload/gallery, payout, analytics hook, and Friday retro workflows
- add matching pull request templates for onboarding shell, upload/gallery flow, and payout flow

## Testing
- not run (templates only)


------
https://chatgpt.com/codex/tasks/task_e_68ed95c1f6c08329a165d11f862f89c7