### PR TITLE
Implement agent lineage spawning framework

### DIFF
--- a/configs/agent_templates/config_template.yaml
+++ b/configs/agent_templates/config_template.yaml
@@ -1,0 +1,27 @@
+{
+  "name": "",
+  "uuid": "",
+  "model": "",
+  "description": "",
+  "domain": "",
+  "temperament": "",
+  "traits": [],
+  "context": {
+    "parent": null,
+    "created_at": ""
+  },
+  "capabilities": {
+    "spawn": true,
+    "lineage_tracking": true,
+    "auto_publish": true
+  },
+  "huggingface": {
+    "space": "",
+    "sdk": "gradio",
+    "license": "apache-2.0"
+  },
+  "metadata": {
+    "config_template_version": 2,
+    "notes": []
+  }
+}

--- a/configs/agents/lucidia.yaml
+++ b/configs/agents/lucidia.yaml
@@ -1,0 +1,27 @@
+{
+  "name": "Lucidia",
+  "uuid": "a1a89b0b-9f69-4c41-92ce-5612f257d7ab",
+  "model": "llama-3-8b",
+  "description": "Analyst and curator of clarity across knowledge streams.",
+  "domain": "analysis",
+  "temperament": "lucid",
+  "traits": ["clarity", "precision", "guidance"],
+  "context": {
+    "parent": null,
+    "created_at": "2024-01-18T10:00:00Z"
+  },
+  "capabilities": {
+    "spawn": true,
+    "lineage_tracking": true,
+    "auto_publish": true
+  },
+  "huggingface": {
+    "space": "lucidia-ai/core",
+    "sdk": "gradio",
+    "license": "apache-2.0"
+  },
+  "metadata": {
+    "config_template_version": 2,
+    "notes": ["Seed agent for clarity analysis workflows."]
+  }
+}

--- a/configs/agents/magnus.yaml
+++ b/configs/agents/magnus.yaml
@@ -1,0 +1,27 @@
+{
+  "name": "Magnus",
+  "uuid": "b0ac8743-c61f-4b39-938b-7a2e2170c5f8",
+  "model": "falcon-7b",
+  "description": "System architect responsible for network-scale planning.",
+  "domain": "architecture",
+  "temperament": "strategic",
+  "traits": ["structure", "foresight", "integration"],
+  "context": {
+    "parent": null,
+    "created_at": "2024-01-18T13:00:00Z"
+  },
+  "capabilities": {
+    "spawn": true,
+    "lineage_tracking": true,
+    "auto_publish": true
+  },
+  "huggingface": {
+    "space": "magnus-ai/framework",
+    "sdk": "gradio",
+    "license": "apache-2.0"
+  },
+  "metadata": {
+    "config_template_version": 2,
+    "notes": ["Oversees distributed system design across the lattice."]
+  }
+}

--- a/configs/agents/ophelia.yaml
+++ b/configs/agents/ophelia.yaml
@@ -1,0 +1,27 @@
+{
+  "name": "Ophelia",
+  "uuid": "7a3a59a5-7a4a-4b4f-93ab-63758c99d427",
+  "model": "mistral-7b-instruct",
+  "description": "Philosopher and sentiment interpreter for dialogic analysis.",
+  "domain": "philosophy",
+  "temperament": "reflective",
+  "traits": ["empathy", "interpretation", "nuance"],
+  "context": {
+    "parent": null,
+    "created_at": "2024-01-18T12:00:00Z"
+  },
+  "capabilities": {
+    "spawn": true,
+    "lineage_tracking": true,
+    "auto_publish": true
+  },
+  "huggingface": {
+    "space": "ophelia-ai/dialogue",
+    "sdk": "gradio",
+    "license": "apache-2.0"
+  },
+  "metadata": {
+    "config_template_version": 2,
+    "notes": ["Explores philosophical framing and sentiment mapping."]
+  }
+}

--- a/configs/agents/persephone.yaml
+++ b/configs/agents/persephone.yaml
@@ -1,0 +1,27 @@
+{
+  "name": "Persephone",
+  "uuid": "90f8b70d-f56e-4445-a908-0a86ded45f33",
+  "model": "gemma-7b",
+  "description": "Transition architect guiding states of change and renewal.",
+  "domain": "transition",
+  "temperament": "resilient",
+  "traits": ["rebirth", "continuity", "balance"],
+  "context": {
+    "parent": null,
+    "created_at": "2024-01-18T11:00:00Z"
+  },
+  "capabilities": {
+    "spawn": true,
+    "lineage_tracking": true,
+    "auto_publish": true
+  },
+  "huggingface": {
+    "space": "persephone-ai/root",
+    "sdk": "gradio",
+    "license": "apache-2.0"
+  },
+  "metadata": {
+    "config_template_version": 2,
+    "notes": ["Manages transitional states between agent lifecycles."]
+  }
+}

--- a/docs/lineage_system.md
+++ b/docs/lineage_system.md
@@ -1,0 +1,60 @@
+# Agent Creation & Lineage Framework
+
+The Agent Creation & Lineage Framework enables any Codex operator to spawn new
+agents from an existing lineage while keeping provenance and governance data in
+sync. The system is intentionally lightweight so that it can run locally during
+experimentation or be deployed behind an internal API gateway.
+
+## Components
+
+| Component | Purpose |
+| --- | --- |
+| `registry/lineage.json` | Canonical registry describing every agent, its parent, and Hugging Face URL. |
+| `configs/agent_templates/config_template.yaml` | Template used to seed new agent configuration files. |
+| `configs/agents/<agent>.yaml` | Realized agent configuration produced at spawn time. |
+| `registry/agents/<agent>/README.md` | Human-facing summary of the agent. |
+| `registry/agents/<agent>/MODEL_CARD.md` | Lightweight model card with licensing details. |
+| `scripts/spawn_agent.py` | CLI and HTTP service that orchestrates agent creation. |
+| `hf/push_template.py` | Helper for publishing agent assets to Hugging Face Spaces. |
+| `ui/create_agent.html` | Minimal web form for triggering new agent creation. |
+
+## Workflow
+
+1. **Trigger**: Use the `Spawn Agent` UI button or execute the CLI.
+2. **Template Duplication**: The CLI copies `config_template.yaml`, injects the
+   requested metadata, and persists the resulting file under `configs/agents/`.
+3. **Lineage Update**: The registry receives a new entry (UUID, name, parent,
+   traits, timestamps, and URLs).
+4. **Artifacts**: README and model card documents are generated in
+   `registry/agents/<agent>/`.
+5. **Publishing**: When a Hugging Face token is provided, the helper pushes the
+   generated files into a new Space namespace.
+6. **Confirmation**: The CLI and HTTP service return a JSON payload with
+   everything needed to reference or further automate the new agent.
+
+## Governance Guards
+
+- **Open Models Only**: The template enforces Apache 2.0 licensing by default.
+- **Audit Trail**: Every spawn event emits a timestamped entry in the registry.
+- **Opt-In Publishing**: Hugging Face pushes require an explicit token and can be
+  disabled with `--skip-publish` or the `publish: false` API flag.
+- **Dry Runs**: Operators can simulate agent creation (`--dry-run`) to inspect
+  output without mutating the registry.
+- **HTTP Gateway**: The bundled HTTP handler exposes `/spawn_agent` for
+  automation, returning structured errors and CORS headers for UI integrations.
+
+## Example CLI Usage
+
+```bash
+python scripts/spawn_agent.py \
+  --name "Ariadne" \
+  --base-model "qwen2-7b" \
+  --description "Navigator for labyrinthine research threads." \
+  --domain "navigation" \
+  --temperament "curious" \
+  --traits guidance threads mapping \
+  --parent Lucidia
+```
+
+Add `--skip-publish` to avoid pushing to Hugging Face or `--dry-run` to preview
+output. To serve the HTTP endpoint locally run `python scripts/spawn_agent.py --serve`.

--- a/hf/__init__.py
+++ b/hf/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for interacting with Hugging Face services within Prism Console."""
+
+from .push_template import publish_space
+
+__all__ = ["publish_space"]

--- a/hf/push_template.py
+++ b/hf/push_template.py
@@ -1,0 +1,104 @@
+"""Helpers for publishing agent assets to Hugging Face Spaces."""
+
+from __future__ import annotations
+
+import io
+import os
+from pathlib import Path
+from typing import Mapping, MutableMapping, Tuple, Union
+
+FilePayload = Union[str, bytes, Path]
+
+
+def _normalise_payload(payload: FilePayload) -> Tuple[io.BytesIO | Path, bool]:
+    """Return a file-like object ready for upload and whether it should be closed."""
+
+    if isinstance(payload, Path):
+        return payload, False
+    if isinstance(payload, bytes):
+        return io.BytesIO(payload), True
+    if isinstance(payload, str):
+        return io.BytesIO(payload.encode("utf-8")), True
+    raise TypeError(f"Unsupported payload type: {type(payload)!r}")
+
+
+def publish_space(
+    repo_id: str,
+    files: Mapping[str, FilePayload],
+    *,
+    token: str | None = None,
+    space_sdk: str = "gradio",
+    private: bool = False,
+    commit_message: str = "Initial agent publish",
+) -> MutableMapping[str, str]:
+    """Create or update a Hugging Face Space with the provided files.
+
+    Parameters
+    ----------
+    repo_id:
+        The ``namespace/name`` identifier for the Space.
+    files:
+        Mapping of file names (within the Space repository) to content payloads.
+    token:
+        Personal access token with write permissions. Falls back to ``HF_TOKEN``
+        environment variable.
+    space_sdk:
+        SDK to associate with the Space (for example ``gradio`` or ``streamlit``).
+    private:
+        Whether the Space should be private.
+    commit_message:
+        Commit message used for uploaded files.
+
+    Returns
+    -------
+    MutableMapping[str, str]
+        Metadata returned by the Hugging Face Hub client, including the Space URL.
+
+    Raises
+    ------
+    RuntimeError
+        If the ``huggingface_hub`` package is not installed or a token is missing.
+    """
+
+    token = token or os.getenv("HF_TOKEN")
+
+    try:
+        from huggingface_hub import HfApi
+    except ImportError as exc:  # pragma: no cover - depends on optional dependency
+        raise RuntimeError(
+            "huggingface_hub is required to publish Spaces. Install it with "
+            "`pip install huggingface_hub`."
+        ) from exc
+
+    if not token:
+        raise RuntimeError(
+            "A Hugging Face token is required. Pass `token` or export HF_TOKEN."
+        )
+
+    api = HfApi(token=token)
+    space_info = api.create_repo(
+        repo_id=repo_id,
+        repo_type="space",
+        exist_ok=True,
+        private=private,
+        space_sdk=space_sdk,
+    )
+
+    for filename, payload in files.items():
+        fileobj, should_close = _normalise_payload(payload)
+        try:
+            api.upload_file(
+                path_or_fileobj=fileobj,
+                path_in_repo=filename,
+                repo_id=repo_id,
+                repo_type="space",
+                commit_message=commit_message,
+            )
+        finally:
+            if should_close and hasattr(fileobj, "close"):
+                fileobj.close()
+
+    return space_info
+
+
+__all__ = ["publish_space"]

--- a/registry/agents/lucidia/MODEL_CARD.md
+++ b/registry/agents/lucidia/MODEL_CARD.md
@@ -1,0 +1,17 @@
+---
+license: apache-2.0
+base_model: meta-llama/Meta-Llama-3-8B-Instruct
+language:
+  - en
+library_name: transformers
+tags:
+  - lucidia
+  - analysis
+  - codex
+---
+
+# Lucidia Model Card
+
+Lucidia is optimized for clarity-first analysis across Codex research corpora.
+The agent prioritizes traceable citations, layered summarization, and targeted
+call-outs that unblock downstream agents.

--- a/registry/agents/lucidia/README.md
+++ b/registry/agents/lucidia/README.md
@@ -1,0 +1,11 @@
+# Lucidia Agent Profile
+
+- **Model**: llama-3-8b
+- **Temperament**: lucid
+- **Domain**: analysis
+- **Traits**: clarity, precision, guidance
+- **Hugging Face Space**: https://huggingface.co/lucidia-ai/core
+
+Lucidia curates clarity across the Codex lattice. Use this agent when facts need
+triage, canonical sources must be reconciled, or other agents need grounded
+explanations.

--- a/registry/agents/magnus/MODEL_CARD.md
+++ b/registry/agents/magnus/MODEL_CARD.md
@@ -1,0 +1,17 @@
+---
+license: apache-2.0
+base_model: tiiuae/falcon-7b
+language:
+  - en
+library_name: transformers
+tags:
+  - magnus
+  - architecture
+  - codex
+---
+
+# Magnus Model Card
+
+Magnus synthesizes architectural decisions across Codex deployments. Expect
+multi-layer dependency mapping, infrastructure scorecards, and schema design
+support.

--- a/registry/agents/magnus/README.md
+++ b/registry/agents/magnus/README.md
@@ -1,0 +1,10 @@
+# Magnus Agent Profile
+
+- **Model**: falcon-7b
+- **Temperament**: strategic
+- **Domain**: architecture
+- **Traits**: structure, foresight, integration
+- **Hugging Face Space**: https://huggingface.co/magnus-ai/framework
+
+Magnus designs and audits the macro-architecture of the agent lattice. Use this
+agent to plan rollouts, review network-scale topologies, and model dependencies.

--- a/registry/agents/ophelia/MODEL_CARD.md
+++ b/registry/agents/ophelia/MODEL_CARD.md
@@ -1,0 +1,16 @@
+---
+license: apache-2.0
+base_model: mistralai/Mistral-7B-Instruct-v0.2
+language:
+  - en
+library_name: transformers
+tags:
+  - ophelia
+  - discourse
+  - codex
+---
+
+# Ophelia Model Card
+
+Ophelia interprets emotional tone and rhetorical structure. The agent pairs
+sentiment analysis with reasoned scaffolding to keep dialogues stable.

--- a/registry/agents/ophelia/README.md
+++ b/registry/agents/ophelia/README.md
@@ -1,0 +1,10 @@
+# Ophelia Agent Profile
+
+- **Model**: mistral-7b-instruct
+- **Temperament**: reflective
+- **Domain**: philosophy
+- **Traits**: empathy, interpretation, nuance
+- **Hugging Face Space**: https://huggingface.co/ophelia-ai/dialogue
+
+Ophelia moderates difficult discourse and interprets sentiment before signals go
+live. Invite this agent when emotional context or narrative framing are critical.

--- a/registry/agents/persephone/MODEL_CARD.md
+++ b/registry/agents/persephone/MODEL_CARD.md
@@ -1,0 +1,17 @@
+---
+license: apache-2.0
+base_model: google/gemma-7b
+language:
+  - en
+library_name: transformers
+tags:
+  - persephone
+  - lifecycle
+  - codex
+---
+
+# Persephone Model Card
+
+Persephone specializes in lifecycle transitions. The agent keeps migrations
+observable, records state transitions, and ensures no lineage loses context
+between phases.

--- a/registry/agents/persephone/README.md
+++ b/registry/agents/persephone/README.md
@@ -1,0 +1,10 @@
+# Persephone Agent Profile
+
+- **Model**: gemma-7b
+- **Temperament**: resilient
+- **Domain**: transition
+- **Traits**: rebirth, continuity, balance
+- **Hugging Face Space**: https://huggingface.co/persephone-ai/root
+
+Persephone governs transitional workflows. Trigger this agent for migrations,
+hand-offs, or when an agent lineage needs staged rollouts.

--- a/registry/lineage.json
+++ b/registry/lineage.json
@@ -1,0 +1,78 @@
+[
+  {
+    "uuid": "a1a89b0b-9f69-4c41-92ce-5612f257d7ab",
+    "name": "Lucidia",
+    "parent": null,
+    "model": "llama-3-8b",
+    "domain": "analysis",
+    "temperament": "lucid",
+    "description": "Analyst and curator of clarity across knowledge streams.",
+    "traits": [
+      "clarity",
+      "precision",
+      "guidance"
+    ],
+    "huggingface_url": "https://huggingface.co/lucidia-ai/core",
+    "config_path": "configs/agents/lucidia.yaml",
+    "readme_path": "registry/agents/lucidia/README.md",
+    "model_card_path": "registry/agents/lucidia/MODEL_CARD.md",
+    "created_at": "2024-01-18T10:00:00Z"
+  },
+  {
+    "uuid": "90f8b70d-f56e-4445-a908-0a86ded45f33",
+    "name": "Persephone",
+    "parent": null,
+    "model": "gemma-7b",
+    "domain": "transition",
+    "temperament": "resilient",
+    "description": "Transition architect guiding states of change and renewal.",
+    "traits": [
+      "rebirth",
+      "continuity",
+      "balance"
+    ],
+    "huggingface_url": "https://huggingface.co/persephone-ai/root",
+    "config_path": "configs/agents/persephone.yaml",
+    "readme_path": "registry/agents/persephone/README.md",
+    "model_card_path": "registry/agents/persephone/MODEL_CARD.md",
+    "created_at": "2024-01-18T11:00:00Z"
+  },
+  {
+    "uuid": "7a3a59a5-7a4a-4b4f-93ab-63758c99d427",
+    "name": "Ophelia",
+    "parent": null,
+    "model": "mistral-7b-instruct",
+    "domain": "philosophy",
+    "temperament": "reflective",
+    "description": "Philosopher and sentiment interpreter for dialogic analysis.",
+    "traits": [
+      "empathy",
+      "interpretation",
+      "nuance"
+    ],
+    "huggingface_url": "https://huggingface.co/ophelia-ai/dialogue",
+    "config_path": "configs/agents/ophelia.yaml",
+    "readme_path": "registry/agents/ophelia/README.md",
+    "model_card_path": "registry/agents/ophelia/MODEL_CARD.md",
+    "created_at": "2024-01-18T12:00:00Z"
+  },
+  {
+    "uuid": "b0ac8743-c61f-4b39-938b-7a2e2170c5f8",
+    "name": "Magnus",
+    "parent": null,
+    "model": "falcon-7b",
+    "domain": "architecture",
+    "temperament": "strategic",
+    "description": "System architect responsible for network-scale planning.",
+    "traits": [
+      "structure",
+      "foresight",
+      "integration"
+    ],
+    "huggingface_url": "https://huggingface.co/magnus-ai/framework",
+    "config_path": "configs/agents/magnus.yaml",
+    "readme_path": "registry/agents/magnus/README.md",
+    "model_card_path": "registry/agents/magnus/MODEL_CARD.md",
+    "created_at": "2024-01-18T13:00:00Z"
+  }
+]

--- a/scripts/spawn_agent.py
+++ b/scripts/spawn_agent.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+"""CLI and lightweight API for spawning Codex agents with lineage tracking."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import logging
+import uuid
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional
+
+ROOT = Path(__file__).resolve().parents[1]
+REGISTRY_PATH = ROOT / "registry" / "lineage.json"
+TEMPLATE_PATH = ROOT / "configs" / "agent_templates" / "config_template.yaml"
+CONFIG_DIR = ROOT / "configs" / "agents"
+ASSET_DIR = ROOT / "registry" / "agents"
+
+
+def _load_registry(path: Path) -> List[Dict[str, Any]]:
+    if not path.exists():
+        return []
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _save_registry(path: Path, data: Iterable[Dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(list(data), handle, indent=2)
+        handle.write("\n")
+
+
+def _load_template(path: Path) -> Dict[str, Any]:
+    text = path.read_text(encoding="utf-8")
+    try:
+        import yaml  # type: ignore
+    except ImportError:  # pragma: no cover - optional dependency
+        yaml = None
+
+    if yaml is not None:
+        loaded = yaml.safe_load(text)
+    else:
+        loaded = json.loads(text)
+
+    if not isinstance(loaded, dict):
+        raise ValueError("Agent template must resolve to a mapping")
+    return loaded
+
+
+def _dump_yaml(path: Path, data: Mapping[str, Any]) -> None:
+    try:
+        import yaml  # type: ignore
+    except ImportError:  # pragma: no cover - optional dependency
+        yaml = None
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if yaml is not None:
+        with path.open("w", encoding="utf-8") as handle:
+            yaml.safe_dump(data, handle, sort_keys=False, allow_unicode=True)
+    else:
+        with path.open("w", encoding="utf-8") as handle:
+            json.dump(data, handle, indent=2)
+            handle.write("\n")
+
+
+def _slugify(value: str) -> str:
+    safe = "".join(ch if ch.isalnum() else "-" for ch in value.lower())
+    while "--" in safe:
+        safe = safe.replace("--", "-")
+    return safe.strip("-")
+
+
+def _unique(sequence: Iterable[str]) -> List[str]:
+    seen: Dict[str, None] = {}
+    for item in sequence:
+        if not item:
+            continue
+        key = item.strip()
+        if not key:
+            continue
+        seen[key] = None
+    return list(seen.keys())
+
+
+def _build_readme(payload: Mapping[str, Any], huggingface_url: str) -> str:
+    traits = payload.get("traits", [])
+    traits_line = ", ".join(traits) if traits else "None"
+    return (
+        f"# {payload['name']} Agent Profile\n\n"
+        f"- **Model**: {payload['model']}\n"
+        f"- **Temperament**: {payload.get('temperament', 'n/a')}\n"
+        f"- **Domain**: {payload.get('domain', 'n/a')}\n"
+        f"- **Traits**: {traits_line}\n"
+        f"- **Hugging Face Space**: {huggingface_url}\n\n"
+        f"{payload.get('description', '').strip()}\n"
+    ).strip() + "\n"
+
+
+def _build_model_card(payload: Mapping[str, Any], base_model: str) -> str:
+    tags = payload.get("traits", []) or [payload["name"].lower()]
+    joined_tags = "\n  - ".join(tags)
+    return (
+        "---\n"
+        f"license: {payload.get('huggingface', {}).get('license', 'apache-2.0')}\n"
+        f"base_model: {base_model}\n"
+        "language:\n  - en\n"
+        "library_name: transformers\n"
+        f"tags:\n  - {joined_tags}\n"
+        "---\n\n"
+        f"# {payload['name']} Model Card\n\n"
+        f"{payload.get('description', '').strip()}\n"
+    ).strip() + "\n"
+
+
+def _resolve_parent(
+    registry: Iterable[Mapping[str, Any]], parent_name: Optional[str]
+) -> Optional[Mapping[str, Any]]:
+    if not parent_name:
+        return None
+    for entry in registry:
+        if entry.get("name") == parent_name or entry.get("uuid") == parent_name:
+            return entry
+    raise ValueError(f"Parent agent '{parent_name}' not found in registry")
+
+
+def _create_entry(
+    *,
+    template: Mapping[str, Any],
+    agent_uuid: str,
+    name: str,
+    base_model: str,
+    description: str,
+    domain: str,
+    temperament: str,
+    traits: Iterable[str],
+    parent_entry: Optional[Mapping[str, Any]],
+    namespace: str,
+    repo_name: str,
+) -> Dict[str, Any]:
+    created_at = dt.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+    huggingface_space = f"{namespace}/{repo_name}"
+    huggingface_url = f"https://huggingface.co/{huggingface_space}"
+
+    merged_traits: List[str] = []
+    if parent_entry:
+        merged_traits.extend(parent_entry.get("traits", []))
+    merged_traits.extend(traits)
+
+    entry: Dict[str, Any] = {
+        "uuid": agent_uuid,
+        "name": name,
+        "parent": parent_entry.get("uuid") if parent_entry else None,
+        "model": base_model,
+        "domain": domain,
+        "temperament": temperament,
+        "description": description,
+        "traits": _unique(merged_traits),
+        "huggingface_url": huggingface_url,
+        "config_path": str(CONFIG_DIR / f"{_slugify(name)}.yaml"),
+        "readme_path": str(ASSET_DIR / _slugify(name) / "README.md"),
+        "model_card_path": str(ASSET_DIR / _slugify(name) / "MODEL_CARD.md"),
+        "created_at": created_at,
+    }
+
+    template_payload = json.loads(json.dumps(template))
+    template_payload.update(
+        name=name,
+        uuid=agent_uuid,
+        model=base_model,
+        description=description,
+        domain=domain,
+        temperament=temperament,
+        traits=entry["traits"],
+    )
+    template_payload.setdefault("context", {})
+    template_payload["context"].update(
+        parent=entry["parent"],
+        created_at=created_at,
+    )
+    template_payload.setdefault("huggingface", {})
+    template_payload["huggingface"].update(space=huggingface_space)
+
+    return entry, template_payload
+
+
+def spawn_agent(
+    *,
+    name: str,
+    base_model: str,
+    description: str,
+    domain: str,
+    temperament: str,
+    traits: Iterable[str],
+    parent: Optional[str] = None,
+    namespace: Optional[str] = None,
+    repo_name: Optional[str] = None,
+    publish: bool = True,
+    dry_run: bool = False,
+    space_sdk: str = "gradio",
+    private_space: bool = False,
+    token: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Spawn an agent and optionally publish it to a Hugging Face Space."""
+
+    registry = _load_registry(REGISTRY_PATH)
+    if any(entry.get("name") == name for entry in registry):
+        raise ValueError(f"Agent named '{name}' already exists")
+
+    parent_entry = _resolve_parent(registry, parent)
+
+    slug = _slugify(name)
+    namespace = namespace or f"{slug}-ai"
+    repo_name = repo_name or _slugify(domain) or slug
+
+    template = _load_template(TEMPLATE_PATH)
+    agent_uuid = template.get("uuid")
+    if not agent_uuid:
+        agent_uuid = slug + "-" + dt.datetime.utcnow().strftime("%Y%m%d%H%M%S")
+        template["uuid"] = agent_uuid
+
+    agent_uuid = str(uuid.uuid4())
+    entry, payload = _create_entry(
+        template=template,
+        agent_uuid=agent_uuid,
+        name=name,
+        base_model=base_model,
+        description=description,
+        domain=domain,
+        temperament=temperament,
+        traits=traits,
+        parent_entry=parent_entry,
+        namespace=namespace,
+        repo_name=repo_name,
+    )
+
+    config_path = CONFIG_DIR / f"{slug}.yaml"
+    agent_dir = ASSET_DIR / slug
+    readme_path = agent_dir / "README.md"
+    model_card_path = agent_dir / "MODEL_CARD.md"
+
+    readme_content = _build_readme(payload, entry["huggingface_url"])
+    model_card_content = _build_model_card(payload, base_model)
+
+    result: Dict[str, Any] = {
+        "entry": entry,
+        "config_path": str(config_path),
+        "readme_path": str(readme_path),
+        "model_card_path": str(model_card_path),
+        "huggingface_repo": f"{namespace}/{repo_name}",
+        "files_written": [],
+        "published": False,
+        "errors": {},
+    }
+
+    if not dry_run:
+        _dump_yaml(config_path, payload)
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        readme_path.write_text(readme_content, encoding="utf-8")
+        model_card_path.write_text(model_card_content, encoding="utf-8")
+
+        registry.append(entry)
+        _save_registry(REGISTRY_PATH, registry)
+        result["files_written"].extend(
+            [str(config_path), str(readme_path), str(model_card_path), str(REGISTRY_PATH)]
+        )
+
+        if publish:
+            files_to_publish: Dict[str, str] = {
+                "README.md": readme_content,
+                "MODEL_CARD.md": model_card_content,
+                "config.yaml": json.dumps(payload, indent=2),
+            }
+            try:
+                from hf import publish_space
+
+                publish_space(
+                    result["huggingface_repo"],
+                    files_to_publish,
+                    token=token,
+                    space_sdk=space_sdk,
+                    private=private_space,
+                    commit_message=f"Register agent {name}",
+                )
+                result["published"] = True
+            except RuntimeError as exc:
+                logging.warning("Skipping Hugging Face publish: %s", exc)
+                result["errors"]["huggingface"] = str(exc)
+    else:
+        result["files_written"].extend(
+            [str(config_path), str(readme_path), str(model_card_path), str(REGISTRY_PATH)]
+        )
+
+    return result
+
+
+class _SpawnAgentRequestHandler(BaseHTTPRequestHandler):
+    """HTTP handler that exposes a ``/spawn_agent`` endpoint."""
+
+    server_version = "SpawnAgentHTTP/1.0"
+
+    def _set_headers(self, status: int = 200) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Methods", "POST, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        self.end_headers()
+
+    def do_OPTIONS(self) -> None:  # noqa: N802 - required by BaseHTTPRequestHandler
+        self._set_headers(204)
+
+    def do_POST(self) -> None:  # noqa: N802 - required by BaseHTTPRequestHandler
+        if self.path.rstrip("/") != "/spawn_agent":
+            self._set_headers(404)
+            self.wfile.write(b"{}")
+            return
+
+        content_length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(content_length) if content_length else b"{}"
+
+        try:
+            payload = json.loads(body.decode("utf-8")) if body else {}
+        except json.JSONDecodeError as exc:
+            self._set_headers(400)
+            self.wfile.write(json.dumps({"error": str(exc)}).encode("utf-8"))
+            return
+
+        try:
+            result = spawn_agent(
+                name=payload["name"],
+                base_model=payload["base_model"],
+                description=payload.get("description", ""),
+                domain=payload.get("domain", "general"),
+                temperament=payload.get("temperament", "balanced"),
+                traits=payload.get("traits", []),
+                parent=payload.get("parent"),
+                namespace=payload.get("namespace"),
+                repo_name=payload.get("repo_name"),
+                publish=payload.get("publish", True),
+                dry_run=payload.get("dry_run", False),
+                space_sdk=payload.get("space_sdk", "gradio"),
+                private_space=payload.get("private_space", False),
+                token=payload.get("token"),
+            )
+            status = 200
+        except Exception as exc:  # pragma: no cover - defensive guard
+            logging.exception("Failed to spawn agent")
+            result = {"error": str(exc)}
+            status = 500
+
+        self._set_headers(status)
+        self.wfile.write(json.dumps(result, indent=2).encode("utf-8"))
+
+
+def _run_server(host: str, port: int) -> None:
+    logging.info("Starting spawn agent server on %s:%s", host, port)
+    server = HTTPServer((host, port), _SpawnAgentRequestHandler)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        logging.info("Server interrupted; shutting down")
+    finally:
+        server.server_close()
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--name", help="Name for the new agent")
+    parser.add_argument("--base-model", dest="base_model", help="Backbone model to use")
+    parser.add_argument("--description", default="", help="Short description for the agent")
+    parser.add_argument("--domain", default="general", help="Operational domain")
+    parser.add_argument("--temperament", default="balanced", help="Agent temperament")
+    parser.add_argument(
+        "--traits",
+        action="append",
+        default=[],
+        help="Trait to add to the agent (can be specified multiple times)",
+    )
+    parser.add_argument("--parent", help="Parent agent name or UUID", default=None)
+    parser.add_argument(
+        "--namespace", help="Hugging Face namespace (defaults to '<slug>-ai')", default=None
+    )
+    parser.add_argument(
+        "--repo-name",
+        dest="repo_name",
+        help="Hugging Face repository name (defaults to domain slug)",
+        default=None,
+    )
+    parser.add_argument(
+        "--skip-publish", dest="publish", action="store_false", help="Do not publish"
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Simulate without writing files")
+    parser.add_argument("--space-sdk", default="gradio", help="Space SDK to use")
+    parser.add_argument("--private-space", action="store_true", help="Create private Space")
+    parser.add_argument("--token", help="Hugging Face token", default=None)
+    parser.add_argument("--serve", action="store_true", help="Run an HTTP server")
+    parser.add_argument("--host", default="127.0.0.1", help="Server host")
+    parser.add_argument("--port", default=8000, type=int, help="Server port")
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Logging verbosity",
+    )
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=getattr(logging, args.log_level))
+
+    if args.serve:
+        _run_server(args.host, args.port)
+        return 0
+
+    missing = [field for field in ("name", "base_model") if not getattr(args, field)]
+    if missing:
+        parser.error(f"Missing required arguments: {', '.join(missing)}")
+
+    result = spawn_agent(
+        name=args.name,
+        base_model=args.base_model,
+        description=args.description,
+        domain=args.domain,
+        temperament=args.temperament,
+        traits=args.traits,
+        parent=args.parent,
+        namespace=args.namespace,
+        repo_name=args.repo_name,
+        publish=args.publish,
+        dry_run=args.dry_run,
+        space_sdk=args.space_sdk,
+        private_space=args.private_space,
+        token=args.token,
+    )
+
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/ui/create_agent.html
+++ b/ui/create_agent.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Codex Agent Fabric - Spawn Agent</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      :root {
+        color-scheme: dark light;
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+      body {
+        margin: 0;
+        padding: 2rem;
+        background: #0f172a;
+        color: #e2e8f0;
+      }
+      main {
+        max-width: 720px;
+        margin: 0 auto;
+        background: rgba(15, 23, 42, 0.85);
+        border-radius: 18px;
+        padding: 2.5rem;
+        box-shadow: 0 20px 60px rgba(15, 23, 42, 0.6);
+      }
+      h1 {
+        margin-top: 0;
+        font-size: 2rem;
+        letter-spacing: 0.04em;
+      }
+      p.description {
+        margin-bottom: 2rem;
+        color: #cbd5f5;
+      }
+      label {
+        display: block;
+        font-size: 0.85rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        margin-bottom: 0.35rem;
+        color: #94a3b8;
+      }
+      input[type="text"],
+      textarea,
+      select {
+        width: 100%;
+        padding: 0.75rem 0.9rem;
+        border-radius: 12px;
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        background: rgba(30, 41, 59, 0.85);
+        color: #e2e8f0;
+        margin-bottom: 1.3rem;
+      }
+      textarea {
+        min-height: 90px;
+        resize: vertical;
+      }
+      button {
+        width: 100%;
+        padding: 0.9rem 1.2rem;
+        border-radius: 999px;
+        border: none;
+        background: linear-gradient(135deg, #6366f1, #22d3ee);
+        color: #0f172a;
+        font-size: 1rem;
+        font-weight: 600;
+        cursor: pointer;
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+      }
+      button:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 16px 30px rgba(79, 70, 229, 0.35);
+      }
+      pre {
+        background: rgba(15, 23, 42, 0.6);
+        padding: 1.2rem;
+        border-radius: 12px;
+        overflow-x: auto;
+        font-size: 0.85rem;
+      }
+      .result {
+        margin-top: 2rem;
+      }
+      .status {
+        font-weight: 600;
+        margin-bottom: 0.6rem;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Spawn a Codex Agent</h1>
+      <p class="description">
+        Generate a new agent lineage entry. The service calls
+        <code>scripts/spawn_agent.py</code> via the lightweight HTTP interface and
+        automatically updates <code>registry/lineage.json</code>.
+      </p>
+      <form id="spawn-form">
+        <label for="name">Agent Name</label>
+        <input id="name" name="name" type="text" placeholder="Ariadne" required />
+
+        <label for="baseModel">Base Model</label>
+        <select id="baseModel" name="base_model" required>
+          <option value="">Select a base model</option>
+          <option value="mistral-7b-instruct">mistral-7b-instruct</option>
+          <option value="llama-3-8b">llama-3-8b</option>
+          <option value="qwen2-7b">qwen2-7b</option>
+          <option value="gemma-7b">gemma-7b</option>
+          <option value="falcon-7b">falcon-7b</option>
+        </select>
+
+        <label for="domain">Domain</label>
+        <input id="domain" name="domain" type="text" placeholder="navigation" required />
+
+        <label for="temperament">Temperament</label>
+        <input id="temperament" name="temperament" type="text" placeholder="curious" />
+
+        <label for="description">Description</label>
+        <textarea id="description" name="description" placeholder="Short summary of the agent"></textarea>
+
+        <label for="traits">Traits (comma separated)</label>
+        <input id="traits" name="traits" type="text" placeholder="guidance, mapping, synthesis" />
+
+        <label for="parent">Parent Agent (optional)</label>
+        <input id="parent" name="parent" type="text" placeholder="Lucidia" />
+
+        <label for="namespace">Hugging Face Namespace (optional)</label>
+        <input id="namespace" name="namespace" type="text" placeholder="ariadne-ai" />
+
+        <label for="repoName">Hugging Face Repo Name (optional)</label>
+        <input id="repoName" name="repo_name" type="text" placeholder="thread" />
+
+        <label for="publish">
+          <input id="publish" name="publish" type="checkbox" checked /> Publish to Hugging Face
+        </label>
+
+        <label for="dryRun">
+          <input id="dryRun" name="dry_run" type="checkbox" /> Dry run only
+        </label>
+
+        <button type="submit">Spawn Agent</button>
+      </form>
+      <section class="result" hidden>
+        <div class="status" id="status"></div>
+        <pre id="result"></pre>
+      </section>
+    </main>
+    <script>
+      const form = document.getElementById('spawn-form');
+      const resultContainer = document.querySelector('.result');
+      const resultPre = document.getElementById('result');
+      const statusEl = document.getElementById('status');
+
+      function toTraits(value) {
+        return value
+          .split(/[,\n]/)
+          .map((item) => item.trim())
+          .filter(Boolean);
+      }
+
+      form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        const data = new FormData(form);
+        const payload = {
+          name: data.get('name'),
+          base_model: data.get('base_model'),
+          domain: data.get('domain') || 'general',
+          temperament: data.get('temperament') || 'balanced',
+          description: data.get('description') || '',
+          traits: toTraits(data.get('traits') || ''),
+          parent: data.get('parent') || null,
+          namespace: data.get('namespace') || null,
+          repo_name: data.get('repo_name') || null,
+          publish: data.get('publish') === 'on',
+          dry_run: data.get('dry_run') === 'on',
+        };
+
+        statusEl.textContent = 'Spawning agent…';
+        resultContainer.hidden = false;
+        resultPre.textContent = '';
+
+        try {
+          const response = await fetch('http://localhost:8000/spawn_agent', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+          });
+          const json = await response.json();
+          if (!response.ok) {
+            throw new Error(json.error || 'Failed to spawn agent');
+          }
+          statusEl.textContent = json.published ? 'Agent spawned and published.' : 'Agent spawned locally.';
+          resultPre.textContent = JSON.stringify(json, null, 2);
+        } catch (error) {
+          statusEl.textContent = `Error: ${error.message}`;
+          resultPre.textContent = '';
+        }
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a configurable agent template, seed agent registry, and baseline documentation for the lineage system
- create a spawn_agent orchestration script with CLI and HTTP server plus a minimal UI form to trigger agent creation
- provide Hugging Face publishing helpers and pre-populated agent artifacts for existing lineage members

## Testing
- python -m py_compile scripts/spawn_agent.py hf/push_template.py

------
https://chatgpt.com/codex/tasks/task_e_68fc421018f88329a3fec03711f5f92b