### PR TITLE
Expand quick quality gates coverage

### DIFF
--- a/.github/workflows/quick-gates.yml
+++ b/.github/workflows/quick-gates.yml
@@ -15,6 +15,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '18'
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
       - name: Run quick quality gates
         run: |
           bash scripts/quick_quality_gates.sh

--- a/scripts/quick_quality_gates.sh
+++ b/scripts/quick_quality_gates.sh
@@ -8,6 +8,19 @@ cd "$ROOT"
 echo "Running ops/install.sh (may install deps)"
 bash ops/install.sh
 
+if [ -f "package.json" ]; then
+  echo "Running npm run format:check"
+  npm run format:check
+
+  echo "Running npm run lint"
+  npm run lint
+
+  echo "Running npm test"
+  npm test
+else
+  echo "Warning: package.json not found; skipping repository npm checks"
+fi
+
 if [ -d "srv/blackroad-api" ]; then
   echo "Running API tests and lint"
   pushd srv/blackroad-api >/dev/null
@@ -16,6 +29,13 @@ if [ -d "srv/blackroad-api" ]; then
   popd >/dev/null
 else
   echo "Warning: srv/blackroad-api not found; skipping API tests"
+fi
+
+if [ -d "srv/lucidia-llm" ]; then
+  echo "Running Pytest for srv/lucidia-llm/test_app.py"
+  pytest srv/lucidia-llm/test_app.py
+else
+  echo "Warning: srv/lucidia-llm not found; skipping Pytest"
 fi
 
 echo "Running health checks"


### PR DESCRIPTION
## Summary
- extend the quick quality gates script to run repository formatting, linting, unit tests, and lucidia LLM pytest before health checks
- update the workflow to provision Python alongside Node so the expanded suite runs in CI

## Testing
- bash scripts/quick_quality_gates.sh *(fails: ops/install.sh generated ENOENT when initializing srv/blackroad-api/package.json under Node v22.19.0)*

------
https://chatgpt.com/codex/tasks/task_e_68edd3f7852483299f60bf3becf6d2d7