### PR TITLE
Add Alice & Lucidia cooperative agent framework (provide models package)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,8 @@ benchmarks/
 secrets/*
 datasets/
 models/
+!alice_lucidia/models/
+!alice_lucidia/models/**
 !br-dbt/models/
 !br-dbt/models/**
 checkpoints/

--- a/alice_lucidia/models/__init__.py
+++ b/alice_lucidia/models/__init__.py
@@ -1,0 +1,22 @@
+"""Model primitives used by the Alice & Lucidia agents."""
+from .encoders import EncoderConfig, GeneratorConfig, TextEncoder, TextGenerator
+from .hopfield import HopfieldConfig, ModernHopfieldHead
+from .natural_grad import NaturalGradientConfig, NaturalGradientOptimizer
+from .ot import BridgeConfig, schrodinger_bridge, sinkhorn_transport
+from .world_model import LatentWorldModel, WorldModelConfig
+
+__all__ = [
+    "EncoderConfig",
+    "TextEncoder",
+    "GeneratorConfig",
+    "TextGenerator",
+    "HopfieldConfig",
+    "ModernHopfieldHead",
+    "NaturalGradientConfig",
+    "NaturalGradientOptimizer",
+    "BridgeConfig",
+    "schrodinger_bridge",
+    "sinkhorn_transport",
+    "WorldModelConfig",
+    "LatentWorldModel",
+]

--- a/alice_lucidia/models/encoders.py
+++ b/alice_lucidia/models/encoders.py
@@ -1,0 +1,112 @@
+"""Light-weight text encoding and generation utilities for the agents."""
+from __future__ import annotations
+
+import hashlib
+import math
+import re
+from dataclasses import dataclass
+from typing import Sequence
+
+import torch
+from torch import Tensor, nn
+
+_TOKEN_PATTERN = re.compile(r"\w+")
+
+
+def _token_to_index(token: str, seed: int, vocab_size: int) -> int:
+    data = f"{token}|{seed}".encode("utf-8")
+    digest = hashlib.sha1(data).digest()
+    return int.from_bytes(digest[:8], "big") % vocab_size
+
+
+@dataclass
+class EncoderConfig:
+    """Configuration for the deterministic hash encoder."""
+
+    model_name: str = "distilbert-base-uncased"
+    embedding_dim: int = 256
+    hash_vocab_size: int = 4096
+
+
+class TextEncoder:
+    """A tiny deterministic encoder based on hashed bag-of-words features."""
+
+    def __init__(self, config: EncoderConfig) -> None:
+        self.config = config
+        self.embedding_dim = config.embedding_dim
+        self._seed = int.from_bytes(hashlib.sha1(config.model_name.encode("utf-8")).digest()[:8], "big")
+        generator = torch.Generator()
+        generator.manual_seed(self._seed & 0xFFFFFFFF)
+        self.embedding = nn.Embedding(config.hash_vocab_size, config.embedding_dim)
+        with torch.no_grad():
+            self.embedding.weight.normal_(mean=0.0, std=1.0 / math.sqrt(config.embedding_dim), generator=generator)
+
+    def _token_indices(self, text: str) -> torch.LongTensor:
+        tokens = _TOKEN_PATTERN.findall(text.lower())
+        if not tokens:
+            return torch.empty(0, dtype=torch.long)
+        indices = [
+            _token_to_index(token, self._seed, self.config.hash_vocab_size)
+            for token in tokens
+        ]
+        return torch.tensor(indices, dtype=torch.long)
+
+    def encode(self, texts: Sequence[str]) -> Tensor:
+        vectors = []
+        for text in texts:
+            token_indices = self._token_indices(text)
+            if token_indices.numel() == 0:
+                vectors.append(torch.zeros(self.embedding_dim))
+                continue
+            embeds = self.embedding(token_indices)
+            vector = embeds.mean(dim=0)
+            norm = vector.norm(p=2)
+            if torch.isfinite(norm) and norm > 0:
+                vector = vector / norm
+            vectors.append(vector)
+        return torch.stack(vectors)
+
+
+@dataclass
+class GeneratorConfig:
+    """Configuration for the light-weight text generator."""
+
+    model_name: str = "lucidia-scribe"
+    max_length: int = 64
+    temperature: float = 0.8
+
+
+class TextGenerator:
+    """A heuristic generator that synthesises short continuations."""
+
+    def __init__(self, config: GeneratorConfig) -> None:
+        self.config = config
+
+    def _summarise(self, prompt: str) -> str:
+        tokens = _TOKEN_PATTERN.findall(prompt.lower())
+        if not tokens:
+            return "insight"
+        unique = list(dict.fromkeys(tokens))[:5]
+        return " ".join(unique)
+
+    def generate(self, prompt: str, steering_vector: Tensor | None = None) -> str:
+        prompt = prompt.strip()
+        base = prompt if prompt else "Lucidia reflects"
+        summary = self._summarise(base)
+        tone = "balanced"
+        if steering_vector is not None and steering_vector.numel() > 0:
+            magnitude = float(torch.tanh(steering_vector.mean()).item())
+            tone = "calm" if magnitude < 0 else "bold"
+        continuation = f"{tone} insight on {summary}".strip()
+        text = f"{base} -> {continuation}".strip()
+        if len(text) > self.config.max_length:
+            text = text[: self.config.max_length].rstrip()
+        return text
+
+
+__all__ = [
+    "EncoderConfig",
+    "TextEncoder",
+    "GeneratorConfig",
+    "TextGenerator",
+]

--- a/alice_lucidia/models/hopfield.py
+++ b/alice_lucidia/models/hopfield.py
@@ -1,0 +1,59 @@
+"""Modern Hopfield-style attention head used for Lucidia's memory."""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import torch
+from torch import Tensor, nn
+
+
+@dataclass
+class HopfieldConfig:
+    """Configuration for the Hopfield retrieval head."""
+
+    beta: float = 10.0
+    projection_dim: int = 64
+    memory_size: int = 256
+
+
+class ModernHopfieldHead(nn.Module):
+    """Implements a differentiable Hopfield-style associative memory."""
+
+    def __init__(self, config: HopfieldConfig, input_dim: int) -> None:
+        super().__init__()
+        self.config = config
+        self.query_proj = nn.Linear(input_dim, config.projection_dim, bias=False)
+        self.key_proj = nn.Linear(input_dim, config.projection_dim, bias=False)
+        nn.init.orthogonal_(self.query_proj.weight)
+        nn.init.orthogonal_(self.key_proj.weight)
+
+    def forward(self, query: Tensor, candidates: Tensor) -> tuple[Tensor, Tensor]:
+        """Return attention-weighted memory readout and energy."""
+
+        if candidates.dim() != 3:
+            raise ValueError("candidates must be of shape (batch, memory, dim)")
+        if query.dim() != 2:
+            raise ValueError("query must be of shape (batch, dim)")
+        proj_query = self.query_proj(query)
+        proj_memory = self.key_proj(candidates)
+        scale = math.sqrt(self.config.projection_dim)
+        scores = torch.einsum("bd,bmd->bm", proj_query, proj_memory) / scale
+        weights = torch.softmax(self.config.beta * scores, dim=-1)
+        readout = torch.einsum("bm,bmd->bd", weights, candidates)
+        shift = scores.max(dim=-1, keepdim=True).values
+        stabilised = self.config.beta * (scores - shift)
+        logsum = torch.logsumexp(stabilised, dim=-1)
+        energy = -(shift.squeeze(-1) + logsum / max(self.config.beta, 1e-6))
+        return readout, energy
+
+    def gated_write(self, memory: Tensor, new_value: Tensor, gate: Tensor) -> Tensor:
+        """Blend ``new_value`` into ``memory`` according to ``gate`` weights."""
+
+        if gate.dim() == 1:
+            gate = gate.unsqueeze(-1)
+        gate = gate.clamp(0.0, 1.0)
+        return memory + gate * (new_value - memory)
+
+
+__all__ = ["HopfieldConfig", "ModernHopfieldHead"]

--- a/alice_lucidia/models/natural_grad.py
+++ b/alice_lucidia/models/natural_grad.py
@@ -1,0 +1,55 @@
+"""Simple natural-gradient style optimiser for Lucidia training."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Iterable, Optional
+
+import torch
+from torch import Tensor
+from torch.optim import Optimizer
+
+
+@dataclass
+class NaturalGradientConfig:
+    """Hyper-parameters for the natural gradient optimiser."""
+
+    base_lr: float = 1e-3
+    damping: float = 1e-3
+    momentum: float = 0.9
+
+
+class NaturalGradientOptimizer(Optimizer):
+    """A lightweight optimiser that keeps a diagonal Fisher estimate."""
+
+    def __init__(self, params: Iterable[Tensor], config: NaturalGradientConfig) -> None:
+        defaults = dict(lr=config.base_lr, damping=config.damping, momentum=config.momentum)
+        super().__init__(params, defaults)
+        self.config = config
+
+    @torch.no_grad()
+    def step(self, closure: Optional[Callable[[], Tensor]] = None) -> Optional[Tensor]:
+        loss: Optional[Tensor] = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        for group in self.param_groups:
+            lr = group["lr"]
+            damping = group["damping"]
+            momentum = group["momentum"]
+            for param in group["params"]:
+                if param.grad is None:
+                    continue
+                grad = param.grad.detach()
+                state = self.state[param]
+                fisher = state.get("fisher")
+                if fisher is None:
+                    fisher = torch.zeros_like(grad)
+                fisher.mul_(momentum).addcmul_(grad, grad, value=1 - momentum)
+                preconditioner = grad / (fisher + damping)
+                param.add_(preconditioner, alpha=-lr)
+                state["fisher"] = fisher
+        return loss
+
+
+__all__ = ["NaturalGradientConfig", "NaturalGradientOptimizer"]

--- a/alice_lucidia/models/ot.py
+++ b/alice_lucidia/models/ot.py
@@ -1,0 +1,74 @@
+"""Optimal transport utilities for Lucidia's simulation tools."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+from torch import Tensor
+
+
+@dataclass
+class BridgeConfig:
+    """Configuration controlling the Schrödinger bridge interpolation."""
+
+    steps: int = 4
+    epsilon: float = 1e-2
+    alpha: float = 0.5
+
+
+def sinkhorn_transport(
+    p: Tensor,
+    q: Tensor,
+    cost: Tensor,
+    epsilon: float = 1e-1,
+    max_iters: int = 100,
+    tol: float = 1e-6,
+) -> tuple[Tensor, tuple[Tensor, Tensor]]:
+    """Compute an entropic OT plan via Sinkhorn iterations."""
+
+    if p.dim() != 1 or q.dim() != 1:
+        raise ValueError("p and q must be 1D tensors")
+    if cost.shape != (p.shape[0], q.shape[0]):
+        raise ValueError("cost matrix shape must match marginals")
+    kernel = torch.exp(-cost / max(epsilon, 1e-6))
+    u = torch.ones_like(p)
+    v = torch.ones_like(q)
+    for _ in range(max_iters):
+        u_prev = u
+        Kv = kernel @ v + 1e-12
+        u = p / Kv
+        Ku = kernel.t() @ u + 1e-12
+        v = q / Ku
+        if torch.max(torch.abs(u - u_prev)) < tol:
+            break
+    plan = torch.einsum("i,ij,j->ij", u, kernel, v)
+    total = plan.sum()
+    if total > 0:
+        plan = plan / total
+    return plan, (u, v)
+
+
+def schrodinger_bridge(prior: Tensor, target: Tensor, config: BridgeConfig) -> Tensor:
+    """Construct a smooth path from ``prior`` to ``target`` using OT heuristics."""
+
+    if prior.shape != target.shape:
+        raise ValueError("prior and target must have matching shapes")
+    if config.steps < 1:
+        raise ValueError("steps must be positive")
+    device = prior.device
+    dtype = prior.dtype
+    schedule = torch.linspace(0.0, 1.0, config.steps + 2, device=device, dtype=dtype)
+    path = []
+    for tau in schedule:
+        intermediate = torch.lerp(prior, target, tau)
+        if 0.0 < tau < 1.0 and config.alpha > 0:
+            mean = intermediate.mean(dim=-1, keepdim=True)
+            intermediate = (1 - config.alpha) * intermediate + config.alpha * mean
+        if config.epsilon > 0:
+            smoothing = config.epsilon * (1 - tau) * tau * (target - prior)
+            intermediate = intermediate + smoothing
+        path.append(intermediate)
+    return torch.stack(path, dim=0)
+
+
+__all__ = ["BridgeConfig", "schrodinger_bridge", "sinkhorn_transport"]

--- a/alice_lucidia/models/world_model.py
+++ b/alice_lucidia/models/world_model.py
@@ -1,0 +1,54 @@
+"""Latent dynamics model backing the Lucidia agent."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from torch import Tensor, nn
+
+
+@dataclass
+class WorldModelConfig:
+    """Configuration for the latent world model."""
+
+    input_dim: int
+    latent_dim: int = 64
+    hidden_dim: int = 128
+    dropout: float = 0.0
+    drift_penalty: float = 0.1
+
+
+class LatentWorldModel(nn.Module):
+    """A lightweight latent-variable model implemented with a GRU."""
+
+    def __init__(self, config: WorldModelConfig) -> None:
+        super().__init__()
+        self.config = config
+        self.encoder = nn.GRU(config.input_dim, config.hidden_dim, batch_first=True)
+        self.to_latent = nn.Linear(config.hidden_dim, config.latent_dim)
+        self.decoder = nn.Linear(config.latent_dim, config.input_dim)
+        self.norm = nn.LayerNorm(config.latent_dim)
+        self.input_projection = nn.Linear(config.input_dim, config.latent_dim)
+        self.dropout = nn.Dropout(config.dropout) if config.dropout > 0 else nn.Identity()
+
+    def forward(self, sequence: Tensor) -> tuple[Tensor, Tensor, Tensor]:
+        if sequence.dim() != 3:
+            raise ValueError("sequence must be (batch, steps, input_dim)")
+        encoded, _ = self.encoder(sequence)
+        latent = self.norm(self.to_latent(encoded))
+        latent = self.dropout(latent)
+        reconstruction = self.decoder(latent)
+        next_state = latent[:, -1, :]
+        regulariser = latent.pow(2).mean()
+        return reconstruction, next_state, regulariser
+
+    def fokker_planck_regularizer(self, current_state: Tensor, next_state: Tensor) -> Tensor:
+        if current_state.dim() == 1:
+            current_state = current_state.unsqueeze(0)
+        projected_current = self.input_projection(current_state)
+        if next_state.dim() == 1:
+            next_state = next_state.unsqueeze(0)
+        mismatch = next_state - projected_current
+        return self.config.drift_penalty * mismatch.pow(2).mean()
+
+
+__all__ = ["WorldModelConfig", "LatentWorldModel"]


### PR DESCRIPTION
## Summary
- add the alice_lucidia package implementing the Alice planner and Lucidia world-model agents with Hopfield memory and OT utilities
- provide training, evaluation, CLI, and notebook assets plus configuration and packaging metadata for the cooperative agent system
- cover critical behaviours with pytest suites for Hopfield energy, OT routines, natural-gradient optimiser, and agent planning logic
- include the alice_lucidia.models package with encoder, Hopfield, world model, natural gradient, and OT primitives so Lucidia imports succeed
- allow the models package to bypass the repository ignore rules

## Testing
- pytest -q alice_lucidia/tests

------
https://chatgpt.com/codex/tasks/task_e_68fa94f9bbd48329a0a7317437d23400