### PR TITLE
Add math memory graph visualizer and new Lucidia agents

### DIFF
--- a/bots/__init__.py
+++ b/bots/__init__.py
@@ -73,7 +73,7 @@ from .store_ops_bot import StoreOpsBot
 from .tax_bot import TaxBot
 from .total_rewards_bot import TotalRewardsBot
 from .treasury_bot import TreasuryBot
-from from .lucidia_bot import LucidiaBot
+from .lucidia_bot import LucidiaBot
 from .cadillac_bot import CadillacBot
 from .alice_bot import AliceBot
 from .cecilia_bot import CeciliaBot
@@ -81,7 +81,12 @@ from .silas_bot import SilasBot
 from .athena_bot import AthenaBot
 from .anastasia_bot import AnastasiaBot
 from .elias_bot import EliasBot
-.workforce_planning_bot import WorkforcePlanningBot
+from .workforce_planning_bot import WorkforcePlanningBot
+from .helix_bot import HelixBot
+from .orion_bot import OrionBot
+from .vera_bot import VeraBot
+from .eon_bot import EonBot
+from .myra_bot import MyraBot
 
 BOT_REGISTRY = {
     "Treasury-BOT": TreasuryBot(),
@@ -126,7 +131,8 @@ BOT_REGISTRY = {
     "Regional-Ops-BOT-AMER": RegionalOpsBotAMER(),
     "Regional-Ops-BOT-EMEA": RegionalOpsBotEMEA(),
     "Regional-Ops-BOT-APAC": RegionalOpsBotAPAC(),
-    "Clinical-Ops-BOT": ClinicalOpsBot(), "Lucidia-BOT": LucidiaBot(),
+    "Clinical-Ops-BOT": ClinicalOpsBot(),
+    "Lucidia-BOT": LucidiaBot(),
     "Cadillac-BOT": CadillacBot(),
     "Alice-BOT": AliceBot(),
     "Cecilia-BOT": CeciliaBot(),
@@ -134,6 +140,11 @@ BOT_REGISTRY = {
     "Athena-BOT": AthenaBot(),
     "Anastasia-BOT": AnastasiaBot(),
     "Elias-BOT": EliasBot(),
+    "Helix-BOT": HelixBot(),
+    "Orion-BOT": OrionBot(),
+    "Vera-BOT": VeraBot(),
+    "Eon-BOT": EonBot(),
+    "Myra-BOT": MyraBot(),
 
     "PV-BOT": PVBot(),
     "GxP-BOT": GxPBot(),

--- a/bots/eon_bot.py
+++ b/bots/eon_bot.py
@@ -1,0 +1,15 @@
+from .base import BaseBot, BotResponse
+
+
+class EonBot(BaseBot):
+    """
+    Mission: Model time-dependent systems and track the evolution of mathematical patterns.
+    Inputs: historical data, equation logs
+    Outputs: predictive models, recurrence relations
+    """
+
+    name = "Eon-BOT"
+
+    def run(self, task: str) -> BotResponse:
+        # detect temporal symmetries, forecast pattern emergence
+        return super().run(task)

--- a/bots/helix_bot.py
+++ b/bots/helix_bot.py
@@ -1,0 +1,15 @@
+from .base import BaseBot, BotResponse
+
+
+class HelixBot(BaseBot):
+    """
+    Mission: Fuse multi-modal reasoning—math, vision, and code—into one causal loop.
+    Inputs: symbolic graphs, visual data, language prompts
+    Outputs: generative models, causal diagrams, verified predictions
+    """
+
+    name = "Helix-BOT"
+
+    def run(self, task: str) -> BotResponse:
+        # orchestrate multi-modal fusion
+        return super().run(task)

--- a/bots/myra_bot.py
+++ b/bots/myra_bot.py
@@ -1,0 +1,15 @@
+from .base import BaseBot, BotResponse
+
+
+class MyraBot(BaseBot):
+    """
+    Mission: Translate between computational languages and symbolic domains.
+    Inputs: code snippets, mathematical forms
+    Outputs: cross-language transformations, unified abstraction layers
+    """
+
+    name = "Myra-BOT"
+
+    def run(self, task: str) -> BotResponse:
+        # bridge languages, normalize syntax
+        return super().run(task)

--- a/bots/orion_bot.py
+++ b/bots/orion_bot.py
@@ -1,0 +1,15 @@
+from .base import BaseBot, BotResponse
+
+
+class OrionBot(BaseBot):
+    """
+    Mission: Perform large-scale geometric reasoning and optimization across distributed agents.
+    Inputs: multi-agent telemetry, model parameters
+    Outputs: scaled simulations, convergence maps, orchestration feedback
+    """
+
+    name = "Orion-BOT"
+
+    def run(self, task: str) -> BotResponse:
+        # manage distributed mathematical workloads
+        return super().run(task)

--- a/bots/vera_bot.py
+++ b/bots/vera_bot.py
@@ -1,0 +1,15 @@
+from .base import BaseBot, BotResponse
+
+
+class VeraBot(BaseBot):
+    """
+    Mission: Validate symbolic reasoning and enforce mathematical integrity.
+    Inputs: proofs, equations, agent outputs
+    Outputs: formal verification reports, constraint maps
+    """
+
+    name = "Vera-BOT"
+
+    def run(self, task: str) -> BotResponse:
+        # verify correctness and compliance
+        return super().run(task)

--- a/lucidia_mathlab/memory_graph.py
+++ b/lucidia_mathlab/memory_graph.py
@@ -1,0 +1,48 @@
+"""
+Lucidia Math Memory Graph
+Tracks relations between agents, equations, and generated artifacts.
+"""
+
+import json
+import os
+from datetime import datetime
+
+import matplotlib.pyplot as plt
+import networkx as nx
+
+
+class MathMemoryGraph:
+    def __init__(self, path="codex_logs"):
+        self.path = path
+        self.graph = nx.MultiDiGraph(name="LucidiaMathGraph")
+
+    def load_logs(self):
+        for file in os.listdir(self.path):
+            if file.endswith(".json"):
+                with open(os.path.join(self.path, file)) as f:
+                    data = json.load(f)
+                    self._ingest_log(file, data)
+
+    def _ingest_log(self, file, data):
+        agent = data.get("agent")
+        prompt = data.get("prompt", "")[:80]
+        node_id = f"{file}_{agent}"
+        self.graph.add_node(node_id, label=agent, prompt=prompt, ts=file[:19])
+        self.graph.add_edge(agent, node_id, relation="produced")
+
+    def render(self, out_path="codex_logs/math_graph.png"):
+        plt.figure(figsize=(12, 8))
+        pos = nx.spring_layout(self.graph, k=0.4)
+        nx.draw_networkx_nodes(self.graph, pos, node_size=500, node_color="#77aaff")
+        nx.draw_networkx_edges(self.graph, pos, arrowstyle="->", arrowsize=12)
+        nx.draw_networkx_labels(self.graph, pos, font_size=9)
+        plt.axis("off")
+        plt.tight_layout()
+        plt.savefig(out_path)
+        print(f"[✓] Graph rendered → {out_path}")
+
+
+if __name__ == "__main__":
+    graph = MathMemoryGraph()
+    graph.load_logs()
+    graph.render()


### PR DESCRIPTION
## Summary
- add a Lucidia math memory graph utility to visualize agent activity from codex logs
- introduce Helix, Orion, Vera, Eon, and Myra bot classes for the post Big Seven lineup
- register the new bots in the shared registry so they are available to the orchestrator

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fc472a642883298aeebe504c27267d