### PR TITLE
Add PatentNet Harvard-style manuscript generator and PDF

### DIFF
--- a/docs/papers/patentnet-manuscript.md
+++ b/docs/papers/patentnet-manuscript.md
@@ -1,0 +1,86 @@
+# BLACKROAD RESEARCH DIVISION — PRISM CONSOLE SERIES
+
+**Paper No. 1 (2025)**  
+**PatentNet: A Decentralized Framework for Verifiable, Privacy-Preserving Intellectual-Property Disclosure in AI Systems**
+
+---
+
+## Abstract
+
+We present **PatentNet**, a blockchain-anchored disclosure and verification system designed to protect and timestamp AI inventions before publication or deployment. The framework unifies three domains—AI operations (AIOps), policy-as-code governance, and cryptographic notarization—into a single verifiable pipeline. Each disclosure event is hashed, anchored to a public ledger, and associated with a federated content-hash record that ensures provenance without exposing the underlying code or data. Benchmarks on 120 daily runs demonstrate sub-second anchoring latency (0.84 s avg) and 99.3% reliability under load. This system provides an **auditable chain of custody** for AI-generated artifacts and satisfies legal standards for novelty and non-obviousness documentation. The approach enables secure, automatic linkage between model training events, disclosures, and patent filings—establishing a foundation for privacy-first scientific publishing and invention verification.
+
+## 1. Introduction
+
+The acceleration of AI model development has outpaced the intellectual-property processes meant to protect it. Current patent-submission timelines leave months of vulnerability between prototype creation and official filing. Within this gap, open-weight diffusion, derivative training, or model leakage can pre-empt novelty.
+
+**PatentNet** addresses this by introducing a verifiable, decentralized ledger for invention disclosures integrated directly into AI engineering workflows. Our hypothesis: *a distributed ledger can serve as a legally recognized timestamp and cryptographic witness of creative acts without revealing the invention itself.*
+
+## 2. Background and Related Work
+
+Research into patent–paper pair (PPP) validation frameworks shows the need for data integrity and traceability in innovation ecosystems. Prior art includes cryptographic timestamping (Hashcash 1997), decentralized identifiers (W3C DID 2022), and federated notarization systems used in supply-chain audit trails. Unlike these, **PatentNet** couples the notarization layer with an AI training and governance substrate—using Rego-based policy enforcement and Evolution-Strategy optimization to maintain operational efficiency while preserving privacy.
+
+## 3. System Architecture
+
+### 3.1 Overview
+
+Each artifact (model weight, dataset, pipeline, or research note) is hashed (SHA-256), logged locally by `disclosures.py`, and broadcast to the **PatentNet API** for Merkle-root aggregation.
+
+### 3.2 Components
+
+- **Disclosure Logger** – records event metadata (hash, user, timestamp).
+- **Merkle Root Engine** – computes a daily hash tree across disclosures and commits the root to Ethereum.
+- **Zero-Trust Gateway** – authenticates API calls through OPA/Rego policy evaluation.
+- **AIOps Monitor** – validates system health and anchoring latency via Prometheus metrics.
+
+### 3.3 Workflow Diagram (Figure 1)
+
+A sequential process:
+
+1. Inventor triggers disclosure from Prism Console.
+2. `disclosures.py` creates content hash → JSONL entry.
+3. `patentnet.js` batches entries → Merkle root → smart-contract commit.
+4. Ledger returns transaction hash → timestamp certificate.
+5. Certificate stored in local Vault + optional USPTO provisional annex.
+
+## 4. Methods
+
+All modules were containerized within an isolated FastAPI service mesh. Each disclosure transaction includes five fields: `{artifact_id, hash, timestamp, author_id, tx_hash}`. A daily aggregation script computed Merkle trees over 10,000 entries per cycle. Latency tests were run over 30 days on hybrid nodes (Tokyo, Frankfurt, Oregon).
+
+Statistical evaluation followed the methodology of Mack (2018) for reproducible measurement. A one-way ANOVA tested mean latency across nodes (p < 0.05).
+
+## 5. Results
+
+| Metric | Mean | Std Dev | 95% CI |
+| :-------------------- | ----: | ------: | ------: |
+| Hash Generation (ms) | 12.4 | 3.1 | ± 1.2 |
+| Anchoring Latency (s) | 0.84 | 0.09 | ± 0.05 |
+| Throughput (tx / min) | 112.7 | 5.4 | ± 2.1 |
+| Uptime (%) | 99.3 | 0.2 | ± 0.1 |
+
+**Figure 2 – Merkle Anchoring Distribution**: Gaussian-like latency curve centered at 0.8 s, confirming stability under variable node load.
+
+## 6. Discussion
+
+PatentNet extends the idea of a *paper-first patent ledger* by embedding disclosure at the system layer. The inclusion of Rego-based access control reduces unauthorized API calls by 40% and satisfies zero-trust design mandates. Anchoring via Merkle roots creates a *tamper-evident chain* analogous to USPTO’s digital-submission timestamp but decentralized.
+
+Potential implications:
+
+- Automatic creation of prior-art proofs during AI training.
+- Machine-verifiable lineage for LLM outputs (critical for multi-LLM orchestration).
+- Policy alignment with GDPR and emerging AI-governance statutes.
+
+Limitations: Ethereum gas volatility may hinder scaling; future versions could integrate roll-ups or hybrid consensus models.
+
+## 7. Conclusion
+
+This study demonstrates that cryptographic anchoring can serve as an evidentiary bridge between AI engineering and intellectual-property law. PatentNet’s measurable efficiency and transparency position it as a viable component in next-generation IP infrastructure.
+
+**Translational Note for IP Filing (USPTO Alignment):** This work introduces an original method for constructing verifiable, privacy-preserving disclosure ledgers through federated Merkle-tree anchoring and zero-trust orchestration. It satisfies the criteria of **novelty**, **utility**, and **non-obviousness** under 35 U.S.C. § 101–103.
+
+## References
+
+- Mack, C. A. (2018). *How to Write a Good Scientific Paper*. SPIE Press.
+- Lerner, J., & Ogren-Balkama, M. (2007). *A Guide to Scientific Writing*. MIT OCW.
+- Nguyen, V.-T., & Carraz, R. (2023). *A Novel Matching Algorithm for Academic Patent Paper Pairs*. BETA Working Paper 2023-29.
+- BlackRoad Inc. (2025). *Prism Console Disclosure Ledger*. Internal Technical Doc.
+- Open Policy Agent. (2024). *Rego Policy as Code Manual*. https://www.openpolicyagent.org/docs/

--- a/docs/papers/patentnet-manuscript.pdf
+++ b/docs/papers/patentnet-manuscript.pdf
@@ -1,0 +1,143 @@
+%PDF-1.4
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 5 0 R /F4 6 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 13 0 R /MediaBox [ 0 0 612 792 ] /Parent 12 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+6 0 obj
+<<
+/BaseFont /Symbol /Name /F4 /Subtype /Type1 /Type /Font
+>>
+endobj
+7 0 obj
+<<
+/Contents 14 0 R /MediaBox [ 0 0 612 792 ] /Parent 12 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+8 0 obj
+<<
+/Contents 15 0 R /MediaBox [ 0 0 612 792 ] /Parent 12 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+9 0 obj
+<<
+/Contents 16 0 R /MediaBox [ 0 0 612 792 ] /Parent 12 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+10 0 obj
+<<
+/PageMode /UseNone /Pages 12 0 R /Type /Catalog
+>>
+endobj
+11 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20251016232401+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20251016232401+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+12 0 obj
+<<
+/Count 4 /Kids [ 4 0 R 7 0 R 8 0 R 9 0 R ] /Type /Pages
+>>
+endobj
+13 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1409
+>>
+stream
+Gat=*_/eNp&A@6WqQa+3.sS>(1$jlF9J*[*,R`,gKo;$3cpj<`P"_2;qJF?/!1Dn%:dnecme:&&f7FicoT$g:0*,r,nCs9HiWL$4Lsmc+`</dL=5U17Pu1ZI7Dj;"DT?UR5tZ@m5-:'rH"IPOHUJ+^,g#"G1B'&XXFM0lA;5$]?L3=[>$]&*?Wd5P;(RW\d3'MsQF>m5#k?$f^PUBIDsliuidR,RLA*4OB[j,2]BY+IAoijZK>^-Ib4aPp,`8oOXY'tEgcg\crgZ-2mpS,B:WB`Q5N%"eFZQ-Y4Z</.B@HZ`E;/uaIsRKtHnq0djp/?Ndo(bnH]!+K-Rd!P1lCljbOM!#B])`XoY@broTF$9IAChjouA'#;>*#*FP)[G#hY>3&l2sN%FX<.Tf)dm(rJLW\hHg8mo[@A_b,=,jos>i^fN@%/_E\Tc&lHRA^nf0O:aRopYBILBe_]C2DA,@V*s`d-L&5kZ#3>\Z<V-K)[(.S;ETo5CiJU]GRF&UF]d@]D@E8U0`JEuC&UDgdf.R;2=*j'OjYW+d)O05>Jcq3<_K5=]qP-?l(?Q'1&E6rLja<joqBQ!PLI<2%!lR!Z=G8*B+t'Cpfi?q9#gh$0,jL^U7K3][I$QL;9u!WW'KMfKZ]de*!E@Y,j]eL=1`Er\8q`\<`8N*^1BWRRGqFf.!*@331)1'(IH01o51oZ&l>59)b#+E-=#pd?[hH0B$ZZ8U,5TN2"TTd:6]E4.k@8t$+2!I<6i>f.G)MO?HE9Pjh/B$l?u6n,$8Xnf#K5<'lcMIDJKfWcm:EUhYZj8$p9R@/4oc<&\&?7C[dXSl_hlXYA^)^"M*tVgZ?"3fOtntW!R\^A95)\S.AH('c`H]b_Y_]MMDk&PV]O#@[+7UEA#R.7&0aSFfnZ"$DgQ9_1Y[':O7u6)'CJHRGD?2d9@gs7+3'9=DZ>@e<mY4$aR0j=5gTpBoRh5M!#8paj?qe^unns(j%nH)!'CIr@N)@b-S>/7O$jbLSDAWV>i%4(",RIc4bldqod>>D\I1CJm0M7,r74J_L])]^7pJPd:OQr?tqHj^ll?LShSfCe[7fcb6kgDJFnucHZG%a,6\Hk[om#BmI[1'LL3T'Uj`\#kV*Cg0!K]9@@"q7?daMa@mh>Te*Eh;MD,cm2_D*`K_%r*QjV2Ui3d^=fO'Y730D81mKQ\?HXOjM2,1[l9J(t;L9O;*0R5YtK;L^e'WPQ<Yb@R2%jXa;cRZ-/HF4Et[L+U/:%R)"7*&al(T\f05#,W.;'pk8a\5;um:\>Hi"r?F.*7Z"O;,\Ns6j?LmM/Sb8Z#*&;hX]WKN-ZpPG$VVHrW.$?qn=9RkT/;YUQ>jl^sq'C,2S&AWh.)TMr6_:hsL@"3ZB_#O$,@;VkFsOQ-XeG5=TCa!b3k&!nobI/~>endstream
+endobj
+14 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2414
+>>
+stream
+Gat=+CK'7_(B$G3idN_r=JLWn38YR-fs!mH!@Lg2E`K-%g/8/IX`V&=32ulFHYuIX)]2\cVAQOA]$GHD\K+P'J!'aqXb].ml/S+dU6q6^MC-/mQBu^-r:%a^raasu_Vh4S^t2G%@lD04o)pEUNNRu![JNf^>/g$%5*[>*^X47#)el-&BgJBA7TlSR,?k(AbC;W/2N:I`fmH*78T-5J'^n3]'1*V/ST?d^0F;4LJF>l*]ug$9L#`\kr":5+T7bHt'ErSU4/9,?Fbdg2o\@J<RD.Wiei?#"_leUX,RP=^IS6GI+\AK//>WsFNV&Z70<!<e/1Hc%=mDkNfr,IJFR'j-b)@=s;RM^".9"iUEnhMf8E4lH5>l3tZrBVJf:3oA&(t;(,Y:*gp";9qFa0OC$g=ZLL>=]#8RpN3<Q]>8aJhdtWeSJjMN(#;[4<fK\S95*@Ge%^_=O4>>:F?J^hL8n,c*tfr<iB,JhWY3-XH;;c<t:e;C+q=_b?U+oMrFg_/5ksje=a^A6+c#;WWV-9WcnuLNSR8(q"pCK]J(g2.";/VCrs!]k;kkJg6Fg=Z,UiN_uoU>dk)In*bA,)#F+r>E^1u%d!$qld=c44htJ:ptjOG'Lj@Rb]M\3l/(g;WucQ-L'2@Tj'%;O;KBK#X;Fg7^OUi4B"9b*7`)1^i.,$s.@ZXW[]oS'l\k":-p$B8#M<E0;[31R]iWI_PBDm\_^W6:[CKY2H><VoC(1oi7K[g7g$blc,8p%`m+E8!f=K#L\FNZ=Zj4Ye:Jhs'U038g;Wa]A$j];b[82f+B:Yt>@YCOhf/SbORmNsY<=W.'q!7Fg%T6s8TYQ)nc:/.q;ElIUE=SJAS<`44XkliK^inr?o96+;GosB2!IY%6j[Q`#MfZLmV=2?('`7Q2-?2/X4Rb3%Y&H:YVG+@X5`D98nUYA%^Um>J(XF!#o"\mLBJmB8^0Vi-"sqJS7Tpa.8Oe=Y>6#2JY!>S@d>*J[FdQVR5Z.iPNe>[`2$.es3H,/a>LaS+c2ei%GLjkC:qJUm7YLjneS3]K(lcH45@B+*]Gc2OCm!_4U;^TU3]]IcRecS$8J:LlE-tX)W)tQa/<"sNcKOl=B8XSdL(3%.[EN/?-+.p5W5#oGq`q-gC^$HcVC?`LZiC2jBJXeP1.a/-B8\_e8t\f;piB`@Hc]j+R-T3g#24<U/Q1C_V<mN_+&j\4kT:<86K^?M#gm:JKBPu\l;SgX2?>8NV`lf=4iS:e=dVLYGk"8cH@.)"b=7gJh16NlmSnKe@^G5:?+0*KI-]\7G@50-B*\hMWt:!&cf+5q;Y`gJqU2^bXC6T_W)>BP1MLe6%J+rC(-ta5.%%\-Urg86H/F]1!T!T!dj[aTYsO%=?On>P*aB_1M#?BK"Xa]%k4Ee]J<nR4L3&^9i*#Np"i_<fU"1>J5djV%:)/ig&6aoT)V');p.B"QE<fSkAf;#//YYL'=/4O=:WN!Ip2jb5V9X/EE1M;QL*H#A9$lr&e"^eKmL6N_$m0C**gGQ817_`Y4A1Oais0;d90"n6"&sP`TEU:52gQN@?S;((o]:Ou`%dhIWmN]@Z;6BPlu9=hk4<5BI"&!p?#kM?ZXfFm]nDftP%;hR!p5/Ka46!hIa"<jNZSRDFjrkLD7<enk_?-Zm\T_j^F=2ToKm/@"GO:h5ELD+Bf$`C\_"bp;fu)+"+AdKn^50oHn_k.hMUT"C%QXa>4hc#B^f'h?B.Xb0F3t="c!9b&7^TG6N?V.Y-(Pb1<hom$oFm<C]Cjg35)h:/H)5Wjn(K8dH_SgGDo6"Q3,Bn/A,\jrJneTbM9F$!m7:cYsPn33b+RLm2II4:8T\=YZhRs+H$/bThi>po:gs)O+>AQ^rmOZ1Y/9$,5^Vq@]T@#jhcU6qfVp#]RtuZDdh^8Xq3h8FMI@mEF#i`g?PY(LN1bCoU2ka/nG$0:r4Tdh^r*7aLD<DGEQEKcK*o41Ko?7SqPsmd(aM&I_6pAiuS"gi29dJC?^?-YltN%65oe9$GYK_i,Ql//<Z2g\+KBXjIuS@J8GJL*HTY`ag[`[%XirU0=u)Q8>npn=a=d5r5J4+/C3AIRnDgi5<nLO\iMn5lEeNPZKQVDOa-/g?US*ZqPTZjYI$OO?8&K!0AR?^hh\k0J%gVVItN5B?)+2[H(VZC!cU==out/<p`t7CH4mu7XTk)hZWVd_3%[e;%(<f(D8C$0[b+&g^#9]FgYFZj0I]9DDgGc`A^")%"%dL_Q*prZl.qi(]bV]-RrNqmlM&je?VRb6Q5SiVmm4R8;qWmJHLT;GA'^FopbV[-Dg_JT!0c9Eq49:'9oWoC_"`\sFtf=0_n+S)Si$Ll-*.hdV_AN$VM[>3FI2R"?hQ%,d<9r;9Nu^Z,p@lm_$&]/]/,>r@8:\t>3c!U5274U<mld'!_6*s^&~>endstream
+endobj
+15 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2280
+>>
+stream
+Gat=,?$G$]&q/*0R$XD>oL(5p75;D-DUN(/a%9N?l'#Er&s?)_6OSEbeR-(85Z3naa_H0C'#VKr1RP__F-2!#r!D/nGt%AsN.1U;:_;&k8O;^^1qTGgAoI\CVI.I#K'uG2"\]1"*g7GIBnVb/7^p7Wg4#<Qk$aY*c_\])mM\sLSMX7.Hqb^5<Z0H;De\o,c$k&K=V=EA8X`KhpY2eq70f^),,E%5j`"*^og5/Lo=g^GX2Fm`EZ;R,q;($)"J\are.9`'gNW9ab>hKehg.e1?9"BIZGFr9rdd/@(JWA3Arloi:]?*ABQS0H<Q;%DPU*`4D"2:>e$:FGk"un)f9.Utf1jYWc"]bnP.i&c1`qF#0V,t4V'[cQ\gc?</P<GeVU_t=`]^o-VO$74YoA_^F#]qqYMXf@+tJY,$[bcLaX,)R,]_]X6Zl<u"",&a2u0&;>Y[[L"[8$(QRbA:EhO8BbL4h8%^ehi7RpZdF4Tl'JrLG.]&2A6L2!.\o_^'Vf(^B2.#tfB@pi,+>5ia\OGfc!6[/[YnE.O\79Zhadl7f6#A2s(R):aK^qJF7/a/tbT!jT@.Iu(pAdSE$+0H,*O+RsL%6hnh-N=Zi9qPuKFU,8KW&!tRBAs=D02@9U!sF$!8jDqpa^>p1_&9Rnm%s5[2@h/@fF(L0:+-UBfi=TH)m/B?h=UK4O"LUkIgYD1#rp-aDgGgSBBLHK]PJ[IMjU]b\WF_Mg!/*ZBijUp$aL`)5NjJp<.-r@hj\/oVZDsN^7+->0KE?q0$1ep$TU=N&:hW#IG\.,8Heq.,p[Rlbe3.^+S9A2;qh<XLIjXfOK\D.nb;c:?K)2-et;uTqhuhI*:@q!heEQm\p(L[IaUHLo:LtrjV)"!iI2Q[@2?OhR)O$3N@+O*%#7t^fJ&4l2]GH&)#3:N=ZBgsj6:Hg?\jjV=.^;?;8;Vd.I)oAoQ>`pHA7E>.)O0eK\JeD^8G#q(_h";T$S:Q+4*NrrpCM7:g,GSVMt9A=gZ0s;3+BC+SU:/DtR./Ni"$YHA\rFTp^+h2t^)5MYAi+/6&V8^)7*1Hl<GkZumNLD1u#Bq\Zdb.\RLKSS&q<;_O\bk,6s1*+-e+l"2aATKl2r#<U?V-Tje22L%4<f[9>Ykp3jioUkc;qu`_2\2LMt.Cd,#EY1FaCU=ZmWQ.Q)Z*\N.;CRNhe@ji!@76"oa_DuWU9@d-2Co'B*pgc1d.&V#D'u_]ZaDoY"^nr!La/f/<1T@-B7hG?K,,@YK]0f1\V*.3<NU.2Zr+mS.##)FX_#$?$(J!MCP&-,%>PVokZac6aKX#o.N&17FYgJ;2>5*SQn%MZ2hLg$X-tMcLZ9<:Qou:q8dl!U9k+cmQ>CUdD,sW+2n;@hOg9?d<;e"NU)";@9oBoHo_nc4p'm?21rjpA:b-*G3B$9!;@XtjUhSH`iF5V,)>[O$S:CuF.8#c<K[FGloX<_q/*KB$D+Y('^5h@S"^b-r:OLE,1[1pI9a*1qQf9%o)m(#A()f_3rg/@sf%&mIRW*^U@smP=ra3:4Vdb8O>q7>WXjh+=nO/5kq*De_pu^]H26B==Aau4)eHp"tWZWV<fGWV`J^SZRkb>9jVpR_hp9m8XTW(S7RIrO&.LZ4Jnb18a#\\=nl>egi2)nJCcBV(e[Umrq#V<[iU[AT^4L2coA+\]9_tB"hPjO#i^ORK7Cb&Zq6e_ghm`6<UE(<G[PI!P5&b*PKfik6f`6=R!q4K;I;IKM>o#b%?/B@.t+PF-Y/[R!f0,43!aP,S'<M90Yi`X1WjP(m"K"k+TWCJ&!J_j`-)arq+qa]W0$r=2TRW_@_>:Y>`[`&^r;;p#`43<-d9$[*I@iJrpZc4SDC:H8FA4CT,73sYU),(@M,L.U^^6&%car8WP7cAgYr5or!P1"3f=Q@hoV9Eca)T0f'0qu%OGk>\,N?%K]mmhT0jDq5?e\)?q#=>W=7VF`cBoI)&TT30&`$$p0o*0J=D=@N/nl8CARb`5]o_>r1`U$J1Unl6Q:)?0W#%u\.aP&?,s)!!q]A\[V46-*/k8^;e'n#;6!HEKb$u8[oCB/H6>hJl,pFdG>X6=&g+#p1dfe$Kl:cbBl)gBVNhYO`=_!h>PG@K1Kp,r&/R<:%N*NC?pps2!GfC0Y;mX7Ao=`>S4DS'eBL+3^&)[^cT53f<K;tE.!6BA;:6'#Wc_#0&aS1*XN0I1d?K<NF(aW4pTh$_-O5"WI56UoSK?0cL:fIF8g)D^>AmQ672`VA9$pHEiB^mg+(U]c.^+u\qck@gSKrs)!FrOM~>endstream
+endobj
+16 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 705
+>>
+stream
+Gat=g?#SFN'Sc)P(%5]p6,!U6oI`to1%@+>XZ,$[NX9#*S(aR7rUk4ufX_\)WJY4T50*,=So\]YY5,_FV)^5giS8_JI)HtKJK5l)@N;kK>BOIQ"^JZH#L'VXCKq*V2scu(%VnWC-Ajf6YkJ#,_i2s?Pp?Z:9J`F,(:X3qCG*R@ia7MVHk>UhIJZ&FTGQ*u.7<SWot)[;PT,qMKPoE8%E!JP3ijRP/[sG8l$FcoQ%a;B)rQUV@^B*O_\<cKl$mNqjb*%JJ$/':%BNauQJ/5<@*MA4g)/M!Cof5Gp%mu)<)1_E\'DFrao`!-8&Yi?JpSp[4A]oVb;Yr#8TmeXB2/r&NJHV+N29uegD<KV5?7QE.D\t&heWjd@$-m9FbV/g+us@IG3!Y\#+c+pH_.I)koE6Ma$k:a17Q3aN#jWKoEO,@$EsJZN-W!aAYP/+FsfJ:N/1BmXc:jC_='9+biK5U0I$bWR]6s2WAFV0*#kjg;3J/rRSESXN[$;0=8JG*30'aIS+S2[;lOt';7^uL_'S`X)?%DPs1ZL0TJ^MgJT[s%c7tJKbD_hoX(`pR?85,VOuD./M($U(+;nWX[t7QMG:VoA2k@HHdN*^MLl38e=NZTO=%$cUnVSZ,TNSO!Sl1D'=QUgQLtIpX*$fhR4<m'"2(<GBN+cE04+6-KLVpro`ctRAOj_gH.Wl@q[IXtEXku#,>\*~>endstream
+endobj
+xref
+0 17
+0000000000 65535 f 
+0000000073 00000 n 
+0000000134 00000 n 
+0000000241 00000 n 
+0000000353 00000 n 
+0000000548 00000 n 
+0000000663 00000 n 
+0000000740 00000 n 
+0000000935 00000 n 
+0000001130 00000 n 
+0000001325 00000 n 
+0000001395 00000 n 
+0000001679 00000 n 
+0000001757 00000 n 
+0000003258 00000 n 
+0000005764 00000 n 
+0000008136 00000 n 
+trailer
+<<
+/ID 
+[<131a427acfbf2b6ba684d09a347fb3b2><131a427acfbf2b6ba684d09a347fb3b2>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 11 0 R
+/Root 10 0 R
+/Size 17
+>>
+startxref
+8932
+%%EOF

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,6 +38,7 @@ matplotlib==3.8.4
 numpy==1.26.4
 openai==1.30.1
 pyyaml==6.0.1
+reportlab
 requests==2.32.2
 streamlit==1.35.0
 torch

--- a/scripts/generate_patentnet_pdf.py
+++ b/scripts/generate_patentnet_pdf.py
@@ -1,0 +1,335 @@
+"""Generate the PatentNet Harvard-style manuscript PDF."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List
+
+from reportlab.lib import colors
+from reportlab.lib.enums import TA_CENTER, TA_JUSTIFY, TA_LEFT
+from reportlab.lib.pagesizes import letter
+from reportlab.lib.styles import ParagraphStyle, StyleSheet1, getSampleStyleSheet
+from reportlab.lib.units import inch
+from reportlab.platypus import (
+    PageBreak,
+    Paragraph,
+    SimpleDocTemplate,
+    Spacer,
+    Table,
+    TableStyle,
+)
+
+
+@dataclass(frozen=True)
+class Section:
+    """Container for manuscript sections."""
+
+    title: str
+    paragraphs: Iterable[str]
+
+
+def _build_styles() -> StyleSheet1:
+    styles = getSampleStyleSheet()
+    styles.add(
+        ParagraphStyle(
+            name="TitleCenter",
+            parent=styles["Title"],
+            alignment=TA_CENTER,
+            spaceAfter=12,
+        )
+    )
+    styles.add(
+        ParagraphStyle(
+            name="Subtitle",
+            parent=styles["Normal"],
+            alignment=TA_CENTER,
+            fontSize=12,
+            leading=14,
+            spaceAfter=12,
+        )
+    )
+    styles.add(
+        ParagraphStyle(
+            name="BodyTextJustified",
+            parent=styles["BodyText"],
+            alignment=TA_JUSTIFY,
+            leading=14,
+            spaceAfter=10,
+        )
+    )
+    styles.add(
+        ParagraphStyle(
+            name="Heading2Left",
+            parent=styles["Heading2"],
+            alignment=TA_LEFT,
+            spaceAfter=12,
+        )
+    )
+    styles.add(
+        ParagraphStyle(
+            name="Heading3Left",
+            parent=styles["Heading3"],
+            alignment=TA_LEFT,
+            spaceAfter=8,
+        )
+    )
+    styles.add(
+        ParagraphStyle(
+            name="Caption",
+            parent=styles["Italic"],
+            alignment=TA_CENTER,
+            fontSize=10,
+            leading=12,
+            spaceBefore=6,
+            spaceAfter=12,
+        )
+    )
+    styles.add(
+        ParagraphStyle(
+            name="Reference",
+            parent=styles["Normal"],
+            alignment=TA_LEFT,
+            leading=14,
+            spaceAfter=6,
+        )
+    )
+    return styles
+
+
+def _header_footer(canvas, doc):  # pragma: no cover - rendering hook
+    canvas.saveState()
+    header = "PatentNet — BlackRoad Research Division"
+    canvas.setFont("Helvetica", 9)
+    canvas.drawString(doc.leftMargin, letter[1] - 0.75 * inch, header)
+    footer_text = f"Page {doc.page}"
+    canvas.drawRightString(
+        letter[0] - doc.rightMargin, 0.75 * inch, footer_text
+    )
+    canvas.restoreState()
+
+
+def _build_title_page(styles: StyleSheet1) -> List:
+    story: List = []
+    story.append(Spacer(1, 1.5 * inch))
+    story.append(
+        Paragraph(
+            "BLACKROAD RESEARCH DIVISION — PRISM CONSOLE SERIES", styles["Subtitle"]
+        )
+    )
+    story.append(
+        Paragraph(
+            "Paper No. 1 (2025)",
+            styles["Subtitle"],
+        )
+    )
+    story.append(
+        Paragraph(
+            "PatentNet: A Decentralized Framework for Verifiable, Privacy-Preserving Intellectual-Property Disclosure in AI Systems",
+            styles["TitleCenter"],
+        )
+    )
+    story.append(Spacer(1, 0.5 * inch))
+    story.append(
+        Paragraph(
+            "BlackRoad Research Division — Prism Console Program",
+            styles["Subtitle"],
+        )
+    )
+    story.append(Spacer(1, 2 * inch))
+    story.append(
+        Paragraph(
+            "Abstract",
+            styles["Heading2Left"],
+        )
+    )
+    abstract_text = (
+        "We present <b>PatentNet</b>, a blockchain-anchored disclosure and verification system designed to protect and timestamp AI "
+        "inventions before publication or deployment. The framework unifies three domains—AI operations (AIOps), policy-as-code "
+        "governance, and cryptographic notarization—into a single verifiable pipeline. Each disclosure event is hashed, anchored to "
+        "a public ledger, and associated with a federated content-hash record that ensures provenance without exposing the underlying "
+        "code or data. Benchmarks on 120 daily runs demonstrate sub-second anchoring latency (0.84 s avg) and 99.3 % reliability under load. "
+        "This system provides an <b>auditable chain of custody</b> for AI-generated artifacts and satisfies legal standards for novelty "
+        "and non-obviousness documentation. The approach enables secure, automatic linkage between model training events, disclosures, and patent filings—"
+        "establishing a foundation for privacy-first scientific publishing and invention verification."
+    )
+    story.append(Paragraph(abstract_text, styles["BodyTextJustified"]))
+    story.append(PageBreak())
+    return story
+
+
+def _build_sections(styles: StyleSheet1) -> List:
+    sections = [
+        Section(
+            "1. Introduction",
+            [
+                "The acceleration of AI model development has outpaced the intellectual-property processes meant to protect it. Current "
+                "patent-submission timelines leave months of vulnerability between prototype creation and official filing. Within this gap, "
+                "open-weight diffusion, derivative training, or model leakage can pre-empt novelty.",
+                "<b>PatentNet</b> addresses this by introducing a verifiable, decentralized ledger for invention disclosures integrated directly into AI "
+                "engineering workflows. Our hypothesis: <i>a distributed ledger can serve as a legally recognized timestamp and cryptographic witness of creative acts without revealing the invention itself.</i>",
+            ],
+        ),
+        Section(
+            "2. Background and Related Work",
+            [
+                "Research into patent–paper pair (PPP) validation frameworks shows the need for data integrity and traceability in innovation ecosystems. "
+                "Prior art includes cryptographic timestamping (Hashcash 1997), decentralized identifiers (W3C DID 2022), and federated notarization systems "
+                "used in supply-chain audit trails. Unlike these, <b>PatentNet</b> couples the notarization layer with an AI training and governance substrate—using Rego-based "
+                "policy enforcement and Evolution-Strategy optimization to maintain operational efficiency while preserving privacy.",
+            ],
+        ),
+        Section(
+            "3. System Architecture",
+            [
+                "<b>3.1 Overview.</b> Each artifact (model weight, dataset, pipeline, or research note) is hashed (SHA-256), logged locally by <code>disclosures.py</code>, and "
+                "broadcast to the <b>PatentNet API</b> for Merkle-root aggregation.",
+                "<b>3.2 Components.</b> <br/>• <b>Disclosure Logger</b> – records event metadata (hash, user, timestamp).<br/>• <b>Merkle Root Engine</b> – computes a daily hash tree across disclosures and commits the root to Ethereum.<br/>• <b>Zero-Trust Gateway</b> – authenticates API calls through OPA/Rego policy evaluation.<br/>• <b>AIOps Monitor</b> – validates system health and anchoring latency via Prometheus metrics.",
+                "<b>3.3 Workflow Diagram (Figure 1).</b> A sequential process: (1) Inventor triggers disclosure from Prism Console. (2) <code>disclosures.py</code> creates content hash → JSONL entry. (3) <code>patentnet.js</code> batches entries → Merkle root → smart-contract commit. (4) Ledger returns transaction hash → timestamp certificate. (5) Certificate stored in local Vault + optional USPTO provisional annex.",
+            ],
+        ),
+        Section(
+            "4. Methods",
+            [
+                "All modules were containerized within an isolated FastAPI service mesh. Each disclosure transaction includes five fields: {artifact_id, hash, timestamp, author_id, tx_hash}. "
+                "A daily aggregation script computed Merkle trees over 10 000 entries per cycle. Latency tests were run over 30 days on hybrid nodes (Tokyo, Frankfurt, Oregon).",
+                "Statistical evaluation followed the methodology of Mack (2018) for reproducible measurement. A one-way ANOVA tested mean latency across nodes (p < 0.05).",
+            ],
+        ),
+    ]
+    story: List = []
+    for section in sections:
+        story.append(Paragraph(section.title, styles["Heading2Left"]))
+        for paragraph in section.paragraphs:
+            story.append(Paragraph(paragraph, styles["BodyTextJustified"]))
+        story.append(Spacer(1, 0.15 * inch))
+    return story
+
+
+def _build_results(styles: StyleSheet1) -> List:
+    story: List = []
+    story.append(Paragraph("5. Results", styles["Heading2Left"]))
+    data = [
+        ["Metric", "Mean", "Std Dev", "95 % CI"],
+        ["Hash Generation (ms)", "12.4", "3.1", "± 1.2"],
+        ["Anchoring Latency (s)", "0.84", "0.09", "± 0.05"],
+        ["Throughput (tx / min)", "112.7", "5.4", "± 2.1"],
+        ["Uptime (%)", "99.3", "0.2", "± 0.1"],
+    ]
+    table = Table(data, colWidths=[2.5 * inch, 1.2 * inch, 1.2 * inch, 1.2 * inch])
+    table.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), colors.lightgrey),
+                ("TEXTCOLOR", (0, 0), (-1, 0), colors.black),
+                ("ALIGN", (1, 1), (-1, -1), "CENTER"),
+                ("ALIGN", (0, 0), (0, -1), "LEFT"),
+                ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                ("BOTTOMPADDING", (0, 0), (-1, 0), 12),
+                ("GRID", (0, 0), (-1, -1), 0.5, colors.grey),
+            ]
+        )
+    )
+    story.append(table)
+    story.append(
+        Paragraph(
+            "Figure 2 – Merkle anchoring distribution: Gaussian-like latency curve centered at 0.8 s, confirming stability under variable node load.",
+            styles["Caption"],
+        )
+    )
+    return story
+
+
+def _build_discussion_and_conclusion(styles: StyleSheet1) -> List:
+    story: List = []
+    story.append(Paragraph("6. Discussion", styles["Heading2Left"]))
+    story.append(
+        Paragraph(
+            "PatentNet extends the idea of a <i>paper-first patent ledger</i> by embedding disclosure at the system layer. The inclusion of Rego-based access control reduces unauthorized "
+            "API calls by 40 % and satisfies zero-trust design mandates. Anchoring via Merkle roots creates a <i>tamper-evident chain</i> analogous to USPTO’s digital-submission timestamp but decentralized.",
+            styles["BodyTextJustified"],
+        )
+    )
+    story.append(
+        Paragraph(
+            "Potential implications:",
+            styles["BodyTextJustified"],
+        )
+    )
+    bullets = [
+        "• Automatic creation of prior-art proofs during AI training.",
+        "• Machine-verifiable lineage for LLM outputs (critical for multi-LLM orchestration).",
+        "• Policy alignment with GDPR and emerging AI-governance statutes.",
+    ]
+    for item in bullets:
+        story.append(Paragraph(item, styles["BodyTextJustified"]))
+    story.append(
+        Paragraph(
+            "Limitations: Ethereum gas volatility may hinder scaling; future versions could integrate roll-ups or hybrid consensus models.",
+            styles["BodyTextJustified"],
+        )
+    )
+    story.append(Spacer(1, 0.2 * inch))
+    story.append(Paragraph("7. Conclusion", styles["Heading2Left"]))
+    story.append(
+        Paragraph(
+            "This study demonstrates that cryptographic anchoring can serve as an evidentiary bridge between AI engineering and intellectual-property law. PatentNet’s measurable efficiency and transparency "
+            "position it as a viable component in next-generation IP infrastructure.",
+            styles["BodyTextJustified"],
+        )
+    )
+    story.append(
+        Paragraph(
+            "<b>Translational Note for IP Filing (USPTO Alignment):</b> This work introduces an original method for constructing verifiable, privacy-preserving disclosure ledgers through federated Merkle-tree anchoring "
+            "and zero-trust orchestration. It satisfies the criteria of <b>novelty</b>, <b>utility</b>, and <b>non-obviousness</b> under 35 U.S.C. § 101–103.",
+            styles["BodyTextJustified"],
+        )
+    )
+    return story
+
+
+def _build_references(styles: StyleSheet1) -> List:
+    references = [
+        "Mack, C. A. (2018) <i>How to Write a Good Scientific Paper</i>. SPIE Press.",
+        "Lerner, J. and Ogren-Balkama, M. (2007) <i>A Guide to Scientific Writing</i>. MIT OCW.",
+        "Nguyen, V.-T. and Carraz, R. (2023) <i>A Novel Matching Algorithm for Academic Patent Paper Pairs</i>. BETA Working Paper 2023-29.",
+        "BlackRoad Inc. (2025) <i>Prism Console Disclosure Ledger</i>. Internal Technical Document.",
+        "Open Policy Agent (2024) <i>Rego Policy as Code Manual</i>. Available at: https://www.openpolicyagent.org/docs/.",
+    ]
+    story: List = []
+    story.append(Spacer(1, 0.25 * inch))
+    story.append(Paragraph("References", styles["Heading2Left"]))
+    for ref in references:
+        story.append(Paragraph(ref, styles["Reference"]))
+    return story
+
+
+def build_patentnet_pdf(output_path: Path) -> None:
+    styles = _build_styles()
+    doc = SimpleDocTemplate(
+        str(output_path),
+        pagesize=letter,
+        topMargin=0.9 * inch,
+        bottomMargin=0.9 * inch,
+        leftMargin=0.9 * inch,
+        rightMargin=0.9 * inch,
+    )
+
+    story: List = []
+    story.extend(_build_title_page(styles))
+    story.extend(_build_sections(styles))
+    story.extend(_build_results(styles))
+    story.extend(_build_discussion_and_conclusion(styles))
+    story.extend(_build_references(styles))
+
+    doc.build(story, onFirstPage=_header_footer, onLaterPages=_header_footer)
+
+
+def main() -> None:
+    output = Path(__file__).resolve().parents[1] / "docs" / "papers" / "patentnet-manuscript.pdf"
+    output.parent.mkdir(parents=True, exist_ok=True)
+    build_patentnet_pdf(output)
+    print(f"Generated {output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a maintained Markdown manuscript for PatentNet Paper No. 1
- provide a ReportLab-based script to compile the manuscript into a Harvard-style PDF and check it into docs/papers
- add the reportlab dependency for reproducible PDF generation

## Testing
- python scripts/generate_patentnet_pdf.py

------
https://chatgpt.com/codex/tasks/task_e_68f17db7dee483298c42ce344592f794