### PR TITLE
Add connector sync orchestration tool

### DIFF
--- a/sync_connectors.py
+++ b/sync_connectors.py
@@ -1,0 +1,15 @@
+"""
+Setup Instructions:
+1. Install dependencies: ``pip install -r requirements.txt``.
+2. Create a ``.env`` file (optionally by copying an existing example) and populate tokens such as ``GITHUB_TOKEN``, ``LINEAR_API_KEY``, ``ASANA_ACCESS_TOKEN``, ``NOTION_TOKEN``, ``SLACK_BOT_TOKEN``, ``DROPBOX_ACCESS_TOKEN``, ``FIGMA_ACCESS_TOKEN``, ``FIGMA_TEAM_ID``, ``CANVA_API_TOKEN``, ``HUBSPOT_ACCESS_TOKEN``, and ``CLICKUP_API_TOKEN``.
+3. Run the sync tool: ``python sync_connectors.py``.
+
+This script loads API credentials from the environment, connects to each service, and
+prints a summary table describing connection status and project counts.
+"""
+
+from sync_connectors.main import run
+
+
+if __name__ == "__main__":
+    run()

--- a/sync_connectors/__init__.py
+++ b/sync_connectors/__init__.py
@@ -1,0 +1,5 @@
+"""Connector sync orchestration package."""
+
+from .main import run
+
+__all__ = ["run"]

--- a/sync_connectors/connectors/__init__.py
+++ b/sync_connectors/connectors/__init__.py
@@ -1,0 +1,29 @@
+"""Service connector implementations."""
+
+from .asana import AsanaConnector
+from .base import ConnectorBase, ConnectorError, ConnectorResult
+from .canva import CanvaConnector
+from .clickup import ClickUpConnector
+from .dropbox import DropboxConnector
+from .figma import FigmaConnector
+from .github import GitHubConnector
+from .hubspot import HubSpotConnector
+from .linear import LinearConnector
+from .notion import NotionConnector
+from .slack import SlackConnector
+
+__all__ = [
+    "AsanaConnector",
+    "CanvaConnector",
+    "ClickUpConnector",
+    "DropboxConnector",
+    "FigmaConnector",
+    "GitHubConnector",
+    "HubSpotConnector",
+    "LinearConnector",
+    "NotionConnector",
+    "SlackConnector",
+    "ConnectorBase",
+    "ConnectorResult",
+    "ConnectorError",
+]

--- a/sync_connectors/connectors/asana.py
+++ b/sync_connectors/connectors/asana.py
@@ -1,0 +1,32 @@
+"""Asana connector implementation."""
+from __future__ import annotations
+
+from typing import Optional
+
+from .base import ConnectorBase
+
+
+class AsanaConnector(ConnectorBase):
+    name = "Asana"
+    token_env_var = "ASANA_ACCESS_TOKEN"
+
+    def _sync_impl(self, token: str) -> tuple[str, Optional[int]]:
+        headers = {
+            "Authorization": f"Bearer {token}",
+        }
+        user = self._request_with_retries(
+            "GET", "https://app.asana.com/api/1.0/users/me", headers=headers
+        )
+        account_name = user.get("data", {}).get("name") or "Asana User"
+        workspaces = self._request_with_retries(
+            "GET", "https://app.asana.com/api/1.0/workspaces", headers=headers
+        )
+        active_workspaces = [
+            workspace
+            for workspace in workspaces.get("data", [])
+            if not workspace.get("is_archived", False)
+        ]
+        return account_name, len(active_workspaces)
+
+
+__all__ = ["AsanaConnector"]

--- a/sync_connectors/connectors/base.py
+++ b/sync_connectors/connectors/base.py
@@ -1,0 +1,114 @@
+"""Base classes and utilities for service connectors."""
+from __future__ import annotations
+
+import os
+import time
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import requests
+
+
+class ConnectorError(Exception):
+    """Custom exception for connector failures."""
+
+
+@dataclass
+class ConnectorResult:
+    service_name: str
+    success: bool
+    status_message: str
+    account_name: Optional[str] = None
+    active_projects: Optional[int] = None
+    error_message: Optional[str] = None
+
+
+class ConnectorBase(ABC):
+    """Base connector with shared retry and token helpers."""
+
+    name: str = "Unknown"
+    token_env_var: str = ""
+    max_retries: int = 3
+    retry_delay: float = 1.0
+    timeout: float = 10.0
+
+    def __init__(self) -> None:
+        self._session = requests.Session()
+
+    def _get_token(self) -> str:
+        token = os.getenv(self.token_env_var)
+        if not token:
+            raise ConnectorError(
+                f"Environment variable {self.token_env_var} is not set."
+            )
+        return token
+
+    def _request_with_retries(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+        params: Optional[Dict[str, Any]] = None,
+        json: Optional[Any] = None,
+        data: Optional[Any] = None,
+    ) -> Any:
+        """Perform an HTTP request with basic retry handling."""
+        last_error: Optional[Exception] = None
+        for attempt in range(1, self.max_retries + 1):
+            try:
+                response = self._session.request(
+                    method=method,
+                    url=url,
+                    headers=headers,
+                    params=params,
+                    json=json,
+                    data=data,
+                    timeout=self.timeout,
+                )
+                if response.status_code >= 500 or response.status_code == 429:
+                    raise ConnectorError(
+                        f"Upstream error {response.status_code}: {response.text[:200]}"
+                    )
+                if response.status_code >= 400:
+                    raise ConnectorError(
+                        f"Request failed ({response.status_code}): {response.text[:200]}"
+                    )
+                if response.headers.get("Content-Type", "").startswith("application/json"):
+                    return response.json()
+                return response.text
+            except Exception as exc:  # noqa: BLE001
+                last_error = exc
+                if attempt < self.max_retries:
+                    time.sleep(self.retry_delay * attempt)
+                else:
+                    break
+        raise ConnectorError(str(last_error))
+
+    def sync(self) -> ConnectorResult:
+        """Execute the connector flow and package the result."""
+        try:
+            token = self._get_token()
+            account_name, active_projects = self._sync_impl(token)
+            return ConnectorResult(
+                service_name=self.name,
+                success=True,
+                status_message="Connected",
+                account_name=account_name,
+                active_projects=active_projects,
+            )
+        except ConnectorError as err:
+            return ConnectorResult(
+                service_name=self.name,
+                success=False,
+                status_message="Failed",
+                error_message=str(err),
+            )
+
+    @abstractmethod
+    def _sync_impl(self, token: str) -> tuple[str, Optional[int]]:
+        """Perform the connector-specific logic."""
+
+
+__all__ = ["ConnectorBase", "ConnectorResult", "ConnectorError"]

--- a/sync_connectors/connectors/canva.py
+++ b/sync_connectors/connectors/canva.py
@@ -1,0 +1,34 @@
+"""Canva connector implementation."""
+from __future__ import annotations
+
+from typing import Optional
+
+from .base import ConnectorBase, ConnectorError
+
+
+class CanvaConnector(ConnectorBase):
+    name = "Canva"
+    token_env_var = "CANVA_API_TOKEN"
+
+    def _sync_impl(self, token: str) -> tuple[str, Optional[int]]:
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        }
+        account = self._request_with_retries(
+            "GET", "https://api.canva.com/rest/v1/users/me", headers=headers
+        )
+        account_name = account.get("displayName") or account.get("email") or "Canva User"
+        teams = self._request_with_retries(
+            "GET", "https://api.canva.com/rest/v1/teams", headers=headers
+        )
+        entries = teams.get("teams", []) if isinstance(teams, dict) else []
+        if not entries and isinstance(teams, list):
+            entries = teams
+        active_teams = len(entries)
+        if active_teams == 0:
+            raise ConnectorError("No teams returned from Canva API.")
+        return account_name, active_teams
+
+
+__all__ = ["CanvaConnector"]

--- a/sync_connectors/connectors/clickup.py
+++ b/sync_connectors/connectors/clickup.py
@@ -1,0 +1,37 @@
+"""ClickUp connector implementation."""
+from __future__ import annotations
+
+from typing import Optional
+
+from .base import ConnectorBase, ConnectorError
+
+
+class ClickUpConnector(ConnectorBase):
+    name = "ClickUp"
+    token_env_var = "CLICKUP_API_TOKEN"
+
+    def _sync_impl(self, token: str) -> tuple[str, Optional[int]]:
+        headers = {"Authorization": token}
+        teams_response = self._request_with_retries(
+            "GET", "https://api.clickup.com/api/v2/team", headers=headers
+        )
+        teams = teams_response.get("teams", [])
+        if not teams:
+            raise ConnectorError("No teams available for ClickUp token.")
+        account_name = teams[0].get("name") or "ClickUp Workspace"
+        total_spaces = 0
+        for team in teams:
+            team_id = team.get("id")
+            if not team_id:
+                continue
+            spaces = self._request_with_retries(
+                "GET",
+                f"https://api.clickup.com/api/v2/team/{team_id}/space",
+                headers=headers,
+                params={"archived": "false"},
+            )
+            total_spaces += len(spaces.get("spaces", []))
+        return account_name, total_spaces
+
+
+__all__ = ["ClickUpConnector"]

--- a/sync_connectors/connectors/dropbox.py
+++ b/sync_connectors/connectors/dropbox.py
@@ -1,0 +1,47 @@
+"""Dropbox connector implementation."""
+from __future__ import annotations
+
+from typing import Optional
+
+from .base import ConnectorBase
+
+
+class DropboxConnector(ConnectorBase):
+    name = "Dropbox"
+    token_env_var = "DROPBOX_ACCESS_TOKEN"
+
+    def _sync_impl(self, token: str) -> tuple[str, Optional[int]]:
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        }
+        account = self._request_with_retries(
+            "POST",
+            "https://api.dropboxapi.com/2/users/get_current_account",
+            headers=headers,
+            json={},
+        )
+        account_name = account.get("name", {}).get("display_name") or "Dropbox User"
+        payload = {"limit": 200}
+        active_folders = 0
+        response = self._request_with_retries(
+            "POST",
+            "https://api.dropboxapi.com/2/sharing/list_folders",
+            headers=headers,
+            json=payload,
+        )
+        active_folders += len(response.get("entries", []))
+        cursor = response.get("cursor")
+        while response.get("has_more") and cursor:
+            response = self._request_with_retries(
+                "POST",
+                "https://api.dropboxapi.com/2/sharing/list_folders/continue",
+                headers=headers,
+                json={"cursor": cursor},
+            )
+            active_folders += len(response.get("entries", []))
+            cursor = response.get("cursor")
+        return account_name, active_folders
+
+
+__all__ = ["DropboxConnector"]

--- a/sync_connectors/connectors/figma.py
+++ b/sync_connectors/connectors/figma.py
@@ -1,0 +1,32 @@
+"""Figma connector implementation."""
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from .base import ConnectorBase, ConnectorError
+
+
+class FigmaConnector(ConnectorBase):
+    name = "Figma"
+    token_env_var = "FIGMA_ACCESS_TOKEN"
+
+    def _sync_impl(self, token: str) -> tuple[str, Optional[int]]:
+        team_id = os.getenv("FIGMA_TEAM_ID")
+        if not team_id:
+            raise ConnectorError("Environment variable FIGMA_TEAM_ID is not set.")
+        headers = {"X-Figma-Token": token}
+        profile = self._request_with_retries(
+            "GET", "https://api.figma.com/v1/me", headers=headers
+        )
+        account_name = profile.get("handle") or profile.get("email") or "Figma User"
+        projects = self._request_with_retries(
+            "GET",
+            f"https://api.figma.com/v1/teams/{team_id}/projects",
+            headers=headers,
+        )
+        active_projects = len(projects.get("projects", []))
+        return account_name, active_projects
+
+
+__all__ = ["FigmaConnector"]

--- a/sync_connectors/connectors/github.py
+++ b/sync_connectors/connectors/github.py
@@ -1,0 +1,32 @@
+"""GitHub connector implementation."""
+from __future__ import annotations
+
+from typing import Optional
+
+from .base import ConnectorBase
+
+
+class GitHubConnector(ConnectorBase):
+    name = "GitHub"
+    token_env_var = "GITHUB_TOKEN"
+
+    def _sync_impl(self, token: str) -> tuple[str, Optional[int]]:
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+        }
+        user = self._request_with_retries(
+            "GET", "https://api.github.com/user", headers=headers
+        )
+        account_name = user.get("name") or user.get("login") or "GitHub User"
+        repos = self._request_with_retries(
+            "GET",
+            "https://api.github.com/user/repos",
+            headers=headers,
+            params={"per_page": 100, "type": "owner"},
+        )
+        active_count = sum(1 for repo in repos if not repo.get("archived"))
+        return account_name, active_count
+
+
+__all__ = ["GitHubConnector"]

--- a/sync_connectors/connectors/hubspot.py
+++ b/sync_connectors/connectors/hubspot.py
@@ -1,0 +1,29 @@
+"""HubSpot connector implementation."""
+from __future__ import annotations
+
+from typing import Optional
+
+from .base import ConnectorBase
+
+
+class HubSpotConnector(ConnectorBase):
+    name = "HubSpot"
+    token_env_var = "HUBSPOT_ACCESS_TOKEN"
+
+    def _sync_impl(self, token: str) -> tuple[str, Optional[int]]:
+        headers = {"Authorization": f"Bearer {token}"}
+        account = self._request_with_retries(
+            "GET", "https://api.hubapi.com/account-info/v3/details", headers=headers
+        )
+        account_name = account.get("name") or account.get("portalId") or "HubSpot Account"
+        deals = self._request_with_retries(
+            "GET",
+            "https://api.hubapi.com/crm/v3/objects/deals",
+            headers=headers,
+            params={"limit": 100, "archived": "false"},
+        )
+        active_deals = len(deals.get("results", []))
+        return account_name, active_deals
+
+
+__all__ = ["HubSpotConnector"]

--- a/sync_connectors/connectors/linear.py
+++ b/sync_connectors/connectors/linear.py
@@ -1,0 +1,60 @@
+"""Linear connector implementation."""
+from __future__ import annotations
+
+from typing import Optional
+
+from .base import ConnectorBase, ConnectorError
+
+
+class LinearConnector(ConnectorBase):
+    name = "Linear"
+    token_env_var = "LINEAR_API_KEY"
+
+    def _sync_impl(self, token: str) -> tuple[str, Optional[int]]:
+        headers = {
+            "Authorization": token,
+            "Content-Type": "application/json",
+        }
+        query = (
+            "query LinearTeams($after: String) {"
+            " viewer { name displayName }"
+            " teams(first: 50, after: $after) {"
+            "   nodes { id name archivedAt }"
+            "   pageInfo { hasNextPage endCursor }"
+            " }"
+            "}"
+        )
+        active_count = 0
+        account_name: Optional[str] = None
+        cursor: Optional[str] = None
+        while True:
+            payload = {"query": query, "variables": {"after": cursor}}
+            response = self._request_with_retries(
+                "POST",
+                "https://api.linear.app/graphql",
+                headers=headers,
+                json=payload,
+            )
+            if "errors" in response:
+                raise ConnectorError(str(response["errors"]))
+            viewer = response.get("data", {}).get("viewer", {})
+            account_name = (
+                viewer.get("name")
+                or viewer.get("displayName")
+                or account_name
+                or "Linear User"
+            )
+            teams = response.get("data", {}).get("teams", {})
+            nodes = teams.get("nodes", [])
+            active_count += sum(1 for node in nodes if not node.get("archivedAt"))
+            page_info = teams.get("pageInfo", {})
+            if page_info.get("hasNextPage"):
+                cursor = page_info.get("endCursor")
+            else:
+                break
+        if account_name is None:
+            account_name = "Linear User"
+        return account_name, active_count
+
+
+__all__ = ["LinearConnector"]

--- a/sync_connectors/connectors/notion.py
+++ b/sync_connectors/connectors/notion.py
@@ -1,0 +1,42 @@
+"""Notion connector implementation."""
+from __future__ import annotations
+
+from typing import Optional
+
+from .base import ConnectorBase, ConnectorError
+
+
+class NotionConnector(ConnectorBase):
+    name = "Notion"
+    token_env_var = "NOTION_TOKEN"
+
+    def _sync_impl(self, token: str) -> tuple[str, Optional[int]]:
+        try:
+            from notion_client import Client
+        except ImportError as exc:  # pragma: no cover - defensive
+            raise ConnectorError("notion-client package is required for Notion") from exc
+
+        client = Client(auth=token)
+        user = client.users.me()
+        account_name = (
+            user.get("name")
+            or user.get("email")
+            or user.get("bot")
+            or "Notion Integration"
+        )
+        active_databases = 0
+        cursor: Optional[str] = None
+        while True:
+            response = client.search(
+                filter={"property": "object", "value": "database"},
+                start_cursor=cursor,
+                page_size=100,
+            )
+            active_databases += len(response.get("results", []))
+            if not response.get("has_more"):
+                break
+            cursor = response.get("next_cursor")
+        return account_name, active_databases
+
+
+__all__ = ["NotionConnector"]

--- a/sync_connectors/connectors/slack.py
+++ b/sync_connectors/connectors/slack.py
@@ -1,0 +1,46 @@
+"""Slack connector implementation."""
+from __future__ import annotations
+
+from typing import Optional
+
+from .base import ConnectorBase, ConnectorError
+
+
+class SlackConnector(ConnectorBase):
+    name = "Slack"
+    token_env_var = "SLACK_BOT_TOKEN"
+
+    def _sync_impl(self, token: str) -> tuple[str, Optional[int]]:
+        headers = {"Authorization": f"Bearer {token}"}
+        auth_test = self._request_with_retries(
+            "POST", "https://slack.com/api/auth.test", headers=headers
+        )
+        if not auth_test.get("ok"):
+            raise ConnectorError(auth_test.get("error", "Unknown Slack error"))
+        team_name = auth_test.get("team") or "Slack Workspace"
+        cursor: Optional[str] = None
+        active_channels = 0
+        while True:
+            params = {
+                "limit": 200,
+                "types": "public_channel,private_channel",
+            }
+            if cursor:
+                params["cursor"] = cursor
+            response = self._request_with_retries(
+                "GET",
+                "https://slack.com/api/conversations.list",
+                headers=headers,
+                params=params,
+            )
+            if not response.get("ok"):
+                raise ConnectorError(response.get("error", "Failed to list channels"))
+            channels = response.get("channels", [])
+            active_channels += sum(1 for channel in channels if not channel.get("is_archived"))
+            cursor = response.get("response_metadata", {}).get("next_cursor")
+            if not cursor:
+                break
+        return team_name, active_channels
+
+
+__all__ = ["SlackConnector"]

--- a/sync_connectors/main.py
+++ b/sync_connectors/main.py
@@ -1,0 +1,123 @@
+"""Main orchestration for syncing external service connectors."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List
+
+from dotenv import load_dotenv
+
+from .connectors.asana import AsanaConnector
+from .connectors.base import ConnectorBase, ConnectorResult
+from .connectors.canva import CanvaConnector
+from .connectors.clickup import ClickUpConnector
+from .connectors.dropbox import DropboxConnector
+from .connectors.figma import FigmaConnector
+from .connectors.github import GitHubConnector
+from .connectors.hubspot import HubSpotConnector
+from .connectors.linear import LinearConnector
+from .connectors.notion import NotionConnector
+from .connectors.slack import SlackConnector
+
+
+@dataclass
+class SummaryRow:
+    service: str
+    status: str
+    account: str
+    projects: str
+    details: str
+
+
+def build_connectors() -> List[ConnectorBase]:
+    """Instantiate all connectors."""
+    return [
+        GitHubConnector(),
+        LinearConnector(),
+        AsanaConnector(),
+        NotionConnector(),
+        SlackConnector(),
+        DropboxConnector(),
+        FigmaConnector(),
+        CanvaConnector(),
+        HubSpotConnector(),
+        ClickUpConnector(),
+    ]
+
+
+def render_table(rows: Iterable[SummaryRow]) -> str:
+    """Render a plain-text table for the given rows."""
+    headers = [
+        "Service",
+        "Status",
+        "Account / Workspace",
+        "Active Projects / Teams",
+        "Details",
+    ]
+    data_rows = [
+        [row.service, row.status, row.account, row.projects, row.details]
+        for row in rows
+    ]
+    if not data_rows:
+        data_rows.append(["-", "-", "-", "-", "-"])
+
+    widths = [
+        max(len(headers[idx]), *(len(row[idx]) for row in data_rows))
+        for idx in range(len(headers))
+    ]
+
+    def format_line(values: Iterable[str]) -> str:
+        return "| " + " | ".join(
+            value.ljust(widths[idx]) for idx, value in enumerate(values)
+        ) + " |"
+
+    divider = "+" + "+".join("-" * (width + 2) for width in widths) + "+"
+    table_lines = [divider, format_line(headers), divider]
+    for row in data_rows:
+        table_lines.append(format_line(row))
+    table_lines.append(divider)
+    return "\n".join(table_lines)
+
+
+def summarize(results: Iterable[ConnectorResult]) -> List[SummaryRow]:
+    summary: List[SummaryRow] = []
+    for result in results:
+        status_icon = "✅" if result.success else "❌"
+        status = f"{status_icon} {result.status_message}"
+        account = result.account_name or "—"
+        projects = (
+            str(result.active_projects) if result.active_projects is not None else "—"
+        )
+        details = result.error_message or ""
+        summary.append(
+            SummaryRow(
+                service=result.service_name,
+                status=status,
+                account=account,
+                projects=projects,
+                details=details,
+            )
+        )
+    return summary
+
+
+def run() -> None:
+    """Load environment, execute each connector, and print results."""
+    load_dotenv()
+    results: List[ConnectorResult] = []
+    for connector in build_connectors():
+        print(f"Checking {connector.name}...")
+        result = connector.sync()
+        results.append(result)
+        if result.success:
+            print(
+                f"  Connected to {result.account_name or 'unknown account'}: "
+                f"{result.active_projects or 0} active projects/teams"
+            )
+        else:
+            print(f"  Failed: {result.error_message}")
+    print()
+    summary_rows = summarize(results)
+    print(render_table(summary_rows))
+
+
+__all__ = ["run"]


### PR DESCRIPTION
## Summary
- add a modular connector sync utility with per-service modules for GitHub, Linear, Asana, Notion, Slack, Dropbox, Figma, Canva, HubSpot, and ClickUp
- implement a reusable connector base with retry logic, environment variable handling, and summary table output
- load tokens from .env via python-dotenv and expose an entry script for running the checks

## Testing
- python -m compileall sync_connectors
- python sync_connectors.py


------
https://chatgpt.com/codex/tasks/task_e_68fc21a0e2b883298e412c9ef5b91e14