### PR TITLE
Fix ollama bridge packaging and update merge plan

### DIFF
--- a/MERGE_PLAN.md
+++ b/MERGE_PLAN.md
@@ -20,17 +20,17 @@
 | PR | Title | State | Impacts | Risks |
 |---|---|---|---|---|
 | #1016 | feat: wire nginx health and telemetry | open | api | conflicts with PR #1023; conflicts with PR #1020; conflicts with PR #1014; conflicts with PR #1027; conflicts with PR #1024; conflicts with PR #1021 |
-| #1015 | feat: add observability and readiness for ollama bridge | open | bridge | bridge missing package.json with type module; conflicts with PR #1014; conflicts with PR #1029; conflicts with PR #1026; conflicts with PR #1012 |
-| #1029 | feat: add observability and readiness for ollama bridge | merged | bridge | bridge missing package.json with type module; conflicts with PR #1015; conflicts with PR #1014; conflicts with PR #1026; conflicts with PR #1012 |
-| #1026 | feat: secure llm bridge with origin auth and model switcher | merged | bridge | bridge missing package.json with type module; conflicts with PR #1015; conflicts with PR #1014; conflicts with PR #1029; conflicts with PR #1012 |
+| #1015 | feat: add observability and readiness for ollama bridge | open | bridge | package.json with type module present; conflicts with PR #1014; conflicts with PR #1029; conflicts with PR #1026; conflicts with PR #1012 |
+| #1029 | feat: add observability and readiness for ollama bridge | merged | bridge | package.json with type module present; conflicts with PR #1015; conflicts with PR #1014; conflicts with PR #1026; conflicts with PR #1012 |
+| #1026 | feat: secure llm bridge with origin auth and model switcher | merged | bridge | package.json with type module present; conflicts with PR #1015; conflicts with PR #1014; conflicts with PR #1029; conflicts with PR #1012 |
 | #1021 | feat: add mtls partner relay | merged | api, nginx | conflicts with PR #1023; conflicts with PR #1020; conflicts with PR #1016; conflicts with PR #1014; conflicts with PR #1027; conflicts with PR #1024 |
 | #1023 | Add Yjs collaborative editing server and client | open | api, ui | conflicts with PR #1020; conflicts with PR #1016; conflicts with PR #1014; conflicts with PR #1027; conflicts with PR #1024; conflicts with PR #1021 |
 | #1022 | Add collaboration presence bus, LED webhooks, and voice room | open | ui | none |
 | #1020 | Add devices backplane with WebSocket endpoints and admin UI | open | api, ui | conflicts with PR #1023; conflicts with PR #1016; conflicts with PR #1027; conflicts with PR #1024; conflicts with PR #1021 |
-| #1014 | feat: secure llm bridge with origin auth and model switcher | open | bridge, ui | bridge missing package.json with type module; conflicts with PR #1023; conflicts with PR #1016; conflicts with PR #1015; conflicts with PR #1029; conflicts with PR #1026; conflicts with PR #1021; conflicts with PR #1012 |
+| #1014 | feat: secure llm bridge with origin auth and model switcher | open | bridge, ui | package.json with type module present; conflicts with PR #1023; conflicts with PR #1016; conflicts with PR #1015; conflicts with PR #1029; conflicts with PR #1026; conflicts with PR #1021; conflicts with PR #1012 |
 | #1027 | feat: add project rooms API and UI | merged | api, ui | conflicts with PR #1023; conflicts with PR #1020; conflicts with PR #1016; conflicts with PR #1024; conflicts with PR #1021 |
 | #1024 | Add devices backplane with WebSocket endpoints and admin UI | merged | api, ui | conflicts with PR #1023; conflicts with PR #1020; conflicts with PR #1016; conflicts with PR #1027; conflicts with PR #1021 |
-| #1012 | feat: identity beacon, streaming bridge, and snapshots | merged | bridge, ui, units | bridge missing package.json with type module; conflicts with PR #1015; conflicts with PR #1014; conflicts with PR #1029; conflicts with PR #1026 |
+| #1012 | feat: identity beacon, streaming bridge, and snapshots | merged | bridge, ui, units | package.json with type module present; conflicts with PR #1015; conflicts with PR #1014; conflicts with PR #1029; conflicts with PR #1026 |
 | #1017 | fix(webber): centralize prettier execution | open | none | conflicts with PR #1011; conflicts with PR #1007; conflicts with PR #1006; conflicts with PR #1013; conflicts with PR #1008 |
 | #1011 | feat(agents): add webber bot for web file editing | open | none | conflicts with PR #1017; conflicts with PR #1007; conflicts with PR #1006; conflicts with PR #1013; conflicts with PR #1008 |
 | #1010 | Enhance cleanup bot with summary and error handling | open | none | conflicts with PR #999; conflicts with PR #998 |
@@ -534,8 +534,4 @@ api,yjs,bridge,jsond -> nginx -> ui
 
 ## Fix-Forward Tasks
 
-- Add srv/ollama-bridge/package.json with {"type":"module"}
-- Add srv/ollama-bridge/package.json with {"type":"module"}
-- Add srv/ollama-bridge/package.json with {"type":"module"}
-- Add srv/ollama-bridge/package.json with {"type":"module"}
-- Add srv/ollama-bridge/package.json with {"type":"module"}
+- ✅ Added `srv/ollama-bridge/package.json` with `{ "type": "module" }` to support bridge ESM builds.

--- a/merge_plan.json
+++ b/merge_plan.json
@@ -37,7 +37,6 @@
         "bridge"
       ],
       "risks": [
-        "bridge missing package.json with type module",
         "conflicts with PR #1014",
         "conflicts with PR #1029",
         "conflicts with PR #1026",
@@ -64,7 +63,6 @@
         "bridge"
       ],
       "risks": [
-        "bridge missing package.json with type module",
         "conflicts with PR #1015",
         "conflicts with PR #1014",
         "conflicts with PR #1026",
@@ -91,7 +89,6 @@
         "bridge"
       ],
       "risks": [
-        "bridge missing package.json with type module",
         "conflicts with PR #1015",
         "conflicts with PR #1014",
         "conflicts with PR #1029",
@@ -225,7 +222,6 @@
         "ui"
       ],
       "risks": [
-        "bridge missing package.json with type module",
         "conflicts with PR #1023",
         "conflicts with PR #1016",
         "conflicts with PR #1015",
@@ -313,7 +309,6 @@
         "units"
       ],
       "risks": [
-        "bridge missing package.json with type module",
         "conflicts with PR #1015",
         "conflicts with PR #1014",
         "conflicts with PR #1029",
@@ -879,11 +874,5 @@
       ]
     }
   ],
-  "fix_forward": [
-    "Add srv/ollama-bridge/package.json with {\"type\":\"module\"}",
-    "Add srv/ollama-bridge/package.json with {\"type\":\"module\"}",
-    "Add srv/ollama-bridge/package.json with {\"type\":\"module\"}",
-    "Add srv/ollama-bridge/package.json with {\"type\":\"module\"}",
-    "Add srv/ollama-bridge/package.json with {\"type\":\"module\"}"
-  ]
+  "fix_forward": []
 }

--- a/scripts/merge_recon.py
+++ b/scripts/merge_recon.py
@@ -77,7 +77,11 @@ def detect_risks(pr_files: List[dict], impacts: Set[str]) -> List[str]:
     paths = {f["filename"] for f in pr_files}
     # Bridge ESM check
     if "bridge" in impacts:
-        if any(f["filename"].startswith("srv/ollama-bridge/") and f["filename"].endswith(".js") for f in pr_files):
+        bridge_pkg_exists = Path("srv/ollama-bridge/package.json").exists()
+        if not bridge_pkg_exists and any(
+            f["filename"].startswith("srv/ollama-bridge/") and f["filename"].endswith(".js")
+            for f in pr_files
+        ):
             if not any(f["filename"] == "srv/ollama-bridge/package.json" for f in pr_files):
                 risks.append("bridge missing package.json with type module")
     # CSP checks

--- a/srv/ollama-bridge/package.json
+++ b/srv/ollama-bridge/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "ollama-bridge",
+  "private": true,
+  "type": "module",
+  "main": "server.js"
+}
+

--- a/srv/ollama-bridge/server.js
+++ b/srv/ollama-bridge/server.js
@@ -1,10 +1,10 @@
-const express = require('express');
-const os = require('os');
-const fs = require('fs');
-const crypto = require('crypto');
+import fs from 'node:fs';
+import os from 'node:os';
+import crypto from 'node:crypto';
+import express from 'express';
 
 const app = express();
-app.use(express.json({limit: '1mb'}));
+app.use(express.json({ limit: '1mb' }));
 
 const PORT = process.env.PORT || 4010;
 const MODEL_DEFAULT = 'qwen2:1.5b';
@@ -12,29 +12,30 @@ const PERSONA_DEFAULT = 'You are a kind, curious BlackRoad assistant. ALWAYS ask
 
 let identityCache = { ts: 0, data: null };
 
-function base32(buf){
+function base32(buf) {
   const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
-  let out='';
-  let bits=0, value=0;
-  for(const byte of buf){
-    value = (value<<8) | byte;
+  let out = '';
+  let bits = 0;
+  let value = 0;
+  for (const byte of buf) {
+    value = (value << 8) | byte;
     bits += 8;
-    while(bits >= 5){
-      out += alphabet[(value >>> (bits-5)) & 31];
+    while (bits >= 5) {
+      out += alphabet[(value >>> (bits - 5)) & 31];
       bits -= 5;
     }
   }
-  if(bits>0){
-    out += alphabet[(value << (5-bits)) & 31];
+  if (bits > 0) {
+    out += alphabet[(value << (5 - bits)) & 31];
   }
   return out;
 }
 
-function primaryIPv4(){
+function primaryIPv4() {
   const nets = os.networkInterfaces();
-  for(const name of Object.keys(nets)){
-    for(const net of nets[name]){
-      if(net.family==='IPv4' && !net.internal){
+  for (const name of Object.keys(nets)) {
+    for (const net of nets[name]) {
+      if (net.family === 'IPv4' && !net.internal) {
         return net.address;
       }
     }
@@ -42,41 +43,43 @@ function primaryIPv4(){
   return '127.0.0.1';
 }
 
-async function detectModel(){
-  try{
+async function detectModel() {
+  try {
     const r = await fetch('http://127.0.0.1:11434/api/tags');
     const j = await r.json();
-    if(Array.isArray(j.models) && j.models.length>0) return j.models[0].name;
-  }catch(e){}
+    if (Array.isArray(j.models) && j.models.length > 0) return j.models[0].name;
+  } catch (e) {}
   return 'unknown';
 }
 
-function getSeed(){
-  if(process.env.LUCIDIA_SEED) return process.env.LUCIDIA_SEED;
-  try{
-    return fs.readFileSync('/srv/lucidia-llm/.seed','utf8').trim();
-  }catch(e){return ''};
+function getSeed() {
+  if (process.env.LUCIDIA_SEED) return process.env.LUCIDIA_SEED;
+  try {
+    return fs.readFileSync('/srv/lucidia-llm/.seed', 'utf8').trim();
+  } catch (e) {
+    return '';
+  }
 }
 
-async function buildIdentity(){
+async function buildIdentity() {
   const host = os.hostname();
   const ip = primaryIPv4();
   const model = await detectModel();
   const time = new Date().toISOString();
-  const date = time.slice(0,10); // YYYY-MM-DD
+  const date = time.slice(0, 10); // YYYY-MM-DD
   const seed = getSeed();
   let code = 'UNKNOWN';
-  if(seed){
+  if (seed) {
     const msg = `${date}|blackboxprogramming|copilot`;
     const hmac = crypto.createHmac('sha256', seed).update(msg).digest();
-    const b32 = base32(hmac).slice(0,16);
-    code = `LUCIDIA-AWAKEN-${date.replace(/-/g,'')}-${b32}`;
+    const b32 = base32(hmac).slice(0, 16);
+    code = `LUCIDIA-AWAKEN-${date.replace(/-/g, '')}-${b32}`;
   }
   const services = { nginx: 'active', 'ollama-bridge': 'active', 'blackroad-api': 'unknown' };
-  try{
+  try {
     const r = await fetch('http://127.0.0.1:4000/health');
-    if(r.ok) services['blackroad-api'] = 'active';
-  }catch(e){}
+    if (r.ok) services['blackroad-api'] = 'active';
+  } catch (e) {}
   return {
     host,
     ip,
@@ -88,8 +91,8 @@ async function buildIdentity(){
   };
 }
 
-app.get('/api/codex/identity', async (req,res)=>{
-  if(Date.now() - identityCache.ts < 60000 && identityCache.data){
+app.get('/api/codex/identity', async (req, res) => {
+  if (Date.now() - identityCache.ts < 60000 && identityCache.data) {
     return res.json(identityCache.data);
   }
   const data = await buildIdentity();
@@ -97,96 +100,98 @@ app.get('/api/codex/identity', async (req,res)=>{
   res.json(data);
 });
 
-function logPersona(str){
+function logPersona(str) {
   const line = `${new Date().toISOString()} ${str}\n`;
-  fs.mkdirSync('/var/log/blackroad', {recursive:true});
-  fs.appendFile('/var/log/blackroad/persona.log', line, ()=>{});
+  fs.mkdirSync('/var/log/blackroad', { recursive: true });
+  fs.appendFile('/var/log/blackroad/persona.log', line, () => {});
 }
 
-function getSystem(body){
+function getSystem(body) {
   const sys = body.system && body.system.trim() ? body.system : PERSONA_DEFAULT;
   logPersona(sys);
   return sys;
 }
 
-function buildPrompt(messages){
-  if(!Array.isArray(messages)) return '';
-  return messages.map(m=>`${m.role}: ${m.content}`).join('\n') + '\nassistant:';
+function buildPrompt(messages) {
+  if (!Array.isArray(messages)) return '';
+  return messages.map(m => `${m.role}: ${m.content}`).join('\n') + '\nassistant:';
 }
 
-app.post('/api/llm/chat', async (req,res)=>{
+app.post('/api/llm/chat', async (req, res) => {
   const system = getSystem(req.body);
-  const prompt = buildPrompt(req.body.messages||[]);
-  try{
+  const prompt = buildPrompt(req.body.messages || []);
+  try {
     const r = await fetch('http://127.0.0.1:11434/api/generate', {
-      method:'POST',
-      headers:{'Content-Type':'application/json'},
-      body: JSON.stringify({model: MODEL_DEFAULT, prompt, stream:false, system})
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: MODEL_DEFAULT, prompt, stream: false, system })
     });
     const j = await r.json();
     const text = j.response || j.output || j.text || '';
-    return res.json({choices:[{message:{role:'assistant',content:text}}]});
-  }catch(e){
-    const last = (req.body.messages||[]).filter(m=>m.role==='user').pop();
-    return res.json({choices:[{message:{role:'assistant',content:last?last.content:''}}]});
+    return res.json({ choices: [{ message: { role: 'assistant', content: text } }] });
+  } catch (e) {
+    const last = (req.body.messages || []).filter(m => m.role === 'user').pop();
+    return res.json({ choices: [{ message: { role: 'assistant', content: last ? last.content : '' } }] });
   }
 });
 
-app.post('/api/llm/stream', async (req,res)=>{
+app.post('/api/llm/stream', async (req, res) => {
   const system = getSystem(req.body);
-  const prompt = buildPrompt(req.body.messages||[]);
-  try{
+  const prompt = buildPrompt(req.body.messages || []);
+  try {
     const r = await fetch('http://127.0.0.1:11434/api/generate', {
-      method:'POST',
-      headers:{'Content-Type':'application/json'},
-      body: JSON.stringify({model: MODEL_DEFAULT, prompt, stream:true, system})
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model: MODEL_DEFAULT, prompt, stream: true, system })
     });
-    res.setHeader('Content-Type','text/event-stream');
-    res.setHeader('Cache-Control','no-cache');
-    res.setHeader('Connection','keep-alive');
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Connection', 'keep-alive');
     const reader = r.body.getReader();
     const decoder = new TextDecoder();
-    let buffer='';
-    while(true){
-      const {value,done} = await reader.read();
-      if(done) break;
-      buffer += decoder.decode(value, {stream:true});
+    let buffer = '';
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
       let idx;
-      while((idx = buffer.indexOf('\n')) >= 0){
+      while ((idx = buffer.indexOf('\n')) >= 0) {
         const line = buffer.slice(0, idx);
-        buffer = buffer.slice(idx+1);
-        if(!line.trim()) continue;
-        try{
+        buffer = buffer.slice(idx + 1);
+        if (!line.trim()) continue;
+        try {
           const obj = JSON.parse(line);
-          if(obj.response){
-            res.write(`data: ${JSON.stringify({delta: obj.response})}\n\n`);
+          if (obj.response) {
+            res.write(`data: ${JSON.stringify({ delta: obj.response })}\n\n`);
           }
-        }catch(err){/* ignore */}
+        } catch (err) {
+          /* ignore */
+        }
       }
     }
     res.write('data: {"done":true}\n\n');
     res.end();
-  }catch(e){
+  } catch (e) {
     res.write('data: {"done":true}\n\n');
     res.end();
   }
 });
 
-app.get('/api/llm/health', (req,res)=>{
-  res.json({ok:true});
+app.get('/api/llm/health', (req, res) => {
+  res.json({ ok: true });
 });
 
-app.get('/api/backups/last', (req,res)=>{
-  try{
-    const t = fs.readFileSync('/srv/blackroad-backups/.last_snapshot','utf8').trim();
-    res.json({time:t});
-  }catch(e){
-    res.json({time:null});
+app.get('/api/backups/last', (req, res) => {
+  try {
+    const t = fs.readFileSync('/srv/blackroad-backups/.last_snapshot', 'utf8').trim();
+    res.json({ time: t });
+  } catch (e) {
+    res.json({ time: null });
   }
 });
 
-app.listen(PORT, ()=>{
+app.listen(PORT, () => {
   console.log(`ollama-bridge listening on ${PORT}`);
 });
 
-module.exports = app;
+export default app;


### PR DESCRIPTION
## Summary
- convert the Ollama bridge service to ESM and add a local package manifest so it runs under a module build
- update the merge reconciliation script and queue artifacts to drop the resolved "missing package.json" risk
- mark the fix-forward task as complete in the merge plan documentation

## Testing
- ⚠️ `PORT=0 node srv/ollama-bridge/server.js` *(fails: express is not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68edb7645848832989865cce1ee91559