### PR TITLE
Fix descriptor wallet restore command

### DIFF
--- a/sites/blackroad/content/blog/bitcoin-core-descriptor-backups.md
+++ b/sites/blackroad/content/blog/bitcoin-core-descriptor-backups.md
@@ -64,10 +64,10 @@ When it is time to rebuild the node, decrypt the descriptor set and import it in
 gpg -o /tmp/descriptors.json -d /path/to/btc_descriptors_<WALLET>.json.gpg
    ```
 
-2. Create a descriptor wallet and import the JSON:
+2. Create a descriptor wallet and import the JSON (leave private keys enabled so the wallet can sign after the restore):
 
    ```bash
-   bitcoin-cli createwallet "<WALLET>" true true "" true
+   bitcoin-cli createwallet "<WALLET>" false true "" false true
    bitcoin-cli -rpcwallet="<WALLET>" importdescriptors "$(cat /tmp/descriptors.json)"
    ```
 


### PR DESCRIPTION
## Summary
- update the restore instructions to create a descriptor wallet with private keys enabled
- clarify that leaving private keys enabled is required for a spendable wallet restore

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68f1ac01e42c8329bdcc0965e3a1826e