### PR TITLE
docs: enrich environment manifests

### DIFF
--- a/environments/README.md
+++ b/environments/README.md
@@ -17,9 +17,14 @@ in sync:
 - `domains` — canonical hostnames or URL patterns served by the environment.
 - `deployments` — per-service blocks describing workflow triggers, hosting
   providers, Terraform roots (when applicable), and health checks. Use
-  `state` inside each block when a service is still being wired up.
+  `state` inside each block when a service is still being wired up. When the
+  infrastructure is provisioned through Terraform modules, reference the
+  relative module path so the manifest doubles as navigation for ops engineers.
 - `change_management` — approvals or runbooks that must be followed.
 - `observability` — scripts or commands teams use to verify the environment.
+- Optional fields like `environment`, `secrets`, or `notes` help describe the
+  inputs a workflow expects and any gotchas future maintainers should keep in
+  mind. List them when they save a trip to other repos or credential stores.
 
 Update the manifest whenever the environment changes (new workflow, Terraform
 module, domain, or approval requirement). These files should stay aligned with
@@ -29,4 +34,5 @@ module, domain, or approval requirement). These files should stay aligned with
 
 - `production.yml` — customer-facing blackroad.io footprint.
 - `staging.yml` — stage.blackroad.io plus the AWS scaffolding that mirrors prod.
-- `preview.yml` — ephemeral PR preview infrastructure under dev.blackroad.io.
+- `preview.yml` — ephemeral PR preview infrastructure under dev.blackroad.io,
+  backed by the reusable Terraform stack in `infra/preview-env`.

--- a/environments/preview.yml
+++ b/environments/preview.yml
@@ -6,6 +6,8 @@ description: >-
   Each PR receives a dedicated hostname under dev.blackroad.io and tears down
   automatically when the PR closes.
 contacts:
+  reviewers:
+    - blackboxprogramming
   slack: "#eng"
 domains:
   root: https://dev.blackroad.io
@@ -16,6 +18,7 @@ deployments:
     provider: aws-ecs-fargate
     workflow: .github/workflows/preview-env.yml
     terraform_directory: infra/preview-env
+    module: modules/preview-env
     domain_pattern: https://pr-<pr-number>.dev.blackroad.io
     health_check: https://pr-<pr-number>.dev.blackroad.io/health
     environment:
@@ -39,5 +42,8 @@ deployments:
 change_management:
   approvals: []
 observability:
+  health_checks:
+    - name: pr-web
+      url: https://pr-<pr-number>.dev.blackroad.io/health
   verification:
     - terraform output -raw preview_url

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -5,6 +5,8 @@ description: >-
   Pre-production environment for QA. Static assets publish to stage.blackroad.io
   while AWS infrastructure scaffolding mirrors production.
 contacts:
+  reviewers:
+    - blackboxprogramming
   slack: "#eng"
 domains:
   marketing: https://stage.blackroad.io
@@ -22,6 +24,7 @@ deployments:
     type: container-service
     provider: aws-ecs-fargate
     terraform_directory: br-infra-iac/envs/stg
+    module: modules/ecs-service-alb
     state: planned
     notes: >-
       Network, ECS, and RDS resources are defined; service wiring will follow the
@@ -29,7 +32,12 @@ deployments:
 change_management:
   approvals:
     - .github/workflows/change-approve.yml
+  runbooks:
+    - README-DEPLOY.md
+    - README-OPS.md
 observability:
   health_checks:
     - name: static-health
       url: https://stage.blackroad.io/health.json
+  verification:
+    - curl -sf https://stage.blackroad.io/health.json


### PR DESCRIPTION
## Summary
- document optional manifest fields and link the preview stack readme
- add reviewer contacts and runbook references to the staging manifest
- capture the preview module and health check metadata in the preview manifest

## Testing
- not run (docs only change)


------
https://chatgpt.com/codex/tasks/task_e_68ee06dd5874832991d5cd0b956756dd