### PR TITLE
feat: enrich plm and mfg data artifacts

### DIFF
--- a/contracts/schemas/mfg_coq.schema.json
+++ b/contracts/schemas/mfg_coq.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "patternProperties": {
+    ".+": {"type": "number"}
+  },
+  "additionalProperties": false
+}

--- a/contracts/schemas/mfg_mrp.schema.json
+++ b/contracts/schemas/mfg_mrp.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "patternProperties": {
+    ".+": {"type": "number"}
+  },
+  "additionalProperties": false
+}

--- a/contracts/schemas/mfg_routings.schema.json
+++ b/contracts/schemas/mfg_routings.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["item_rev", "steps"],
+    "properties": {
+      "item_rev": {"type": "string"},
+      "steps": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["wc", "op", "std_time_min", "yield_pct"],
+          "properties": {
+            "wc": {"type": "string"},
+            "op": {"type": "string"},
+            "std_time_min": {"type": "number"},
+            "yield_pct": {"type": "number"},
+            "instructions_path": {"type": ["string", "null"]}
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "additionalProperties": false
+  }
+}

--- a/contracts/schemas/mfg_spc.schema.json
+++ b/contracts/schemas/mfg_spc.schema.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "array",
+  "items": {
+    "type": "string"
+  }
+}

--- a/contracts/schemas/mfg_wi.schema.json
+++ b/contracts/schemas/mfg_wi.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["item", "rev", "steps", "markdown", "html"],
+    "properties": {
+      "item": {"type": "string"},
+      "rev": {"type": "string"},
+      "steps": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["wc", "op", "std_time_min", "yield_pct"],
+          "properties": {
+            "wc": {"type": "string"},
+            "op": {"type": "string"},
+            "std_time_min": {"type": "number"},
+            "yield_pct": {"type": "number"},
+            "instructions_path": {"type": ["string", "null"]}
+          },
+          "additionalProperties": false
+        }
+      },
+      "markdown": {"type": "string"},
+      "html": {"type": "string"}
+    },
+    "additionalProperties": false
+  }
+}

--- a/contracts/schemas/mfg_work_centers.schema.json
+++ b/contracts/schemas/mfg_work_centers.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["id", "name", "capacity_per_shift", "skills", "cost_rate"],
+    "properties": {
+      "id": {"type": "string"},
+      "name": {"type": "string"},
+      "capacity_per_shift": {"type": "integer", "minimum": 0},
+      "skills": {"type": "string"},
+      "cost_rate": {"type": "number"}
+    },
+    "additionalProperties": false
+  }
+}

--- a/contracts/schemas/mfg_yield.schema.json
+++ b/contracts/schemas/mfg_yield.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["period", "fpy", "rty"],
+  "properties": {
+    "period": {"type": "string"},
+    "fpy": {"type": "number"},
+    "rty": {"type": "number"}
+  },
+  "additionalProperties": false
+}

--- a/contracts/schemas/plm_boms.schema.json
+++ b/contracts/schemas/plm_boms.schema.json
@@ -1,4 +1,27 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "type": "array"
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["item_id", "rev", "lines"],
+    "properties": {
+      "item_id": {"type": "string"},
+      "rev": {"type": "string"},
+      "lines": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["component_id", "qty"],
+          "properties": {
+            "component_id": {"type": "string"},
+            "qty": {"type": "number"},
+            "refdes": {"type": "string"},
+            "scrap_pct": {"type": "number"}
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "additionalProperties": false
+  }
 }

--- a/contracts/schemas/plm_changes.schema.json
+++ b/contracts/schemas/plm_changes.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": [
+      "id",
+      "type",
+      "item_id",
+      "from_rev",
+      "to_rev",
+      "reason",
+      "risk",
+      "status",
+      "effects",
+      "approvals"
+    ],
+    "properties": {
+      "id": {"type": "string"},
+      "type": {"type": "string", "enum": ["ECR", "ECO"]},
+      "item_id": {"type": "string"},
+      "from_rev": {"type": "string"},
+      "to_rev": {"type": "string"},
+      "reason": {"type": "string"},
+      "risk": {"type": "string"},
+      "status": {"type": "string"},
+      "effects": {
+        "type": "array",
+        "items": {"type": "string"}
+      },
+      "approvals": {
+        "type": "array",
+        "items": {"type": "string"}
+      }
+    },
+    "additionalProperties": false
+  }
+}

--- a/contracts/schemas/plm_items.schema.json
+++ b/contracts/schemas/plm_items.schema.json
@@ -1,4 +1,29 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "type": "array"
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": [
+      "id",
+      "rev",
+      "type",
+      "uom",
+      "lead_time_days",
+      "cost",
+      "suppliers"
+    ],
+    "properties": {
+      "id": {"type": "string"},
+      "rev": {"type": "string"},
+      "type": {"type": "string", "enum": ["assembly", "component", "raw"]},
+      "uom": {"type": "string"},
+      "lead_time_days": {"type": "integer", "minimum": 0},
+      "cost": {"type": "number"},
+      "suppliers": {
+        "type": "array",
+        "items": {"type": "string"}
+      }
+    },
+    "additionalProperties": false
+  }
 }

--- a/contracts/schemas/plm_where_used.schema.json
+++ b/contracts/schemas/plm_where_used.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["component_id", "parent_id", "parent_rev"],
+    "properties": {
+      "component_id": {"type": "string"},
+      "parent_id": {"type": "string"},
+      "parent_rev": {"type": "string"}
+    },
+    "additionalProperties": false
+  }
+}

--- a/mfg/mrp.py
+++ b/mfg/mrp.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
 import csv
-import json
 from pathlib import Path
 from typing import Dict, List
 
-from tools import storage
+from tools import storage, artifacts
 from plm import bom
+from orchestrator import metrics
 
 ROOT = Path(__file__).resolve().parents[1]
 ART_DIR = ROOT / "artifacts" / "mfg" / "mrp"
+LAKE_DIR = ROOT / "artifacts" / "mfg" / "lake"
+SCHEMA_DIR = ROOT / "contracts" / "schemas"
 
 
 def _read_csv(path: str) -> List[Dict[str, str]]:
@@ -34,7 +36,11 @@ def plan(demand_file: str, inventory_file: str, pos_file: str):
         for _, comp, comp_qty in bom.explode(item, d.get("rev", "A"), level=2):
             plan[comp] = plan.get(comp, 0) + comp_qty * net
     ART_DIR.mkdir(parents=True, exist_ok=True)
-    storage.write(str(ART_DIR / "plan.json"), json.dumps(plan, indent=2))
+    artifacts.validate_and_write(
+        str(ART_DIR / "plan.json"),
+        plan,
+        str(SCHEMA_DIR / "mfg_mrp.schema.json"),
+    )
     # kitting lists
     for d in demand:
         item = d["item_id"]
@@ -43,4 +49,18 @@ def plan(demand_file: str, inventory_file: str, pos_file: str):
         for _, comp, comp_qty in bom.explode(item, rev, level=1):
             lines.append(f"{comp},{comp_qty * float(d['qty'])}")
         storage.write(str(ART_DIR / f"kitting_{item}.csv"), "\n".join(lines))
+    LAKE_DIR.mkdir(parents=True, exist_ok=True)
+    lake_path = LAKE_DIR / "mfg_mrp.jsonl"
+    if lake_path.exists():
+        lake_path.unlink()
+    storage.write(
+        str(lake_path),
+        {
+            "demand_file": demand_file,
+            "inventory_file": inventory_file,
+            "pos_file": pos_file,
+            "plan": plan,
+        },
+    )
+    metrics.inc("mrp_planned")
     return plan


### PR DESCRIPTION
## Summary
- persist PLM item, BOM, and where-used catalogs through validated artifacts, lake feeds, and release metrics
- extend ECO persistence with indexed change logs and add metrics-gated manufacturing pipelines for routings, work instructions, SPC, yield, COQ, and MRP outputs
- add JSON schemas covering the new PLM and manufacturing datasets to enforce contract validation

## Testing
- pytest tests/test_bom.py tests/test_eco.py tests/test_routing_cap.py tests/test_mrp.py tests/test_wi.py tests/test_spc.py tests/test_yield_coq.py *(fails: pyproject.toml duplicate project.scripts definition)*

------
https://chatgpt.com/codex/tasks/task_e_68f1b5892c70832980092d2a49709d9d