### PR TITLE
feat: add pi 400 admin console helper

### DIFF
--- a/docs/pi/pi-400-admin-console.md
+++ b/docs/pi/pi-400-admin-console.md
@@ -1,0 +1,77 @@
+# Pi 400 Admin Console Setup
+
+The Pi 400 keyboard computer anchors the bench as the operator console. Use
+this guide to turn a fresh Raspberry Pi OS install into a ready-to-go
+controller for the Pi-Ops, Pi-Holo, and Pi-Sim nodes.
+
+## 1. Prerequisites
+
+- Raspberry Pi OS (64-bit Desktop) installed on the Pi 400.
+- Network access to the Pi-Ops broker and peer devices.
+- A user account with sudo access (defaults assume `pi`).
+
+## 2. Run the configuration helper
+
+From the repository root on the Pi 400 execute:
+
+```bash
+chmod +x scripts/configure_pi_400.sh
+./scripts/configure_pi_400.sh
+```
+
+Environment variables can be supplied to override defaults:
+
+- `PI_USER` – remote username (default `pi`).
+- `PI_OPS_HOST` – hostname or IP for the Pi-Ops broker (`pi-ops.local`).
+- `PI_HOLO_HOST` – hostname/IP for the hologram node (`pi-holo.local`).
+- `PI_SIM_HOST` – hostname/IP for the simulator node (`pi-sim.local`).
+- `MQTT_HOST` – MQTT host for shortcuts (defaults to `PI_OPS_HOST`).
+
+### What the script configures
+
+1. Installs handy CLI tooling (`git`, `jq`, `tmux`, `mosquitto-clients`,
+   `rsync`, Python virtualenv support).
+2. Generates an Ed25519 SSH key (if none exists) and writes a managed block to
+   `~/.ssh/config` with shortcuts for `pi-ops`, `pi-holo`, and `pi-sim`.
+3. Adds shell aliases (`ph`, `po`, `ps`, `mm`) in `~/.bash_aliases` and ensures
+   `.bashrc` sources the file.
+4. Drops `~/bin/pi-mqtt-watch` for quickly tailing MQTT topics on the broker.
+
+The helper is idempotent — rerunning it updates the managed blocks in-place
+without duplicating configuration.
+
+## 3. Copy the SSH key to peer devices
+
+After the script completes, push the public key to each device so the aliases
+work without passwords:
+
+```bash
+ssh-copy-id pi@pi-ops.local
+ssh-copy-id pi@pi-holo.local
+ssh-copy-id pi@pi-sim.local
+```
+
+Substitute hostnames if you provided overrides.
+
+## 4. Verify shortcuts
+
+Open a new terminal (or `source ~/.bash_aliases`) and check:
+
+```bash
+ph   # should SSH into the holo node
+po   # should SSH into the ops broker
+ps   # should SSH into the simulator
+mm   # should tail all MQTT topics via mosquitto_sub
+pi-mqtt-watch sim/output  # scoped MQTT watcher helper
+```
+
+## 5. Optional tweaks
+
+- Add `~/bin` to `PATH` if it is not already present (`echo 'export PATH="$HOME/bin:$PATH"' >> ~/.profile`).
+- Set up `tmux` default sessions or drop dotfiles into `~/share` over the Samba
+  share created on Pi-Ops.
+- If the console will manage additional nodes, extend the managed block in
+  `~/.ssh/config` by rerunning the helper with updated hostnames.
+
+With these steps the Pi 400 is ready to run bench bring-up tasks, monitor MQTT
+traffic, and drive the rest of the stack with minimal friction.

--- a/docs/pi/stack_v2.md
+++ b/docs/pi/stack_v2.md
@@ -40,8 +40,9 @@ Every command passes through the Pydantic validators before it hits MQTT. Any ma
 
 ## Quick Start
 
-1. Copy `scripts/install_pi_ops.sh` and `pis/pi-ops/hb_log.py` to the Pi-Ops host and run the installer.
-2. Execute `scripts/push_pi_holo.sh` and `scripts/push_pi_sim.sh` from your workstation to deploy heartbeat publishers.
-3. Activate the agent virtualenv on macOS and start `agent/mac/api.py` (FastAPI + Uvicorn) to drive `/holo/text` and `/sim/panel` endpoints.
+1. Configure the Pi 400 admin console with `scripts/configure_pi_400.sh` (see `docs/pi/pi-400-admin-console.md` for details).
+2. Copy `scripts/install_pi_ops.sh` and `pis/pi-ops/hb_log.py` to the Pi-Ops host and run the installer.
+3. Execute `scripts/push_pi_holo.sh` and `scripts/push_pi_sim.sh` from your workstation to deploy heartbeat publishers.
+4. Activate the agent virtualenv on macOS and start `agent/mac/api.py` (FastAPI + Uvicorn) to drive `/holo/text` and `/sim/panel` endpoints.
 
 This aligns with the "fast path" checklist in the release notes.

--- a/scripts/configure_pi_400.sh
+++ b/scripts/configure_pi_400.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Configure the Pi 400 admin console with shortcuts, tooling, and SSH keys.
+set -euo pipefail
+
+log() { printf '\n[pi-400] %s\n' "$*"; }
+warn() { printf '[pi-400] WARN: %s\n' "$*" >&2; }
+
+PI_USER=${PI_USER:-pi}
+PI_OPS_HOST=${PI_OPS_HOST:-pi-ops.local}
+PI_HOLO_HOST=${PI_HOLO_HOST:-pi-holo.local}
+PI_SIM_HOST=${PI_SIM_HOST:-pi-sim.local}
+MQTT_HOST=${MQTT_HOST:-$PI_OPS_HOST}
+SSH_DIR="${HOME}/.ssh"
+SSH_KEY_PATH="${SSH_DIR}/id_ed25519"
+SSH_CONFIG="${SSH_DIR}/config"
+ALIAS_FILE="${HOME}/.bash_aliases"
+BIN_DIR="${HOME}/bin"
+
+PACKAGES=(git jq tmux mosquitto-clients rsync python3-pip python3-venv)
+
+update_block() {
+  local file="$1" marker="$2" content="$3"
+  local start="# >>> ${marker} >>>"
+  local end="# <<< ${marker} <<<"
+  python3 - "$file" "$start" "$end" <<'PY' <<<"$content"
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+start = sys.argv[2]
+end = sys.argv[3]
+body = sys.stdin.read().rstrip("\n")
+block = f"{start}\n{body}\n{end}\n"
+if path.exists():
+    text = path.read_text()
+else:
+    text = ""
+if start in text and end in text:
+    before, rest = text.split(start, 1)
+    _, after = rest.split(end, 1)
+    new_text = before.rstrip("\n") + "\n" + block + after.lstrip("\n")
+else:
+    if text and not text.endswith("\n"):
+        text += "\n"
+    new_text = text + block
+path.parent.mkdir(parents=True, exist_ok=True)
+path.write_text(new_text)
+PY
+}
+
+log "Installing base packages (${PACKAGES[*]})"
+sudo apt-get update
+sudo apt-get install -y "${PACKAGES[@]}"
+
+log "Ensuring SSH key (${SSH_KEY_PATH})"
+mkdir -p "$SSH_DIR"
+chmod 700 "$SSH_DIR"
+if [[ ! -f "${SSH_KEY_PATH}" ]]; then
+  ssh-keygen -t ed25519 -N "" -f "$SSH_KEY_PATH"
+else
+  log "SSH key already exists; skipping generation"
+fi
+chmod 600 "$SSH_KEY_PATH" "${SSH_KEY_PATH}.pub"
+
+log "Configuring SSH host shortcuts"
+ssh_block=$(cat <<EOSSH
+Host pi-ops
+    HostName ${PI_OPS_HOST}
+    User ${PI_USER}
+    PreferredAuthentications publickey
+    IdentityFile ~/.ssh/id_ed25519
+    IdentitiesOnly yes
+    ForwardAgent yes
+
+Host pi-holo
+    HostName ${PI_HOLO_HOST}
+    User ${PI_USER}
+    PreferredAuthentications publickey
+    IdentityFile ~/.ssh/id_ed25519
+    IdentitiesOnly yes
+    ForwardAgent yes
+
+Host pi-sim
+    HostName ${PI_SIM_HOST}
+    User ${PI_USER}
+    PreferredAuthentications publickey
+    IdentityFile ~/.ssh/id_ed25519
+    IdentitiesOnly yes
+    ForwardAgent yes
+EOSSH
+)
+update_block "$SSH_CONFIG" "pi-console hosts" "$ssh_block"
+chmod 600 "$SSH_CONFIG"
+
+log "Adding shell aliases"
+alias_block=$(cat <<EOALIAS
+alias ph='ssh pi-holo'
+alias po='ssh pi-ops'
+alias ps='ssh pi-sim'
+alias mm='mosquitto_sub -h ${MQTT_HOST} -t "#" -v'
+EOALIAS
+)
+update_block "$ALIAS_FILE" "pi-console aliases" "$alias_block"
+
+if [[ -f "$HOME/.bashrc" ]]; then
+  if ! grep -q "\\.bash_aliases" "$HOME/.bashrc"; then
+    log "Linking .bash_aliases from .bashrc"
+    printf '\nif [ -f "$HOME/.bash_aliases" ]; then\n  . "$HOME/.bash_aliases"\nfi\n' >> "$HOME/.bashrc"
+  fi
+else
+  log "Creating minimal .bashrc that sources .bash_aliases"
+  printf 'if [ -f "$HOME/.bash_aliases" ]; then\n  . "$HOME/.bash_aliases"\nfi\n' > "$HOME/.bashrc"
+fi
+
+log "Dropping MQTT watch helper"
+mkdir -p "$BIN_DIR"
+cat <<EOSCRIPT > "${BIN_DIR}/pi-mqtt-watch"
+#!/usr/bin/env bash
+set -euo pipefail
+HOST="${MQTT_HOST}"
+TOPIC="${1:-#}"
+shift || true
+exec mosquitto_sub -h "$HOST" -t "$TOPIC" -v "$@"
+EOSCRIPT
+chmod +x "${BIN_DIR}/pi-mqtt-watch"
+
+if [[ -d "$HOME/.local/bin" && ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+  warn "Consider adding ~/.local/bin to PATH"
+fi
+
+log "Configuration complete"
+echo "Next steps:"
+echo "  1. Run 'source ~/.bash_aliases' or open a new shell to load aliases."
+echo "  2. Copy your SSH key to each host (will prompt for password):"
+echo "       ssh-copy-id pi@${PI_OPS_HOST}"
+echo "       ssh-copy-id pi@${PI_HOLO_HOST}"
+echo "       ssh-copy-id pi@${PI_SIM_HOST}"
+echo "  3. Verify shortcuts: 'ph', 'po', 'ps', and 'mm'."


### PR DESCRIPTION
## Summary
- add a configure_pi_400.sh helper to automate Pi 400 console setup and shortcuts
- document the workflow in a dedicated Pi 400 admin console guide and link it from the stack v2 notes

## Testing
- not run (documentation and scripting changes only)


------
https://chatgpt.com/codex/tasks/task_e_68ede4b949b08329b4373aae01b8243b