### PR TITLE
feat: let worker bot assign tasks

### DIFF
--- a/AGENT_WORKBOARD.md
+++ b/AGENT_WORKBOARD.md
@@ -9,7 +9,6 @@
   - Extend release runbooks with rollback/forward procedures and policy gates for infra changes.
 
 ## To Do
-- [ ] Deploy site (`WebsiteBot`)
 - [ ] Build site (`BuildBlackRoadSiteAgent`)
 - [ ] Clean up merged branches (`CleanupBot`)
 - [ ] Format/validate web files (`WebberBot`)
@@ -24,6 +23,7 @@
 ## In Progress
 <!-- Agents move tasks here when running -->
 
+- [ ] Deploy site (`WebsiteBot`) (owner: WorkerBot)
 ## Blocked
 <!-- Agents move tasks here if they fail, with error info -->
 

--- a/agents/job_board.py
+++ b/agents/job_board.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 
 
 class JobBoard:
-    """Read and provide tasks from ``AGENT_WORKBOARD.md``."""
+    """Read and manipulate tasks from ``AGENT_WORKBOARD.md``."""
 
     def __init__(self, path: Optional[Path] = None) -> None:
         self.path = path or Path(__file__).resolve().parents[1] / "AGENT_WORKBOARD.md"
@@ -32,6 +32,63 @@ class JobBoard:
         """Return the next pending task or ``None`` if none exist."""
         tasks = self.tasks()
         return tasks[0] if tasks else None
+
+    def assign_next_task(self, assignee: str) -> Optional[str]:
+        """Move the next task into the "In Progress" section with the given assignee.
+
+        Returns the task description, or ``None`` if no tasks remain.
+        """
+
+        lines = self.path.read_text().splitlines()
+
+        todo_start: Optional[int] = None
+        todo_end: Optional[int] = None
+        in_progress_start: Optional[int] = None
+
+        for idx, line in enumerate(lines):
+            if line.startswith("## To Do"):
+                todo_start = idx + 1
+                continue
+            if line.startswith("## In Progress"):
+                in_progress_start = idx
+                if todo_start is not None and todo_end is None:
+                    todo_end = idx
+                continue
+            if line.startswith("##") and todo_start is not None and todo_end is None:
+                todo_end = idx
+
+        if todo_start is None:
+            return None
+        if todo_end is None:
+            todo_end = len(lines)
+        if in_progress_start is None:
+            return None
+
+        task_line_index: Optional[int] = None
+        task_text: Optional[str] = None
+        for idx in range(todo_start, todo_end):
+            line = lines[idx]
+            if line.strip().startswith("- [ ]"):
+                task_line_index = idx
+                task_text = line.split("]", 1)[1].strip()
+                break
+
+        if task_line_index is None or task_text is None:
+            return None
+
+        del lines[task_line_index]
+
+        insert_idx = in_progress_start + 1
+        while insert_idx < len(lines) and lines[insert_idx].strip().startswith("<!--"):
+            insert_idx += 1
+        while insert_idx < len(lines) and lines[insert_idx].strip() == "":
+            insert_idx += 1
+
+        assignment_line = f"- [ ] {task_text} (owner: {assignee})"
+        lines.insert(insert_idx, assignment_line)
+
+        self.path.write_text("\n".join(lines) + "\n")
+        return task_text
 
 
 if __name__ == "__main__":

--- a/agents/worker_bot.py
+++ b/agents/worker_bot.py
@@ -20,9 +20,13 @@ class WorkerBot:
         self.name = name
 
     def work(self) -> str:
-        """Return the task the bot will work on or ``"idle"``."""
+        """Assign the next available task and return its description.
+
+        If no tasks remain, ``"idle"`` is returned.
+        """
+
         board = JobBoard()
-        task: Optional[str] = board.next_task()
+        task: Optional[str] = board.assign_next_task(self.name)
         return task or "idle"
 
 


### PR DESCRIPTION
## Summary
- extend the job board helper so it can move the next to-do item into the In Progress section and tag the assignee
- update WorkerBot to claim tasks via the new helper and surface the assigned work
- reflect the WorkerBot assignment in `AGENT_WORKBOARD.md`

## Testing
- python agents/worker_bot.py
- python -m py_compile agents/job_board.py agents/worker_bot.py
- python -m py_compile agents/*.py *(fails: existing indentation error in agents/auto_novel_agent.py)*

------
https://chatgpt.com/codex/tasks/task_e_68f1f95a58b88329bb846d19d3093bb1