### PR TITLE
Add Vercel deployment configs for BlackRoad domains

### DIFF
--- a/sites/blackroad/vercel.json
+++ b/sites/blackroad/vercel.json
@@ -1,0 +1,16 @@
+{
+  "rewrites": [
+    { "source": "/((?!api|_next/|assets/|.*\\.).*)", "destination": "/index.html" }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "Strict-Transport-Security", "value": "max-age=15552000; includeSubDomains; preload" }
+      ]
+    }
+  ],
+  "redirects": [
+    { "source": "/blackroadinc", "destination": "https://blackroadinc.io", "permanent": true }
+  ]
+}

--- a/sites/blackroadinc/vercel.json
+++ b/sites/blackroadinc/vercel.json
@@ -1,0 +1,13 @@
+{
+  "redirects": [
+    { "source": "/:path*", "destination": "https://blackroad.io/:path*", "permanent": true }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "Strict-Transport-Security", "value": "max-age=15552000; includeSubDomains; preload" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a Vercel configuration for the blackroad.io site with SPA rewrites, HSTS headers, and a redirect to blackroadinc.io
- add a Vercel configuration for the blackroadinc.io redirector project with global HSTS headers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f67773cce083299456e6647f5ed5d3