### PR TITLE
chore: add infra release policy gates

### DIFF
--- a/README-OPS.md
+++ b/README-OPS.md
@@ -11,6 +11,13 @@ Bridge runs on :4000; nginx routes `/api` and `/ws`. Static web artifacts publis
 
 Reference the manifests whenever DNS, workflow, or Terraform parameters change so automation and runbooks stay aligned.
 
+Infrastructure pushes now run through the codified policy gate in
+`runbooks/examples/infra_release_policy.yaml`. The runbook checks that the
+Change Advisory Board workflow has approved the change, triggers the
+`.github/workflows/blackroad-deploy.yml` release, and falls back to
+`infra_release_rollback` so `scripts/rollback.sh` is exercised when health
+checks fail. Keep both runbooks handy during CAB reviews.
+
 ## Deployment workflows
 
 ### Preview (per PR)

--- a/environments/production.yml
+++ b/environments/production.yml
@@ -76,9 +76,18 @@ deployments:
 change_management:
   approvals:
     - .github/workflows/change-approve.yml
+  policy_gates:
+    - name: cab-approval
+      description: Change Advisory Board approval must clear via the change-approve workflow before promoting builds.
+      workflow: .github/workflows/change-approve.yml
+    - name: release-runbook
+      description: Execute the infra release runbook so rollbacks and notifications stay coordinated across teams.
+      runbook: runbooks/examples/infra_release_policy.yaml
   runbooks:
     - README-DEPLOY.md
     - README-OPS.md
+    - runbooks/examples/infra_release_policy.yaml
+    - runbooks/examples/infra_release_rollback.yaml
 observability:
   health_checks:
     - name: frontend

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -65,6 +65,10 @@ deployments:
 change_management:
   approvals:
     - .github/workflows/change-approve.yml
+  policy_gates:
+    - name: release-runbook
+      description: Run the infra release policy to coordinate verification and fast rollback while staging matures.
+      runbook: runbooks/examples/infra_release_policy.yaml
 observability:
   health_checks:
     - name: static-health

--- a/runbooks/examples/infra_release_policy.yaml
+++ b/runbooks/examples/infra_release_policy.yaml
@@ -1,0 +1,22 @@
+name: infra_release_policy
+steps:
+  - action: gate
+    params:
+      when: "change_approved('CAB')"
+      on_fail: "abort:missing_change_approval"
+  - action: notify
+    params:
+      channel: "#eng"
+      message: "Starting infrastructure release for {{ env }} / {{ service }}"
+  - action: trigger_workflow
+    params:
+      workflow: ".github/workflows/blackroad-deploy.yml"
+      ref: "{{ release_ref }}"
+  - action: gate
+    params:
+      when: "workflow_status == 'success'"
+      on_fail: "invoke:infra_release_rollback"
+  - action: notify
+    params:
+      channel: "#eng"
+      message: "Release complete for {{ env }} / {{ service }}"

--- a/runbooks/examples/infra_release_rollback.yaml
+++ b/runbooks/examples/infra_release_rollback.yaml
@@ -1,0 +1,19 @@
+name: infra_release_rollback
+steps:
+  - action: notify
+    params:
+      channel: "#eng"
+      message: "Rolling back infrastructure release for {{ env }} / {{ service }}"
+  - action: run_script
+    params:
+      path: "scripts/rollback.sh"
+      args:
+        - "latest"
+  - action: gate
+    params:
+      when: "last_exit_code == 0"
+      on_fail: "abort:rollback_failed"
+  - action: notify
+    params:
+      channel: "#eng"
+      message: "Rollback complete for {{ env }} / {{ service }}"


### PR DESCRIPTION
## Summary
- add infra release policy and rollback runbooks to codify CAB approval and recovery steps
- reference the new policy gate from staging and production environment manifests and ops guide

## Testing
- not run (docs and config updates only)


------
https://chatgpt.com/codex/tasks/task_e_68f1f6f0cfa48329bbf1850b6786c6f5