### PR TITLE
Add broadcast and ping summary for admin devices

### DIFF
--- a/apps/api/src/routes/admin/devices.ts
+++ b/apps/api/src/routes/admin/devices.ts
@@ -1,25 +1,151 @@
 import { Router } from 'express';
 import fs from 'fs';
+import { dirname, join, resolve } from 'path';
 
-const r = Router();
-const file = 'data/admin/devices.json';
-const read = () => fs.existsSync(file) ? JSON.parse(fs.readFileSync(file,'utf-8')) : [];
-const write = (arr:any) => { fs.mkdirSync('data/admin',{recursive:true}); fs.writeFileSync(file, JSON.stringify(arr,null,2)); };
+type DeviceRecord = Record<string, any> & { deviceId?: string; lastSeen?: number };
 
-r.post('/devices/register', (req,res)=>{
+const ONLINE_WINDOW_MS = 5 * 60 * 1000;
+
+const router = Router();
+
+const resolveBase = () => resolve(process.env.API_DATA_ROOT || '.');
+const resolveAgentsRoot = () => resolve(process.env.API_AGENTS_ROOT || 'agents');
+
+const devicesFile = () => join(resolveBase(), 'data', 'admin', 'devices.json');
+const broadcastLogFile = () => join(resolveBase(), 'data', 'admin', 'device_broadcasts.jsonl');
+const iamDevicesFile = () => join(resolveBase(), 'iam', 'devices.json');
+const connectorsSourcesFile = () => join(resolveBase(), 'elt', 'sources.json');
+const connectorsSinksFile = () => join(resolveBase(), 'elt', 'sinks.json');
+
+function ensureDir(path: string) {
+  fs.mkdirSync(dirname(path), { recursive: true });
+}
+
+function readJson<T>(path: string, fallback: T): T {
+  try {
+    if (!fs.existsSync(path)) return fallback;
+    return JSON.parse(fs.readFileSync(path, 'utf-8')) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+function writeJson(path: string, value: unknown) {
+  ensureDir(path);
+  fs.writeFileSync(path, JSON.stringify(value, null, 2));
+}
+
+const readDevices = (): DeviceRecord[] => readJson(devicesFile(), [] as DeviceRecord[]);
+const writeDevices = (arr: DeviceRecord[]) => writeJson(devicesFile(), arr);
+
+const recordBroadcast = (entry: { ts: number; message: string; devices: string[] }) => {
+  const file = broadcastLogFile();
+  ensureDir(file);
+  fs.appendFileSync(file, `${JSON.stringify(entry)}\n`);
+};
+
+const readLastBroadcast = () => {
+  const file = broadcastLogFile();
+  if (!fs.existsSync(file)) return null as null | { ts: number; message: string; devices: string[] };
+  const content = fs.readFileSync(file, 'utf-8').trim();
+  if (!content) return null;
+  const lastLine = content.split('\n').filter(Boolean).pop();
+  if (!lastLine) return null;
+  try {
+    return JSON.parse(lastLine) as { ts: number; message: string; devices: string[] };
+  } catch {
+    return null;
+  }
+};
+
+function countAgents(): number {
+  const root = resolveAgentsRoot();
+  if (!fs.existsSync(root)) return 0;
+  try {
+    return fs
+      .readdirSync(root, { withFileTypes: true })
+      .filter((dir) => dir.isDirectory())
+      .filter((dir) => fs.existsSync(join(root, dir.name, 'manifest.json')))
+      .length;
+  } catch {
+    return 0;
+  }
+}
+
+function collectPingSummary() {
+  const now = Date.now();
+  const devices = readDevices();
+  const onlineDevices = devices.filter((device) =>
+    typeof device.lastSeen === 'number' && now - device.lastSeen <= ONLINE_WINDOW_MS,
+  ).length;
+
+  const iam = readJson<{ devices?: Record<string, any> }>(iamDevicesFile(), { devices: {} });
+  const iamValues = Object.values(iam.devices || {});
+  const compliantIam = iamValues.filter((entry: any) => entry?.posture?.compliant === true).length;
+
+  const sources = readJson<{ sources?: Record<string, any> }>(connectorsSourcesFile(), { sources: {} }).sources || {};
+  const sinks = readJson<{ sinks?: Record<string, any> }>(connectorsSinksFile(), { sinks: {} }).sinks || {};
+
+  return {
+    devices: {
+      total: devices.length,
+      online: onlineDevices,
+    },
+    iam: {
+      total: iamValues.length,
+      compliant: compliantIam,
+    },
+    connectors: {
+      sources: Object.keys(sources).length,
+      sinks: Object.keys(sinks).length,
+    },
+    agents: {
+      total: countAgents(),
+    },
+    lastBroadcast: readLastBroadcast(),
+  };
+}
+
+router.post('/devices/register', (req, res) => {
   const { deviceId, owner, platform } = req.body || {};
-  if (!deviceId || !owner || !platform) return res.status(400).json({ error:'bad_request' });
-  const arr = read().filter((d:any)=>d.deviceId!==deviceId);
-  arr.push({ deviceId, owner, platform, encrypted:false, compliant:false, lastSeen: Date.now() });
-  write(arr); res.json({ ok:true });
+  if (!deviceId || !owner || !platform) return res.status(400).json({ error: 'bad_request' });
+  const arr = readDevices().filter((d) => d.deviceId !== deviceId);
+  arr.push({ deviceId, owner, platform, encrypted: false, compliant: false, lastSeen: Date.now() });
+  writeDevices(arr);
+  res.json({ ok: true });
 });
 
-r.post('/devices/update', (req,res)=>{
+router.post('/devices/update', (req, res) => {
   const { deviceId, key, value } = req.body || {};
-  const arr = read().map((d:any)=> d.deviceId===deviceId ? { ...d, [key]: value, lastSeen: Date.now() } : d);
-  write(arr); res.json({ ok:true });
+  const arr = readDevices().map((d) =>
+    d.deviceId === deviceId ? { ...d, [key]: value, lastSeen: Date.now() } : d,
+  );
+  writeDevices(arr);
+  res.json({ ok: true });
 });
 
-r.get('/devices/list', (_req,res)=> res.json({ items: read() }));
+router.post('/devices/broadcast', (req, res) => {
+  const message = typeof req.body?.message === 'string' ? req.body.message.trim() : '';
+  if (!message) {
+    return res.status(400).json({ error: 'message_required' });
+  }
+  const devices = readDevices();
+  const ts = Date.now();
+  const targets = devices.map((d) => d.deviceId).filter((id): id is string => Boolean(id));
 
-export default r;
+  const updated = devices.map((device) => ({ ...device, lastPostAt: ts, lastPostMessage: message }));
+  writeDevices(updated);
+
+  recordBroadcast({ ts, message, devices: targets });
+
+  const summary = collectPingSummary();
+  res.json({ ok: true, delivered: targets.length, summary });
+});
+
+router.get('/devices/ping', (_req, res) => {
+  res.json({ ok: true, summary: collectPingSummary() });
+});
+
+router.get('/devices/list', (_req, res) => res.json({ items: readDevices() }));
+
+export default router;

--- a/apps/api/tests/helpers/test_server.ts
+++ b/apps/api/tests/helpers/test_server.ts
@@ -1,9 +1,11 @@
 import express from 'express';
 import health from '../../src/routes/health.ts';
 import reco from '../../src/routes/reco.ts';
+import adminDevices from '../../src/routes/admin/devices.ts';
 export function mkServer(){
   const app = express(); app.use(express.json());
   app.use('/api/health', health);
   app.use('/api/reco', reco);
+  app.use('/api/admin', adminDevices);
   return app.listen(0);
 }

--- a/apps/api/tests/unit/admin_devices.test.ts
+++ b/apps/api/tests/unit/admin_devices.test.ts
@@ -1,0 +1,130 @@
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { mkServer } from '../helpers/test_server.ts';
+
+type JsonResponse = { statusCode: number; body: any };
+
+function requestJson(port: number, method: string, path: string, payload?: unknown): Promise<JsonResponse> {
+  return new Promise((resolve, reject) => {
+    const data = payload !== undefined ? JSON.stringify(payload) : undefined;
+    const headers: Record<string, string> = {};
+    if (data) {
+      headers['Content-Type'] = 'application/json';
+      headers['Content-Length'] = Buffer.byteLength(data).toString();
+    }
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port,
+        path,
+        method,
+        headers,
+      },
+      (res) => {
+        let raw = '';
+        res.setEncoding('utf8');
+        res.on('data', (chunk) => {
+          raw += chunk;
+        });
+        res.on('end', () => {
+          const body = raw ? JSON.parse(raw) : undefined;
+          resolve({ statusCode: res.statusCode ?? 0, body });
+        });
+      },
+    );
+    req.on('error', reject);
+    if (data) req.write(data);
+    req.end();
+  });
+}
+
+test('broadcast updates devices and returns ping summary', async () => {
+  const tmpRoot = mkdtempSync(join(tmpdir(), 'api-devices-'));
+  const agentsRoot = join(tmpRoot, 'agents');
+  process.env.API_DATA_ROOT = tmpRoot;
+  process.env.API_AGENTS_ROOT = agentsRoot;
+
+  mkdirSync(join(tmpRoot, 'data', 'admin'), { recursive: true });
+  const now = Date.now();
+  writeFileSync(
+    join(tmpRoot, 'data', 'admin', 'devices.json'),
+    JSON.stringify(
+      [
+        { deviceId: 'pi-01', owner: 'ops', platform: 'linux', encrypted: true, compliant: true, lastSeen: now },
+        { deviceId: 'jetson-01', owner: 'ml', platform: 'linux', encrypted: false, compliant: false, lastSeen: now },
+      ],
+      null,
+      2,
+    ),
+  );
+
+  mkdirSync(join(tmpRoot, 'iam'), { recursive: true });
+  writeFileSync(
+    join(tmpRoot, 'iam', 'devices.json'),
+    JSON.stringify(
+      {
+        devices: {
+          'pi-01': { posture: { compliant: true } },
+          'jetson-01': { posture: { compliant: false } },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+
+  mkdirSync(join(tmpRoot, 'elt'), { recursive: true });
+  writeFileSync(join(tmpRoot, 'elt', 'sources.json'), JSON.stringify({ sources: { src1: { status: 'ok' } } }, null, 2));
+  writeFileSync(
+    join(tmpRoot, 'elt', 'sinks.json'),
+    JSON.stringify({ sinks: { sink1: { status: 'ok' }, sink2: { status: 'ok' } } }, null, 2),
+  );
+
+  mkdirSync(join(agentsRoot, 'alpha'), { recursive: true });
+  writeFileSync(join(agentsRoot, 'alpha', 'manifest.json'), JSON.stringify({ name: 'alpha' }));
+  mkdirSync(join(agentsRoot, 'beta'), { recursive: true });
+  writeFileSync(join(agentsRoot, 'beta', 'manifest.json'), JSON.stringify({ name: 'beta' }));
+
+  const server = mkServer();
+  const addr = server.address();
+  const port = typeof addr === 'object' && addr ? addr.port : 0;
+
+  try {
+    const broadcast = await requestJson(port, 'POST', '/api/admin/devices/broadcast', { message: 'Status update' });
+    assert.equal(broadcast.statusCode, 200);
+    assert.equal(broadcast.body.ok, true);
+    assert.equal(broadcast.body.delivered, 2);
+    assert.equal(broadcast.body.summary.devices.total, 2);
+    assert.equal(broadcast.body.summary.devices.online, 2);
+    assert.equal(broadcast.body.summary.connectors.sources, 1);
+    assert.equal(broadcast.body.summary.connectors.sinks, 2);
+    assert.equal(broadcast.body.summary.agents.total, 2);
+    assert.equal(broadcast.body.summary.iam.total, 2);
+    assert.equal(broadcast.body.summary.iam.compliant, 1);
+    assert.ok(broadcast.body.summary.lastBroadcast);
+
+    const logPath = join(tmpRoot, 'data', 'admin', 'device_broadcasts.jsonl');
+    assert.equal(existsSync(logPath), true);
+    const logLines = readFileSync(logPath, 'utf-8').trim().split('\n').filter(Boolean);
+    assert.equal(logLines.length, 1);
+
+    const storedDevices = JSON.parse(readFileSync(join(tmpRoot, 'data', 'admin', 'devices.json'), 'utf-8'));
+    assert.ok(storedDevices.every((d: any) => typeof d.lastPostAt === 'number'));
+    assert.ok(storedDevices.every((d: any) => d.lastPostMessage === 'Status update'));
+
+    const ping = await requestJson(port, 'GET', '/api/admin/devices/ping');
+    assert.equal(ping.statusCode, 200);
+    assert.equal(ping.body.ok, true);
+    assert.equal(ping.body.summary.devices.total, 2);
+    assert.equal(ping.body.summary.lastBroadcast.message, 'Status update');
+    assert.equal(ping.body.summary.lastBroadcast.devices.length, 2);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    delete process.env.API_DATA_ROOT;
+    delete process.env.API_AGENTS_ROOT;
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add admin device broadcast endpoint that logs posts and returns fleet summaries
- surface a ping endpoint that counts agents, IAM devices, and connectors alongside device health
- extend the test harness and add a unit test covering broadcast + ping flows

## Testing
- node --test tests/unit/*.test.ts *(fails: missing express dependency in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f191a96b6c83298fbbfd1e05f90e4b