### PR TITLE
docs: record 2025-10-11 platform health check

### DIFF
--- a/status/2025-10-11.md
+++ b/status/2025-10-11.md
@@ -1,0 +1,12 @@
+# Daily Operations Brief — 2025-10-11
+
+## Platform & Tooling Health
+- **GitHub:** Status page shows no active incidents in the last 24 hours and all past events resolved. Keep standard monitoring cadence.
+- **Vercel:** All systems operational. Most recent incident was a sign-in disruption on 2025-10-10, now closed; no mitigation actions needed.
+- **Slack:** Core surfaces (authentication, messaging, files, integrations) all reporting "No issues." Continue to rely on automated alerts.
+- **Google Cloud:** Global dashboard clear of outages. Project-level alerting and export pipelines remain ready if future events trigger.
+
+## Recommended Actions
+- Maintain passive monitoring; no failover or incident-response steps required today.
+- Confirm status alert subscriptions (email/RSS/API) stay active for GitHub, Vercel, Slack, and Google Cloud.
+- Log this health check in the weekly ops report to preserve uptime audit trail.


### PR DESCRIPTION
## Summary
- add the 2025-10-11 daily operations brief capturing GitHub, Vercel, Slack, and Google Cloud status reports

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f66fc79a488329ba7f53e9df74677d