### PR TITLE
Fix update_block content handling

### DIFF
--- a/scripts/configure_pi_400.sh
+++ b/scripts/configure_pi_400.sh
@@ -22,14 +22,16 @@ update_block() {
   local file="$1" marker="$2" content="$3"
   local start="# >>> ${marker} >>>"
   local end="# <<< ${marker} <<<"
-  python3 - "$file" "$start" "$end" <<'PY' <<<"$content"
+  python3 - "$file" "$start" "$end" 3<<<"$content" <<'PY'
+import os
 import sys
 from pathlib import Path
 
 path = Path(sys.argv[1])
 start = sys.argv[2]
 end = sys.argv[3]
-body = sys.stdin.read().rstrip("\n")
+with os.fdopen(3) as block_fd:
+    body = block_fd.read().rstrip("\n")
 block = f"{start}\n{body}\n{end}\n"
 if path.exists():
     text = path.read_text()


### PR DESCRIPTION
## Summary
- read update_block content from a dedicated file descriptor so the Python helper receives the block data
- keep the Python update logic unchanged while preventing the heredoc from being treated as the script

## Testing
- not run (script change only)


------
https://chatgpt.com/codex/tasks/task_e_68f1a8af4bb48329810cc74cf3b50a80