### PR TITLE
Add portal index tiles and sync scripts to Next site

### DIFF
--- a/sites/blackroad-next/app/portal/lucidia/page.tsx
+++ b/sites/blackroad-next/app/portal/lucidia/page.tsx
@@ -1,0 +1,10 @@
+export default function Page() {
+  return (
+    <section className="container-x py-12">
+      <h1 className="h1">Lucidia</h1>
+      <p className="mt-2 text-zinc-400">
+        This module is stubbed in. When you say <em>next</em>, I’ll drop in the live UI and wire data.
+      </p>
+    </section>
+  );
+}

--- a/sites/blackroad-next/app/portal/page.tsx
+++ b/sites/blackroad-next/app/portal/page.tsx
@@ -1,0 +1,50 @@
+import Link from "next/link";
+
+type Tile = { key: string; title: string; blurb: string; href: string; status: "live" | "stub" };
+
+const tiles: Tile[] = [
+  { key: "roadbook", title: "Roadbook", blurb: "Projects, notes, and flows.", href: "/portal/roadbook", status: "stub" },
+  { key: "roadview", title: "Roadview", blurb: "Live journey streams on a globe.", href: "/portal/roadview/index.html", status: "live" },
+  { key: "lucidia", title: "Lucidia", blurb: "Reasoning studio & co-agents.", href: "/portal/lucidia", status: "stub" },
+  { key: "roadcode", title: "Roadcode", blurb: "Code, review, and ship fast.", href: "/portal/roadcode/index.html", status: "live" },
+  { key: "roadcoin", title: "Roadcoin", blurb: "Wallet, staking, token economy.", href: "/portal/roadcoin/index.html", status: "live" },
+  { key: "roadchain", title: "Roadchain", blurb: "Pipelines, lineage, and trust.", href: "/portal/roadchain", status: "stub" },
+  { key: "radius", title: "Radius", blurb: "Signals, telemetry, and ops.", href: "/portal/radius", status: "stub" }
+];
+
+export const metadata = { title: "Portal — BlackRoad.io" };
+
+export default function PortalIndex() {
+  return (
+    <section className="container-x py-12">
+      <header className="mb-8">
+        <h1 className="h1">Portal</h1>
+        <p className="mt-2 text-zinc-400">Everything in one dark, precise surface.</p>
+      </header>
+
+      <ul className="grid sm:grid-cols-2 lg:grid-cols-3 gap-5">
+        {tiles.map((t) => (
+          <li key={t.key} className="card relative overflow-hidden">
+            <div
+              className="pointer-events-none absolute inset-0 opacity-20"
+              style={{ background: "linear-gradient(135deg, #ff3ea5 0%, #7c3aed 50%, #fb923c 100%)" }}
+            />
+            <div className="relative">
+              <h3 className="h2">{t.title}</h3>
+              <p className="mt-2 text-zinc-400">{t.blurb}</p>
+
+              <div className="mt-5 flex items-center gap-3">
+                <Link href={t.href} className="btn-primary">
+                  Open
+                </Link>
+                {t.status === "stub" && (
+                  <span className="rounded-xl bg-ink-800/60 px-3 py-1 text-xs text-zinc-400">stub • coming online</span>
+                )}
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/sites/blackroad-next/app/portal/radius/page.tsx
+++ b/sites/blackroad-next/app/portal/radius/page.tsx
@@ -1,0 +1,10 @@
+export default function Page() {
+  return (
+    <section className="container-x py-12">
+      <h1 className="h1">Radius</h1>
+      <p className="mt-2 text-zinc-400">
+        This module is stubbed in. When you say <em>next</em>, I’ll drop in the live UI and wire data.
+      </p>
+    </section>
+  );
+}

--- a/sites/blackroad-next/app/portal/roadbook/page.tsx
+++ b/sites/blackroad-next/app/portal/roadbook/page.tsx
@@ -1,0 +1,10 @@
+export default function Page() {
+  return (
+    <section className="container-x py-12">
+      <h1 className="h1">Roadbook</h1>
+      <p className="mt-2 text-zinc-400">
+        This module is stubbed in. When you say <em>next</em>, I’ll drop in the live UI and wire data.
+      </p>
+    </section>
+  );
+}

--- a/sites/blackroad-next/app/portal/roadchain/page.tsx
+++ b/sites/blackroad-next/app/portal/roadchain/page.tsx
@@ -1,0 +1,10 @@
+export default function Page() {
+  return (
+    <section className="container-x py-12">
+      <h1 className="h1">Roadchain</h1>
+      <p className="mt-2 text-zinc-400">
+        This module is stubbed in. When you say <em>next</em>, I’ll drop in the live UI and wire data.
+      </p>
+    </section>
+  );
+}

--- a/sites/blackroad-next/package.json
+++ b/sites/blackroad-next/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "node scripts/sync-docs.mjs && node scripts/sync-portal.mjs && node scripts/build-docs-index.mjs && next build",
     "start": "next start",
     "lint": "next lint"
   },

--- a/sites/blackroad-next/scripts/build-docs-index.mjs
+++ b/sites/blackroad-next/scripts/build-docs-index.mjs
@@ -1,0 +1,26 @@
+import { readdirSync, writeFileSync } from "fs";
+import { join, relative } from "path";
+
+const DOCS_DIR = join(process.cwd(), "public", "docs");
+const INDEX_FILE = join(DOCS_DIR, "index.json");
+
+function listFiles(dir, base) {
+  const entries = [];
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) {
+      entries.push(...listFiles(full, base));
+    } else {
+      entries.push({ path: relative(base, full).replace(/\\/g, "/") });
+    }
+  }
+  return entries;
+}
+
+try {
+  const files = listFiles(DOCS_DIR, DOCS_DIR);
+  writeFileSync(INDEX_FILE, JSON.stringify({ files }, null, 2));
+  console.log("[docs] built docs index");
+} catch {
+  // ok if docs directory missing
+}

--- a/sites/blackroad-next/scripts/sync-docs.mjs
+++ b/sites/blackroad-next/scripts/sync-docs.mjs
@@ -1,0 +1,26 @@
+import { mkdirSync, readdirSync, copyFileSync } from "fs";
+import { join } from "path";
+
+const SRC = join(process.cwd(), "..", "..", "sites", "blackroad", "public", "docs");
+const DST = join(process.cwd(), "public", "docs");
+mkdirSync(DST, { recursive: true });
+
+function cpdir(src, dst) {
+  for (const e of readdirSync(src, { withFileTypes: true })) {
+    const s = join(src, e.name);
+    const d = join(dst, e.name);
+    if (e.isDirectory()) {
+      mkdirSync(d, { recursive: true });
+      cpdir(s, d);
+    } else {
+      copyFileSync(s, d);
+    }
+  }
+}
+
+try {
+  cpdir(SRC, DST);
+  console.log("[docs] synced public/docs");
+} catch {
+  // ok if docs source missing
+}

--- a/sites/blackroad-next/scripts/sync-portal.mjs
+++ b/sites/blackroad-next/scripts/sync-portal.mjs
@@ -1,0 +1,26 @@
+import { mkdirSync, readdirSync, copyFileSync } from "fs";
+import { join } from "path";
+
+const SRC = join(process.cwd(), "..", "..", "sites", "blackroad", "public", "portal");
+const DST = join(process.cwd(), "public", "portal");
+mkdirSync(DST, { recursive: true });
+
+function cpdir(src, dst) {
+  for (const e of readdirSync(src, { withFileTypes: true })) {
+    const s = join(src, e.name);
+    const d = join(dst, e.name);
+    if (e.isDirectory()) {
+      mkdirSync(d, { recursive: true });
+      cpdir(s, d);
+    } else {
+      copyFileSync(s, d);
+    }
+  }
+}
+
+try {
+  cpdir(SRC, DST);
+  console.log("[portal] synced public/portal");
+} catch {
+  // ok if missing
+}


### PR DESCRIPTION
## Summary
- add scripts to sync docs and portal assets before building the Next app
- create a portal index page with tiles that link to live and stub destinations
- add stub pages for roadbook, lucidia, roadchain, and radius within the portal

## Testing
- npm run build *(fails: SyntaxError: Expected ',' or '}' after property value in JSON at position 361645 while patching incorrect lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68f67d36fa088329a599f63adfd1b960