### PR TITLE
Add integration prompts for ops automation

### DIFF
--- a/prompts/integrations/asana_merge_gate_v1.yaml
+++ b/prompts/integrations/asana_merge_gate_v1.yaml
@@ -1,0 +1,38 @@
+# --- CODEx PROMPT ---
+id: asana_merge_gate_v1
+name: Asana Merge Gate
+owner: Eng
+systems_of_record: [GitHub, Asana]
+triggers: [webhook:github.pull_request.labeled, pr_comment:/asana approve]
+secrets: [ASANA_AUTH_BOT_TOKEN]
+risk_level: L2
+kpis: [approvals, denials, latency_ms]
+# --------------------
+
+Goal
+----
+Ensure merges only proceed when the linked Asana approval task is marked ready or when `/asana approve` passes validation.
+
+Inputs
+------
+- pr.labels
+- pr.comment_cmd
+- asana.task_gid
+
+Outputs
+-------
+- GitHub status `probot/manual-approval: success|failure`
+- PR comment confirming approval decision
+
+Steps
+-----
+1. When label `asana-approval` is added, create or update the Asana task and assign the approver.
+2. On `/asana approve`, query the Asana task status via API to confirm readiness.
+3. Set the GitHub status context `probot/manual-approval` to success for approved tasks; otherwise leave or set to failure.
+4. Reply on the PR thread summarizing the approval result and next steps.
+
+Guardrails
+----------
+- Log every action to `logs/asana-auth-bot/` for traceability.
+- If the Asana API times out or is unreachable, fail safe by keeping merge blocked.
+- Avoid storing or echoing sensitive tokens outside secure storage.

--- a/prompts/integrations/collaborator_ai_router_v1.yaml
+++ b/prompts/integrations/collaborator_ai_router_v1.yaml
@@ -1,0 +1,40 @@
+# --- CODEx PROMPT ---
+id: collaborator_ai_router_v1
+name: Collaborator AI Router
+owner: Ops/Eng
+systems_of_record: [Slack, Asana, GitHub, Notion]
+triggers: [webhook:slack.message, manual]
+secrets: [OPENAI_API_KEY, ASANA_TOKEN]
+risk_level: L2
+kpis: [auto_routed_actions, escalation_rate]
+# --------------------
+
+Goal
+----
+Automatically classify inbound Slack queries and route them to the correct action: answer from docs, create an Asana task, open a GitHub issue, or summarize a thread to Notion.
+
+Inputs
+------
+- slack.text
+- channel
+- thread_ts
+
+Outputs
+-------
+- Slack reply or reaction acknowledging handling
+- Asana task, GitHub issue, or Notion summary depending on intent
+
+Steps
+-----
+1. Classify intent (`answer`, `task`, `issue`, `summary`) using the router model with context from recent messages.
+2. For `answer`, retrieve relevant content from `docs/prism/*` and Notion and respond with cited references in Slack.
+3. For `task`, create an Asana task with necessary context and link back to the originating Slack thread.
+4. For `issue`, open a GitHub issue using the standard template populated with Slack context and attachments.
+5. For `summary`, generate a Notion page capturing the thread and drop the link into the Slack conversation.
+6. Escalate to a human if confidence falls below the threshold or ambiguity persists.
+
+Guardrails
+----------
+- Always request clarification when intent confidence is low before taking action.
+- Block destructive or high-risk actions; only perform additive operations.
+- Store processing logs securely without copying message content to external systems unnecessarily.

--- a/prompts/integrations/friday_retro_seed_v1.yaml
+++ b/prompts/integrations/friday_retro_seed_v1.yaml
@@ -1,0 +1,37 @@
+# --- CODEx PROMPT ---
+id: friday_retro_seed_v1
+name: Friday Retro Seed
+owner: Product
+systems_of_record: [Asana, Slack]
+triggers: [cron:FRI@15:00-0500]
+secrets: [ASANA_TOKEN, SLACK_WEBHOOK_URL]
+risk_level: L1
+kpis: [retro_completion_rate]
+# --------------------
+
+Goal
+----
+Automatically create the weekly Friday Retro task with a standard agenda and nudge owners to participate.
+
+Inputs
+------
+- board: PRISM
+- owners[]
+
+Outputs
+-------
+- Asana task `Retro – YYYY-MM-DD` with agenda template
+- Slack reminder in `#products-prism`
+
+Steps
+-----
+1. Generate an Asana task titled `Retro – YYYY-MM-DD` including agenda sections (Start/Stop/Continue, improvements, owners) and assign product and engineering leads.
+2. Ensure the task is placed in the appropriate Asana project section and due the following Monday.
+3. Post a Slack reminder in `#products-prism` tagging the assigned owners with the meeting details.
+4. Automatically close retro tasks older than 14 days to keep the board clean.
+
+Guardrails
+----------
+- Skip task creation if a retro for the week already exists.
+- Confirm Slack channel visibility before posting reminders to avoid private channels.
+- Respect holiday overrides by checking calendar exceptions when provided.

--- a/prompts/integrations/incident_one_click_v1.yaml
+++ b/prompts/integrations/incident_one_click_v1.yaml
@@ -1,0 +1,40 @@
+# --- CODEx PROMPT ---
+id: incident_one_click_v1
+name: Incident One-Click
+owner: Reliability
+systems_of_record: [Status, Asana, Slack]
+triggers: [manual, webhook:monitor.alert]
+secrets: [SLACK_WEBHOOK_URL, ASANA_TOKEN]
+risk_level: L2
+kpis: [time_to_post, time_to_close]
+# --------------------
+
+Goal
+----
+Create the Asana incident task, publish a status page update, and announce in Slack from a single triggering action.
+
+Inputs
+------
+- service
+- severity
+- summary
+- links[]
+
+Outputs
+-------
+- Asana task titled `INCIDENT: <service> <summary>`
+- Status page entry with initial incident state
+- Slack messages in `#announcements` and `#security` channels
+
+Steps
+-----
+1. Create an Asana task with severity mapped into the incident custom field and attach reference links.
+2. Publish a status update via the status API (or S3 asset) marking the incident as “Investigating”.
+3. Post structured Slack blocks highlighting owner, severity, ETA, and status page link to `#announcements` and `#security`.
+4. On resolution, update the Asana task to completed and transition the status entry to “Resolved”.
+
+Guardrails
+----------
+- Require owner and ETA fields before announcing publicly.
+- Strip stack traces or sensitive payloads from public-facing updates.
+- Ensure idempotent task creation by checking existing incidents with the same summary and service.

--- a/prompts/integrations/investor_portal_digest_v1.yaml
+++ b/prompts/integrations/investor_portal_digest_v1.yaml
@@ -1,0 +1,40 @@
+# --- CODEx PROMPT ---
+id: investor_portal_digest_v1
+name: Investor Deck + KPI Digest
+owner: Exec
+systems_of_record: [Notion, Slack, Status]
+triggers: [cron:FRI@16:00-0500]
+secrets: []
+risk_level: L1
+kpis: [weekly_send_rate]
+# --------------------
+
+Goal
+----
+Generate and distribute a weekly investor summary covering product progress, uptime, and key risks while updating the investor deck.
+
+Inputs
+------
+- status.last7d
+- product.changelog
+- kpi.snapshots
+- risks.top3
+
+Outputs
+-------
+- Notion page under `/Investor Updates/YYYY-MM-DD`
+- Slide deck section titled “This Week” with 5–7 slides
+- Slack DM to investor list containing summary and link
+
+Steps
+-----
+1. Pull uptime metrics from status feeds and highlights from PRISM “What’s new” or the product changelog.
+2. Compile KPI snapshots and top risks into a structured Notion page for the current week.
+3. Append or regenerate the “This Week” slide section in the investor deck with visuals or bullet slides.
+4. Send a Slack DM to the investor distribution list summarizing highlights and linking to the Notion page and deck.
+
+Guardrails
+----------
+- Exclude revenue or sensitive financials unless `public_ok=true` is explicitly provided.
+- Maintain consistent titling and date formatting across Notion and slide artifacts.
+- Store generated assets in the investor workspace with proper permissions.

--- a/prompts/integrations/ops_day_one_loader_v1.yaml
+++ b/prompts/integrations/ops_day_one_loader_v1.yaml
@@ -1,0 +1,37 @@
+# --- CODEx PROMPT ---
+id: ops_day_one_loader_v1
+name: Ops Day-One Loader
+owner: Ops
+systems_of_record: [Asana, Slack]
+triggers: [manual]
+secrets: [ASANA_TOKEN, SLACK_WEBHOOK_URL]
+risk_level: L1
+kpis: [tasks_seeded]
+# --------------------
+
+Goal
+----
+Seed the Asana HQ Ops project with the Day-One checklist and broadcast kickoff Slack messages across key channels.
+
+Inputs
+------
+- asana.project_id
+- slack.channels[]
+
+Outputs
+-------
+- Day-One tasks populated in Asana sections (Inbox → Done)
+- Slack posts to `#announcements`, `#security`, and `#products-prism`
+
+Steps
+-----
+1. Create Asana tasks from the standardized Day-One checklist, mapping each item into the correct project section and assigning owners.
+2. Avoid duplicates by checking for existing tasks with the same title and current date before creation.
+3. Post predefined Slack blocks for kickoff, security onboarding, and product briefings to the specified channels.
+4. Return a structured run log indicating tasks created, skipped, and Slack messages posted.
+
+Guardrails
+----------
+- Skip posting to channels marked private or not included in the provided list.
+- Do not include sensitive onboarding tokens or credentials in Slack messages or logs.
+- Ensure task creation failures are surfaced with actionable error messages.

--- a/prompts/integrations/pr_to_asana_lifecycle_v1.yaml
+++ b/prompts/integrations/pr_to_asana_lifecycle_v1.yaml
@@ -1,0 +1,40 @@
+# --- CODEx PROMPT ---
+id: pr_to_asana_lifecycle_v1
+name: PR ↔ Asana Task
+owner: Ops
+systems_of_record: [GitHub, Asana, Slack]
+triggers: [webhook:github.pull_request.opened, webhook:github.pull_request.closed]
+secrets: [ASANA_PROJECT_ID, ASANA_TOKEN, SLACK_WEBHOOK_URL]
+risk_level: L1
+kpis: [created_tasks, completed_tasks, failures]
+# --------------------
+
+Goal
+----
+When a PR opens, create `PR: <title>` in Asana (notes = PR URL). When the PR merges, mark the task complete and post a Slack confirmation.
+
+Inputs
+------
+- pr.title
+- pr.url
+- pr.state (opened|closed)
+- asana.project_id
+
+Outputs
+-------
+- Asana task created for opened PRs
+- Asana task marked completed for merged PRs
+- Slack message posted to #dev-prs confirming completion
+
+Steps
+-----
+1. On `opened`, call `POST /tasks` with `{ name, notes, projects:[ASANA_PROJECT_ID] }`.
+2. Persist the resulting `task_gid` on the PR (e.g., comment or label `asana:<gid>`).
+3. On `closed` with merge, call `PUT /tasks/{gid}` with `{ completed: true }`.
+4. Post Slack message: `Merged ✅ ${pr.title} → ${asana_link}` to `#dev-prs`.
+
+Guardrails
+----------
+- If `ASANA_PROJECT_ID` is missing, fail fast and log the error.
+- Retry up to three times with exponential backoff; enforce idempotency by checking for existing PR URL.
+- Never expose secrets in logs or outbound notifications.

--- a/prompts/integrations/roadchain_stage_to_ops_v1.yaml
+++ b/prompts/integrations/roadchain_stage_to_ops_v1.yaml
@@ -1,0 +1,39 @@
+# --- CODEx PROMPT ---
+id: roadchain_stage_to_ops_v1
+name: Financing Stage → Ops
+owner: RevOps
+systems_of_record: [Airtable/Supabase, Asana, Slack]
+triggers: [webhook:deal.updated]
+secrets: [ASANA_TOKEN, SLACK_WEBHOOK_URL]
+risk_level: L2
+kpis: [task_sla_breaches, stage_latency]
+# --------------------
+
+Goal
+----
+Convert RoadChain financing stage updates into actionable Asana tasks and Slack communications for the Ops team.
+
+Inputs
+------
+- deal.id
+- stage
+- amount
+- owner
+- docs[]
+
+Outputs
+-------
+- Stage-specific Asana task with checklist items
+- Slack digest message for the relevant channels with stage, owner, and due date
+
+Steps
+-----
+1. On stages `Negotiation` or `Closed Won`, create or update an Asana task with checklist items and assign the owner with stage-based SLA.
+2. Attach supporting documents or evidence links to the Asana task for auditability.
+3. Post a Slack update to `#sales` and `#exec` summarizing the stage, owner, due date, and key documents.
+
+Guardrails
+----------
+- Enforce idempotency by deduplicating on `deal.id + stage`.
+- Redact personally identifiable information or sensitive deal notes from Slack messages.
+- Record SLA timers and alert if tasks approach breach thresholds.


### PR DESCRIPTION
## Summary
- add CODEx prompt definitions for PR-Asana lifecycle and manual approval guardrails
- seed additional integration prompts for incidents, investor updates, and financing stages
- include automation prompts for AI routing, Friday retro seeding, and ops day-one loader

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fbb631b6a08329b9496f07c3c4e921