### PR TITLE
Create blackroad.com login hub

### DIFF
--- a/sites/blackroad-next/app/globals.css
+++ b/sites/blackroad-next/app/globals.css
@@ -1,1 +1,110 @@
-html,body{margin:0;padding:0;font-family:Inter,system-ui,sans-serif;}
+:root {
+  color-scheme: dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #0b0d0f;
+  color: #e6e8ea;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  background: #0b0d0f;
+  color: #e6e8ea;
+  display: grid;
+  place-items: center;
+  padding: 24px 16px;
+}
+
+a {
+  color: inherit;
+}
+
+.hub-page {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.hub-card {
+  background: #121417;
+  padding: 32px;
+  border-radius: 16px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
+  max-width: 460px;
+  width: min(92%, 460px);
+}
+
+.hub-card h1 {
+  font-size: 1.5rem;
+  margin: 0 0 8px;
+}
+
+.hub-lead {
+  margin: 0 0 24px;
+  opacity: 0.8;
+}
+
+.hub-btn {
+  display: block;
+  text-align: center;
+  padding: 12px 16px;
+  border-radius: 10px;
+  text-decoration: none;
+  margin: 8px 0;
+  border: 1px solid #2a2f36;
+  transition: transform 0.15s ease, border-color 0.15s ease, background-color 0.15s ease, color 0.15s ease;
+  font-weight: 500;
+}
+
+.hub-btn:hover,
+.hub-btn:focus-visible {
+  transform: translateY(-1px);
+  border-color: #3a4049;
+}
+
+.hub-btn.primary {
+  background: #e6e8ea;
+  color: #0b0d0f;
+  font-weight: 600;
+}
+
+.hub-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.hub-row .hub-btn {
+  flex: 1 1 160px;
+}
+
+.hub-muted {
+  opacity: 0.7;
+  font-size: 0.875rem;
+  margin-top: 16px;
+}
+
+.hub-muted a {
+  color: inherit;
+  text-decoration: underline;
+}
+
+@media (max-width: 480px) {
+  body {
+    padding: 16px;
+  }
+
+  .hub-card {
+    padding: 28px 24px;
+  }
+}

--- a/sites/blackroad-next/app/layout.tsx
+++ b/sites/blackroad-next/app/layout.tsx
@@ -1,9 +1,25 @@
 import './globals.css';
+import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
 
-export const metadata = {
-  title: 'BlackRoad',
-  description: '[NEEDS VERIFICATION]'
+export const metadata: Metadata = {
+  title: {
+    default: 'Blackroad',
+    template: '%s | Blackroad'
+  },
+  description: 'Login hub for Blackroad accounts.',
+  metadataBase: new URL('https://blackroad.com'),
+  openGraph: {
+    title: 'Blackroad',
+    description: 'Login hub for Blackroad accounts.',
+    url: 'https://blackroad.com/',
+    siteName: 'Blackroad'
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Blackroad',
+    description: 'Login hub for Blackroad accounts.'
+  }
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {

--- a/sites/blackroad-next/app/page.tsx
+++ b/sites/blackroad-next/app/page.tsx
@@ -1,8 +1,93 @@
+import type { Metadata } from 'next';
+
+const idpDomain = process.env.NEXT_PUBLIC_IDP_DOMAIN ?? 'id.blackroadinc.us';
+const clientId = process.env.NEXT_PUBLIC_IDP_CLIENT_ID;
+const redirectUri = process.env.NEXT_PUBLIC_IDP_REDIRECT ?? 'https://blackroad.com/auth/callback';
+const scope = process.env.NEXT_PUBLIC_IDP_SCOPE ?? 'openid email profile';
+const authorizePath = process.env.NEXT_PUBLIC_IDP_AUTHORIZE_PATH ?? 'oauth2/default/v1/authorize';
+const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'https://app.blackroad.io';
+const statusUrl = process.env.NEXT_PUBLIC_STATUS_URL ?? 'https://status.blackroad.io';
+const magicLinkUrl = process.env.NEXT_PUBLIC_MAGIC_LINK_URL;
+const contact = process.env.NEXT_PUBLIC_ACCESS_EMAIL ?? 'it@blackroad.com';
+
+const contactHref = contact.startsWith('mailto:') || !contact.includes('@')
+  ? contact
+  : `mailto:${contact}`;
+
+const buildAuthorizeUrl = (forcePrompt = false) => {
+  if (!clientId) {
+    const loginUrl = new URL(`https://${idpDomain}/login/login.htm`);
+    loginUrl.searchParams.set('fromURI', '/app/UserHome');
+    if (forcePrompt) {
+      loginUrl.searchParams.set('prompt', 'login');
+    }
+    return loginUrl.toString();
+  }
+
+  const authorizeUrl = new URL(`https://${idpDomain}/${authorizePath}`);
+  authorizeUrl.searchParams.set('client_id', clientId);
+  authorizeUrl.searchParams.set('redirect_uri', redirectUri);
+  authorizeUrl.searchParams.set('response_type', 'code');
+  authorizeUrl.searchParams.set('scope', scope);
+  if (forcePrompt) {
+    authorizeUrl.searchParams.set('prompt', 'login');
+  }
+  return authorizeUrl.toString();
+};
+
+const primarySsoUrl = buildAuthorizeUrl();
+const companyAccountUrl = buildAuthorizeUrl(true);
+const emailMagicLinkUrl = magicLinkUrl ?? contactHref;
+
+export const metadata: Metadata = {
+  title: 'Login',
+  description: 'Central login hub for all Blackroad environments.',
+  alternates: { canonical: 'https://blackroad.com/' },
+  openGraph: {
+    title: 'Blackroad — Login',
+    description: 'Central login hub for all Blackroad environments.',
+    url: 'https://blackroad.com/'
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Blackroad — Login',
+    description: 'Central login hub for all Blackroad environments.'
+  }
+};
+
 export default function Page() {
   return (
-    <main>
-      <h1>BlackRoad</h1>
-      <p>[NEEDS VERIFICATION]</p>
-    </main>
+    <div className="hub-page">
+      <main className="hub-card">
+        <h1>Blackroad</h1>
+        <p className="hub-lead">Central login for all environments.</p>
+
+        <a className="hub-btn primary" href={primarySsoUrl}>
+          Sign in with SSO
+        </a>
+
+        <div className="hub-row">
+          <a className="hub-btn" href={companyAccountUrl}>
+            Use Company Account
+          </a>
+          <a className="hub-btn" href={emailMagicLinkUrl}>
+            Email Magic Link
+          </a>
+        </div>
+
+        <div className="hub-row">
+          <a className="hub-btn" href={appUrl}>
+            Go to App
+          </a>
+          <a className="hub-btn" href={statusUrl}>
+            Status
+          </a>
+        </div>
+
+        <div className="hub-muted">
+          Need access? Contact: <a href={contactHref}>{contact.replace(/^mailto:/, '')}</a>
+        </div>
+      </main>
+    </div>
   );
 }

--- a/sites/blackroad-next/app/robots.ts
+++ b/sites/blackroad-next/app/robots.ts
@@ -1,6 +1,6 @@
 export default function robots() {
   return {
     rules: [{ userAgent: '*', allow: '/' }],
-    sitemap: 'https://blackroadinc.us/sitemap.xml'
+    sitemap: 'https://blackroad.com/sitemap.xml'
   };
 }

--- a/sites/blackroad-next/app/sitemap.ts
+++ b/sites/blackroad-next/app/sitemap.ts
@@ -1,6 +1,5 @@
 export default function sitemap() {
   return [
-    { url: 'https://blackroadinc.us/' },
-    { url: 'https://blackroadinc.us/solutions' }
+    { url: 'https://blackroad.com/' }
   ];
 }

--- a/sites/blackroad-next/lib/seo.ts
+++ b/sites/blackroad-next/lib/seo.ts
@@ -1,13 +1,13 @@
 export const buildMeta = (title: string, description: string, path = '/') => ({
-  title: `${title} | BlackRoad`,
+  title: `${title} | Blackroad`,
   description,
-  canonical: `https://blackroadinc.us${path}`
+  canonical: `https://blackroad.com${path}`
 });
 
 export const orgJsonLd = {
   "@context": "https://schema.org",
   "@type": "Organization",
-  "name": "BlackRoad, Inc.",
-  "url": "https://blackroadinc.us",
-  "logo": "https://blackroadinc.us/logo.png"
+  "name": "Blackroad",
+  "url": "https://blackroad.com",
+  "logo": "https://blackroad.com/logo.png"
 };


### PR DESCRIPTION
## Summary
- replace the placeholder Next.js landing page with a styled login hub for blackroad.com
- update metadata, robots, sitemap, and SEO helpers to point at the .com domain
- allow runtime configuration of IdP, magic link, status, and app links via environment variables

## Testing
- npm --prefix sites/blackroad-next run lint *(fails: Next.js ESLint parser is misconfigured for module syntax)*

------
https://chatgpt.com/codex/tasks/task_e_68f2c5f7a794832999f2bef0d2c3cdbc