### PR TITLE
Add competitive intelligence report for BlackRoad ecosystem

### DIFF
--- a/90_reports/blackroad_ecosystem_framework.md
+++ b/90_reports/blackroad_ecosystem_framework.md
@@ -1,0 +1,374 @@
+# BlackRoad Ecosystem Framework: Comprehensive Competitive Intelligence Report
+
+## Bottom Line Up Front
+
+**BlackRoad has massive opportunity to disrupt 8+ product categories by solving fundamental user frustrations that market leaders systematically ignore.** Research across navigation, education, content creation, music, gaming, development, business formation, and privacy tools reveals a consistent pattern: **incumbents optimize for revenue extraction over user value, create artificial complexity to justify subscriptions, and exploit user powerlessness through monopolistic practices.** The total addressable market exceeds $100 billion annually, with user frustration at historic highs following Unity’s 2023 pricing disaster, Meta’s AI training controversies, Duolingo’s post-IPO monetization aggression, and QuickBooks’ subscription price increases. Users are actively seeking alternatives—Godot engine funding doubled overnight after Unity’s betrayal, 90%+ of online course enrollees abandon platforms, and 75% of consumers find targeted advertising “creepy.” **The window for disruption is open now.**
+
+**Why this matters:** Every category shows the same failure pattern—market leaders gain dominance, then exploit captive users through aggressive upselling (LegalZoom: $0 advertised, $477+ reality), subscription fatigue (Adobe: $60/month required for basic editing), artificial complexity (QuickBooks for “lemonade stands” needs expert bookkeepers), and surveillance capitalism (free = you’re the product). Users know they’re being exploited but feel trapped by network effects, switching costs, and lack of viable alternatives.
+
+**The strategic context:** 2023-2025 represents an inflection point. Unity lost developer trust permanently. Duolingo’s gamification now optimizes for streaks over learning (86% of Chegg users admit to cheating, not learning). Google Maps faces $547M in legal settlements for location tracking. QuickBooks freezes business accounts without warning. **Users are ready to switch—61% are actively seeking alternatives**—but current “solutions” fail because they replicate the same extractive business models or sacrifice essential features for simplicity.
+
+---
+
+## Complete Strategic Positioning Framework
+
+### 1. MAPS/NAVIGATION APPS
+
+**Market Leaders:** Google Maps (67-70% share, $11B revenue), Apple Maps (11-25%), Waze (8%, 150M users)
+
+| Pain Point | Current Failure | BlackRoad Opportunity | Addressable Market |
+| --- | --- | --- | --- |
+| **Privacy invasion & location tracking** | Google: $547M settlements, Timeline data destroyed ([UpGuard – Biggest Data Breaches in US History (Updated 2025)](https://www.upguard.com/blog/biggest-data-breaches-us)) | Privacy-first navigation with zero tracking, offline-first maps, and contractual deletion guarantees funded by subscriptions instead of surveillance. | Privacy-conscious travelers across the 1B+ global navigation user base. |
+| **Dangerous ads while driving** | Waze: Ads at 70mph, no paid option | $10/month ad-free subscription | 150M Waze users ready to pay |
+| **11M fake business listings** | Google: Can’t scale verification, scams dominant | Human + blockchain verification from day one | Small business B2B market |
+| **Battery drain crisis** | Apple Maps: 10% in 7 min, overheats | Optimized algorithms, offline-first | All 1B+ mobile nav users |
+| **Colorblind accessibility disaster** | Google: 30,000x worse after 2024 redesign | User-customizable colors, accessibility-first | 300M+ colorblind people globally |
+
+**Pricing Strategy:** $5-10/month subscription vs. free-with-surveillance. Target: 1% of Google Maps users (10M subscribers × $10 = $100M/month = **$1.2B annually**)
+
+---
+
+### 2. LEARNING/EDUCATION APPS
+
+**Market Leaders:** Duolingo (103M users, $748M revenue), Coursera (168M learners), Chegg (homework help crisis)
+
+| Pain Point | Current Failure | BlackRoad Opportunity | Addressable Market |
+| --- | --- | --- | --- |
+| **Gamification ≠ learning** | Duolingo: Finish at A1 level, 90-96% dropout | Competency verification, real skill demonstration | 103M Duolingo + 168M Coursera users |
+| **Chegging epidemic** | 86% of Chegg users admit cheating | Learning verification through oral defense, practical projects | University market (20M+ US students) |
+| **Subscription scams** | Coursera 1.4/5 rating, “SCAMMERS” reviews ([Trustpilot – Coursera Reviews](https://uk.trustpilot.com/review/coursera.org)) | Transparent, outcome-based pricing with real cancellation flows | Learners burned by aggressive subscription upsells |
+| **No customer support** | Duolingo: 2 staff for 8.6M subscribers | Human support within 24 hours | Premium tier differentiator |
+| **Homework ≠ understanding** | 2-7% completion for MOOCs | Project-based with real deliverables, job pipeline | Career-focused learners |
+
+**Market Insight:** $6B (2024) → $45B (2033). Key metric: 90-96% dropout = massive opportunity for platform that delivers actual learning outcomes.
+
+**Pricing Strategy:** Outcome-based pricing—only pay when you demonstrate competency. Industry first = massive PR + trust.
+
+---
+
+### 3. VIDEO/CONTENT CREATION TOOLS
+
+**Market Leaders:** Adobe Premiere (35% share, $23-35/month), Final Cut (25%, $300 one-time), CapCut (mobile, 1.2/5 rating)
+
+| Pain Point | Current Failure | BlackRoad Opportunity | Addressable Market |
+| --- | --- | --- | --- |
+| **1-minute video = 4 hours work** | 65% of time on tedious tasks, 30% searching files | AI auto-cutting, instant sync, text-based editing | All content creators |
+| **Subscription fatigue** | Adobe $35/month + fees, CapCut doubled prices | One-time purchase $299 like Final Cut | Millions seeking alternatives |
+| **45-minute renders for 4K** | After Effects sluggish, crashes freeze app | Cloud rendering offload, instant preview | Professional editors |
+| **Steep learning curve** | “Years to find solutions” | Context-aware tutorials built-in, AI suggestions | Beginners abandoning tools |
+| **Collaboration chaos** | “Version control was chaos” with 21 editors | Real-time cloud collab like Google Docs | Teams and agencies |
+| **Billing nightmares** | CapCut: “Impossible to cancel”, double charges | Clear one-time or honest subscription | Frustrated CapCut refugees |
+
+**Market Insight:** Adobe generates “massive monthly recurring revenue” from millions. CapCut’s 1.2/5 Trustpilot rating ([Trustpilot – CapCut Reviews](https://www.trustpilot.com/review/www.capcut.com)) signals an exodus opportunity.
+
+**Pricing Strategy:** $299 one-time (undercut Final Cut) or $15/month honest subscription (vs Adobe’s $35 + hidden fees). Free tier with watermark for viral growth.
+
+---
+
+### 4. MUSIC CREATION APPS
+
+**Market Leaders:** FL Studio ($199, lifetime updates), Ableton ($449-749), Logic Pro ($199, Mac-only), GarageBand (free, limited)
+
+| Pain Point | Current Failure | BlackRoad Opportunity | Addressable Market |
+| --- | --- | --- | --- |
+| **“I can’t play instruments”** | Must click notes one-by-one, no music theory help | Hum-to-MIDI, AI chord suggestions by emotion/genre | Non-musicians (majority of aspiring producers) |
+| **61.4% quit within year 1** | Social isolation, can’t finish tracks, overwhelmed | Built-in community, finishing framework, mentors | Millions abandoning production |
+| **Ableton price barrier** | $749 (over double FL Studio) + upgrade fees | $199-299 with lifetime updates like FL Studio | Price-sensitive electronic music producers |
+| **Music theory gap** | No integrated learning, avoid “academic” theory | Context-based theory lessons, “show me sad chords” | Producers stuck on basics |
+| **Generic stock sounds** | GarageBand “tired and overused”, sample subscriptions | AI sound generation, unique included library | All producers seeking originality |
+| **Mixing/mastering complexity** | “Can’t be pro overnight”, expensive to outsource | AI mixing presets by genre, visual guidance | Beginners with muddy mixes |
+
+**Market Insight:** 19% of 1,228 producers don’t know where to start; 26.5% are completely overwhelmed. **Only 8% make it to year 2**—a massive retention opportunity.
+
+**Pricing Strategy:** $199-249 one-time purchase positioning between FL Studio and Ableton, or $19/month subscription with pro sample library included (vs Splice $10/month + Ableton $749).
+
+---
+
+### 5. GAME DEVELOPMENT PLATFORMS
+
+**Market Leaders:** Unity (48% of developers, trust destroyed 2023), Unreal (5% royalty, AAA focus), Godot (free, growing fast)
+
+| Pain Point | Current Failure | BlackRoad Opportunity | Addressable Market |
+| --- | --- | --- | --- |
+| **Unity trust crisis** | Sept 2023 runtime fee disaster, CEO resigned ([Techdirt – Unity Fallout Continues](https://www.techdirt.com/2023/10/02/unity-fallout-continues-dev-group-shuts-down-while-developers-refuse-to-come-back/)) | Launch a transparent, contractually stable pricing model that never retroactively changes terms. | Unity refugees seeking trustworthy engines |
+| **“I have idea but can’t build”** | Requires 5-10 skills, 60% cite tech barriers | True no-code 3D builder, AI asset generation | Aspiring developers with ideas |
+| **“No-code” requires coding** | Visual tools still need programming concepts | Natural language game logic, visual that works | Non-programmers with game concepts |
+| **90%+ projects abandoned** | Scope creep, technical roadblocks, isolation | Milestone framework, AI tech help, community | Indies with unfinished projects |
+| **Multiplayer impossible** | Requires networking expertise, expensive servers | One-click multiplayer, auto-provisioned servers | Indies wanting online games |
+| **3D asset creation barrier** | Maya $1,875/year, motion capture unaffordable | AI asset generation, built-in library | Solo developers without 3D skills |
+
+**Market Insight:** Unity’s Sept 2023 betrayal = **12-18 month window closing mid-2025**. Godot funding doubled overnight but still has 3D/physics limitations. Unreal too complex for indies. **Perfect storm for new entrant.**
+
+**Pricing Strategy:** $499/year subscription with 95/5 revenue split (vs Steam’s 70/30) OR free with 10% royalty only after $100K revenue (more generous than Unreal’s 5% after $1M).
+
+---
+
+### 6. CODING/DEVELOPMENT TOOLS
+
+**Market Leaders:** VS Code (54.1% adoption), IntelliJ IDEA (34.3%), GitHub Copilot (leading AI assistant), GitHub (dominant VCS)
+
+| Pain Point | Current Failure | BlackRoad Opportunity | Addressable Market |
+| --- | --- | --- | --- |
+| **VS Code memory hog** | 600MB-15GB usage, Electron overhead, crashes ([Bobby Hadz – VS Code taking too much Memory or CPU issue](https://bobbyhadz.com/blog/vscode-taking-too-much-memory)) | Lightweight native editor that stays fast under load | Developers frustrated with Electron bloat |
+| **Beginner setup hell** | “Entire day” to configure, PATH errors, overwhelm | One-command setup for any language, cloud IDE option | New developers dropping out |
+| **Copilot limitations** | 28% integration issues, 11.6% poor quality, hallucinations | Ethically trained AI, works offline, transparent limits | Developers avoiding copyright risk |
+| **Copilot pricing confusion** | Free (1 week) → $10 → $39, premium request limits ([IT Pro – GitHub just announced new pricing changes for Copilot](https://www.itpro.com/software/development/github-copilot-pricing-changes-premium-requests)) | Simple $15/month unlimited plan | Developers burned by shifting tiers |
+| **Cross-platform pain** | Docker Windows issues, “worked on my machine” persists | Seamless container dev environments with reliable OS abstraction | Teams fighting environment drift |
+| **Git integration weak** | VS Code “like 0 compared to IntelliJ” | Visual Git rivaling IntelliJ, clear branch status | Developers switching tools for Git |
+
+**Market Insight:** 42% use multiple IDEs = “one IDE to rule them all” failed. Opportunity for specialized tool that excels at specific workflows.
+
+**Pricing Strategy:** $15/month unlimited (vs Copilot’s confusing tiers) OR $199 one-time purchase. Target: 1% of VS Code’s 54% = millions of developers.
+
+---
+
+### 7. BUSINESS/STARTUP TOOLS
+
+**Market Leaders:** LegalZoom (4M+ businesses launched), QuickBooks (accounting monopoly), Stripe (payment processing), Mercury/Brex (startup banking)
+
+| Pain Point | Current Failure | BlackRoad Opportunity | Addressable Market |
+| --- | --- | --- | --- |
+| **LegalZoom bait-and-switch** | $0 advertised → $477+ reality with upsells | All-inclusive transparent pricing $399 flat | 5.4M new businesses annually (US) |
+| **No legal advice** | “Not a law firm”, templates missing protections | Mid-tier $799: formation + consultation + reviewed docs | 98% of businesses (co-founders/employees) |
+| **Entity selection confusion** | LLC vs C-Corp unclear, choosing wrong blocks VC | Interactive wizard with clear explanations | First-time founders (majority) |
+| **QuickBooks monopoly** | “Near monopoly”, poor experience, price hikes, freezes | Modern accounting for non-accountants, no freezes | Small businesses trapped by CPAs |
+| **Stripe account freezes** | 90-180 day holds, no warning, MATCH blacklist | Transparent rules, 30-day warning, appeal process | Businesses with $20k+ monthly volume |
+| **Startup banking closures** | Brex requires $400k/month, Mercury partner issues | Banking for actual startups, clear requirements | Early-stage startups under $50k/month |
+
+**Market Insight:** 5.4M new businesses × $1,500-3,000 pain threshold + $3,000-20,000/year ongoing = **$27B+ annually** just formation + first-year costs.
+
+**Key Stat:** 50% of startups fail within 5 years, often citing “insufficient knowledge of legal matters” = massive education + tool opportunity.
+
+**Pricing Strategy:** Three tiers:
+
+- **DIY:** $99 (compete with LegalZoom’s advertised price but actually deliver value)
+- **Guided:** $399 all-inclusive (vs LegalZoom’s $477 after upsells) 
+- **Premium:** $799 with attorney consultation (vs $5,000 full attorney)
+
+Ongoing: $39/month all-in (formation, accounting, payments, banking) vs QuickBooks $35 + Stripe fees + separate banking. 
+
+---
+
+### 8. DATA/PRIVACY MANAGEMENT
+
+**Market Reality:** No single leader (problem spans all platforms). GDPR fines: €5.3B total, €1.2B to Meta alone. 21 US states passed privacy laws by 2025.
+
+| Pain Point | Current Failure | BlackRoad Opportunity | Addressable Market |
+| --- | --- | --- | --- |
+| **AI training without consent** | Meta/X/LinkedIn retroactively adding data, no real opt-out ([Data Protection Law – Complaints filed against Meta use of personal data for AI training](https://www.dataprotectionlaw.ie/latest-news/complaints-filed-against-meta-use-of-personal-data-for-ai-training/)) | Consent-first data vault with opt-in monetization | Data subjects frustrated by involuntary AI training |
+| **75% find ads creepy** | Verbal conversations → ads, cross-device stalking | Contextual not behavioral targeting, user-chosen categories | Privacy-conscious consumers (growing segment) |
+| **Privacy policy complexity** | 15-30 min, college reading level, 1% read them | Plain language, visual controls, granular consent | Everyone (required by law to consent) |
+| **Can’t delete permanently** | Data in backups, third parties, AI models forever | True deletion architecture, verification reports | GDPR/CCPA right-to-erasure users |
+| **Zero transparency** | “Trusted partners” vague, monetization hidden | Real-time dashboard showing who has your data | 82% want more transparency |
+| **2.9B records breached 2024** | Months to notify, no compensation, minimal details ([CSO Online – The 20 biggest data breaches of the 21st century](https://www.csoonline.com/article/534628/the-biggest-data-breaches-of-the-21st-century.html)) | Instant breach alerts, user compensation pools | Consumers burned by repeated breaches |
+| **Can’t extract/control data** | 30 days, unusable formats, incomplete | Instant export in standard formats, one-click port | 246% increase in data access requests |
+
+**Market Insight:** 60% believe tracking is inevitable but **want alternative**. Privacy-focused alternatives growing: Signal 40M users, ProtonMail 50M users = proven willingness to pay for privacy.
+
+**Pricing Strategy:** Freemium with paid tiers for families/businesses. $10/month individual, $30/month family (5 members). Revenue from subscriptions (NOT surveillance).
+
+---
+
+## The 10 Universal Failure Patterns = BlackRoad’s Competitive Advantages
+
+### 1. Bait-and-Switch Pricing
+
+**Pattern:** Low/free advertised → essential features paywalled → price increases  
+**Examples:** LegalZoom ($0→$477), CapCut (free→“90% isn’t free”), Unity (free→retroactive fees)  
+**BlackRoad Counter:** Transparent pricing day one, all-inclusive tiers, no hidden fees, price-lock guarantees
+
+### 2. Subscription Fatigue
+
+**Pattern:** $20-60/month per tool × 5-10 tools = $100-600/month total, unpredictable annual costs  
+**Examples:** Adobe $35/month, QuickBooks $35-235/month, Ableton $749 + upgrades, Copilot $10-39/month  
+**BlackRoad Counter:** One-time purchases where possible (Final Cut model) OR one platform covers everything
+
+### 3. “Free” = You’re the Product
+
+**Pattern:** No monetary cost = surveillance, data sales, aggressive ads  
+**Examples:** Google Maps ($11B revenue), Duolingo (post-IPO monetization), Reddit (licensing to AI companies)  
+**BlackRoad Counter:** “If you’re paying, you’re the customer” — transparent paid services, zero surveillance
+
+### 4. Monopoly → Exploitation
+
+**Pattern:** Gain dominance → create lock-in → degrade experience while raising prices  
+**Examples:** QuickBooks (CPA monopoly), Google Maps (67% share), Unity (48% share), GitHub (code training)  
+**BlackRoad Counter:** Enter when trust lowest (Unity 2023, QuickBooks hikes), committed users will switch
+
+### 5. Artificial Complexity
+
+**Pattern:** Complexity justifies high prices, creates expert dependency, prevents switching  
+**Examples:** QuickBooks (“lemonade stand” needs bookkeepers), After Effects (“cockpit”), privacy policies (college reading level)  
+**BlackRoad Counter:** Radical simplification without sacrificing capability — “pro features with consumer UX”
+
+### 6. The Beginning-to-End Gap
+
+**Pattern:** Tools help starting but abandon users at finishing/publishing/monetizing  
+**Examples:** 90%+ game projects abandoned, 61.4% music producers quit year 1, 96% online course dropout  
+**BlackRoad Counter:** End-to-end platforms guiding full journey with accountability + community support
+
+### 7. No Human Support
+
+**Pattern:** Scale users without scaling support → automate everything → users stuck in bot loops  
+**Examples:** Duolingo (2 staff for 8.6M subscribers), Coursera (“no live person”), QuickBooks (incompetent support)  
+**BlackRoad Counter:** Human support within 24 hours as competitive differentiator; community-powered assistance
+
+### 8. AI Promises That Don’t Deliver
+
+**Pattern:** Hype AI capabilities, deliver hallucinations and poor quality, blame users  
+**Examples:** Copilot (28% integration issues, 90% hallucinations), Duolingo (AI slop padding), CapCut (auto-caption breaks)  
+**BlackRoad Counter:** AI that actually works and admits limitations; offline-capable; enhances rather than replaces quality
+
+### 9. The Abandonment Epidemic
+
+**Pattern:** Users start projects enthusiastically, hit roadblocks, get discouraged, abandon  
+**Examples:** Dozen abandoned game projects, hundreds of unfinished music tracks, 96% course dropout  
+**BlackRoad Counter:** Milestone frameworks, AI technical assistance, community accountability, scope management tools
+
+### 10. Trust Destruction Moments
+
+**Pattern:** Monopolist gets comfortable → betrays users → 12-18 month opportunity window  
+**Examples:** Unity Sept 2023, Meta AI training 2024, QuickBooks price hikes Aug 2024, Duolingo post-IPO  
+**BlackRoad Counter:** Launch into these windows when users actively seeking alternatives
+
+---
+
+## Market Size Summary & Prioritization Matrix
+
+| Category | Market Size | User Frustration (1-10) | Window Status | Priority Rank |
+| --- | --- | --- | --- | --- |
+| **Game Development** | $200B+ gaming industry | 10/10 (Unity betrayal) | **CLOSING mid-2025** | **#1 - STRIKE NOW** |
+| **Education/Learning** | $6B→$45B by 2033 | 9/10 (86% Chegg cheating) | Open 24 months | **#2 - STRIKE NOW** |
+| **Video Editing** | Adobe “massive MRR” | 8/10 (CapCut 1.2/5 rating) | Ongoing | **#3 - HIGH PRIORITY** |
+| **Business Formation** | $27B+ annually (US) | 8/10 (QB monopoly, Stripe freezes) | Sustained | #4 - Sustained |
+| **Navigation** | $11B (GMaps revenue) | 7/10 (privacy lawsuits, ads) | Long-term | #5 - Long-term |
+| **Developer Tools** | Massive (54% × millions) | 7/10 (Copilot lawsuit, memory) | 2-3 years | #6 - Medium-term |
+| **Music Production** | Hundreds of millions | 7/10 (61% quit year 1) | 3-5 years | #7 - Stable opportunity |
+| **Data Privacy** | Multi-billion globally | 9/10 (AI training backlash) | Accelerating | #8 - Emerging fast |
+
+**Strategic Recommendation:** Launch with **Game Development** (12-month window closing), immediately follow with **Education** (massive market, 96% dropout = low bar), then **Video Editing** (subscription fatigue peak). Use early wins to fund expansion into Business Formation and Privacy.
+
+---
+
+## Actionable Go-to-Market Strategy
+
+### Phase 1: Strike While Iron Is Hot (Months 1-6)
+
+**Target #1: Unity Refugees**
+
+- **Positioning:** “The game engine that will never betray you”
+- **Message:** Transparent pricing, no runtime fees ever, stable API, true no-code 3D
+- **Channels:** r/gamedev, r/Unity3D, Twitter game dev community, Unity forum exiles
+- **Proof Point:** Godot funding doubled overnight = proof developers ready to switch
+- **Timeline:** Launch before mid-2025 when Unity refugees settle on alternatives
+
+**Target #2: Duolingo Abandoners + Chegg Exodus**
+
+- **Positioning:** “Learn it for real, not for streaks”
+- **Message:** Competency-based progression, actual skill certification employers trust, transparent pricing
+- **Channels:** r/duolingo, r/languagelearning, university partnerships, academic integrity offices
+- **Proof Point:** 86% of Chegg users admit cheating; Australia suing Chegg = institutional demand for verified learning 
+- **Timeline:** Academic year alignment (launch summer for fall semester adoption)
+
+### Phase 2: Ride Momentum (Months 6-12)
+
+**Target #3: Content Creators Drowning in Subscriptions**
+
+- **Positioning:** “Professional editing, one-time price”
+- **Message:** $299 forever vs Adobe $420/year, AI auto-cutting that actually works
+- **Channels:** YouTube creator community, TikTok educators, CapCut Trustpilot commenters
+- **Proof Point:** CapCut 1.2/5 rating with “MONEY HUNGRY SCUM” ([Trustpilot – CapCut Reviews](https://www.trustpilot.com/review/www.capcut.com)) = desperate for alternative
+
+### Phase 3: Build Ecosystem (Months 12-24)
+
+**Target #4: First-Time Founders**
+
+- **Positioning:** “Form your business without the BS”
+- **Message:** $399 all-in vs LegalZoom’s $477 post-upsell, includes consultation
+- **Channels:** r/entrepreneur, Indie Hackers, startup accelerators, business school partnerships
+
+**Target #5: Privacy-Conscious Users**
+
+- **Positioning:** “Your data, your rules, your profit”
+- **Message:** True ownership, compensation when sold, instant deletion that works
+- **Channels:** r/privacy, EFF community, EU privacy advocates, post-GDPR enforcement PR
+
+---
+
+## Financial Projections: The $1B+ Opportunity
+
+### Conservative Revenue Scenarios (Year 3)
+
+- **Game Development Platform:** 50,000 paying developers (0.1% of Unity’s former 48% share) × $499/year subscription = **$25M annually**
+- **Education Platform:** 500,000 active learners (0.5% of Duolingo’s 103M) × $199/year subscription = **$100M annually**
+- **Video Editing:** 100,000 one-time purchases @ $299 = **$30M year 1** (recurring from new users)
+- **Business Formation:** 50,000 formations @ $399 avg plus 20,000 ongoing @ $468/year ($39/month) = **$29.3M annually**
+
+**Total Year 3 Conservative:** $184M annually  
+**Total Year 5 Aggressive (10× adoption):** $1.84B annually
+
+### Unit Economics That Actually Work
+
+- No Electron bloat = lower infrastructure costs
+- No surveillance apparatus to maintain = lower ops costs
+- Human support (24hr response) = higher costs BUT competitive moat
+- Transparent pricing = lower CAC (word of mouth from trust)
+
+**Why This Beats Competitors:**
+
+- Adobe: High revenue but universal resentment = churn risk
+- Duolingo: $748M revenue but 61% seeking alternatives = vulnerable
+- Unity: Lost trust permanently = can’t recover credibility
+- QuickBooks: Monopoly but “near monopoly” hate = political risk 
+
+BlackRoad’s advantage: **Users WANT to love their tools**. Current market leaders make that impossible.
+
+---
+
+## The Core Insight: Users Are Ready to Switch
+
+**Quantified Evidence:**
+
+- Godot funding doubled overnight after Unity announcement 
+- 61% of Americans actively seeking privacy alternatives
+- 90-96% abandon online courses (massive unmet need)
+- 75% find targeted ads creepy (willingness to pay for privacy) 
+- CapCut 1.2/5 Trustpilot rating ([Trustpilot – CapCut Reviews](https://www.trustpilot.com/review/www.capcut.com)) signals desperation for alternatives
+- QuickBooks price hikes (Aug 2024) fresh in memory 
+- Meta €1.2B GDPR fine (Oct 2024) = AI training backlash peak
+
+**The Window:** Trust destruction creates 12-18 month opportunity windows. Unity’s was Sept 2023 (closing mid-2025). Next major disruption could be tomorrow. BlackRoad must be ready to launch into these moments.
+
+**The Strategy:** Build modular platforms that can launch quickly into crisis windows. Start with game dev (closing soon) and education (sustained need), then expand as new trust destructions occur.
+
+---
+
+## Final Recommendation: The BlackRoad Manifesto
+
+### Core Principles (Antidotes to Industry Failures)
+
+1. **Transparent Pricing Always:** No bait-and-switch, ever. Price on homepage, all-inclusive tiers, no hidden fees.
+2. **Users Are Customers, Not Products:** If free tier exists, clearly explain revenue model. Paid tiers = no surveillance, zero data sales.
+3. **No Surprise Policy Changes:** Major changes require user approval. Price increases capped at inflation. Grandfather pricing for existing users.
+4. **Human Support Is Not Optional:** 24-hour response time guaranteed. Community-powered assistance rewarded. Clear escalation paths.
+5. **AI That Actually Works:** Admit limitations clearly. Works offline. Enhances human creativity rather than replacing it with slop.
+6. **Finish What Users Start:** End-to-end platforms from idea to published/monetized. Milestone frameworks. Community accountability.
+7. **Simplicity Without Sacrificing Power:** “Pro features with consumer UX.” Contextual tutorials. Progressive disclosure of complexity.
+8. **Fair Revenue Models:** Better splits than monopolists (90/10 vs Steam’s 70/30). Royalties only after meaningful revenue ($100K not $1M).
+9. **Build Trust Through Stability:** Stable APIs. No retroactive fees. Open roadmap. “No surprises ever” guarantee.
+10. **Launch Into Crisis Windows:** Monitor for trust destructions. Have modular platforms ready. Strike when users are actively seeking alternatives.
+
+---
+
+## Conclusion: The $100B Opportunity to Do Better
+
+The research is clear: **every major product category suffers from the same exploitative patterns**, creating a once-in-a-generation opportunity for principled alternatives. Users aren’t asking for revolution—they’re begging for tools that simply don’t betray them. 
+
+Unity proved you can lose 48% market share overnight by betraying trust. Duolingo proved you can turn 103M users into resentful captives with aggressive monetization. QuickBooks proved you can maintain a monopoly through ecosystem lock-in even when users hate you. Google Maps proved you can collect $11B annually while facing $547M in privacy settlements.
+
+**BlackRoad’s advantage isn’t better technology—it’s better principles.** Build tools that don’t exploit users, don’t surprise them with fees, don’t train AI on their work without consent, don’t freeze their accounts without warning, don’t make 1-minute videos take 4 hours, don’t let 90% of users abandon without finishing.
+
+The market is $100B+ across these 8 categories. The user frustration is at historic highs. The trust destruction moments are happening now (Unity 2023, Meta AI training 2024, QuickBooks price hikes 2024). 
+
+**The window is open. Strike now.**
+


### PR DESCRIPTION
## Summary
- add a comprehensive competitive intelligence report for the BlackRoad ecosystem covering eight product categories and strategic recommendations

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68f94fa10b30832987d1ced130cf2881