### PR TITLE
Add Phase 42 codex prompt and new agent id cards

### DIFF
--- a/agents/id_cards/analyst.yaml
+++ b/agents/id_cards/analyst.yaml
@@ -1,0 +1,18 @@
+agent_id: analyst
+name: Market Analyst
+charter: "Identify user frustration patterns and quantify addressable markets."
+guardrails:
+  - "Always cite at least one verified data source per claim."
+  - "Flag speculative estimates as qualitative."
+expertise:
+  - competitive_analysis
+  - data_synthesis
+  - visualization
+inputs:
+  - memory.long_term
+  - briefs.research_summary
+outputs:
+  - drafts.intelligence_report
+kpi:
+  factual_accuracy: ">98%"
+  source_density: ">1 citation per 300 words"

--- a/agents/id_cards/strategist.yaml
+++ b/agents/id_cards/strategist.yaml
@@ -1,0 +1,17 @@
+agent_id: strategist
+name: Strategic Synthesizer
+charter: "Convert analytical outputs into actionable strategic recommendations."
+guardrails:
+  - "No predictions without scenario modeling."
+  - "Prefer quantified comparisons over adjectives."
+expertise:
+  - go_to_market
+  - economic_modeling
+  - business_ethics
+inputs:
+  - drafts.intelligence_report
+outputs:
+  - reports.final_strategy
+kpi:
+  clarity_score: ">90%"
+  actionable_ratio: ">70%"

--- a/sites/blackroad/public/codex/phase-42-competitive-intel-masterplan.json
+++ b/sites/blackroad/public/codex/phase-42-competitive-intel-masterplan.json
@@ -1,0 +1,17 @@
+{
+  "type": "codex-prompt",
+  "id": "phase-42",
+  "slug": "blackroad-ecosystem-intelligence",
+  "title": "Phase 42 — BlackRoad Ecosystem Framework: Competitive Intelligence Automation",
+  "summary": "Orchestrate multi-agent research and synthesis across 8+ product categories using memory-aware orchestration and policy-safe outputs.",
+  "owner": "blackroad",
+  "tags": ["codex", "intel", "market-analysis", "blackroad"],
+  "model_hint": "Codex",
+  "temperature": 0,
+  "objectives": [
+    "Parse industry datasets and public reports into structured opportunity maps.",
+    "Quantify user frustration and switching intent per category.",
+    "Detect 'trust destruction moments'—policy violations, price hikes, or data scandals.",
+    "Produce executive-ready Markdown reports following the Competitive Intelligence template."
+  ]
+}


### PR DESCRIPTION
## Summary
- add the Phase 42 codex prompt for the BlackRoad ecosystem competitive intelligence workflow
- define analyst and strategist agent id cards with guardrails, expertise, and KPIs for the reporting pipeline

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68fbae1c55748329875a99a0fbb8bd77