### PR TITLE
Revamp BlackRoad home hero with proof-driven layout

### DIFF
--- a/sites/blackroad/public/img/proof-agents.svg
+++ b/sites/blackroad/public/img/proof-agents.svg
@@ -1,0 +1,48 @@
+<svg width="640" height="360" viewBox="0 0 640 360" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="640" height="360" rx="24" fill="url(#paint0_linear_2_1)"/>
+  <g filter="url(#filter0_d_2_1)">
+    <rect x="60" y="72" width="520" height="216" rx="28" fill="rgba(15,23,42,0.75)"/>
+    <rect x="92" y="104" width="120" height="120" rx="20" fill="rgba(56,189,248,0.25)" stroke="#38bdf8" stroke-width="2"/>
+    <rect x="260" y="104" width="120" height="120" rx="20" fill="rgba(16,185,129,0.25)" stroke="#34d399" stroke-width="2"/>
+    <rect x="428" y="104" width="120" height="120" rx="20" fill="rgba(244,114,182,0.25)" stroke="#f472b6" stroke-width="2"/>
+    <text x="120" y="142" fill="#38bdf8" font-size="14" font-weight="600" font-family="'Inter',sans-serif">Roadie</text>
+    <text x="290" y="142" fill="#34d399" font-size="14" font-weight="600" font-family="'Inter',sans-serif">Guardian</text>
+    <text x="456" y="142" fill="#f472b6" font-size="14" font-weight="600" font-family="'Inter',sans-serif">Lucidia</text>
+    <text x="100" y="194" fill="#e2e8f0" font-size="12" font-family="'Inter',sans-serif">Review · Pair · Ship</text>
+    <text x="274" y="194" fill="#dcfce7" font-size="12" font-family="'Inter',sans-serif">Ops · Alerts · Compliance</text>
+    <text x="444" y="194" fill="#fce7f3" font-size="12" font-family="'Inter',sans-serif">Finance · Splits · Treasury</text>
+    <path d="M212 164H244" stroke="#38bdf8" stroke-width="4" stroke-linecap="round" opacity="0.7"/>
+    <path d="M380 164H412" stroke="#34d399" stroke-width="4" stroke-linecap="round" opacity="0.7"/>
+    <path d="M244 178C244 178 256 210 320 210C384 210 396 178 396 178" stroke="#e2e8f0" stroke-width="2" stroke-dasharray="6 8" opacity="0.4"/>
+  </g>
+  <g filter="url(#filter1_d_2_1)">
+    <rect x="96" y="260" width="448" height="44" rx="22" fill="rgba(8,145,178,0.85)"/>
+    <text x="120" y="286" fill="#ecfeff" font-size="16" font-weight="600" font-family="'Inter',sans-serif">Ops graph synced · Release window opens in 12m · Wallet audit clean</text>
+  </g>
+  <defs>
+    <linearGradient id="paint0_linear_2_1" x1="120" y1="48" x2="520" y2="312" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#020617"/>
+      <stop offset="1" stop-color="#0f172a"/>
+    </linearGradient>
+    <filter id="filter0_d_2_1" x="36" y="52" width="568" height="264" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+      <feOffset dy="10"/>
+      <feGaussianBlur stdDeviation="14"/>
+      <feComposite in2="hardAlpha" operator="out"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.07 0 0 0 0 0.24 0 0 0 0 0.36 0 0 0 0.32 0"/>
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+    </filter>
+    <filter id="filter1_d_2_1" x="76" y="248" width="488" height="88" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+      <feOffset dy="6"/>
+      <feGaussianBlur stdDeviation="10"/>
+      <feComposite in2="hardAlpha" operator="out"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.05 0 0 0 0 0.27 0 0 0 0 0.39 0 0 0 0.34 0"/>
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+    </filter>
+  </defs>
+</svg>

--- a/sites/blackroad/public/img/proof-build.svg
+++ b/sites/blackroad/public/img/proof-build.svg
@@ -1,0 +1,60 @@
+<svg width="640" height="360" viewBox="0 0 640 360" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="640" height="360" rx="24" fill="url(#paint0_linear_1_1)"/>
+  <g filter="url(#filter0_d_1_1)">
+    <rect x="40" y="56" width="360" height="248" rx="16" fill="rgba(15,23,42,0.88)"/>
+    <rect x="56" y="96" width="200" height="16" rx="8" fill="#38bdf8" opacity="0.8"/>
+    <rect x="56" y="128" width="248" height="12" rx="6" fill="#f8fafc" opacity="0.9"/>
+    <rect x="56" y="152" width="220" height="12" rx="6" fill="#cbd5f5" opacity="0.8"/>
+    <rect x="56" y="176" width="180" height="12" rx="6" fill="#94a3b8" opacity="0.7"/>
+    <rect x="56" y="200" width="260" height="12" rx="6" fill="#f8fafc" opacity="0.85"/>
+    <rect x="56" y="232" width="280" height="28" rx="10" fill="#38bdf8" opacity="0.95"/>
+    <text x="70" y="250" fill="#0f172a" font-size="14" font-weight="600" font-family="'Inter',sans-serif">/ship creator-os build</text>
+  </g>
+  <g filter="url(#filter1_d_1_1)">
+    <rect x="424" y="92" width="176" height="120" rx="18" fill="rgba(8,145,178,0.92)"/>
+    <rect x="440" y="120" width="144" height="12" rx="6" fill="#ecfeff"/>
+    <rect x="440" y="144" width="96" height="12" rx="6" fill="#cffafe"/>
+    <rect x="440" y="176" width="128" height="28" rx="14" fill="#ecfeff" opacity="0.9"/>
+    <text x="452" y="195" fill="#0f172a" font-size="13" font-weight="600" font-family="'Inter',sans-serif">Storyboard synced</text>
+  </g>
+  <g filter="url(#filter2_d_1_1)">
+    <rect x="80" y="280" width="480" height="40" rx="20" fill="rgba(15,118,110,0.85)"/>
+    <text x="100" y="305" fill="#ecfdf5" font-size="16" font-weight="600" font-family="'Inter',sans-serif">Chat: "Ship build + render preview"</text>
+  </g>
+  <defs>
+    <linearGradient id="paint0_linear_1_1" x1="88" y1="32" x2="552" y2="344" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0f172a"/>
+      <stop offset="1" stop-color="#1e293b"/>
+    </linearGradient>
+    <filter id="filter0_d_1_1" x="24" y="44" width="392" height="280" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+      <feOffset dy="4"/>
+      <feGaussianBlur stdDeviation="8"/>
+      <feComposite in2="hardAlpha" operator="out"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.05 0 0 0 0 0.12 0 0 0 0 0.3 0 0 0 0.35 0"/>
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+    </filter>
+    <filter id="filter1_d_1_1" x="404" y="80" width="216" height="176" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+      <feOffset dy="6"/>
+      <feGaussianBlur stdDeviation="10"/>
+      <feComposite in2="hardAlpha" operator="out"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.02 0 0 0 0 0.17 0 0 0 0 0.24 0 0 0 0.25 0"/>
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+    </filter>
+    <filter id="filter2_d_1_1" x="60" y="268" width="520" height="80" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+      <feOffset dy="6"/>
+      <feGaussianBlur stdDeviation="10"/>
+      <feComposite in2="hardAlpha" operator="out"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.02 0 0 0 0 0.28 0 0 0 0 0.25 0 0 0 0.35 0"/>
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+    </filter>
+  </defs>
+</svg>

--- a/sites/blackroad/public/img/proof-money.svg
+++ b/sites/blackroad/public/img/proof-money.svg
@@ -1,0 +1,61 @@
+<svg width="640" height="360" viewBox="0 0 640 360" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="640" height="360" rx="24" fill="url(#paint0_linear_4_1)"/>
+  <g filter="url(#filter0_d_4_1)">
+    <rect x="80" y="88" width="480" height="216" rx="28" fill="rgba(15,23,42,0.85)"/>
+    <rect x="112" y="120" width="200" height="144" rx="20" fill="rgba(16,185,129,0.2)" stroke="#22c55e" stroke-width="2"/>
+    <rect x="336" y="120" width="192" height="64" rx="16" fill="rgba(20,184,166,0.3)" stroke="#14b8a6" stroke-width="2"/>
+    <rect x="336" y="200" width="192" height="64" rx="16" fill="rgba(56,189,248,0.3)" stroke="#38bdf8" stroke-width="2"/>
+    <text x="140" y="156" fill="#bbf7d0" font-size="14" font-family="'Inter',sans-serif">Creator Wallet</text>
+    <text x="356" y="156" fill="#5eead4" font-size="13" font-family="'Inter',sans-serif">Tips + One-time</text>
+    <text x="356" y="236" fill="#bae6fd" font-size="13" font-family="'Inter',sans-serif">Splits + Payouts</text>
+    <rect x="132" y="176" width="160" height="12" rx="6" fill="#22c55e" opacity="0.8"/>
+    <rect x="132" y="198" width="180" height="12" rx="6" fill="#34d399" opacity="0.7"/>
+    <rect x="132" y="220" width="120" height="12" rx="6" fill="#86efac" opacity="0.6"/>
+    <rect x="132" y="242" width="200" height="32" rx="10" fill="#ecfdf5"/>
+    <text x="150" y="264" fill="#047857" font-size="14" font-weight="600" font-family="'Inter',sans-serif">Next payout · 12:00 UTC</text>
+  </g>
+  <g filter="url(#filter1_d_4_1)">
+    <rect x="120" y="64" width="220" height="44" rx="22" fill="rgba(16,185,129,0.85)"/>
+    <text x="146" y="90" fill="#ecfdf5" font-size="16" font-weight="600" font-family="'Inter',sans-serif">Live wallet balance: $48,920</text>
+  </g>
+  <g filter="url(#filter2_d_4_1)">
+    <rect x="160" y="296" width="320" height="40" rx="20" fill="rgba(56,189,248,0.9)"/>
+    <text x="186" y="322" fill="#0f172a" font-size="16" font-weight="600" font-family="'Inter',sans-serif">Automated split sent to 12 creators</text>
+  </g>
+  <defs>
+    <linearGradient id="paint0_linear_4_1" x1="100" y1="40" x2="520" y2="320" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0f172a"/>
+      <stop offset="1" stop-color="#064e3b"/>
+    </linearGradient>
+    <filter id="filter0_d_4_1" x="60" y="72" width="520" height="260" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+      <feOffset dy="10"/>
+      <feGaussianBlur stdDeviation="14"/>
+      <feComposite in2="hardAlpha" operator="out"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.08 0 0 0 0 0.33 0 0 0 0 0.24 0 0 0 0.34 0"/>
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+    </filter>
+    <filter id="filter1_d_4_1" x="100" y="52" width="260" height="84" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+      <feOffset dy="6"/>
+      <feGaussianBlur stdDeviation="10"/>
+      <feComposite in2="hardAlpha" operator="out"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.02 0 0 0 0 0.21 0 0 0 0 0.17 0 0 0 0.28 0"/>
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+    </filter>
+    <filter id="filter2_d_4_1" x="140" y="284" width="360" height="80" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+      <feOffset dy="6"/>
+      <feGaussianBlur stdDeviation="10"/>
+      <feComposite in2="hardAlpha" operator="out"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.05 0 0 0 0 0.31 0 0 0 0 0.44 0 0 0 0.36 0"/>
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+    </filter>
+  </defs>
+</svg>

--- a/sites/blackroad/public/img/proof-simulation.svg
+++ b/sites/blackroad/public/img/proof-simulation.svg
@@ -1,0 +1,60 @@
+<svg width="640" height="360" viewBox="0 0 640 360" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="640" height="360" rx="24" fill="url(#paint0_linear_3_1)"/>
+  <g filter="url(#filter0_d_3_1)">
+    <rect x="72" y="84" width="496" height="196" rx="24" fill="rgba(15,23,42,0.82)"/>
+    <rect x="108" y="120" width="160" height="112" rx="18" fill="rgba(125,211,252,0.18)" stroke="#38bdf8" stroke-width="2"/>
+    <rect x="250" y="120" width="132" height="112" rx="18" fill="rgba(99,102,241,0.18)" stroke="#6366f1" stroke-width="2"/>
+    <rect x="380" y="120" width="152" height="112" rx="18" fill="rgba(16,185,129,0.2)" stroke="#34d399" stroke-width="2"/>
+    <text x="136" y="210" fill="#bae6fd" font-size="13" font-family="'Inter',sans-serif">Sim Scene</text>
+    <text x="272" y="210" fill="#e0e7ff" font-size="13" font-family="'Inter',sans-serif">Render Queue</text>
+    <text x="412" y="210" fill="#bbf7d0" font-size="13" font-family="'Inter',sans-serif">Publish</text>
+    <path d="M268 176H306" stroke="#38bdf8" stroke-width="4" stroke-linecap="round" opacity="0.8"/>
+    <path d="M402 176H438" stroke="#34d399" stroke-width="4" stroke-linecap="round" opacity="0.8"/>
+    <path d="M188 164C188 164 216 128 260 128C304 128 332 164 332 164" stroke="#38bdf8" stroke-width="2" stroke-dasharray="6 8" opacity="0.4"/>
+    <path d="M332 200C332 200 352 232 396 232C440 232 460 200 460 200" stroke="#a5b4fc" stroke-width="2" stroke-dasharray="6 8" opacity="0.4"/>
+  </g>
+  <g filter="url(#filter1_d_3_1)">
+    <rect x="104" y="60" width="224" height="48" rx="20" fill="rgba(56,189,248,0.9)"/>
+    <text x="128" y="90" fill="#0f172a" font-size="16" font-weight="600" font-family="'Inter',sans-serif">GPU burst render ready</text>
+  </g>
+  <g filter="url(#filter2_d_3_1)">
+    <rect x="160" y="268" width="320" height="44" rx="22" fill="rgba(59,130,246,0.85)"/>
+    <text x="188" y="294" fill="#dbeafe" font-size="16" font-weight="600" font-family="'Inter',sans-serif">Export video + interactive build</text>
+  </g>
+  <defs>
+    <linearGradient id="paint0_linear_3_1" x1="84" y1="36" x2="556" y2="324" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#1e3a8a"/>
+      <stop offset="1" stop-color="#111827"/>
+    </linearGradient>
+    <filter id="filter0_d_3_1" x="52" y="68" width="536" height="240" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+      <feOffset dy="10"/>
+      <feGaussianBlur stdDeviation="14"/>
+      <feComposite in2="hardAlpha" operator="out"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.07 0 0 0 0 0.17 0 0 0 0 0.35 0 0 0 0.3 0"/>
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+    </filter>
+    <filter id="filter1_d_3_1" x="84" y="44" width="264" height="88" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+      <feOffset dy="6"/>
+      <feGaussianBlur stdDeviation="10"/>
+      <feComposite in2="hardAlpha" operator="out"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.03 0 0 0 0 0.24 0 0 0 0 0.39 0 0 0 0.35 0"/>
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+    </filter>
+    <filter id="filter2_d_3_1" x="140" y="256" width="360" height="84" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+      <feOffset dy="6"/>
+      <feGaussianBlur stdDeviation="10"/>
+      <feComposite in2="hardAlpha" operator="out"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.07 0 0 0 0 0.34 0 0 0 0 0.52 0 0 0 0.4 0"/>
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+    </filter>
+  </defs>
+</svg>

--- a/sites/blackroad/src/pages/Home.jsx
+++ b/sites/blackroad/src/pages/Home.jsx
@@ -2,16 +2,127 @@ import { useEffect } from 'react'
 import { Link, useLocation } from 'react-router-dom'
 import { localeFromPath, withPrefix } from '../lib/i18n.ts'
 import { logToWorker } from '../lib/logger.ts'
-
-export default function Home(){
-  const lang = localeFromPath(useLocation().pathname)
-
-import { t, localeFromPath, withPrefix } from '../lib/i18n.ts'
-import { logToWorker } from '../lib/logger.ts'
 import { recordConversion } from '../lib/convert.ts'
 
-export default function Home(){
-  const lang = localeFromPath(useLocation().pathname)
+const proofBlocks = [
+  {
+    id: 'build',
+    title: 'Build Together',
+    outcome:
+      'Code and media flow in one workspace so teams can script features, frame scenes, and review inline in minutes.',
+    image: '/img/proof-build.svg',
+    alt: 'BlackRoad editor with timeline and chat side-by-side',
+    receipts: [
+      'Sub-200ms agent replies inside shared repos',
+      'Branch-aware IDE, storyboard, and asset vault',
+      'Shipped 100+ creator releases last quarter',
+    ],
+  },
+  {
+    id: 'agents',
+    title: 'Multi-Agent Ops',
+    outcome:
+      'Roadie, Guardian, and Lucidia automate review, ops, and finance so you stay focused on shipping.',
+    image: '/img/proof-agents.svg',
+    alt: 'Agents coordinating across review, ops, and finance dashboards',
+    receipts: [
+      '24/7 code review, release, and compliance runs',
+      'Guardian patches drift before it hits prod',
+      'Lucidia reconciles tips, splits, and payouts automatically',
+    ],
+  },
+  {
+    id: 'simulation',
+    title: 'Sim-to-Studio',
+    outcome:
+      'Spin up physics-grade scenes, iterate in real time, and export footage or interactive builds without leaving chat.',
+    image: '/img/proof-simulation.svg',
+    alt: 'Simulation pipeline from 3D scene to rendered experience',
+    receipts: [
+      'Unity & Unreal pipelines pre-integrated',
+      'GPU burst renders streamed under 3 seconds',
+      'Scene-to-video and playable export in one click',
+    ],
+  },
+  {
+    id: 'money',
+    title: 'Native Money',
+    outcome:
+      'Creator Wallet handles tipping, revenue splits, and payouts so every project launches with a business model.',
+    image: '/img/proof-money.svg',
+    alt: 'Wallet dashboard showing tips, splits, and payout schedule',
+    receipts: [
+      'Self-custodied wallet with instant settlement',
+      'Programmable revenue splits per asset bundle',
+      'Supports USD, stablecoins, and creator tokens',
+    ],
+  },
+]
+
+const howItWorks = [
+  {
+    title: 'Start',
+    description: 'Spin up a Creator-OS workspace, invite collaborators, and link your repos, scenes, and channels.',
+  },
+  {
+    title: 'Create',
+    description:
+      'Co-build code, media, and simulations with agents that prep assets, run tests, and tune renders automatically.',
+  },
+  {
+    title: 'Publish',
+    description: 'Ship to web, app stores, or marketplaces with built-in wallets, analytics, and post-launch automation.',
+  },
+]
+
+const pricingTiers = [
+  {
+    name: 'Free',
+    price: '$0',
+    description: 'Personal Creator-OS with local agents and 5GB asset storage.',
+  },
+  {
+    name: 'Pro',
+    price: '$39',
+    description: 'Cloud agent fleet, GPU renders, and production-grade publishing for teams.',
+  },
+  {
+    name: 'Studio',
+    price: 'Let’s talk',
+    description: 'Dedicated ops graph, custom compliance, and revenue-partner tooling.',
+  },
+]
+
+const faqs = [
+  {
+    question: 'What is BlackRoad?',
+    answer: 'BlackRoad is a Creator-OS for code + media—one place to build products, video, and games with agent help.',
+  },
+  {
+    question: 'Can I use my own repos?',
+    answer: 'Yes. Connect GitHub or GitLab, sync assets, and agents will branch, review, and merge with policy guardrails.',
+  },
+  {
+    question: 'How do simulations work?',
+    answer: 'Drop in Unity or Unreal scenes and the sim-to-studio pipeline renders videos or deploys interactive builds.',
+  },
+  {
+    question: 'Is the wallet optional?',
+    answer: 'Creator Wallet is bundled but optional—you decide when to enable tipping, splits, and payouts.',
+  },
+  {
+    question: 'Do you support teams?',
+    answer: 'Pro and Studio plans include shared workspaces, role-based access, and multi-agent orchestration.',
+  },
+  {
+    question: 'How do I get started?',
+    answer: 'Click “Start creating” to launch the Creator-OS workspace or message us for an onboarding session.',
+  },
+]
+
+export default function Home() {
+  const location = useLocation()
+  const lang = localeFromPath(location.pathname)
 
   useEffect(() => {
     const url = import.meta.env.VITE_LOG_WRITE_URL
@@ -19,65 +130,141 @@ export default function Home(){
   }, [])
 
   return (
-    <>
-      <section className="grid grid-2 gap-4">
-        <div className="card">
-          <h2 className="text-xl font-semibold mb-2">Studio</h2>
-          <p>Multi-agent coding with files and canvas all in chat.</p>
-          <Link className="btn mt-4" to={withPrefix('/studio', lang)}>Open Studio</Link>
+    <main className="space-y-16">
+      <section className="card relative overflow-hidden bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white">
+        <div className="absolute inset-0 opacity-20" aria-hidden="true">
+          <div className="h-full w-full bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.45),_transparent_60%)]" />
         </div>
-        <div className="card">
-          <h2 className="text-xl font-semibold mb-2">Animator</h2>
-          <p>Drop assets, storyboard, and render directly to MP4.</p>
-          <Link className="btn mt-4" to={withPrefix('/animator', lang)}>Try Animator</Link>
-        </div>
-        <div className="card">
-          <h2 className="text-xl font-semibold mb-2">Game Maker</h2>
-          <p>Collect assets and export Unity/Unreal project templates.</p>
-          <Link className="btn mt-4" to={withPrefix('/game', lang)}>Build a Game</Link>
-        </div>
-        <div className="card">
-          <h2 className="text-xl font-semibold mb-2">Homework</h2>
-          <p>Research, draft, cite, and export from chat alone.</p>
-          <Link className="btn mt-4" to={withPrefix('/homework', lang)}>Do Homework</Link>
-        </div>
-      </section>
-
-      <section className="card mt-6">
-        <h2 className="text-2xl font-bold mb-2">Pricing</h2>
-        <ul className="list-disc ml-5">
-          <li>Free: explore with local agents</li>
-          <li>Pro $20/mo: cloud workers and priority builds</li>
-          <li>Enterprise: contact us for custom agent graphs</li>
-        </ul>
-      </section>
-      <section className="grid grid-2">
-        <div className="card">
-          <h2 className="text-xl font-semibold mb-2">{t('quickCommands')}</h2>
-          <ul className="list-disc ml-5">
-            <li><code>/deploy blackroad pages</code> (or <code>vercel</code> / <code>cloudflare</code> / <code>staging</code>)</li>
-            <li><code>/toggle ai off</code> &amp; <code>/toggle security off</code></li>
-            <li><code>/fix</code>, <code>/lint</code>, <code>/bump deps</code>, <code>/release</code></li>
-          </ul>
-        </div>
-        <div className="card">
-          <h2 className="text-xl font-semibold mb-2">{t('explore')}</h2>
-          <ul className="list-disc ml-5">
-            <li><Link to={withPrefix('/portal', lang)}>{t('coCodingPortal')}</Link></li>
-            <li><Link to={withPrefix('/status', lang)}>{t('status')}</Link> &nbsp; • &nbsp;<Link to={withPrefix('/snapshot', lang)}>{t('snapshot')}</Link></li>
-            <li><Link to={withPrefix('/docs', lang)}>{t('docs')}</Link></li>
-          </ul>
+        <div className="relative z-10 flex flex-col gap-6">
+          <p className="inline-flex w-fit items-center gap-2 rounded-full bg-slate-800/70 px-4 py-1 text-sm font-medium uppercase tracking-wider text-cyan-200">
+            Creator-OS for code + media
+          </p>
+          <h1 className="text-4xl font-bold leading-tight md:text-5xl">
+            Build, simulate, and publish with multi-agent speed.
+          </h1>
+          <p className="max-w-2xl text-lg text-slate-100">
+            Chat to ship apps, videos, and games with agents that handle review, simulation, and payouts—no context switching, no extra tabs.
+          </p>
+          <div className="flex flex-wrap gap-3">
+            <Link
+              className="btn"
+              onClick={() => recordConversion('cta_click', 1, { where: 'home.start-creating' })}
+              to={withPrefix('/studio', lang)}
+            >
+              Start creating
+            </Link>
+            <Link className="btn-secondary" to={withPrefix('/docs', lang)}>
+              See how it works
+            </Link>
+          </div>
         </div>
       </section>
 
-      <div className="card mt-6">
-        <h1 className="text-2xl font-bold mb-2">BlackRoad</h1>
-        <p>Welcome. Explore MathLab, Metrics, Logs, and the Agent Inbox.</p>
-        <button className="btn mt-4" onClick={() => recordConversion('cta_click', 1, { where: 'home.hero' })}>
-          Demo: Record Conversion (cta_click)
-        </button>
-        <p className="text-xs opacity-70 mt-2">Set <code>VITE_ANALYTICS_BASE</code> to your worker base URL (e.g. https://&lt;name&gt;.workers.dev).</p>
-      </div>
-    </>
+      <section className="card flex flex-wrap items-center justify-between gap-6">
+        <div>
+          <h2 className="text-sm font-semibold uppercase tracking-widest text-slate-500">Launch proof</h2>
+          <p className="text-lg font-medium text-slate-700">100+ Creator-OS projects shipped since Q1</p>
+        </div>
+        <div className="flex flex-wrap gap-4 text-sm text-slate-500">
+          <span>Trusted by frontier labs</span>
+          <span>Backed by realtime ops</span>
+          <span>Deployed to 35 countries</span>
+        </div>
+      </section>
+
+      <section className="space-y-8">
+        <header className="space-y-3">
+          <h2 className="text-2xl font-bold">Prove the Creator-OS for code + media</h2>
+          <p className="text-slate-600">
+            Every block shows how BlackRoad turns multi-agent creation into shipped software, stories, and worlds.
+          </p>
+        </header>
+        <div className="grid gap-8 md:grid-cols-2">
+          {proofBlocks.map((block) => (
+            <article key={block.id} className="card h-full space-y-5">
+              <div className="space-y-2">
+                <h3 className="text-sm font-semibold uppercase tracking-widest text-slate-500">{block.title}</h3>
+                <p className="text-lg text-slate-700">{block.outcome}</p>
+              </div>
+              <img
+                alt={block.alt}
+                className="w-full rounded-lg border border-slate-200 bg-white object-cover"
+                src={block.image}
+              />
+              <ul className="list-disc space-y-1 pl-5 text-sm text-slate-600">
+                {block.receipts.map((receipt) => (
+                  <li key={receipt}>{receipt}</li>
+                ))}
+              </ul>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="card space-y-8">
+        <header className="space-y-2 text-center">
+          <h2 className="text-2xl font-bold">How it works</h2>
+          <p className="text-slate-600">Three steps from idea to revenue-ready launch.</p>
+        </header>
+        <div className="grid gap-6 md:grid-cols-3">
+          {howItWorks.map((step) => (
+            <div key={step.title} className="rounded-xl border border-slate-200 bg-slate-50 p-6 shadow-sm">
+              <h3 className="text-lg font-semibold text-slate-800">{step.title}</h3>
+              <p className="mt-3 text-sm text-slate-600">{step.description}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="card space-y-6" id="pricing">
+        <header className="space-y-2 text-center">
+          <h2 className="text-2xl font-bold">Pricing</h2>
+          <p className="text-slate-600">Choose the Creator-OS plan that fits your team.</p>
+        </header>
+        <div className="grid gap-6 md:grid-cols-3">
+          {pricingTiers.map((tier) => (
+            <div key={tier.name} className="rounded-xl border border-slate-200 bg-white p-6 text-center shadow-sm">
+              <h3 className="text-lg font-semibold text-slate-800">{tier.name}</h3>
+              <p className="mt-2 text-3xl font-bold text-slate-900">{tier.price}</p>
+              <p className="mt-3 text-sm text-slate-600">{tier.description}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="card space-y-6">
+        <header className="space-y-2 text-center">
+          <h2 className="text-2xl font-bold">FAQ</h2>
+          <p className="text-slate-600">Answers to the questions creators ask first.</p>
+        </header>
+        <dl className="space-y-4">
+          {faqs.map((faq) => (
+            <div key={faq.question} className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+              <dt className="text-base font-semibold text-slate-800">{faq.question}</dt>
+              <dd className="mt-2 text-sm text-slate-600">{faq.answer}</dd>
+            </div>
+          ))}
+        </dl>
+      </section>
+
+      <section className="card bg-slate-900 text-center text-white">
+        <h2 className="text-3xl font-bold">Creator-OS for code + media</h2>
+        <p className="mt-3 text-lg text-slate-200">
+          Bring your team, plug in your stack, and let agents help you build, simulate, and publish every launch.
+        </p>
+        <div className="mt-6 flex flex-wrap justify-center gap-3">
+          <Link
+            className="btn"
+            onClick={() => recordConversion('cta_click', 1, { where: 'home.final-cta' })}
+            to={withPrefix('/studio', lang)}
+          >
+            Start creating
+          </Link>
+          <Link className="btn-secondary" to={withPrefix('/contact', lang)}>
+            Talk to us
+          </Link>
+        </div>
+      </section>
+    </main>
   )
 }


### PR DESCRIPTION
## Summary
- rebuild the Home page hero around the "Creator-OS for code + media" positioning with supporting proof, pricing, FAQ, and CTAs
- add reusable content arrays that render four proof blocks, a how-it-works flow, and a refreshed final call to action
- create matching SVG illustrations that visually reinforce build, agents, simulation, and wallet capabilities

## Testing
- npm run lint *(fails: existing duplicate identifier StableFluidsLab in src/App.jsx and unused React/router imports flagged across legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68f06eefee5c8329be4474ac933ec09f