### PR TITLE
Fix pyproject configuration duplication

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,8 @@ requires-python = ">=3.10"
 description = "Offline PLM & Manufacturing Ops (Phase 37) — deterministic, file-backed."
 readme = "README.md"
 authors = [{ name = "Blackroad", email = "eng@blackroadinc.us" }]
-dependencies = ["paho-mqtt", "typer"]
 dependencies = [
+    "paho-mqtt",
     "typer",
     "fastapi",
     "pydantic",
@@ -20,6 +20,7 @@ blackroad-api = "agent.api:main"
 [tool.pytest.ini_options]
 pythonpath = ["."]
 addopts = "-q"
+testpaths = ["tests"]
 
 [tool.black]
 line-length = 100
@@ -31,9 +32,4 @@ profile = "black"
 [tool.ruff]
 line-length = 100
 extend-select = ["I"]
-
-[tool.pytest.ini_options]
-pythonpath = ["."]
-extend-select = ["I"]  # import sort
-testpaths = ["tests/core", "tests/fuzz"]
 


### PR DESCRIPTION
## Summary
- consolidate the dependency list in `pyproject.toml` to avoid duplicate keys
- merge pytest configuration entries into a single block and default to running the full test suite

## Testing
- pytest tests/test_bom.py tests/test_routing_cap.py tests/test_mrp.py tests/test_wi.py tests/test_spc.py tests/test_yield_coq.py -q

------
https://chatgpt.com/codex/tasks/task_e_68edb0c17e8c83299859020e92937635