### PR TITLE
Add documentation on Google Coral NPU platform

### DIFF
--- a/docs/ai/google-coral-npu.md
+++ b/docs/ai/google-coral-npu.md
@@ -1,0 +1,21 @@
+# Google Coral NPU Platform Brief
+
+## Overview
+- **Announcement**: Google introduced Coral NPU, a full-stack open platform focused on always-on AI workloads for wearables and other ultra-low-power edge devices.
+- **Architecture**: Built with an AI-first mindset, emphasizing efficient matrix operations instead of treating machine learning acceleration as a bolt-on component.
+- **Open Standards**: Implements the RISC-V ISA, MLIR, and IREE to reduce fragmentation across edge ecosystems and encourage community-driven tooling.
+
+## Key Capabilities
+- **Power Profile**: Targets sub-watt deployments such as smart sensors, ambient computing systems, and wearable devices where battery life and thermals are critical.
+- **Privacy & Security**: Incorporates hardware-enforced memory safety and isolation features (e.g., CHERI-like capabilities) to compartmentalize models and sensitive data.
+- **Partner Silicon**: Synaptics is the first silicon collaborator, integrating Coral's Torq NPU subsystem into its Astra SL2610 AI-native processors.
+
+## Why It Matters
+- Establishes an open, standardized baseline for edge AI accelerators, easing the workload for teams building heterogeneous fleets.
+- Enables always-on inference without round-tripping to the cloud, supporting privacy-sensitive and low-latency applications.
+- Provides a template for secure, battery-conscious AI deployments that can scale across wearables, industrial monitoring, and smart home products.
+
+## Follow-Up Questions
+- What performance and efficiency benchmarks has Google published for Coral NPU reference designs?
+- How does the Torq NPU subsystem integrate with existing Coral Edge TPU tooling and software stacks?
+- What is the roadmap for broader silicon partner availability and software ecosystem support?


### PR DESCRIPTION
## Summary
- add a brief describing Google's newly announced Coral NPU platform and its objectives
- highlight hardware architecture, privacy posture, and initial silicon partner collaboration

## Testing
- not run (documentation change)

------
https://chatgpt.com/codex/tasks/task_e_68f06e4127ac83298e64382afbceffb5