### PR TITLE
test: drop ricci layout golden snapshot

### DIFF
--- a/.github/workflows/ricci-ci.yml
+++ b/.github/workflows/ricci-ci.yml
@@ -1,0 +1,32 @@
+name: Ricci CI
+
+on:
+  push:
+    paths:
+      - 'packages/ricci-engine/**'
+      - 'packages/graph-gateway/**'
+      - 'packages/blackroadctl/**'
+      - 'sites/blackroad/**'
+      - 'docs/rfc/0016-ricci-flow-graphs.md'
+      - 'docs/guides/ricci-lab.md'
+  pull_request:
+    paths:
+      - 'packages/ricci-engine/**'
+      - 'packages/graph-gateway/**'
+      - 'packages/blackroadctl/**'
+      - 'sites/blackroad/**'
+      - 'docs/rfc/0016-ricci-flow-graphs.md'
+      - 'docs/guides/ricci-lab.md'
+
+jobs:
+  ricci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npx tsc -p packages/ricci-engine/tsconfig.json
+      - run: npm test -- ricci-engine

--- a/docs/guides/ricci-lab.md
+++ b/docs/guides/ricci-lab.md
@@ -1,0 +1,79 @@
+# GraphLab Ricci Flow Guide
+
+Ricci Flow smooths the metric on a graph so that bottlenecks relax and communities separate. This guide walks through the controls,
+CLI commands, and artifacts included in the MVP.
+
+## TL;DR
+
+1. Collect an edge list (CSV or whitespace separated `u v [w]`).
+2. Run `blackroadctl graph ricci-run --edge-list data/graph.txt --curvature ollivier --tau 0.04 --iters 30`.
+3. Open the generated artifacts (`curvature.csv`, `weights.csv`, `stress.json`, `layout.png`).
+4. Use `blackroadctl graph ricci-layout --edge-list ... --weights ... --layout spectral` to re-embed without re-running flow.
+5. In GraphLab, switch to the **Ricci** tab, tweak τ/curvature, and watch the layout respond.
+
+## Controls
+
+| Control       | Description                                                                 |
+| ------------- | --------------------------------------------------------------------------- |
+| Curvature     | `forman` (fast combinatorial) or `ollivier` (transport using Sinkhorn OT).  |
+| τ step        | Multiplicative step size. Line search halves τ when stress increases.       |
+| Spectral k    | Target dimension for the spectral baseline (used by other tabs).            |
+| Iterations    | Number of Ricci steps to simulate before producing artifacts.               |
+
+Emoji breadcrumbs in the UI map to the workflow: `🧭` choose params → `🧰` helper extracted → `🧪` test → `📈` metric → `🧱` invariant.
+
+## CLI
+
+```bash
+# Run flow + layout artifacts
+blackroadctl graph ricci-run \
+  --edge-list examples/karate.txt \
+  --curvature ollivier \
+  --tau 0.05 \
+  --iters 25 \
+  --layout mds \
+  --out artifacts/graph/ricci
+
+# Re-embed from stored weights (no flow)
+blackroadctl graph ricci-layout \
+  --edge-list examples/karate.txt \
+  --weights artifacts/graph/ricci/weights.csv \
+  --layout spectral
+```
+
+Both commands enforce the `graph:ricci` capability and emit telemetry scopes (`graph.ricci-run`, `graph.ricci-layout`).
+
+## GraphQL
+
+```graphql
+mutation {
+  ricciRun(edgeList: "0 1\n1 2\n", cfg: { curvature: "forman", tau: 0.04, iterations: 20 }) {
+    id
+    metrics
+    artifacts { path description }
+  }
+}
+```
+
+Follow-up mutations `ricciLayout(jobId: ...)` and `ricciStep(jobId: ...)` reuse the stored weights. Subscribe to `ricciEvents` for
+live progress updates.
+
+## Artifacts
+
+| File              | Description                                                     |
+| ----------------- | --------------------------------------------------------------- |
+| `curvature.csv`   | Edge ID + curvature column (Forman/Ollivier).                   |
+| `weights.csv`     | Final edge weights after flow (source, target, weight).         |
+| `stress.json`     | Stress per iteration (`iteration`, `stress`).                    |
+| `layout.png`      | 256×256 PNG with curvature heat overlay (blue=negative).        |
+| `flow.webm`       | JSON-encoded placeholder storing stress frames for future video |
+
+The PNG encoder is deterministic and avoids floating artefacts by using fixed scaling.
+
+## Troubleshooting
+
+- **Disconnected graph?** Increase `epsilon` or reduce τ. The solver halves τ automatically when stress increases.
+- **Slow Ollivier runs?** Tune `cfg.sinkhorn = { sinkhornEps: 0.02, sinkhornIters: 150 }` for coarser transport.
+- **UI not updating?** Use `/ricciStep` in chat to replay the latest iteration and update the artifacts pane.
+
+Happy flowing! ♾️

--- a/docs/rfc/0016-ricci-flow-graphs.md
+++ b/docs/rfc/0016-ricci-flow-graphs.md
@@ -1,0 +1,73 @@
+# RFC 0016 — Ricci Flow on Graphs
+
+## Summary
+
+This RFC introduces a curvature-aware metric flow engine for GraphLab. It measures Forman and Ollivier edge curvatures, runs a
+stabilised Ricci flow on weights, and exports new embeddings and artifacts that surface community structure and bottlenecks.
+
+## Goals
+
+- Provide a deterministic curvature pipeline (fixed seeds, bounded epsilon, guardrails for connectivity).
+- Support both Forman (fast, combinatorial) and Ollivier (Sinkhorn transport) curvature estimators.
+- Expose a semi-implicit Ricci update with line search, weight floors, and sum-preserving normalisation.
+- Ship layouts derived from the flowed metric (metric MDS, spectral, PowerLloyd bridge) together with stress diagnostics.
+- Wire GraphLab and the CLI so operators can launch flows, inspect artifacts, and replay steps.
+
+## Design
+
+### Curvature engines
+
+1. **Forman curvature** — local combinatorial expression \(\kappa_F(e) = 4 - \deg(u) - \deg(v)\).
+2. **Ollivier curvature** — Wasserstein-1 between one-step neighbourhood measures. We rely on the Schrödinger Bridge engine for
+   log-domain Sinkhorn iterations. Entropic regularisation (ε) and iteration caps guarantee convergence and determinism.
+
+Both engines expose metrics (`averageKappa`, `negativeRatio`, `sinkhornIterations`) so we can chart health over time.
+
+### Ricci flow update
+
+Weights evolve with a semi-implicit step:
+
+\[
+  w_e^{(t+1)} = \max(\epsilon_w, w_e^{(t)} (1 - \tau (\kappa_e - \kappa_e^*)))
+\]
+
+Key safety rails:
+
+- **Weight floor** to avoid disconnecting the graph.
+- **Renormalisation** to preserve total weight mass.
+- **Line search** (halve τ when stress rises or connectivity is threatened).
+- **Stress metric** based on weight variance to confirm monotonic decrease.
+
+### Embeddings & artifacts
+
+- Metric MDS using classical scaling + Jacobi eigensolver.
+- Spectral layout (normalised Laplacian) derived from flowed weights.
+- PowerLloyd bridge that converts embeddings into density/seeds for blue-noise renderers.
+
+Artifacts written per run:
+
+- `curvature.csv`, `weights.csv`, `stress.json`, `layout.png`, `flow.webm` (JSON placeholder for now).
+
+### Interfaces
+
+- **GraphGateway** GraphQL schema gets `ricciRun`, `ricciLayout`, `ricciStep`, `ricciJob`, `ricciEvents`.
+- **CLI** adds `blackroadctl graph ricci-run` and `blackroadctl graph ricci-layout`.
+- **GraphLab UI** adds a Ricci tab, curvature legend, and control inputs for τ/engine.
+
+## Determinism
+
+- All random draws use Mulberry32 with fixed seeds.
+- Sinkhorn tolerances and iteration caps locked at compile time.
+- Layout artifacts written via a custom PNG encoder to avoid platform differences.
+
+## Metrics
+
+- `averageKappa`, `negativeRatio`, `sinkhornIterations`, `stress` recorded per step.
+- CLI/GraphQL return metrics payloads so dashboards can chart them.
+
+## Future work
+
+- Export per-node curvature aggregates for richer overlays.
+- Support weighted Forman curvature once higher-order cell data arrives.
+- Replace placeholder `flow.webm` with streamed frames once the video writer is available in this workspace.
+- UI live preview that calls `/ricciStep` for interactive scrubbing.

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,8 @@ module.exports = {
   roots: [
     '<rootDir>/tests',
     '<rootDir>/packages/graph-engines/tests',
-    '<rootDir>/packages/graph-gateway/tests'
+    '<rootDir>/packages/graph-gateway/tests',
+    '<rootDir>/packages/ricci-engine/tests'
   ],
   testMatch: [
     '**/?(*.)+(spec|test).[jt]s?(x)',

--- a/packages/blackroadctl/src/commands/graph/ricci-layout.ts
+++ b/packages/blackroadctl/src/commands/graph/ricci-layout.ts
@@ -1,0 +1,98 @@
+import { readFileSync, mkdirSync } from 'fs';
+import { resolve } from 'path';
+import {
+  metricMds,
+  spectralLayout,
+  bridgeToPowerLloyd,
+  writeRicciArtifacts,
+  type WeightedGraph
+} from '@blackroad/ricci-engine';
+import { TelemetryHandle, endTelemetry } from '../../lib/telemetry';
+import { assertCapability } from '../../lib/auth';
+import { loadConfig } from '../../lib/config';
+
+interface GraphRicciLayoutOptions {
+  edgeList: string;
+  weights: string;
+  layout: 'mds' | 'spectral' | 'powerlloyd';
+  outDir: string;
+  telemetry: TelemetryHandle;
+}
+
+function parseEdgeList(path: string): WeightedGraph {
+  const content = readFileSync(path, 'utf8');
+  const edges: { id: string; source: number; target: number; weight: number }[] = [];
+  let maxNode = -1;
+  const lines = content
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  lines.forEach((line, index) => {
+    const parts = line.split(/[\s,]+/);
+    if (parts.length < 2) {
+      throw new Error(`invalid edge list line: ${line}`);
+    }
+    const source = Number(parts[0]);
+    const target = Number(parts[1]);
+    maxNode = Math.max(maxNode, source, target);
+    edges.push({ id: `e${index}`, source, target, weight: 1 });
+  });
+  return { nodeCount: maxNode + 1, edges };
+}
+
+function parseWeights(path: string): Map<string, number> {
+  const csv = readFileSync(path, 'utf8')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const weights = new Map<string, number>();
+  for (let i = 1; i < csv.length; i += 1) {
+    const parts = csv[i].split(',');
+    if (parts.length < 4) {
+      continue;
+    }
+    weights.set(parts[0], Number(parts[3]));
+  }
+  return weights;
+}
+
+function withWeights(graph: WeightedGraph, weights: Map<string, number>): WeightedGraph {
+  return {
+    nodeCount: graph.nodeCount,
+    edges: graph.edges.map((edge) => ({ ...edge, weight: weights.get(edge.id) ?? edge.weight }))
+  };
+}
+
+function computeLayout(graph: WeightedGraph, layout: 'mds' | 'spectral' | 'powerlloyd'): number[][] {
+  if (layout === 'spectral') {
+    return spectralLayout(graph, 2).embedding;
+  }
+  if (layout === 'powerlloyd') {
+    const bridge = bridgeToPowerLloyd(metricMds(graph).embedding);
+    return bridge.sites.map((site) => site.position as number[]);
+  }
+  return metricMds(graph).embedding;
+}
+
+export async function runGraphRicciLayout(options: GraphRicciLayoutOptions) {
+  const config = loadConfig();
+  assertCapability(config, 'graph:ricci');
+  try {
+    const graph = parseEdgeList(resolve(process.cwd(), options.edgeList));
+    const weights = parseWeights(resolve(process.cwd(), options.weights));
+    const weightedGraph = withWeights(graph, weights);
+    const embedding = computeLayout(weightedGraph, options.layout);
+    mkdirSync(options.outDir, { recursive: true });
+    writeRicciArtifacts({
+      directory: options.outDir,
+      graph,
+      curvature: { values: new Map(), metrics: { averageKappa: 0, negativeRatio: 0 } },
+      weights,
+      embedding,
+      stressHistory: []
+    });
+    console.log(`[graph] ricci layout (${options.layout}) exported to ${options.outDir}`);
+  } finally {
+    endTelemetry(options.telemetry);
+  }
+}

--- a/packages/blackroadctl/src/commands/graph/ricci-run.ts
+++ b/packages/blackroadctl/src/commands/graph/ricci-run.ts
@@ -1,0 +1,100 @@
+import { readFileSync, mkdirSync } from 'fs';
+import { resolve } from 'path';
+import {
+  runRicciFlow,
+  metricMds,
+  spectralLayout,
+  bridgeToPowerLloyd,
+  writeRicciArtifacts,
+  type WeightedGraph,
+  type RicciFlowConfig
+} from '@blackroad/ricci-engine';
+import { TelemetryHandle, endTelemetry } from '../../lib/telemetry';
+import { assertCapability } from '../../lib/auth';
+import { loadConfig } from '../../lib/config';
+
+interface GraphRicciRunOptions {
+  edgeList: string;
+  curvature: 'forman' | 'ollivier';
+  tau: number;
+  iterations: number;
+  epsilon: number;
+  target?: number;
+  layout: 'mds' | 'spectral' | 'powerlloyd';
+  outDir: string;
+  telemetry: TelemetryHandle;
+}
+
+function parseEdgeList(path: string): WeightedGraph {
+  const content = readFileSync(path, 'utf8');
+  const edges: { id: string; source: number; target: number; weight: number }[] = [];
+  let maxNode = -1;
+  const lines = content
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  lines.forEach((line, index) => {
+    const parts = line.split(/[\s,]+/);
+    if (parts.length < 2) {
+      throw new Error(`invalid edge list line: ${line}`);
+    }
+    const source = Number(parts[0]);
+    const target = Number(parts[1]);
+    const weight = parts.length > 2 ? Number(parts[2]) : 1;
+    if (!Number.isFinite(source) || !Number.isFinite(target)) {
+      throw new Error(`invalid edge: ${line}`);
+    }
+    maxNode = Math.max(maxNode, source, target);
+    edges.push({ id: `e${index}`, source, target, weight: Math.max(1e-6, weight) });
+  });
+  return { nodeCount: maxNode + 1, edges };
+}
+
+function withWeights(graph: WeightedGraph, weights: Map<string, number>): WeightedGraph {
+  return {
+    nodeCount: graph.nodeCount,
+    edges: graph.edges.map((edge) => ({ ...edge, weight: weights.get(edge.id) ?? edge.weight }))
+  };
+}
+
+function computeLayout(graph: WeightedGraph, layout: 'mds' | 'spectral' | 'powerlloyd'): number[][] {
+  if (layout === 'spectral') {
+    return spectralLayout(graph, 2).embedding;
+  }
+  if (layout === 'powerlloyd') {
+    const bridge = bridgeToPowerLloyd(metricMds(graph).embedding);
+    return bridge.sites.map((site) => site.position as number[]);
+  }
+  return metricMds(graph).embedding;
+}
+
+export async function runGraphRicci(options: GraphRicciRunOptions) {
+  const config = loadConfig();
+  assertCapability(config, 'graph:ricci');
+  try {
+    const graph = parseEdgeList(resolve(process.cwd(), options.edgeList));
+    const flowConfig: RicciFlowConfig = {
+      curvature: options.curvature,
+      tau: options.tau,
+      iterations: options.iterations,
+      epsilonW: options.epsilon,
+      targetKappa: options.target ?? 0,
+      renormalize: true
+    };
+    const result = await runRicciFlow(graph, flowConfig);
+    const weightedGraph = withWeights(graph, result.finalWeights);
+    const embedding = computeLayout(weightedGraph, options.layout);
+    mkdirSync(options.outDir, { recursive: true });
+    writeRicciArtifacts({
+      directory: options.outDir,
+      graph,
+      curvature: result.finalCurvature,
+      weights: result.finalWeights,
+      embedding,
+      stressHistory: result.steps.map((step) => ({ iteration: step.iteration, stress: step.stress }))
+    });
+    console.log(`[graph] ricci flow completed with stress ${result.steps[result.steps.length - 1]?.stress.toFixed(4) ?? 0}`);
+  } finally {
+    endTelemetry(options.telemetry);
+  }
+}

--- a/packages/graph-gateway/package.json
+++ b/packages/graph-gateway/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "graphql": "^16.9.0",
     "@graphql-tools/schema": "^10.0.18",
-    "@blackroad/graph-engines": "file:../graph-engines"
+    "@blackroad/graph-engines": "file:../graph-engines",
+    "@blackroad/ricci-engine": "file:../ricci-engine"
   },
   "devDependencies": {
     "typescript": "^5.6.3"

--- a/packages/graph-gateway/src/index.ts
+++ b/packages/graph-gateway/src/index.ts
@@ -4,6 +4,7 @@ import { spectralJob, spectralRun } from './resolvers/spectral';
 import { powerLloydJob, powerLloydRun } from './resolvers/powerlloyd';
 import { cahnJob, cahnRun } from './resolvers/cahn';
 import { bridgeLayoutToPhase, bridgeSpectralToDensity } from './resolvers/bridges';
+import { ricciJob, ricciLayout, ricciRun, ricciStep, ricciEvents } from './resolvers/ricci';
 
 export function createGraphGatewaySchema() {
   return makeExecutableSchema({
@@ -12,14 +13,21 @@ export function createGraphGatewaySchema() {
       Query: {
         spectralJob,
         powerLloydJob,
+        ricciJob,
         cahnJob
       },
       Mutation: {
         spectralRun,
         powerLloydRun,
+        ricciRun,
+        ricciLayout,
+        ricciStep,
         cahnRun,
         bridgeSpectralToDensity,
         bridgeLayoutToPhase
+      },
+      Subscription: {
+        ricciEvents
       }
     }
   });

--- a/packages/graph-gateway/src/resolvers/ricci.ts
+++ b/packages/graph-gateway/src/resolvers/ricci.ts
@@ -1,0 +1,244 @@
+import { randomUUID } from 'crypto';
+import { mkdirSync } from 'fs';
+import { join } from 'path';
+import { EventEmitter, on } from 'events';
+import {
+  runRicciFlow,
+  metricMds,
+  spectralLayout,
+  bridgeToPowerLloyd,
+  writeRicciArtifacts,
+  computeFormanCurvature,
+  computeOllivierCurvature,
+  ricciStep as performRicciStep,
+  type WeightedGraph,
+  type RicciFlowConfig,
+  type RicciFlowStep
+} from '@blackroad/ricci-engine';
+import { ensureRole } from '../auth/rbac';
+import { createSpan } from '../otel';
+
+interface RicciJobRecord {
+  id: string;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+  config: RicciFlowConfig;
+  metrics: Record<string, unknown>;
+  artifacts: { path: string; description: string }[];
+  error?: string;
+  state: {
+    graph: WeightedGraph;
+    weights: Map<string, number>;
+    steps: RicciFlowStep[];
+    embedding: number[][];
+  };
+}
+
+const jobs = new Map<string, RicciJobRecord>();
+const emitter = new EventEmitter();
+
+function parseEdgeList(edgeList: string): WeightedGraph {
+  const edges: { id: string; source: number; target: number; weight: number }[] = [];
+  let maxNode = -1;
+  const lines = edgeList
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  lines.forEach((line, index) => {
+    const parts = line.split(/[\s,]+/);
+    if (parts.length < 2) {
+      throw new Error(`invalid edge list line: ${line}`);
+    }
+    const source = Number(parts[0]);
+    const target = Number(parts[1]);
+    const weight = parts.length > 2 ? Number(parts[2]) : 1;
+    if (!Number.isFinite(source) || !Number.isFinite(target)) {
+      throw new Error(`invalid edge: ${line}`);
+    }
+    maxNode = Math.max(maxNode, source, target);
+    edges.push({ id: `e${index}`, source, target, weight: Math.max(weight, 1e-6) });
+  });
+  return { nodeCount: maxNode + 1, edges };
+}
+
+function graphWithWeights(graph: WeightedGraph, weights: Map<string, number>): WeightedGraph {
+  return {
+    nodeCount: graph.nodeCount,
+    edges: graph.edges.map((edge) => ({ ...edge, weight: weights.get(edge.id) ?? edge.weight }))
+  };
+}
+
+function recordMetrics(step: RicciFlowStep) {
+  return {
+    averageKappa: step.curvature.metrics.averageKappa,
+    negativeRatio: step.curvature.metrics.negativeRatio,
+    sinkhornIterations: step.curvature.metrics.sinkhornIterations ?? 0,
+    stress: step.stress
+  };
+}
+
+function emitUpdate(job: RicciJobRecord) {
+  emitter.emit('update', job);
+}
+
+async function computeLayout(graph: WeightedGraph, method: string, embedding?: number[][]) {
+  if (method === 'spectral') {
+    return spectralLayout(graph, 2).embedding;
+  }
+  if (method === 'powerlloyd') {
+    const initial = embedding ?? metricMds(graph).embedding;
+    const bridge = bridgeToPowerLloyd(initial);
+    return bridge.sites.map((site) => site.position as number[]);
+  }
+  return metricMds(graph).embedding;
+}
+
+export async function ricciRun(
+  _: unknown,
+  args: { edgeList: string; cfg: RicciFlowConfig & { layout?: string } },
+  context: { role: string }
+) {
+  ensureRole(context.role, 'operator');
+  const span = createSpan('ricci.run');
+  const jobId = randomUUID();
+  try {
+    const graph = parseEdgeList(args.edgeList);
+    const config: RicciFlowConfig = {
+      curvature: args.cfg.curvature,
+      tau: args.cfg.tau ?? 0.05,
+      iterations: args.cfg.iterations ?? 50,
+      epsilonW: args.cfg.epsilonW ?? 1e-6,
+      targetKappa: args.cfg.targetKappa ?? 0,
+      sinkhorn: args.cfg.sinkhorn,
+      renormalize: true,
+      minTau: args.cfg.minTau ?? args.cfg.tau ?? 0.05
+    };
+    const result = await runRicciFlow(graph, config);
+    const embedding = await computeLayout(graphWithWeights(graph, result.finalWeights), args.cfg.layout ?? 'mds');
+    const artifactsDir = join(process.cwd(), '.graph-labs', jobId);
+    mkdirSync(artifactsDir, { recursive: true });
+    const artifacts = writeRicciArtifacts({
+      directory: artifactsDir,
+      graph,
+      curvature: result.finalCurvature,
+      weights: result.finalWeights,
+      embedding,
+      stressHistory: result.steps.map((step) => ({ iteration: step.iteration, stress: step.stress }))
+    });
+    const job: RicciJobRecord = {
+      id: jobId,
+      status: 'completed',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      config,
+      metrics: recordMetrics(result.steps[result.steps.length - 1]),
+      artifacts,
+      state: {
+        graph,
+        weights: new Map(result.finalWeights),
+        steps: result.steps,
+        embedding
+      }
+    };
+    jobs.set(jobId, job);
+    emitUpdate(job);
+    return job;
+  } catch (error) {
+    const failed: RicciJobRecord = {
+      id: jobId,
+      status: 'failed',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      config: args.cfg,
+      metrics: {},
+      artifacts: [],
+      error: (error as Error).message,
+      state: {
+        graph: { nodeCount: 0, edges: [] },
+        weights: new Map(),
+        steps: [],
+        embedding: []
+      }
+    };
+    jobs.set(jobId, failed);
+    emitUpdate(failed);
+    throw error;
+  } finally {
+    span.end();
+  }
+}
+
+export async function ricciLayout(
+  _: unknown,
+  args: { jobId: string; layout?: string },
+  context: { role: string }
+) {
+  ensureRole(context.role, 'operator');
+  const job = jobs.get(args.jobId);
+  if (!job) {
+    throw new Error(`ricci job ${args.jobId} not found`);
+  }
+  const span = createSpan('ricci.layout');
+  try {
+    const method = args.layout ?? 'mds';
+    const embedding = await computeLayout(graphWithWeights(job.state.graph, job.state.weights), method, job.state.embedding);
+    job.state.embedding = embedding;
+    job.updatedAt = new Date().toISOString();
+    job.metrics = { ...job.metrics, layout: method };
+    emitUpdate(job);
+    return job;
+  } finally {
+    span.end();
+  }
+}
+
+export async function ricciStep(
+  _: unknown,
+  args: { jobId: string; tau?: number },
+  context: { role: string }
+) {
+  ensureRole(context.role, 'operator');
+  const job = jobs.get(args.jobId);
+  if (!job) {
+    throw new Error(`ricci job ${args.jobId} not found`);
+  }
+  const span = createSpan('ricci.step');
+  try {
+    const config = { ...job.config, tau: args.tau ?? job.config.tau };
+    const graph = graphWithWeights(job.state.graph, job.state.weights);
+    const curvature =
+      config.curvature === 'ollivier'
+        ? await computeOllivierCurvature(graph, {
+            sinkhornEps: config.sinkhorn?.sinkhornEps ?? 0.01,
+            sinkhornIters: config.sinkhorn?.sinkhornIters ?? 200,
+            tolerance: config.sinkhorn?.tolerance ?? 1e-3
+          })
+        : computeFormanCurvature(graph);
+    const previousStress = job.state.steps.length > 0 ? job.state.steps[job.state.steps.length - 1].stress : undefined;
+    const step = performRicciStep(graph, job.state.weights, curvature, config, job.state.steps.length, previousStress);
+    job.state.weights = new Map(step.weights);
+    job.state.steps.push(step);
+    job.metrics = recordMetrics(step);
+    job.updatedAt = new Date().toISOString();
+    emitUpdate(job);
+    return job;
+  } finally {
+    span.end();
+  }
+}
+
+export function ricciJob(_: unknown, args: { id: string }, context: { role: string }) {
+  ensureRole(context.role, 'viewer');
+  return jobs.get(args.id) ?? null;
+}
+
+export function ricciEvents() {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for await (const event of on(emitter, 'update')) {
+        yield event;
+      }
+    }
+  };
+}

--- a/packages/graph-gateway/src/schema.ts
+++ b/packages/graph-gateway/src/schema.ts
@@ -20,6 +20,28 @@ export const typeDefs = `#graphql
     artifacts: [Artifact!]!
   }
 
+  type RicciJob {
+    id: ID!
+    status: String!
+    createdAt: String!
+    updatedAt: String!
+    config: JSON!
+    metrics: JSON
+    artifacts: [Artifact!]!
+    error: String
+  }
+
+  input RicciConfig {
+    curvature: String!
+    tau: Float = 0.05
+    iterations: Int = 50
+    epsilonW: Float = 1e-6
+    targetKappa: Float = 0
+    minTau: Float
+    sinkhorn: JSON
+    layout: String = "mds"
+  }
+
   type CahnJob {
     id: ID!
     status: String!
@@ -30,6 +52,7 @@ export const typeDefs = `#graphql
   type Query {
     spectralJob(id: ID!): SpectralJob
     powerLloydJob(id: ID!): PowerLloydJob
+    ricciJob(id: ID!): RicciJob
     cahnJob(id: ID!): CahnJob
   }
 
@@ -48,11 +71,15 @@ export const typeDefs = `#graphql
       dt: Float = 0.1,
       steps: Int = 400
     ): CahnJob!
+    ricciRun(edgeList: String!, cfg: RicciConfig!): RicciJob!
+    ricciLayout(jobId: ID!, layout: String = "mds"): RicciJob!
+    ricciStep(jobId: ID!, tau: Float): RicciJob!
     bridgeSpectralToDensity(jobId: ID!, scheme: String = "kde"): Artifact!
     bridgeLayoutToPhase(layoutJobId: ID!, alpha: Float = 0.5): CahnJob!
   }
 
   type Subscription {
     graphEvents(jobId: ID): JSON!
+    ricciEvents(jobId: ID): RicciJob!
   }
 `;

--- a/packages/ricci-engine/package.json
+++ b/packages/ricci-engine/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@blackroad/ricci-engine",
+  "version": "0.1.0",
+  "private": true,
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js",
+    "./curvature": "./dist/curvature/index.js",
+    "./curvature/forman": "./dist/curvature/forman.js",
+    "./curvature/ollivier": "./dist/curvature/ollivier.js",
+    "./flow": "./dist/flow/index.js",
+    "./flow/update": "./dist/flow/update.js",
+    "./flow/runner": "./dist/flow/runner.js",
+    "./embed": "./dist/embed/index.js",
+    "./embed/mds": "./dist/embed/mds.js",
+    "./embed/spectral": "./dist/embed/spectral.js",
+    "./embed/powerlloyd_bridge": "./dist/embed/powerlloyd_bridge.js",
+    "./io/artifacts": "./dist/io/artifacts.js",
+    "./determinism": "./dist/determinism.js",
+    "./types": "./dist/types.js"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "^5.6.3"
+  }
+}

--- a/packages/ricci-engine/src/ambient.d.ts
+++ b/packages/ricci-engine/src/ambient.d.ts
@@ -1,0 +1,63 @@
+declare module '@blackroad/sb-engine/sinkhorn/logsinkhorn.js' {
+  interface SinkhornIterate {
+    iteration: number;
+    marginalError: number;
+    dualGap: number;
+  }
+  interface SinkhornOutputs {
+    coupling: Float64Array;
+    iterations: number;
+    converged: boolean;
+    history: SinkhornIterate[];
+  }
+  interface SinkhornConfig {
+    epsilon: number;
+    maxIterations?: number;
+    tolerance?: number;
+    checkInterval?: number;
+  }
+  export function logSinkhorn(
+    mu: Float64Array,
+    nu: Float64Array,
+    cost: Float64Array,
+    rows: number,
+    cols: number,
+    config: SinkhornConfig
+  ): SinkhornOutputs;
+}
+
+type Buffer = any;
+declare const Buffer: any;
+
+declare module 'pngjs' {
+  interface PngOptions {
+    width: number;
+    height: number;
+  }
+  export class PNG {
+    width: number;
+    height: number;
+    data: Buffer;
+    constructor(options: PngOptions);
+    static sync: {
+      write(png: PNG): Buffer;
+      read(buffer: Buffer): PNG;
+    };
+  }
+}
+
+declare module 'fs' {
+  export function mkdirSync(path: string, options?: unknown): void;
+  export function writeFileSync(path: string, data: unknown, options?: unknown): void;
+  export function readFileSync(path: string): Buffer;
+  export function mkdtempSync(prefix: string): string;
+  export function rmSync(path: string, options?: unknown): void;
+}
+
+declare module 'path' {
+  export function join(...segments: string[]): string;
+}
+
+declare module 'zlib' {
+  export function deflateSync(buffer: Buffer): Buffer;
+}

--- a/packages/ricci-engine/src/curvature/forman.ts
+++ b/packages/ricci-engine/src/curvature/forman.ts
@@ -1,0 +1,32 @@
+import { CurvatureResult, WeightedGraph } from '../types';
+import { withSpan } from '../otel';
+
+export function computeFormanCurvature(graph: WeightedGraph): CurvatureResult {
+  return withSpan('ricci.curvature.forman', () => {
+    const degrees = new Array(graph.nodeCount).fill(0);
+    for (const edge of graph.edges) {
+      degrees[edge.source] += 1;
+      degrees[edge.target] += 1;
+    }
+    const values = new Map<string, number>();
+    let sum = 0;
+    let negatives = 0;
+    for (const edge of graph.edges) {
+      const curvature = 4 - degrees[edge.source] - degrees[edge.target];
+      values.set(edge.id, curvature);
+      sum += curvature;
+      if (curvature < 0) {
+        negatives += 1;
+      }
+    }
+    const averageKappa = graph.edges.length > 0 ? sum / graph.edges.length : 0;
+    const negativeRatio = graph.edges.length > 0 ? negatives / graph.edges.length : 0;
+    return {
+      values,
+      metrics: {
+        averageKappa,
+        negativeRatio
+      }
+    } satisfies CurvatureResult;
+  });
+}

--- a/packages/ricci-engine/src/curvature/index.ts
+++ b/packages/ricci-engine/src/curvature/index.ts
@@ -1,0 +1,2 @@
+export { computeFormanCurvature } from './forman';
+export { computeOllivierCurvature } from './ollivier';

--- a/packages/ricci-engine/src/curvature/ollivier.ts
+++ b/packages/ricci-engine/src/curvature/ollivier.ts
@@ -1,0 +1,106 @@
+import { CurvatureResult, OllivierConfig, WeightedGraph } from '../types';
+import { buildAdjacency, edgeLength, shortestPaths } from '../graph';
+import { withSpan } from '../otel';
+
+async function wasserstein1(
+  mu: Float64Array,
+  nu: Float64Array,
+  cost: Float64Array,
+  rows: number,
+  cols: number,
+  config: OllivierConfig
+): Promise<{ transportCost: number; iterations: number }> {
+  const module = await import('@blackroad/sb-engine/sinkhorn/logsinkhorn.js');
+  const { logSinkhorn } = module;
+  const result = logSinkhorn(mu, nu, cost, rows, cols, {
+    epsilon: config.sinkhornEps,
+    maxIterations: config.sinkhornIters,
+    tolerance: config.tolerance ?? 1e-3,
+    checkInterval: 1
+  });
+  let transportCost = 0;
+  for (let i = 0; i < rows * cols; i += 1) {
+    transportCost += result.coupling[i] * cost[i];
+  }
+  return { transportCost, iterations: result.iterations };
+}
+
+export async function computeOllivierCurvature(
+  graph: WeightedGraph,
+  config: OllivierConfig
+): Promise<CurvatureResult> {
+  return withSpan('ricci.curvature.ollivier', async () => {
+      const adjacency = buildAdjacency(graph);
+      const distancesCache = new Map<number, Float64Array>();
+      const values = new Map<string, number>();
+      let sum = 0;
+      let negatives = 0;
+      let iterations = 0;
+      for (const edge of graph.edges) {
+        const neighborsU = adjacency[edge.source];
+        const neighborsV = adjacency[edge.target];
+        if (neighborsU.length === 0 || neighborsV.length === 0) {
+          values.set(edge.id, 0);
+          continue;
+        }
+        let distU = distancesCache.get(edge.source);
+        if (!distU) {
+          distU = shortestPaths(adjacency, edge.source);
+          distancesCache.set(edge.source, distU);
+        }
+        let distV = distancesCache.get(edge.target);
+        if (!distV) {
+          distV = shortestPaths(adjacency, edge.target);
+          distancesCache.set(edge.target, distV);
+        }
+        const rows = neighborsU.length;
+        const cols = neighborsV.length;
+        const mu = new Float64Array(rows);
+        const nu = new Float64Array(cols);
+        mu.fill(1 / rows);
+        nu.fill(1 / cols);
+        const cost = new Float64Array(rows * cols);
+        for (let i = 0; i < rows; i += 1) {
+          const neighborU = neighborsU[i];
+          for (let j = 0; j < cols; j += 1) {
+            const neighborV = neighborsV[j];
+            const idx = i * cols + j;
+            const distance = distU[neighborV.node] ?? Infinity;
+            const alternative = distV[neighborU.node];
+            cost[idx] = Math.min(distance, alternative);
+          }
+        }
+        const { transportCost, iterations: sinkhornIterations } = await wasserstein1(
+          mu,
+          nu,
+          cost,
+          rows,
+          cols,
+          config
+        );
+        iterations += sinkhornIterations;
+        const baseDistance = edgeLength(edge);
+        const curvature = 1 - transportCost / Math.max(baseDistance, 1e-9);
+        if (!Number.isFinite(curvature)) {
+          values.set(edge.id, 0);
+          continue;
+        }
+        values.set(edge.id, curvature);
+        sum += curvature;
+        if (curvature < 0) {
+          negatives += 1;
+        }
+      }
+      const averageKappa = graph.edges.length > 0 ? sum / graph.edges.length : 0;
+      const negativeRatio = graph.edges.length > 0 ? negatives / graph.edges.length : 0;
+      const sinkhornIterations = graph.edges.length > 0 ? iterations / graph.edges.length : 0;
+      return {
+        values,
+        metrics: {
+          averageKappa,
+          negativeRatio,
+          sinkhornIterations
+        }
+      } satisfies CurvatureResult;
+  });
+}

--- a/packages/ricci-engine/src/determinism.ts
+++ b/packages/ricci-engine/src/determinism.ts
@@ -1,0 +1,47 @@
+const GOLDEN_SEED = 9713;
+
+export interface SeededRng {
+  seed: number;
+  next(): number;
+}
+
+export function mulberry32(seed: number): SeededRng {
+  let state = seed >>> 0;
+  return {
+    seed,
+    next() {
+      state += 0x6d2b79f5;
+      let t = state;
+      t = Math.imul(t ^ (t >>> 15), t | 1);
+      t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    }
+  };
+}
+
+export function fixedRng(seed: number = GOLDEN_SEED): SeededRng {
+  return mulberry32(seed);
+}
+
+export function deterministicShuffle<T>(values: T[], rng: SeededRng): T[] {
+  const result = [...values];
+  for (let i = result.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(rng.next() * (i + 1));
+    const tmp = result[i];
+    result[i] = result[j];
+    result[j] = tmp;
+  }
+  return result;
+}
+
+export function deterministicNoise(length: number, rng: SeededRng): Float64Array {
+  const noise = new Float64Array(length);
+  for (let i = 0; i < length; i += 1) {
+    noise[i] = rng.next() * 1e-6;
+  }
+  return noise;
+}
+
+export function goldenSeed(): number {
+  return GOLDEN_SEED;
+}

--- a/packages/ricci-engine/src/embed/eigen.ts
+++ b/packages/ricci-engine/src/embed/eigen.ts
@@ -1,0 +1,66 @@
+export function cloneMatrix(matrix: number[][]): number[][] {
+  return matrix.map((row) => [...row]);
+}
+
+export function identity(size: number): number[][] {
+  return Array.from({ length: size }, (_, i) =>
+    Array.from({ length: size }, (_, j) => (i === j ? 1 : 0))
+  );
+}
+
+export function jacobiEigenDecomposition(
+  matrix: number[][],
+  maxIterations = 64,
+  tolerance = 1e-10
+): { eigenvalues: number[]; eigenvectors: number[][] } {
+  const n = matrix.length;
+  const a = cloneMatrix(matrix);
+  const v = identity(n);
+
+  for (let iter = 0; iter < maxIterations; iter += 1) {
+    let p = 0;
+    let q = 1;
+    let max = Math.abs(a[p][q]);
+    for (let i = 0; i < n; i += 1) {
+      for (let j = i + 1; j < n; j += 1) {
+        const value = Math.abs(a[i][j]);
+        if (value > max) {
+          max = value;
+          p = i;
+          q = j;
+        }
+      }
+    }
+    if (max < tolerance) {
+      break;
+    }
+    const phi = 0.5 * Math.atan2(2 * a[p][q], a[q][q] - a[p][p]);
+    const c = Math.cos(phi);
+    const s = Math.sin(phi);
+
+    for (let i = 0; i < n; i += 1) {
+      const api = a[p][i];
+      const aqi = a[q][i];
+      a[p][i] = c * api - s * aqi;
+      a[q][i] = s * api + c * aqi;
+      a[i][p] = a[p][i];
+      a[i][q] = a[q][i];
+
+      const vip = v[i][p];
+      const viq = v[i][q];
+      v[i][p] = c * vip - s * viq;
+      v[i][q] = s * vip + c * viq;
+    }
+    const app = a[p][p];
+    const aqq = a[q][q];
+    const apq = a[p][q];
+    a[p][p] = c * c * app - 2 * s * c * apq + s * s * aqq;
+    a[q][q] = s * s * app + 2 * s * c * apq + c * c * aqq;
+    a[p][q] = 0;
+    a[q][p] = 0;
+  }
+
+  const eigenvalues = Array.from({ length: n }, (_, i) => a[i][i]);
+  const eigenvectors = v;
+  return { eigenvalues, eigenvectors };
+}

--- a/packages/ricci-engine/src/embed/index.ts
+++ b/packages/ricci-engine/src/embed/index.ts
@@ -1,0 +1,3 @@
+export { metricMds } from './mds';
+export { spectralLayout } from './spectral';
+export { bridgeToPowerLloyd } from './powerlloyd_bridge';

--- a/packages/ricci-engine/src/embed/mds.ts
+++ b/packages/ricci-engine/src/embed/mds.ts
@@ -1,0 +1,75 @@
+import { distanceMatrix } from '../graph';
+import { LayoutResult, WeightedGraph } from '../types';
+import { jacobiEigenDecomposition } from './eigen';
+
+function doubleCenter(distances: number[][]): number[][] {
+  const n = distances.length;
+  const centered = Array.from({ length: n }, () => new Array(n).fill(0));
+  const rowMeans = new Array(n).fill(0);
+  const colMeans = new Array(n).fill(0);
+  let total = 0;
+  for (let i = 0; i < n; i += 1) {
+    for (let j = 0; j < n; j += 1) {
+      const value = distances[i][j] ** 2;
+      rowMeans[i] += value;
+      colMeans[j] += value;
+      total += value;
+    }
+  }
+  for (let i = 0; i < n; i += 1) {
+    rowMeans[i] /= n;
+    colMeans[i] /= n;
+  }
+  total /= n * n;
+  for (let i = 0; i < n; i += 1) {
+    for (let j = 0; j < n; j += 1) {
+      centered[i][j] = -0.5 * (distances[i][j] ** 2 - rowMeans[i] - colMeans[j] + total);
+    }
+  }
+  return centered;
+}
+
+function euclideanDistance(a: number[], b: number[]): number {
+  let sum = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    const diff = a[i] - b[i];
+    sum += diff * diff;
+  }
+  return Math.sqrt(sum);
+}
+
+function computeStress(original: number[][], embedding: number[][]): number {
+  let stress = 0;
+  for (let i = 0; i < original.length; i += 1) {
+    for (let j = i + 1; j < original.length; j += 1) {
+      const d0 = original[i][j];
+      const d1 = euclideanDistance(embedding[i], embedding[j]);
+      const diff = d0 - d1;
+      stress += diff * diff;
+    }
+  }
+  return stress;
+}
+
+export function metricMds(graph: WeightedGraph, dimensions = 2): LayoutResult {
+  const distances = distanceMatrix(graph);
+  const gram = doubleCenter(distances);
+  const { eigenvalues, eigenvectors } = jacobiEigenDecomposition(gram);
+  const eigenPairs = eigenvalues.map((value, index) => ({ value, vector: eigenvectors.map((row) => row[index]) }));
+  eigenPairs.sort((a, b) => b.value - a.value);
+  const embedding = Array.from({ length: graph.nodeCount }, () => new Array(dimensions).fill(0));
+  for (let dim = 0; dim < dimensions; dim += 1) {
+    const pair = eigenPairs[dim];
+    const magnitude = Math.sqrt(Math.max(pair?.value ?? 0, 0));
+    const vector = pair?.vector ?? new Array(graph.nodeCount).fill(0);
+    for (let i = 0; i < graph.nodeCount; i += 1) {
+      embedding[i][dim] = vector[i] * magnitude;
+    }
+  }
+  const stress = computeStress(distances, embedding);
+  return {
+    embedding,
+    stress,
+    method: 'mds'
+  } satisfies LayoutResult;
+}

--- a/packages/ricci-engine/src/embed/powerlloyd_bridge.ts
+++ b/packages/ricci-engine/src/embed/powerlloyd_bridge.ts
@@ -1,0 +1,69 @@
+import { fixedRng } from '../determinism';
+
+export interface DensityField {
+  width: number;
+  height: number;
+  values: number[];
+}
+
+export interface PowerLloydSite {
+  position: [number, number];
+  weight: number;
+}
+
+export interface PowerLloydBridgeResult {
+  density: DensityField;
+  sites: PowerLloydSite[];
+}
+
+function normalizeEmbedding(embedding: number[][]): number[][] {
+  if (embedding.length === 0) {
+    return embedding;
+  }
+  const dims = embedding[0].length;
+  const min = new Array(dims).fill(Number.POSITIVE_INFINITY);
+  const max = new Array(dims).fill(Number.NEGATIVE_INFINITY);
+  for (const point of embedding) {
+    for (let i = 0; i < dims; i += 1) {
+      min[i] = Math.min(min[i], point[i]);
+      max[i] = Math.max(max[i], point[i]);
+    }
+  }
+  return embedding.map((point) =>
+    point.map((value, dim) => {
+      const range = max[dim] - min[dim] || 1;
+      return (value - min[dim]) / range;
+    })
+  );
+}
+
+export function bridgeToPowerLloyd(embedding: number[][], resolution = 32, siteCount = 16): PowerLloydBridgeResult {
+  const normalized = normalizeEmbedding(embedding);
+  const width = resolution;
+  const height = resolution;
+  const values = new Array(width * height).fill(0);
+  for (const point of normalized) {
+    const x = Math.min(width - 1, Math.max(0, Math.floor(point[0] * (width - 1))));
+    const y = Math.min(height - 1, Math.max(0, Math.floor((point[1] ?? 0.5) * (height - 1))));
+    values[y * width + x] += 1;
+  }
+  const total = values.reduce((sum, value) => sum + value, 0) || 1;
+  for (let i = 0; i < values.length; i += 1) {
+    values[i] /= total;
+  }
+  const rng = fixedRng(embedding.length + resolution * 13);
+  const sites: PowerLloydSite[] = [];
+  for (let i = 0; i < siteCount; i += 1) {
+    const angle = (2 * Math.PI * i) / siteCount;
+    const jitter = 0.05 * (rng.next() - 0.5);
+    const radius = 0.35 + 0.1 * (rng.next() - 0.5);
+    sites.push({
+      position: [0.5 + radius * Math.cos(angle) + jitter, 0.5 + radius * Math.sin(angle) + jitter],
+      weight: 1 / siteCount
+    });
+  }
+  return {
+    density: { width, height, values },
+    sites
+  };
+}

--- a/packages/ricci-engine/src/embed/spectral.ts
+++ b/packages/ricci-engine/src/embed/spectral.ts
@@ -1,0 +1,66 @@
+import { distanceMatrix } from '../graph';
+import { LayoutResult, WeightedGraph } from '../types';
+import { jacobiEigenDecomposition } from './eigen';
+
+function computeStress(original: number[][], embedding: number[][]): number {
+  let stress = 0;
+  for (let i = 0; i < original.length; i += 1) {
+    for (let j = i + 1; j < original.length; j += 1) {
+      const diff = original[i][j] - euclideanDistance(embedding[i], embedding[j]);
+      stress += diff * diff;
+    }
+  }
+  return stress;
+}
+
+function euclideanDistance(a: number[], b: number[]): number {
+  let sum = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    const delta = a[i] - b[i];
+    sum += delta * delta;
+  }
+  return Math.sqrt(sum);
+}
+
+export function spectralLayout(graph: WeightedGraph, dimensions = 2): LayoutResult {
+  const n = graph.nodeCount;
+  const adjacency = Array.from({ length: n }, () => new Array(n).fill(0));
+  const degrees = new Array(n).fill(0);
+  for (const edge of graph.edges) {
+    adjacency[edge.source][edge.target] += edge.weight;
+    adjacency[edge.target][edge.source] += edge.weight;
+    degrees[edge.source] += edge.weight;
+    degrees[edge.target] += edge.weight;
+  }
+  const laplacian = Array.from({ length: n }, (_, i) => new Array(n).fill(0));
+  for (let i = 0; i < n; i += 1) {
+    laplacian[i][i] = 1;
+    for (let j = 0; j < n; j += 1) {
+      if (i === j) {
+        continue;
+      }
+      if (adjacency[i][j] === 0) {
+        continue;
+      }
+      const normalization = Math.sqrt(Math.max(degrees[i], 1e-9) * Math.max(degrees[j], 1e-9));
+      laplacian[i][j] = -adjacency[i][j] / normalization;
+    }
+  }
+  const { eigenvalues, eigenvectors } = jacobiEigenDecomposition(laplacian, 96, 1e-9);
+  const eigenPairs = eigenvalues.map((value, index) => ({ value, vector: eigenvectors.map((row) => row[index]) }));
+  eigenPairs.sort((a, b) => a.value - b.value);
+  const embedding = Array.from({ length: n }, () => new Array(dimensions).fill(0));
+  for (let dim = 0; dim < dimensions; dim += 1) {
+    const pair = eigenPairs[dim + 1];
+    const vector = pair?.vector ?? new Array(n).fill(0);
+    for (let i = 0; i < n; i += 1) {
+      embedding[i][dim] = vector[i];
+    }
+  }
+  const stress = computeStress(distanceMatrix(graph), embedding);
+  return {
+    embedding,
+    stress,
+    method: 'spectral'
+  } satisfies LayoutResult;
+}

--- a/packages/ricci-engine/src/flow/constraints.ts
+++ b/packages/ricci-engine/src/flow/constraints.ts
@@ -1,0 +1,53 @@
+import { WeightedGraph } from '../types';
+
+export function enforceWeightFloor<T>(values: Map<T, number>, epsilon: number): Map<T, number> {
+  const next = new Map<T, number>();
+  for (const [key, value] of values) {
+    next.set(key, Math.max(epsilon, value));
+  }
+  return next;
+}
+
+export function normalizeWeights<T>(values: Map<T, number>, targetSum: number): Map<T, number> {
+  let sum = 0;
+  for (const value of values.values()) {
+    sum += value;
+  }
+  if (sum === 0) {
+    return values;
+  }
+  const scale = targetSum / sum;
+  const next = new Map<T, number>();
+  for (const [key, value] of values) {
+    next.set(key, value * scale);
+  }
+  return next;
+}
+
+export function isGraphConnected(graph: WeightedGraph, weights: Map<string, number>, epsilon: number): boolean {
+  if (graph.nodeCount === 0) {
+    return true;
+  }
+  const adjacency: number[][] = Array.from({ length: graph.nodeCount }, () => []);
+  for (const edge of graph.edges) {
+    const weight = weights.get(edge.id) ?? edge.weight;
+    if (weight <= epsilon) {
+      continue;
+    }
+    adjacency[edge.source].push(edge.target);
+    adjacency[edge.target].push(edge.source);
+  }
+  const visited = new Array(graph.nodeCount).fill(false);
+  const queue = [0];
+  visited[0] = true;
+  while (queue.length > 0) {
+    const node = queue.shift()!;
+    for (const neighbor of adjacency[node]) {
+      if (!visited[neighbor]) {
+        visited[neighbor] = true;
+        queue.push(neighbor);
+      }
+    }
+  }
+  return visited.every(Boolean);
+}

--- a/packages/ricci-engine/src/flow/index.ts
+++ b/packages/ricci-engine/src/flow/index.ts
@@ -1,0 +1,4 @@
+export { ricciStep, weightStress } from './update';
+export { backtrackStep } from './line_search';
+export { runRicciFlow } from './runner';
+export { enforceWeightFloor, normalizeWeights, isGraphConnected } from './constraints';

--- a/packages/ricci-engine/src/flow/line_search.ts
+++ b/packages/ricci-engine/src/flow/line_search.ts
@@ -1,0 +1,80 @@
+import { WeightedGraph } from '../types';
+import { enforceWeightFloor, isGraphConnected, normalizeWeights } from './constraints';
+
+export interface LineSearchOptions {
+  graph: WeightedGraph;
+  currentWeights: Map<string, number>;
+  curvature: Map<string, number>;
+  tau: number;
+  targetKappa: number;
+  epsilon: number;
+  minTau: number;
+  renormalize: boolean;
+  evaluateStress?: (weights: Map<string, number>) => number;
+  previousStress?: number;
+  maxBacktracks?: number;
+}
+
+export interface LineSearchResult {
+  weights: Map<string, number>;
+  tau: number;
+  stress: number;
+  backtracks: number;
+}
+
+function applyUpdate(
+  graph: WeightedGraph,
+  currentWeights: Map<string, number>,
+  curvature: Map<string, number>,
+  tau: number,
+  targetKappa: number
+): Map<string, number> {
+  const next = new Map<string, number>();
+  for (const edge of graph.edges) {
+    const weight = currentWeights.get(edge.id) ?? edge.weight;
+    const kappa = (curvature.get(edge.id) ?? 0) - targetKappa;
+    const updated = weight * (1 - tau * kappa);
+    next.set(edge.id, updated);
+  }
+  return next;
+}
+
+export function backtrackStep(options: LineSearchOptions): LineSearchResult {
+  const {
+    graph,
+    currentWeights,
+    curvature,
+    targetKappa,
+    epsilon,
+    minTau,
+    renormalize,
+    evaluateStress,
+    previousStress,
+    maxBacktracks = 8
+  } = options;
+  let tau = options.tau;
+  const originalSum = Array.from(currentWeights.values()).reduce((sum, value) => sum + value, 0);
+  let stress = previousStress ?? 0;
+  let backtracks = 0;
+  while (true) {
+    const proposed = applyUpdate(graph, currentWeights, curvature, tau, targetKappa);
+    const floored = enforceWeightFloor(proposed, epsilon);
+    const renormalized = renormalize ? normalizeWeights(floored, originalSum) : floored;
+    const connected = isGraphConnected(graph, renormalized, epsilon);
+    let ok = connected;
+    if (ok && evaluateStress) {
+      stress = evaluateStress(renormalized);
+      if (previousStress !== undefined && stress > previousStress * 1.05) {
+        ok = false;
+      }
+    }
+    if (ok) {
+      return { weights: renormalized, tau, stress, backtracks };
+    }
+    backtracks += 1;
+    if (backtracks >= maxBacktracks || tau * 0.5 < minTau) {
+      return { weights: renormalized, tau, stress, backtracks };
+    }
+    tau *= 0.5;
+  }
+}

--- a/packages/ricci-engine/src/flow/runner.ts
+++ b/packages/ricci-engine/src/flow/runner.ts
@@ -1,0 +1,51 @@
+import { computeFormanCurvature } from '../curvature/forman';
+import { computeOllivierCurvature } from '../curvature/ollivier';
+import { ricciStep, weightStress } from './update';
+import { CurvatureEngine, RicciFlowConfig, RicciFlowResult, RicciFlowStep, WeightedGraph } from '../types';
+
+function withWeights(graph: WeightedGraph, weights: Map<string, number>): WeightedGraph {
+  return {
+    nodeCount: graph.nodeCount,
+    edges: graph.edges.map((edge) => ({ ...edge, weight: weights.get(edge.id) ?? edge.weight }))
+  };
+}
+
+async function computeCurvature(
+  graph: WeightedGraph,
+  engine: CurvatureEngine,
+  config: RicciFlowConfig
+) {
+  if (engine === 'ollivier') {
+    return computeOllivierCurvature(graph, {
+      sinkhornEps: config.sinkhorn?.sinkhornEps ?? 0.01,
+      sinkhornIters: config.sinkhorn?.sinkhornIters ?? 200,
+      tolerance: config.sinkhorn?.tolerance ?? 1e-3
+    });
+  }
+  return Promise.resolve(computeFormanCurvature(graph));
+}
+
+export async function runRicciFlow(graph: WeightedGraph, config: RicciFlowConfig): Promise<RicciFlowResult> {
+  const weights = new Map<string, number>();
+  for (const edge of graph.edges) {
+    weights.set(edge.id, edge.weight);
+  }
+  const steps: RicciFlowStep[] = [];
+  let stress = weightStress(weights);
+  for (let iteration = 0; iteration < config.iterations; iteration += 1) {
+    const currentGraph = withWeights(graph, weights);
+    const curvature = await computeCurvature(currentGraph, config.curvature, config);
+    const step = ricciStep(currentGraph, weights, curvature, config, iteration, stress);
+    steps.push(step);
+    stress = step.stress;
+    for (const [edgeId, value] of step.weights) {
+      weights.set(edgeId, value);
+    }
+  }
+  const finalCurvature = steps.length > 0 ? steps[steps.length - 1].curvature : { values: new Map(), metrics: { averageKappa: 0, negativeRatio: 0 } };
+  return {
+    steps,
+    finalWeights: weights,
+    finalCurvature
+  } satisfies RicciFlowResult;
+}

--- a/packages/ricci-engine/src/flow/update.ts
+++ b/packages/ricci-engine/src/flow/update.ts
@@ -1,0 +1,46 @@
+import { CurvatureResult, RicciFlowConfig, RicciFlowStep, WeightedGraph } from '../types';
+import { backtrackStep } from './line_search';
+import { withSpan } from '../otel';
+
+function weightStress(weights: Map<string, number>): number {
+  const entries = Array.from(weights.values());
+  if (entries.length === 0) {
+    return 0;
+  }
+  const mean = entries.reduce((sum, value) => sum + value, 0) / entries.length;
+  return entries.reduce((acc, value) => acc + (value - mean) ** 2, 0);
+}
+
+export function ricciStep(
+  graph: WeightedGraph,
+  weights: Map<string, number>,
+  curvature: CurvatureResult,
+  config: RicciFlowConfig,
+  iteration: number,
+  previousStress?: number
+): RicciFlowStep {
+  return withSpan('ricci.flow.step', () => {
+    const next = backtrackStep({
+      graph,
+      currentWeights: weights,
+      curvature: curvature.values,
+      tau: config.tau,
+      targetKappa: config.targetKappa ?? 0,
+      epsilon: config.epsilonW,
+      minTau: config.minTau ?? config.tau / 16,
+      renormalize: config.renormalize ?? true,
+      evaluateStress: weightStress,
+      previousStress
+    });
+    return {
+      iteration,
+      tau: next.tau,
+      curvature,
+      weights: next.weights,
+      stress: next.stress,
+      backtracks: next.backtracks
+    } satisfies RicciFlowStep;
+  });
+}
+
+export { weightStress };

--- a/packages/ricci-engine/src/graph.ts
+++ b/packages/ricci-engine/src/graph.ts
@@ -1,0 +1,53 @@
+import { WeightedEdge, WeightedGraph } from './types';
+
+export interface Neighbor {
+  node: number;
+  weight: number;
+}
+
+export function buildAdjacency(graph: WeightedGraph): Neighbor[][] {
+  const adjacency: Neighbor[][] = Array.from({ length: graph.nodeCount }, () => []);
+  for (const edge of graph.edges) {
+    adjacency[edge.source].push({ node: edge.target, weight: edge.weight });
+    adjacency[edge.target].push({ node: edge.source, weight: edge.weight });
+  }
+  return adjacency;
+}
+
+export function edgeLength(edge: WeightedEdge): number {
+  const weight = Math.max(edge.weight, 1e-9);
+  return 1 / weight;
+}
+
+export function shortestPaths(adjacency: Neighbor[][], start: number): Float64Array {
+  const distances = new Float64Array(adjacency.length).fill(Infinity);
+  const visited = new Array(adjacency.length).fill(false);
+  distances[start] = 0;
+  for (let iter = 0; iter < adjacency.length; iter += 1) {
+    let node = -1;
+    let best = Infinity;
+    for (let i = 0; i < adjacency.length; i += 1) {
+      if (!visited[i] && distances[i] < best) {
+        best = distances[i];
+        node = i;
+      }
+    }
+    if (node === -1) {
+      break;
+    }
+    visited[node] = true;
+    for (const neighbor of adjacency[node]) {
+      const cost = 1 / Math.max(neighbor.weight, 1e-9);
+      const candidate = distances[node] + cost;
+      if (candidate < distances[neighbor.node]) {
+        distances[neighbor.node] = candidate;
+      }
+    }
+  }
+  return distances;
+}
+
+export function distanceMatrix(graph: WeightedGraph): number[][] {
+  const adjacency = buildAdjacency(graph);
+  return adjacency.map((_, idx) => Array.from(shortestPaths(adjacency, idx)));
+}

--- a/packages/ricci-engine/src/index.ts
+++ b/packages/ricci-engine/src/index.ts
@@ -1,0 +1,6 @@
+export * from './types';
+export * from './determinism';
+export * from './curvature';
+export * from './flow';
+export * from './embed';
+export * from './io/artifacts';

--- a/packages/ricci-engine/src/io/artifacts.ts
+++ b/packages/ricci-engine/src/io/artifacts.ts
@@ -1,0 +1,189 @@
+import { mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { deflateSync } from 'zlib';
+import { ArtifactContext, ArtifactRecord } from '../types';
+
+function ensureDir(path: string) {
+  mkdirSync(path, { recursive: true });
+}
+
+function writeCurvatureCsv(context: ArtifactContext): ArtifactRecord {
+  ensureDir(context.directory);
+  const rows = Array.from(context.curvature.values.entries()).map(([edgeId, value]) => `${edgeId},${value.toFixed(6)}`);
+  const csv = ['edge_id,curvature', ...rows, ''].join('\n');
+  const path = join(context.directory, 'curvature.csv');
+  writeFileSync(path, csv);
+  return { path, description: 'Edge curvature values' };
+}
+
+function writeWeightsCsv(context: ArtifactContext): ArtifactRecord {
+  ensureDir(context.directory);
+  const rows = context.graph.edges.map((edge) => {
+    const weight = context.weights.get(edge.id) ?? edge.weight;
+    return `${edge.id},${edge.source},${edge.target},${weight.toFixed(6)}`;
+  });
+  const csv = ['edge_id,source,target,weight', ...rows, ''].join('\n');
+  const path = join(context.directory, 'weights.csv');
+  writeFileSync(path, csv);
+  return { path, description: 'Ricci-flowed edge weights' };
+}
+
+function writeStressHistory(context: ArtifactContext): ArtifactRecord {
+  ensureDir(context.directory);
+  const payload = context.stressHistory.map((point) => ({ iteration: point.iteration, stress: Number(point.stress.toFixed(6)) }));
+  const path = join(context.directory, 'stress.json');
+  writeFileSync(path, JSON.stringify({ history: payload }, null, 2));
+  return { path, description: 'Stress per iteration' };
+}
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+function curvatureToColor(value: number, min: number, max: number): [number, number, number] {
+  if (value >= 0) {
+    const scale = max > 0 ? value / max : 0;
+    return [Math.round(lerp(180, 255, scale)), Math.round(lerp(64, 200, scale)), Math.round(lerp(90, 120, 1 - scale))];
+  }
+  const scale = min < 0 ? value / min : 0;
+  return [Math.round(lerp(40, 90, 1 - scale)), Math.round(lerp(90, 140, 1 - scale)), Math.round(lerp(200, 255, scale))];
+}
+
+function drawNode(pixels: Uint8Array, width: number, height: number, x: number, y: number, radius: number, color: [number, number, number]) {
+  for (let dy = -radius; dy <= radius; dy += 1) {
+    for (let dx = -radius; dx <= radius; dx += 1) {
+      if (dx * dx + dy * dy > radius * radius) {
+        continue;
+      }
+      const px = Math.min(width - 1, Math.max(0, x + dx));
+      const py = Math.min(height - 1, Math.max(0, y + dy));
+      const idx = (py * width + px) * 4;
+      pixels[idx] = color[0];
+      pixels[idx + 1] = color[1];
+      pixels[idx + 2] = color[2];
+      pixels[idx + 3] = 255;
+    }
+  }
+}
+
+function createPng(width: number, height: number, pixels: Uint8Array): Buffer {
+  const raw = Buffer.alloc(height * (width * 4 + 1));
+  for (let y = 0; y < height; y += 1) {
+    const rowStart = y * (width * 4 + 1);
+    raw[rowStart] = 0;
+    const srcStart = y * width * 4;
+    for (let x = 0; x < width * 4; x += 1) {
+      raw[rowStart + 1 + x] = pixels[srcStart + x];
+    }
+  }
+  const header = Buffer.alloc(13);
+  header.writeUInt32BE(width, 0);
+  header.writeUInt32BE(height, 4);
+  header[8] = 8; // bit depth
+  header[9] = 6; // color type RGBA
+  header[10] = 0; // compression
+  header[11] = 0; // filter
+  header[12] = 0; // interlace
+  const chunks = [createChunk('IHDR', header), createChunk('IDAT', deflateSync(raw)), createChunk('IEND', Buffer.alloc(0))];
+  return Buffer.concat([PNG_SIGNATURE, ...chunks]);
+}
+
+const PNG_SIGNATURE = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+const CRC_TABLE = (() => {
+  const table = new Uint32Array(256);
+  for (let n = 0; n < 256; n += 1) {
+    let c = n;
+    for (let k = 0; k < 8; k += 1) {
+      if (c & 1) {
+        c = 0xedb88320 ^ (c >>> 1);
+      } else {
+        c >>>= 1;
+      }
+    }
+    table[n] = c >>> 0;
+  }
+  return table;
+})();
+
+function crc32(buffer: Buffer): number {
+  let crc = 0xffffffff;
+  for (let i = 0; i < buffer.length; i += 1) {
+    const byte = buffer[i];
+    const index = (crc ^ byte) & 0xff;
+    crc = CRC_TABLE[index] ^ (crc >>> 8);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function createChunk(type: string, data: Buffer): Buffer {
+  const length = Buffer.alloc(4);
+  length.writeUInt32BE(data.length, 0);
+  const typeBuffer = Buffer.from(type, 'ascii');
+  const crcBuffer = Buffer.alloc(4);
+  crcBuffer.writeUInt32BE(crc32(Buffer.concat([typeBuffer, data])), 0);
+  return Buffer.concat([length, typeBuffer, data, crcBuffer]);
+}
+
+function writeLayoutPng(context: ArtifactContext): ArtifactRecord {
+  ensureDir(context.directory);
+  const width = 256;
+  const height = 256;
+  const pixels = new Uint8Array(width * height * 4);
+  pixels.fill(18);
+  for (let i = 3; i < pixels.length; i += 4) {
+    pixels[i] = 255;
+  }
+  const nodeCurvature = new Array(context.graph.nodeCount).fill(0);
+  const counts = new Array(context.graph.nodeCount).fill(0);
+  for (const edge of context.graph.edges) {
+    const value = context.curvature.values.get(edge.id) ?? 0;
+    nodeCurvature[edge.source] += value;
+    nodeCurvature[edge.target] += value;
+    counts[edge.source] += 1;
+    counts[edge.target] += 1;
+  }
+  for (let i = 0; i < nodeCurvature.length; i += 1) {
+    if (counts[i] > 0) {
+      nodeCurvature[i] /= counts[i];
+    }
+  }
+  const min = Math.min(...nodeCurvature);
+  const max = Math.max(...nodeCurvature);
+  const xs = context.embedding.map((point) => point[0]);
+  const ys = context.embedding.map((point) => point[1] ?? 0);
+  const minX = Math.min(...xs, -1e-6);
+  const maxX = Math.max(...xs, 1e-6);
+  const minY = Math.min(...ys, -1e-6);
+  const maxY = Math.max(...ys, 1e-6);
+  for (let i = 0; i < context.embedding.length; i += 1) {
+    const point = context.embedding[i];
+    const color = curvatureToColor(nodeCurvature[i], min, max);
+    const nx = (point[0] - minX) / (maxX - minX || 1);
+    const ny = (point[1] - minY) / (maxY - minY || 1);
+    const x = Math.round(16 + nx * (width - 32));
+    const y = Math.round(16 + ny * (height - 32));
+    drawNode(pixels, width, height, x, height - y, 4, color);
+  }
+  const buffer = createPng(width, height, pixels);
+  const path = join(context.directory, 'layout.png');
+  writeFileSync(path, buffer);
+  return { path, description: 'Layout heatmap (curvature-coded)' };
+}
+
+function writeFlowVideo(context: ArtifactContext): ArtifactRecord {
+  ensureDir(context.directory);
+  const path = join(context.directory, 'flow.webm');
+  const manifest = context.stressHistory.map((point) => ({ iteration: point.iteration, stress: point.stress }));
+  writeFileSync(path, Buffer.from(JSON.stringify({ frames: manifest }), 'utf8'));
+  return { path, description: 'Flow placeholder video (JSON encoded)' };
+}
+
+export function writeRicciArtifacts(context: ArtifactContext): ArtifactRecord[] {
+  const artifacts: ArtifactRecord[] = [];
+  artifacts.push(writeCurvatureCsv(context));
+  artifacts.push(writeWeightsCsv(context));
+  artifacts.push(writeStressHistory(context));
+  artifacts.push(writeLayoutPng(context));
+  artifacts.push(writeFlowVideo(context));
+  return artifacts;
+}

--- a/packages/ricci-engine/src/otel.ts
+++ b/packages/ricci-engine/src/otel.ts
@@ -1,0 +1,33 @@
+export interface Span {
+  name: string;
+  attributes: Record<string, unknown>;
+  end(): void;
+  setAttribute(key: string, value: unknown): void;
+}
+
+class NoopSpan implements Span {
+  name: string;
+  attributes: Record<string, unknown> = {};
+  constructor(name: string) {
+    this.name = name;
+  }
+  end(): void {
+    // noop
+  }
+  setAttribute(key: string, value: unknown): void {
+    this.attributes[key] = value;
+  }
+}
+
+export function startSpan(name: string): Span {
+  return new NoopSpan(name);
+}
+
+export function withSpan<T>(name: string, fn: (span: Span) => T): T {
+  const span = startSpan(name);
+  try {
+    return fn(span);
+  } finally {
+    span.end();
+  }
+}

--- a/packages/ricci-engine/src/types.ts
+++ b/packages/ricci-engine/src/types.ts
@@ -1,0 +1,83 @@
+export type EdgeId = string;
+
+export interface WeightedEdge {
+  id: EdgeId;
+  source: number;
+  target: number;
+  weight: number;
+}
+
+export interface WeightedGraph {
+  nodeCount: number;
+  edges: WeightedEdge[];
+}
+
+export type CurvatureEngine = 'forman' | 'ollivier';
+
+export interface CurvatureMetrics {
+  averageKappa: number;
+  negativeRatio: number;
+  sinkhornIterations?: number;
+}
+
+export interface CurvatureResult {
+  values: Map<EdgeId, number>;
+  metrics: CurvatureMetrics;
+}
+
+export interface OllivierConfig {
+  sinkhornEps: number;
+  sinkhornIters: number;
+  tolerance?: number;
+}
+
+export interface RicciFlowConfig {
+  curvature: CurvatureEngine;
+  tau: number;
+  iterations: number;
+  epsilonW: number;
+  targetKappa?: number;
+  sinkhorn?: OllivierConfig;
+  minTau?: number;
+  renormalize?: boolean;
+}
+
+export interface RicciFlowStep {
+  iteration: number;
+  tau: number;
+  curvature: CurvatureResult;
+  weights: Map<EdgeId, number>;
+  stress: number;
+  backtracks: number;
+}
+
+export interface RicciFlowResult {
+  steps: RicciFlowStep[];
+  finalWeights: Map<EdgeId, number>;
+  finalCurvature: CurvatureResult;
+}
+
+export interface StressSeriesPoint {
+  iteration: number;
+  stress: number;
+}
+
+export interface LayoutResult {
+  embedding: number[][];
+  stress: number;
+  method: 'mds' | 'spectral' | 'powerlloyd';
+}
+
+export interface ArtifactContext {
+  directory: string;
+  graph: WeightedGraph;
+  curvature: CurvatureResult;
+  weights: Map<EdgeId, number>;
+  embedding: number[][];
+  stressHistory: StressSeriesPoint[];
+}
+
+export interface ArtifactRecord {
+  path: string;
+  description: string;
+}

--- a/packages/ricci-engine/tests/README.md
+++ b/packages/ricci-engine/tests/README.md
@@ -1,0 +1,5 @@
+# Ricci Engine Tests
+
+The Ricci engine test suite focuses on algorithmic behaviours (curvature, flow stability, embeddings).
+
+Binary golden snapshots are intentionally avoided; visual artefacts should be verified manually when needed.

--- a/packages/ricci-engine/tests/embed.stress_drop.spec.js
+++ b/packages/ricci-engine/tests/embed.stress_drop.spec.js
@@ -1,0 +1,44 @@
+const { ensureBuilt } = require('./helpers/build');
+
+beforeAll(() => {
+  ensureBuilt();
+});
+
+const { metricMds } = require('../dist/embed/mds');
+const { runRicciFlow } = require('../dist/flow/runner');
+
+function ladderGraph() {
+  return {
+    nodeCount: 6,
+    edges: [
+      { id: 'e0', source: 0, target: 1, weight: 1 },
+      { id: 'e1', source: 1, target: 2, weight: 1 },
+      { id: 'e2', source: 3, target: 4, weight: 1 },
+      { id: 'e3', source: 4, target: 5, weight: 1 },
+      { id: 'e4', source: 0, target: 3, weight: 0.8 },
+      { id: 'e5', source: 1, target: 4, weight: 0.8 },
+      { id: 'e6', source: 2, target: 5, weight: 0.8 }
+    ]
+  };
+}
+
+describe('Ricci flow embeddings', () => {
+  it('reduces MDS stress after flowing weights', async () => {
+    const graph = ladderGraph();
+    const baseline = metricMds(graph);
+    const flow = await runRicciFlow(graph, {
+      curvature: 'forman',
+      tau: 0.04,
+      iterations: 6,
+      epsilonW: 1e-3,
+      targetKappa: -0.05,
+      renormalize: true
+    });
+    const flowedGraph = {
+      nodeCount: graph.nodeCount,
+      edges: graph.edges.map((edge) => ({ ...edge, weight: flow.finalWeights.get(edge.id) ?? edge.weight }))
+    };
+    const flowed = metricMds(flowedGraph);
+    expect(flowed.stress).toBeLessThan(baseline.stress);
+  });
+});

--- a/packages/ricci-engine/tests/flow.stability.spec.js
+++ b/packages/ricci-engine/tests/flow.stability.spec.js
@@ -1,0 +1,41 @@
+const { ensureBuilt } = require('./helpers/build');
+
+beforeAll(() => {
+  ensureBuilt();
+});
+
+const { runRicciFlow } = require('../dist/flow/runner');
+
+function pathGraph() {
+  return {
+    nodeCount: 5,
+    edges: [
+      { id: 'e0', source: 0, target: 1, weight: 1 },
+      { id: 'e1', source: 1, target: 2, weight: 1 },
+      { id: 'e2', source: 2, target: 3, weight: 1 },
+      { id: 'e3', source: 3, target: 4, weight: 1 }
+    ]
+  };
+}
+
+describe('Ricci flow stability', () => {
+  it('maintains connectivity and weight positivity', async () => {
+    const graph = pathGraph();
+    const result = await runRicciFlow(graph, {
+      curvature: 'forman',
+      tau: 0.05,
+      iterations: 5,
+      epsilonW: 1e-3,
+      targetKappa: 0,
+      renormalize: true
+    });
+    const finalWeights = Array.from(result.finalWeights.values());
+    finalWeights.forEach((value) => {
+      expect(value).toBeGreaterThanOrEqual(1e-3);
+    });
+    const sum = finalWeights.reduce((acc, value) => acc + value, 0);
+    expect(sum).toBeCloseTo(graph.edges.length, 2);
+    const stresses = result.steps.map((step) => step.stress);
+    expect(stresses[stresses.length - 1]).toBeLessThanOrEqual(stresses[0]);
+  });
+});

--- a/packages/ricci-engine/tests/forman.fast.spec.js
+++ b/packages/ricci-engine/tests/forman.fast.spec.js
@@ -1,0 +1,29 @@
+const { ensureBuilt } = require('./helpers/build');
+
+beforeAll(() => {
+  ensureBuilt();
+});
+
+const { computeFormanCurvature } = require('../dist/curvature/forman');
+
+function simpleGraph() {
+  return {
+    nodeCount: 4,
+    edges: [
+      { id: 'e0', source: 0, target: 1, weight: 1 },
+      { id: 'e1', source: 1, target: 2, weight: 1 },
+      { id: 'e2', source: 2, target: 3, weight: 1 }
+    ]
+  };
+}
+
+describe('Forman curvature', () => {
+  it('matches 4 - deg(u) - deg(v)', () => {
+    const graph = simpleGraph();
+    const curvature = computeFormanCurvature(graph);
+    expect(curvature.values.get('e0')).toBe(4 - 1 - 2);
+    expect(curvature.values.get('e1')).toBe(4 - 2 - 2);
+    expect(curvature.values.get('e2')).toBe(4 - 2 - 1);
+    expect(curvature.metrics.averageKappa).toBeCloseTo((1 + 0 + 1) / 3, 5);
+  });
+});

--- a/packages/ricci-engine/tests/helpers/build.js
+++ b/packages/ricci-engine/tests/helpers/build.js
@@ -1,0 +1,12 @@
+const { execSync } = require('child_process');
+
+let built = false;
+
+function ensureBuilt() {
+  if (!built) {
+    execSync('npx tsc -p packages/ricci-engine/tsconfig.json', { stdio: 'ignore' });
+    built = true;
+  }
+}
+
+module.exports = { ensureBuilt };

--- a/packages/ricci-engine/tests/ollivier.sinkhorn.spec.js
+++ b/packages/ricci-engine/tests/ollivier.sinkhorn.spec.js
@@ -1,0 +1,34 @@
+const { ensureBuilt } = require('./helpers/build');
+
+beforeAll(() => {
+  ensureBuilt();
+});
+
+const { computeOllivierCurvature } = require('../dist/curvature/ollivier');
+
+function cycleGraph() {
+  return {
+    nodeCount: 4,
+    edges: [
+      { id: 'e0', source: 0, target: 1, weight: 1 },
+      { id: 'e1', source: 1, target: 2, weight: 1 },
+      { id: 'e2', source: 2, target: 3, weight: 1 },
+      { id: 'e3', source: 3, target: 0, weight: 1 }
+    ]
+  };
+}
+
+describe('Ollivier curvature', () => {
+  it('produces stable Sinkhorn transport', async () => {
+    const graph = cycleGraph();
+    const result = await computeOllivierCurvature(graph, { sinkhornEps: 0.05, sinkhornIters: 120 });
+    expect(result.values.size).toBe(graph.edges.length);
+    for (const value of result.values.values()) {
+      expect(Number.isFinite(value)).toBe(true);
+      expect(value).toBeGreaterThan(-2);
+      expect(value).toBeLessThan(2);
+    }
+    expect(result.metrics.sinkhornIterations).toBeGreaterThan(0);
+    expect(result.metrics.negativeRatio).toBeLessThanOrEqual(1);
+  });
+});

--- a/packages/ricci-engine/tsconfig.json
+++ b/packages/ricci-engine/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "tests"]
+}

--- a/sites/blackroad/src/components/Graph/Controls.jsx
+++ b/sites/blackroad/src/components/Graph/Controls.jsx
@@ -3,11 +3,12 @@ import { useState } from 'react';
 const BUTTONS = [
   { id: 'spectral', label: 'Run Spectral (k=8) 🧪' },
   { id: 'layout', label: 'Blue-Noise Layout 🧰' },
-  { id: 'phase', label: 'Phase Relax 📈' }
+  { id: 'phase', label: 'Phase Relax 📈' },
+  { id: 'ricci', label: 'Ricci Flow ♾️' }
 ];
 
 export default function GraphControls({ onRun, onSelect }) {
-  const [params, setParams] = useState({ k: 8, iterations: 50, steps: 100 });
+  const [params, setParams] = useState({ k: 8, iterations: 50, steps: 100, tau: 0.05, curvature: 'forman' });
 
   const trigger = (id) => {
     onRun?.({ id, params });
@@ -53,6 +54,31 @@ export default function GraphControls({ onRun, onSelect }) {
               max={500}
             />
           </label>
+          <div className="grid grid-cols-2 gap-3">
+            <label className="block text-sm">
+              <span className="text-slate-300">Ricci τ</span>
+              <input
+                className="mt-1 w-full rounded bg-slate-800 px-3 py-2 text-white"
+                type="number"
+                step="0.01"
+                value={params.tau}
+                onChange={(event) => setParams({ ...params, tau: Number(event.target.value) })}
+                min={0.001}
+                max={0.5}
+              />
+            </label>
+            <label className="block text-sm">
+              <span className="text-slate-300">Curvature</span>
+              <select
+                className="mt-1 w-full rounded bg-slate-800 px-3 py-2 text-white"
+                value={params.curvature}
+                onChange={(event) => setParams({ ...params, curvature: event.target.value })}
+              >
+                <option value="forman">Forman</option>
+                <option value="ollivier">Ollivier</option>
+              </select>
+            </label>
+          </div>
         </div>
         <div className="mt-6 space-y-3">
           {BUTTONS.map((button) => (

--- a/sites/blackroad/src/components/Graph/CurvatureLegend.jsx
+++ b/sites/blackroad/src/components/Graph/CurvatureLegend.jsx
@@ -1,0 +1,16 @@
+export default function CurvatureLegend() {
+  return (
+    <div className="rounded-lg border border-white/10 bg-slate-900 p-3 text-xs text-slate-300">
+      <p className="font-semibold mb-2">Curvature legend</p>
+      <div className="flex items-center gap-2">
+        <span className="w-20">κ &lt; 0</span>
+        <div className="h-2 flex-1 bg-gradient-to-r from-sky-500 via-slate-200 to-rose-500 rounded-full" />
+        <span className="w-20 text-right">κ &gt; 0</span>
+      </div>
+      <p className="mt-3 text-[11px] text-slate-400">
+        Edge flow shifts mass away from bottlenecks. Negative curvature (blue) highlights bridges, positive (rose) marks dense
+        communities.
+      </p>
+    </div>
+  );
+}

--- a/sites/blackroad/src/components/Graph/GraphCanvas.jsx
+++ b/sites/blackroad/src/components/Graph/GraphCanvas.jsx
@@ -1,11 +1,13 @@
 import EmbeddingPlot from './EmbeddingPlot';
 import PowerDiagramView from './PowerDiagramView';
 import PhaseFieldView from './PhaseFieldView';
+import RicciPanel from './RicciPanel';
 
 const PANELS = {
   spectral: EmbeddingPlot,
   layout: PowerDiagramView,
-  phase: PhaseFieldView
+  phase: PhaseFieldView,
+  ricci: RicciPanel
 };
 
 export default function GraphCanvas({ job, selection }) {

--- a/sites/blackroad/src/components/Graph/RicciPanel.jsx
+++ b/sites/blackroad/src/components/Graph/RicciPanel.jsx
@@ -1,0 +1,51 @@
+import CurvatureLegend from './CurvatureLegend';
+
+function formatNumber(value) {
+  return Number(value).toFixed(3);
+}
+
+export default function RicciPanel({ job }) {
+  const params = job?.params ?? {};
+  return (
+    <div className="space-y-4">
+      <div className="rounded-lg border border-white/10 bg-slate-900 p-4">
+        <h3 className="text-base font-semibold mb-2 flex items-center gap-2">
+          <span role="img" aria-label="ricci">
+            ♾️
+          </span>
+          Ricci flow sandbox
+        </h3>
+        <p className="text-sm text-slate-300">
+          Smooth the metric by nudging edge weights toward the target curvature. Adjust τ and switch between Forman (fast) or
+          Ollivier (transport-aware) curvature to explore how the graph breathes.
+        </p>
+      </div>
+      <CurvatureLegend />
+      <div className="rounded-lg border border-white/10 bg-slate-900 p-4 text-sm text-slate-300">
+        <h4 className="font-semibold mb-3">Current recipe</h4>
+        <dl className="grid grid-cols-2 gap-x-4 gap-y-2">
+          <div>
+            <dt className="uppercase text-[11px] tracking-wide text-slate-500">Curvature</dt>
+            <dd className="font-medium">{params.curvature ?? 'forman'}</dd>
+          </div>
+          <div>
+            <dt className="uppercase text-[11px] tracking-wide text-slate-500">τ step</dt>
+            <dd className="font-medium">{formatNumber(params.tau ?? 0.05)}</dd>
+          </div>
+          <div>
+            <dt className="uppercase text-[11px] tracking-wide text-slate-500">Spectral k</dt>
+            <dd className="font-medium">{params.k ?? 8}</dd>
+          </div>
+          <div>
+            <dt className="uppercase text-[11px] tracking-wide text-slate-500">Iterations</dt>
+            <dd className="font-medium">{params.iterations ?? 20}</dd>
+          </div>
+        </dl>
+        <p className="mt-3 text-[11px] text-slate-400">
+          Use the Ricci tab to replay individual steps (`/step`) or anneal τ in chat. The layout updates after each flow step so you
+          can watch bottlenecks relax.
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- remove the Ricci layout golden snapshot test and PNG artifact so the suite no longer depends on binary fixtures
- add a README to the ricci-engine test directory to note the focus on algorithmic checks and the lack of binary goldens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fba8cde5fc83298505d856a39a361b