### PR TITLE
Add Slack notifications and Grafana observability assets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,3 +84,44 @@ jobs:
           ssh root@${{ vars.DROPLET_HOST || '159.65.43.12' }} "mkdir -p ${RELEASE}"
           rsync -az --delete ./apps/api/dist/ root@${{ vars.DROPLET_HOST || '159.65.43.12' }}:${RELEASE}/
           ssh root@${{ vars.DROPLET_HOST || '159.65.43.12' }} "ln -sfn ${RELEASE} /srv/blackroad-api && systemctl restart blackroad-api || pm2 restart blackroad-api || true"
+
+      - name: Notify Slack (Deploy Success)
+        if: success()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          payload=$(jq -n \
+            --arg actor "$GITHUB_ACTOR" \
+            --arg repo "$GITHUB_REPOSITORY" \
+            '{
+              blocks: [
+                {type: "header", text: {type: "plain_text", text: "🚀 Deploy Successful!"}},
+                {type: "section", text: {type: "mrkdwn", text: "Main branch deployed to *codex-infinity*"}},
+                {type: "context", elements: [{type: "mrkdwn", text: ("Triggered by " + $actor)}]},
+                {type: "actions", elements: [
+                  {type: "button", text: {type: "plain_text", text: "View Build"}, url: ("https://github.com/" + $repo + "/actions")},
+                  {type: "button", text: {type: "plain_text", text: "View Grafana"}, url: "https://grafana.blackroadinc.us/d/system-metrics"}
+                ]}
+              ]
+            }')
+          curl -X POST -H 'Content-type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL"
+
+      - name: Notify Slack (Deploy Failed)
+        if: failure()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          payload=$(jq -n \
+            --arg repo "$GITHUB_REPOSITORY" \
+            --arg job "$GITHUB_JOB" \
+            '{
+              blocks: [
+                {type: "header", text: {type: "plain_text", text: "🔥 Deployment Failed!"}},
+                {type: "section", text: {type: "mrkdwn", text: ("*Build error in " + $repo + "*")}},
+                {type: "context", elements: [{type: "mrkdwn", text: ("Job: " + $job)}]},
+                {type: "actions", elements: [
+                  {type: "button", text: {type: "plain_text", text: "View Logs"}, url: ("https://github.com/" + $repo + "/actions")}
+                ]}
+              ]
+            }')
+          curl -X POST -H 'Content-type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL"

--- a/config/slack/alertmanager.yml
+++ b/config/slack/alertmanager.yml
@@ -1,0 +1,52 @@
+global:
+  resolve_timeout: 5m
+
+route:
+  receiver: slack
+
+receivers:
+  - name: 'slack'
+    slack_configs:
+      - api_url: ${SLACK_WEBHOOK_URL}
+        channel: '#dev-ops'
+        send_resolved: true
+        title: "[{{ .Status | toUpper }}] {{ .CommonLabels.alertname }}"
+        title_link: "https://grafana.blackroadinc.us/d/alerts"
+        icon_emoji: ":satellite_antenna:"
+        blocks:
+          - type: section
+            text:
+              type: mrkdwn
+              text: "*{{ .CommonAnnotations.summary }}*\n{{ .CommonAnnotations.description }}"
+          - type: context
+            elements:
+              - type: mrkdwn
+                text: "*Severity:* {{ .CommonLabels.severity | toUpper }}"
+              - type: mrkdwn
+                text: "*Service:* {{ .CommonLabels.job }}"
+              - type: mrkdwn
+                text: "*Instance:* {{ .CommonLabels.instance }}"
+          - type: divider
+          - type: section
+            fields:
+              - type: mrkdwn
+                text: "*Started:* {{ .StartsAt }}"
+              - type: mrkdwn
+                text: "*Ends:* {{ .EndsAt | default \"N/A\" }}"
+          - type: actions
+            elements:
+              - type: button
+                text:
+                  type: plain_text
+                  text: "🧠 Open Grafana"
+                url: "https://grafana.blackroadinc.us/d/system-metrics"
+              - type: button
+                text:
+                  type: plain_text
+                  text: "🛠 View Logs"
+                url: "https://grafana.blackroadinc.us/explore"
+              - type: button
+                text:
+                  type: plain_text
+                  text: "📦 Trigger Redeploy"
+                url: "https://github.com/blackboxprogramming/blackroad-prism-console/actions"

--- a/grafana/provisioning/dashboards/ai-console.json
+++ b/grafana/provisioning/dashboards/ai-console.json
@@ -1,0 +1,314 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": false,
+        "iconColor": "rgba(255, 96, 96, 1)",
+        "name": "Docker Error Stream",
+        "type": "dashboard",
+        "text": "docker logs -f codex-infinity-gateway | grep ERROR"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Slack Delivery Rate",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PROMETHEUS_DS"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red"
+              },
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "rate(alertmanager_notifications_total{integration=\"slack\"}[5m])",
+          "legendFormat": "Slack Notification Rate",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "JWT Refresh Failures (10m)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PROMETHEUS_DS"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "hidden"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "increase(jwt_refresh_failed_total[10m])",
+          "legendFormat": "JWT Refresh Failures",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "CI/CD Events (24h)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PROMETHEUS_DS"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red"
+              },
+              {
+                "color": "yellow",
+                "value": 3
+              },
+              {
+                "color": "green",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "expr": "count_over_time(ci_pipeline_runs_total[24h])",
+          "legendFormat": "Deployments (24h)",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Service Health Composite",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PROMETHEUS_DS"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-GrYlRd"
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 0,
+                  "text": "Down"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 1,
+                  "text": "Up"
+                }
+              }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red"
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Latency"
+            },
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 3
+                    },
+                    {
+                      "color": "red",
+                      "value": 5
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "expr": "up{job=~\"codex-infinity|nextjs-ui\"}",
+          "legendFormat": "{{job}}",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [
+    "ai-console",
+    "codex"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "AI Console Operations",
+  "uid": "ai-console-ops",
+  "version": 1
+}

--- a/grafana/provisioning/dashboards/dashboard.yml
+++ b/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+providers:
+  - name: AI Console Observability
+    orgId: 1
+    folder: AI Console
+    folderUid: ai-console
+    type: file
+    disableDeletion: false
+    editable: true
+    updateIntervalSeconds: 30
+    options:
+      path: /var/lib/grafana/dashboards/ai-console

--- a/scripts/slack_bot_ack.py
+++ b/scripts/slack_bot_ack.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Helper to acknowledge Alertmanager alerts triggered from Slack interactions."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import getpass
+import os
+import sys
+from typing import Sequence
+
+import requests
+
+
+def parse_duration(text: str) -> dt.timedelta:
+    """Parse a duration string like ``30m`` or ``1h15m`` into ``timedelta``."""
+    if not text:
+        raise ValueError("Duration cannot be empty")
+
+    units = {"s": 1, "m": 60, "h": 3600, "d": 86400}
+    total_seconds = 0
+    number = []
+
+    for char in text.strip():
+        if char.isdigit():
+            number.append(char)
+            continue
+        if char not in units:
+            raise ValueError(f"Unsupported duration unit: {char}")
+        if not number:
+            raise ValueError("Duration value missing before unit")
+        total_seconds += int("".join(number)) * units[char]
+        number.clear()
+
+    if number:
+        total_seconds += int("".join(number))
+
+    if total_seconds <= 0:
+        raise ValueError("Duration must be positive")
+
+    return dt.timedelta(seconds=total_seconds)
+
+
+def create_silence(
+    alertmanager_url: str,
+    alertname: str,
+    author: str,
+    duration: dt.timedelta,
+    comment: str,
+) -> str:
+    """Create an Alertmanager silence that acts as an acknowledgement."""
+    now = dt.datetime.utcnow().replace(tzinfo=dt.timezone.utc)
+    payload = {
+        "matchers": [
+            {"name": "alertname", "value": alertname, "isRegex": False},
+        ],
+        "startsAt": now.isoformat(),
+        "endsAt": (now + duration).isoformat(),
+        "createdBy": author,
+        "comment": comment,
+    }
+
+    url = alertmanager_url.rstrip("/") + "/api/v2/silences"
+
+    auth = None
+    username = os.getenv("ALERTMANAGER_USER")
+    password = os.getenv("ALERTMANAGER_PASSWORD")
+    if username and password:
+        auth = (username, password)
+
+    response = requests.post(url, json=payload, auth=auth, timeout=10)
+    response.raise_for_status()
+    data = response.json()
+    silence_id = data.get("silenceID") or data.get("id")
+    if not silence_id:
+        raise RuntimeError("Alertmanager did not return a silence ID")
+    return silence_id
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Acknowledge an alert by creating an Alertmanager silence.",
+    )
+    parser.add_argument("alertname", help="Exact alertname label to silence.")
+    parser.add_argument(
+        "--duration",
+        default="1h",
+        help="Silence duration (e.g. 30m, 2h, 1h30m). Defaults to 1h.",
+    )
+    parser.add_argument(
+        "--author",
+        default=os.getenv("SLACK_ACK_USER") or getpass.getuser(),
+        help="Name recorded in Alertmanager. Defaults to $SLACK_ACK_USER or current user.",
+    )
+    parser.add_argument(
+        "--comment",
+        default=None,
+        help="Optional acknowledgement comment to store with the silence.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    alertmanager_url = os.getenv("ALERTMANAGER_URL")
+    if not alertmanager_url:
+        parser.error("ALERTMANAGER_URL environment variable must be set")
+
+    try:
+        duration = parse_duration(args.duration)
+    except ValueError as exc:
+        parser.error(str(exc))
+
+    comment = args.comment or f"Acknowledged via Slack by {args.author}"
+
+    try:
+        silence_id = create_silence(alertmanager_url, args.alertname, args.author, duration, comment)
+    except requests.HTTPError as exc:
+        print(f"Alertmanager responded with error: {exc.response.text}", file=sys.stderr)
+        return 2
+    except Exception as exc:  # pragma: no cover - CLI utility
+        print(f"Failed to acknowledge alert: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Created silence {silence_id} for alert '{args.alertname}' lasting {args.duration}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add Alertmanager Slack Block Kit configuration and helper script for Slack acks
- integrate Slack success/failure notifications into the deploy workflow
- provision Grafana dashboard assets covering delivery, JWT failures, CI cadence, and service health

## Testing
- python -m compileall scripts/slack_bot_ack.py

------
https://chatgpt.com/codex/tasks/task_e_68fc3e242f108329b8ac1d4a36aeeb0a