### PR TITLE
feat: highlight best continued fraction approximation

### DIFF
--- a/sites/blackroad/src/pages/ContinuedFractionsLab.jsx
+++ b/sites/blackroad/src/pages/ContinuedFractionsLab.jsx
@@ -14,6 +14,7 @@ function cfrac(x, maxK=12){
 }
 function convergents(a){
   // build p/q from continued fraction coefficients
+  if(a.length === 0) return [];
   const res=[];
   let p0=1, q0=0, p1=a[0], q1=1;
   res.push({p:p1,q:q1});
@@ -33,29 +34,69 @@ export default function ContinuedFractionsLab(){
 
   const a = useMemo(()=>cfrac(val, maxK),[val,maxK]);
   const conv = useMemo(()=>convergents(a),[a]);
+  const rows = useMemo(()=>{
+    let bestIndex = 0;
+    let bestErr = Infinity;
+    const valMag = Math.abs(val);
+    const base = conv.map((c,i)=>{
+      const value = c.p/c.q;
+      const absErr = Math.abs(val - value);
+      if(absErr < bestErr){
+        bestErr = absErr;
+        bestIndex = i;
+      }
+      return {
+        index:i,
+        ...c,
+        value,
+        absErr,
+        relErr: valMag < 1e-15 ? null : absErr/valMag
+      };
+    });
+    return base.map(r=>({ ...r, isBest: r.index === bestIndex }));
+  },[conv,val]);
+  const bestRow = useMemo(()=>{
+    if(rows.length === 0) return null;
+    return rows.reduce((min,row)=>row.absErr < min.absErr ? row : min, rows[0]);
+  },[rows]);
 
   return (
     <div className="p-4 space-y-3">
       <h2 className="text-xl font-semibold">Continued Fractions — Best Rational Approximations</h2>
+      {bestRow && (
+        <section className="p-3 rounded-lg bg-emerald-500/10 border border-emerald-500/40">
+          <h3 className="font-semibold mb-1">Closest convergent</h3>
+          <p className="text-sm opacity-90">
+            {val.toPrecision(10)} ≈ {bestRow.p}/{bestRow.q} ({bestRow.value.toPrecision(10)}) with |
+            x−p/q| ≈ {bestRow.absErr.toExponential(3)}
+            {bestRow.relErr !== null && (
+              <>
+                {" "}(relative error {bestRow.relErr.toExponential(3)})
+              </>
+            )}.
+          </p>
+        </section>
+      )}
       <div className="grid" style={{gridTemplateColumns:"1fr 320px", gap:16}}>
         <section className="p-3 rounded-lg bg-white/5 border border-white/10">
           <table className="w-full text-sm">
             <thead><tr className="opacity-80">
-              <th className="text-left">k</th><th className="text-left">p/q</th><th className="text-left">value</th><th className="text-left">|x−p/q|</th>
+              <th className="text-left">k</th>
+              <th className="text-left">p/q</th>
+              <th className="text-left">value</th>
+              <th className="text-left">|x−p/q|</th>
+              <th className="text-left">relative error</th>
             </tr></thead>
             <tbody>
-              {conv.map((c,i)=>{
-                const valpq = c.p/c.q;
-                const err = Math.abs(val - valpq);
-                return (
-                  <tr key={i}>
-                    <td>{i}</td>
-                    <td>{c.p}/{c.q}</td>
-                    <td>{valpq.toPrecision(10)}</td>
-                    <td>{err.toExponential(3)}</td>
-                  </tr>
-                );
-              })}
+              {rows.map(row=>(
+                <tr key={row.index} className={row.isBest ? "bg-emerald-500/10" : undefined}>
+                  <td>{row.index}</td>
+                  <td>{row.p}/{row.q}</td>
+                  <td>{row.value.toPrecision(10)}</td>
+                  <td>{row.absErr.toExponential(3)}</td>
+                  <td>{row.relErr === null ? "—" : row.relErr.toExponential(3)}</td>
+                </tr>
+              ))}
             </tbody>
           </table>
         </section>
@@ -87,7 +128,7 @@ function Slider({label,v,set,min,max,step}){
     <div className="mb-2">
       <label className="text-sm opacity-80">{label}: <b>{v}</b></label>
       <input className="w-full" type="range" min={min} max={max} step={step}
-             value={v} onChange={e=>set(parseInt(e.target.value))}/>
+             value={v} onChange={e=>set(parseInt(e.target.value,10))}/>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a guard to continued fraction convergents to avoid generating invalid entries when no coefficients are present
- compute convergent metadata so the closest approximation is highlighted in the table and summarized for the reader
- surface relative error values and a quick summary card to make approximation quality easier to compare

## Testing
- npm run lint *(reports existing parsing error in src/App.jsx about StableFluidsLab already being declared along with pre-existing unused variable warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68f1b3bc87c48329b6d556cf608a236f