### PR TITLE
fix: handle binary cookbook files

### DIFF
--- a/cli/console.py
+++ b/cli/console.py
@@ -1210,7 +1210,11 @@ def cmd_cookbook(args):
         print("unknown cookbook name", slug)
         print("available:", ", ".join(_list_cookbook()))
         return
-    text = path.read_text()
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        print("Binary files are not supported; provide a UTF-8 Markdown task instead.")
+        return
     context = _parse_context(text)
     ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)
     out_path = ARTIFACT_DIR / f"{slug}.json"

--- a/tests/test_cli_cookbook.py
+++ b/tests/test_cli_cookbook.py
@@ -1,0 +1,23 @@
+"""Tests for the cookbook CLI helpers."""
+
+from types import SimpleNamespace
+
+import cli.console as console
+
+
+def test_cmd_cookbook_rejects_binary(tmp_path, capsys, monkeypatch):
+    """Binary cookbook inputs are rejected with a helpful message."""
+
+    cookbook_dir = tmp_path / "cookbook" / "tasks"
+    cookbook_dir.mkdir(parents=True)
+    (cookbook_dir / "binary.md").write_bytes(b"\x00\x01\x02")
+    artifact_dir = tmp_path / "artifacts"
+
+    monkeypatch.setattr(console, "COOKBOOK_DIR", cookbook_dir)
+    monkeypatch.setattr(console, "ARTIFACT_DIR", artifact_dir)
+
+    console.cmd_cookbook(SimpleNamespace(name="binary"))
+
+    captured = capsys.readouterr()
+    assert "Binary files are not supported" in captured.out
+    assert not artifact_dir.exists()


### PR DESCRIPTION
## Summary
- prevent the cookbook runner from attempting to parse binary Markdown files
- add a regression test that exercises the binary guard and ensures no artifacts are created

## Testing
- `pytest tests/test_cli_cookbook.py -q` *(fails: /workspace/blackroad-prism-console/pyproject.toml: Cannot declare ('project', 'scripts') twice)*

------
https://chatgpt.com/codex/tasks/task_e_68f2654cb5248329b629b3b01416445b