### PR TITLE
fix: restore coq build return contract

### DIFF
--- a/mfg/coq.py
+++ b/mfg/coq.py
@@ -33,4 +33,4 @@ def build(period: str):
         "\n".join(f"{k}: {v}" for k, v in totals.items()),
     )
     metrics.inc("coq_built")
-    return report
+    return totals


### PR DESCRIPTION
## Summary
- return the bucket totals from `mfg.coq.build` to preserve the existing contract while still writing the structured artifact report

## Testing
- pytest tests/test_yield_coq.py *(fails: /workspace/blackroad-prism-console/pyproject.toml: Cannot declare ('project', 'scripts') twice (at line 27, column 17))*

------
https://chatgpt.com/codex/tasks/task_e_68f1fe4ea9008329aa1e31ffca3aa90c