### PR TITLE
Add Modern Hopfield transformer training pipeline

### DIFF
--- a/ml/hopfield_transformer/README.md
+++ b/ml/hopfield_transformer/README.md
@@ -1,0 +1,11 @@
+# Modern Hopfield Transformer Experiment
+
+This module trains a compact vision transformer augmented with a Modern Hopfield memory head on CIFAR-10.
+
+## Usage
+1. Install dependencies: `pip install torch torchvision torchmetrics`.
+2. Launch training with the default configuration: `python -m ml.hopfield_transformer.train --epochs 20 --beta 20 --mem-size 256 --lambda-retr 0.2 --seed 0`.
+3. Metrics (accuracy, retrieval AUC, rare recall) are printed each epoch and saved to `metrics.json` under the chosen `--output-dir`.
+4. The best checkpoint is written to `best.pt` in the same directory.
+5. Append `--run-ablation` to compute the rare-recall ablation with the Hopfield head temporarily disabled after training.
+6. Launch a fresh run with `--disable-hopfield` to obtain a transformer baseline without the memory head.

--- a/ml/hopfield_transformer/__init__.py
+++ b/ml/hopfield_transformer/__init__.py
@@ -1,0 +1,31 @@
+"""Modern Hopfield transformer training package."""
+
+from .models import HopfieldVisionTransformer, ModernHopfieldHead
+from .utils import (
+    MemoryDescription,
+    RareRecallResult,
+    build_dataloaders,
+    build_memory_description,
+    class_to_memory_indices,
+    evaluate_rare_recall,
+    identity_normalizer,
+    sample_memory_indices,
+    save_metrics,
+    set_seed,
+)
+
+__all__ = [
+    "HopfieldVisionTransformer",
+    "ModernHopfieldHead",
+    "MemoryDescription",
+    "RareRecallResult",
+    "build_dataloaders",
+    "build_memory_description",
+    "class_to_memory_indices",
+    "evaluate_rare_recall",
+    "identity_normalizer",
+    "sample_memory_indices",
+    "save_metrics",
+    "set_seed",
+]
+

--- a/ml/hopfield_transformer/models.py
+++ b/ml/hopfield_transformer/models.py
@@ -1,0 +1,254 @@
+"""Model definitions for the Modern Hopfield transformer experiment."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+import torch
+from torch import Tensor, nn
+
+
+@dataclass
+class HopfieldReadout:
+    """Container for Hopfield read outputs."""
+
+    logits: Tensor
+    energies: Tensor
+    attention: Tensor
+
+
+class PatchEmbedding(nn.Module):
+    """Embed 2-D images into a sequence of patch tokens."""
+
+    def __init__(
+        self,
+        img_size: int = 32,
+        patch_size: int = 4,
+        in_channels: int = 3,
+        embed_dim: int = 192,
+    ) -> None:
+        super().__init__()
+        if img_size % patch_size != 0:
+            raise ValueError("Image size must be divisible by patch size.")
+        self.proj = nn.Conv2d(in_channels, embed_dim, kernel_size=patch_size, stride=patch_size)
+        self.num_patches = (img_size // patch_size) ** 2
+
+    def forward(self, x: Tensor) -> Tensor:
+        bsz = x.shape[0]
+        x = self.proj(x)
+        x = x.flatten(2).transpose(1, 2)
+        assert x.shape[1] == self.num_patches
+        return x
+
+
+class TransformerEncoderBlock(nn.Module):
+    """A light-weight transformer encoder block used for CIFAR-10."""
+
+    def __init__(
+        self,
+        embed_dim: int,
+        num_heads: int,
+        mlp_ratio: float = 4.0,
+        dropout: float = 0.1,
+    ) -> None:
+        super().__init__()
+        self.norm1 = nn.LayerNorm(embed_dim)
+        self.attn = nn.MultiheadAttention(embed_dim, num_heads, dropout=dropout, batch_first=False)
+        self.drop_path = nn.Dropout(dropout)
+        self.norm2 = nn.LayerNorm(embed_dim)
+        mlp_hidden = int(embed_dim * mlp_ratio)
+        self.mlp = nn.Sequential(
+            nn.Linear(embed_dim, mlp_hidden),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            nn.Linear(mlp_hidden, embed_dim),
+            nn.Dropout(dropout),
+        )
+
+    def forward(self, x: Tensor) -> Tensor:
+        # MultiheadAttention expects sequence first.
+        y = self.norm1(x)
+        attn_out, _ = self.attn(y, y, y, need_weights=False)
+        x = x + self.drop_path(attn_out)
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+
+class ModernHopfieldHead(nn.Module):
+    """Modern Hopfield memory with EMA writes and energy-based readout."""
+
+    def __init__(
+        self,
+        embed_dim: int,
+        proj_dim: int,
+        memory_init: Tensor,
+        beta: float = 20.0,
+        momentum: float = 0.1,
+        disabled: bool = False,
+    ) -> None:
+        super().__init__()
+        if memory_init.ndim != 2:
+            raise ValueError("memory_init must be rank-2 [mem_size, embed_dim].")
+        self.embed_dim = embed_dim
+        self.proj_dim = proj_dim
+        self.beta = beta
+        self.momentum = momentum
+        self.disabled = disabled
+        # Memory patterns stored as parameters but excluded from gradient updates.
+        self.memory_bank = nn.Parameter(memory_init.clone(), requires_grad=False)
+        self.phi = nn.Linear(embed_dim, proj_dim, bias=False)
+        nn.init.orthogonal_(self.phi.weight)
+
+    @property
+    def mem_size(self) -> int:
+        return int(self.memory_bank.shape[0])
+
+    def forward(self, queries: Tensor) -> HopfieldReadout:
+        if self.disabled:
+            raise RuntimeError("Hopfield head is disabled; forward should not be called.")
+        projected_queries = self.phi(queries)
+        projected_memory = self.phi(self.memory_bank)
+        # Energy: E(x) = -log sum_i exp(beta * phi(x)^T phi(x_i)).
+        logits = self.beta * projected_queries @ projected_memory.t()
+        energies = -torch.logsumexp(logits, dim=1)
+        attention = torch.softmax(logits, dim=1)
+        return HopfieldReadout(logits=logits, energies=energies, attention=attention)
+
+    def update(self, encodings: Tensor, indices: Tensor, momentum: Optional[float] = None) -> None:
+        if self.disabled:
+            return
+        if momentum is None:
+            momentum = self.momentum
+        with torch.no_grad():
+            for vector, index in zip(encodings, indices):
+                idx = int(index.item())
+                # EMA write: m_i <- (1 - momentum) * m_i + momentum * x.
+                self.memory_bank[idx].lerp_(vector, momentum)
+
+    def temporary_write(self, encoding: Tensor, index: int, momentum: Optional[float] = None) -> Tensor:
+        """Create a temporary memory bank with a one-shot update for evaluation."""
+        if self.disabled:
+            raise RuntimeError("Hopfield head is disabled; temporary writes are unsupported.")
+        if momentum is None:
+            momentum = self.momentum
+        temp_bank = self.memory_bank.clone()
+        temp_bank[index].lerp_(encoding, momentum)
+        return temp_bank
+
+    def read_with_bank(self, queries: Tensor, memory_bank: Tensor) -> HopfieldReadout:
+        """Read using a provided memory bank (useful for what-if analysis)."""
+        if self.disabled:
+            raise RuntimeError("Hopfield head is disabled; reads are unsupported.")
+        projected_queries = self.phi(queries)
+        projected_memory = self.phi(memory_bank)
+        logits = self.beta * projected_queries @ projected_memory.t()
+        energies = -torch.logsumexp(logits, dim=1)
+        attention = torch.softmax(logits, dim=1)
+        return HopfieldReadout(logits=logits, energies=energies, attention=attention)
+
+
+class HopfieldVisionTransformer(nn.Module):
+    """Vision transformer augmented with a Modern Hopfield memory head."""
+
+    def __init__(
+        self,
+        img_size: int,
+        patch_size: int,
+        in_channels: int,
+        embed_dim: int,
+        depth: int,
+        num_heads: int,
+        num_classes: int,
+        hopfield_proj_dim: int,
+        memory_init: Tensor,
+        beta: float,
+        dropout: float = 0.1,
+        momentum: float = 0.1,
+        disable_hopfield: bool = False,
+    ) -> None:
+        super().__init__()
+        self.disable_hopfield = disable_hopfield
+        self.patch_embed = PatchEmbedding(
+            img_size=img_size,
+            patch_size=patch_size,
+            in_channels=in_channels,
+            embed_dim=embed_dim,
+        )
+        self.cls_token = nn.Parameter(torch.zeros(1, 1, embed_dim))
+        num_tokens = 1 + self.patch_embed.num_patches
+        self.pos_embed = nn.Parameter(torch.zeros(1, num_tokens, embed_dim))
+        self.pos_drop = nn.Dropout(dropout)
+        self.blocks = nn.ModuleList(
+            [
+                TransformerEncoderBlock(embed_dim, num_heads, dropout=dropout)
+                for _ in range(depth)
+            ]
+        )
+        self.norm = nn.LayerNorm(embed_dim)
+        self.head = nn.Linear(embed_dim, num_classes)
+        nn.init.trunc_normal_(self.pos_embed, std=0.02)
+        nn.init.trunc_normal_(self.cls_token, std=0.02)
+        nn.init.xavier_uniform_(self.head.weight)
+        nn.init.zeros_(self.head.bias)
+        self.hopfield = ModernHopfieldHead(
+            embed_dim=embed_dim,
+            proj_dim=hopfield_proj_dim,
+            memory_init=memory_init,
+            beta=beta,
+            momentum=momentum,
+            disabled=disable_hopfield,
+        )
+
+    def forward_features(self, x: Tensor) -> Tensor:
+        bsz = x.shape[0]
+        x = self.patch_embed(x)
+        cls_tokens = self.cls_token.expand(bsz, -1, -1)
+        x = torch.cat((cls_tokens, x), dim=1)
+        x = x + self.pos_embed
+        x = self.pos_drop(x)
+        x = x.transpose(0, 1)
+        for block in self.blocks:
+            x = block(x)
+        x = x.transpose(0, 1)
+        x = self.norm(x)
+        cls = x[:, 0]
+        return cls
+
+    def forward(self, x: Tensor, memory_indices: Optional[Tensor] = None) -> Dict[str, Tensor]:
+        cls_embedding = self.forward_features(x)
+        logits = self.head(cls_embedding)
+        output: Dict[str, Tensor] = {"logits": logits, "cls": cls_embedding}
+        if not self.disable_hopfield:
+            hopfield_read = self.hopfield(cls_embedding)
+            output["memory_logits"] = hopfield_read.logits
+            output["hopfield_energy"] = hopfield_read.energies
+            output["memory_attention"] = hopfield_read.attention
+            if memory_indices is not None:
+                output["memory_indices"] = memory_indices
+        return output
+
+    def write_memory(self, encodings: Tensor, indices: Tensor) -> None:
+        if self.disable_hopfield:
+            return
+        self.hopfield.update(encodings, indices)
+
+    def encode(self, x: Tensor) -> Tensor:
+        """Return CLS embeddings without applying the classification head."""
+        return self.forward_features(x)
+
+    def read_memory(self, encodings: Tensor) -> HopfieldReadout:
+        if self.disable_hopfield:
+            raise RuntimeError("Hopfield memory disabled; cannot read.")
+        return self.hopfield(encodings)
+
+    def read_with_external_bank(self, encodings: Tensor, memory_bank: Tensor) -> HopfieldReadout:
+        if self.disable_hopfield:
+            raise RuntimeError("Hopfield memory disabled; cannot read.")
+        return self.hopfield.read_with_bank(encodings, memory_bank)
+
+    def temporary_memory(self, encoding: Tensor, index: int) -> Tensor:
+        if self.disable_hopfield:
+            raise RuntimeError("Hopfield memory disabled; cannot create temp bank.")
+        return self.hopfield.temporary_write(encoding, index)
+

--- a/ml/hopfield_transformer/train.py
+++ b/ml/hopfield_transformer/train.py
@@ -1,0 +1,344 @@
+"""Command-line entry point for training the Hopfield transformer on CIFAR-10."""
+
+from __future__ import annotations
+
+import argparse
+import math
+from pathlib import Path
+from typing import Dict, Tuple
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+from torch.optim import AdamW
+from torch.optim.lr_scheduler import LambdaLR
+from torch.utils.data import DataLoader
+from torchmetrics.classification import BinaryAUROC, MulticlassAccuracy
+from torchvision import datasets, transforms
+
+from .models import HopfieldVisionTransformer
+from .utils import (
+    CIFAR_MEAN,
+    CIFAR_STD,
+    MemoryDescription,
+    build_dataloaders,
+    build_memory_description,
+    class_to_memory_indices,
+    evaluate_rare_recall,
+    save_metrics,
+    sample_memory_indices,
+    set_seed,
+)
+
+NUM_CLASSES = 10
+
+
+def build_scheduler(
+    optimizer: AdamW,
+    epochs: int,
+    steps_per_epoch: int,
+    warmup_epochs: int,
+) -> LambdaLR:
+    """Construct a cosine-decay learning rate schedule with linear warmup."""
+    total_steps = epochs * steps_per_epoch
+    warmup_steps = max(1, warmup_epochs * steps_per_epoch)
+
+    def lr_lambda(step: int) -> float:
+        if step < warmup_steps:
+            return float(step + 1) / float(warmup_steps)
+        progress = (step - warmup_steps) / max(1, total_steps - warmup_steps)
+        return 0.5 * (1.0 + math.cos(math.pi * progress))
+
+    return LambdaLR(optimizer, lr_lambda)
+
+
+def compute_retrieval_auc(logits: Tensor, targets: Tensor) -> Tuple[Tensor, Tensor]:
+    """Return positive/negative scores for binary AUC computation."""
+    probs = torch.softmax(logits, dim=1)
+    positives = probs[torch.arange(probs.size(0), device=probs.device), targets]
+    mask = F.one_hot(targets, num_classes=probs.size(1)).bool()
+    negative_scores = probs.masked_fill(mask, -1.0)
+    negatives = negative_scores.max(dim=1).values.clamp(min=0.0)
+    preds = torch.cat([positives, negatives], dim=0)
+    labels = torch.cat([
+        torch.ones_like(positives),
+        torch.zeros_like(negatives),
+    ])
+    return preds.detach().cpu(), labels.detach().cpu()
+
+
+def train_one_epoch(
+    model: HopfieldVisionTransformer,
+    loader: DataLoader,
+    optimizer: AdamW,
+    scheduler: LambdaLR,
+    device: torch.device,
+    memory_desc: MemoryDescription,
+    lambda_retrieval: float,
+    use_amp: bool,
+    scaler: torch.cuda.amp.GradScaler,
+) -> Dict[str, float]:
+    """Train the model for one epoch and aggregate core metrics."""
+    model.train()
+    train_mapping = class_to_memory_indices(memory_desc)
+    accuracy_metric = MulticlassAccuracy(num_classes=NUM_CLASSES).to(device)
+    retrieval_accuracy = None
+    retrieval_auc = None
+    if not model.disable_hopfield:
+        retrieval_accuracy = MulticlassAccuracy(num_classes=model.hopfield.mem_size).to(device)
+        retrieval_auc = BinaryAUROC()
+    total_loss = 0.0
+    ce_loss_total = 0.0
+    retrieval_loss_total = 0.0
+    energy_total = 0.0
+    steps = 0
+    for images, labels in loader:
+        images = images.to(device)
+        labels = labels.to(device)
+        memory_indices = None
+        if not model.disable_hopfield:
+            memory_indices = sample_memory_indices(labels, train_mapping)
+        optimizer.zero_grad(set_to_none=True)
+        with torch.cuda.amp.autocast(enabled=use_amp):
+            outputs = model(images, memory_indices=memory_indices)
+            ce_loss = F.cross_entropy(outputs["logits"], labels)
+            loss = ce_loss
+            retrieval_loss = torch.tensor(0.0, device=device)
+            if not model.disable_hopfield and memory_indices is not None:
+                retrieval_logits = outputs["memory_logits"]
+                retrieval_loss = F.cross_entropy(retrieval_logits, memory_indices)
+                loss = loss + lambda_retrieval * retrieval_loss
+        if use_amp:
+            scaler.scale(loss).backward()
+            scaler.step(optimizer)
+            scaler.update()
+        else:
+            loss.backward()
+            optimizer.step()
+        scheduler.step()
+        if not model.disable_hopfield and memory_indices is not None:
+            model.write_memory(outputs["cls"].detach(), memory_indices.detach())
+        accuracy_metric.update(outputs["logits"], labels)
+        if not model.disable_hopfield and memory_indices is not None:
+            retrieval_accuracy.update(outputs["memory_logits"], memory_indices)
+            if retrieval_auc is not None:
+                preds, labels_auc = compute_retrieval_auc(outputs["memory_logits"], memory_indices)
+                retrieval_auc.update(preds, labels_auc)
+            energy_total += outputs["hopfield_energy"].detach().sum().item()
+        total_loss += loss.detach().item()
+        ce_loss_total += ce_loss.detach().item()
+        retrieval_loss_total += float(retrieval_loss.detach().item())
+        steps += 1
+    metrics: Dict[str, float] = {
+        "loss": total_loss / steps,
+        "ce_loss": ce_loss_total / steps,
+        "accuracy": float(accuracy_metric.compute().item()),
+    }
+    accuracy_metric.reset()
+    if not model.disable_hopfield and retrieval_accuracy is not None and retrieval_auc is not None:
+        metrics["retrieval_loss"] = retrieval_loss_total / steps
+        metrics["retrieval_accuracy"] = float(retrieval_accuracy.compute().item())
+        metrics["retrieval_auc"] = float(retrieval_auc.compute().item())
+        metrics["energy"] = energy_total / steps
+        retrieval_accuracy.reset()
+        retrieval_auc.reset()
+    return metrics
+
+
+@torch.no_grad()
+def evaluate(
+    model: HopfieldVisionTransformer,
+    loader: DataLoader,
+    device: torch.device,
+    memory_desc: MemoryDescription,
+) -> Dict[str, float]:
+    """Evaluate classification and retrieval metrics on a data loader."""
+    model.eval()
+    eval_mapping = class_to_memory_indices(memory_desc)
+    accuracy_metric = MulticlassAccuracy(num_classes=NUM_CLASSES).to(device)
+    retrieval_accuracy = None
+    retrieval_auc = None
+    total_loss = 0.0
+    ce_loss_total = 0.0
+    retrieval_loss_total = 0.0
+    energy_total = 0.0
+    steps = 0
+    for images, labels in loader:
+        images = images.to(device)
+        labels = labels.to(device)
+        memory_indices = None
+        if not model.disable_hopfield:
+            memory_indices = sample_memory_indices(labels, eval_mapping)
+        outputs = model(images, memory_indices=memory_indices)
+        loss = F.cross_entropy(outputs["logits"], labels)
+        total_loss += loss.item()
+        ce_loss_total += loss.item()
+        accuracy_metric.update(outputs["logits"], labels)
+        if not model.disable_hopfield and memory_indices is not None:
+            logits = outputs["memory_logits"]
+            retrieval_loss = F.cross_entropy(logits, memory_indices)
+            retrieval_loss_total += retrieval_loss.item()
+            if retrieval_accuracy is None:
+                retrieval_accuracy = MulticlassAccuracy(num_classes=model.hopfield.mem_size).to(device)
+                retrieval_auc = BinaryAUROC()
+            retrieval_accuracy.update(logits, memory_indices)
+            if retrieval_auc is not None:
+                preds, labels_auc = compute_retrieval_auc(logits, memory_indices)
+                retrieval_auc.update(preds, labels_auc)
+            energy_total += outputs["hopfield_energy"].detach().sum().item()
+        steps += 1
+    metrics: Dict[str, float] = {
+        "loss": total_loss / steps,
+        "ce_loss": ce_loss_total / steps,
+        "accuracy": float(accuracy_metric.compute().item()),
+    }
+    accuracy_metric.reset()
+    if not model.disable_hopfield and retrieval_accuracy is not None and retrieval_auc is not None:
+        metrics["retrieval_loss"] = retrieval_loss_total / steps
+        metrics["retrieval_accuracy"] = float(retrieval_accuracy.compute().item())
+        metrics["retrieval_auc"] = float(retrieval_auc.compute().item())
+        metrics["energy"] = energy_total / steps
+        retrieval_accuracy.reset()
+        retrieval_auc.reset()
+    return metrics
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments for the training CLI."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--data-dir", type=Path, default=Path.home() / ".cache" / "torch" / "datasets")
+    parser.add_argument("--output-dir", type=Path, default=Path("runs/hopfield"))
+    parser.add_argument("--epochs", type=int, default=20)
+    parser.add_argument("--batch-size", type=int, default=128)
+    parser.add_argument("--lr", type=float, default=3e-4)
+    parser.add_argument("--weight-decay", type=float, default=0.05)
+    parser.add_argument("--warmup-epochs", type=int, default=2)
+    parser.add_argument("--beta", type=float, default=20.0)
+    parser.add_argument("--mem-size", type=int, default=256)
+    parser.add_argument("--lambda-retr", type=float, default=0.2)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--num-workers", type=int, default=4)
+    parser.add_argument("--embed-dim", type=int, default=192)
+    parser.add_argument("--depth", type=int, default=3)
+    parser.add_argument("--heads", type=int, default=3)
+    parser.add_argument("--patch-size", type=int, default=4)
+    parser.add_argument("--proj-dim", type=int, default=128)
+    parser.add_argument("--ema", type=float, default=0.1, help="EMA momentum for memory writes")
+    parser.add_argument("--holdout-fraction", type=float, default=0.2)
+    parser.add_argument("--amp", action="store_true", help="Enable mixed precision training")
+    parser.add_argument("--disable-hopfield", action="store_true", help="Bypass the Hopfield memory head")
+    parser.add_argument("--run-ablation", action="store_true", help="Evaluate metrics with Hopfield disabled after training")
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Entry point used when launching training via ``python -m``."""
+    args = parse_args()
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    set_seed(args.seed)
+    train_loader, test_loader = build_dataloaders(args.data_dir, args.batch_size, args.num_workers)
+    memory_desc = build_memory_description(
+        mem_size=args.mem_size,
+        embed_dim=args.embed_dim,
+        num_classes=NUM_CLASSES,
+        seed=args.seed,
+        holdout_fraction=args.holdout_fraction,
+    )
+    model = HopfieldVisionTransformer(
+        img_size=32,
+        patch_size=args.patch_size,
+        in_channels=3,
+        embed_dim=args.embed_dim,
+        depth=args.depth,
+        num_heads=args.heads,
+        num_classes=NUM_CLASSES,
+        hopfield_proj_dim=args.proj_dim,
+        memory_init=memory_desc.memory_init,
+        beta=args.beta,
+        dropout=0.1,
+        momentum=args.ema,
+        disable_hopfield=args.disable_hopfield,
+    ).to(device)
+    optimizer = AdamW(model.parameters(), lr=args.lr, weight_decay=args.weight_decay)
+    scaler = torch.cuda.amp.GradScaler(enabled=args.amp)
+    scheduler = build_scheduler(optimizer, args.epochs, len(train_loader), args.warmup_epochs)
+    output_dir = args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+    metrics_log = []
+    best_acc = 0.0
+    best_path = output_dir / "best.pt"
+    rare_dataset = datasets.CIFAR10(root=args.data_dir, train=False, transform=None, download=True)
+    normalize = transforms.Normalize(CIFAR_MEAN, CIFAR_STD)
+    for epoch in range(1, args.epochs + 1):
+        train_stats = train_one_epoch(
+            model=model,
+            loader=train_loader,
+            optimizer=optimizer,
+            scheduler=scheduler,
+            device=device,
+            memory_desc=memory_desc,
+            lambda_retrieval=args.lambda_retr,
+            use_amp=args.amp,
+            scaler=scaler,
+        )
+        val_stats = evaluate(model=model, loader=test_loader, device=device, memory_desc=memory_desc)
+        rare_stats = evaluate_rare_recall(
+            model=model,
+            device=device,
+            dataset=rare_dataset,
+            holdout_indices=memory_desc.holdout_indices,
+            key_to_class=memory_desc.key_to_class,
+            normalize_fn=normalize,
+        )
+        epoch_metrics = {
+            "epoch": epoch,
+            "train_loss": train_stats.get("loss", 0.0),
+            "train_accuracy": train_stats.get("accuracy", 0.0),
+            "train_retrieval_accuracy": train_stats.get("retrieval_accuracy", 0.0),
+            "train_retrieval_auc": train_stats.get("retrieval_auc", 0.0),
+            "val_loss": val_stats.get("loss", 0.0),
+            "val_accuracy": val_stats.get("accuracy", 0.0),
+            "val_retrieval_accuracy": val_stats.get("retrieval_accuracy", 0.0),
+            "val_retrieval_auc": val_stats.get("retrieval_auc", 0.0),
+            "rare_recall": rare_stats.accuracy,
+        }
+        metrics_log.append(epoch_metrics)
+        print(
+            f"Epoch {epoch:02d} | "
+            f"train acc: {epoch_metrics['train_accuracy']:.3f} | "
+            f"val acc: {epoch_metrics['val_accuracy']:.3f} | "
+            f"rare recall: {epoch_metrics['rare_recall']:.3f}"
+        )
+        if epoch_metrics["val_accuracy"] > best_acc:
+            best_acc = epoch_metrics["val_accuracy"]
+            torch.save({
+                "epoch": epoch,
+                "model_state": model.state_dict(),
+                "optimizer_state": optimizer.state_dict(),
+                "metrics": epoch_metrics,
+                "args": vars(args),
+            }, best_path)
+    save_metrics(metrics_log, output_dir)
+    if args.run_ablation and not model.disable_hopfield:
+        print("Running Hopfield ablation (memory disabled)...")
+        model.disable_hopfield = True
+        model.hopfield.disabled = True
+        ablation_stats = evaluate(model=model, loader=test_loader, device=device, memory_desc=memory_desc)
+        ablation_rare = evaluate_rare_recall(
+            model=model,
+            device=device,
+            dataset=rare_dataset,
+            holdout_indices=memory_desc.holdout_indices,
+            key_to_class=memory_desc.key_to_class,
+            normalize_fn=normalize,
+        )
+        print(
+            f"Ablation | val acc: {ablation_stats.get('accuracy', 0.0):.3f} | "
+            f"rare recall: {ablation_rare.accuracy:.3f}"
+        )
+    print(f"Training complete. Best validation accuracy: {best_acc:.3f}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/ml/hopfield_transformer/utils.py
+++ b/ml/hopfield_transformer/utils.py
@@ -1,0 +1,290 @@
+"""Utility helpers for the Hopfield transformer experiment."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+
+import torch
+from torch import Tensor
+from torch.utils.data import DataLoader
+from torchvision import datasets, transforms
+
+CIFAR_MEAN = (0.4914, 0.4822, 0.4465)
+CIFAR_STD = (0.2470, 0.2435, 0.2616)
+
+
+@dataclass
+class MemoryDescription:
+    """Metadata describing the synthetic key-value memory."""
+
+    keys: List[str]
+    key_to_class: List[int]
+    train_indices: List[int]
+    holdout_indices: List[int]
+    memory_init: Tensor
+
+
+@dataclass
+class RareRecallResult:
+    """Metrics for the rare fact recall evaluation."""
+
+    accuracy: float
+    retrieved: int
+    total: int
+
+
+def set_seed(seed: int) -> None:
+    random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+
+def build_transforms() -> Tuple[transforms.Compose, transforms.Compose]:
+    train_tfm = transforms.Compose(
+        [
+            transforms.RandomCrop(32, padding=4),
+            transforms.RandomHorizontalFlip(),
+            transforms.ToTensor(),
+            transforms.Normalize(CIFAR_MEAN, CIFAR_STD),
+        ]
+    )
+    test_tfm = transforms.Compose(
+        [
+            transforms.ToTensor(),
+            transforms.Normalize(CIFAR_MEAN, CIFAR_STD),
+        ]
+    )
+    return train_tfm, test_tfm
+
+
+def build_dataloaders(
+    data_dir: Path,
+    batch_size: int,
+    num_workers: int = 4,
+) -> Tuple[DataLoader, DataLoader]:
+    train_tfm, test_tfm = build_transforms()
+    train_set = datasets.CIFAR10(root=data_dir, train=True, transform=train_tfm, download=True)
+    test_set = datasets.CIFAR10(root=data_dir, train=False, transform=test_tfm, download=True)
+    train_loader = DataLoader(
+        train_set,
+        batch_size=batch_size,
+        shuffle=True,
+        num_workers=num_workers,
+        pin_memory=True,
+    )
+    test_loader = DataLoader(
+        test_set,
+        batch_size=batch_size,
+        shuffle=False,
+        num_workers=num_workers,
+        pin_memory=True,
+    )
+    return train_loader, test_loader
+
+
+def _hashed_vector(key: str, embed_dim: int, seed: int) -> Tensor:
+    digest = hashlib.sha256(f"{seed}:{key}".encode("utf-8")).digest()
+    seed_int = int.from_bytes(digest[:8], "little")
+    generator = torch.Generator().manual_seed(seed_int)
+    return torch.randn(embed_dim, generator=generator)
+
+
+def generate_textual_keys(num_keys: int, seed: int) -> List[str]:
+    random.seed(seed)
+    adjectives = [
+        "aurora",
+        "luminous",
+        "crimson",
+        "silent",
+        "vector",
+        "fractal",
+        "mythic",
+        "stellar",
+        "hidden",
+        "quantum",
+        "silver",
+        "sunset",
+        "violet",
+        "ember",
+        "zenith",
+        "radial",
+        "neural",
+        "glacial",
+        "spectral",
+        "velvet",
+    ]
+    nouns = [
+        "falcon",
+        "cascade",
+        "harbor",
+        "nebula",
+        "citadel",
+        "voyager",
+        "horizon",
+        "cipher",
+        "rift",
+        "atlas",
+        "mosaic",
+        "satchel",
+        "harp",
+        "arbor",
+        "lattice",
+        "vector",
+        "archive",
+        "aurora",
+        "plasma",
+        "signal",
+    ]
+    keys: List[str] = []
+    for _ in range(num_keys):
+        keys.append(f"{random.choice(adjectives)} {random.choice(nouns)}")
+    return keys
+
+
+def assign_classes_to_keys(keys: Sequence[str], num_classes: int) -> List[int]:
+    mapping: List[int] = []
+    for idx, _ in enumerate(keys):
+        mapping.append(idx % num_classes)
+    random.shuffle(mapping)
+    return mapping
+
+
+def build_memory_description(
+    mem_size: int,
+    embed_dim: int,
+    num_classes: int,
+    seed: int,
+    holdout_fraction: float = 0.2,
+    textual_key_count: int = 100,
+) -> MemoryDescription:
+    num_text_keys = min(textual_key_count, mem_size)
+    keys = generate_textual_keys(num_text_keys, seed=seed)
+    key_classes = assign_classes_to_keys(keys, num_classes)
+    key_to_class = [-1 for _ in range(mem_size)]
+    for idx, cls in enumerate(key_classes):
+        key_to_class[idx] = cls
+    rng = random.Random(seed)
+    valid_indices = list(range(num_text_keys))
+    rng.shuffle(valid_indices)
+    holdout_count = max(1, int(len(valid_indices) * holdout_fraction))
+    holdout_indices = sorted(valid_indices[:holdout_count])
+    train_indices = sorted(valid_indices[holdout_count:])
+    memory_init = torch.zeros(mem_size, embed_dim)
+    for idx in range(mem_size):
+        if idx < num_text_keys:
+            memory_init[idx] = _hashed_vector(keys[idx], embed_dim, seed)
+        else:
+            fallback_key = f"unused-{idx}"
+            memory_init[idx] = _hashed_vector(fallback_key, embed_dim, seed)
+    return MemoryDescription(
+        keys=keys,
+        key_to_class=key_to_class,
+        train_indices=train_indices,
+        holdout_indices=holdout_indices,
+        memory_init=memory_init,
+    )
+
+
+def class_to_memory_indices(description: MemoryDescription) -> Dict[int, List[int]]:
+    mapping: Dict[int, List[int]] = {}
+    for idx in description.train_indices:
+        cls = description.key_to_class[idx]
+        if cls < 0:
+            continue
+        mapping.setdefault(cls, []).append(idx)
+    return mapping
+
+
+def sample_memory_indices(
+    labels: Tensor,
+    mapping: Dict[int, List[int]],
+    generator: Optional[random.Random] = None,
+) -> Tensor:
+    if generator is None:
+        generator = random
+    choices: List[int] = []
+    for label in labels.tolist():
+        candidates = mapping.get(int(label), None)
+        if not candidates:
+            # Fall back to random available index.
+            flat_indices = [idx for values in mapping.values() for idx in values]
+            choices.append(generator.choice(flat_indices))
+        else:
+            choices.append(generator.choice(candidates))
+    return torch.tensor(choices, dtype=torch.long, device=labels.device)
+
+
+def save_metrics(metrics: List[Dict[str, float]], output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    metrics_path = output_dir / "metrics.json"
+    with metrics_path.open("w", encoding="utf-8") as fp:
+        json.dump(metrics, fp, indent=2)
+
+
+def collect_support_query_pairs(
+    dataset: datasets.CIFAR10,
+    holdout_indices: Sequence[int],
+    key_to_class: Sequence[int],
+) -> Dict[int, Tuple[Tensor, Tensor]]:
+    """Return support/query tensors per holdout key."""
+
+    class_to_items: Dict[int, List[Tensor]] = {}
+    for image, label in dataset:
+        tensor = transforms.ToTensor()(image)
+        class_to_items.setdefault(label, []).append(tensor)
+    result: Dict[int, Tuple[Tensor, Tensor]] = {}
+    for key_idx in holdout_indices:
+        cls = key_to_class[key_idx]
+        items = class_to_items.get(cls, [])
+        if len(items) < 2:
+            continue
+        support, query = items[0], items[1]
+        result[key_idx] = (support, query)
+    return result
+
+
+def evaluate_rare_recall(
+    model,
+    device: torch.device,
+    dataset: datasets.CIFAR10,
+    holdout_indices: Sequence[int],
+    key_to_class: Sequence[int],
+    normalize_fn,
+) -> RareRecallResult:
+    """Compute recall after a one-shot memory write for each rare key."""
+
+    if getattr(model, "disable_hopfield", False):
+        total = len(holdout_indices)
+        return RareRecallResult(accuracy=0.0, retrieved=0, total=total)
+
+    support_pairs = collect_support_query_pairs(dataset, holdout_indices, key_to_class)
+    correct = 0
+    total = 0
+    was_training = model.training
+    model.eval()
+    with torch.no_grad():
+        for key_idx, (support_img, query_img) in support_pairs.items():
+            support = normalize_fn(support_img.clone()).unsqueeze(0).to(device)
+            query = normalize_fn(query_img.clone()).unsqueeze(0).to(device)
+            support_embed = model.encode(support)
+            temp_bank = model.temporary_memory(support_embed[0], key_idx)
+            query_embed = model.encode(query)
+            readout = model.read_with_external_bank(query_embed, temp_bank)
+            prediction = int(readout.attention.argmax(dim=1).item())
+            if prediction == key_idx:
+                correct += 1
+            total += 1
+    if was_training:
+        model.train()
+    accuracy = float(correct / max(total, 1))
+    return RareRecallResult(accuracy=accuracy, retrieved=correct, total=total)
+
+
+def identity_normalizer(tensor: Tensor) -> Tensor:
+    return tensor
+


### PR DESCRIPTION
## Summary
- add a Hopfield-augmented vision transformer with EMA memory writes and energy readout for CIFAR-10
- provide utilities for CIFAR-10 dataloaders, synthetic memory key generation, and rare recall evaluation
- expose a training CLI with cosine schedule, retrieval loss logging, ablation hooks, and usage README

## Testing
- `python -m py_compile ml/hopfield_transformer/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68fa87d5bc5c832988dca587fa91bd61