### PR TITLE
Update API Dockerfile to use npm install

### DIFF
--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -4,7 +4,7 @@ FROM node:20-alpine AS base
 WORKDIR /app
 ENV NODE_ENV=production PORT=4000
 COPY package.json package-lock.json* ./
-RUN npm ci --omit=dev
+RUN npm install --omit=dev
 COPY server.mjs healthcheck.mjs ./
 
 # tiny runtime


### PR DESCRIPTION
## Summary
- replace the API Dockerfile dependency installation step to use `npm install --omit=dev`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fbdaafd7e88329afdef7dcf216b37c