### PR TITLE
Add AI infrastructure strategy summary

### DIFF
--- a/docs/ai_infrastructure_strategy.md
+++ b/docs/ai_infrastructure_strategy.md
@@ -1,0 +1,56 @@
+# AI-Automated Infrastructure Strategy for BlackRoad
+
+## Executive Summary
+- Deploy production-grade automation infrastructure for 10,000+ monthly users at **$1,200-1,800/month**, reducing spend by 60-75% compared to SaaS bundles.
+- Combine self-hosted workflow automation, hybrid LLM orchestration, and open-source replacements to consolidate the current 75+ tool stack to **35-40 strategic platforms**.
+- Build once, scale to 100K+ users with the same architecture by leveraging Digital Ocean Kubernetes, autoscaling policies, and modular application boundaries.
+
+## Workflow Automation Platform
+- Choose **Windmill** for performance (10ms cold starts, 26M monthly tasks on a $5 worker, Rust scheduler) or **n8n** for rapid integration delivery (1,100+ connectors, visual builder).
+- Run the chosen platform on **Digital Ocean Kubernetes (DOKS)** with a 3-5 node CPU-optimized pool that can scale to 10 nodes and idle to zero after hours.
+- Pair with **Managed PostgreSQL** (primary + standby), **DO Load Balancer**, and **Spaces** object storage for a foundational cost of roughly **$450-550/month**.
+
+## API Gateway Layer
+- Use **KrakenD** for stateless, lightweight aggregation (≈30MB memory footprint, JSON-configured) or **Apache APISIX** when live reconfiguration is required.
+- Both options deliver rate limiting, auth, and request transformation for the 75+ integrations while outperforming heavier gateways such as Kong.
+
+## Multi-Agent AI Orchestration
+- Adopt **LangGraph** for graph-based, stateful orchestration and multi-agent coordination; consider managed LangGraph Platform for hosted control plane.
+- **CrewAI** accelerates role-based agent collaboration for sequential workloads, while **AutoGen** supports conversational, event-driven multi-agent systems.
+- Establish domain-specialized agents (Slack, Notion, GitHub, Asana, RAG context) and route requests through LangGraph for supervised coordination and failure isolation.
+
+## Retrieval-Augmented Generation (RAG)
+- Target <100ms retrieval latency with **Pinecone** (fastest, serverless) or self-hosted **Weaviate** for lower costs; **Chroma** remains suitable for prototypes.
+- Favor state-of-the-art embeddings (BGE-large, nomic-embed-text, Cohere Embed v3) and semantic chunking (512-1,000 token targets, 10-20% overlap).
+- Monitor chunk utilization (>80%), recall@k, latency distributions, and cache hit rates as primary RAG health metrics.
+
+## Hybrid LLM Deployment
+- Self-host **Mistral 7B** (or Llama 3 8B) on Digital Ocean droplets for ~70% of routine queries; orchestrate fallbacks to **Claude Haiku** (25%) and **Claude Sonnet** (5%).
+- Operate multiple Ollama/vLLM instances behind a load balancer, add Redis-backed exact + semantic caching (30-50% hit rate) to curb API spend.
+- Expect total AI compute cost around **$1,000-1,350/month**, yielding 57-71% savings versus all-API usage at similar volume.
+
+## Security and Tenant Isolation
+- Secure the investor portal with **Keycloak SSO**, MFA, custom themes, and short-lived JWT access tokens.
+- Enforce **PostgreSQL Row-Level Security** with tenant-scoped policies and application roles; employ the "Pool" multi-tenant pattern initially.
+- Maintain store-and-forward webhook ingestion with HMAC verification, replay protection, and idempotent processing for reliability.
+
+## Application Architecture
+- Maintain the eight-application platform in an **Nx monorepo** with Module Federation for independent deployments and shared component libraries.
+- Implement Terraform-managed Digital Ocean infrastructure (DOKS, Managed PostgreSQL, Spaces, Load Balancers, VPC) with environment-specific state and automated pipelines.
+- Balance real-time vs. batch processing based on latency requirements; use NATS/queues for event-driven workflows and scheduled jobs for reconciliation.
+
+## Tool Consolidation & Cost Strategy
+- Replace redundant SaaS with open-source alternatives (e.g., **Mattermost** vs. Slack, **SuiteCRM** vs. Salesforce) to achieve 80-98% savings per category.
+- Leverage startup credit programs (AWS Activate, GCP, Azure, HubSpot) to offset initial infrastructure costs by $50K-300K over 2 years.
+- Track ROI: $314K-522K optimized annual spend vs. $1.5-2M baseline, producing payback within 1-3 months after implementation.
+
+## Implementation Roadmap
+1. **Phase 1 (Weeks 1-4)**: Terraform infrastructure, Keycloak deployment, investor portal MVP, CI/CD pipelines.
+2. **Phase 2 (Weeks 5-8)**: Deploy Windmill/n8n, API gateway, NATS messaging, top 10 integrations, LangGraph agents, self-hosted Mistral + Claude APIs.
+3. **Phase 3 (Weeks 9-16)**: Extend integrations, observability (OpenTelemetry, Loki, Grafana), finalize multi-tenant protections, roll out Nx-based apps.
+4. **Phase 4 (Weeks 17-24)**: Security audits, disaster recovery testing, database optimization, SaaS consolidation, governance and documentation.
+
+## Key Success Factors
+- Prioritize high-impact integrations first, add observability from day zero, and keep humans in the loop for critical decisions.
+- Document architecture choices, operational runbooks, and integration playbooks to ensure maintainability.
+- Celebrate cost-saving wins to reinforce stakeholder confidence and sustain momentum.


### PR DESCRIPTION
## Summary
- add a new documentation page capturing the AI-automated infrastructure strategy for BlackRoad, including architecture, platform, and rollout guidance

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fbc70fba048329a654a0c7371ae06c