### PR TITLE
Add RIA self-audit fill-in checklist

### DIFF
--- a/docs/regulatory/ria_self_audit_checklist.md
+++ b/docs/regulatory/ria_self_audit_checklist.md
@@ -1,0 +1,142 @@
+# RIA Self-Audit Checklist (Form ADV ↔ Contract Mapper)
+
+Use this one-pager to confirm your Form ADV filings, advisory agreements, and compliance program line up before registration, an annual update, or an exam. Customize the fill-in sections, save the completed copy to your compliance records, and document any follow-up tasks.
+
+---
+
+## 1. Form ADV Alignment Tracker
+| Topic | Part 1 Response | Part 2A / 2B Disclosure | Form CRS Language | Advisory Agreement Clause | Notes & Follow-Ups |
+| --- | --- | --- | --- | --- | --- |
+| Client Types | | | | | |
+| Services / Investment Authority | | | | | |
+| Conflicts of Interest | | | | | |
+| Fee Methodologies | | | | | |
+| Custody & Asset Movement Authority | | | | | |
+| Disciplinary Information | | | | | |
+| Financial Industry Affiliations | | | | | |
+| Outsourced / Third-Party Providers | | | | | |
+
+**Action Items:**
+- [ ] Update inconsistent disclosures
+- [ ] Issue client communication (if required)
+- [ ] Capture board / CCO approval (date: ________)
+
+---
+
+## 2. Fee Disclosure Grid
+| Billing Item | Schedule (Tier / Breakpoint) | Rate | Billing Frequency | In Advance / In Arrears | Custodian Invoicing Support | Refund / Termination Method | Third-Party or Platform Fees | Cross-Check (Brochure § / Contract §) |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Advisory Fee | | | | | | | | |
+| Financial Planning Fee | | | | | | | | |
+| Performance Fee | | | | | | | | |
+| Custodial / Transaction Fees | | | | | | | | |
+| Model Marketplace / SMA Platform Fees | | | | | | | | |
+| Other (describe) | | | | | | | | |
+
+**Reconciliation Steps:**
+- [ ] Confirm invoices match fee schedule
+- [ ] Validate fee calculations (sample date: ________)
+- [ ] Verify refund language matches billing practice
+
+---
+
+## 3. Code of Ethics & MNPI Oversight (Rules 204A / 204A-1)
+| Access Person | Role | Initial Holdings Report (Date) | Quarterly Transaction Reports (Dates) | Pre-Clearance Status | MNPI / Insider List Notes | Training Completion (Date) |
+| --- | --- | --- | --- | --- | --- | --- |
+| | | | | | | |
+| | | | | | | |
+| | | | | | | |
+
+**Program Checks:**
+- [ ] Identify new access persons since last review
+- [ ] Test timeliness of holdings & transaction reports
+- [ ] Review alternative data, expert network, and research relationships for MNPI controls
+
+---
+
+## 4. Custody Decision Matrix (Rule 206(4)-2)
+| Authority / Scenario | Does It Create Custody? (Y/N) | Required Controls | Evidence on File | Gaps / Next Steps |
+| --- | --- | --- | --- | --- |
+| Fee Debiting Authority | | QC statements, ADV consistency | | |
+| Standing Letter of Authorization (SLOA) | | SLOA checklist, custodian confirmation | | |
+| Trustee / Executor Role | | Qualified custodian statements, ADV-E | | |
+| Power of Attorney Beyond Trading | | Surprise exam scope | | |
+| Online Credential / Password Access | | Written procedures, client attestations | | |
+| Related-Party Custody (family accounts, affiliates) | | Conflicts memo, disclosures | | |
+
+**Annual Steps:**
+- [ ] Confirm qualified custodian statements delivered
+- [ ] Schedule / complete surprise exam (date: ________)
+- [ ] File Form ADV-E (if applicable) by __________
+
+---
+
+## 5. Marketing Rule Substantiation Log (Rule 206(4)-1)
+| Advertisement / Campaign | Type (Performance, Hypothetical, Testimonial, Endorsement, Third-Party Rating) | Date First Used | Substantiation / Backup Location | Disclosures Included | ADV Part 1 Item 5.L Accurate? | Reviewer (Initials / Date) |
+| --- | --- | --- | --- | --- | --- | --- |
+| | | | | | | |
+| | | | | | | |
+| | | | | | | |
+
+**Review Points:**
+- [ ] Label hypothetical or model performance clearly
+- [ ] Confirm testimonial / endorsement agreements and disclosures
+- [ ] Maintain performance backup and net vs. gross calculations
+
+---
+
+## 6. Books & Records and Annual Review (Rules 204-2 / 206(4)-7)
+| Record Category | Location | Retention Schedule | Last QA Date | Owner | Issues Found |
+| --- | --- | --- | --- | --- | --- |
+| Advertising & Marketing Materials | | | | | |
+| Performance Support & Calculations | | | | | |
+| Code of Ethics Reports | | | | | |
+| Email / Communications Archive | | | | | |
+| Compliance Testing & Annual Review Workpapers | | | | | |
+| Vendor / Technology Due Diligence | | | | | |
+
+**Annual Review Focus Areas:**
+- [ ] Fees & Expenses
+- [ ] Custody Controls
+- [ ] Conflicts Management
+- [ ] Vendor / Cybersecurity Oversight
+- [ ] Retail & Senior Investors
+- [ ] Other Priority Risks: ______________________
+
+---
+
+## 7. State Registration Cross-Check
+| State | Checklist Source / Link | Items Reviewed | Notes |
+| --- | --- | --- | --- |
+| | | | |
+| | | | |
+
+**Before filing:**
+- [ ] Compare ADV Parts 1 & 2 against state common deficiency lists
+- [ ] Align advisory agreement terms with state-specific requirements
+
+---
+
+## 8. SEC FY 2025 Exam Priorities Mapping
+| Priority Area | Applicable to Firm? (Y/N) | Controls / Policies Referenced | Evidence Reviewed | Enhancements Needed |
+| --- | --- | --- | --- | --- |
+| Marketing & Advertising | | | | |
+| Fees & Expenses | | | | |
+| Custody & Safeguarding | | | | |
+| Conflicts of Interest & Compensation | | | | |
+| Vendor / Third-Party / Operational Resilience | | | | |
+| Retail & Retiree Investors | | | | |
+| Emerging Technology / AI Use | | | | |
+
+**Next Steps:**
+- [ ] Document remediation tasks with owners & due dates
+- [ ] Update compliance calendar / testing plan
+- [ ] Report results to leadership (meeting date: ________)
+
+---
+
+### Sign-Off
+- Prepared by: ____________________ (Title: ____________)  Date: ___________
+- Reviewed by: ____________________ (CCO / Designee)       Date: ___________
+- Board / Committee Acknowledgement (if applicable): _________________________
+


### PR DESCRIPTION
## Summary
- add a one-page RIA self-audit checklist that maps Form ADV disclosures to advisory agreements
- include fill-in tables covering fees, custody, marketing rule substantiation, and exam priorities

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f06e603f388329a4974ba121437e9d