### PR TITLE
feat: add environment manifest summary helper

### DIFF
--- a/README-OPS.md
+++ b/README-OPS.md
@@ -22,6 +22,9 @@ Reference the manifests whenever DNS, workflow, or Terraform parameters change s
 ### Staging
 - Pushes to `main` touching `blackroad-stage/**` or manual dispatch run `pages-stage.yml`.
 - Generates a daily proof + `health.json` for `stage.blackroad.io` and uploads the artifact (no automatic publish step yet).
+- Run `gh workflow run stage-stress.yml -f STRESS=true` to execute the optional
+  **Stage Stress** workflow before promoting a build; it replays the generated
+  artifact under controlled load.
 - Use the artifact for QA sign-off or handoff to downstream deploy automation.
 
 ### Production

--- a/environments/README.md
+++ b/environments/README.md
@@ -37,6 +37,21 @@ Update the manifest whenever the environment changes (new workflow, Terraform
 module, domain, or approval requirement). These files should stay aligned with
 `br-infra-iac`, `.github/workflows/*`, and the documented runbooks.
 
+## CLI helper
+
+Generate a quick summary for release tooling (or manual spot checks) with the
+environment summary script:
+
+```bash
+python tools/environments_summary.py --format text
+```
+
+Filter to a single environment by slug when wiring automation:
+
+```bash
+python tools/environments_summary.py --env stg
+```
+
 ## Current coverage
 
 - `production.yml` — customer-facing blackroad.io footprint.

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -44,6 +44,15 @@ automation:
         without publishing DNS changes.
       secrets:
         - AWAKEN_SEED
+    - name: Stage Stress (safe)
+      file: .github/workflows/stage-stress.yml
+      triggers:
+        - workflow_dispatch (STRESS input)
+        - push (stage, blackroad-stage/**)
+      summary: >-
+        Optional load test that reuses the stage artifact to simulate user
+        traffic before promoting a build downstream. Defaults to a no-op unless
+        the STRESS input is set to "true".
 deployments:
   - service: marketing-site
     type: static-site
@@ -54,6 +63,7 @@ deployments:
       path: blackroad-stage
     domain: https://stage.blackroad.io
     health_check: https://stage.blackroad.io/health.json
+    state: active
   - service: api-gateway
     type: container-service
     provider: aws-ecs-fargate
@@ -69,3 +79,6 @@ observability:
   health_checks:
     - name: static-health
       url: https://stage.blackroad.io/health.json
+  verification:
+    - curl -fsS https://stage.blackroad.io/ >/dev/null
+    - gh workflow run stage-stress.yml -f STRESS=true

--- a/tools/environments_summary.py
+++ b/tools/environments_summary.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Summarise environment manifests for automation tooling.
+
+This helper reads the YAML manifests under ``environments/`` and produces a
+concise JSON or text summary that other scripts (or humans) can consume when
+wiring deploy workflows, approvals, or health checks.
+
+Examples
+--------
+# Emit JSON for all environments
+python tools/environments_summary.py
+
+# Print a human readable view for staging only
+python tools/environments_summary.py --env stg --format text
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_DIR = REPO_ROOT / "environments"
+
+
+def _load_manifest(path: Path) -> Dict[str, Any]:
+    raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    raw.setdefault("name", path.stem)
+    raw.setdefault("slug", raw.get("name", path.stem))
+    raw.setdefault("state", "unknown")
+    raw.setdefault("description", "")
+    raw["_file"] = str(path.relative_to(REPO_ROOT))
+    return raw
+
+
+def _iter_manifests() -> Iterable[Dict[str, Any]]:
+    for manifest in sorted(MANIFEST_DIR.glob("*.y*ml")):
+        yield _load_manifest(manifest)
+
+
+def _summarise_manifest(data: Dict[str, Any]) -> Dict[str, Any]:
+    automation = data.get("automation", {})
+    deployments = data.get("deployments", [])
+    infrastructure = data.get("infrastructure", {})
+
+    workflows = []
+    for wf in automation.get("workflows", []) or []:
+        workflows.append(
+            {
+                "name": wf.get("name"),
+                "file": wf.get("file"),
+                "triggers": wf.get("triggers", []),
+                "secrets": wf.get("secrets", []),
+                "summary": wf.get("summary"),
+            }
+        )
+
+    services = []
+    for dep in deployments:
+        services.append(
+            {
+                "service": dep.get("service"),
+                "type": dep.get("type"),
+                "provider": dep.get("provider"),
+                "state": dep.get("state", data.get("state")),
+                "workflow": dep.get("workflow"),
+                "domain": dep.get("domain") or dep.get("domain_pattern"),
+                "terraform_directory": dep.get("terraform_directory"),
+                "notes": dep.get("notes"),
+            }
+        )
+
+    terraform = infrastructure.get("terraform", {})
+    return {
+        "name": data.get("name"),
+        "slug": data.get("slug"),
+        "state": data.get("state"),
+        "description": data.get("description", ""),
+        "file": data.get("_file"),
+        "contacts": data.get("contacts", {}),
+        "domains": data.get("domains", {}),
+        "workflows": workflows,
+        "services": services,
+        "infrastructure": {
+            "cloud": infrastructure.get("cloud"),
+            "region": infrastructure.get("region"),
+            "terraform_root": terraform.get("root"),
+            "terraform_backend": terraform.get("backend"),
+        },
+        "change_management": data.get("change_management", {}),
+        "observability": data.get("observability", {}),
+    }
+
+
+def _render_text(summaries: Iterable[Dict[str, Any]]) -> str:
+    lines: List[str] = []
+    for env in summaries:
+        header = f"{env['name']} ({env['slug']}) — {env['state']} — {env['file']}"
+        lines.append(header)
+        if env.get("description"):
+            lines.append(f"  {env['description']}")
+        if env.get("domains"):
+            formatted_domains = ", ".join(f"{k}: {v}" for k, v in env["domains"].items())
+            lines.append(f"  Domains: {formatted_domains}")
+        if env.get("workflows"):
+            lines.append("  Workflows:")
+            for wf in env["workflows"]:
+                triggers = ", ".join(wf.get("triggers") or [])
+                trigger_text = f" ({triggers})" if triggers else ""
+                lines.append(
+                    f"    - {wf.get('name')} [{wf.get('file')}]" + trigger_text
+                )
+        if env.get("services"):
+            lines.append("  Services:")
+            for svc in env["services"]:
+                detail_parts = [
+                    svc.get("type"),
+                    svc.get("provider"),
+                    f"state={svc.get('state')}" if svc.get("state") else None,
+                ]
+                detail = ", ".join(part for part in detail_parts if part)
+                domain = f" → {svc['domain']}" if svc.get("domain") else ""
+                workflow = (
+                    f" (workflow: {svc['workflow']})" if svc.get("workflow") else ""
+                )
+                lines.append(
+                    f"    - {svc.get('service')}"
+                    + (f" — {detail}" if detail else "")
+                    + domain
+                    + workflow
+                )
+        infra = env.get("infrastructure") or {}
+        terraform_root = infra.get("terraform_root")
+        if terraform_root:
+            lines.append(f"  Terraform root: {terraform_root}")
+        if infra.get("terraform_backend"):
+            lines.append(
+                f"  Terraform backend: {infra['terraform_backend']}"
+            )
+        if env.get("observability"):
+            verification = env["observability"].get("verification")
+            if verification:
+                lines.append("  Verification:")
+                for command in verification:
+                    lines.append(f"    - {command}")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def parse_args(argv: List[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Summarise environment manifests for automation tooling."
+    )
+    parser.add_argument(
+        "--env",
+        "-e",
+        dest="env",
+        help="Filter by environment slug (e.g. prod, stg, pr)",
+    )
+    parser.add_argument(
+        "--format",
+        "-f",
+        choices=["json", "text"],
+        default="json",
+        help="Output format (default: json)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: List[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+
+    manifests = [_summarise_manifest(m) for m in _iter_manifests()]
+    if args.env:
+        manifests = [m for m in manifests if m.get("slug") == args.env]
+        if not manifests:
+            print(f"No environment manifest found for slug '{args.env}'.", file=sys.stderr)
+            return 1
+
+    if args.format == "json":
+        json.dump({"environments": manifests}, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    else:
+        sys.stdout.write(_render_text(manifests))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a CLI helper that emits JSON or text summaries of the environment manifests
- document the new helper and surface the stage stress workflow in the ops guide
- extend the staging manifest with the stress workflow metadata and verification steps

## Testing
- python tools/environments_summary.py --format text
- python -m py_compile tools/environments_summary.py

------
https://chatgpt.com/codex/tasks/task_e_68f1af6956b48329968464a6e2d3c7fe