### PR TITLE
Add automated agent onboarding pipeline and dashboard

### DIFF
--- a/api/auth/register_agent.py
+++ b/api/auth/register_agent.py
@@ -1,0 +1,119 @@
+"""FastAPI endpoint and helper for registering deployed agents."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import MutableMapping
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+ROOT = Path(__file__).resolve().parents[2]
+REGISTRY_PATH = ROOT / "registry" / "platform_connections.json"
+
+router = APIRouter()
+
+
+class PlatformLink(BaseModel):
+    """Platform attachment metadata persisted for an agent."""
+
+    name: str
+    integration_id: str
+    status: str
+    scopes: List[str] = Field(default_factory=list)
+    credential_source: str = "unknown"
+    verified_at: datetime
+    details: Optional[str] = None
+
+
+class AgentRegistrationRequest(BaseModel):
+    """Registration payload emitted by the onboarding workflow."""
+
+    name: str
+    role: str
+    email: Optional[str] = None
+    key_id: str
+    key_fingerprint: str
+    permissions: List[str] = Field(default_factory=list)
+    platforms: List[PlatformLink] = Field(default_factory=list)
+    credentials: Optional[Mapping[str, Any]] = None
+
+
+class AgentRegistrationResponse(BaseModel):
+    """Response returned when an agent is stored in the registry."""
+
+    status: str
+    agent: Dict[str, Any]
+
+
+def _load_registry() -> Dict[str, Any]:
+    if not REGISTRY_PATH.exists():
+        return {"agents": []}
+    with REGISTRY_PATH.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, MutableMapping):
+        raise ValueError("platform registry must be a JSON object")
+    registry: Dict[str, Any] = dict(data)
+    registry.setdefault("agents", [])
+    return registry
+
+
+def _save_registry(registry: Mapping[str, Any]) -> None:
+    REGISTRY_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with REGISTRY_PATH.open("w", encoding="utf-8") as handle:
+        json.dump(registry, handle, indent=2)
+
+
+def _serialise_agent(agent: AgentRegistrationRequest) -> Dict[str, Any]:
+    data = agent.model_dump(mode="json")
+    data.setdefault("platforms", [])
+    return data
+
+
+def register_agent(payload: AgentRegistrationRequest | Mapping[str, Any]) -> Dict[str, Any]:
+    """Persist an agent registration request to the platform registry."""
+
+    if isinstance(payload, AgentRegistrationRequest):
+        agent = payload
+    else:
+        agent = AgentRegistrationRequest.model_validate(payload)
+
+    registry = _load_registry()
+    agents: List[Dict[str, Any]] = list(registry.get("agents", []))
+
+    serialised = _serialise_agent(agent)
+    for idx, existing in enumerate(agents):
+        if existing.get("name") == agent.name:
+            agents[idx] = serialised
+            break
+    else:
+        agents.append(serialised)
+
+    registry["agents"] = agents
+    registry["generated_at"] = datetime.now(tz=timezone.utc).isoformat().replace("+00:00", "Z")
+    _save_registry(registry)
+    return {"status": "registered", "agent": serialised}
+
+
+@router.post("/auth/register_agent", response_model=AgentRegistrationResponse)
+def register_agent_endpoint(request: AgentRegistrationRequest) -> AgentRegistrationResponse:
+    """FastAPI endpoint used by automation to register agents."""
+
+    if not request.platforms:
+        raise HTTPException(status_code=400, detail={"code": "missing_platforms"})
+
+    response = register_agent(request)
+    return AgentRegistrationResponse.model_validate(response)
+
+
+__all__ = [
+    "AgentRegistrationRequest",
+    "AgentRegistrationResponse",
+    "PlatformLink",
+    "register_agent",
+    "register_agent_endpoint",
+    "router",
+]

--- a/docs/platform_setup.md
+++ b/docs/platform_setup.md
@@ -1,0 +1,74 @@
+# Platform Setup Guide
+
+This document describes how to provision credentials and infrastructure for the
+Codex agent deployment pipeline. Use it as the source of truth when refreshing
+secrets, onboarding new operators, or verifying that the integration matrix is
+healthy after a redeploy.
+
+## 1. Prerequisites
+
+- Access to the shared secret manager (Keycloak realm **codex-ops** or the
+  Supabase project configured for automation).
+- Membership in the relevant platform organizations (GitHub, Slack, Notion,
+  Linear, Dropbox, HubSpot, Hugging Face).
+- Docker and Docker Compose installed locally, or access to the automation
+  runner on DigitalOcean.
+
+## 2. Credential Issuance Checklist
+
+For each platform use the following baseline:
+
+| Platform      | Credential Type                         | Notes |
+| ------------- | --------------------------------------- | ----- |
+| GitHub        | Personal Access Token (Fine-grained)    | Enable `Contents`, `Issues`, and `Actions` scopes. Rotate every 90 days. |
+| Hugging Face  | User Access Token                       | Grant `read` + `write` scopes for models and spaces. |
+| Slack         | Bot Token (`xoxb-…`)                    | Install the "Codex Ops" app in the workspace and enable `chat:write` + `channels:read`. |
+| Notion        | Internal Integration Token              | Share required databases and spaces with the integration. |
+| Linear        | API Key                                 | Assign to the `Automation` team with `write` permissions on issues. |
+| Dropbox       | OAuth 2 Refresh Token                   | Limit to the `/Codex` folder; enable automatic refresh via Keycloak. |
+| HubSpot       | Private App Token                       | Scope for `crm.objects.contacts.read`/`write` and `tickets.read`. |
+
+Store tokens in Keycloak secrets or encrypt them with `sops-age` before
+committing to configuration repositories.
+
+## 3. Environment Bootstrapping
+
+```bash
+bash setup_env.sh
+export GITHUB_TOKEN=<token>
+export HF_TOKEN=<token>
+export SLACK_BOT_TOKEN=<token>
+export NOTION_TOKEN=<token>
+export LINEAR_API_KEY=<token>
+export DROPBOX_KEY=<token>
+export HUBSPOT_TOKEN=<token>
+docker compose up -d
+python scripts/onboard_agents.py
+```
+
+- The script writes deployment logs to `logs/deployment.log` and an aggregated
+  registry to `registry/platform_connections.json`.
+- When running inside CI, inject credentials as environment variables and allow
+  the script to consume them dynamically.
+
+## 4. Verification Procedure
+
+1. Run the ping checks:
+   - `GET /api/github/ping`
+   - `GET /api/slack/ping`
+   - `GET /api/huggingface/ping`
+2. Review the onboarding dashboard (`ui/pages/onboarding.tsx`) for current
+   status and any agents pending action.
+3. Confirm that a Slack summary arrives in `#codex-ops` with the deployment
+   counts.
+
+## 5. Monitoring Expectations
+
+- Heartbeat interval: **10 minutes**
+- Alert routing: `#dev-ops` Slack channel + Grafana Alertmanager
+- Track metrics for token refresh failures, failed logins, and API latency.
+
+## 6. Role Downgrade Rule
+
+If an agent has not logged activity in >90 days downgrade the role to
+`observer` and remove write scopes from the associated tokens.

--- a/logs/deployment.log
+++ b/logs/deployment.log
@@ -1,0 +1,39 @@
+2025-10-25 03:29:42,639 [INFO] Starting agent onboarding pipeline
+2025-10-25 03:29:42,640 [INFO] Loaded 8 agent definitions
+2025-10-25 03:29:42,640 [INFO] Generated credential set for Athena (key id 538f9d205c0f8de0)
+2025-10-25 03:29:42,640 [INFO] [github] GitHub credential check → connected
+2025-10-25 03:29:42,640 [INFO] [slack] Slack credential check → connected
+2025-10-25 03:29:42,640 [INFO] [linear] Linear credential check → connected
+2025-10-25 03:29:43,256 [INFO] Registered Athena with status registered
+2025-10-25 03:29:43,256 [INFO] Generated credential set for Lucidia (key id 9e41a98e9db4a5b5)
+2025-10-25 03:29:43,256 [INFO] [github] GitHub credential check → connected
+2025-10-25 03:29:43,256 [INFO] [notion] Notion credential check → connected
+2025-10-25 03:29:43,257 [INFO] Registered Lucidia with status registered
+2025-10-25 03:29:43,257 [INFO] Generated credential set for Seraphina (key id a9e66372fbd2389a)
+2025-10-25 03:29:43,257 [INFO] [slack] Slack credential check → connected
+2025-10-25 03:29:43,257 [INFO] [linear] Linear credential check → connected
+2025-10-25 03:29:43,258 [INFO] Registered Seraphina with status registered
+2025-10-25 03:29:43,258 [INFO] Generated credential set for Genevieve (key id 4cf5b5214b874c32)
+2025-10-25 03:29:43,258 [INFO] [hubspot] HubSpot credential check → expired
+2025-10-25 03:29:43,259 [INFO] Registered Genevieve with status registered
+2025-10-25 03:29:43,259 [INFO] Generated credential set for Calliope (key id 641af8b2ba589a24)
+2025-10-25 03:29:43,259 [INFO] [huggingface] Hugging Face credential check → connected
+2025-10-25 03:29:43,260 [INFO] Registered Calliope with status registered
+2025-10-25 03:29:43,260 [INFO] Generated credential set for Kai (key id 7fbd300aea6eeba3)
+2025-10-25 03:29:43,260 [INFO] [github] GitHub credential check → missing_credentials
+2025-10-25 03:29:43,260 [INFO] Registered Kai with status registered
+2025-10-25 03:29:43,261 [INFO] Generated credential set for Alice (key id fbeed12d4a88bffd)
+2025-10-25 03:29:43,261 [INFO] [notion] Notion credential check → connected
+2025-10-25 03:29:43,261 [INFO] Registered Alice with status registered
+2025-10-25 03:29:43,261 [INFO] Generated credential set for Miriam (key id 2e14136e1e5307cd)
+2025-10-25 03:29:43,261 [INFO] [dropbox] Dropbox credential check → connected
+2025-10-25 03:29:43,274 [INFO] Registered Miriam with status registered
+2025-10-25 03:29:43,275 [INFO] Onboarding summary ready
+2025-10-25 03:29:43,275 [INFO] SUMMARY ✅ Athena — GitHub + Slack + Linear linked
+2025-10-25 03:29:43,275 [INFO] SUMMARY ✅ Lucidia — GitHub + Notion linked
+2025-10-25 03:29:43,275 [INFO] SUMMARY ✅ Seraphina — Slack + Linear linked
+2025-10-25 03:29:43,275 [INFO] SUMMARY ⚠️ Genevieve — HubSpot key expired
+2025-10-25 03:29:43,275 [INFO] SUMMARY ✅ Calliope — Hugging Face linked
+2025-10-25 03:29:43,275 [INFO] SUMMARY ❌ Kai — GitHub credentials missing
+2025-10-25 03:29:43,275 [INFO] SUMMARY ✅ Alice — Notion linked
+2025-10-25 03:29:43,275 [INFO] SUMMARY ✅ Miriam — Dropbox linked

--- a/registry/agent_roles.json
+++ b/registry/agent_roles.json
@@ -1,0 +1,201 @@
+{
+  "roles": {
+    "admin": {
+      "description": "Full administrative access to provisioning, credentials, and monitoring dashboards.",
+      "members": ["Athena", "Minerva", "Magnus"],
+      "scopes": {
+        "github": ["repos:full", "org:admin"],
+        "slack": ["chat:write", "channels:manage"],
+        "linear": ["issues:manage", "projects:manage"],
+        "notion": ["databases:manage", "pages:publish"],
+        "monitoring": ["dashboards:configure", "alerts:manage"]
+      }
+    },
+    "maintainer": {
+      "description": "Can operate day-to-day integrations, refresh tokens, and manage deployment health.",
+      "members": ["Lucidia", "Persephone", "Cassius", "Seraphina", "Genevieve", "Cordelia"],
+      "scopes": {
+        "github": ["repos:write", "issues:triage"],
+        "huggingface": ["models:write", "spaces:manage"],
+        "slack": ["chat:write", "channels:read"],
+        "notion": ["databases:write", "pages:update"],
+        "hubspot": ["crm.objects.contacts.write"],
+        "monitoring": ["dashboards:view"]
+      }
+    },
+    "contributor": {
+      "description": "Create content, triage items, and trigger pre-approved automation.",
+      "members": ["Kai", "Octavia", "Silas", "Calliope"],
+      "scopes": {
+        "github": ["issues:create"],
+        "huggingface": ["models:read"],
+        "linear": ["issues:create"],
+        "notion": ["pages:create"]
+      }
+    },
+    "observer": {
+      "description": "Read-only view into dashboards and shared documents.",
+      "members": ["Alice", "Miriam", "Elias"],
+      "scopes": {
+        "github": ["repos:read"],
+        "notion": ["pages:read"],
+        "dropbox": ["files.metadata.read"],
+        "monitoring": ["dashboards:view"]
+      }
+    }
+  },
+  "agents": [
+    {
+      "name": "Athena",
+      "role": "admin",
+      "email": "athena.ops@example.com",
+      "platforms": [
+        {
+          "name": "GitHub",
+          "integration_id": "github",
+          "credential_env": "ATHENA_GITHUB_TOKEN",
+          "scopes": ["repos:full", "org:admin"],
+          "test_token": "ghp_athena_demo_token",
+          "expires_at": "2030-01-01T00:00:00Z"
+        },
+        {
+          "name": "Slack",
+          "integration_id": "slack",
+          "credential_env": "ATHENA_SLACK_BOT_TOKEN",
+          "scopes": ["chat:write", "channels:manage"],
+          "test_token": "xoxb-athena-demo",
+          "expires_at": "2029-06-01T00:00:00Z"
+        },
+        {
+          "name": "Linear",
+          "integration_id": "linear",
+          "credential_env": "ATHENA_LINEAR_TOKEN",
+          "scopes": ["issues:manage"],
+          "test_token": "lin_tok_athena_demo",
+          "expires_at": "2028-12-31T00:00:00Z"
+        }
+      ]
+    },
+    {
+      "name": "Lucidia",
+      "role": "maintainer",
+      "email": "lucidia.ops@example.com",
+      "platforms": [
+        {
+          "name": "GitHub",
+          "integration_id": "github",
+          "credential_env": "LUCIDIA_GITHUB_TOKEN",
+          "scopes": ["repos:write", "issues:triage"],
+          "test_token": "ghp_lucidia_demo",
+          "expires_at": "2029-01-01T00:00:00Z"
+        },
+        {
+          "name": "Notion",
+          "integration_id": "notion",
+          "credential_env": "LUCIDIA_NOTION_TOKEN",
+          "scopes": ["databases:write", "pages:update"],
+          "test_token": "notion_demo_secret_lucidia",
+          "expires_at": "2031-04-01T00:00:00Z"
+        }
+      ]
+    },
+    {
+      "name": "Seraphina",
+      "role": "maintainer",
+      "email": "seraphina.ops@example.com",
+      "platforms": [
+        {
+          "name": "Slack",
+          "integration_id": "slack",
+          "credential_env": "SERAPHINA_SLACK_TOKEN",
+          "scopes": ["chat:write", "channels:read"],
+          "test_token": "xoxb-seraphina-demo",
+          "expires_at": "2029-09-01T00:00:00Z"
+        },
+        {
+          "name": "Linear",
+          "integration_id": "linear",
+          "credential_env": "SERAPHINA_LINEAR_TOKEN",
+          "scopes": ["issues:manage"],
+          "test_token": "lin_tok_seraphina_demo",
+          "expires_at": "2028-12-31T00:00:00Z"
+        }
+      ]
+    },
+    {
+      "name": "Genevieve",
+      "role": "maintainer",
+      "email": "genevieve.crm@example.com",
+      "platforms": [
+        {
+          "name": "HubSpot",
+          "integration_id": "hubspot",
+          "credential_env": "GENEVIEVE_HUBSPOT_TOKEN",
+          "scopes": ["crm.objects.contacts.write"],
+          "test_token": "pat-genevieve-demo",
+          "expires_at": "2023-01-01T00:00:00Z"
+        }
+      ]
+    },
+    {
+      "name": "Calliope",
+      "role": "contributor",
+      "email": "calliope.ml@example.com",
+      "platforms": [
+        {
+          "name": "Hugging Face",
+          "integration_id": "huggingface",
+          "credential_env": "CALLIOPE_HF_TOKEN",
+          "scopes": ["models:write", "spaces:manage"],
+          "test_token": "hf_demo_calliope",
+          "expires_at": "2030-05-01T00:00:00Z"
+        }
+      ]
+    },
+    {
+      "name": "Kai",
+      "role": "contributor",
+      "email": "kai.ops@example.com",
+      "platforms": [
+        {
+          "name": "GitHub",
+          "integration_id": "github",
+          "credential_env": "KAI_GITHUB_TOKEN",
+          "scopes": ["issues:create"],
+          "test_token": null,
+          "expires_at": null
+        }
+      ]
+    },
+    {
+      "name": "Alice",
+      "role": "observer",
+      "email": "alice.memory@example.com",
+      "platforms": [
+        {
+          "name": "Notion",
+          "integration_id": "notion",
+          "credential_env": "ALICE_NOTION_TOKEN",
+          "scopes": ["pages:read"],
+          "test_token": "notion_demo_observer_alice",
+          "expires_at": "2032-01-01T00:00:00Z"
+        }
+      ]
+    },
+    {
+      "name": "Miriam",
+      "role": "observer",
+      "email": "miriam.archive@example.com",
+      "platforms": [
+        {
+          "name": "Dropbox",
+          "integration_id": "dropbox",
+          "credential_env": "MIRIAM_DROPBOX_TOKEN",
+          "scopes": ["files.metadata.read"],
+          "test_token": "dropbox_demo_miriam",
+          "expires_at": "2030-08-01T00:00:00Z"
+        }
+      ]
+    }
+  ]
+}

--- a/registry/platform_connections.json
+++ b/registry/platform_connections.json
@@ -1,0 +1,287 @@
+{
+  "generated_at": "2025-10-25T03:29:43.274707Z",
+  "agents": [
+    {
+      "name": "Athena",
+      "role": "admin",
+      "email": "athena.ops@example.com",
+      "key_id": "538f9d205c0f8de0",
+      "key_fingerprint": "003cfbb6164cd3d1",
+      "permissions": [
+        "github:org:admin",
+        "github:repos:full",
+        "linear:issues:manage",
+        "linear:projects:manage",
+        "monitoring:alerts:manage",
+        "monitoring:dashboards:configure",
+        "notion:databases:manage",
+        "notion:pages:publish",
+        "slack:channels:manage",
+        "slack:chat:write"
+      ],
+      "platforms": [
+        {
+          "name": "GitHub",
+          "integration_id": "github",
+          "status": "connected",
+          "scopes": [
+            "repos:full",
+            "org:admin"
+          ],
+          "credential_source": "seed",
+          "verified_at": "2025-10-25T03:29:42.640728Z",
+          "details": null
+        },
+        {
+          "name": "Slack",
+          "integration_id": "slack",
+          "status": "connected",
+          "scopes": [
+            "chat:write",
+            "channels:manage"
+          ],
+          "credential_source": "seed",
+          "verified_at": "2025-10-25T03:29:42.640844Z",
+          "details": null
+        },
+        {
+          "name": "Linear",
+          "integration_id": "linear",
+          "status": "connected",
+          "scopes": [
+            "issues:manage"
+          ],
+          "credential_source": "seed",
+          "verified_at": "2025-10-25T03:29:42.640922Z",
+          "details": null
+        }
+      ]
+    },
+    {
+      "name": "Lucidia",
+      "role": "maintainer",
+      "email": "lucidia.ops@example.com",
+      "key_id": "9e41a98e9db4a5b5",
+      "key_fingerprint": "23f5d31cebd4f771",
+      "permissions": [
+        "github:issues:triage",
+        "github:repos:write",
+        "hubspot:crm.objects.contacts.write",
+        "huggingface:models:write",
+        "huggingface:spaces:manage",
+        "monitoring:dashboards:view",
+        "notion:databases:write",
+        "notion:pages:update",
+        "slack:channels:read",
+        "slack:chat:write"
+      ],
+      "platforms": [
+        {
+          "name": "GitHub",
+          "integration_id": "github",
+          "status": "connected",
+          "scopes": [
+            "repos:write",
+            "issues:triage"
+          ],
+          "credential_source": "seed",
+          "verified_at": "2025-10-25T03:29:43.256704Z",
+          "details": null
+        },
+        {
+          "name": "Notion",
+          "integration_id": "notion",
+          "status": "connected",
+          "scopes": [
+            "databases:write",
+            "pages:update"
+          ],
+          "credential_source": "seed",
+          "verified_at": "2025-10-25T03:29:43.256761Z",
+          "details": null
+        }
+      ]
+    },
+    {
+      "name": "Seraphina",
+      "role": "maintainer",
+      "email": "seraphina.ops@example.com",
+      "key_id": "a9e66372fbd2389a",
+      "key_fingerprint": "0175d3cfe564d19b",
+      "permissions": [
+        "github:issues:triage",
+        "github:repos:write",
+        "hubspot:crm.objects.contacts.write",
+        "huggingface:models:write",
+        "huggingface:spaces:manage",
+        "monitoring:dashboards:view",
+        "notion:databases:write",
+        "notion:pages:update",
+        "slack:channels:read",
+        "slack:chat:write"
+      ],
+      "platforms": [
+        {
+          "name": "Slack",
+          "integration_id": "slack",
+          "status": "connected",
+          "scopes": [
+            "chat:write",
+            "channels:read"
+          ],
+          "credential_source": "seed",
+          "verified_at": "2025-10-25T03:29:43.257625Z",
+          "details": null
+        },
+        {
+          "name": "Linear",
+          "integration_id": "linear",
+          "status": "connected",
+          "scopes": [
+            "issues:manage"
+          ],
+          "credential_source": "seed",
+          "verified_at": "2025-10-25T03:29:43.257680Z",
+          "details": null
+        }
+      ]
+    },
+    {
+      "name": "Genevieve",
+      "role": "maintainer",
+      "email": "genevieve.crm@example.com",
+      "key_id": "4cf5b5214b874c32",
+      "key_fingerprint": "ab42b341fd5d651c",
+      "permissions": [
+        "github:issues:triage",
+        "github:repos:write",
+        "hubspot:crm.objects.contacts.write",
+        "huggingface:models:write",
+        "huggingface:spaces:manage",
+        "monitoring:dashboards:view",
+        "notion:databases:write",
+        "notion:pages:update",
+        "slack:channels:read",
+        "slack:chat:write"
+      ],
+      "platforms": [
+        {
+          "name": "HubSpot",
+          "integration_id": "hubspot",
+          "status": "expired",
+          "scopes": [
+            "crm.objects.contacts.write"
+          ],
+          "credential_source": "seed",
+          "verified_at": "2025-10-25T03:29:43.258443Z",
+          "details": "Token expired at 2023-01-01T00:00:00Z"
+        }
+      ]
+    },
+    {
+      "name": "Calliope",
+      "role": "contributor",
+      "email": "calliope.ml@example.com",
+      "key_id": "641af8b2ba589a24",
+      "key_fingerprint": "04c9033cb92e98fb",
+      "permissions": [
+        "github:issues:create",
+        "huggingface:models:read",
+        "linear:issues:create",
+        "notion:pages:create"
+      ],
+      "platforms": [
+        {
+          "name": "Hugging Face",
+          "integration_id": "huggingface",
+          "status": "connected",
+          "scopes": [
+            "models:write",
+            "spaces:manage"
+          ],
+          "credential_source": "seed",
+          "verified_at": "2025-10-25T03:29:43.259372Z",
+          "details": null
+        }
+      ]
+    },
+    {
+      "name": "Kai",
+      "role": "contributor",
+      "email": "kai.ops@example.com",
+      "key_id": "7fbd300aea6eeba3",
+      "key_fingerprint": "5dc23b0afa3521ea",
+      "permissions": [
+        "github:issues:create",
+        "huggingface:models:read",
+        "linear:issues:create",
+        "notion:pages:create"
+      ],
+      "platforms": [
+        {
+          "name": "GitHub",
+          "integration_id": "github",
+          "status": "missing_credentials",
+          "scopes": [
+            "issues:create"
+          ],
+          "credential_source": "unavailable",
+          "verified_at": "2025-10-25T03:29:43.260278Z",
+          "details": "No credential found in environment or seed data."
+        }
+      ]
+    },
+    {
+      "name": "Alice",
+      "role": "observer",
+      "email": "alice.memory@example.com",
+      "key_id": "fbeed12d4a88bffd",
+      "key_fingerprint": "763cc301ade325c5",
+      "permissions": [
+        "dropbox:files.metadata.read",
+        "github:repos:read",
+        "monitoring:dashboards:view",
+        "notion:pages:read"
+      ],
+      "platforms": [
+        {
+          "name": "Notion",
+          "integration_id": "notion",
+          "status": "connected",
+          "scopes": [
+            "pages:read"
+          ],
+          "credential_source": "seed",
+          "verified_at": "2025-10-25T03:29:43.261115Z",
+          "details": null
+        }
+      ]
+    },
+    {
+      "name": "Miriam",
+      "role": "observer",
+      "email": "miriam.archive@example.com",
+      "key_id": "2e14136e1e5307cd",
+      "key_fingerprint": "5a34e992f05bf9e9",
+      "permissions": [
+        "dropbox:files.metadata.read",
+        "github:repos:read",
+        "monitoring:dashboards:view",
+        "notion:pages:read"
+      ],
+      "platforms": [
+        {
+          "name": "Dropbox",
+          "integration_id": "dropbox",
+          "status": "connected",
+          "scopes": [
+            "files.metadata.read"
+          ],
+          "credential_source": "seed",
+          "verified_at": "2025-10-25T03:29:43.261936Z",
+          "details": null
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/onboard_agents.py
+++ b/scripts/onboard_agents.py
@@ -1,0 +1,345 @@
+"""Automated onboarding workflow for Codex deployment agents.
+
+This script coordinates credential verification, agent registration,
+platform linking, and status reporting.  It consumes the declarative
+registry under ``registry/agent_roles.json`` and produces
+``registry/platform_connections.json`` as well as a log stream at
+``logs/deployment.log``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import secrets
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional
+import urllib.error
+import urllib.request
+
+# Ensure the repository root is importable when the script runs directly.
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+REGISTRY_DIR = ROOT / "registry"
+AGENT_ROLE_PATH = REGISTRY_DIR / "agent_roles.json"
+PLATFORM_CONNECTIONS_PATH = REGISTRY_DIR / "platform_connections.json"
+LOG_PATH = ROOT / "logs" / "deployment.log"
+
+STATUS_MESSAGES = {
+    "connected": "connected",
+    "expired": "key expired",
+    "missing_credentials": "credentials missing",
+    "invalid": "credential check failed",
+}
+
+
+@dataclass
+class PlatformSpec:
+    """Declarative configuration for a single platform integration."""
+
+    name: str
+    integration_id: str
+    credential_env: str
+    scopes: List[str]
+    test_token: Optional[str]
+    expires_at: Optional[datetime]
+
+
+@dataclass
+class AgentSpec:
+    """Agent metadata sourced from ``agent_roles.json``."""
+
+    name: str
+    role: str
+    email: str
+    platforms: List[PlatformSpec]
+
+
+@dataclass
+class PlatformStatus:
+    """Result of verifying a platform credential during onboarding."""
+
+    name: str
+    integration_id: str
+    status: str
+    scopes: List[str]
+    credential_source: str
+    last_verified: datetime
+    details: Optional[str] = None
+
+    def payload(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "integration_id": self.integration_id,
+            "status": self.status,
+            "scopes": self.scopes,
+            "credential_source": self.credential_source,
+            "verified_at": self.last_verified.isoformat().replace("+00:00", "Z"),
+            "details": self.details,
+        }
+
+
+@dataclass
+class AgentResult:
+    """Aggregate onboarding output for a single agent."""
+
+    name: str
+    role: str
+    email: str
+    key_id: str
+    key_fingerprint: str
+    permissions: List[str]
+    platforms: List[PlatformStatus]
+
+    def registration_payload(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "role": self.role,
+            "email": self.email,
+            "key_id": self.key_id,
+            "key_fingerprint": self.key_fingerprint,
+            "permissions": self.permissions,
+            "platforms": [platform.payload() for platform in self.platforms],
+        }
+
+
+def configure_logging() -> None:
+    """Wire log output to both stdout and the deployment log file."""
+
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    handlers = [logging.StreamHandler(sys.stdout), logging.FileHandler(LOG_PATH)]
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        handlers=handlers,
+    )
+
+
+def load_agent_registry(path: Path) -> tuple[Mapping[str, Any], List[AgentSpec]]:
+    """Load and validate the agent role manifest."""
+
+    if not path.exists():
+        raise FileNotFoundError(f"Agent role registry not found at {path}")
+
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+    roles: Mapping[str, Any] = payload.get("roles", {})
+    agent_specs: List[AgentSpec] = []
+
+    for agent_entry in payload.get("agents", []):
+        platforms: List[PlatformSpec] = []
+        for platform_entry in agent_entry.get("platforms", []):
+            expires_raw = platform_entry.get("expires_at")
+            expires_at = None
+            if isinstance(expires_raw, str) and expires_raw:
+                expires_at = parse_timestamp(expires_raw)
+            platforms.append(
+                PlatformSpec(
+                    name=platform_entry["name"],
+                    integration_id=platform_entry.get("integration_id", platform_entry["name"].lower()),
+                    credential_env=platform_entry.get("credential_env", ""),
+                    scopes=list(platform_entry.get("scopes", [])),
+                    test_token=platform_entry.get("test_token"),
+                    expires_at=expires_at,
+                )
+            )
+        agent_specs.append(
+            AgentSpec(
+                name=agent_entry["name"],
+                role=agent_entry["role"],
+                email=agent_entry.get("email", ""),
+                platforms=platforms,
+            )
+        )
+
+    return roles, agent_specs
+
+
+def parse_timestamp(value: str) -> datetime:
+    """Parse ISO-8601 timestamps that may include a ``Z`` suffix."""
+
+    if value.endswith("Z"):
+        value = value[:-1]
+    return datetime.fromisoformat(value).replace(tzinfo=timezone.utc)
+
+
+def resolve_role_permissions(role: str, roles: Mapping[str, Any]) -> List[str]:
+    """Expand a role definition into platform-scope permission strings."""
+
+    role_info = roles.get(role, {})
+    scopes: MutableMapping[str, Iterable[str]] = role_info.get("scopes", {})
+    permissions: List[str] = []
+    for platform, platform_scopes in scopes.items():
+        for scope in platform_scopes:
+            permissions.append(f"{platform}:{scope}")
+    return sorted(set(permissions))
+
+
+def generate_api_keypair(agent_name: str) -> tuple[str, str, str]:
+    """Generate a unique API keypair and a safe-to-log fingerprint."""
+
+    key_id = secrets.token_hex(8)
+    secret = secrets.token_urlsafe(32)
+    fingerprint = hashlib.sha256(f"{agent_name}:{secret}".encode("utf-8")).hexdigest()[:16]
+    return key_id, secret, fingerprint
+
+
+def verify_platform_credentials(platform: PlatformSpec) -> PlatformStatus:
+    """Perform lightweight verification of credentials for a platform."""
+
+    now = datetime.now(tz=timezone.utc)
+    raw_token = os.environ.get(platform.credential_env)
+    credential_source = "env" if raw_token else "seed"
+    if not raw_token:
+        raw_token = platform.test_token
+
+    status = "connected"
+    details: Optional[str] = None
+
+    if not raw_token:
+        status = "missing_credentials"
+        credential_source = "unavailable"
+        details = "No credential found in environment or seed data."
+    elif platform.expires_at and platform.expires_at < now:
+        status = "expired"
+        details = f"Token expired at {platform.expires_at.isoformat().replace('+00:00', 'Z')}"
+    elif len(raw_token) < 12:
+        status = "invalid"
+        details = "Token too short to satisfy basic validity heuristics."
+
+    logging.info(
+        "[%s] %s credential check → %s",
+        platform.integration_id,
+        platform.name,
+        status,
+    )
+    return PlatformStatus(
+        name=platform.name,
+        integration_id=platform.integration_id,
+        status=status,
+        scopes=platform.scopes,
+        credential_source=credential_source,
+        last_verified=now,
+        details=details,
+    )
+
+
+def register_agent(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Register the agent either via HTTP or the local FastAPI handler."""
+
+    api_root = os.environ.get("ONBOARDING_API_URL")
+    if api_root:
+        url = f"{api_root.rstrip('/')}/auth/register_agent"
+        try:
+            request = urllib.request.Request(
+                url,
+                data=json.dumps(payload).encode("utf-8"),
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            with urllib.request.urlopen(request, timeout=10) as response:
+                return json.loads(response.read().decode("utf-8"))
+        except urllib.error.URLError as exc:  # pragma: no cover - network optional
+            logging.warning("Remote registration at %s failed: %s", url, exc)
+
+    try:
+        from api.auth.register_agent import register_agent as local_register
+    except Exception as exc:  # pragma: no cover - import errors surface loudly
+        logging.error("Unable to import local register_agent handler: %s", exc)
+        raise
+
+    return local_register(payload)
+
+
+def compile_summary(results: List[AgentResult]) -> str:
+    """Generate a human-readable summary of onboarding outcomes."""
+
+    lines: List[str] = []
+    for result in results:
+        statuses = result.platforms
+        if statuses and all(status.status == "connected" for status in statuses):
+            platforms_linked = " + ".join(status.name for status in statuses)
+            lines.append(f"✅ {result.name} — {platforms_linked} linked")
+            continue
+
+        issues: List[str] = []
+        emoji = "❌"
+        for status in statuses:
+            if status.status != "connected":
+                message = STATUS_MESSAGES.get(status.status, status.status)
+                issues.append(f"{status.name} {message}")
+                if status.status == "expired":
+                    emoji = "⚠️"
+        if not statuses:
+            issues.append("no integrations configured")
+        lines.append(f"{emoji} {result.name} — {', '.join(issues)}")
+    return "\n".join(lines)
+
+
+def write_platform_registry(payload: Mapping[str, Any]) -> None:
+    """Persist the aggregated platform connection registry."""
+
+    REGISTRY_DIR.mkdir(parents=True, exist_ok=True)
+    with PLATFORM_CONNECTIONS_PATH.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2)
+
+
+def main() -> None:
+    configure_logging()
+    logging.info("Starting agent onboarding pipeline")
+
+    roles, agents = load_agent_registry(AGENT_ROLE_PATH)
+    logging.info("Loaded %d agent definitions", len(agents))
+
+    results: List[AgentResult] = []
+
+    for agent in agents:
+        key_id, secret, fingerprint = generate_api_keypair(agent.name)
+        logging.info("Generated credential set for %s (key id %s)", agent.name, key_id)
+        # Secret is intentionally not logged beyond this point; a real deployment
+        # would store it in a vault. Here we retain the fingerprint for auditing.
+
+        permissions = resolve_role_permissions(agent.role, roles)
+        platform_statuses: List[PlatformStatus] = [
+            verify_platform_credentials(platform) for platform in agent.platforms
+        ]
+
+        agent_result = AgentResult(
+            name=agent.name,
+            role=agent.role,
+            email=agent.email,
+            key_id=key_id,
+            key_fingerprint=fingerprint,
+            permissions=permissions,
+            platforms=platform_statuses,
+        )
+        payload = agent_result.registration_payload()
+        payload["credentials"] = {"secret_preview": secret[:4] + "…" + secret[-4:]}
+
+        response = register_agent(payload)
+        logging.info("Registered %s with status %s", agent.name, response.get("status"))
+        results.append(agent_result)
+
+    registry_snapshot = {
+        "generated_at": datetime.now(tz=timezone.utc).isoformat().replace("+00:00", "Z"),
+        "agents": [result.registration_payload() for result in results],
+    }
+    write_platform_registry(registry_snapshot)
+
+    summary = compile_summary(results)
+    logging.info("Onboarding summary ready")
+    for line in summary.splitlines():
+        logging.info("SUMMARY %s", line)
+    print(summary)
+
+
+if __name__ == "__main__":
+    main()

--- a/ui/pages/onboarding.tsx
+++ b/ui/pages/onboarding.tsx
@@ -1,0 +1,286 @@
+import { useEffect, useMemo, useState } from "react";
+
+type PlatformStatus = {
+  name: string;
+  integration_id: string;
+  status: string;
+  scopes: string[];
+  credential_source: string;
+  verified_at?: string;
+  details?: string | null;
+};
+
+type AgentRecord = {
+  name: string;
+  role: string;
+  email?: string;
+  key_id: string;
+  key_fingerprint: string;
+  permissions: string[];
+  platforms: PlatformStatus[];
+};
+
+type RegistrySnapshot = {
+  generated_at?: string;
+  agents: AgentRecord[];
+};
+
+type SummaryCounts = {
+  total: number;
+  healthy: number;
+  warnings: number;
+  blocking: number;
+};
+
+const STATUS_BADGE: Record<string, { label: string; tone: string }> = {
+  connected: { label: "Connected", tone: "#0f9d58" },
+  expired: { label: "Token Expired", tone: "#f4b400" },
+  missing_credentials: { label: "Missing Credentials", tone: "#db4437" },
+  invalid: { label: "Verification Failed", tone: "#db4437" },
+};
+
+function fetchRegistry(): Promise<RegistrySnapshot> {
+  return fetch("/registry/platform_connections.json", { cache: "no-store" })
+    .then(async (response) => {
+      if (!response.ok) {
+        throw new Error(`Failed to load registry (${response.status})`);
+      }
+      return (await response.json()) as RegistrySnapshot;
+    });
+}
+
+function computeSummary(snapshot: RegistrySnapshot | null): SummaryCounts {
+  if (!snapshot) {
+    return { total: 0, healthy: 0, warnings: 0, blocking: 0 };
+  }
+
+  return snapshot.agents.reduce<SummaryCounts>((acc, agent) => {
+    acc.total += 1;
+    const statuses = agent.platforms.map((platform) => platform.status);
+    if (statuses.every((status) => status === "connected")) {
+      acc.healthy += 1;
+    } else if (statuses.some((status) => status === "expired")) {
+      acc.warnings += 1;
+    } else {
+      acc.blocking += 1;
+    }
+    return acc;
+  }, { total: 0, healthy: 0, warnings: 0, blocking: 0 });
+}
+
+function formatTimestamp(value?: string): string {
+  if (!value) {
+    return "—";
+  }
+  try {
+    return new Date(value).toLocaleString();
+  } catch (error) {
+    return value;
+  }
+}
+
+function renderStatusBadge(status: string): JSX.Element {
+  const badge = STATUS_BADGE[status] ?? { label: status, tone: "#5f6368" };
+  return (
+    <span
+      style={{
+        backgroundColor: `${badge.tone}1f`,
+        border: `1px solid ${badge.tone}`,
+        borderRadius: "999px",
+        color: badge.tone,
+        display: "inline-block",
+        fontSize: "0.75rem",
+        fontWeight: 600,
+        padding: "0.15rem 0.6rem",
+        textTransform: "uppercase",
+      }}
+    >
+      {badge.label}
+    </span>
+  );
+}
+
+export default function OnboardingDashboard(): JSX.Element {
+  const [registry, setRegistry] = useState<RegistrySnapshot | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchRegistry()
+      .then((snapshot) => {
+        if (!cancelled) {
+          setRegistry(snapshot);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setError((err as Error).message);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const summary = useMemo(() => computeSummary(registry), [registry]);
+
+  return (
+    <div
+      style={{
+        backgroundColor: "#0f172a",
+        color: "#e2e8f0",
+        minHeight: "100vh",
+        padding: "2.5rem 3rem",
+        fontFamily: "'Inter', 'Segoe UI', sans-serif",
+      }}
+    >
+      <header style={{ marginBottom: "2rem" }}>
+        <h1 style={{ fontSize: "2.25rem", marginBottom: "0.25rem" }}>
+          Agent Deployment & Onboarding
+        </h1>
+        <p style={{ color: "#94a3b8", maxWidth: "48rem" }}>
+          Live view of credential verification, platform integrations, and role
+          assignments across the Codex agent fleet.
+        </p>
+      </header>
+
+      <section
+        style={{
+          backgroundColor: "#1e293b",
+          borderRadius: "1rem",
+          display: "grid",
+          gap: "1.25rem",
+          gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+          marginBottom: "2rem",
+          padding: "1.5rem",
+        }}
+      >
+        {[{
+          label: "Agents",
+          value: summary.total,
+        }, {
+          label: "Healthy",
+          value: summary.healthy,
+        }, {
+          label: "Warnings",
+          value: summary.warnings,
+        }, {
+          label: "Blocking",
+          value: summary.blocking,
+        }].map((card) => (
+          <div key={card.label} style={{ textAlign: "center" }}>
+            <div style={{ fontSize: "2rem", fontWeight: 700 }}>{card.value}</div>
+            <div style={{ color: "#94a3b8", fontSize: "0.9rem" }}>{card.label}</div>
+          </div>
+        ))}
+      </section>
+
+      {loading && (
+        <div style={{ color: "#94a3b8" }}>Loading deployment data…</div>
+      )}
+
+      {error && !loading && (
+        <div
+          style={{
+            backgroundColor: "#7f1d1d",
+            borderRadius: "0.75rem",
+            padding: "1rem 1.25rem",
+          }}
+        >
+          <strong style={{ display: "block", marginBottom: "0.5rem" }}>
+            Unable to load onboarding registry
+          </strong>
+          <span style={{ color: "#fecaca" }}>{error}</span>
+        </div>
+      )}
+
+      {!error && !loading && registry && (
+        <div style={{ display: "flex", flexDirection: "column", gap: "1.5rem" }}>
+          {registry.agents.map((agent) => (
+            <article
+              key={agent.name}
+              style={{
+                backgroundColor: "#1f2937",
+                borderRadius: "1rem",
+                padding: "1.5rem",
+              }}
+            >
+              <header
+                style={{
+                  alignItems: "baseline",
+                  display: "flex",
+                  flexWrap: "wrap",
+                  gap: "0.75rem",
+                  justifyContent: "space-between",
+                }}
+              >
+                <div>
+                  <h2 style={{ fontSize: "1.5rem", margin: 0 }}>{agent.name}</h2>
+                  <p style={{ color: "#94a3b8", margin: 0 }}>
+                    {agent.role.toUpperCase()} • Key {agent.key_id} • Fingerprint {agent.key_fingerprint}
+                  </p>
+                </div>
+                <div style={{ textAlign: "right" }}>
+                  <div style={{ color: "#94a3b8", fontSize: "0.75rem" }}>Permissions</div>
+                  <div style={{ fontSize: "0.85rem" }}>
+                    {agent.permissions.length > 0 ? agent.permissions.join(", ") : "—"}
+                  </div>
+                </div>
+              </header>
+
+              <table
+                style={{
+                  marginTop: "1.25rem",
+                  width: "100%",
+                  borderSpacing: "0 0.5rem",
+                }}
+              >
+                <thead style={{ textAlign: "left", color: "#94a3b8", fontSize: "0.8rem" }}>
+                  <tr>
+                    <th style={{ padding: "0.25rem 0.5rem" }}>Platform</th>
+                    <th style={{ padding: "0.25rem 0.5rem" }}>Status</th>
+                    <th style={{ padding: "0.25rem 0.5rem" }}>Scopes</th>
+                    <th style={{ padding: "0.25rem 0.5rem" }}>Source</th>
+                    <th style={{ padding: "0.25rem 0.5rem" }}>Verified</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {agent.platforms.map((platform) => (
+                    <tr key={`${agent.name}-${platform.integration_id}`}>
+                      <td style={{ padding: "0.4rem 0.5rem" }}>
+                        <strong>{platform.name}</strong>
+                        {platform.details && (
+                          <div style={{ color: "#fcd34d", fontSize: "0.75rem" }}>
+                            {platform.details}
+                          </div>
+                        )}
+                      </td>
+                      <td style={{ padding: "0.4rem 0.5rem" }}>
+                        {renderStatusBadge(platform.status)}
+                      </td>
+                      <td style={{ padding: "0.4rem 0.5rem", color: "#cbd5f5" }}>
+                        {platform.scopes.length > 0 ? platform.scopes.join(", ") : "—"}
+                      </td>
+                      <td style={{ padding: "0.4rem 0.5rem", color: "#94a3b8" }}>
+                        {platform.credential_source}
+                      </td>
+                      <td style={{ padding: "0.4rem 0.5rem", color: "#94a3b8" }}>
+                        {formatTimestamp(platform.verified_at)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </article>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add an agent role manifest with an onboarding script that registers agents, verifies credentials, and writes the platform registry/logs
- expose a FastAPI endpoint for agent registration and document the platform setup process
- add a UI onboarding dashboard to visualize deployment health per agent

## Testing
- python scripts/onboard_agents.py
- python -m py_compile scripts/onboard_agents.py api/auth/register_agent.py

------
https://chatgpt.com/codex/tasks/task_e_68fc42ac9a188329b1894d2c969e4602