### PR TITLE
Add foundational Codex prompt scaffold

### DIFF
--- a/docs/codex/001_foundations.md
+++ b/docs/codex/001_foundations.md
@@ -1,0 +1,352 @@
+# 🧩 PRISM CODEX — Internal Genesis Draft
+
+## 0. Intent
+
+Define a unified physical–geometric grammar for intelligence. Every model is a dynamical system. Every loss is an energy. Every optimization is a flow. The Codex anchors that math and keeps the representation aligned with Prism's instrumentation stack.
+
+---
+
+## 1. Geometric Core — Hamiltonian Formulation of Learning
+
+### Core Equation
+
+\[
+\dot{q} = \frac{\partial H}{\partial p}, \qquad
+\dot{p} = -\frac{\partial H}{\partial q}
+\]
+
+- **H(q,p)** = total system energy = data fit + regularization + control priors.
+- Integrate symplectically ⇒ preserve phase-space volume and long-horizon stability.
+- Replace vanilla SGD with discrete Hamiltonian flow:
+  \[
+  (q_{t+1}, p_{t+1}) = \Phi_\epsilon(q_t, p_t)
+  \]
+
+### Physical Analogy
+- **q** ↔ position of the learner in hypothesis space.
+- **p** ↔ momentum accumulated from past gradients.
+- **H** ↔ total energy; conservation keeps learning trajectories smooth.
+
+### Implementation Sketch
+```python
+from typing import Callable, Tuple
+
+Vector = TensorLike  # alias used throughout the Codex prompt scaffolds
+
+
+def symplectic_euler(H: Callable[[Vector, Vector], float],
+                     grad_q: Callable[[Vector, Vector], Vector],
+                     grad_p: Callable[[Vector, Vector], Vector],
+                     q: Vector,
+                     p: Vector,
+                     eps: float) -> Tuple[Vector, Vector]:
+    # Half-step momentum update
+    p_half = p - eps * grad_q(q, p)
+    # Position update with mid-point momentum
+    q_next = q + eps * grad_p(q, p_half)
+    # Finalize momentum
+    p_next = p_half - eps * grad_q(q_next, p_half)
+    return q_next, p_next
+```
+
+### Diagnostics
+- Verify \(\det J_{\Phi_\epsilon} = 1\) numerically to confirm symplecticity.
+- Track energy drift `|H(q_t, p_t) - H(q_0, p_0)|` as a conservation check.
+
+---
+
+## 2. Natural Gradient Field — Geodesic Descent
+
+### Core Equation
+
+\[
+\Delta\theta = -\eta F^{-1}\nabla_\theta L
+\]
+
+- **F** = Fisher information metric encoding local curvature of the belief manifold.
+- Implement via low-rank or Kronecker factorization to keep updates tractable.
+
+### Physical Analogy
+- Think of **F** as a Riemannian metric; gradients follow geodesics in information space.
+- Energy minimization becomes shortest-path routing on the statistical manifold.
+
+### Implementation Sketch
+```python
+def natural_gradient_step(params, grad, fisher_inv, lr: float):
+    preconditioned = fisher_inv @ grad  # apply approximate inverse metric
+    return params - lr * preconditioned
+```
+
+### Diagnostics
+- Ensure the approximate Fisher inverse is symmetric positive definite.
+- Monitor KL divergence between steps to verify smooth belief updates.
+
+---
+
+## 3. Wasserstein Objective — Optimal Transport Alignment
+
+### Core Equation
+
+\[
+W_2^2(P, Q_\theta) = \inf_{\gamma \in \Pi(P, Q_\theta)} \mathbb{E}_{(x, y) \sim \gamma}[\|x - y\|^2]
+\]
+
+- For alignment, replace KL divergence with Wasserstein to capture support shifts.
+- Gradient corresponds to the optimal transport map ⇒ smoother distribution morphing.
+
+### Physical Analogy
+- Treat \(P\) and \(Q_\theta\) as mass distributions; Wasserstein computes minimal transport work.
+
+### Implementation Sketch
+```python
+import ott
+
+
+def wasserstein_loss(samples_p, samples_q, reg=1e-2):
+    ot_plan = ott.core.solve(samples_p, samples_q, reg=reg)
+    return ot_plan.primal_cost()
+```
+
+### Diagnostics
+- Validate transport plans satisfy marginal constraints within tolerance.
+- Compare against KL-based loss to measure stability improvements.
+
+---
+
+## 4. Schrödinger Bridge — Time-Symmetric Control
+
+### Core Equation
+
+Control between marginals \(P_0\) and \(P_1\):
+\[
+\min_{p(x_{0:T})} \operatorname{KL}\big(p(x_{0:T}) \| q(x_{0:T})\big) \quad \text{s.t. } p_0 = P_0,\ p_T = P_1
+\]
+
+- Produces a time-symmetric diffusion model with explicit steering cost.
+- Dual to score-based generative modeling with entropic regularization.
+
+### Physical Analogy
+- Interpolate between thermodynamic states with minimal entropy production.
+
+### Implementation Sketch
+```python
+def schrodinger_bridge_forward_backward(prior_path, p0, p1, steps):
+    fwd = propagate_forward(prior_path, p0, steps)
+    bwd = propagate_backward(prior_path, p1, steps)
+    # Combine via iterative proportional fitting
+    bridge = normalize(fwd * bwd)
+    return bridge
+```
+
+### Diagnostics
+- Boundary consistency: check that `bridge[0]` ≈ `p0` and `bridge[-1]` ≈ `p1`.
+- KL gap vs. prior path quantifies steering energy.
+
+---
+
+## 5. Memory & Energy — Modern Hopfield Dynamics
+
+### Core Equation
+
+\[
+E(x) = -\frac{1}{2} \log \sum_i \exp(\beta x^\top \xi_i)
+\]
+
+- Minimizing \(E(x)\) retrieves stored pattern \(\xi_i\).
+- Integrate with attention to supply associative recall for long contexts.
+
+### Physical Analogy
+- Energy wells correspond to stored memories; trajectories fall into nearest attractor.
+
+### Implementation Sketch
+```python
+def hopfield_update(x, keys, beta):
+    logits = beta * (x @ keys.T)
+    weights = logits.softmax(dim=-1)
+    return weights @ keys
+```
+
+### Diagnostics
+- Check Lyapunov decrease: \(E(x_{t+1}) \leq E(x_t)\).
+- Evaluate recall accuracy on key-value stress tests.
+
+---
+
+## 6. Information Bottleneck — Adaptive Compression
+
+### Core Equation
+
+\[
+\max I(Z; Y) - \beta I(Z; X)
+\]
+
+- Controls trade-off between plasticity and stability.
+- Use as a regularizer across agents or temporal segments.
+
+### Physical Analogy
+- \(\beta\) acts like temperature: high values encourage compression (cooling), low values keep plasticity (heating).
+
+### Implementation Sketch
+```python
+def information_bottleneck_loss(enc, dec, x, y, beta):
+    z, mu, logvar = enc(x)
+    y_hat = dec(z)
+    recon = loss_fn(y_hat, y)
+    kl = -0.5 * (1 + logvar - mu.pow(2) - logvar.exp()).sum()
+    return recon + beta * kl
+```
+
+### Diagnostics
+- Track mutual information estimates with MINE or variational bounds.
+- Adjust \(\beta\) dynamically based on forgetting metrics.
+
+---
+
+## 7. Quantum-Inspired Layer — Tensor Network Bridge
+
+### Core Equation
+
+\[
+|\psi_\theta\rangle = U_\theta |0\rangle, \qquad L = \langle \psi_\theta | H | \psi_\theta \rangle
+\]
+
+- Optimize via hybrid gradients (parameter-shift rule) or classical low-rank symplectic factorization.
+
+### Physical Analogy
+- Treat entanglement as structured correlation across feature partitions.
+
+### Implementation Sketch
+```python
+def parameter_shift_gradient(circuit, params, hamiltonian):
+    grads = []
+    for i, theta in enumerate(params):
+        shift = basis_vector(len(params), i) * (np.pi / 2)
+        plus = circuit(params + shift).expectation(hamiltonian)
+        minus = circuit(params - shift).expectation(hamiltonian)
+        grads.append(0.5 * (plus - minus))
+    return np.array(grads)
+```
+
+### Diagnostics
+- Monitor entanglement entropy or bond dimensions for expressivity.
+- Compare classical surrogate to quantum-inspired outputs for fidelity.
+
+---
+
+## 8. Unified Training Flow
+
+1. Initialize model state \((q_0, p_0)\) under Hamiltonian dynamics.
+2. Evolve parameters using natural gradient + Schrödinger Bridge control.
+3. Optimize Wasserstein objective with Information Bottleneck regularization.
+4. Maintain differentiable memory via Hopfield energy updates.
+5. Instrument every transition (prompt, diff, run, deploy) for replay and audit.
+
+### Flow Orchestration Pseudocode
+```python
+def codex_train_step(state, batch, hyper):
+    q, p = state.params, state.momentum
+    q, p = symplectic_euler(state.H, state.grad_q, state.grad_p, q, p, hyper.eps)
+    fisher_inv = state.metric_estimator(q, batch)
+    q = natural_gradient_step(q, state.grad_loss(batch), fisher_inv, hyper.lr)
+    bridge = schrodinger_bridge_forward_backward(state.prior_path, state.p0, state.p1, hyper.sb_steps)
+    loss = wasserstein_loss(batch.true, state.model(q, bridge))
+    loss += hyper.beta * state.ib_regularizer(batch)
+    memory = hopfield_update(state.memory, state.keys, hyper.beta_memory)
+    diagnostics = compute_invariants(q, p, loss, memory)
+    return UpdatedState(q=q, p=p, memory=memory), diagnostics
+```
+
+### Invariant Tests
+- `assert_energy_conservation`: tolerances on Hamiltonian drift.
+- `assert_fisher_symmetry`: compare `fisher_inv.T` vs `fisher_inv`.
+- `assert_sb_boundaries`: verify Schrödinger bridge endpoints.
+
+---
+
+## 9. Instrumentation Schema
+
+Every event logged to Prism follows:
+
+```json
+{
+  "id": "ulid",
+  "ts": "2025-03-30T12:00:00Z",
+  "actor": "agent/prism-codex",
+  "kind": "prompt|diff|run|deploy",
+  "projectId": "prism-console",
+  "sessionId": "session-ulid",
+  "facet": "codex",
+  "summary": "Hamiltonian step + Wasserstein update",
+  "ctx": {
+    "energy_drift": 1.7e-4,
+    "wasserstein": 0.42
+  }
+}
+```
+
+Policy layer enforces mode (`playground`, `dev`, `trusted`, `prod`) on write/network actions.
+
+---
+
+## 10. Immediate To-Dos
+
+- [x] Formalize each section as runnable pseudocode block.
+- [x] Add physical analogy per formula (mass, energy, entropy, information).
+- [ ] Add tests verifying invariants: energy conservation, Fisher symmetry, SB boundary consistency.
+- [x] Version this file under `/docs/codex/001_foundations.md`.
+
+---
+
+## Appendix A. Runnable Prompt Block
+
+This scaffold can be pasted directly into the Prism console. It defines inputs, outputs, reusable macros, and embeds each mathematical module as an experiment-ready snippet.
+
+```prompt
+[prompt]
+name = "prism-codex-foundations"
+version = "001"
+mode = "dev"
+authors = ["lucidia:codex"]
+description = "Hamiltonian-natural gradient training loop with Wasserstein + SB alignment"
+
+defaults {
+  epsilon = 1e-2
+  lr = 1e-3
+  beta_ib = 0.5
+  beta_memory = 4.0
+  sb_steps = 16
+}
+
+[input]
+batch = tensor(shape="(B, d)", description="Training batch of embeddings")
+prior_path = diffusion(name="reference", steps=sb_steps)
+keys = tensor(shape="(M, d)", description="Hopfield memory keys")
+
+[context]
+# Hamiltonian block
+def symplectic_step(H, grad_q, grad_p, q, p):
+    return symplectic_euler(H, grad_q, grad_p, q, p, epsilon)
+
+# Natural gradient block
+natural_update(params, grad, fisher_inv) = natural_gradient_step(params, grad, fisher_inv, lr)
+
+# Schrödinger bridge controller
+bridge = schrodinger_bridge_forward_backward(prior_path, batch.start, batch.target, sb_steps)
+
+# Wasserstein alignment
+transport_cost = wasserstein_loss(batch.true, model.forward(params, bridge))
+
+# Information bottleneck + memory
+ib_penalty = beta_ib * state.ib_regularizer(batch)
+memory_state = hopfield_update(state.memory, keys, beta_memory)
+
+[output]
+loss = transport_cost + ib_penalty
+telemetry = {
+  energy_drift: invariant.energy_conservation(params, momentum),
+  fisher_symmetry: invariant.fisher_symmetry(fisher_inv),
+  sb_boundary: invariant.sb_boundary(bridge, batch.start, batch.target)
+}
+```
+
+> Fork this prompt for experimentation: clone the block, tweak defaults, and annotate telemetry drift. Every fork should keep the invariant tests alive.


### PR DESCRIPTION
## Summary
- add the initial PRISM Codex foundations document under docs/codex
- capture Hamiltonian, natural gradient, Wasserstein, Schrödinger bridge, and memory primitives with pseudocode and analogies
- provide a runnable prompt block template for integrating the codex flow into the Prism console

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68fa8ca7ae348329a545205e4a7192e7