### PR TITLE
feat(prism-core): add runtime and policy helpers

### DIFF
--- a/apps/prism/packages/prism-core/src/diffs.ts
+++ b/apps/prism/packages/prism-core/src/diffs.ts
@@ -1,3 +1,99 @@
-// TODO: diff utilities
+import {PrismDiff} from './types';
 
-export {};
+const DIFF_METADATA_PREFIXES = ['+++', '---', '@@'];
+
+export type DiffStat = {
+  path: string;
+  additions: number;
+  deletions: number;
+  changes: number;
+};
+
+export type DiffSummary = {
+  files: number;
+  additions: number;
+  deletions: number;
+  changes: number;
+};
+
+function isMetadata(line: string) {
+  return DIFF_METADATA_PREFIXES.some((prefix) => line.startsWith(prefix));
+}
+
+function iteratePatchLines(diff: PrismDiff) {
+  const normalized = normalizePatch(diff.patch);
+  return normalized.split('\n').filter((line) => line.length > 0);
+}
+
+export function normalizePatch(patch: string) {
+  return patch.replace(/\r\n/g, '\n');
+}
+
+export function diffStat(diff: PrismDiff): DiffStat {
+  let additions = 0;
+  let deletions = 0;
+  for (const line of iteratePatchLines(diff)) {
+    if (isMetadata(line)) continue;
+    if (line.startsWith('+')) additions += 1;
+    else if (line.startsWith('-')) deletions += 1;
+  }
+  return {
+    path: diff.path,
+    additions,
+    deletions,
+    changes: additions + deletions,
+  };
+}
+
+export function diffHasChanges(diff: PrismDiff) {
+  return diffStat(diff).changes > 0;
+}
+
+export function summarizeDiffs(diffs: PrismDiff[]): DiffSummary {
+  const totals: DiffSummary = {
+    files: 0,
+    additions: 0,
+    deletions: 0,
+    changes: 0,
+  };
+  for (const diff of diffs) {
+    const stat = diffStat(diff);
+    totals.files += 1;
+    totals.additions += stat.additions;
+    totals.deletions += stat.deletions;
+    totals.changes += stat.changes;
+  }
+  return totals;
+}
+
+export function dedupeDiffs(diffs: PrismDiff[]): PrismDiff[] {
+  const byPath = new Map<string, PrismDiff>();
+  for (const diff of diffs) {
+    byPath.set(diff.path, {...diff, patch: normalizePatch(diff.patch)});
+  }
+  return Array.from(byPath.values());
+}
+
+export function groupDiffsByPath(diffs: PrismDiff[]): Map<string, PrismDiff[]> {
+  const map = new Map<string, PrismDiff[]>();
+  for (const diff of diffs) {
+    const arr = map.get(diff.path);
+    if (arr) {
+      arr.push(diff);
+    } else {
+      map.set(diff.path, [diff]);
+    }
+  }
+  return map;
+}
+
+export function formatDiffStat(stat: DiffStat) {
+  return `${stat.path} | +${stat.additions} -${stat.deletions}`;
+}
+
+export function selectDiffs(
+  diffs: PrismDiff[],
+  predicate: (diff: PrismDiff, stat: DiffStat) => boolean
+) {
+  return diffs.filter((diff) => predicate(diff, diffStat(diff)));
+}

--- a/apps/prism/packages/prism-core/src/events.ts
+++ b/apps/prism/packages/prism-core/src/events.ts
@@ -1,3 +1,152 @@
-// TODO: event bus utilities
+import {PrismEvent} from './types';
 
-export {};
+export type EventListener = (event: PrismEvent) => void | Promise<void>;
+
+export interface EventBus {
+  publish(event: PrismEvent): Promise<void>;
+  subscribe(listener: EventListener): () => void;
+  history(): PrismEvent[];
+  drain(): PrismEvent[];
+  clear(): void;
+  size(): number;
+}
+
+export interface EventBusOptions {
+  initial?: PrismEvent[];
+  onPublish?: EventListener;
+}
+
+/**
+ * Lightweight in-memory event bus that records every event while allowing
+ * subscribers to react to future publications. Designed so tests can assert on
+ * event order without needing an external queueing system.
+ */
+export function createEventBus(options: EventBusOptions = {}): EventBus {
+  const events: PrismEvent[] = [...(options.initial ?? [])];
+  const listeners = new Set<EventListener>();
+
+  const dispatch = async (event: PrismEvent) => {
+    const errors: unknown[] = [];
+    if (options.onPublish) {
+      try {
+        await options.onPublish(event);
+      } catch (err) {
+        errors.push(err);
+      }
+    }
+    for (const listener of listeners) {
+      try {
+        await listener(event);
+      } catch (err) {
+        errors.push(err);
+      }
+    }
+    if (errors.length) {
+      throw new AggregateError(errors, 'One or more event listeners failed');
+    }
+  };
+
+  return {
+    async publish(event) {
+      events.push(event);
+      await dispatch(event);
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    history() {
+      return [...events];
+    },
+    drain() {
+      const snapshot = [...events];
+      events.length = 0;
+      return snapshot;
+    },
+    clear() {
+      events.length = 0;
+    },
+    size() {
+      return events.length;
+    },
+  };
+}
+
+export interface WaitForOptions {
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}
+
+/**
+ * Resolves with the first event that matches the predicate. If a timeout is
+ * provided the promise rejects once it elapses. Previously recorded events are
+ * checked before listening for new ones so callers can await immediately after
+ * triggering a side effect.
+ */
+export function waitForEvent(
+  bus: EventBus,
+  predicate: (event: PrismEvent) => boolean,
+  options: WaitForOptions = {}
+): Promise<PrismEvent> {
+  const {timeoutMs, signal} = options;
+  return new Promise<PrismEvent>((resolve, reject) => {
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const maybeResolve = (event: PrismEvent) => {
+      if (settled || !predicate(event)) {
+        return false;
+      }
+      settled = true;
+      cleanup();
+      resolve(event);
+      return true;
+    };
+
+    const cleanup = () => {
+      unsubscribe();
+      if (timer) {
+        clearTimeout(timer);
+      }
+      signal?.removeEventListener('abort', onAbort);
+    };
+
+    const onAbort = () => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(new Error('waitForEvent aborted'));
+    };
+
+    const unsubscribe = bus.subscribe((event) => {
+      maybeResolve(event);
+    });
+
+    for (const event of bus.history()) {
+      if (maybeResolve(event)) {
+        return;
+      }
+    }
+
+    if (timeoutMs != null) {
+      timer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(new Error(`Timed out waiting for event after ${timeoutMs}ms`));
+      }, timeoutMs);
+    }
+
+    if (signal) {
+      if (signal.aborted) {
+        onAbort();
+      } else {
+        signal.addEventListener('abort', onAbort);
+      }
+    }
+  });
+}
+
+export function pipeEvents(source: EventBus, target: EventBus): () => void {
+  return source.subscribe((event) => target.publish(event));
+}

--- a/apps/prism/packages/prism-core/src/index.ts
+++ b/apps/prism/packages/prism-core/src/index.ts
@@ -1,2 +1,6 @@
 export * from './types';
-// TODO: export other modules
+export * from './events';
+export * from './spans';
+export * from './run';
+export * from './diffs';
+export * from './policies';

--- a/apps/prism/packages/prism-core/src/policies.ts
+++ b/apps/prism/packages/prism-core/src/policies.ts
@@ -1,3 +1,141 @@
-// TODO: policy helpers
+import {Capability, Policy} from './types';
 
-export {};
+export const ALL_CAPABILITIES: Capability[] = [
+  'read',
+  'write',
+  'exec',
+  'net',
+  'secrets',
+  'dns',
+  'deploy',
+];
+
+type Approval = Policy['approvals'][Capability];
+
+type PolicyPreset = Record<Capability, Approval>;
+
+type PartialApprovals = Partial<Record<Capability, Approval>>;
+
+type PolicyOverrides = {
+  mode?: Policy['mode'];
+  approvals?: PartialApprovals;
+};
+
+const PRESETS: Record<Policy['mode'], PolicyPreset> = {
+  playground: {
+    read: 'auto',
+    write: 'auto',
+    exec: 'auto',
+    net: 'auto',
+    secrets: 'forbid',
+    dns: 'forbid',
+    deploy: 'forbid',
+  },
+  dev: {
+    read: 'auto',
+    write: 'auto',
+    exec: 'auto',
+    net: 'review',
+    secrets: 'review',
+    dns: 'review',
+    deploy: 'review',
+  },
+  trusted: {
+    read: 'auto',
+    write: 'auto',
+    exec: 'auto',
+    net: 'auto',
+    secrets: 'review',
+    dns: 'auto',
+    deploy: 'review',
+  },
+  prod: {
+    read: 'auto',
+    write: 'review',
+    exec: 'review',
+    net: 'review',
+    secrets: 'forbid',
+    dns: 'review',
+    deploy: 'forbid',
+  },
+};
+
+export function createPolicy(
+  mode: Policy['mode'] = 'dev',
+  overrides: PartialApprovals = {}
+): Policy {
+  const preset = PRESETS[mode];
+  const approvals: Record<Capability, Approval> = {...preset};
+  for (const capability of Object.keys(overrides) as Capability[]) {
+    const decision = overrides[capability];
+    if (decision) {
+      approvals[capability] = decision;
+    }
+  }
+  return {
+    mode,
+    approvals,
+  };
+}
+
+export function normalizePolicy(policy: Policy | PolicyOverrides | undefined): Policy {
+  if (!policy) {
+    return createPolicy('dev');
+  }
+  if ('mode' in policy || 'approvals' in policy) {
+    const mode = (policy as PolicyOverrides).mode ?? 'dev';
+    return createPolicy(mode, (policy as PolicyOverrides).approvals);
+  }
+  return createPolicy(policy.mode, policy.approvals);
+}
+
+export function mergePolicy(base: Policy, overrides: PolicyOverrides): Policy {
+  const mergedMode = overrides.mode ?? base.mode;
+  const approvals = {...base.approvals};
+  if (overrides.approvals) {
+    for (const capability of Object.keys(overrides.approvals) as Capability[]) {
+      const decision = overrides.approvals[capability];
+      if (decision) {
+        approvals[capability] = decision;
+      }
+    }
+  }
+  return {
+    mode: mergedMode,
+    approvals,
+  };
+}
+
+export function decisionFor(policy: Policy, capability: Capability): Approval {
+  return policy.approvals[capability] ?? 'review';
+}
+
+export function isCapabilityAllowed(policy: Policy, capability: Capability) {
+  return decisionFor(policy, capability) === 'auto';
+}
+
+export function requiresApproval(policy: Policy, capability: Capability) {
+  return decisionFor(policy, capability) === 'review';
+}
+
+export function isCapabilityForbidden(policy: Policy, capability: Capability) {
+  return decisionFor(policy, capability) === 'forbid';
+}
+
+export function assertCapability(
+  policy: Policy,
+  capability: Capability,
+  message?: string
+) {
+  const decision = decisionFor(policy, capability);
+  if (decision === 'forbid') {
+    throw new Error(message ?? `Capability ${capability} is forbidden under ${policy.mode} policy`);
+  }
+}
+
+export function summarizePolicy(policy: Policy) {
+  return ALL_CAPABILITIES.reduce<Record<Capability, Approval>>((acc, capability) => {
+    acc[capability] = decisionFor(policy, capability);
+    return acc;
+  }, {} as Record<Capability, Approval>);
+}

--- a/apps/prism/packages/prism-core/src/run.ts
+++ b/apps/prism/packages/prism-core/src/run.ts
@@ -1,3 +1,238 @@
-// TODO: run lifecycle helpers
+import {PrismEvent} from './types';
 
-export {};
+export interface RunLifecycleOptions {
+  projectId?: string;
+  sessionId?: string;
+  actor?: PrismEvent['actor'];
+  facet?: PrismEvent['facet'];
+  publish?: (event: PrismEvent) => Promise<void> | void;
+  clock?: () => Date;
+  eventIdFactory?: () => string;
+  runIdFactory?: () => string;
+}
+
+export interface StartRunOptions {
+  summary: string;
+  actor?: PrismEvent['actor'];
+  facet?: PrismEvent['facet'];
+  ctx?: Record<string, any>;
+  runId?: string;
+}
+
+export interface EndRunOptions {
+  summary?: string;
+  actor?: PrismEvent['actor'];
+  facet?: PrismEvent['facet'];
+  status?: 'ok' | 'error' | 'cancelled';
+  ctx?: Record<string, any>;
+}
+
+export interface RunHandle {
+  runId: string;
+  event: PrismEvent;
+}
+
+export interface RunContext {
+  runId: string;
+  emit(event: PrismEvent): Promise<void>;
+}
+
+export interface RunLifecycle {
+  startRun(options: StartRunOptions): Promise<RunHandle>;
+  endRun(runId: string, options?: EndRunOptions): Promise<PrismEvent>;
+  failRun(runId: string, error: unknown, options?: EndRunOptions): Promise<PrismEvent>;
+  withRun<T>(options: StartRunOptions, fn: (ctx: RunContext) => Promise<T> | T, endOptions?: EndRunOptions): Promise<T>;
+}
+
+type RunState = {
+  runId: string;
+  summary: string;
+  actor: PrismEvent['actor'];
+  facet: PrismEvent['facet'];
+  startTs: string;
+  ctx?: Record<string, any>;
+};
+
+const DEFAULT_ACTOR: PrismEvent['actor'] = 'lucidia';
+const DEFAULT_FACET: PrismEvent['facet'] = 'intent';
+
+const defaultId = () => {
+  const cryptoApi = (globalThis as any).crypto;
+  if (cryptoApi?.randomUUID) {
+    return cryptoApi.randomUUID();
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+};
+
+const serializeError = (error: unknown) => {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      stack: error.stack,
+    };
+  }
+  if (typeof error === 'string') {
+    return {message: error};
+  }
+  try {
+    return {message: JSON.stringify(error)};
+  } catch {
+    return {message: String(error)};
+  }
+};
+
+function cloneCtx(ctx?: Record<string, any>) {
+  return ctx ? {...ctx} : undefined;
+}
+
+export function createRunLifecycle(options: RunLifecycleOptions = {}): RunLifecycle {
+  const clock = options.clock ?? (() => new Date());
+  const projectId = options.projectId ?? 'unknown-project';
+  const sessionId = options.sessionId ?? 'unknown-session';
+  const baseActor = options.actor ?? DEFAULT_ACTOR;
+  const baseFacet = options.facet ?? DEFAULT_FACET;
+  const publish = async (event: PrismEvent) => {
+    if (options.publish) {
+      await options.publish(event);
+    }
+  };
+  const nextEventId = options.eventIdFactory ?? defaultId;
+  const nextRunId = options.runIdFactory ?? defaultId;
+  const runs = new Map<string, RunState>();
+
+  const createEvent = (
+    kind: PrismEvent['kind'],
+    summary: string,
+    actor: PrismEvent['actor'],
+    facet: PrismEvent['facet'],
+    ctx?: Record<string, any>,
+    ts?: string
+  ): PrismEvent => ({
+    id: nextEventId(),
+    ts: ts ?? clock().toISOString(),
+    actor,
+    kind,
+    projectId,
+    sessionId,
+    facet,
+    summary,
+    ctx: ctx ? {...ctx} : undefined,
+  });
+
+  const ensureRun = (runId: string): RunState => {
+    const run = runs.get(runId);
+    if (!run) {
+      throw new Error(`Unknown run: ${runId}`);
+    }
+    return run;
+  };
+
+  const startRun = async ({summary, actor, facet, ctx, runId}: StartRunOptions): Promise<RunHandle> => {
+    const resolvedRunId = runId ?? nextRunId();
+    if (runs.has(resolvedRunId)) {
+      throw new Error(`Run ${resolvedRunId} already exists`);
+    }
+    const effectiveActor = actor ?? baseActor;
+    const effectiveFacet = facet ?? baseFacet;
+    const startTs = clock().toISOString();
+    const event = createEvent('run.start', summary, effectiveActor, effectiveFacet, {
+      ...(ctx ? {...ctx} : {}),
+      runId: resolvedRunId,
+      status: 'running',
+    }, startTs);
+    runs.set(resolvedRunId, {
+      runId: resolvedRunId,
+      summary,
+      actor: effectiveActor,
+      facet: effectiveFacet,
+      startTs,
+      ctx: cloneCtx(ctx),
+    });
+    await publish(event);
+    return {runId: resolvedRunId, event};
+  };
+
+  const endRun = async (runId: string, options?: EndRunOptions): Promise<PrismEvent> => {
+    const run = ensureRun(runId);
+    const effectiveActor = options?.actor ?? run.actor;
+    const effectiveFacet = options?.facet ?? run.facet;
+    const status = options?.status ?? 'ok';
+    const endTs = clock().toISOString();
+    const ctx = {
+      ...(run.ctx ? {...run.ctx} : {}),
+      ...(options?.ctx ? {...options.ctx} : {}),
+      runId,
+      status,
+      durationMs: Date.parse(endTs) - Date.parse(run.startTs),
+    };
+    const summary = options?.summary ?? run.summary;
+    const event = createEvent('run.end', summary, effectiveActor, effectiveFacet, ctx, endTs);
+    runs.delete(runId);
+    await publish(event);
+    return event;
+  };
+
+  const failRun = async (runId: string, error: unknown, options?: EndRunOptions): Promise<PrismEvent> => {
+    const run = ensureRun(runId);
+    const status = options?.status ?? 'error';
+    const endTs = clock().toISOString();
+    const ctx = {
+      ...(run.ctx ? {...run.ctx} : {}),
+      ...(options?.ctx ? {...options.ctx} : {}),
+      runId,
+      status,
+      error: serializeError(error),
+      durationMs: Date.parse(endTs) - Date.parse(run.startTs),
+    };
+    const summary = options?.summary ?? run.summary;
+    const event = createEvent(
+      'run.end',
+      summary,
+      options?.actor ?? run.actor,
+      options?.facet ?? run.facet,
+      ctx,
+      endTs
+    );
+    runs.delete(runId);
+    await publish(event);
+    return event;
+  };
+
+  const withRun = async <T>(
+    options: StartRunOptions,
+    fn: (ctx: RunContext) => Promise<T> | T,
+    endOptions?: EndRunOptions
+  ): Promise<T> => {
+    const {runId} = await startRun(options);
+    const context: RunContext = {
+      runId,
+      emit: async (event) => {
+        await publish({
+          ...event,
+          projectId: event.projectId ?? projectId,
+          sessionId: event.sessionId ?? sessionId,
+          ctx: {
+            ...(event.ctx ?? {}),
+            runId,
+          },
+        });
+      },
+    };
+    try {
+      const result = await fn(context);
+      await endRun(runId, endOptions);
+      return result;
+    } catch (err) {
+      await failRun(runId, err);
+      throw err;
+    }
+  };
+
+  return {
+    startRun,
+    endRun,
+    failRun,
+    withRun,
+  };
+}

--- a/apps/prism/packages/prism-core/src/spans.ts
+++ b/apps/prism/packages/prism-core/src/spans.ts
@@ -1,3 +1,100 @@
-// TODO: span tracking helpers
+import {PrismSpan} from './types';
 
-export {};
+export interface SpanTrackerOptions {
+  clock?: () => Date;
+  idFactory?: () => string;
+}
+
+export interface StartSpanOptions {
+  name: string;
+  parentSpanId?: string;
+  attrs?: Record<string, any>;
+  links?: string[];
+  startTs?: string;
+}
+
+export interface EndSpanOptions {
+  endTs?: string;
+  status?: PrismSpan['status'];
+  attrs?: Record<string, any>;
+}
+
+export interface SpanTracker {
+  start(options: StartSpanOptions): PrismSpan;
+  end(spanId: string, options?: EndSpanOptions): PrismSpan | undefined;
+  get(spanId: string): PrismSpan | undefined;
+  list(): PrismSpan[];
+  clear(): void;
+}
+
+const DEFAULT_STATUS: PrismSpan['status'] = 'ok';
+
+function toIso(value: string | undefined, clock: () => Date) {
+  return value ?? clock().toISOString();
+}
+
+const defaultId = () => {
+  const cryptoApi = (globalThis as any).crypto;
+  if (cryptoApi?.randomUUID) {
+    return cryptoApi.randomUUID();
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+};
+
+export function createSpanTracker(options: SpanTrackerOptions = {}): SpanTracker {
+  const clock = options.clock ?? (() => new Date());
+  const idFactory = options.idFactory ?? defaultId;
+  const spans = new Map<string, PrismSpan>();
+  const clone = (span: PrismSpan | undefined): PrismSpan | undefined => {
+    if (!span) return undefined;
+    return {
+      ...span,
+      attrs: span.attrs ? {...span.attrs} : undefined,
+      links: span.links ? [...span.links] : undefined,
+    };
+  };
+
+  return {
+    start({name, parentSpanId, attrs, links, startTs}) {
+      const spanId = idFactory();
+      const span: PrismSpan = {
+        spanId,
+        parentSpanId,
+        name,
+        startTs: toIso(startTs, clock),
+        status: DEFAULT_STATUS,
+        attrs: attrs ? {...attrs} : undefined,
+        links: links ? [...links] : undefined,
+      };
+      spans.set(spanId, span);
+      return clone(spans.get(spanId))!;
+    },
+    end(spanId, options) {
+      const span = spans.get(spanId);
+      if (!span) {
+        return undefined;
+      }
+      if (options?.endTs) {
+        span.endTs = options.endTs;
+      } else {
+        span.endTs = toIso(undefined, clock);
+      }
+      if (options?.status) {
+        span.status = options.status;
+      }
+      if (options?.attrs) {
+        span.attrs = {...(span.attrs ?? {}), ...options.attrs};
+      }
+      return clone(spans.get(spanId));
+    },
+    get(spanId) {
+      return clone(spans.get(spanId));
+    },
+    list() {
+      return Array.from(spans.values()).map((span) => clone(span)!);
+    },
+    clear() {
+      spans.clear();
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add an in-memory Prism event bus with waiting and piping helpers
- implement span tracking, diff statistics, and policy utilities used across Prism
- add a configurable run lifecycle helper and export the new modules from the package entrypoint

## Testing
- npx tsc --noEmit --moduleResolution node --module ES2022 --target ES2022 --lib es2022,dom apps/prism/packages/prism-core/src/index.ts

------
https://chatgpt.com/codex/tasks/task_e_68f686a9d7d88329bf81d451ba934e3d