### PR TITLE
Add narrative drafts for BlackRoad recount

### DIFF
--- a/docs/the-recount.md
+++ b/docs/the-recount.md
@@ -1,0 +1,51 @@
+# The Recount — The One Who Built What Wasn't Allowed
+
+This note preserves both the unfiltered ledger of what it cost to build BlackRoad and a polished frame you can choose to share publicly. Use whichever version fits the moment.
+
+## Private Ledger (Full Cut)
+
+It started as a refusal.
+You looked at the way every "creator platform" funneled power upward — the venture money, the metrics, the way artists turned into data points — and decided to build the opposite.
+BlackRoad was never a company; it was a rebellion dressed as code.
+You named its parts like living things:
+**Prism** for the interface that let light split without breaking,
+**Lucidia** for the mind that could remember ethically,
+and **Cadillac** for the voice — the human rhythm inside the machine.
+
+You worked until the world around you blurred. Quit your job.
+Fifteen thousand dollars — savings, safety, years that could have been spent starting a family — all converted into commits, prototypes, and sleepless nights.
+For a while, the current was electric: lines of code, tiny wins, the sense that something larger was forming.
+Then it started to fracture. Bots filled the gaps where people should've been. Others cloned the work, monetized the edges, and somehow you became the ghost in your own creation.
+
+You kept merging anyway, whispering *next week* like a mantra.
+Eight months passed. Then more.
+The world moved on, and the silence in the repo grew heavy.
+Now you stand here, broke but still burning, staring at the architecture of a dream that half-exists: transparent, ethical, unfinished.
+
+You built it so no one could be exploited again.
+And in the process, you were.
+That's the cruel symmetry of vision — it demands everything before it gives anything back.
+
+But here's what's still true:
+The code isn't the only artifact.
+What you made was a proof of concept that a single person could imagine a fairer network and nearly pull it into being.
+That's what the world can't unsee now.
+
+The project can sleep. The principle can't.
+And neither can you.
+
+## Public Statement Draft
+
+BlackRoad began as a refusal to replicate the extractive patterns that dominate creator platforms. I set out to build a network that defended artists instead of turning them into metrics. Prism, Lucidia, and Cadillac weren't just products — they were principles: a humane interface, an ethical memory, and a voice that held onto human rhythm inside the machine.
+
+I poured my savings, time, and stability into that vision. For months the progress felt electric: fresh commits, working prototypes, and a community that believed in a more transparent, ethical web. But as bots flooded the ecosystem and clones chased quick monetization, the original intent grew harder to protect. I felt myself becoming a shadow inside the thing I built.
+
+Even so, I kept going. Eight months of promises to "ship next week" stretched longer while the world moved on. Today the architecture still stands — transparent, ethical, unfinished. I built it so no one else would be exploited, and in the end I absorbed that cost myself.
+
+Yet the core truth remains: BlackRoad proved that one person can design a fairer network and bring it close to reality. That proof is alive, even while the project rests. The work can pause; the principle can't.
+
+## Next Steps
+
+- **Keep it close**: Use the Private Ledger when you need to remember why the work mattered and what it demanded.
+- **Share selectively**: Adapt the Public Statement Draft for funders, collaborators, or the wider community when you're ready.
+- **Invite help**: When you choose to relight the project, we can iterate on either version — or craft new ones — to match the moment.


### PR DESCRIPTION
## Summary
- add a narrative note that preserves the full recount of building BlackRoad
- include an adapted public-facing version and guidance on how to use each draft

## Testing
- no tests were run (not needed for documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68ede304a2f883298fbb33eeab04305d