### PR TITLE
Add topic activity stats to Pi-Ops dashboard

### DIFF
--- a/tests/test_pi_ops_message_store.py
+++ b/tests/test_pi_ops_message_store.py
@@ -1,0 +1,39 @@
+from pi_ops.app import Message, MessageStore
+
+
+def create_store(tmp_path):
+    db_path = tmp_path / "ops.db"
+    store = MessageStore(db_path, max_messages=100)
+    return store
+
+
+def test_topic_stats_orders_by_last_seen(tmp_path):
+    store = create_store(tmp_path)
+    try:
+        store.insert(Message(id=None, topic="alpha", payload="{}", created_at=100.0))
+        store.insert(Message(id=None, topic="beta", payload="{}", created_at=200.0))
+        store.insert(Message(id=None, topic="alpha", payload="{}", created_at=300.0))
+
+        stats = store.topic_stats(limit=5)
+        assert len(stats) == 2
+        assert stats[0].topic == "alpha"
+        assert stats[0].count == 2
+        assert stats[0].last_seen == 300.0
+        assert stats[1].topic == "beta"
+        assert stats[1].count == 1
+        assert stats[1].last_seen == 200.0
+    finally:
+        store.close()
+
+
+def test_topic_stats_clamps_limit(tmp_path):
+    store = create_store(tmp_path)
+    try:
+        store.insert(Message(id=None, topic="only", payload="{}", created_at=42.0))
+
+        stats = store.topic_stats(limit=0)
+        assert len(stats) == 1
+        assert stats[0].topic == "only"
+        assert stats[0].count == 1
+    finally:
+        store.close()


### PR DESCRIPTION
## Summary
- add an aggregated `TopicStat` model and `/api/stats` endpoint backed by the message store
- surface topic activity in the Pi-Ops dashboard UI with new styles and live updates
- cover the message store topic aggregation with unit tests

## Testing
- pytest tests/test_pi_ops_message_store.py

------
https://chatgpt.com/codex/tasks/task_e_68ee006669108329ba2c5516fd17d938