### PR TITLE
chore: expand staging and production environment manifests

### DIFF
--- a/README-OPS.md
+++ b/README-OPS.md
@@ -6,8 +6,8 @@ Bridge runs on :4000; nginx routes `/api` and `/ws`. Static web artifacts publis
 | Environment | Domains | Primary workflow | Notes |
 | --- | --- | --- | --- |
 | Preview (`pr`) | `https://dev.blackroad.io`, `https://pr-<n>.dev.blackroad.io` | `.github/workflows/preview.yml` | Spins up ephemeral ECS services + ALB rules per pull request. Terraform config lives in `infra/preview-env/` and the manifest is documented in `environments/preview.yml`. |
-| Staging (`stg`) | `https://stage.blackroad.io` | `.github/workflows/pages-stage.yml` | Builds and archives the static site proof artifact. API wiring is planned; see `environments/staging.yml` for current status. |
-| Production (`prod`) | `https://blackroad.io`, `https://www.blackroad.io`, `https://api.blackroad.io` | `.github/workflows/blackroad-deploy.yml` | GitHub Pages publishes the marketing site; API gateway will promote via the same workflow once the ECS module is enabled. Full manifest: `environments/production.yml`. |
+| Staging (`stg`) | `https://stage.blackroad.io` | `.github/workflows/pages-stage.yml` | Builds and archives the static site proof artifact. AWS scaffolding (VPC `10.30.0.0/16`, `us-west-2a/2b`, single-task ECS scaling) is defined and ready for the API promotion path in `modules/ecs-service-alb`. See `environments/staging.yml` for the manifest. |
+| Production (`prod`) | `https://blackroad.io`, `https://www.blackroad.io`, `https://api.blackroad.io` | `.github/workflows/blackroad-deploy.yml` | GitHub Pages publishes the marketing site; the same workflow drives the webhook-based deploy and exposes a `workflow_dispatch` escape hatch (`target=legacy-ssh`) for the SSH fallback. Full manifest: `environments/production.yml`. |
 
 Reference the manifests whenever DNS, workflow, or Terraform parameters change so automation and runbooks stay aligned.
 
@@ -23,11 +23,13 @@ Reference the manifests whenever DNS, workflow, or Terraform parameters change s
 - Pushes to `main` touching `blackroad-stage/**` or manual dispatch run `pages-stage.yml`.
 - Generates a daily proof + `health.json` for `stage.blackroad.io` and uploads the artifact (no automatic publish step yet).
 - Use the artifact for QA sign-off or handoff to downstream deploy automation.
+- AWS networking, RDS, and ECS cluster scaffolding already exist via `br-infra-iac/envs/stg`. When ready to promote the API, reuse `modules/ecs-service-alb` with `desired_count=1` and the staging ECR repository `br-api-gateway`.
 
 ### Production
 - `blackroad-deploy.yml` runs on every `main` push and exposes a `workflow_dispatch` entry for manual redeploys.
 - Builds the SPA, triggers the deploy webhook (`BR_DEPLOY_SECRET` / `BR_DEPLOY_URL`), then lets downstream infra promote the build.
 - API and NGINX remain accessible over SSH while we finish migrating to ECS; scripts live under `scripts/` for TLS + health.
+- The same workflow exposes `target=legacy-ssh` to package artifacts and ship them to the legacy hosts when required.
 
 ## Rollback and forward
 
@@ -48,6 +50,7 @@ Document every rollback/forward action in the incident log and update the corres
   scripts/nginx-ensure-and-health.sh
   scripts/nginx-enable-tls.sh   # optional TLS helper
   ```
+- ECS checks: `aws ecs describe-services --cluster <cluster-arn> --services api-gateway --region us-west-2`
 - Cleanup broom: `usr/local/sbin/br-cleanup.sh` audits API, Yjs, bridges, nginx, IPFS, etc. Modes:
   ```sh
   sudo br-cleanup.sh audit | tee /srv/ops/cleanup-audit.txt

--- a/environments/production.yml
+++ b/environments/production.yml
@@ -17,6 +17,11 @@ domains:
 infrastructure:
   cloud: aws
   region: us-west-2
+  availability_zones:
+    - us-west-2a
+    - us-west-2b
+  network:
+    vpc_cidr: 10.40.0.0/16
   terraform:
     root: br-infra-iac/envs/prod
     backend:
@@ -29,6 +34,10 @@ infrastructure:
       - modules/ecs-cluster
       - modules/ecr
       - modules/rds-postgres
+    variables:
+      rds_instance_class: db.t4g.medium
+      rds_multi_az: true
+      rds_backup_retention_days: 30
     outputs:
       - ecs_cluster
       - private_subnets
@@ -52,6 +61,20 @@ automation:
         - CF_ZONE_ID
         - CF_API_TOKEN
         - SLACK_WEBHOOK_URL
+    - name: BlackRoad • Deploy (legacy SSH fallback)
+      file: .github/workflows/blackroad-deploy.yml
+      triggers:
+        - workflow_dispatch (target=legacy-ssh)
+      summary: >-
+        Provides a manual escape hatch that packages site and API bundles,
+        ships them over SSH, and restarts the legacy hosts while verifying
+        health endpoints.
+      secrets:
+        - DEPLOY_HOST
+        - DEPLOY_USER
+        - DEPLOY_KEY
+  notifications:
+    slack_channel: "#eng"
 deployments:
   - service: marketing-site
     type: static-site
@@ -73,6 +96,13 @@ deployments:
       behind an ALB-backed Fargate service.
     health_check: https://api.blackroad.io/health
     workflow: .github/workflows/blackroad-deploy.yml
+    image_repository: br-api-gateway
+    scaling:
+      desired_count: 2
+      min_capacity: 2
+      max_capacity: 6
+    environment:
+      NODE_ENV: production
 change_management:
   approvals:
     - .github/workflows/change-approve.yml
@@ -87,3 +117,5 @@ observability:
       url: https://api.blackroad.io/health
   scripts:
     - scripts/blackroad-autoheal.sh
+  commands:
+    - aws ecs describe-services --cluster <cluster-arn> --services api-gateway --region us-west-2

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -11,6 +11,11 @@ domains:
 infrastructure:
   cloud: aws
   region: us-west-2
+  availability_zones:
+    - us-west-2a
+    - us-west-2b
+  network:
+    vpc_cidr: 10.30.0.0/16
   terraform:
     root: br-infra-iac/envs/stg
     backend:
@@ -23,6 +28,10 @@ infrastructure:
       - modules/ecs-cluster
       - modules/ecr
       - modules/rds-postgres
+    variables:
+      rds_instance_class: db.t4g.small
+      rds_multi_az: false
+      rds_backup_retention_days: 14
     outputs:
       - vpc_id
       - private_subnets
@@ -44,6 +53,8 @@ automation:
         without publishing DNS changes.
       secrets:
         - AWAKEN_SEED
+  notifications:
+    slack_channel: "#eng"
 deployments:
   - service: marketing-site
     type: static-site
@@ -58,10 +69,18 @@ deployments:
     type: container-service
     provider: aws-ecs-fargate
     terraform_directory: br-infra-iac/envs/stg
+    module: modules/ecs-service-alb
     state: planned
     notes: >-
       Network, ECS, and RDS resources are defined; service wiring will follow the
       production module once ready.
+    image_repository: br-api-gateway
+    scaling:
+      desired_count: 1
+      min_capacity: 1
+      max_capacity: 2
+    environment:
+      NODE_ENV: staging
 change_management:
   approvals:
     - .github/workflows/change-approve.yml
@@ -69,3 +88,5 @@ observability:
   health_checks:
     - name: static-health
       url: https://stage.blackroad.io/health.json
+  commands:
+    - aws ecs describe-services --cluster <cluster-arn> --services api-gateway --region us-west-2


### PR DESCRIPTION
## Summary
- add AWS network, database, and scaling metadata to the staging manifest plus ECS command references
- enrich the production manifest with availability zones, fallback workflow details, and container scaling context
- update the ops guide to highlight the new manifest details and legacy SSH escape hatch

## Testing
- not run (docs-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68f1eb1d4e5083299096be2b075f01de