### PR TITLE
docs: expand environment manifests and rollback playbook

### DIFF
--- a/README-DEPLOY.md
+++ b/README-DEPLOY.md
@@ -69,6 +69,26 @@ left blank, the workflow checks `https://blackroad.io/health` and
 `https://blackroad.io/api/health` respectively. Provide alternate URLs if you
 are targeting a different host.
 
+## Canary + rollback workflows
+
+Production traffic now flows through paired workflows that mirror the
+environment manifest entries:
+
+- **deploy-canary** — build, publish, and shift a configurable percentage of
+  requests to the green target group while watching CloudWatch latency/5xx
+  baselines. Use this for quick spot checks or a single promotion.
+- **deploy-canary-ladder** — iterate through multiple percentages (defaults to
+  `1,50,100`) with soak times and automated rollback to blue if the metrics or
+  HTTP probes cross thresholds.
+- **Deploy & Self-Heal** — rsync to long-lived hosts, run
+  `scripts/deploy.sh`, and invoke the self-heal automation capable of rolling
+  back via Git or Docker. Useful when ECS or the webhook path is unhealthy.
+
+The secrets/variables called out in `environments/production.yml` must stay in
+sync with GitHub repository settings so these jobs can assume the correct AWS
+roles and reference the ALB listener or target groups. For step-by-step
+procedures, see [`docs/ops/rollback-forward.md`](docs/ops/rollback-forward.md).
+
 ## Related documentation
 
 - [`DEPLOYMENT.md`](DEPLOYMENT.md) — GitHub App setup, branch policy, and

--- a/docs/ops/rollback-forward.md
+++ b/docs/ops/rollback-forward.md
@@ -1,0 +1,63 @@
+# Production rollback & forward playbook
+
+The production manifest (`environments/production.yml`) documents automation and
+infrastructure wiring. This playbook translates those references into concrete
+steps for safely promoting a change or rolling back when the release pipeline
+flags regressions.
+
+## Canary ladder (forward deploy)
+
+1. Run the reusable **deploy-canary** workflow when you need a quick health
+   check with a specific percentage (1%, 5%, 10%, 50%, 100%).
+   - Ensure repository variables (`AWS_REGION`, `ECR_REPO`, `ECS_CLUSTER`,
+     `ECS_SERVICE`, `TG_BLUE_ARN`, `TG_GREEN_ARN`, `HTTPS_LISTENER_ARN`,
+     `APP_URL`, `ALB_ARN_SUFFIX`) are up to date.
+   - Provide the `AWS_ROLE_TO_ASSUME` secret with rights to push images and touch
+     ECS/ELB resources.
+   - Use the run output to confirm the ALB 5xx counts remain within baseline
+     tolerances before increasing traffic.
+2. Promote through multiple percentages by running **deploy-canary-ladder**.
+   - Leave the default step ladder (`1,50,100`) or supply your own comma
+     separated list.
+   - The ladder job performs curl probes and CloudWatch comparisons at each
+     step, automatically rolling back to the blue target group if the thresholds
+     are exceeded.
+3. Once the ladder finishes, leave the ALB listener at 100% green. The workflow
+   forces the final promotion but continues to emit status for observability and
+   incident review.
+
+## Rollback + legacy forward path
+
+1. Trigger **Deploy & Self-Heal** if ECS is degraded or automation is blocked.
+   - The workflow rsyncs the repository to the long-lived host identified by
+     `BR_HOST`, executes `scripts/deploy.sh`, and then runs the
+     `/usr/local/bin/self_heal.sh` routine with the configured endpoint list.
+   - Configure `ROLLOBACK_STRATEGY` (`git` or `docker`) and `ROLLOBACK_REF` so
+     the helper scripts know how to revert.
+2. If the self-heal routine fails, connect via SSH and run the same scripts to
+   diagnose the failing component. The automation leaves the repository at the
+   attempted ref so manual comparisons (`git status`, `git log -1`) are quick.
+3. After recovering, re-run the canary workflow so future deploys do not drift
+   away from the baseline container image.
+
+## Verification checklist
+
+Run these commands locally or through the workflow outputs to confirm the
+environment is healthy after either path:
+
+```bash
+curl -fsS https://blackroad.io/healthz >/dev/null
+curl -fsS https://api.blackroad.io/health >/dev/null
+aws ecs describe-services --cluster "$ECS_CLUSTER" --services "$ECS_SERVICE" --region us-west-2
+aws cloudwatch get-metric-statistics \
+  --namespace AWS/ApplicationELB \
+  --metric-name HTTPCode_ELB_5XX_Count \
+  --dimensions Name=LoadBalancer,Value=$ALB_ARN_SUFFIX \
+  --start-time "$(date -u -d '15 minutes ago' +%Y-%m-%dT%H:%M:%SZ)" \
+  --end-time "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --period 300 \
+  --statistics Sum
+```
+
+If the verification fails, re-run the ladder at a lower percentage or the
+self-heal workflow before attempting another promotion.

--- a/environments/preview.yml
+++ b/environments/preview.yml
@@ -50,6 +50,42 @@ automation:
         - PREVIEW_ENV_TF_LOCK_TABLE
         - SLACK_PREVIEW_CHANNEL
         - SLACK_BOT_TOKEN
+    - name: PR Preview Containers
+      file: .github/workflows/preview-containers.yml
+      triggers:
+        - pull_request (opened, reopened, synchronize, ready_for_review)
+      summary: >-
+        Builds and publishes GHCR container images for each PR, generating SBOMs
+        and vulnerability reports plus a sticky comment with pull instructions.
+    - name: Cleanup Preview Containers
+      file: .github/workflows/preview-containers-cleanup.yml
+      triggers:
+        - pull_request (closed)
+      summary: >-
+        Removes the GHCR image tags created for preview containers once the pull
+        request closes to avoid stale registries and unnecessary storage costs.
+    - name: preview-frontend-host
+      file: .github/workflows/preview-frontend-host.yml
+      triggers:
+        - pull_request (opened, reopened, synchronize, closed)
+      summary: >-
+        Provisions or tears down ECS services behind the dev.blackroad.io ALB for
+        frontend-only previews, wiring Route53 records and listener rules per PR.
+      secrets:
+        - AWS_ROLE_TO_ASSUME
+      variables:
+        - AWS_REGION
+        - ECR_REPO
+        - ECS_CLUSTER
+        - VPC_ID
+        - SUBNETS
+        - SERVICE_SG
+        - ALB_ARN
+        - HTTPS_LISTENER_ARN
+        - ALB_ZONE_ID
+        - ALB_DNS
+        - HOSTED_ZONE_ID
+        - CONTAINER_PORT
 deployments:
   - service: web-console
     type: container-service

--- a/environments/production.yml
+++ b/environments/production.yml
@@ -52,6 +52,64 @@ automation:
         - CF_ZONE_ID
         - CF_API_TOKEN
         - SLACK_WEBHOOK_URL
+    - name: deploy-canary
+      file: .github/workflows/deploy-canary.yml
+      triggers:
+        - push (main)
+        - workflow_dispatch (canary percent input)
+      summary: >-
+        Builds a fresh container image, pushes to ECR, updates the ECS service,
+        and shifts a configurable percentage of traffic through the green target
+        group while watching CloudWatch metrics for regression.
+      secrets:
+        - AWS_ROLE_TO_ASSUME
+      variables:
+        - AWS_REGION
+        - ECR_REPO
+        - ECS_CLUSTER
+        - ECS_SERVICE
+        - TG_BLUE_ARN
+        - TG_GREEN_ARN
+        - HTTPS_LISTENER_ARN
+        - APP_URL
+        - ALB_ARN_SUFFIX
+    - name: deploy-canary-ladder
+      file: .github/workflows/deploy-canary-ladder.yml
+      triggers:
+        - workflow_dispatch (steps + soak configuration)
+      summary: >-
+        Automates a progressive promotion through multiple canary percentages,
+        running health and CloudWatch checks at each step and rolling back to
+        blue on failure.
+      secrets:
+        - AWS_ROLE_TO_ASSUME
+      variables:
+        - AWS_REGION
+        - ECR_REPO
+        - ECS_CLUSTER
+        - ECS_SERVICE
+        - TG_BLUE_ARN
+        - TG_GREEN_ARN
+        - HTTPS_LISTENER_ARN
+        - APP_URL
+        - ALB_ARN_SUFFIX
+        - API_URL
+    - name: Deploy & Self-Heal
+      file: .github/workflows/deploy-self-heal.yml
+      triggers:
+        - push (main)
+      summary: >-
+        Rsyncs the repo to long-lived hosts, runs the legacy deploy script, and
+        executes the self-heal routine that can roll back via git or Docker when
+        the health probes fail.
+      secrets:
+        - BR_HOST
+        - BR_USER
+        - BR_SSH_KEY
+      variables:
+        - optional HEALTH_ENDPOINTS list
+        - ROLLBACK_STRATEGY
+        - ROLLBACK_REF
 deployments:
   - service: marketing-site
     type: static-site
@@ -67,6 +125,11 @@ deployments:
     provider: aws-ecs-fargate
     terraform_directory: br-infra-iac/envs/prod
     module: modules/ecs-service-alb
+    terraform_backend:
+      bucket: br-tfstate-<unique>
+      key: prod/terraform.tfstate
+      region: us-west-2
+      lock_table: br-terraform-lock
     state: planned
     notes: >-
       Production wiring follows the dev module that provisions api.blackroad.io
@@ -79,6 +142,7 @@ change_management:
   runbooks:
     - README-DEPLOY.md
     - README-OPS.md
+    - docs/ops/rollback-forward.md
 observability:
   health_checks:
     - name: frontend
@@ -87,3 +151,12 @@ observability:
       url: https://api.blackroad.io/health
   scripts:
     - scripts/blackroad-autoheal.sh
+  verification:
+    - curl -fsS https://blackroad.io/healthz >/dev/null
+    - curl -fsS https://api.blackroad.io/health >/dev/null
+    - aws ecs describe-services --cluster "$ECS_CLUSTER" --services "$ECS_SERVICE" \
+        --region us-west-2
+    - aws cloudwatch get-metric-statistics --namespace AWS/ApplicationELB \
+        --metric-name HTTPCode_ELB_5XX_Count --dimensions Name=LoadBalancer,Value=$ALB_ARN_SUFFIX \
+        --start-time "$(date -u -d '15 minutes ago' +%Y-%m-%dT%H:%M:%SZ)" \
+        --end-time "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --period 300 --statistics Sum

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -44,6 +44,18 @@ automation:
         without publishing DNS changes.
       secrets:
         - AWAKEN_SEED
+    - name: Stage Stress (safe)
+      file: .github/workflows/stage-stress.yml
+      triggers:
+        - workflow_dispatch (with STRESS toggle)
+        - push (stage, paths: blackroad-stage/**)
+      summary: >-
+        Runs guarded load tests against stage.blackroad.io using autocannon to
+        validate that recent deploys and infrastructure wiring hold up under
+        concurrent traffic.
+      notes: >-
+        Requires operators to explicitly opt in via the STRESS input so casual
+        pushes do not overload the environment.
 deployments:
   - service: marketing-site
     type: static-site
@@ -58,6 +70,11 @@ deployments:
     type: container-service
     provider: aws-ecs-fargate
     terraform_directory: br-infra-iac/envs/stg
+    terraform_backend:
+      bucket: br-tfstate-<unique>
+      key: stg/terraform.tfstate
+      region: us-west-2
+      lock_table: br-terraform-lock
     state: planned
     notes: >-
       Network, ECS, and RDS resources are defined; service wiring will follow the
@@ -69,3 +86,8 @@ observability:
   health_checks:
     - name: static-health
       url: https://stage.blackroad.io/health.json
+  verification:
+    - curl -fsS https://stage.blackroad.io/ >/dev/null
+    - curl -fsS https://stage.blackroad.io/health.json >/dev/null
+    - aws ecs describe-clusters --cluster $(terraform output -raw ecs_cluster) \
+        --region us-west-2


### PR DESCRIPTION
## Summary
- document additional workflows, terraform backends, and verification commands across staging, preview, and production environment manifests
- add a rollback/forward playbook clarifying how to use the canary and self-heal workflows and link it from the deploy README

## Testing
- not run (docs-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68f1f83354e0832995ec489b7fcb9e3f