### PR TITLE
Add Prism service tests and CI workflow

### DIFF
--- a/.github/workflows/prism.yml
+++ b/.github/workflows/prism.yml
@@ -1,0 +1,46 @@
+name: prism-service
+
+on:
+  push:
+    paths:
+      - 'services/prism/**'
+      - 'docker-compose.prism.yml'
+      - '.github/workflows/prism.yml'
+  pull_request:
+    paths:
+      - 'services/prism/**'
+      - 'docker-compose.prism.yml'
+      - '.github/workflows/prism.yml'
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+      - name: Run unit tests
+        working-directory: services/prism
+        env:
+          GOWORK: off
+        run: go test ./...
+
+  integration-tests:
+    runs-on: ubuntu-latest
+    needs: unit-tests
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+      - name: Start API dependencies
+        run: docker compose -f docker-compose.prism.yml up -d api
+      - name: Run integration tests
+        working-directory: services/prism
+        env:
+          GOWORK: off
+        run: go test ./test -count=1
+      - name: Tear down environment
+        if: always()
+        run: docker compose -f docker-compose.prism.yml down -v

--- a/services/prism/internal/http/server.go
+++ b/services/prism/internal/http/server.go
@@ -1,0 +1,87 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/blackroad/prism-console/services/prism/internal/service"
+)
+
+// API exposes HTTP handlers that mirror the JavaScript API bridge.
+type API struct {
+	svc *service.Service
+}
+
+// NewAPI constructs a new HTTP API instance.
+func NewAPI(svc *service.Service) *API {
+	return &API{svc: svc}
+}
+
+// Router returns an http.Handler that serves the Prism endpoints.
+func (a *API) Router() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/health.json", a.handleHealth)
+	mux.HandleFunc("/api/echo", a.handleEcho)
+	mux.HandleFunc("/api/mini/infer", a.handleMiniInfer)
+	return mux
+}
+
+func (a *API) handleHealth(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	resp, err := a.svc.Health(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, resp)
+}
+
+func (a *API) handleEcho(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var body interface{}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil && err.Error() != "EOF" {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	writeJSON(w, a.svc.Echo(r.Context(), body))
+}
+
+type miniInferPayload struct {
+	X float64 `json:"x"`
+	Y float64 `json:"y"`
+}
+
+func (a *API) handleMiniInfer(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var payload miniInferPayload
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	result, err := a.svc.MiniInfer(r.Context(), payload.X, payload.Y)
+	if err != nil {
+		if err == service.ErrInvalidNumber {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, result)
+}
+
+func writeJSON(w http.ResponseWriter, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(v)
+}

--- a/services/prism/internal/http/server_test.go
+++ b/services/prism/internal/http/server_test.go
@@ -1,0 +1,171 @@
+package httpapi
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/blackroad/prism-console/services/prism/internal/service"
+)
+
+func newAPI(t *testing.T) (*API, *sql.DB) {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	svc, err := service.New(db, service.WithClock(func() time.Time { return time.Unix(1, 0).UTC() }))
+	if err != nil {
+		t.Fatalf("new service: %v", err)
+	}
+	return NewAPI(svc), db
+}
+
+func TestHealthHandler(t *testing.T) {
+	api, db := newAPI(t)
+	t.Cleanup(func() { _ = db.Close() })
+	req := httptest.NewRequest(http.MethodGet, "/api/health.json", nil)
+	rec := httptest.NewRecorder()
+	api.Router().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body["status"] != "ok" {
+		t.Fatalf("unexpected status: %v", body["status"])
+	}
+}
+
+func TestEchoHandler(t *testing.T) {
+	api, db := newAPI(t)
+	t.Cleanup(func() { _ = db.Close() })
+	payload := map[string]string{"foo": "bar"}
+	buf, _ := json.Marshal(payload)
+	req := httptest.NewRequest(http.MethodPost, "/api/echo", bytes.NewReader(buf))
+	rec := httptest.NewRecorder()
+	api.Router().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	received := body["received"].(map[string]interface{})
+	if received["foo"] != "bar" {
+		t.Fatalf("unexpected echo payload: %v", received)
+	}
+}
+
+func TestMiniInferHandler(t *testing.T) {
+	api, db := newAPI(t)
+	t.Cleanup(func() { _ = db.Close() })
+	payload := map[string]float64{"x": 6, "y": 7}
+	buf, _ := json.Marshal(payload)
+	req := httptest.NewRequest(http.MethodPost, "/api/mini/infer", bytes.NewReader(buf))
+	rec := httptest.NewRecorder()
+	api.Router().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+	var body map[string]float64
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body["output"] != 42 {
+		t.Fatalf("unexpected output: %v", body["output"])
+	}
+}
+
+func TestMiniInferHandlerBadPayload(t *testing.T) {
+	api, db := newAPI(t)
+	t.Cleanup(func() { _ = db.Close() })
+	req := httptest.NewRequest(http.MethodPost, "/api/mini/infer", bytes.NewBufferString("not-json"))
+	rec := httptest.NewRecorder()
+	api.Router().ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", rec.Code)
+	}
+}
+
+func TestMiniInferHandlerInvalidNumbers(t *testing.T) {
+	api, db := newAPI(t)
+	t.Cleanup(func() { _ = db.Close() })
+	payload := map[string]float64{"x": math.Inf(1), "y": 1}
+	buf, _ := json.Marshal(payload)
+	req := httptest.NewRequest(http.MethodPost, "/api/mini/infer", bytes.NewReader(buf))
+	rec := httptest.NewRecorder()
+	api.Router().ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", rec.Code)
+	}
+}
+
+func TestHealthMethodNotAllowed(t *testing.T) {
+	api, db := newAPI(t)
+	t.Cleanup(func() { _ = db.Close() })
+	req := httptest.NewRequest(http.MethodPost, "/api/health.json", nil)
+	rec := httptest.NewRecorder()
+	api.Router().ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected status 405, got %d", rec.Code)
+	}
+}
+
+func TestEchoMethodNotAllowed(t *testing.T) {
+	api, db := newAPI(t)
+	t.Cleanup(func() { _ = db.Close() })
+	req := httptest.NewRequest(http.MethodGet, "/api/echo", nil)
+	rec := httptest.NewRecorder()
+	api.Router().ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected status 405, got %d", rec.Code)
+	}
+}
+
+func TestMiniInferMethodNotAllowed(t *testing.T) {
+	api, db := newAPI(t)
+	t.Cleanup(func() { _ = db.Close() })
+	req := httptest.NewRequest(http.MethodGet, "/api/mini/infer", nil)
+	rec := httptest.NewRecorder()
+	api.Router().ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected status 405, got %d", rec.Code)
+	}
+}
+
+func TestHealthErrorPropagation(t *testing.T) {
+	api, db := newAPI(t)
+	_ = db.Close()
+	req := httptest.NewRequest(http.MethodGet, "/api/health.json", nil)
+	rec := httptest.NewRecorder()
+	api.Router().ServeHTTP(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", rec.Code)
+	}
+}
+
+func TestMiniInferHandlerInsertError(t *testing.T) {
+	api, db := newAPI(t)
+	if _, err := db.ExecContext(context.Background(), `DROP TABLE mini_infer_requests`); err != nil {
+		t.Fatalf("drop table: %v", err)
+	}
+	_ = db.Close()
+	payload := map[string]float64{"x": 1, "y": 2}
+	buf, _ := json.Marshal(payload)
+	req := httptest.NewRequest(http.MethodPost, "/api/mini/infer", bytes.NewReader(buf))
+	rec := httptest.NewRecorder()
+	api.Router().ServeHTTP(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", rec.Code)
+	}
+}

--- a/services/prism/internal/service/service.go
+++ b/services/prism/internal/service/service.go
@@ -1,0 +1,116 @@
+package service
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"math"
+	"time"
+)
+
+// ErrNilDB is returned when constructing a Service without a database handle.
+var ErrNilDB = errors.New("service: db is required")
+
+// ErrInvalidNumber is returned when MiniInfer receives a NaN or infinite operand.
+var ErrInvalidNumber = errors.New("service: operands must be finite numbers")
+
+// Service coordinates the Prism console domain primitives.
+type Service struct {
+	db  *sql.DB
+	now func() time.Time
+}
+
+// Option mutates the service configuration during construction.
+type Option func(*Service)
+
+// WithClock overrides the clock used for timestamping persisted records.
+func WithClock(now func() time.Time) Option {
+	return func(s *Service) {
+		if now != nil {
+			s.now = now
+		}
+	}
+}
+
+// New constructs a Service bound to the provided database handle.
+func New(db *sql.DB, opts ...Option) (*Service, error) {
+	if db == nil {
+		return nil, ErrNilDB
+	}
+	svc := &Service{
+		db:  db,
+		now: func() time.Time { return time.Now().UTC() },
+	}
+	for _, opt := range opts {
+		opt(svc)
+	}
+	if err := svc.ensureSchema(context.Background()); err != nil {
+		return nil, fmt.Errorf("service: ensure schema: %w", err)
+	}
+	return svc, nil
+}
+
+// Health describes the health status returned by the service.
+type Health struct {
+	Status  string    `json:"status"`
+	Service string    `json:"service"`
+	Time    time.Time `json:"time"`
+}
+
+// Health reports the service health after pinging the database.
+func (s *Service) Health(ctx context.Context) (Health, error) {
+	if err := s.db.PingContext(ctx); err != nil {
+		return Health{}, fmt.Errorf("service: health ping: %w", err)
+	}
+	return Health{
+		Status:  "ok",
+		Service: "prism-service",
+		Time:    s.now(),
+	}, nil
+}
+
+// EchoResult mirrors the body received via the Echo endpoint.
+type EchoResult struct {
+	OK       bool        `json:"ok"`
+	Received interface{} `json:"received"`
+}
+
+// Echo returns the payload provided by callers, mirroring the Node API contract.
+func (s *Service) Echo(_ context.Context, payload interface{}) EchoResult {
+	return EchoResult{OK: true, Received: payload}
+}
+
+// MiniInferResult represents the multiplication result used by the mini inference flow.
+type MiniInferResult struct {
+	Output float64 `json:"output"`
+}
+
+// MiniInfer multiplies the provided operands and records the invocation.
+func (s *Service) MiniInfer(ctx context.Context, x, y float64) (MiniInferResult, error) {
+	if math.IsNaN(x) || math.IsNaN(y) || math.IsInf(x, 0) || math.IsInf(y, 0) {
+		return MiniInferResult{}, ErrInvalidNumber
+	}
+	output := x * y
+	if _, err := s.db.ExecContext(
+		ctx,
+		`INSERT INTO mini_infer_requests (x, y, output, created_at) VALUES (?, ?, ?, ?)`,
+		x, y, output, s.now(),
+	); err != nil {
+		return MiniInferResult{}, fmt.Errorf("service: record mini infer: %w", err)
+	}
+	return MiniInferResult{Output: output}, nil
+}
+
+func (s *Service) ensureSchema(ctx context.Context) error {
+	_, err := s.db.ExecContext(ctx, `
+        CREATE TABLE IF NOT EXISTS mini_infer_requests (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            x REAL NOT NULL,
+            y REAL NOT NULL,
+            output REAL NOT NULL,
+            created_at TIMESTAMP NOT NULL
+        )
+    `)
+	return err
+}

--- a/services/prism/internal/service/service_test.go
+++ b/services/prism/internal/service/service_test.go
@@ -1,0 +1,127 @@
+package service
+
+import (
+	"context"
+	"database/sql"
+	"math"
+	"testing"
+	"time"
+)
+
+func newTestService(t *testing.T) (*Service, *sql.DB) {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	svc, err := New(db, WithClock(func() time.Time { return time.Unix(1, 0).UTC() }))
+	if err != nil {
+		t.Fatalf("construct service: %v", err)
+	}
+	return svc, db
+}
+
+func TestNewServiceRequiresDB(t *testing.T) {
+	if _, err := New(nil); err != ErrNilDB {
+		t.Fatalf("expected ErrNilDB, got %v", err)
+	}
+}
+
+func TestHealth(t *testing.T) {
+	svc, db := newTestService(t)
+	t.Cleanup(func() { _ = db.Close() })
+
+	ctx := context.Background()
+	got, err := svc.Health(ctx)
+	if err != nil {
+		t.Fatalf("Health() error = %v", err)
+	}
+	if got.Status != "ok" {
+		t.Errorf("unexpected status: %s", got.Status)
+	}
+	if got.Service != "prism-service" {
+		t.Errorf("unexpected service name: %s", got.Service)
+	}
+	if !got.Time.Equal(time.Unix(1, 0).UTC()) {
+		t.Errorf("unexpected time: %v", got.Time)
+	}
+}
+
+func TestHealthPingFailure(t *testing.T) {
+	svc, db := newTestService(t)
+	_ = db.Close()
+	if _, err := svc.Health(context.Background()); err == nil {
+		t.Fatal("expected error when database is closed")
+	}
+}
+
+func TestEcho(t *testing.T) {
+	svc, db := newTestService(t)
+	t.Cleanup(func() { _ = db.Close() })
+	payload := map[string]string{"hello": "world"}
+	got := svc.Echo(context.Background(), payload)
+	if !got.OK {
+		t.Fatalf("expected OK result")
+	}
+	if got.Received.(map[string]string)["hello"] != "world" {
+		t.Fatalf("payload mismatch: %+v", got.Received)
+	}
+}
+
+func TestMiniInfer(t *testing.T) {
+	svc, db := newTestService(t)
+	t.Cleanup(func() { _ = db.Close() })
+
+	tests := []struct {
+		name    string
+		x, y    float64
+		want    float64
+		wantErr error
+	}{
+		{name: "positive", x: 3, y: 7, want: 21},
+		{name: "zero", x: 0, y: 42, want: 0},
+		{name: "negative", x: -4, y: 2.5, want: -10},
+		{name: "nan", x: math.NaN(), y: 1, wantErr: ErrInvalidNumber},
+		{name: "inf", x: math.Inf(1), y: 2, wantErr: ErrInvalidNumber},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := svc.MiniInfer(context.Background(), tc.x, tc.y)
+			if tc.wantErr != nil {
+				if err == nil {
+					t.Fatalf("expected error %v, got nil", tc.wantErr)
+				}
+				if err != tc.wantErr {
+					t.Fatalf("expected error %v, got %v", tc.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("MiniInfer() error = %v", err)
+			}
+			if got.Output != tc.want {
+				t.Fatalf("MiniInfer() output = %v, want %v", got.Output, tc.want)
+			}
+		})
+	}
+
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(1) FROM mini_infer_requests`).Scan(&count); err != nil {
+		t.Fatalf("count records: %v", err)
+	}
+	if count != 3 {
+		t.Fatalf("expected 3 persisted rows, got %d", count)
+	}
+}
+
+func TestMiniInferInsertFailure(t *testing.T) {
+	svc, db := newTestService(t)
+	if _, err := db.Exec(`DROP TABLE mini_infer_requests`); err != nil {
+		t.Fatalf("drop table: %v", err)
+	}
+	_ = db.Close()
+	if _, err := svc.MiniInfer(context.Background(), 1, 2); err == nil {
+		t.Fatal("expected insert failure")
+	}
+}

--- a/services/prism/internal/service/sqlite.go
+++ b/services/prism/internal/service/sqlite.go
@@ -1,0 +1,3 @@
+package service
+
+import _ "github.com/glebarez/sqlite"

--- a/services/prism/test/integration_test.go
+++ b/services/prism/test/integration_test.go
@@ -1,0 +1,130 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+var (
+	composeStarted bool
+)
+
+func TestAPIHealthFlow(t *testing.T) {
+	ensureCompose(t)
+	resp, err := http.Get("http://localhost:4000/api/health.json")
+	if err != nil {
+		t.Fatalf("request health: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status: %d", resp.StatusCode)
+	}
+	var body map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["status"] != "ok" {
+		t.Fatalf("unexpected status value: %v", body["status"])
+	}
+}
+
+func TestAPIEchoFlow(t *testing.T) {
+	ensureCompose(t)
+	payload := map[string]string{"hello": "world"}
+	buf, _ := json.Marshal(payload)
+	resp, err := http.Post("http://localhost:4000/api/echo", "application/json", bytes.NewReader(buf))
+	if err != nil {
+		t.Fatalf("post echo: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status: %d", resp.StatusCode)
+	}
+	var body map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	received := body["received"].(map[string]interface{})
+	if received["hello"] != "world" {
+		t.Fatalf("unexpected echo payload: %v", received)
+	}
+}
+
+func TestAPIMiniInferFlow(t *testing.T) {
+	ensureCompose(t)
+	payload := map[string]float64{"x": 8, "y": 9}
+	buf, _ := json.Marshal(payload)
+	resp, err := http.Post("http://localhost:4000/api/mini/infer", "application/json", bytes.NewReader(buf))
+	if err != nil {
+		t.Fatalf("post mini infer: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status: %d", resp.StatusCode)
+	}
+	var body map[string]float64
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["output"] != 72 {
+		t.Fatalf("unexpected output: %v", body["output"])
+	}
+}
+
+func ensureCompose(t *testing.T) {
+	t.Helper()
+	if !composeStarted {
+		startCompose(t)
+		composeStarted = true
+	}
+}
+
+func startCompose(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("docker is required for integration tests")
+	}
+	composeFile := filepath.Join("..", "..", "..", "docker-compose.prism.yml")
+	cmd := exec.Command("docker", "compose", "-f", composeFile, "up", "-d", "api")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Skipf("failed to start docker compose: %v\n%s", err, string(out))
+	}
+	t.Cleanup(func() {
+		cmd := exec.Command("docker", "compose", "-f", composeFile, "down", "-v")
+		_ = cmd.Run()
+		composeStarted = false
+	})
+	waitForAPI(t)
+}
+
+func waitForAPI(t *testing.T) {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get("http://localhost:4000/api/health.json")
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+		}
+		time.Sleep(1 * time.Second)
+	}
+	t.Fatal("API did not become ready within timeout")
+}
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+	if composeStarted {
+		composeFile := filepath.Join("..", "..", "..", "docker-compose.prism.yml")
+		cmd := exec.Command("docker", "compose", "-f", composeFile, "down", "-v")
+		_ = cmd.Run()
+	}
+	os.Exit(code)
+}


### PR DESCRIPTION
## Summary
- introduce a Go-based Prism service package with health, echo, and mini inference helpers backed by SQLite
- add comprehensive unit tests and HTTP handler coverage plus docker-driven integration tests mirroring API flows
- wire a dedicated GitHub Actions workflow to run unit and integration suites with docker-compose fixtures

## Testing
- `cd services/prism && GOWORK=off go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68f1a84abb688329b045ff0494417982