### PR TITLE
feat: add reusable deploy workflows

### DIFF
--- a/.github/workflows/reusable-aws-ecs-deploy.yml
+++ b/.github/workflows/reusable-aws-ecs-deploy.yml
@@ -1,0 +1,158 @@
+name: Reusable AWS ECS Deploy
+
+on:
+  workflow_call:
+    inputs:
+      cluster:
+        description: 'ECS cluster name or ARN'
+        required: true
+        type: string
+      service:
+        description: 'ECS service name'
+        required: true
+        type: string
+      image:
+        description: 'Container image to roll out (e.g., 123456789012.dkr.ecr.us-west-2.amazonaws.com/app:sha)'
+        required: true
+        type: string
+      container-name:
+        description: 'Container definition name inside the task definition to update'
+        required: false
+        type: string
+        default: app
+      region:
+        description: 'AWS region where the ECS service runs'
+        required: false
+        type: string
+        default: us-west-2
+      desired-count:
+        description: 'Optional desired count override applied during the update'
+        required: false
+        type: string
+      wait-for-stable:
+        description: 'Wait for the service to reach a stable state before completing'
+        required: false
+        type: boolean
+        default: true
+      environment:
+        description: 'Environment name to associate with this deployment run'
+        required: false
+        type: string
+    secrets:
+      aws-role-to-assume:
+        required: false
+        description: 'IAM role ARN assumed for deployment (preferred)'
+      aws-external-id:
+        required: false
+        description: 'External ID required when assuming the IAM role'
+      aws-access-key-id:
+        required: false
+        description: 'Static access key used when no role is supplied'
+      aws-secret-access-key:
+        required: false
+        description: 'Static secret key used when no role is supplied'
+      aws-session-token:
+        required: false
+        description: 'Session token used when assuming STS credentials directly'
+    outputs:
+      task-definition:
+        description: 'ARN of the registered task definition revision'
+        value: ${{ jobs.deploy.outputs.task-definition }}
+      service-arn:
+        description: 'ARN of the ECS service that was updated'
+        value: ${{ jobs.deploy.outputs.service-arn }}
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy to AWS ECS
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.environment != '' && inputs.environment || format('ecs-{0}', inputs.service) }}
+    outputs:
+      task-definition: ${{ steps.register.outputs.task-def-arn }}
+      service-arn: ${{ steps.update.outputs.service-arn }}
+    steps:
+      - name: Configure AWS credentials (assume role)
+        if: ${{ secrets.aws-role-to-assume != '' }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.aws-role-to-assume }}
+          role-session-name: GitHubActionsECSDeploy
+          aws-region: ${{ inputs.region }}
+          role-duration-seconds: 3600
+          role-external-id: ${{ secrets.aws-external-id }}
+
+      - name: Configure AWS credentials (static keys)
+        if: ${{ secrets.aws-role-to-assume == '' }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.aws-access-key-id }}
+          aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
+          aws-session-token: ${{ secrets.aws-session-token }}
+          aws-region: ${{ inputs.region }}
+
+      - name: Fetch current task definition
+        id: describe
+        env:
+          CLUSTER: ${{ inputs.cluster }}
+          SERVICE: ${{ inputs.service }}
+        run: |
+          set -euo pipefail
+          task_def=$(aws ecs describe-services --cluster "$CLUSTER" --services "$SERVICE" --query 'services[0].taskDefinition' --output text)
+          if [ -z "$task_def" ] || [ "$task_def" = "None" ]; then
+            echo "::error::Failed to resolve task definition for service $SERVICE in cluster $CLUSTER" >&2
+            exit 1
+          fi
+          aws ecs describe-task-definition --task-definition "$task_def" --query 'taskDefinition' > taskdef.json
+          echo "current-task-def=${task_def}" >> "$GITHUB_OUTPUT"
+
+      - name: Register new task definition revision
+        id: register
+        env:
+          IMAGE: ${{ inputs.image }}
+          CONTAINER: ${{ inputs['container-name'] }}
+        run: |
+          set -euo pipefail
+          jq --arg image "$IMAGE" --arg container "$CONTAINER" '
+            del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy, .deregisteredAt, .deregisteredBy, .inferenceAccelerators, .proxyConfiguration?.containerName, .tags, .createdAt) |
+            .containerDefinitions |= map(if .name == $container then .image = $image else . end)
+          ' taskdef.json > taskdef-processed.json
+          if ! jq -e --arg container "$CONTAINER" --arg image "$IMAGE" '.containerDefinitions[] | select(.name == $container and .image == $image)' taskdef-processed.json >/dev/null; then
+            echo "::error::Container definition $CONTAINER not found when preparing task definition" >&2
+            exit 1
+          fi
+          new_task=$(aws ecs register-task-definition --cli-input-json file://taskdef-processed.json --query 'taskDefinition.taskDefinitionArn' --output text)
+          if [ -z "$new_task" ] || [ "$new_task" = "None" ]; then
+            echo "::error::Failed to register new task definition revision" >&2
+            exit 1
+          fi
+          echo "task-def-arn=${new_task}" >> "$GITHUB_OUTPUT"
+
+      - name: Update service
+        id: update
+        env:
+          CLUSTER: ${{ inputs.cluster }}
+          SERVICE: ${{ inputs.service }}
+          DESIRED: ${{ inputs['desired-count'] }}
+          WAIT: ${{ inputs['wait-for-stable'] }}
+        run: |
+          set -euo pipefail
+          task_def="${{ steps.register.outputs.task-def-arn }}"
+          if [ -z "$task_def" ]; then
+            echo "::error::Task definition ARN missing" >&2
+            exit 1
+          fi
+          args=(aws ecs update-service --cluster "$CLUSTER" --service "$SERVICE" --task-definition "$task_def" --force-new-deployment)
+          if [ -n "$DESIRED" ]; then
+            args+=(--desired-count "$DESIRED")
+          fi
+          update_output=$("${args[@]}")
+          echo "$update_output" > update.json
+          service_arn=$(jq -r '.service.serviceArn' update.json)
+          echo "service-arn=${service_arn}" >> "$GITHUB_OUTPUT"
+          if [ "$WAIT" = "true" ]; then
+            aws ecs wait services-stable --cluster "$CLUSTER" --services "$SERVICE"
+          fi

--- a/.github/workflows/reusable-fly-deploy.yml
+++ b/.github/workflows/reusable-fly-deploy.yml
@@ -1,0 +1,126 @@
+name: Reusable Fly Deploy
+
+on:
+  workflow_call:
+    inputs:
+      app:
+        description: 'Fly.io application name'
+        required: true
+        type: string
+      image:
+        description: 'Optional image reference to deploy (skips local build when provided)'
+        required: false
+        type: string
+      config:
+        description: 'fly.toml path to use when building from the repository'
+        required: false
+        type: string
+        default: fly.toml
+      secrets:
+        description: 'Optional newline-separated KEY=VALUE secrets to stage before deploy'
+        required: false
+        type: string
+      strategy:
+        description: 'Deployment strategy passed to flyctl deploy'
+        required: false
+        type: string
+        default: rolling
+      release-command:
+        description: 'Optional release command executed after the deploy'
+        required: false
+        type: string
+      environment:
+        description: 'Environment name to associate with the deployment run'
+        required: false
+        type: string
+      detach:
+        description: 'Run deploy in detached mode so the workflow can continue once rollout starts'
+        required: false
+        type: boolean
+        default: true
+    secrets:
+      fly-api-token:
+        required: true
+        description: 'Personal access token or deploy token for the Fly.io organization'
+    outputs:
+      release-version:
+        description: 'Latest release version reported by Fly.io after the deploy'
+        value: ${{ jobs.deploy.outputs.release-version }}
+      app:
+        description: 'Fly.io application name that was deployed'
+        value: ${{ jobs.deploy.outputs.app }}
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy to Fly.io
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.environment != '' && inputs.environment || format('fly-{0}', inputs.app) }}
+    env:
+      FLY_API_TOKEN: ${{ secrets.fly-api-token }}
+    outputs:
+      release-version: ${{ steps.capture-release.outputs.release || '' }}
+      app: ${{ inputs.app }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        if: ${{ inputs.image == '' }}
+
+      - name: Set up flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@v1
+
+      - name: Stage secrets
+        if: ${{ inputs.secrets != '' }}
+        env:
+          APP: ${{ inputs.app }}
+          RAW_SECRETS: ${{ inputs.secrets }}
+        run: |
+          set -euo pipefail
+          mapfile -t secrets <<<"${RAW_SECRETS}"
+          args=()
+          for entry in "${secrets[@]}"; do
+            entry="${entry%%$'\r'}"
+            if [ -n "$entry" ]; then
+              args+=("$entry")
+            fi
+          done
+          if [ "${#args[@]}" -gt 0 ]; then
+            flyctl secrets set --app "$APP" --stage "${args[@]}"
+          fi
+
+      - name: Deploy application
+        id: deploy
+        env:
+          APP: ${{ inputs.app }}
+          IMAGE: ${{ inputs.image }}
+          CONFIG: ${{ inputs.config }}
+          STRATEGY: ${{ inputs.strategy }}
+          RELEASE_COMMAND: ${{ inputs['release-command'] }}
+          DETACH: ${{ inputs.detach }}
+        run: |
+          set -euo pipefail
+          cmd=(flyctl deploy --app "$APP" --strategy "$STRATEGY")
+          if [ -n "$IMAGE" ]; then
+            cmd+=(--image "$IMAGE")
+          else
+            cmd+=(--config "$CONFIG")
+          fi
+          if [ -n "$RELEASE_COMMAND" ]; then
+            cmd+=(--release-command "$RELEASE_COMMAND")
+          fi
+          if [ "$DETACH" = "true" ]; then
+            cmd+=(--detach)
+          fi
+          "${cmd[@]}"
+
+      - name: Capture latest release
+        id: capture-release
+        env:
+          APP: ${{ inputs.app }}
+        run: |
+          set -euo pipefail
+          release=$(flyctl releases list --app "$APP" --json | jq -r '.[0].Version' 2>/dev/null || true)
+          echo "release=${release}" >> "$GITHUB_OUTPUT"

--- a/AGENT_WORKBOARD.md
+++ b/AGENT_WORKBOARD.md
@@ -35,6 +35,10 @@
 ## Last Status Report
 <!-- Agents append latest status, error, or notifications here -->
 
+### 2025-10-06
+- Added reusable Fly.io and AWS ECS deployment workflows so CI jobs can hand off
+  releases to managed infrastructure targets directly.
+
 ### 2025-10-05
 - Reconciled "next" track selection: prioritizing deployment integrations so shipping work can land on managed infra with the current automation stack.
 - Drafted objectives covering environment manifests, multi-target deploy hooks, and infra-aware release guardrails to guide upcoming branch work.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -22,6 +22,23 @@ If not using a GitHub App, create a classic webhook pointing to `/api/webhooks/g
 - `main` → production
 - `staging` → staging
 
+## CI/CD workflows
+
+Release automation now leans on reusable GitHub workflows so service-specific
+pipelines stay small while still targeting the managed infrastructure footprint:
+
+- `.github/workflows/reusable-aws-ecs-deploy.yml` registers a fresh task
+  definition revision and forces an ECS deployment. Supply the ECS cluster,
+  service, and image along with credentials (preferably an IAM role) to push new
+  backend builds.
+- `.github/workflows/reusable-fly-deploy.yml` handles Fly.io rollouts. Provide
+  the Fly app name plus an image reference (or rely on `fly.toml`) and the
+  workflow will stage secrets and kick off the deploy.
+
+These workflows are referenced from the environment manifests in
+`environments/` so bots and humans alike know which automation path owns each
+target.
+
 ## Admin UI
 
 Serve `var/www/blackroad/admin/index.html` and access it. Enter the internal token to use deployment actions.

--- a/environments/production.yml
+++ b/environments/production.yml
@@ -52,6 +52,25 @@ automation:
         - CF_ZONE_ID
         - CF_API_TOKEN
         - SLACK_WEBHOOK_URL
+    - name: Fly.io deploy (reusable)
+      file: .github/workflows/reusable-fly-deploy.yml
+      triggers:
+        - workflow_call
+      summary: >-
+        Provides a shared Fly.io deploy harness so edge and bridge services can
+        push fresh images or configs using the same release guardrails.
+      secrets:
+        - FLY_API_TOKEN
+    - name: AWS ECS deploy (reusable)
+      file: .github/workflows/reusable-aws-ecs-deploy.yml
+      triggers:
+        - workflow_call
+      summary: >-
+        Registers a new task definition revision and forces an ECS deployment
+        for production services when invoked by release workflows.
+      secrets:
+        - AWS_PROD_DEPLOY_ROLE_ARN
+        - AWS_PROD_EXTERNAL_ID
 deployments:
   - service: marketing-site
     type: static-site

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -44,6 +44,16 @@ automation:
         without publishing DNS changes.
       secrets:
         - AWAKEN_SEED
+    - name: AWS ECS deploy (reusable)
+      file: .github/workflows/reusable-aws-ecs-deploy.yml
+      triggers:
+        - workflow_call
+      summary: >-
+        Registers a new task definition revision and forces an ECS deployment
+        for staging services when invoked by API or bridge pipelines.
+      secrets:
+        - AWS_STAGING_DEPLOY_ROLE_ARN
+        - AWS_STAGING_EXTERNAL_ID
 deployments:
   - service: marketing-site
     type: static-site


### PR DESCRIPTION
## Summary
- add reusable Fly.io and AWS ECS deployment workflows for managed infrastructure targets
- document the new automation in deployment runbooks and environment manifests
- log the status update on the agent workboard

## Testing
- not run (documentation and workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68f1f5fc4f888329a9d02cebb74263ba