### PR TITLE
feat: structure plm and mfg artifact pipelines

### DIFF
--- a/cli/console.py
+++ b/cli/console.py
@@ -531,9 +531,6 @@ def plm_bom_explode(
 def plm_bom_where_used(component: str = typer.Option(..., "--component")):
     rows = plm_bom.where_used(component)
     for item_id, rev in rows:
-        typer.echo(f"{item_id}@{rev}")
-    used = plm_bom.where_used(component)
-    for item_id, rev in used:
         typer.echo(f"{item_id}\t{rev}")
 
 
@@ -603,8 +600,11 @@ def mfg_wi_render(item: str = typer.Option(..., "--item"), rev: str = typer.Opti
 def mfg_spc_analyze(
     op: str = typer.Option(..., "--op"), window: int = typer.Option(50, "--window")
 ):
-    findings = mfg_spc.analyze(op, window)
-    typer.echo(" ".join(findings))
+    report = mfg_spc.analyze(op, window)
+    if report["findings"]:
+        typer.echo(" ".join(report["findings"]))
+    else:
+        typer.echo("OK")
 
 
 @app.command("mfg:yield")

--- a/contracts/schemas/mfg_coq.schema.json
+++ b/contracts/schemas/mfg_coq.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["period", "buckets"],
+  "properties": {
+    "period": {"type": "string"},
+    "buckets": {
+      "type": "object",
+      "additionalProperties": {"type": "number"}
+    }
+  },
+  "additionalProperties": false
+}

--- a/contracts/schemas/mfg_mrp_plan.schema.json
+++ b/contracts/schemas/mfg_mrp_plan.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["demand_source", "inventory_source", "pos_source", "planned"],
+  "properties": {
+    "demand_source": {"type": "string"},
+    "inventory_source": {"type": "string"},
+    "pos_source": {"type": "string"},
+    "planned": {
+      "type": "object",
+      "additionalProperties": {"type": "number"}
+    }
+  },
+  "additionalProperties": false
+}

--- a/contracts/schemas/mfg_routings.schema.json
+++ b/contracts/schemas/mfg_routings.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["item_rev", "steps"],
+    "properties": {
+      "item_rev": {"type": "string"},
+      "steps": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["wc", "op", "std_time_min", "yield_pct"],
+          "properties": {
+            "wc": {"type": "string"},
+            "op": {"type": "string"},
+            "std_time_min": {"type": "number", "minimum": 0},
+            "yield_pct": {"type": "number"},
+            "instructions_path": {"type": ["string", "null"]}
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "additionalProperties": false
+  }
+}

--- a/contracts/schemas/mfg_spc.schema.json
+++ b/contracts/schemas/mfg_spc.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["op", "sample_size", "mean", "sigma", "findings", "series", "unstable"],
+  "properties": {
+    "op": {"type": "string"},
+    "sample_size": {"type": "integer", "minimum": 0},
+    "mean": {"type": "number"},
+    "sigma": {"type": "number", "minimum": 0},
+    "unstable": {"type": "boolean"},
+    "findings": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "series": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["index", "value"],
+        "properties": {
+          "index": {"type": "integer", "minimum": 1},
+          "value": {"type": "number"}
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/contracts/schemas/mfg_wi.schema.json
+++ b/contracts/schemas/mfg_wi.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": {
+    "type": "object",
+    "required": ["item", "rev", "steps", "markdown", "html"],
+    "properties": {
+      "item": {"type": "string"},
+      "rev": {"type": "string"},
+      "steps": {"type": "integer", "minimum": 0},
+      "markdown": {"type": "string"},
+      "html": {"type": "string"}
+    },
+    "additionalProperties": false
+  }
+}

--- a/contracts/schemas/mfg_work_centers.schema.json
+++ b/contracts/schemas/mfg_work_centers.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["id", "name", "capacity_per_shift", "skills", "cost_rate"],
+    "properties": {
+      "id": {"type": "string"},
+      "name": {"type": "string"},
+      "capacity_per_shift": {"type": "integer", "minimum": 0},
+      "skills": {"type": "string"},
+      "cost_rate": {"type": "number", "minimum": 0}
+    },
+    "additionalProperties": false
+  }
+}

--- a/contracts/schemas/mfg_yield.schema.json
+++ b/contracts/schemas/mfg_yield.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["period", "fpy", "rty", "stations", "pareto"],
+  "properties": {
+    "period": {"type": "string"},
+    "fpy": {"type": "number"},
+    "rty": {"type": "number"},
+    "stations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["station", "total", "defects", "yield_pct"],
+        "properties": {
+          "station": {"type": "string"},
+          "total": {"type": "integer", "minimum": 0},
+          "defects": {"type": "integer", "minimum": 0},
+          "yield_pct": {"type": "number"}
+        },
+        "additionalProperties": false
+      }
+    },
+    "pareto": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["station", "defects"],
+        "properties": {
+          "station": {"type": "string"},
+          "defects": {"type": "integer", "minimum": 0}
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/contracts/schemas/plm_boms.schema.json
+++ b/contracts/schemas/plm_boms.schema.json
@@ -1,4 +1,27 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "type": "array"
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["item_id", "rev", "lines"],
+    "properties": {
+      "item_id": {"type": "string"},
+      "rev": {"type": "string"},
+      "lines": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["component_id", "qty", "refdes", "scrap_pct"],
+          "properties": {
+            "component_id": {"type": "string"},
+            "qty": {"type": "number"},
+            "refdes": {"type": "string"},
+            "scrap_pct": {"type": "number"}
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "additionalProperties": false
+  }
 }

--- a/contracts/schemas/plm_change.schema.json
+++ b/contracts/schemas/plm_change.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": [
+    "id",
+    "type",
+    "item_id",
+    "from_rev",
+    "to_rev",
+    "reason",
+    "risk",
+    "status",
+    "effects",
+    "approvals"
+  ],
+  "properties": {
+    "id": {"type": "string"},
+    "type": {"enum": ["ECR", "ECO"]},
+    "item_id": {"type": "string"},
+    "from_rev": {"type": "string"},
+    "to_rev": {"type": "string"},
+    "reason": {"type": "string"},
+    "risk": {"enum": ["low", "medium", "high"]},
+    "status": {
+      "enum": ["draft", "review", "approved", "released", "rejected"]
+    },
+    "effects": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "approvals": {
+      "type": "array",
+      "items": {"type": "string"}
+    }
+  },
+  "additionalProperties": false
+}

--- a/contracts/schemas/plm_items.schema.json
+++ b/contracts/schemas/plm_items.schema.json
@@ -1,4 +1,29 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "type": "array"
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": [
+      "id",
+      "rev",
+      "type",
+      "uom",
+      "lead_time_days",
+      "cost",
+      "suppliers"
+    ],
+    "properties": {
+      "id": {"type": "string"},
+      "rev": {"type": "string"},
+      "type": {"enum": ["assembly", "component", "raw"]},
+      "uom": {"type": "string"},
+      "lead_time_days": {"type": "integer", "minimum": 0},
+      "cost": {"type": "number", "minimum": 0},
+      "suppliers": {
+        "type": "array",
+        "items": {"type": "string"}
+      }
+    },
+    "additionalProperties": false
+  }
 }

--- a/contracts/schemas/plm_where_used.schema.json
+++ b/contracts/schemas/plm_where_used.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["component_id", "parent_id", "parent_rev"],
+    "properties": {
+      "component_id": {"type": "string"},
+      "parent_id": {"type": "string"},
+      "parent_rev": {"type": "string"}
+    },
+    "additionalProperties": false
+  }
+}

--- a/mfg/coq.py
+++ b/mfg/coq.py
@@ -4,11 +4,13 @@ import csv
 from pathlib import Path
 from typing import Dict
 
-from tools import storage
+from orchestrator import metrics
+from tools import artifacts
 
 ROOT = Path(__file__).resolve().parents[1]
 ART_DIR = ROOT / "artifacts" / "mfg" / "coq"
 FIXTURES = ROOT / "fixtures" / "mfg"
+SCHEMA = ROOT / "contracts" / "schemas" / "mfg_coq.schema.json"
 
 
 def build(period: str):
@@ -20,12 +22,15 @@ def build(period: str):
             bucket = row["bucket"]
             totals[bucket] = totals.get(bucket, 0.0) + float(row["cost"])
     ART_DIR.mkdir(parents=True, exist_ok=True)
-    storage.write(
+    report = {"period": period, "buckets": totals}
+    artifacts.validate_and_write(str(ART_DIR / "coq.json"), report, str(SCHEMA))
+    artifacts.validate_and_write(
         str(ART_DIR / "coq.csv"),
         "bucket,cost\n" + "\n".join(f"{k},{v}" for k, v in totals.items()),
     )
-    storage.write(
+    artifacts.validate_and_write(
         str(ART_DIR / "coq.md"),
         "\n".join(f"{k}: {v}" for k, v in totals.items()),
     )
-    return totals
+    metrics.inc("coq_built")
+    return report

--- a/mfg/routing.py
+++ b/mfg/routing.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 import csv
 import json
-from dataclasses import dataclass, asdict
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Dict, List
 
 import yaml
 
-from tools import storage
+from orchestrator import metrics
+from tools import artifacts, storage
 
 try:  # optional strict validation
     import jsonschema
@@ -17,6 +18,9 @@ except Exception:  # pragma: no cover
 
 ROOT = Path(__file__).resolve().parents[1]
 ART_DIR = ROOT / "artifacts" / "mfg"
+SCHEMA_DIR = ROOT / "contracts" / "schemas"
+WC_SCHEMA = SCHEMA_DIR / "mfg_work_centers.schema.json"
+ROUTING_SCHEMA = SCHEMA_DIR / "mfg_routings.schema.json"
 
 
 @dataclass
@@ -63,7 +67,12 @@ def load_work_centers(file: str) -> Dict[str, WorkCenter]:
     global WORK_CENTERS
     WORK_CENTERS = wcs
     ART_DIR.mkdir(parents=True, exist_ok=True)
-    storage.write(str(ART_DIR / "work_centers.json"), json.dumps([asdict(w) for w in wcs.values()], indent=2))
+    artifacts.validate_and_write(
+        str(ART_DIR / "work_centers.json"),
+        [asdict(w) for w in wcs.values()],
+        str(WC_SCHEMA),
+    )
+    metrics.inc("mfg_work_centers_loaded", len(wcs) or 1)
     return wcs
 
 
@@ -86,11 +95,17 @@ def load_routings(directory: str, strict: bool = False) -> Dict[str, Routing]:
     global ROUTINGS
     ROUTINGS = rts
     ART_DIR.mkdir(parents=True, exist_ok=True)
-    storage.write(str(ART_DIR / "routings.json"), json.dumps([{"item_rev": r.item_rev, "steps": [asdict(s) for s in r.steps]} for r in rts.values()], indent=2))
+    artifacts.validate_and_write(
+        str(ART_DIR / "routings.json"),
+        [{"item_rev": r.item_rev, "steps": [asdict(s) for s in r.steps]} for r in rts.values()],
+        str(ROUTING_SCHEMA),
+    )
+    metrics.inc("mfg_routings_loaded", len(rts) or 1)
     return rts
 
 
 def capacity_check(item: str, rev: str, qty: int):
+    _ensure_loaded()
     key = f"{item}_{rev}"
     rt = ROUTINGS.get(key)
     if not rt:
@@ -99,7 +114,7 @@ def capacity_check(item: str, rev: str, qty: int):
     for step in rt.steps:
         mins = qty * step.std_time_min / (step.yield_pct or 1)
         totals[step.wc] = totals.get(step.wc, 0.0) + mins
-    results = {}
+    results: Dict[str, Dict[str, float]] = {}
     labor_cost = 0.0
     for wc_id, req in totals.items():
         wc = WORK_CENTERS.get(wc_id)
@@ -108,4 +123,30 @@ def capacity_check(item: str, rev: str, qty: int):
         if wc:
             labor_cost += (req / 60) * wc.cost_rate
     results["labor_cost"] = labor_cost
+    metrics.inc("routing_cap_checked")
     return results
+
+
+def _ensure_loaded() -> None:
+    global WORK_CENTERS, ROUTINGS
+    if not WORK_CENTERS:
+        data = storage.read(str(ART_DIR / "work_centers.json"))
+        if data:
+            rows = json.loads(data)
+            WORK_CENTERS = {row["id"]: WorkCenter(**row) for row in rows}
+    if not ROUTINGS:
+        data = storage.read(str(ART_DIR / "routings.json"))
+        if data:
+            rows = json.loads(data)
+            ROUTINGS = {
+                row["item_rev"]: Routing(
+                    item_rev=row["item_rev"],
+                    steps=[RoutingStep(**s) for s in row.get("steps", [])],
+                )
+                for row in rows
+            }
+
+
+def get_routing(item: str, rev: str) -> Routing | None:
+    _ensure_loaded()
+    return ROUTINGS.get(f"{item}_{rev}")

--- a/mfg/work_instructions.py
+++ b/mfg/work_instructions.py
@@ -1,38 +1,57 @@
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
-from typing import Optional
+from typing import Dict
 
-from tools import storage
-from . import routing
+from orchestrator import metrics
+from tools import artifacts, storage
+
 from plm import bom
+from . import routing
 
 ROOT = Path(__file__).resolve().parents[1]
 ART_DIR = ROOT / "artifacts" / "mfg" / "wi"
+SCHEMA = ROOT / "contracts" / "schemas" / "mfg_wi.schema.json"
 
 
 def render(item: str, rev: str) -> Path:
-    key = f"{item}_{rev}"
-    rt = routing.ROUTINGS.get(key)
+    rt = routing.get_routing(item, rev)
     if not rt:
         raise ValueError("routing not loaded")
-    if (item, rev) not in bom.BOMS:
+    if not bom.get_bom(item, rev):
         raise RuntimeError("DUTY_REV_MISMATCH")
     lines = [f"# Work Instructions for {item} rev {rev}\n"]
     for idx, step in enumerate(rt.steps, 1):
         lines.append(f"{idx}. {step.op} at {step.wc} - {step.std_time_min} min")
-    routing_key = f"{item}_{rev}"
-    routing_dir = os.path.join("fixtures", "mfg", "routings")
-    expected_yaml = os.path.join(routing_dir, f"{item}_{rev}.yaml")
-    if not os.path.exists(expected_yaml):
-        raise SystemExit(
-            "DUTY_REV_MISMATCH: routing & BOM revs mismatch or missing routing fixture"
-        )
+    routing_dir = ROOT / "fixtures" / "mfg" / "routings"
+    expected_yaml = routing_dir / f"{item}_{rev}.yaml"
+    if not expected_yaml.exists():
+        raise RuntimeError("DUTY_REV_MISMATCH")
     ART_DIR.mkdir(parents=True, exist_ok=True)
     md_path = ART_DIR / f"{item}_{rev}.md"
-    storage.write(str(md_path), "\n".join(lines))
+    artifacts.validate_and_write(str(md_path), "\n".join(lines))
     html_path = ART_DIR / f"{item}_{rev}.html"
     html = "<html><body><pre>" + "\n".join(lines) + "</pre></body></html>"
-    storage.write(str(html_path), html)
+    artifacts.validate_and_write(str(html_path), html)
+
+    manifest_path = ART_DIR / "index.json"
+    if manifest_path.exists():
+        try:
+            manifest_raw = storage.read(str(manifest_path))
+            manifest = json.loads(manifest_raw) if manifest_raw else {}
+        except json.JSONDecodeError:
+            manifest = {}
+    else:
+        manifest = {}
+    manifest[f"{item}_{rev}"] = {
+        "item": item,
+        "rev": rev,
+        "steps": len(rt.steps),
+        "markdown": str(md_path),
+        "html": str(html_path),
+    }
+    artifacts.validate_and_write(str(manifest_path), manifest, str(SCHEMA))
+    metrics.inc("wi_rendered")
     return md_path

--- a/mfg/yield.py
+++ b/mfg/yield.py
@@ -2,39 +2,59 @@ from __future__ import annotations
 
 import csv
 from pathlib import Path
-from typing import Dict
+from typing import Dict, List
 
-from tools import storage
+from orchestrator import metrics
+from tools import artifacts
 
 ROOT = Path(__file__).resolve().parents[1]
 ART_DIR = ROOT / "artifacts" / "mfg" / "yield"
 FIXTURES = ROOT / "fixtures" / "mfg"
+SCHEMA = ROOT / "contracts" / "schemas" / "mfg_yield.schema.json"
 
 
 def compute(period: str):
     path = FIXTURES / f"yield_{period}.csv"
-    stations = []
+    stations: List[Dict[str, float]] = []
     with open(path, newline="", encoding="utf-8") as fh:
         reader = csv.DictReader(fh)
         for row in reader:
             total = int(row["total"])
             defects = int(row["defects"])
             yield_pct = (total - defects) / total if total else 0
-            stations.append((row["station"], total, defects, yield_pct))
+            stations.append(
+                {
+                    "station": row["station"],
+                    "total": total,
+                    "defects": defects,
+                    "yield_pct": yield_pct,
+                }
+            )
     if not stations:
         raise ValueError("no data")
-    fpy = stations[0][3]
+    fpy = stations[0]["yield_pct"]
     rty = 1.0
     for s in stations:
-        rty *= s[3]
+        rty *= s["yield_pct"]
     ART_DIR.mkdir(parents=True, exist_ok=True)
-    storage.write(
-        str(ART_DIR / "summary.md"),
-        f"FPY: {fpy:.3f}\nRTY: {rty:.3f}\n",
+    report = {
+        "period": period,
+        "fpy": fpy,
+        "rty": rty,
+        "stations": stations,
+        "pareto": [
+            {"station": s["station"], "defects": s["defects"]}
+            for s in sorted(stations, key=lambda x: x["defects"], reverse=True)
+        ],
+    }
+    artifacts.validate_and_write(str(ART_DIR / "summary.json"), report, str(SCHEMA))
+    artifacts.validate_and_write(
+        str(ART_DIR / "summary.md"), f"FPY: {fpy:.3f}\nRTY: {rty:.3f}\n"
     )
-    pareto_path = ART_DIR / "pareto.csv"
-    storage.write(
-        str(pareto_path),
-        "station,defects\n" + "\n".join(f"{s[0]},{s[2]}" for s in sorted(stations, key=lambda x: x[2], reverse=True)),
+    artifacts.validate_and_write(
+        str(ART_DIR / "pareto.csv"),
+        "station,defects\n"
+        + "\n".join(f"{row['station']},{row['defects']}" for row in report["pareto"]),
     )
-    return {"fpy": fpy, "rty": rty}
+    metrics.inc("yield_reported")
+    return report

--- a/plm/bom.py
+++ b/plm/bom.py
@@ -2,14 +2,19 @@ from __future__ import annotations
 
 import csv
 import json
-from dataclasses import dataclass, asdict
+from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, Iterable, List, Tuple
 
-from tools import storage
+from orchestrator import metrics
+from tools import artifacts, storage
 
 ROOT = Path(__file__).resolve().parents[1]
 ART_DIR = ROOT / "artifacts" / "plm"
+SCHEMA_DIR = ROOT / "contracts" / "schemas"
+ITEM_SCHEMA = SCHEMA_DIR / "plm_items.schema.json"
+BOM_SCHEMA = SCHEMA_DIR / "plm_boms.schema.json"
+WHERE_USED_SCHEMA = SCHEMA_DIR / "plm_where_used.schema.json"
 
 
 @dataclass
@@ -42,8 +47,64 @@ ITEMS: Dict[Tuple[str, str], Item] = {}
 BOMS: Dict[Tuple[str, str], BOM] = {}
 
 
-def _write_json(path: Path, data) -> None:
-    storage.write(str(path), json.dumps(data, indent=2))
+def _artifact_path(name: str) -> Path:
+    return ART_DIR / name
+
+
+def _write_artifact(path: Path, data, schema: Path | None = None) -> None:
+    ART_DIR.mkdir(parents=True, exist_ok=True)
+    schema_path = str(schema) if schema else None
+    artifacts.validate_and_write(str(path), data, schema_path)
+
+
+def _load_items_artifact() -> None:
+    global ITEMS
+    if ITEMS:
+        return
+    data = storage.read(str(_artifact_path("items.json")))
+    if not data:
+        return
+    rows = json.loads(data)
+    ITEMS = {}
+    for row in rows:
+        item = Item(**row)
+        ITEMS[(item.id, item.rev)] = item
+
+
+def _load_boms_artifact() -> None:
+    global BOMS
+    if BOMS:
+        return
+    data = storage.read(str(_artifact_path("boms.json")))
+    if not data:
+        return
+    rows = json.loads(data)
+    BOMS = {}
+    for row in rows:
+        lines = [BOMLine(**line) for line in row.get("lines", [])]
+        bom_obj = BOM(item_id=row["item_id"], rev=row["rev"], lines=lines)
+        BOMS[(bom_obj.item_id, bom_obj.rev)] = bom_obj
+
+
+def ensure_loaded() -> None:
+    """Best-effort load of items and BOMs from existing artifacts."""
+    _load_items_artifact()
+    _load_boms_artifact()
+
+
+def _write_where_used() -> None:
+    ensure_loaded()
+    facts = [
+        {
+            "component_id": line.component_id,
+            "parent_id": bom.item_id,
+            "parent_rev": bom.rev,
+        }
+        for bom in BOMS.values()
+        for line in bom.lines
+    ]
+    _write_artifact(_artifact_path("where_used.json"), facts, WHERE_USED_SCHEMA)
+    metrics.inc("plm_where_used_written", len(facts) or 1)
 
 
 def load_items(directory: str) -> Dict[Tuple[str, str], Item]:
@@ -64,8 +125,9 @@ def load_items(directory: str) -> Dict[Tuple[str, str], Item]:
                 items[(itm.id, itm.rev)] = itm
     global ITEMS
     ITEMS = items
-    ART_DIR.mkdir(parents=True, exist_ok=True)
-    _write_json(ART_DIR / "items.json", [asdict(i) for i in items.values()])
+    payload = [asdict(i) for i in items.values()]
+    _write_artifact(_artifact_path("items.json"), payload, ITEM_SCHEMA)
+    metrics.inc("plm_items_written", len(payload) or 1)
     return items
 
 
@@ -87,15 +149,18 @@ def load_boms(directory: str) -> Dict[Tuple[str, str], BOM]:
                 )
     global BOMS
     BOMS = boms
-    ART_DIR.mkdir(parents=True, exist_ok=True)
-    _write_json(ART_DIR / "boms.json", [
+    payload = [
         {"item_id": b.item_id, "rev": b.rev, "lines": [asdict(l) for l in b.lines]}
         for b in boms.values()
-    ])
+    ]
+    _write_artifact(_artifact_path("boms.json"), payload, BOM_SCHEMA)
+    metrics.inc("plm_boms_written", len(payload) or 1)
+    _write_where_used()
     return boms
 
 
 def explode(item_id: str, rev: str, level: int = 1) -> List[Tuple[int, str, float]]:
+    ensure_loaded()
     result: List[Tuple[int, str, float]] = []
 
     def _exp(item_id: str, rev: str, lvl: int, qty_scale: float = 1.0):
@@ -114,6 +179,7 @@ def explode(item_id: str, rev: str, level: int = 1) -> List[Tuple[int, str, floa
 
 
 def where_used(component_id: str) -> List[Tuple[str, str]]:
+    ensure_loaded()
     used = []
     for (parent_id, rev), bom in BOMS.items():
         for line in bom.lines:
@@ -121,6 +187,21 @@ def where_used(component_id: str) -> List[Tuple[str, str]]:
                 used.append((parent_id, rev))
                 break
     return used
+
+
+def iter_items() -> Iterable[Item]:
+    ensure_loaded()
+    return ITEMS.values()
+
+
+def get_item(item_id: str, rev: str) -> Item | None:
+    ensure_loaded()
+    return ITEMS.get((item_id, rev))
+
+
+def get_bom(item_id: str, rev: str) -> BOM | None:
+    ensure_loaded()
+    return BOMS.get((item_id, rev))
 
 
 def cli_bom_where_used(argv):


### PR DESCRIPTION
## Summary
- persist PLM items, BOMs, and where-used facts as schema-validated artifacts with metrics-aware loaders
- move ECO lifecycle storage to schema-backed artifacts and gate releases using SPC stability checks
- serialize manufacturing data products (work centers, routings, instructions, SPC, MRP, yield, COQ) with schema validation, metrics, and updated CLI output, alongside new contract schemas

## Testing
- python -m compileall plm mfg

------
https://chatgpt.com/codex/tasks/task_e_68f1e9f46ce48329b908e85cd0885f75