### PR TITLE
Add VS Code remote guidance for Alice's Raspberry Pi

### DIFF
--- a/docs/pi-network-setup.md
+++ b/docs/pi-network-setup.md
@@ -81,7 +81,31 @@ You can supply a custom list of users/hosts:
 
 Review the output for `[WARN]` entries and resolve any reported issues (network routing, SSH configuration, firewall rules, etc.).
 
-## 6. Keep Dependencies Updated
+## 6. Reach Alice's Raspberry Pi from VS Code
+
+Once ping and SSH succeed, you can open Alice's Pi directly in Visual Studio Code:
+
+1. Install the **Remote - SSH** extension in VS Code on your local workstation.
+2. From the command palette, choose **Remote-SSH: Connect to Host...** and enter `alice@raspberrypi` (or the IP address).
+3. VS Code will establish an SSH tunnel; reuse the same key that `ssh-copy-id` installed earlier.
+4. After the first connection, VS Code saves the host entry. You can reconnect later with:
+   ```bash
+   code --remote ssh-remote+alice@raspberrypi
+   ```
+5. If prompted to select the remote platform, choose **Linux** and allow VS Code to install the server components on the Pi.
+
+### Optional: enable a lightweight desktop session
+
+If Alice needs a graphical desktop, enable VNC on the Pi after SSHing in:
+
+```bash
+sudo raspi-config
+# Interface Options → VNC → Enable
+```
+
+Use a VNC client (RealVNC, Screens, etc.) to connect to `raspberrypi:5900` with Alice's credentials. Keep SSH enabled so VS Code and terminal sessions remain available.
+
+## 7. Keep Dependencies Updated
 
 For Debian-based Raspberry Pi systems:
 ```bash
@@ -94,7 +118,7 @@ brew update
 brew upgrade
 ```
 
-## 7. Troubleshooting Checklist
+## 8. Troubleshooting Checklist
 
 - Ping by IP first to rule out DNS issues.
 - Confirm that firewalls (UFW on Raspberry Pi, macOS Application Firewall) allow inbound SSH.

--- a/scripts/pi_network_check.sh
+++ b/scripts/pi_network_check.sh
@@ -29,10 +29,12 @@ for host in "${HOSTS[@]}"; do
     echo "[WARN] Host $target did not respond to ping"
   fi
 
-  if ssh -o BatchMode=yes -o ConnectTimeout=5 "$host" exit >/dev/null 2>&1; then
-    echo "[OK] SSH connectivity to $host confirmed"
+  if remote_hostname=$(ssh -o BatchMode=yes -o ConnectTimeout=5 "$host" 'hostname' 2>/dev/null); then
+    echo "[OK] SSH connectivity to $host confirmed (remote hostname: $remote_hostname)"
+    echo "    VS Code Remote: code --remote \"ssh-remote+$host\""
   else
     echo "[WARN] Could not establish passwordless SSH session to $host"
+    echo "      Tip: run 'ssh-copy-id $host' to install your public key"
   fi
 
 done


### PR DESCRIPTION
## Summary
- document how to reach Alice's Raspberry Pi from VS Code and enable VNC if needed
- expand the network check script to print the remote hostname and a ready-to-run VS Code command
- include remediation advice when SSH keys are missing

## Testing
- bash -n scripts/pi_network_check.sh

------
https://chatgpt.com/codex/tasks/task_e_68f1c0342f9c8329a3dbd0de3e11f74d