### PR TITLE
Add multi-agent mission builder UI and scheduling endpoint

### DIFF
--- a/dash/api/main.py
+++ b/dash/api/main.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import datetime
+import json
+import re
+from pathlib import Path
+
+from fastapi import Body, FastAPI
+
+PROMPT_DIR = Path("codex_prompts/prompts")
+PROMPT_DIR.mkdir(parents=True, exist_ok=True)
+
+app = FastAPI(title="Mission Builder API")
+
+
+def _slugify(value: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9_-]+", "_", value).strip("_")
+    return slug.lower() or "mission"
+
+
+@app.post("/prompts")
+def queue_prompt(
+    title: str = Body(...),
+    body: str = Body(...),
+    infer_agent: bool = Body(default=True),
+):
+    slug = _slugify(title)
+    path = PROMPT_DIR / f"{slug}.yaml"
+    path.write_text(body)
+    return {"ok": True, "path": str(path), "infer_agent": infer_agent}
+
+
+@app.post("/schedule")
+def schedule_job(title: str = Body(...), hour: int = Body(...)):
+    sched = Path("codex_prompts/schedule.json")
+    now = datetime.datetime.now().isoformat()
+    data = {"title": title, "hour": hour, "created": now}
+    sched.write_text(json.dumps(data, indent=2))
+    return {"ok": True, "next": f"will trigger {hour}:00 daily"}

--- a/dash/web/src/ui/MissionBuilder.jsx
+++ b/dash/web/src/ui/MissionBuilder.jsx
@@ -1,0 +1,135 @@
+import React, { useState } from "react";
+
+const templates = {
+  "Symbolic Core": {
+    agents: ["Lucidia"],
+    prompt: `prompt: |
+  Implement a modular symbolic math engine for the Prism Console.
+  - Parse LaTeX, SymPy, and natural language.
+  - Output JSON ASTs and real-time visualization feeds.`,
+  },
+  "Quantum Geometry": {
+    agents: ["Helix", "Silas"],
+    prompt: `prompt: |
+  Extend the symbolic engine with Clifford algebra, tensor fields, and Bloch-sphere visualizations.
+  - Implement Hamiltonian dynamics and SU(3) operations.`,
+  },
+  "Fractal Dynamics": {
+    agents: ["Orion", "Anastasia"],
+    prompt: `prompt: |
+  Build a fractal and chaos simulator integrated with the math engine.
+  - Support Lorenz and Mandelbrot sets with real-time WebGL output.`,
+  },
+  "Information Geometry": {
+    agents: ["Silas", "Helix", "Myra"],
+    prompt: `prompt: |
+  Create an information-geometry toolkit for probabilistic manifolds.
+  - Fisher metrics, entropy fields, and loss-surface visualizations.`,
+  },
+  "Language Bridge": {
+    agents: ["Myra", "Cecilia"],
+    prompt: `prompt: |
+  Develop a math-to-language transcriber for narrative explanations.
+  - Bidirectional translation between symbols and prose.`,
+  },
+  "Verification & Ethics": {
+    agents: ["Vera", "Eon"],
+    prompt: `prompt: |
+  Implement formal verification for mathematical proofs and derivations.
+  - Constraint solvers, policy enforcement, and bias detection.`,
+  },
+};
+
+export default function MissionBuilder({ api }) {
+  const [template, setTemplate] = useState("");
+  const [body, setBody] = useState("");
+  const [selectedAgents, setSelectedAgents] = useState([]);
+  const [delay, setDelay] = useState(0);
+  const [msg, setMsg] = useState("");
+
+  const choose = (name) => {
+    const t = templates[name];
+    setTemplate(name);
+    setBody(t.prompt);
+    setSelectedAgents(t.agents);
+    setMsg("");
+  };
+
+  const toggleAgent = (a) => {
+    setSelectedAgents((prev) =>
+      prev.includes(a) ? prev.filter((x) => x !== a) : [...prev, a]
+    );
+  };
+
+  const launch = async () => {
+    if (!body || !selectedAgents.length) return;
+    const title = template || "custom_mission";
+    for (const agent of selectedAgents) {
+      const payload = {
+        title: `${title}_${agent}`,
+        body: `${body}\nagent: ${agent}`,
+        infer_agent: false,
+      };
+      const res = await fetch(api + "/prompts", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const j = await res.json();
+      setMsg((m) => m + `\n${agent}: ${j.ok ? "queued" : "error"}`);
+      if (delay > 0) await new Promise((r) => setTimeout(r, delay * 1000));
+    }
+  };
+
+  return (
+    <div className="card">
+      <h3>Mission Builder</h3>
+      <select onChange={(e) => choose(e.target.value)} value={template}>
+        <option value="">— choose a domain —</option>
+        {Object.keys(templates).map((t) => (
+          <option key={t}>{t}</option>
+        ))}
+      </select>
+
+      <div className="agent-select">
+        <label>Agents:</label>
+        <div className="agent-list">
+          {["Lucidia","Cadillac","Cecilia","Silas","Anastasia","Elias","Helix","Orion","Vera","Eon","Myra"]
+            .map((a) => (
+              <label key={a}>
+                <input
+                  type="checkbox"
+                  checked={selectedAgents.includes(a)}
+                  onChange={() => toggleAgent(a)}
+                />{" "}
+                {a}
+              </label>
+            ))}
+        </div>
+      </div>
+
+      <label>Delay between runs (sec):</label>
+      <input
+        type="number"
+        min="0"
+        step="5"
+        value={delay}
+        onChange={(e) => setDelay(parseInt(e.target.value))}
+      />
+
+      <textarea
+        rows={10}
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+      />
+      <button onClick={launch}>Queue Mission</button>
+      {msg && <pre className="muted">{msg}</pre>}
+
+      <style>{`
+        .agent-select { margin-top:8px; }
+        .agent-list { display:flex; flex-wrap:wrap; gap:8px; }
+        pre { background:#f9fafb; padding:8px; border-radius:8px; white-space:pre-wrap; }
+      `}</style>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add an extended Mission Builder React component that supports multi-agent queuing, templated prompts, and launch delays
- provide a FastAPI backend for queuing prompt YAMLs and scheduling recurring launches

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fc4da9ca7483298ca7bc6c5885f725