### PR TITLE
Fix configure_pi_400 update_block heredoc usage

### DIFF
--- a/scripts/configure_pi_400.sh
+++ b/scripts/configure_pi_400.sh
@@ -22,14 +22,15 @@ update_block() {
   local file="$1" marker="$2" content="$3"
   local start="# >>> ${marker} >>>"
   local end="# <<< ${marker} <<<"
-  python3 - "$file" "$start" "$end" <<'PY' <<<"$content"
+  CONTENT="$content" python3 - "$file" "$start" "$end" <<'PY'
 import sys
+import os
 from pathlib import Path
 
 path = Path(sys.argv[1])
 start = sys.argv[2]
 end = sys.argv[3]
-body = sys.stdin.read().rstrip("\n")
+body = os.environ["CONTENT"].rstrip("\n")
 block = f"{start}\n{body}\n{end}\n"
 if path.exists():
     text = path.read_text()


### PR DESCRIPTION
## Summary
- provide the Python helper script through a heredoc while passing the alias block content via an environment variable to avoid conflicting stdin redirections

## Testing
- not run (script change only)

------
https://chatgpt.com/codex/tasks/task_e_68f1a8b50f648329a5a48a96b9f20618