### PR TITLE
chore: consolidate deploy workflow paths

### DIFF
--- a/.github/workflows/blackroad-deploy.yml
+++ b/.github/workflows/blackroad-deploy.yml
@@ -2,28 +2,49 @@ name: BlackRoad • Deploy
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   workflow_dispatch:
+    inputs:
+      target:
+        description: "Select the deploy path"
+        required: true
+        default: modern
+        type: choice
+        options:
+          - modern
+          - legacy-ssh
+      ref:
+        description: "Git ref to deploy when using the legacy path"
+        required: false
+      health_url:
+        description: "Override the site health URL for the legacy path"
+        required: false
+      api_health_url:
+        description: "Override the API health URL for the legacy path"
+        required: false
 
 jobs:
-  build-and-deploy:
+  modern-deploy:
+    name: Modern webhook deploy
+    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.target == 'modern' }}
     runs-on: ubuntu-latest
     env:
       SITE_URL: ${{ vars.SITE_URL || 'https://blackroad.io' }}
-      API_URL:  ${{ vars.API_URL  || 'https://blackroad.io' }}
+      API_URL: ${{ vars.API_URL || 'https://blackroad.io' }}
       DEPLOY_URL: ${{ secrets.BR_DEPLOY_URL || 'https://blackroad.io/api/deploy/hook' }}
       DEPLOY_BEARER: ${{ secrets.BR_DEPLOY_SECRET }}
       CF_ZONE_ID: ${{ secrets.CF_ZONE_ID }}
       CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Node 20
         uses: actions/setup-node@v4
-        with: { node-version: 20, cache: 'npm' }
+        with:
+          node-version: 20
+          cache: npm
 
       - name: Build SPA
         run: |
@@ -105,19 +126,19 @@ jobs:
             }
         env:
           SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
-name: BlackRoad Deploy
 
-on:
-  push:
-    branches: [ main ]
-  workflow_dispatch:
-
-jobs:
-  deploy:
+  legacy-ssh-deploy:
+    name: Legacy SSH deploy
+    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'legacy-ssh' }}
     runs-on: ubuntu-latest
+    env:
+      HEALTH_URL: ${{ github.event.inputs.health_url || 'https://blackroad.io/health' }}
+      API_HEALTH_URL: ${{ github.event.inputs.api_health_url || 'https://blackroad.io/api/health' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -141,6 +162,7 @@ jobs:
           host: ${{ secrets.DEPLOY_HOST }}
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_KEY }}
+          port: ${{ secrets.DEPLOY_PORT || vars.DEPLOY_PORT || '22' }}
           source: |
             sites/blackroad/blackroad-site.tar.gz
             blackroad-api.tar.gz
@@ -152,11 +174,14 @@ jobs:
           host: ${{ secrets.DEPLOY_HOST }}
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_KEY }}
+          port: ${{ secrets.DEPLOY_PORT || vars.DEPLOY_PORT || '22' }}
           script: |
+            set -euo pipefail
             sudo tar -xzf /tmp/blackroad-site.tar.gz -C /var/www/blackroad --strip-components=1
             sudo tar -xzf /tmp/blackroad-api.tar.gz -C /srv/blackroad-api --strip-components=1
             sudo systemctl restart blackroad-api
             sudo systemctl restart lucidia-llm
             sudo systemctl status blackroad-api
             sudo systemctl status lucidia-llm
-            curl -f https://blackroad.io/health
+            curl -f "${HEALTH_URL}"
+            curl -f "${API_HEALTH_URL}"


### PR DESCRIPTION
# Pull Request

## Summary
- combine the webhook and legacy SSH deploy logic into a single workflow with selectable targets
- document how to trigger each deploy path and which secrets they require

## Checks
- [ ] CI green
- [ ] API /api/health returns 200
- [x] Updated docs/tests as needed
- [ ] Does this change alter power distribution?

## Changes

- Files changed (bullet list):
  - `.github/workflows/blackroad-deploy.yml`
  - `README-DEPLOY.md`
- Why these changes were made:
  - remove the duplicate workflow definition so GitHub picks up both deploy options and document how to use them

## Checklist (required for PRs created by automation)

- [ ] Lint: `npm run lint` (document any auto-fixes)
- [ ] Tests: `npm test` (list failing tests if any)
- [ ] Dependency hygiene: if you added new imports, run `node tools/dep-scan.js --dir <package> --save` (commit only the tool output)
- [ ] Env vars: added/changed? If yes, update `srv/blackroad-api/.env.example` and document defaults
- [ ] Ports/compose changes? If yes, update `ops/install.sh` and `docker-compose*.yml`
- [x] Secrets: no secrets in the diff

## Commands I ran locally

```
# (none)
```

## Notes for reviewers

- The modern job still runs automatically on push; the legacy SSH job now only runs when manually dispatching the workflow with `target=legacy-ssh`.

---

Short summary (1-2 lines):
- unified deploy workflow lets us pick between webhook and manual SSH targets

Files changed and why (1-3 bullets):
- `.github/workflows/blackroad-deploy.yml` — fold both deploy paths into a single workflow with manual inputs
- `README-DEPLOY.md` — explain the workflow options and update secret names

---

Local commands I ran (copyable):

```bash
# none
```

Env vars added? (yes/no):
- no

Ports/compose changes? (yes/no):
- no

Security & secrets checklist:
- Did you avoid committing secrets? yes
- If credentials were required for local testing, were they set via env only? n/a

Notes for reviewers / special instructions:
- Manual dispatch now exposes optional inputs for overriding the ref and health checks when using the legacy path.

# Summary

## Quick pulse
- [ ] Impact assessed (customer, ops, or security)
- [ ] Risk call-out (low / medium / high)
- [ ] Rollback or feature flag noted

## Optional Ops
- [ ] Added or updated dashboards / alerts
- [ ] Announced in release notes or status channel
- [ ] Coordinated with on-call / runbook owners

## Next steps
- [ ] Follow-up issue linked (if needed)
- [x] Docs updated or slated for update
- [ ] Tests or benchmarks captured

### Context
- What changed and why?
  - Consolidated the deploy workflows so the Actions runner exposes both modern webhook and legacy SSH jobs without conflicting YAML keys.
- Anything reviewers should focus on?
  - Ensure the manual inputs and documentation align with how you trigger the legacy pipeline today.

> Comment `@codex fix comments` (or `@cadillac`, `@lucidia`, `@bbpteam`, `@blackboxprogramming`) to trigger bot autofix.

# Testing

- Local build passes
- `npm run build` (site) / API boots
- E2E (Playwright) green

# Checklist

- Docs/README updated if needed
- No secrets committed
- Labels added (area/site, area/api, etc.)

------
https://chatgpt.com/codex/tasks/task_e_68f1959405d88329966e3980a603875e