### PR TITLE
feat: add ecs deployment workflows

### DIFF
--- a/.github/workflows/blackroad-api-ecs.yml
+++ b/.github/workflows/blackroad-api-ecs.yml
@@ -1,0 +1,82 @@
+name: BlackRoad API • ECS Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Target environment to deploy
+        required: true
+        type: choice
+        options:
+          - staging
+          - production
+      image:
+        description: Optional container image reference (defaults to ghcr.io/blackboxprogramming/blackroad-api:<sha>)
+        required: false
+        type: string
+      wait-for-service-stability:
+        description: Wait for the ECS service to report healthy
+        required: false
+        type: boolean
+        default: true
+  workflow_call:
+    inputs:
+      environment:
+        description: Target environment to deploy
+        required: true
+        type: string
+      image:
+        description: Optional container image reference
+        required: false
+        type: string
+      wait-for-service-stability:
+        description: Wait for the ECS service to report healthy
+        required: false
+        type: boolean
+        default: true
+    secrets:
+      AWS_ROLE_TO_ASSUME:
+        description: Optional role ARN to assume during deployment
+        required: false
+      ECS_CLUSTER:
+        description: Optional override for the target ECS cluster
+        required: false
+      ECS_SERVICE:
+        description: Optional override for the target ECS service
+        required: false
+      ECS_CONTAINER:
+        description: Optional override for the ECS container name
+        required: false
+
+permissions:
+  contents: read
+
+env:
+  DEFAULT_IMAGE: ghcr.io/blackboxprogramming/blackroad-api
+
+jobs:
+  staging:
+    if: ${{ inputs.environment == 'staging' }}
+    uses: ./.github/workflows/reusable-ecs-service-deploy.yml
+    with:
+      aws-region: us-west-2
+      image: ${{ inputs.image || format('%s:%s', env.DEFAULT_IMAGE, github.sha) }}
+      wait-for-service-stability: ${{ inputs['wait-for-service-stability'] }}
+    secrets:
+      aws-role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME || secrets.STAGING_AWS_DEPLOY_ROLE_ARN }}
+      ECS_CLUSTER: ${{ secrets.ECS_CLUSTER || secrets.STAGING_ECS_CLUSTER }}
+      ECS_SERVICE: ${{ secrets.ECS_SERVICE || secrets.STAGING_ECS_SERVICE }}
+      ECS_CONTAINER: ${{ secrets.ECS_CONTAINER || secrets.STAGING_ECS_CONTAINER }}
+
+  production:
+    if: ${{ inputs.environment == 'production' }}
+    uses: ./.github/workflows/reusable-ecs-service-deploy.yml
+    with:
+      aws-region: us-west-2
+      image: ${{ inputs.image || format('%s:%s', env.DEFAULT_IMAGE, github.sha) }}
+      wait-for-service-stability: ${{ inputs['wait-for-service-stability'] }}
+    secrets:
+      aws-role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME || secrets.PROD_AWS_DEPLOY_ROLE_ARN }}
+      ECS_CLUSTER: ${{ secrets.ECS_CLUSTER || secrets.PROD_ECS_CLUSTER }}
+      ECS_SERVICE: ${{ secrets.ECS_SERVICE || secrets.PROD_ECS_SERVICE }}
+      ECS_CONTAINER: ${{ secrets.ECS_CONTAINER || secrets.PROD_ECS_CONTAINER }}

--- a/.github/workflows/reusable-ecs-service-deploy.yml
+++ b/.github/workflows/reusable-ecs-service-deploy.yml
@@ -1,0 +1,135 @@
+name: Reusable ECS Service Deploy
+
+on:
+  workflow_call:
+    inputs:
+      aws-region:
+        description: AWS region for ECS operations
+        required: true
+        type: string
+      image:
+        description: Container image reference to deploy
+        required: true
+        type: string
+      wait-for-service-stability:
+        description: Wait for the ECS service to stabilise after the update
+        required: false
+        type: boolean
+        default: true
+    secrets:
+      aws-access-key-id:
+        description: Optional AWS access key ID when not assuming a role
+        required: false
+      aws-secret-access-key:
+        description: Optional AWS secret access key when not assuming a role
+        required: false
+      aws-session-token:
+        description: Optional AWS session token for temporary credentials
+        required: false
+      aws-role-to-assume:
+        description: Optional IAM role ARN to assume for deployment
+        required: false
+      ECS_CLUSTER:
+        description: Target ECS cluster name or ARN
+        required: true
+      ECS_SERVICE:
+        description: Target ECS service name
+        required: true
+      ECS_CONTAINER:
+        description: Container name within the task definition to update
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Update ECS service
+    runs-on: ubuntu-latest
+    outputs:
+      task-definition-arn: ${{ steps.deploy.outputs.task-definition-arn }}
+    env:
+      AWS_REGION: ${{ inputs.aws-region }}
+      CLUSTER: ${{ secrets.ECS_CLUSTER }}
+      SERVICE: ${{ secrets.ECS_SERVICE }}
+      CONTAINER_NAME: ${{ secrets.ECS_CONTAINER }}
+      IMAGE: ${{ inputs.image }}
+      WAIT_FOR_STABILITY: ${{ inputs['wait-for-service-stability'] }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ inputs.aws-region }}
+          role-to-assume: ${{ secrets.aws-role-to-assume }}
+          aws-access-key-id: ${{ secrets.aws-access-key-id }}
+          aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
+          aws-session-token: ${{ secrets.aws-session-token }}
+
+      - name: Update task definition and service
+        id: deploy
+        run: |
+          set -euo pipefail
+
+          if [ -z "$CLUSTER" ] || [ -z "$SERVICE" ] || [ -z "$CONTAINER_NAME" ]; then
+            echo "Cluster, service, and container name must be provided via secrets." >&2
+            exit 1
+          fi
+
+          if [ -z "$IMAGE" ]; then
+            echo "An image reference must be supplied." >&2
+            exit 1
+          fi
+
+          echo "Fetching current task definition for $SERVICE"
+          TASK_DEF_ARN=$(aws ecs describe-services --cluster "$CLUSTER" --services "$SERVICE" --query 'services[0].taskDefinition' --output text)
+
+          if [ "$TASK_DEF_ARN" = "None" ] || [ -z "$TASK_DEF_ARN" ]; then
+            echo "Unable to resolve task definition for service $SERVICE on cluster $CLUSTER" >&2
+            exit 1
+          fi
+
+          aws ecs describe-task-definition --task-definition "$TASK_DEF_ARN" --include TAGS > task-def.json
+
+          echo "Rendering new task definition revision"
+          jq --arg container "$CONTAINER_NAME" --arg image "$IMAGE" '(
+            .taskDefinition
+            | del(
+                .taskDefinitionArn,
+                .revision,
+                .status,
+                .requiresAttributes,
+                .compatibilities,
+                .registeredAt,
+                .registeredBy
+              )
+            | .containerDefinitions = (
+                .containerDefinitions
+                | map(if .name == $container then .image = $image else . end)
+              )
+          ) + { tags: (.tags // []) }' task-def.json > rendered-task-def.json
+
+          if ! jq -e --arg container "$CONTAINER_NAME" '.containerDefinitions | map(select(.name == $container)) | length == 1' rendered-task-def.json >/dev/null; then
+            echo "Container $CONTAINER_NAME not found in task definition." >&2
+            exit 1
+          fi
+
+          echo "Registering new task definition revision"
+          NEW_TASK_DEF_ARN=$(aws ecs register-task-definition --cli-input-json file://rendered-task-def.json --query 'taskDefinition.taskDefinitionArn' --output text)
+
+          echo "Updating service $SERVICE to use $NEW_TASK_DEF_ARN"
+          aws ecs update-service --cluster "$CLUSTER" --service "$SERVICE" --task-definition "$NEW_TASK_DEF_ARN" --force-new-deployment >/dev/null
+
+          if [ "${WAIT_FOR_STABILITY,,}" != "false" ]; then
+            echo "Waiting for service to stabilise"
+            aws ecs wait services-stable --cluster "$CLUSTER" --services "$SERVICE"
+          else
+            echo "Skipping wait for service stability"
+          fi
+
+          echo "task-definition-arn=$NEW_TASK_DEF_ARN" >> "$GITHUB_OUTPUT"
+
+          rm -f task-def.json rendered-task-def.json
+
+      - name: Show deployed revision
+        run: |
+          echo "Updated task definition: ${{ steps.deploy.outputs.task-definition-arn }}"

--- a/README-DEPLOY.md
+++ b/README-DEPLOY.md
@@ -36,6 +36,39 @@ Add the following Action secrets/variables under
 4. Revalidates `/healthz` and `/api/version` before marking the run successful.
 5. Posts a Slack summary when `SLACK_WEBHOOK_URL` is available.
 
+## API ECS deployments
+
+Use `.github/workflows/blackroad-api-ecs.yml` when you need to roll out the API
+service onto AWS ECS. The workflow wraps the reusable
+`reusable-ecs-service-deploy.yml` helper so other pipelines can call it with
+`workflow_call`, while the manual dispatch path provides an operator-friendly
+form in the Actions UI.
+
+### Required secrets and variables
+
+Configure the following repository secrets for each environment:
+
+- `STAGING_AWS_DEPLOY_ROLE_ARN` / `PROD_AWS_DEPLOY_ROLE_ARN` — IAM roles that
+  grant the workflow permission to register task definitions and update the
+  service.
+- `STAGING_ECS_CLUSTER` / `PROD_ECS_CLUSTER` — ECS cluster names or ARNs.
+- `STAGING_ECS_SERVICE` / `PROD_ECS_SERVICE` — Service identifiers to update.
+- `STAGING_ECS_CONTAINER` / `PROD_ECS_CONTAINER` — Container names within the
+  task definition whose image should be replaced.
+
+If another workflow invokes `blackroad-api-ecs.yml` with its own
+`workflow_call` block, it can pass alternative credentials or ECS identifiers by
+providing the optional secrets `AWS_ROLE_TO_ASSUME`, `ECS_CLUSTER`,
+`ECS_SERVICE`, and `ECS_CONTAINER`.
+
+### Dispatch inputs
+
+- `environment` — `staging` or `production` to select the secret set.
+- `image` — Optional image reference. Defaults to
+  `ghcr.io/blackboxprogramming/blackroad-api:<sha>` when left blank.
+- `wait-for-service-stability` — Defaults to `true`. Set to `false` to skip the
+  `aws ecs wait services-stable` step when running parallel smoke tests.
+
 ## Legacy SSH fallback
 
 The historical SSH pipeline still exists as a manual job. Trigger it from the

--- a/environments/production.yml
+++ b/environments/production.yml
@@ -52,6 +52,19 @@ automation:
         - CF_ZONE_ID
         - CF_API_TOKEN
         - SLACK_WEBHOOK_URL
+    - name: BlackRoad API • ECS Deploy
+      file: .github/workflows/blackroad-api-ecs.yml
+      triggers:
+        - workflow_dispatch
+        - workflow_call
+      summary: >-
+        Uses the reusable ECS deployment workflow to roll out the API service on
+        Fargate and optionally waits for stability checks to pass.
+      secrets:
+        - PROD_AWS_DEPLOY_ROLE_ARN
+        - PROD_ECS_CLUSTER
+        - PROD_ECS_SERVICE
+        - PROD_ECS_CONTAINER
 deployments:
   - service: marketing-site
     type: static-site

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -44,6 +44,19 @@ automation:
         without publishing DNS changes.
       secrets:
         - AWAKEN_SEED
+    - name: BlackRoad API • ECS Deploy
+      file: .github/workflows/blackroad-api-ecs.yml
+      triggers:
+        - workflow_dispatch
+        - workflow_call
+      summary: >-
+        Promotes a container image to the staging ECS service using the reusable
+        deployment workflow and waits for service stability by default.
+      secrets:
+        - STAGING_AWS_DEPLOY_ROLE_ARN
+        - STAGING_ECS_CLUSTER
+        - STAGING_ECS_SERVICE
+        - STAGING_ECS_CONTAINER
 deployments:
   - service: marketing-site
     type: static-site


### PR DESCRIPTION
# Pull Request

## Summary
- Add reusable ECS deployment workflow and top-level orchestrator for staging and production API releases.
- Document secrets and automation wiring for the new pipeline in ops runbooks and environment manifests.

## Checks
- [ ] CI green
- [ ] API /api/health returns 200
- [x] Updated docs/tests as needed
- [ ] Does this change alter power distribution? (No)

## Changes
- Files changed (bullet list):
  - Added `.github/workflows/reusable-ecs-service-deploy.yml` to register refreshed task definitions and roll services forward.
  - Added `.github/workflows/blackroad-api-ecs.yml` to target staging or production with shared deployment logic.
  - Updated `README-DEPLOY.md`, `README-OPS.md`, and environment manifests with the new automation and secret expectations.
- Why these changes were made:
  - Provide a reusable, auditable path for promoting API containers onto ECS while keeping operator documentation in sync.

## Checklist (required for PRs created by automation)
- [ ] Lint: `npm run lint`
- [ ] Tests: `npm test`
- [ ] Dependency hygiene: if you added new imports, run `node tools/dep-scan.js --dir <package> --save`
- [ ] Env vars: added/changed? If yes, update `srv/blackroad-api/.env.example` and document defaults
- [ ] Ports/compose changes? If yes, update `ops/install.sh` and `docker-compose*.yml`
- [x] Secrets: no secrets in the diff

## Commands I ran locally
```bash
# not run (workflow and documentation updates only)
```

## Notes for reviewers
- Focus on the workflow secret wiring and manifest references to ensure the new automation lines up with staged infrastructure.


------
https://chatgpt.com/codex/tasks/task_e_68f1f9ed2fdc8329bfed7d98b97475bb