### PR TITLE
Add VS Code Docker build debug setup

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Docker Build: sites/blackroad (BuildKit debug)",
+      "type": "docker-build",
+      "request": "launch",
+      "dockerBuild": {
+        "context": "${workspaceFolder}",
+        "dockerfile": "${workspaceFolder}/docker/Dockerfile.build-debug",
+        "target": "final",
+        "buildCommand": "docker build --debug -f docker/Dockerfile.build-debug ."
+      },
+      "presentation": {
+        "reveal": "always"
+      }
+    }
+  ]
+}

--- a/docker/Dockerfile.build-debug
+++ b/docker/Dockerfile.build-debug
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1.7
+# Sample Dockerfile tailored for BuildKit step debugging.
+# It builds the BlackRoad marketing site (sites/blackroad) using Node.js
+# and Caddy. Each stage is intentionally small so you can step through
+# during a debug build.
+
+ARG NODE_IMAGE=node:22-alpine
+
+FROM ${NODE_IMAGE} AS deps
+WORKDIR /workspace/sites/blackroad
+COPY sites/blackroad/package*.json ./
+RUN npm ci
+
+FROM ${NODE_IMAGE} AS build
+WORKDIR /workspace/sites/blackroad
+COPY --from=deps /workspace/sites/blackroad/node_modules ./node_modules
+COPY sites/blackroad/ ./
+RUN npm run build
+
+FROM caddy:2.8-alpine AS final
+COPY --from=build /workspace/sites/blackroad/dist /srv
+COPY sites/blackroad/Caddyfile /etc/caddy/Caddyfile
+EXPOSE 80
+CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile"]

--- a/docs/developer/docker-build-debug.md
+++ b/docs/developer/docker-build-debug.md
@@ -1,0 +1,34 @@
+# Docker Build Debugging Quickstart
+
+VS Code now understands BuildKit's new debugging hooks. This repo includes a
+sample Dockerfile and a matching launch configuration so you can try it out
+immediately.
+
+## Prerequisites
+
+- VS Code with the **Docker DX** extension (v2.0 or later).
+- Docker Desktop 4.31+ with Buildx 0.29 or newer (`docker buildx version`).
+- Experimental build debugging enabled by invoking builds with `--debug`.
+
+## Files added for you
+
+- `.vscode/launch.json` — Adds **Docker Build: sites/blackroad (BuildKit debug)**.
+  Launch this configuration to attach VS Code to the next BuildKit session.
+- `docker/Dockerfile.build-debug` — Minimal multi-stage build that compiles the
+  marketing site (`sites/blackroad`) and serves it with Caddy. Each stage is
+  separated so you can pause, inspect environment variables, or open a shell in
+  the active layer.
+
+## Running the debug build
+
+1. From the repo root run the build in debug mode:
+   ```bash
+   docker build --debug -f docker/Dockerfile.build-debug .
+   ```
+2. In VS Code open **Run & Debug → Docker Build: sites/blackroad (BuildKit debug)**
+   and press **Start**. VS Code will attach to the live BuildKit session.
+3. Step through instructions, inspect the filesystem after each layer, or open a
+   shell when prompted by the Docker extension.
+
+Because the Dockerfile is grounded in the actual BlackRoad site, any issues you
+find while debugging map directly to production assets.


### PR DESCRIPTION
## Summary
- add a BuildKit-friendly sample Dockerfile that builds the BlackRoad marketing site in three clear stages
- register a Docker build debug configuration in VS Code to attach to BuildKit sessions
- document how to run the debug build locally with the new tooling

## Testing
- not run (docs and config only)


------
https://chatgpt.com/codex/tasks/task_e_68f66fe6b560832985b454c2857da359