### PR TITLE
fix: deduplicate auto novel agent helpers

### DIFF
--- a/agents/auto_novel_agent.py
+++ b/agents/auto_novel_agent.py
@@ -2,7 +2,6 @@
 
 from dataclasses import dataclass
 from typing import ClassVar, List, Set
-from typing import ClassVar
 
 
 @dataclass
@@ -70,7 +69,6 @@ class AutoNovelAgent:
         self.SUPPORTED_ENGINES.discard(engine.lower())
 
     def list_supported_engines(self) -> List[str]:
-    def list_supported_engines(self) -> list[str]:
         """Return a list of supported game engines."""
         return sorted(self.SUPPORTED_ENGINES)
 
@@ -99,90 +97,9 @@ class AutoNovelAgent:
             f"{engine_lower.capitalize()} where creativity reigns."
         )
 
-    def generate_story(self, theme: str, protagonist: str = "An adventurer") -> str:
-        """Generate a short themed story.
-
-        Args:
-            theme: Central theme of the story. Must be a non-empty string.
-            protagonist: Name or description of the main character.
-
-        Returns:
-            A short story string.
-
-        Raises:
-            ValueError: If ``theme`` is empty or whitespace.
-        """
-        if not theme or not theme.strip():
-            raise ValueError("Theme must be a non-empty string.")
-        theme_clean = theme.strip()
-        protagonist_clean = protagonist.strip()
-        excitement = "!" * max(1, int(self.gamma))
-        return (
-            f"{protagonist_clean} set out on a {theme_clean} journey, "
-            f"discovering wonders along the way{excitement}"
-        )
-
-    def generate_story_series(
-        self, themes: List[str], protagonist: str = "An adventurer"
-    ) -> List[str]:
-        """Generate a series of short stories for multiple themes.
-
-        Args:
-            themes: A list of themes. Each must be a non-empty string.
-            protagonist: Name or description of the main character used for all
-                stories.
-
-        Returns:
-            A list containing a short story for each provided theme.
-
-        Raises:
-            ValueError: If ``themes`` is empty or any theme is blank.
-        """
-        if not themes:
-            raise ValueError("Themes list must not be empty.")
-        stories: List[str] = []
-        for theme in themes:
-            if not theme or not theme.strip():
-                raise ValueError("Each theme must be a non-empty string.")
-            stories.append(self.generate_story(theme, protagonist))
-        return stories
-
-    def set_gamma(self, gamma: float) -> None:
-        """Set the creativity scaling factor.
-
-        Args:
-            gamma: Positive scaling factor. Higher values increase excitement.
-
-        Raises:
-            ValueError: If ``gamma`` is not positive.
-        """
-        if gamma <= 0:
-            raise ValueError("gamma must be positive.")
-        self.gamma = gamma
-
-    def add_supported_engine(self, engine: str) -> None:
-        """Register a new game engine.
-
-        Engines are stored in lowercase to keep lookups case-insensitive.
-
-        Args:
-            engine: Name of the engine to allow.
-        """
-        self.SUPPORTED_ENGINES.add(engine.lower())
-
-    def remove_supported_engine(self, engine: str) -> None:
-        """Remove a game engine if it is currently supported.
-
-        Args:
-            engine: Name of the engine to remove.
-        """
-        self.SUPPORTED_ENGINES.discard(engine.lower())
-
-    def list_supported_engines(self) -> List[str]:
-        """Return a list of supported game engines."""
-        return sorted(self.SUPPORTED_ENGINES)
-
-    def generate_story(self, theme: str, protagonist: str = "An adventurer") -> str:
+    def generate_story(
+        self, theme: str, protagonist: str = "An adventurer"
+    ) -> str:
         """Generate a short themed story.
 
         Args:

--- a/tests/test_auto_novel_agent.py
+++ b/tests/test_auto_novel_agent.py
@@ -37,6 +37,11 @@ def test_remove_supported_engine_blocks_creation():
 
 
 def test_create_game_disallows_weapons():
+    agent = AutoNovelAgent()
+    with pytest.raises(ValueError, match="Weapons are not allowed"):
+        agent.create_game("unity", include_weapons=True)
+
+
 @pytest.mark.parametrize(
     ("engine", "expected"),
     [
@@ -59,13 +64,6 @@ def test_create_game_unsupported_engine():
         agent.create_game("godot")
 
 
-def test_create_game_with_weapons():
-    """Creating a game with weapons enabled raises ValueError."""
-    agent = AutoNovelAgent()
-    with pytest.raises(ValueError, match="Weapons are not allowed"):
-        agent.create_game("unity", include_weapons=True)
-
-
 def test_create_game_rejects_unsupported_engine():
     agent = AutoNovelAgent()
     with pytest.raises(ValueError):
@@ -85,6 +83,13 @@ def test_generate_story_series_produces_multiple_stories():
     assert "Explorer" in stories[0]
     assert "mystery" in stories[0]
     assert "space" in stories[1]
+
+
+def test_generate_story_series_rejects_blank_theme():
+    agent = AutoNovelAgent()
+    with pytest.raises(ValueError, match="Each theme must be a non-empty string"):
+        agent.generate_story_series(["mystery", "   "], protagonist="Explorer")
+
 def test_list_supported_engines():
     """list_supported_engines returns the supported engines sorted alphabetically."""
     agent = AutoNovelAgent()


### PR DESCRIPTION
## Summary
- remove redundant helper definitions in `AutoNovelAgent` and normalize typing annotations
- keep the agent API focused while documenting story generation helpers more clearly
- expand the AutoNovelAgent tests to cover blank themes and ensure the weapons guard raises errors

## Testing
- python -m py_compile auto_novel_agent.py
- python auto_novel_agent.py
- pytest tests/test_auto_novel_agent.py *(fails: pyproject.toml declares project.scripts twice)*

------
https://chatgpt.com/codex/tasks/task_e_68f1a7ad52788329beea504935e297b6