### PR TITLE
fix: guard capture_snapshot phase drift calculation

### DIFF
--- a/lucidia_math_lab/iterative_math_build.py
+++ b/lucidia_math_lab/iterative_math_build.py
@@ -102,6 +102,9 @@ def capture_snapshot(
     reference them the next time the "Next!" impulse hits.
     """
 
+    if pulses < 2:
+        raise ValueError("pulses must be at least 2 to compute phase drift")
+
     pulse_levels = iterate_logistic_loop(gain=gain, seed_level=seed_level, pulses=pulses)
     phase_drift = pulse_levels[-1] - pulse_levels[-2]
     mean_level = fmean(pulse_levels)

--- a/tests/test_iterative_math_build.py
+++ b/tests/test_iterative_math_build.py
@@ -1,0 +1,40 @@
+"""Tests for :mod:`lucidia_math_lab.iterative_math_build`."""
+
+from __future__ import annotations
+
+import sys
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from statistics import fmean
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "lucidia_math_lab" / "iterative_math_build.py"
+SPEC = spec_from_file_location("iterative_math_build", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+_module = module_from_spec(SPEC)
+sys.modules[SPEC.name] = _module
+SPEC.loader.exec_module(_module)
+
+capture_snapshot = _module.capture_snapshot
+
+
+def test_capture_snapshot_requires_two_pulses() -> None:
+    """A snapshot needs at least two pulses to compute phase drift."""
+
+    with pytest.raises(ValueError, match="at least 2"):
+        capture_snapshot(pulses=1)
+
+
+def test_capture_snapshot_computes_summary_metrics() -> None:
+    """Snapshot contains derived metrics consistent with the captured pulses."""
+
+    pulses = 5
+    snapshot = capture_snapshot(pulses=pulses, gain=3.8, seed_level=0.3, tag_prefix="test_run")
+
+    assert len(snapshot.pulse_levels) == pulses
+    assert snapshot.phase_drift == pytest.approx(
+        snapshot.pulse_levels[-1] - snapshot.pulse_levels[-2]
+    )
+    assert snapshot.mean_level == pytest.approx(fmean(snapshot.pulse_levels))
+    assert snapshot.tag.startswith("test_run_")


### PR DESCRIPTION
# Pull Request

## Summary
- Guard logistic snapshot capture against insufficient pulses to avoid indexing errors and add coverage.

## Checks
- [ ] CI green
- [ ] API /api/health returns 200
- [x] Updated docs/tests as needed
- [ ] Does this change alter power distribution?

## Changes
- Files changed (bullet list):
  - lucidia_math_lab/iterative_math_build.py
  - tests/test_iterative_math_build.py
- Why these changes were made:
  - Prevent phase drift calculation from indexing a missing prior pulse and cover behaviour with new pytest cases.

## Checklist (required for PRs created by automation)
- [ ] Lint: `npm run lint` (document any auto-fixes)
- [ ] Tests: `npm test` (list failing tests if any)
- [ ] Dependency hygiene: if you added new imports, run `node tools/dep-scan.js --dir <package> --save` (commit only the tool output)
- [ ] Env vars: added/changed? If yes, update `srv/blackroad-api/.env.example` and document defaults
- [ ] Ports/compose changes? If yes, update `ops/install.sh` and `docker-compose*.yml`
- [x] Secrets: no secrets in the diff

## Commands I ran locally
```
python -m pytest -c /dev/null tests/test_iterative_math_build.py
```

## Notes for reviewers
- Added targeted pytest invocation using an alternate config to avoid the invalid `pyproject.toml` metadata error during collection.

# Summary

## Quick pulse
- [x] Impact assessed (customer, ops, or security)
- [x] Risk call-out (low)
- [ ] Rollback or feature flag noted

## Optional Ops
- [ ] Added or updated dashboards / alerts
- [ ] Announced in release notes or status channel
- [ ] Coordinated with on-call / runbook owners

## Next steps
- [ ] Follow-up issue linked (if needed)
- [ ] Docs updated or slated for update
- [x] Tests or benchmarks captured

### Context
- What changed and why?
  - Guarded logistic snapshot capture when fewer than two pulses are requested and added regression coverage.
- Anything reviewers should focus on?
  - Pytest uses explicit module loading to avoid package import errors from the wider lab package.

# Testing
- Local build passes (not run)
- `npm run build` (site) / API boots (not run)
- E2E (Playwright) green (not run)

# Checklist
- Docs/README updated if needed
- [x] No secrets committed
- Labels added (area/site, area/api, etc.)

------
https://chatgpt.com/codex/tasks/task_e_68f1fa04b8f48329a0bdd764c24bbe31