### PR TITLE
docs: detail automation in environment manifests

### DIFF
--- a/environments/README.md
+++ b/environments/README.md
@@ -18,8 +18,18 @@ in sync:
 - `deployments` — per-service blocks describing workflow triggers, hosting
   providers, Terraform roots (when applicable), and health checks. Use
   `state` inside each block when a service is still being wired up.
+- `infrastructure` — cloud region, Terraform roots, and backend state files that
+  provision the footprint.
+- `automation` — deploy workflows, required secrets, and notification routes
+  that move new builds into the environment.
 - `change_management` — approvals or runbooks that must be followed.
 - `observability` — scripts or commands teams use to verify the environment.
+
+The additional `infrastructure` and `automation` sections make it easier for
+release tooling to wire GitHub Actions, Terraform state, and downstream
+dashboards together without trawling the monorepo. Update both sections whenever
+we add a new workflow, change Terraform backends, or swap regions so bots and
+humans stay aligned.
 
 Update the manifest whenever the environment changes (new workflow, Terraform
 module, domain, or approval requirement). These files should stay aligned with

--- a/environments/preview.yml
+++ b/environments/preview.yml
@@ -10,6 +10,46 @@ contacts:
 domains:
   root: https://dev.blackroad.io
   pattern: https://pr-<pr-number>.dev.blackroad.io
+infrastructure:
+  cloud: aws
+  region: us-east-1
+  terraform:
+    root: infra/preview-env
+    module: modules/preview-env
+    backend:
+      bucket_secret: PREVIEW_ENV_TF_STATE_BUCKET
+      key_pattern: preview/pr-<pr-number>.tfstate
+      lock_table_secret: PREVIEW_ENV_TF_LOCK_TABLE
+      region: us-east-1
+    outputs:
+      - preview_url
+      - service_name
+automation:
+  workflows:
+    - name: preview-environment
+      file: .github/workflows/preview-env.yml
+      triggers:
+        - pull_request (opened, reopened, synchronize, closed)
+      summary: >-
+        Builds a PR-specific image, applies the preview Terraform stack, posts
+        the URL to GitHub and Slack, and tears the stack down on close.
+      secrets:
+        - PREVIEW_ENV_AWS_ROLE
+        - PREVIEW_ENV_ECR_REGISTRY
+        - PREVIEW_ENV_ECR_REPOSITORY
+        - PREVIEW_ENV_CLUSTER_ARN
+        - PREVIEW_ENV_EXECUTION_ROLE_ARN
+        - PREVIEW_ENV_TASK_ROLE_ARN
+        - PREVIEW_ENV_PRIVATE_SUBNET_IDS
+        - PREVIEW_ENV_PUBLIC_SUBNET_IDS
+        - PREVIEW_ENV_VPC_ID
+        - PREVIEW_ENV_HOSTED_ZONE_ID
+        - PREVIEW_ENV_VARS_JSON
+        - PREVIEW_ENV_SECRETS_JSON
+        - PREVIEW_ENV_TF_STATE_BUCKET
+        - PREVIEW_ENV_TF_LOCK_TABLE
+        - SLACK_PREVIEW_CHANNEL
+        - SLACK_BOT_TOKEN
 deployments:
   - service: web-console
     type: container-service

--- a/environments/production.yml
+++ b/environments/production.yml
@@ -14,6 +14,44 @@ domains:
   canonical: https://www.blackroad.io
   api: https://api.blackroad.io
   status: https://status.blackroad.io
+infrastructure:
+  cloud: aws
+  region: us-west-2
+  terraform:
+    root: br-infra-iac/envs/prod
+    backend:
+      bucket: br-tfstate-<unique>
+      key: prod/terraform.tfstate
+      region: us-west-2
+      lock_table: br-terraform-lock
+    modules:
+      - modules/network
+      - modules/ecs-cluster
+      - modules/ecr
+      - modules/rds-postgres
+    outputs:
+      - ecs_cluster
+      - private_subnets
+      - db_endpoint
+    repositories:
+      - br-api-gateway
+      - br-products-site
+automation:
+  workflows:
+    - name: BlackRoad • Deploy
+      file: .github/workflows/blackroad-deploy.yml
+      triggers:
+        - push (main)
+        - workflow_dispatch
+      summary: >-
+        Builds the SPA, packages the API, triggers the deploy webhook, verifies
+        health, and posts Slack status updates.
+      secrets:
+        - BR_DEPLOY_SECRET
+        - BR_DEPLOY_URL
+        - CF_ZONE_ID
+        - CF_API_TOKEN
+        - SLACK_WEBHOOK_URL
 deployments:
   - service: marketing-site
     type: static-site

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -8,6 +8,42 @@ contacts:
   slack: "#eng"
 domains:
   marketing: https://stage.blackroad.io
+infrastructure:
+  cloud: aws
+  region: us-west-2
+  terraform:
+    root: br-infra-iac/envs/stg
+    backend:
+      bucket: br-tfstate-<unique>
+      key: stg/terraform.tfstate
+      region: us-west-2
+      lock_table: br-terraform-lock
+    modules:
+      - modules/network
+      - modules/ecs-cluster
+      - modules/ecr
+      - modules/rds-postgres
+    outputs:
+      - vpc_id
+      - private_subnets
+      - ecs_cluster
+      - db_endpoint
+    repositories:
+      - br-api-gateway
+      - br-products-site
+automation:
+  workflows:
+    - name: Stage Proof Artifact
+      file: .github/workflows/pages-stage.yml
+      triggers:
+        - push (main, blackroad-stage/**)
+        - schedule (daily 06:05 UTC)
+        - workflow_dispatch
+      summary: >-
+        Generates a proof payload, bakes stage assets, and archives the build
+        without publishing DNS changes.
+      secrets:
+        - AWAKEN_SEED
 deployments:
   - service: marketing-site
     type: static-site


### PR DESCRIPTION
## Summary
- document the new infrastructure and automation sections in the environment manifest guide
- record AWS region, Terraform backend, and deploy workflows in production and staging manifests
- capture preview environment Terraform backend secrets and PR workflow hooks for the review stack

## Testing
- not run (docs/config only)


------
https://chatgpt.com/codex/tasks/task_e_68ee09738c848329af68d40991fa9e4e