### PR TITLE
Add Geometry-Memory Transport AI framework documentation

### DIFF
--- a/ai/assistants/assistants.json
+++ b/ai/assistants/assistants.json
@@ -1,1 +1,10 @@
-{ "list": [] }
+{
+  "list": [
+    {
+      "id": "geometry-memory-transport",
+      "name": "GeometryMemoryTransportArchitect",
+      "path": "ai/assistants/geometry_memory_transport.json",
+      "status": "draft"
+    }
+  ]
+}

--- a/ai/assistants/geometry_memory_transport.json
+++ b/ai/assistants/geometry_memory_transport.json
@@ -1,0 +1,10 @@
+{
+  "name": "GeometryMemoryTransportArchitect",
+  "description": "LLM placeholder for orchestrating the Geometry-Memory Transport AI framework.",
+  "status": "draft",
+  "notes": [
+    "Attach prompts from prompts/llm/geometry_memory_transport.yaml",
+    "Bind associative memory tools once implemented",
+    "Wire telemetry for energy, transport, and causal audits"
+  ]
+}

--- a/ai/experiments/index.json
+++ b/ai/experiments/index.json
@@ -1,1 +1,13 @@
-{ "list": [] }
+{
+  "list": [
+    {
+      "id": "gmt-fast-start",
+      "title": "Geometry-Memory Transport fast-start experiments",
+      "status": "planned",
+      "references": [
+        "docs/ai/geometry_memory_transport_framework.md",
+        "prompts/llm/geometry_memory_transport.yaml"
+      ]
+    }
+  ]
+}

--- a/docs/ai/geometry_memory_transport_framework.md
+++ b/docs/ai/geometry_memory_transport_framework.md
@@ -1,0 +1,132 @@
+# Geometry-Memory Transport (GMT) AI Framework
+
+## Purpose and positioning
+Geometry-Memory Transport (GMT) is a blueprint for building models that respect the math modern AI already relies on while
+reframing training as structured flows across geometry, memory, and control. The goal is to keep the familiar toolchain in
+view—gradient-based optimization, expressive losses, linear algebra workloads, attention blocks, probabilistic updates, and
+state-of-the-art generative stacks—yet promote different governing equations whenever we want longer-horizon stability,
+interpretable recall, and distributional robustness.
+
+### Canonical stack we inherit
+- **Optimization and calculus core.** Gradient descent and backpropagation update parameters via
+  $\theta_{t+1} = \theta_t - \eta\,\nabla_\theta \mathcal{L}(\theta_t)$, augmented with regularisers such as L1/L2 norms to
+  control the parameter budget.
+- **Behavior-shaping losses.** Cross-entropy / negative log likelihoods, mean-squared error, and KL-based variational objectives
+  remain the primitive levers for shaping predictions, calibrating uncertainty, and matching approximate posteriors.
+- **Linear algebra workhorses.** Matrix products, convolutions, eigendecompositions, and normalisation layers dominate runtime
+  characteristics and define the vector spaces our models move within.
+- **Attention interfaces.** Scaled dot-product attention $\operatorname{softmax}(QK^\top/\sqrt{d})V$ is the dominant
+  addressing scheme for contextual reasoning.
+- **Probabilistic and decision-theoretic updates.** Bayesian conditioning, policy gradient estimators, and control variates give us
+  a language for learning from interaction.
+- **Generative templates.** Diffusion/score matching, GAN objectives, and autoregressive likelihoods power content creation and
+  world-modelling.
+
+GMT keeps these instruments but rearranges the higher-level obligations so that geometry governs learning rates, transport links
+training to controllable evolution, associative memories become first-class citizens, and robustness is negotiated through
+compression-aware objectives.
+
+## Framework pillars
+
+### 1. Symplectic learning core
+- **Hamiltonian flow for parameter dynamics.** Treat the parameter state as $(q, p)$ pairs and evolve them with
+  $\dot{q} = \partial H/\partial p$, $\dot{p} = -\partial H/\partial q$ so training conserves a learned energy $H$. This reduces
+  artificial dissipation and favours faithful long-horizon rollouts.
+- **Information geometry-aware steps.** Replace plain gradients with natural gradients
+  $\theta_{t+1} = \theta_t - \eta F(\theta_t)^{-1} \nabla_\theta \mathcal{L}$, where the Fisher information tensor $F$ encodes the
+  local shape of the output distribution. Optimisation steps now respect the model's own statistical geometry.
+
+### 2. Transport-aligned objectives
+- **Optimal transport distances.** Optimise with Wasserstein costs $W_c(p_\theta, p_{\text{data}})$ to compare model and data
+  distributions by the geometry of their support, handling class imbalance and support mismatch gracefully.
+- **Schrödinger bridges.** When we need guided transitions between boundary distributions $(p_0, p_1)$, minimise pathwise relative
+  entropy over diffusions. This yields stochastic interpolants suitable for controllable generation and planning.
+
+### 3. Associative memory fabric
+- **Energy-based recall.** Equip the model with modern Hopfield layers whose energy is
+  $E(x) = -\log \sum_i \exp(\beta\, \phi(x)^\top \phi(\xi_i))$, so retrieval becomes movement toward stored patterns
+  $\{\xi_i\}$. Rare events and explicit memories are anchored by attractor dynamics rather than soft attention alone.
+- **Memory governance.** Introduce write/read policies that log when new patterns are admitted, how long they persist, and how
+  they decay. This sets up on-demand forgetting as an optimisation constraint, not an afterthought.
+
+### 4. Control-as-inference policy layer
+- **KL-regularised control.** Derive policies by minimising
+  $\mathbb{E}[\sum_t c(s_t, a_t)] + \lambda\,\mathrm{KL}(\pi \Vert \pi_0)$, framing planning as posterior inference. The
+  framework inherits smooth exploration and explicit deviation penalties from a preferred policy $\pi_0$.
+- **Free-energy links.** The same KL structure interfaces naturally with active-inference style free-energy objectives, letting
+  world models, policies, and memory stores share gradients and uncertainty budgets.
+
+### 5. Structural priors and causal training
+- **Symmetry constraints.** Encode equivariances $f(g \cdot x) = \rho(g) f(x)$ for symmetry group $G$ so the model respects the
+  invariances baked into the environment. Noether-style conservation laws then tie back to the Hamiltonian energy.
+- **Interventional risk minimisation.** Optimise against $\mathbb{E}_{p(x) p(y \mid \mathrm{do}(x))}[\ell(f(x), y)]$ to privilege
+  mechanisms over observational shortcuts, yielding memories of causes instead of correlations.
+
+### 6. Dynamics-native generation
+- **Neural ODE/SDE solvers.** Model latent trajectories with $\dot{z} = f_\theta(z, t)$ or
+  $dz = f_\theta(z, t)\,dt + \sigma\,dW_t$ while tracking density evolution via the Fokker–Planck equation
+  $\partial_t p = -\nabla \cdot (\mu p) + \tfrac{1}{2} \nabla^2 (\Sigma p)$. This lets simulations stay stable across long
+  horizons with calibrated uncertainty.
+
+### 7. Compression and robustness safeguards
+- **Minimum description length pressure.** Minimise the total code length $L(\text{model}) + L(\text{data} \mid \text{model})$ as a
+  regulariser so learned memories remain modular and reusable.
+- **Distributionally robust envelopes.** Adopt objectives of the form
+  $\min_\theta \max_{Q \in \mathcal{U}(P)} \mathbb{E}_{Q}[\ell(f_\theta(x), y)]$ with Wasserstein or $f$-divergence uncertainty
+  sets. Models lock onto core features that survive covariate shift.
+
+## System blueprint
+```
+Data & interventions --> Geometry-aware optimiser --> Associative memory --> Transport planner -->
+  Symmetry + causal filters --> Dynamics simulator --> Compression/robustness monitors --> Deployment & evaluation
+```
+Each pillar supplies a service: the optimiser maintains energy, the transport layer aligns distributions, memory enforces
+retrieval guarantees, control assembles actions, structural priors police invariances, the dynamics block simulates forward, and
+compression plus robustness keep the model honest.
+
+## Training and deployment cycle
+1. **Curate interventions and counterfactuals.** Pair standard datasets with targeted interventions so interventional risk can be
+   estimated alongside observational likelihood.
+2. **Pretrain the dynamics core.** Fit the Hamiltonian / neural ODE backbone using transport-aligned losses to capture the data
+   manifold.
+3. **Attach associative memory.** Initialise Hopfield slots with rare or high-value exemplars and enable write policies linked to
+   MDL thresholds.
+4. **Optimise policies via control-as-inference.** Train action heads or decoders using the KL-regularised control objective with
+   natural-gradient steps.
+5. **Enforce structural priors.** Regularly audit equivariance constraints and causal metrics, adjusting data augmentation and
+   group representations when violations occur.
+6. **Stress-test robustness.** Evaluate against DRO adversaries, shifted datasets, and calibrated uncertainty scores before
+   promotion.
+
+## Evaluation metrics
+- **Energy conservation score.** Measure drift in Hamiltonian energy across long rollouts to monitor stability.
+- **Memory fidelity.** Track retrieval accuracy for stored patterns and decay schedules.
+- **Transport alignment.** Report Sinkhorn or unbiased Wasserstein distances between generated and empirical distributions.
+- **Causal fidelity.** Quantify gap between observational and interventional losses.
+- **Robustness index.** Monitor worst-case risk over uncertainty sets and calibration under shift.
+
+## Implementation playbook
+| Phase | Goal | Key artefacts |
+|-------|------|---------------|
+| Sprint 0 | Stand up GMT sandbox | Notebook with Hamiltonian optimiser + OT loss, placeholder Hopfield memory, baseline metrics |
+| Sprint 1 | Couple memory + transport | Prototype energy-preserving trainer with Sinkhorn loss and associative memory head |
+| Sprint 2 | Add control and symmetry | Policy layer with KL control, group representation tests, causal augmentation scripts |
+| Sprint 3 | Harden for deployment | DRO evaluator, MDL-based pruning, observability dashboards |
+
+## Fast-start experiments
+1. **Wasserstein classification pilot.** Swap cross-entropy for $W_1$ distance using Sinkhorn iterations on a small classifier.
+   Expect improved calibration and resilience to class imbalance.
+2. **Associative memory head trial.** Add a modern Hopfield layer after a transformer encoder, training with contrastive retrieval
+   loss so rare facts remain recallable.
+3. **Natural-gradient training run.** Replace Adam/SGD with a Fisher-aware optimiser (e.g., K-FAC) on a compact model to validate
+   sample-efficiency gains.
+4. **Information bottleneck plus interventions.** Introduce a variational information bottleneck penalty $\beta I(Z; X)$ while
+   augmenting data with counterfactual interventions to prioritise causal signals.
+
+Each experiment plugs directly into one or more pillars, giving an incremental path toward a full GMT deployment.
+
+## Next steps
+- Draft instrumentation for energy drift, memory utilisation, and Wasserstein alignment so GMT runs are observable.
+- Extend deployment checklists to include causal risk audits and DRO regression tests.
+- Formalise handoff documents so product teams can request new memories or transport constraints without retraining the entire
+  system.

--- a/prompts/llm/geometry_memory_transport.yaml
+++ b/prompts/llm/geometry_memory_transport.yaml
@@ -1,0 +1,29 @@
+# Geometry-Memory Transport (GMT) prompt pack
+# Placeholder tasks for LLM workflows that support the GMT AI framework.
+description: |
+  Draft prompts that help teams explore the Geometry-Memory Transport (GMT) framework.
+  Each task sketches the type of interaction an assistant should enable once the full
+  workflow is implemented.
+tasks:
+  - id: gmt-overview-001
+    prompt: |
+      Summarize the seven pillars of the Geometry-Memory Transport framework and outline how
+      they interact during a single training cycle. Highlight the Hamiltonian optimiser,
+      transport objectives, associative memory, control layer, symmetry constraints,
+      dynamics model, and robustness safeguards.
+    expect_keywords: [Hamiltonian, transport, Hopfield, KL, symmetry, ODE, robustness]
+
+  - id: gmt-diagnostics-001
+    prompt: |
+      Given a log excerpt describing rising Wasserstein distances, energy drift, and a
+      failing causal audit, produce a triage checklist that references the GMT evaluation
+      metrics. Include suggested telemetry to collect for each issue.
+    expect_keywords: [Wasserstein, energy, causal, telemetry]
+
+  - id: gmt-experiment-001
+    prompt: |
+      Propose a week-long experiment plan that sequences the GMT fast-start experiments:
+      Wasserstein classification, Hopfield memory head, natural-gradient training, and the
+      information bottleneck with interventions. Explain expected outcomes and exit
+      criteria.
+    expect_keywords: [experiment, Sinkhorn, Hopfield, K-FAC, bottleneck]


### PR DESCRIPTION
## Summary
- document the Geometry-Memory Transport (GMT) AI framework with implementation guidance and experiments
- add placeholder LLM prompt pack and assistant record for GMT workflows
- register a GMT experiment stub linking to the new documentation and prompts

## Testing
- not run (documentation and configuration updates only)

------
https://chatgpt.com/codex/tasks/task_e_68fa7b96a5608329a87846c35995aad3