### PR TITLE
chore: add cadillac loop issue and pr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/chore-tracking-slack-hook.yml
+++ b/.github/ISSUE_TEMPLATE/chore-tracking-slack-hook.yml
@@ -1,0 +1,42 @@
+name: "chore: tracking + Slack hook"
+description: "Emit analytics events and post Cadillac Loop summaries to Slack."
+title: "chore: tracking + Slack hook"
+labels:
+  - "prio/normal"
+  - "type/feature"
+assignees:
+  - "Copilot"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Overview
+        Instrument Cadillac Loop milestones and surface a Slack digest for visibility.
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Problem statement, solution outline, and any supporting notes.
+      value: |
+        **Problem**
+        No visibility on key loop events.
+
+        **Solution**
+        Emit analytics events for onboarding, upload, and payout. Post summary to `#cadillac-loop` via existing webhook.
+
+        **Notes**
+        • Reuse `docs/prism/SlackPosts_v0_1.md` copy.
+      render: markdown
+  - type: checkboxes
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      options:
+        - label: "Analytics events fire for onboarding, upload, and payout milestones"
+        - label: "Slack webhook posts to `#cadillac-loop` with summary copy"
+        - label: "Copy aligns with `docs/prism/SlackPosts_v0_1.md`"
+  - type: textarea
+    id: updates
+    attributes:
+      label: Status Updates
+      description: Capture wiring notes, approvals, and rollout tasks.

--- a/.github/ISSUE_TEMPLATE/feat-creator-upload-gallery.yml
+++ b/.github/ISSUE_TEMPLATE/feat-creator-upload-gallery.yml
@@ -1,0 +1,43 @@
+name: "feat: creator upload + gallery"
+description: "Expose upload → publish → gallery loop for Cadillac Loop creators."
+title: "feat: creator upload + gallery"
+labels:
+  - "type/feature"
+  - "prio/normal"
+assignees:
+  - "Copilot"
+  - "Cecilia"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Overview
+        Build the creator-facing upload flow so testers can move content through the Cadillac Loop.
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Problem statement, solution outline, and any supporting notes.
+      value: |
+        **Problem**
+        No visible upload → publish → gallery flow for testers.
+
+        **Solution**
+        Add upload form, gallery view, and mock balance ticker. Wire to `/api/v1/uploads`.
+
+        **Notes**
+        • Assign @Copilot for API and @Cecilia for UI polish.
+      render: markdown
+  - type: checkboxes
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      options:
+        - label: "Upload form posts to `/api/v1/uploads`"
+        - label: "Uploaded items render in gallery view"
+        - label: "Mock balance ticker increments as views increase"
+  - type: textarea
+    id: updates
+    attributes:
+      label: Status Updates
+      description: Provide launch notes, QA results, and outstanding tasks.

--- a/.github/ISSUE_TEMPLATE/feat-onboarding-shell.yml
+++ b/.github/ISSUE_TEMPLATE/feat-onboarding-shell.yml
@@ -1,0 +1,43 @@
+name: "feat: onboarding shell"
+description: "Guide new creators through the Cadillac Loop onboarding shell."
+title: "feat: onboarding shell"
+labels:
+  - "type/feature"
+  - "prio/normal"
+assignees:
+  - "Lucidia"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Overview
+        Spin up the onboarding scaffold for Cadillac Loop creators. Use the copy in [`docs/prism-onboarding-ux.md`](../../docs/prism-onboarding-ux.md) for the welcome, checklist, and dashboard stub screens.
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Problem statement, solution outline, and any supporting notes.
+      value: |
+        **Problem**
+        New creators need a guided first-run: welcome screen → checklist → dashboard stub.
+
+        **Solution**
+        Add pages under `apps/web/app/prism/(onboarding)` with progress tracking and analytics events (`PRISM Checklist Completed`).
+
+        **Notes**
+        • Use doc copy from `prism-onboarding-ux.md`.
+        • Assign @Lucidia for UX review.
+      render: markdown
+  - type: checkboxes
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      options:
+        - label: "Welcome, checklist, and dashboard routes are reachable under `/prism/(onboarding)`"
+        - label: "Checklist progress persists between steps"
+        - label: "`PRISM Checklist Completed` analytics event fires"
+  - type: textarea
+    id: updates
+    attributes:
+      label: Status Updates
+      description: Provide implementation notes, blockers, or launch checklist progress.

--- a/.github/ISSUE_TEMPLATE/feat-test-payout-flow.yml
+++ b/.github/ISSUE_TEMPLATE/feat-test-payout-flow.yml
@@ -1,0 +1,42 @@
+name: "feat: test payout flow"
+description: "Enable Cadillac Loop creators to complete a $5 Stripe test payout."
+title: "feat: test payout flow"
+labels:
+  - "type/feature"
+  - "prio/normal"
+assignees:
+  - "Copilot"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Overview
+        Hook up the Stripe test payout loop and Slack alert so creators can experience the full reward flow.
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Problem statement, solution outline, and any supporting notes.
+      value: |
+        **Problem**
+        Creators can’t complete payout loop.
+
+        **Solution**
+        Integrate Stripe test mode. Trigger `$5` payout when balance ≥ 5. Emit Slack “First Payout” message on success.
+
+        **Notes**
+        • Finance test account lives in secrets → `STRIPE_TEST_KEY`.
+      render: markdown
+  - type: checkboxes
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      options:
+        - label: "Balance threshold of $5 unlocks payout action"
+        - label: "Stripe test charge succeeds using `STRIPE_TEST_KEY`"
+        - label: "Slack #cadillac-loop receives a First Payout message"
+  - type: textarea
+    id: updates
+    attributes:
+      label: Status Updates
+      description: Track integration steps, QA results, and rollout details.

--- a/.github/ISSUE_TEMPLATE/meta-friday-retro.yml
+++ b/.github/ISSUE_TEMPLATE/meta-friday-retro.yml
@@ -1,0 +1,45 @@
+name: "meta: friday retro"
+description: "Automate Friday retro issue creation with checklist and Asana sync."
+title: "meta: friday retro"
+labels:
+  - "prio/normal"
+  - "type/feature"
+assignees:
+  - "Operations"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Overview
+        Automate the weekly retro ritual so the team reflects every Friday at 16:00.
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Problem statement, solution outline, and any supporting notes.
+      value: |
+        **Problem**
+        Team has no weekly reflection ritual.
+
+        **Solution**
+        Automation: every Friday @ 16:00 create “Friday Retro” issue with checklist
+        • What worked?
+        • What drained time?
+        • What to cut?
+
+        **Notes**
+        • Tie to Asana → auto-move to Done after close.
+      render: markdown
+  - type: checkboxes
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      options:
+        - label: "Scheduled automation opens a Friday Retro issue each week at 16:00"
+        - label: "Issue checklist includes reflection prompts"
+        - label: "Asana task auto-moves to Done when issue closes"
+  - type: textarea
+    id: updates
+    attributes:
+      label: Status Updates
+      description: Capture workflow wiring details, approvals, and follow-ups.

--- a/.github/PULL_REQUEST_TEMPLATE/feat-creator-upload-gallery.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feat-creator-upload-gallery.md
@@ -1,0 +1,21 @@
+---
+name: "🧰 feat: creator upload + gallery"
+about: "Adds the Cadillac Loop upload form, gallery view, and mock balance ticker."
+title: "🧰 feat: creator upload + gallery"
+labels:
+  - "type/feature"
+  - "prio/normal"
+---
+
+## Summary
+- Build upload form wired to `/api/v1/uploads`
+- Render uploaded entries in a gallery with refresh-safe routing
+- Display mock RoadCoin balance that increments by 0.01 per view
+
+## Testing
+- [ ] Upload a file and verify it appears in the gallery
+- [ ] Confirm the balance increases by 0.01 for each view event
+- [ ] Refresh the gallery page and confirm it loads without a 404
+
+## Linked Issues
+Closes #2

--- a/.github/PULL_REQUEST_TEMPLATE/feat-onboarding-shell.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feat-onboarding-shell.md
@@ -1,0 +1,21 @@
+---
+name: "✨ feat: onboarding shell"
+about: "Implements the Cadillac Loop onboarding welcome + checklist shell."
+title: "✨ feat: onboarding shell"
+labels:
+  - "type/feature"
+  - "prio/normal"
+---
+
+## Summary
+- Implement welcome, checklist, and dashboard stub routes under `/prism/(onboarding)`
+- Persist checklist progress and emit the `PRISM Checklist Completed` event
+- Align copy with [`docs/prism-onboarding-ux.md`](../../docs/prism-onboarding-ux.md)
+
+## Testing
+- [ ] Run `pnpm dev` and visit `/prism`
+- [ ] Verify the checklist progress bar fills as steps complete
+- [ ] Confirm the `PRISM Checklist Completed` analytics event fires
+
+## Linked Issues
+Closes #1

--- a/.github/PULL_REQUEST_TEMPLATE/feat-test-payout-flow.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feat-test-payout-flow.md
@@ -1,0 +1,21 @@
+---
+name: "💸 feat: test payout flow"
+about: "Integrates Stripe test payouts and Slack confirmation for Cadillac Loop."
+title: "💸 feat: test payout flow"
+labels:
+  - "type/feature"
+  - "prio/normal"
+---
+
+## Summary
+- Enable Stripe test mode payouts when creator balance reaches $5
+- Send a “First Payout” Slack message to `#cadillac-loop` on success
+- Document usage of the `STRIPE_TEST_KEY` secret for local and staging validation
+
+## Testing
+- [ ] Fund a creator balance to ≥ $5 and trigger payout
+- [ ] Verify Stripe test payment completes successfully
+- [ ] Confirm Slack receives the “First Payout” notification
+
+## Linked Issues
+Closes #3


### PR DESCRIPTION
## Summary
- add issue form templates for cadillac loop onboarding, upload, payout, tracking, and retro workstreams
- add matching pull request templates for onboarding, upload, and payout flows

## Testing
- not run (documentation and templates only)


------
https://chatgpt.com/codex/tasks/task_e_68ed9662e9e08329938201eccbc07420