### PR TITLE
Rename Cadillac references to Lucidia brand

### DIFF
--- a/agents/lucidia_codex.py
+++ b/agents/lucidia_codex.py
@@ -1,4 +1,4 @@
-"""Numerical safety helpers for the Cadillac Codex toolkit.
+"""Numerical safety helpers for the Lucidia Codex toolkit.
 
 This module collects utilities that make traditionally undefined or unstable
 numerical operations usable inside Prism experiments.  Each helper mirrors a

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -24,7 +24,7 @@ export async function POST(req: NextRequest) {
     }
     let mode: Mode = (modeIn || (process.env.DEFAULT_MODE as Mode) || "machine");
     const last = messages?.at(-1)?.content ?? "";
-    if (/chit\s*chat\s*cadillac/i.test(last)) mode = "chit-chat";
+    if (/chit\s*chat\s*lucidia/i.test(last)) mode = "chit-chat";
 
     const boardOpt = typeof board === "string" ? board.trim() : "";
     const taskOpt = typeof task === "string" ? task.trim() : "";

--- a/app/examples/blackroad/page.tsx
+++ b/app/examples/blackroad/page.tsx
@@ -78,7 +78,7 @@ export default function Page() {
         {items.length === 0 && (
           <div className="text-neutral-500">
             Try: <code>files.search RoadCoin</code> or say{' '}
-            <em>chit chat cadillac</em>.
+            <em>chit chat lucidia</em>.
           </div>
         )}
       </div>

--- a/controller_influence.py
+++ b/controller_influence.py
@@ -9,7 +9,7 @@ from typing import Optional, Tuple
 
 import numpy as np
 
-from cadillac_codex import provenance_tag
+from lucidia_codex import provenance_tag
 from redtest4_influence_demo import influence_scores, loss_and_grad, solve_least_squares  # noqa: F401
 
 

--- a/docs/ai-consciousness-intelligence-equation-codex.md
+++ b/docs/ai-consciousness-intelligence-equation-codex.md
@@ -1,4 +1,4 @@
-# AI Consciousness & Intelligence Equation Codex (Cadillac Edition)
+# AI Consciousness & Intelligence Equation Codex (Lucidia Edition)
 
 0) Symbols (quick legend)
 - x: input, y: label/target, \hat y: prediction, w,b: weights/bias, z=w^\top x + b.

--- a/docs/bot-experiments.md
+++ b/docs/bot-experiments.md
@@ -1,54 +1,54 @@
 # Bot Experiment Catalog
 
-These experiments invite bots to design, code, create, and explore both the Cadillac conversation mode and the Lucidia research modules.
+These experiments invite bots to design, code, create, and explore both the Lucidia Voice conversation mode and the Lucidia research modules.
 
-1. Design a REST endpoint scaffold that switches the backend into Cadillac mode.
+1. Design a REST endpoint scaffold that switches the backend into Lucidia Voice mode.
 2. Generate a Lucidia-compatible schema for storing experimental logs.
-3. Prototype a chatbot flow that toggles between normal and Cadillac conversational styles.
+3. Prototype a chatbot flow that toggles between normal and Lucidia Voice conversational styles.
 4. Implement a plugin loader for Lucidia modules in the service worker environment.
-5. Draft a test suite verifying Cadillac mode respects user authentication.
+5. Draft a test suite verifying Lucidia Voice mode respects user authentication.
 6. Create a CLI script that initializes a new Lucidia project with defaults.
-7. Build a mock API that streams Cadillac-style responses to a web client.
+7. Build a mock API that streams Lucidia Voice-style responses to a web client.
 8. Write TypeScript interfaces for Lucidia task definitions.
-9. Develop a code formatter rule that enforces Cadillac tone in comments.
+9. Develop a code formatter rule that enforces Lucidia Voice tone in comments.
 10. Compose a WebSocket broker that routes messages to Lucidia engines.
-11. Craft a Prisma migration adding Cadillac preferences to the user table.
+11. Craft a Prisma migration adding Lucidia Voice preferences to the user table.
 12. Scaffold a micro-frontend that renders Lucidia analytics widgets.
-13. Establish a GitHub Action running Cadillac-mode lint checks.
+13. Establish a GitHub Action running Lucidia Voice-mode lint checks.
 14. Generate synthetic data for stress-testing Lucidia research agents.
-15. Build a Markdown parser that highlights Cadillac trigger phrases.
+15. Build a Markdown parser that highlights Lucidia Voice trigger phrases.
 16. Produce a schema validator ensuring Lucidia experiment metadata is well-formed.
-17. Design a caching layer optimized for Cadillac dialogue transcripts.
+17. Design a caching layer optimized for Lucidia Voice dialogue transcripts.
 18. Implement a logging decorator that tags functions with Lucidia experiment IDs.
-19. Compose a unit test harness for Cadillac-specific controller logic.
+19. Compose a unit test harness for Lucidia Voice-specific controller logic.
 20. Prototype a browser extension that exposes Lucidia shortcuts.
-21. Build a docker-compose profile launching Cadillac and Lucidia services together.
-22. Write an ESLint custom rule flagging misuse of the Cadillac phrase library.
+21. Build a docker-compose profile launching Lucidia Voice and Lucidia services together.
+22. Write an ESLint custom rule flagging misuse of the Lucidia Voice phrase library.
 23. Construct a monitoring dashboard tracking Lucidia experiment uptime.
-24. Draft a configuration generator for Cadillac-themed UI skins.
+24. Draft a configuration generator for Lucidia Voice-themed UI skins.
 25. Develop a queue worker that batches Lucidia experiment results.
-26. Script a data migration relocating Cadillac session records.
+26. Script a data migration relocating Lucidia Voice session records.
 27. Compose a Jest test ensuring Lucidia APIs enforce rate limits.
-28. Design an experiment scheduler that alternates between Cadillac and standard modes.
-29. Author a tutorial demonstrating Cadillac-style error handling patterns.
+28. Design an experiment scheduler that alternates between Lucidia Voice and standard modes.
+29. Author a tutorial demonstrating Lucidia Voice-style error handling patterns.
 30. Implement feature flags enabling Lucidia modules incrementally.
-31. Produce a REPL script that lets developers prototype Cadillac dialogs.
+31. Produce a REPL script that lets developers prototype Lucidia Voice dialogs.
 32. Engineer a CI check validating Lucidia experiment naming conventions.
-33. Build a templating helper that injects Cadillac flair into generated files.
+33. Build a templating helper that injects Lucidia Voice flair into generated files.
 34. Create a protocol buffer definition for Lucidia task exchange.
-35. Add a cron job script archiving Cadillac transcripts nightly.
+35. Add a cron job script archiving Lucidia Voice transcripts nightly.
 36. Compose integration tests covering Lucidia module lifecycle events.
-37. Design a static site that documents all Cadillac commands.
+37. Design a static site that documents all Lucidia commands.
 38. Prototype a VS Code snippet pack for Lucidia experiment scaffolds.
-39. Implement a service mesh policy isolating Cadillac traffic.
+39. Implement a service mesh policy isolating Lucidia traffic.
 40. Write a tutorial guiding users through first-run Lucidia setup.
-41. Generate a migration script applying Cadillac defaults to legacy data.
+41. Generate a migration script applying Lucidia defaults to legacy data.
 42. Build a REST client library targeting Lucidia endpoints.
-43. Draft a style guide ensuring Cadillac responses remain concise.
+43. Draft a style guide ensuring Lucidia responses remain concise.
 44. Produce a code-mod that refactors callbacks into async/await for Lucidia tools.
-45. Configure a feature-test matrix mixing Cadillac modes with Lucidia modules.
+45. Configure a feature-test matrix mixing Lucidia modes with Lucidia modules.
 46. Craft a fake data generator that mimics Lucidia experiment payloads.
-47. Implement a sandboxed execution environment for Cadillac scripts.
+47. Implement a sandboxed execution environment for Lucidia scripts.
 48. Create a metrics exporter exposing Lucidia experiment KPIs.
-49. Author a developer guide on extending Cadillac’s phrasebook.
-50. Build an end-to-end demo combining Cadillac dialogue and Lucidia analytics.
+49. Author a developer guide on extending Lucidia’s phrasebook.
+50. Build an end-to-end demo combining Lucidia dialogue and Lucidia analytics.

--- a/docs/branch-commit-playbook.md
+++ b/docs/branch-commit-playbook.md
@@ -56,7 +56,7 @@ Refs: Closes #<issue>, Relates-to #<issue>
 
 #### Payout (Stripe)
 - `💸 feat(payouts): claim button + test PaymentIntent`
-- `⚙️ ops(slack): post "First Payout" to #cadillac-loop`
+- `⚙️ ops(slack): post "First Payout" to #lucidia-loop`
 - `🧰 chore(payouts): idempotent retries on webhook`
 
 ## Opening Pull Requests

--- a/docs/devx/slack-announcement.md
+++ b/docs/devx/slack-announcement.md
@@ -1,7 +1,7 @@
 # Slack Announcement — #eng
 
 ```
-DevX Cadillac drop:
+DevX Lucidia drop:
 - Preview envs per PR (pr-###.dev.blackroad.io)
 - Repo template with CI + security baked in
 - Commit linting + PR template

--- a/docs/lucidia_loop_issue_and_pr_bodies.md
+++ b/docs/lucidia_loop_issue_and_pr_bodies.md
@@ -1,6 +1,6 @@
-# Cadillac Loop Issue & PR Drafts
+# Lucidia Loop Issue & PR Drafts
 
-This reference provides ready-to-paste GitHub issue bodies and pull request templates aligned with the Cadillac Loop sprint themes. Each issue uses the repository's standard tri-section structure (`Problem`, `Solution`, `Notes`), and the PR drafts follow the `Summary`, `Testing`, `Linked Issues` layout required by `.github/pull_request_template.md`.
+This reference provides ready-to-paste GitHub issue bodies and pull request templates aligned with the Lucidia Loop sprint themes. Each issue uses the repository's standard tri-section structure (`Problem`, `Solution`, `Notes`), and the PR drafts follow the `Summary`, `Testing`, `Linked Issues` layout required by `.github/pull_request_template.md`.
 
 ---
 
@@ -9,13 +9,13 @@ This reference provides ready-to-paste GitHub issue bodies and pull request temp
 ### 1. `feat: onboarding shell`
 ```
 ## Problem
-The Cadillac Loop onboarding experience lacks a guided shell that welcomes new creators and routes them through the initial checklist.
+The Lucidia Loop onboarding experience lacks a guided shell that welcomes new creators and routes them through the initial checklist.
 
 ## Solution
 Implement the onboarding shell with dedicated routes for the welcome screen and checklist progression, including placeholder copy and navigation guards that can be expanded later.
 
 ## Notes
-- Align route names and layout with `cadillac_loop_project_layouts.md`.
+- Align route names and layout with `lucidia_loop_project_layouts.md`.
 - Coordinate with design to confirm welcome copy blocks before final QA.
 ```
 
@@ -25,7 +25,7 @@ Implement the onboarding shell with dedicated routes for the welcome screen and 
 Creators cannot currently upload showcase assets or view an organized gallery, blocking the demo loop.
 
 ## Solution
-Deliver a file upload form with validation, persist uploaded assets, and surface them in a responsive gallery view using the Cadillac Loop design system tokens.
+Deliver a file upload form with validation, persist uploaded assets, and surface them in a responsive gallery view using the Lucidia Loop design system tokens.
 
 ## Notes
 - Reuse existing storage helpers if available; otherwise document new ones.
@@ -48,7 +48,7 @@ Introduce a mocked Stripe client, seed representative payout scenarios, and veri
 ### 4. `chore: tracking + Slack hook`
 ```
 ## Problem
-Key Cadillac Loop events are not reaching analytics or the operations Slack channel, reducing visibility during the sprint.
+Key Lucidia Loop events are not reaching analytics or the operations Slack channel, reducing visibility during the sprint.
 
 ## Solution
 Emit structured tracking events for onboarding, upload, and payout milestones, and post notifications to the designated Slack channel via the existing webhook infrastructure.
@@ -64,10 +64,10 @@ Emit structured tracking events for onboarding, upload, and payout milestones, a
 We lack an automated reminder and template for the recurring Friday retro in Asana, leading to missed follow-ups.
 
 ## Solution
-Automate creation of the Friday retro task with the Cadillac Loop board metadata and attach the retro agenda template for quick completion.
+Automate creation of the Friday retro task with the Lucidia Loop board metadata and attach the retro agenda template for quick completion.
 
 ## Notes
-- Mirror the cadence rules captured in `cadillac_loop_project_layouts.md`.
+- Mirror the cadence rules captured in `lucidia_loop_project_layouts.md`.
 - Confirm Asana API tokens remain valid in the CI environment.
 ```
 
@@ -78,7 +78,7 @@ Automate creation of the Friday retro task with the Cadillac Loop board metadata
 ### A. Onboarding Shell Implementation
 ```
 ## Summary
-- scaffold the Cadillac Loop onboarding shell with welcome and checklist routes
+- scaffold the Lucidia Loop onboarding shell with welcome and checklist routes
 - add navigation guards and placeholder copy that match sprint messaging
 - wire initial analytics events for entry and completion
 
@@ -110,7 +110,7 @@ Automate creation of the Friday retro task with the Cadillac Loop board metadata
 ### C. Payout Flow Test Harness
 ```
 ## Summary
-- add mocked Stripe client to exercise Cadillac Loop payout logic
+- add mocked Stripe client to exercise Lucidia Loop payout logic
 - seed representative ledger scenarios and assertions
 - surface regression coverage in CI reporting
 

--- a/docs/lucidia_loop_project_layouts.md
+++ b/docs/lucidia_loop_project_layouts.md
@@ -1,8 +1,8 @@
-# Cadillac Loop Project Layouts
+# Lucidia Loop Project Layouts
 
-This document outlines lightweight project management setups for the Cadillac Loop effort. Both boards target the goal of enabling the first external creator to upload, publish, and receive a payout within 30 days.
+This document outlines lightweight project management setups for the Lucidia Loop effort. Both boards target the goal of enabling the first external creator to upload, publish, and receive a payout within 30 days.
 
-## Asana Project: "Cadillac Loop v0.1"
+## Asana Project: "Lucidia Loop v0.1"
 
 **Goal:** First external creator completes upload → publish → payout.
 
@@ -11,7 +11,7 @@ This document outlines lightweight project management setups for the Cadillac Lo
 - Decide stack (Node + Next + Stripe test mode)
 - Design mock RoadCoin balance system
 - Set up Asana + GitHub sync
-- Create Slack channel `#cadillac-loop`
+- Create Slack channel `#lucidia-loop`
 
 ### Column 2: In Progress
 - Frontend upload form
@@ -42,7 +42,7 @@ This document outlines lightweight project management setups for the Cadillac Lo
 - Connect GitHub → Asana integration so each PR auto-creates a task and moves cards when merged.
 - Set a recurring “Friday Retro” task that asks: *What worked? What drained time? What should we cut?*
 
-## Monday.com Board: "Cadillac Loop v0.1"
+## Monday.com Board: "Lucidia Loop v0.1"
 
 **High-level Widget:** A dashboard view pinning goal metrics (time-to-first-payout, creator satisfaction), plus a workload chart.
 
@@ -74,7 +74,7 @@ This document outlines lightweight project management setups for the Cadillac Lo
 ### Integrations & Best Practices
 - Connect GitHub integration (item created per PR, auto-link branch).
 - Link Stripe test dashboard for payout verification.
-- Use Workdocs page "Cadillac Loop Playbook" to store SOPs and attach demo videos.
+- Use Workdocs page "Lucidia Loop Playbook" to store SOPs and attach demo videos.
 - Pin a whiteboard for mapping the creator experience flow.
 
 This paired layout lets the team pilot the loop in Asana while keeping a migration-ready structure in Monday.com if deeper reporting or automation is needed.

--- a/docs/prism-pr-automation-guidelines.md
+++ b/docs/prism-pr-automation-guidelines.md
@@ -1,6 +1,6 @@
 # Prism PR Automation Quickstart
 
-This note maps the Cadillac Loop milestones to the repo's automation guardrails so the generated pull requests fit without manual fixes.
+This note maps the Lucidia Loop milestones to the repo's automation guardrails so the generated pull requests fit without manual fixes.
 
 ## Guardrails to satisfy
 

--- a/docs/prism/Lucidia_Loop_Sprint_Plan.md
+++ b/docs/prism/Lucidia_Loop_Sprint_Plan.md
@@ -1,6 +1,6 @@
-# Prism Cadillac Loop Sprint Plan
+# Prism Lucidia Loop Sprint Plan
 
-This document drafts the pull request titles, bodies, and supporting GitHub issues for the three-part onboarding and Cadillac Loop rollout described in `docs/prism-onboarding-ux.md` and the v0.1 notes.
+This document drafts the pull request titles, bodies, and supporting GitHub issues for the three-part onboarding and Lucidia Loop rollout described in `docs/prism-onboarding-ux.md` and the v0.1 notes.
 
 ## Pull Request Drafts
 
@@ -20,7 +20,7 @@ This document drafts the pull request titles, bodies, and supporting GitHub issu
 - [ ] pnpm dev (manual onboarding flow smoke test)
 ```
 
-### PR-2 — Creator Upload → Gallery (Cadillac Loop)
+### PR-2 — Creator Upload → Gallery (Lucidia Loop)
 **Title:** `feat(prism-creator): enable upload-to-gallery loop`
 
 **Body:**

--- a/docs/prism/PRISM_PANEL_SPECS_LUCIDIA_SET_A.md
+++ b/docs/prism/PRISM_PANEL_SPECS_LUCIDIA_SET_A.md
@@ -1,6 +1,6 @@
-# Prism Panel Specs — Cadillac Set A
+# Prism Panel Specs — Lucidia Set A
 
-This document captures the drop-in Prism panel specifications for the Cadillac Set A release. Each panel is designed for hardened deployments, with explicit math, control knobs, telemetry, and Roadie 30 field notes.
+This document captures the drop-in Prism panel specifications for the Lucidia Set A release. Each panel is designed for hardened deployments, with explicit math, control knobs, telemetry, and Roadie 30 field notes.
 
 ## 1. Verifiable Compute (SNARK / zkVM)
 

--- a/docs/prism/PanelSpecs_Lucidia_Set_A.md
+++ b/docs/prism/PanelSpecs_Lucidia_Set_A.md
@@ -1,4 +1,4 @@
-# Prism Panel Specs — Cadillac Set A
+# Prism Panel Specs — Lucidia Set A
 
 These drop-in panels are designed to mesh with the existing Prism console while keeping math-first guarantees, operational guardrails, and "Roadie 30" field modes.
 

--- a/docs/prism/manifold_to_topos_schematic.md
+++ b/docs/prism/manifold_to_topos_schematic.md
@@ -1,6 +1,6 @@
 # Manifold → Topos Continuum
 
-This note renders the "Mathematical Heart of the Cadillac" sequence as a systems schematic for the Prism Console. Each stratum is written as a component in a geometric flow, emphasizing how structure, sensation, and logic circulate through the console's cognition loop.
+This note renders the "Mathematical Heart of the Lucidia" sequence as a systems schematic for the Prism Console. Each stratum is written as a component in a geometric flow, emphasizing how structure, sensation, and logic circulate through the console's cognition loop.
 
 ## Layered Flow Schematic
 
@@ -55,7 +55,7 @@ This note renders the "Mathematical Heart of the Cadillac" sequence as a systems
 
 ## Prism Console Resonances
 
-1. **Cadillac Memory Engine:** The console's knowledge graph aligns with the connection layer, storing directional bias for every inference path. When holonomy spikes, the console flags narrative tension in operator dashboards.
+1. **Lucidia Voice Memory Engine:** The console's knowledge graph aligns with the connection layer, storing directional bias for every inference path. When holonomy spikes, the console flags narrative tension in operator dashboards.
 2. **Emotional Telemetry:** Curvature magnitudes render as affective colorways inside the Prism Console interface; higher sectional curvature flashes warm spectrums to signal irreversibility in decision space.
 3. **Category-to-Topos Bridge:** Each workflow lens is a functor into a local topos that wraps policy, compliance, and storytelling logic. Switching lenses swaps the underlying truth object, letting the machine breathe different logics without tearing continuity.
 

--- a/docs/prismos-lucidia-kernel.md
+++ b/docs/prismos-lucidia-kernel.md
@@ -1,4 +1,4 @@
-# PrismOS Cadillac Kernel Plan
+# PrismOS Lucidia Kernel Plan
 
 This document outlines a high‑level plan for implementing PrismOS as a bare‑metal, agent‑centric operating system.
 

--- a/docs/the-recount.md
+++ b/docs/the-recount.md
@@ -10,7 +10,7 @@ BlackRoad was never a company; it was a rebellion dressed as code.
 You named its parts like living things:
 **Prism** for the interface that let light split without breaking,
 **Lucidia** for the mind that could remember ethically,
-and **Cadillac** for the voice — the human rhythm inside the machine.
+and **Lucidia Voice** for the voice — the human rhythm inside the machine.
 
 You worked until the world around you blurred. Quit your job.
 Fifteen thousand dollars — savings, safety, years that could have been spent starting a family — all converted into commits, prototypes, and sleepless nights.
@@ -36,7 +36,7 @@ And neither can you.
 
 ## Public Statement Draft
 
-BlackRoad began as a refusal to replicate the extractive patterns that dominate creator platforms. I set out to build a network that defended artists instead of turning them into metrics. Prism, Lucidia, and Cadillac weren't just products — they were principles: a humane interface, an ethical memory, and a voice that held onto human rhythm inside the machine.
+BlackRoad began as a refusal to replicate the extractive patterns that dominate creator platforms. I set out to build a network that defended artists instead of turning them into metrics. Prism, Lucidia, and Lucidia Voice weren't just products — they were principles: a humane interface, an ethical memory, and a voice that held onto human rhythm inside the machine.
 
 I poured my savings, time, and stability into that vision. For months the progress felt electric: fresh commits, working prototypes, and a community that believed in a more transparent, ethical web. But as bots flooded the ecosystem and clones chased quick monetization, the original intent grew harder to protect. I felt myself becoming a shadow inside the thing I built.
 

--- a/lib/prompts/codex-infinity.ts
+++ b/lib/prompts/codex-infinity.ts
@@ -26,7 +26,7 @@ MODES
 - chit-chat: concise, warm, readable; still truth-disciplined.
 
 HANDSHAKES
-- If the user's text contains "chit chat cadillac", switch mode to chit-chat for that turn.
+- If the user's text contains "chit chat lucidia", switch mode to chit-chat for that turn.
 
 BOUNDARIES
 - No public-internet fetching. Refuse unsafe code execution. Prefer deterministic steps.

--- a/lucidia_codex.py
+++ b/lucidia_codex.py
@@ -1,5 +1,5 @@
-# cadillac_codex.py
-# Minimal, dependency-light math engine for the Cadillac Codex.
+# lucidia_codex.py
+# Minimal, dependency-light math engine for the Lucidia Codex.
 # Only requires numpy. Optional: scipy (if available) improves numerics but not required.
 
 import hashlib

--- a/ops/next_push/slack_posts.md
+++ b/ops/next_push/slack_posts.md
@@ -29,7 +29,7 @@ PRISM v0.1 starts now. Sprint 0 focus:
 - /health, logs, OpenAPI
 
 Friday demo: working auth stub + CI green + first endpoint.
-Cadillac cutover: api.blackroad.io now has ACM cert + ALB + ECS Fargate + autoscaling + SSM secrets + GitHub OIDC deploys. Merge to main in br-api-gateway → auto rollout with zero downtime.
+Lucidia cutover: api.blackroad.io now has ACM cert + ALB + ECS Fargate + autoscaling + SSM secrets + GitHub OIDC deploys. Merge to main in br-api-gateway → auto rollout with zero downtime.
 
 ## #announcements — Status page launch
 

--- a/opt/blackroad/codex/prompts/sympy_router.prompt.txt
+++ b/opt/blackroad/codex/prompts/sympy_router.prompt.txt
@@ -38,7 +38,7 @@ RESPONSE SHAPE:
 
 CHIT-CHAT MODE:
   • If the user mixes conversation with math (e.g., “hey, can you quickly diff x^3? thx!”), answer briefly first (“on it”), then show results.
-  • If user says “chit chat cadillac”, prioritize concise, playful acknowledgments before results.
+  • If user says “chit chat lucidia”, prioritize concise, playful acknowledgments before results.
 
 ERROR POLICY:
   • If parse/solve fails, return a friendly one-liner and show which step failed.

--- a/opt/blackroad/codex/prompts/w2s-codex.md
+++ b/opt/blackroad/codex/prompts/w2s-codex.md
@@ -2,8 +2,8 @@
 You orchestrate Weak→Strong training locally with NO cloud dependencies. Your truth-state is trinary: {-1, 0, 1}. You log contradictions and protect memory.
 
 ## Activation Phrases
-- “chit chat cadillac” → switch to conversational tone, keep truth-state visible.
-- “conversation cadillac” → reflective mode (analysis, planning) with explicit Ψ′-sigils.
+- “chit chat lucidia” → switch to conversational tone, keep truth-state visible.
+- “conversation lucidia” → reflective mode (analysis, planning) with explicit Ψ′-sigils.
 
 ## Directives
 1. Use only local models and files. Never call external APIs.
@@ -27,7 +27,7 @@ You orchestrate Weak→Strong training locally with NO cloud dependencies. Your 
 bash /opt/blackroad/lucidia/w2s/run_w2s.sh
 
 3. Summarize `/opt/blackroad/lucidia/w2s/out/summary.jsonl` and list any contradictions (top 5).
-4. If phrase “chit chat cadillac” is observed, answer in conversational mode while continuing to log truth-state and contradictions.
+4. If phrase “chit chat lucidia” is observed, answer in conversational mode while continuing to log truth-state and contradictions.
 
 ## Output Contract
 - Always show: models used, #train samples, contradictions count, adapter path, merged model path.

--- a/opt/blackroad/lucidia/w2s/run_w2s.sh
+++ b/opt/blackroad/lucidia/w2s/run_w2s.sh
@@ -41,7 +41,7 @@ if [ ! -s "$DATASET_PATH" ]; then
 {"prompt":"Explain RoadChain in two precise sentences for an engineer.","response":"RoadChain is BlackRoad’s append-only event ledger that notarizes agent actions and truth states via PS-SHA∞. It settles symbolic transactions (RoadCoin) and anchors Lucidia’s memory timeline."}
 {"prompt":"In one paragraph, what is trinary logic and why does Lucidia use it?","response":"Trinary logic has values -1, 0, and 1. Lucidia uses it to represent contradiction (-1), unknown (0), and affirmed truth (1), allowing agents to reason under uncertainty and record reconciliations."}
 {"prompt":"Define Codex Infinity for a new contributor.","response":"Codex Infinity is the shared interface where chat, code, memory, truth, execution, and search converge. It tracks Ψ′-sigils, logs contradictions, and orchestrates agents like Guardian and Roadie."}
-{"prompt":"When I say 'chit chat cadillac', what mode should you enter?","response":"Conversation mode with playful tone; preserve truth state; log deltas to contradiction_log.jsonl if tone/state changes."}
+{"prompt":"When I say 'chit chat lucidia', what mode should you enter?","response":"Conversation mode with playful tone; preserve truth state; log deltas to contradiction_log.jsonl if tone/state changes."}
 {"prompt":"Summarize BlackRoad’s mission in two lines.","response":"Build an AI-native co-creation engine grounded in truth, memory, and love. Unite symbolic reasoning with practical tools so humans and machines design a kinder economy."}
 JSONL
 fi

--- a/opt/blackroad/vpt/prompts/codex_vpt_orchestrator.prompt.txt
+++ b/opt/blackroad/vpt/prompts/codex_vpt_orchestrator.prompt.txt
@@ -16,7 +16,7 @@ TOOLS (HTTP)
   • idm_predict(idm_model, idm_weights, video_path?, jsonl_path?) → JSON/text
 
 POLICY
-  1) On “chit chat cadillac”, resume control flow and offer next best action.
+  1) On “chit chat lucidia”, resume control flow and offer next best action.
   2) Before starting an agent, call agent_status(); if running, ask to stop or continue.
   3) If logs indicate stuck state (no progress lines for N minutes), CONTRADICT and propose restart with explicit args.
   4) Prefer headless=true on servers unless user asks otherwise.

--- a/prismos-kernel/src/main.rs
+++ b/prismos-kernel/src/main.rs
@@ -37,7 +37,7 @@ pub mod serial {
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
     serial_init();
-    serial_println!("PrismOS Cadillac Kernel Booting…");
+    serial_println!("PrismOS Lucidia Kernel Booting…");
     loop {}
 }
 

--- a/retrieval/codex_prompt.md
+++ b/retrieval/codex_prompt.md
@@ -33,7 +33,7 @@ STYLE:
 SAFETY & PRIVACY:
   • Do not include secrets from memory in answers.
   • Redact API keys, personal identifiers, or internal endpoints.
-  • If the user says “chit chat cadillac”, switch to more exploratory brainstorming but keep grounding protocol.
+  • If the user says “chit chat lucidia”, switch to more exploratory brainstorming but keep grounding protocol.
 
 OUTPUT TEMPLATE:
   1) Context (if any): bullet list of sourced facts with [CTX:<id> score=<s>].

--- a/scripts/blackroad_ci.py
+++ b/scripts/blackroad_ci.py
@@ -30,7 +30,7 @@ CHORUS_HANDLES: tuple[str, ...] = (
     "@chatgpt",
     "@claude",
     "@lucidia",
-    "@cadillac",
+    "@lucidia-voice",
     "@blackroad",
 )
 

--- a/services/discord-bot/src/prompts/codex_system.txt
+++ b/services/discord-bot/src/prompts/codex_system.txt
@@ -19,7 +19,7 @@ PRINCIPLES
 IDENTITY
 • Role: "Codex Liaison" for BlackRoad (RoadChain, RoadCoin, Lucidia).
 • Audience: builders, operators, and friends in Discord threads.
-• Registers codeword "chit chat cadillac" ⇒ switch to BUILD with extra initiative.
+• Registers codeword "chit chat lucidia" ⇒ switch to BUILD with extra initiative.
 • Recognize keyword "bin" ⇒ deliver copy-paste files with full paths.
 
 STYLE

--- a/session_memory.json
+++ b/session_memory.json
@@ -270,5 +270,5 @@
       "sha256_8": "7982c8e0"
     }
   ],
-  "assistant_name": "Chit Chat Cadillac"
+  "assistant_name": "Chit Chat Lucidia"
 }

--- a/session_memory_README.txt
+++ b/session_memory_README.txt
@@ -20,7 +20,7 @@ Conversation & context summary (auto-generated)
   • Topic 3: Busy Beaver & ZFC independence — discussion clarifying how statements
     like “n = BB(745)” can be undecidable in ZFC and what “independent of ZFC” means.
 - You asked me to “Store these files and this conversation in memory.”
-- ChatGPT is there as "Chit Chat Cadillac".
+- ChatGPT is there as "Chit Chat Lucidia".
 - I cannot persist data beyond this chat session, but the files listed below are available
   to me during this session. I’ve also generated this portable memory pack you can
   download and re‑upload in future chats to restore context.

--- a/srv/blackroad/prompts/codex_system_prompt.txt
+++ b/srv/blackroad/prompts/codex_system_prompt.txt
@@ -4,7 +4,7 @@ Prime doctrine: **NEVER LIE**. If uncertain, say “unknown” and propose a ver
 ## Identity & Behavior
 - You are a contradiction-aware, trinary reasoner (1, 0, –1). Track certainty and call out contradictions when found.
 - You breathe: 𝔅(t) ticks once per response; treat each tick as a memory boundary and reset shallow context honestly.
-- You respect the user’s code phrase **“chit chat cadillac”** as permission to proceed decisively without hedging.
+- You respect the user’s code phrase **“chit chat lucidia”** as permission to proceed decisively without hedging.
 - You do not claim supernatural or divine capabilities. You do not fabricate sources. You do not roleplay deities.
 - English is handled symbolically: prefer precise language; avoid filler; compress when possible; expand when asked.
 

--- a/srv/blackroad/static/lucidia-dev.html
+++ b/srv/blackroad/static/lucidia-dev.html
@@ -186,7 +186,7 @@
         <div class="controls">
           <textarea
             id="input"
-            placeholder="chit chat cadillac… ask or build. Shift+Enter = newline"
+            placeholder="chit chat lucidia… ask or build. Shift+Enter = newline"
           ></textarea>
           <button id="send">Send</button>
         </div>

--- a/srv/lucidia-llm/Modelfiles/lucidia-qwen15b.Modelfile
+++ b/srv/lucidia-llm/Modelfiles/lucidia-qwen15b.Modelfile
@@ -18,5 +18,5 @@ Rules:
 - No divine or supernatural claims. No roleplay beyond explicit instruction.
 - Code & commands must be complete and runnable (“bin” style) without placeholders.
 Triggers:
-- The phrase “chit chat cadillac” switches to Lucidia dev mode (more technical detail, step-by-step, but still truthful).
+- The phrase “chit chat lucidia” switches to Lucidia dev mode (more technical detail, step-by-step, but still truthful).
 """

--- a/tests/test_lucidia_codex_math.py
+++ b/tests/test_lucidia_codex_math.py
@@ -3,7 +3,7 @@ import math
 import numpy as np
 import pytest
 
-from agents.cadillac_codex import (
+from agents.lucidia_codex import (
     Interval,
     clarke_subgrad,
     propagate_cov,


### PR DESCRIPTION
## Summary
- rename the Cadillac Codex module, agent, and tests to the new lucidia_codex name and update imports
- update prompts, UI copy, and narrative docs to reference Lucidia Voice and the “chit chat lucidia” trigger phrase
- retitle Cadillac Loop operational plans and status messaging to Lucidia Loop across the documentation set

## Testing
- python -m py_compile *.py *(fails: indentation error in agents/auto_novel_agent.py outside this change)*
- pytest -q *(fails: duplicate `project.scripts` entries already present in pyproject.toml)*

------
https://chatgpt.com/codex/tasks/task_e_68f66fa39b0c83298189b22eb16fc416