### PR TITLE
Document Jetson Ethernet discovery workflow

### DIFF
--- a/docs/jetson-connectivity.md
+++ b/docs/jetson-connectivity.md
@@ -59,3 +59,25 @@ blackroad status
 
 When the Jetson responds the "Run (stream)" widget will emit the live
 `nvidia-smi` output instead of resolution failures.
+
+## 3. Discover the Jetson over Ethernet
+
+If you have physical Ethernet connected to the same switch/VLAN, the agent can
+scan the subnet and highlight any Jetson-class boards it finds.
+
+1. Open the local agent dashboard and press **Scan LAN**. The table is populated
+   directly from `GET /discover/scan`, so you can also query it via curl:
+
+   ```sh
+   curl -s http://localhost:8080/discover/scan | jq '.hosts[] | select(.kind=="jetson")'
+   ```
+
+2. Each entry includes the IP, any mDNS hostname discovered, and whether SSH is
+   reachable. Click **Set as target** (or POST to `/discover/set`) to update the
+   configured Jetson for subsequent commands.
+
+Behind the scenes the scan walks the local /24, pings each host, resolves
+mDNS/DNS names, and attempts SSH handshakes as the `jetson`, `ubuntu`, and
+`nvidia` users. Hosts that respond and expose NVIDIA GPU telemetry are marked as
+`kind: "jetson"`, making it easy to pick the right IP after a fresh Ethernet
+install.


### PR DESCRIPTION
## Summary
- add documentation on using the agent LAN scan to find Jetson boards over Ethernet
- describe the `/discover/scan` and `/discover/set` endpoints that surface Jetson hosts

## Testing
- not run (documentation change)


------
https://chatgpt.com/codex/tasks/task_e_68ede941862883299cf8e5b7f9caffe9