### PR TITLE
Restyle Codex Nexus dashboard to match console mock

### DIFF
--- a/.github/workflows/nexus-dashboard.yml
+++ b/.github/workflows/nexus-dashboard.yml
@@ -1,0 +1,32 @@
+name: Codex Nexus Dashboard QA
+on:
+  push:
+    paths:
+      - "dash/**"
+      - "codex_prompts/**"
+      - "codex_logs/**"
+jobs:
+  lint-and-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Backend deps
+        run: pip install fastapi uvicorn pyyaml
+      - name: API smoke
+        run: |
+          python - <<'PY'
+          import json
+          from fastapi.testclient import TestClient
+          from dash.api.main import app
+          client = TestClient(app)
+          resp = client.get("/health")
+          assert resp.status_code == 200
+          body = resp.json()
+          assert body.get("ok")
+          print("api ok")
+          PY
+      - name: Web build
+        working-directory: dash/web
+        run: |
+          npm ci || npm i
+          npm run build

--- a/dash/api/Dockerfile
+++ b/dash/api/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+EXPOSE 5055
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "5055"]

--- a/dash/api/main.py
+++ b/dash/api/main.py
@@ -1,0 +1,152 @@
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.responses import FileResponse, JSONResponse
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+from pathlib import Path
+import json
+import time
+import asyncio
+import yaml
+from typing import Dict, Any, List
+
+LOG_DIR = Path("codex_logs")
+PROMPT_DIR = Path("codex_prompts/prompts")
+GRAPH_IMG = LOG_DIR / "math_graph.png"
+FEEDBACK = LOG_DIR / "feedback_metrics.json"
+ROUTER_WEIGHTS = Path("codex_prompts/router_weights.json")
+
+app = FastAPI(title="Codex Nexus API")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+    allow_credentials=True,
+)
+
+
+class NewPrompt(BaseModel):
+    title: str
+    body: str
+    infer_agent: bool = True
+
+
+# --- helpers ---
+def read_json(path: Path, default):
+    try:
+        return json.loads(path.read_text())
+    except Exception:
+        return default
+
+
+def list_logs(limit: int = 200) -> List[Dict[str, Any]]:
+    out: List[Dict[str, Any]] = []
+    for p in sorted(LOG_DIR.glob("*.json"))[::-1][:limit]:
+        if p.name in {"feedback_metrics.json"}:
+            continue
+        try:
+            item = json.loads(p.read_text())
+            item["_file"] = p.name
+            out.append(item)
+        except Exception:
+            pass
+    return out
+
+
+# --- routes ---
+@app.get("/health")
+def health():
+    return {"ok": True, "ts": time.time()}
+
+
+@app.get("/logs")
+def logs(limit: int = 200):
+    return {"items": list_logs(limit=limit)}
+
+
+@app.get("/weights")
+def weights():
+    return read_json(ROUTER_WEIGHTS, {"weights": {}})
+
+
+@app.get("/feedback")
+def feedback():
+    return read_json(FEEDBACK, {"agent_scores": {}})
+
+
+@app.get("/graph.png")
+def graph_png():
+    if GRAPH_IMG.exists():
+        return FileResponse(GRAPH_IMG)
+    return JSONResponse({"error": "graph not found"}, status_code=404)
+
+
+@app.post("/prompts")
+def create_prompt(data: NewPrompt):
+    PROMPT_DIR.mkdir(parents=True, exist_ok=True)
+    try:
+        parsed = yaml.safe_load(data.body)
+        is_yaml = isinstance(parsed, dict) and ("prompt" in parsed or "agent" in parsed)
+    except Exception:
+        is_yaml = False
+
+    if is_yaml:
+        content = data.body
+    else:
+        formatted_body = data.body.replace('\n', '\n  ')
+        content = "prompt: |\n  " + formatted_body + "\n"
+
+    if data.infer_agent and "agent:" not in content:
+        pass
+
+    fn = f"{data.title.lower().replace(' ', '_')}.yaml"
+    path = PROMPT_DIR / fn
+    path.write_text(content)
+    return {"ok": True, "file": str(path)}
+
+
+clients: List[WebSocket] = []
+
+
+@app.websocket("/ws")
+async def ws(ws: WebSocket):
+    await ws.accept()
+    clients.append(ws)
+    try:
+        while True:
+            await ws.receive_text()
+    except WebSocketDisconnect:
+        if ws in clients:
+            clients.remove(ws)
+
+
+@app.on_event("startup")
+async def start_pusher():
+    async def push_loop():
+        last = ""
+        while True:
+            try:
+                payload = {
+                    "type": "tick",
+                    "weights": read_json(ROUTER_WEIGHTS, {}),
+                    "feedback": read_json(FEEDBACK, {}),
+                    "latest": list_logs(limit=30),
+                    "graph_exists": GRAPH_IMG.exists(),
+                }
+                msg = json.dumps(payload)
+                if msg != last:
+                    for c in list(clients):
+                        try:
+                            await c.send_text(msg)
+                        except Exception:
+                            try:
+                                clients.remove(c)
+                            except ValueError:
+                                pass
+                    last = msg
+            except Exception:
+                pass
+            await asyncio.sleep(5)
+
+    asyncio.create_task(push_loop())

--- a/dash/api/requirements.txt
+++ b/dash/api/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn[standard]
+pydantic
+pyyaml

--- a/dash/web/index.html
+++ b/dash/web/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Codex Nexus</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/dash/web/package-lock.json
+++ b/dash/web/package-lock.json
@@ -1,0 +1,1033 @@
+{
+  "name": "codex-nexus-web",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "codex-nexus-web",
+      "dependencies": {
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      },
+      "devDependencies": {
+        "@types/react": "^18.2.0",
+        "@types/react-dom": "^18.2.0",
+        "vite": "^5.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.5.tgz",
+      "integrity": "sha512-8c1vW4ocv3UOMp9K+gToY5zL2XiiVw3k7f1ksf4yO1FlDFQ1C2u72iACFnSOceJFsWskc2WZNqeRhFRPzv+wtQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.5.tgz",
+      "integrity": "sha512-mQGfsIEFcu21mvqkEKKu2dYmtuSZOBMmAl5CFlPGLY94Vlcm+zWApK7F/eocsNzp8tKmbeBP8yXyAbx0XHsFNA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.5.tgz",
+      "integrity": "sha512-takF3CR71mCAGA+v794QUZ0b6ZSrgJkArC+gUiG6LB6TQty9T0Mqh3m2ImRBOxS2IeYBo4lKWIieSvnEk2OQWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.5.tgz",
+      "integrity": "sha512-W901Pla8Ya95WpxDn//VF9K9u2JbocwV/v75TE0YIHNTbhqUTv9w4VuQ9MaWlNOkkEfFwkdNhXgcLqPSmHy0fA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.5.tgz",
+      "integrity": "sha512-QofO7i7JycsYOWxe0GFqhLmF6l1TqBswJMvICnRUjqCx8b47MTo46W8AoeQwiokAx3zVryVnxtBMcGcnX12LvA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.5.tgz",
+      "integrity": "sha512-jr21b/99ew8ujZubPo9skbrItHEIE50WdV86cdSoRkKtmWa+DDr6fu2c/xyRT0F/WazZpam6kk7IHBerSL7LDQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.5.tgz",
+      "integrity": "sha512-PsNAbcyv9CcecAUagQefwX8fQn9LQ4nZkpDboBOttmyffnInRy8R8dSg6hxxl2Re5QhHBf6FYIDhIj5v982ATQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.5.tgz",
+      "integrity": "sha512-Fw4tysRutyQc/wwkmcyoqFtJhh0u31K+Q6jYjeicsGJJ7bbEq8LwPWV/w0cnzOqR2m694/Af6hpFayLJZkG2VQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.5.tgz",
+      "integrity": "sha512-a+3wVnAYdQClOTlyapKmyI6BLPAFYs0JM8HRpgYZQO02rMR09ZcV9LbQB+NL6sljzG38869YqThrRnfPMCDtZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.5.tgz",
+      "integrity": "sha512-AvttBOMwO9Pcuuf7m9PkC1PUIKsfaAJ4AYhy944qeTJgQOqJYJ9oVl2nYgY7Rk0mkbsuOpCAYSs6wLYB2Xiw0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.5.tgz",
+      "integrity": "sha512-DkDk8pmXQV2wVrF6oq5tONK6UHLz/XcEVow4JTTerdeV1uqPeHxwcg7aFsfnSm9L+OO8WJsWotKM2JJPMWrQtA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.5.tgz",
+      "integrity": "sha512-W/b9ZN/U9+hPQVvlGwjzi+Wy4xdoH2I8EjaCkMvzpI7wJUs8sWJ03Rq96jRnHkSrcHTpQe8h5Tg3ZzUPGauvAw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.5.tgz",
+      "integrity": "sha512-sjQLr9BW7R/ZiXnQiWPkErNfLMkkWIoCz7YMn27HldKsADEKa5WYdobaa1hmN6slu9oWQbB6/jFpJ+P2IkVrmw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.5.tgz",
+      "integrity": "sha512-hq3jU/kGyjXWTvAh2awn8oHroCbrPm8JqM7RUpKjalIRWWXE01CQOf/tUNWNHjmbMHg/hmNCwc/Pz3k1T/j/Lg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.5.tgz",
+      "integrity": "sha512-gn8kHOrku8D4NGHMK1Y7NA7INQTRdVOntt1OCYypZPRt6skGbddska44K8iocdpxHTMMNui5oH4elPH4QOLrFQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.5.tgz",
+      "integrity": "sha512-hXGLYpdhiNElzN770+H2nlx+jRog8TyynpTVzdlc6bndktjKWyZyiCsuDAlpd+j+W+WNqfcyAWz9HxxIGfZm1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.5.tgz",
+      "integrity": "sha512-arCGIcuNKjBoKAXD+y7XomR9gY6Mw7HnFBv5Rw7wQRvwYLR7gBAgV7Mb2QTyjXfTveBNFAtPt46/36vV9STLNg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.5.tgz",
+      "integrity": "sha512-QoFqB6+/9Rly/RiPjaomPLmR/13cgkIGfA40LHly9zcH1S0bN2HVFYk3a1eAyHQyjs3ZJYlXvIGtcCs5tko9Cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.5.tgz",
+      "integrity": "sha512-w0cDWVR6MlTstla1cIfOGyl8+qb93FlAVutcor14Gf5Md5ap5ySfQ7R9S/NjNaMLSFdUnKGEasmVnu3lCMqB7w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.5.tgz",
+      "integrity": "sha512-Aufdpzp7DpOTULJCuvzqcItSGDH73pF3ko/f+ckJhxQyHtp67rHw3HMNxoIdDMUITJESNE6a8uh4Lo4SLouOUg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.5.tgz",
+      "integrity": "sha512-UGBUGPFp1vkj6p8wCRraqNhqwX/4kNQPS57BCFc8wYh0g94iVIW33wJtQAx3G7vrjjNtRaxiMUylM0ktp/TRSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.5.tgz",
+      "integrity": "sha512-TAcgQh2sSkykPRWLrdyy2AiceMckNf5loITqXxFI5VuQjS5tSuw3WlwdN8qv8vzjLAUTvYaH/mVjSFpbkFbpTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.26",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.26.tgz",
+      "integrity": "sha512-RFA/bURkcKzx/X9oumPG9Vp3D3JUgus/d0b67KB0t5S/raciymilkOa66olh78MUI92QLbEJevO7rvqU/kjwKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.5.tgz",
+      "integrity": "sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.52.5",
+        "@rollup/rollup-android-arm64": "4.52.5",
+        "@rollup/rollup-darwin-arm64": "4.52.5",
+        "@rollup/rollup-darwin-x64": "4.52.5",
+        "@rollup/rollup-freebsd-arm64": "4.52.5",
+        "@rollup/rollup-freebsd-x64": "4.52.5",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.5",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.5",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.5",
+        "@rollup/rollup-linux-arm64-musl": "4.52.5",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.5",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.5",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.5",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.5",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.5",
+        "@rollup/rollup-linux-x64-gnu": "4.52.5",
+        "@rollup/rollup-linux-x64-musl": "4.52.5",
+        "@rollup/rollup-openharmony-arm64": "4.52.5",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.5",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.5",
+        "@rollup/rollup-win32-x64-gnu": "4.52.5",
+        "@rollup/rollup-win32-x64-msvc": "4.52.5",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/dash/web/package.json
+++ b/dash/web/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "codex-nexus-web",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --port 5174"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "vite": "^5.4.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0"
+  }
+}

--- a/dash/web/src/main.jsx
+++ b/dash/web/src/main.jsx
@@ -1,0 +1,5 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import App from "./ui/App";
+
+createRoot(document.getElementById("root")).render(<App />);

--- a/dash/web/src/ui/App.jsx
+++ b/dash/web/src/ui/App.jsx
@@ -1,0 +1,735 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+
+const API = import.meta.env.VITE_API_URL || "http://localhost:5055";
+
+function useNexus() {
+  const [state, setState] = useState({
+    latest: [],
+    weights: {},
+    feedback: {},
+    graph_exists: false,
+  });
+  const wsRef = useRef(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadInitial = async () => {
+      try {
+        const [logsRes, weightsRes, feedbackRes, graphRes] = await Promise.all([
+          fetch(`${API}/logs`).then((res) => res.json()).catch(() => ({ items: [] })),
+          fetch(`${API}/weights`).then((res) => res.json()).catch(() => ({ weights: {} })),
+          fetch(`${API}/feedback`).then((res) => res.json()).catch(() => ({ agent_scores: {} })),
+          fetch(`${API}/graph.png`, { method: "GET", cache: "no-store" })
+            .then((res) => ({ ok: res.ok, status: res.status }))
+            .catch(() => ({ ok: false })),
+        ]);
+
+        if (!cancelled) {
+          setState((prev) => ({
+            ...prev,
+            latest: logsRes.items || [],
+            weights: weightsRes || {},
+            feedback: feedbackRes || {},
+            graph_exists: graphRes.ok || graphRes.status === 200,
+          }));
+        }
+      } catch (err) {
+        console.warn("failed to load initial nexus data", err);
+      }
+    };
+
+    loadInitial();
+
+    const wsUrl = API.replace("http", "ws") + "/ws";
+    wsRef.current = new WebSocket(wsUrl);
+    wsRef.current.onmessage = (evt) => {
+      try {
+        const payload = JSON.parse(evt.data);
+        setState((prev) => ({ ...prev, ...payload }));
+      } catch (err) {
+        console.error("failed to parse websocket message", err);
+      }
+    };
+    wsRef.current.onerror = (err) => {
+      console.warn("websocket error", err);
+    };
+    wsRef.current.onclose = () => {
+      wsRef.current = null;
+    };
+    return () => {
+      cancelled = true;
+      if (wsRef.current) {
+        wsRef.current.close();
+      }
+    };
+  }, []);
+
+  return state;
+}
+
+function useClock() {
+  const [now, setNow] = useState(() => new Date());
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 30_000);
+    return () => clearInterval(id);
+  }, []);
+
+  return useMemo(() => {
+    const options = { month: "long", day: "numeric" };
+    const date = now.toLocaleDateString(undefined, options);
+    const time = now.toLocaleTimeString(undefined, {
+      hour: "numeric",
+      minute: "2-digit",
+    });
+    return { date, time };
+  }, [now]);
+}
+
+function Sidebar({ latestAgent }) {
+  return (
+    <aside className="sidebar">
+      <div className="sidebar__brand">BlackRoad.io</div>
+      <nav className="sidebar__nav">
+        <div className="sidebar__section">Workspace</div>
+        <button className="sidebar__link sidebar__link--active">Dashboard</button>
+        <button className="sidebar__link">Projects</button>
+        <button className="sidebar__link">Prompts</button>
+        <button className="sidebar__link">Agents</button>
+        <button className="sidebar__link">Streams</button>
+        <button className="sidebar__link">Datasets</button>
+        <div className="sidebar__section">Ops</div>
+        <button className="sidebar__link">Router</button>
+        <button className="sidebar__link">Watchdog</button>
+        <button className="sidebar__link">Memory</button>
+      </nav>
+      <div className="sidebar__cta">
+        <span className="sidebar__cta-label">Start</span>
+        <span className="sidebar__cta-title">Co-Coding</span>
+      </div>
+      <div className="sidebar__status">
+        <div className="sidebar__status-title">Last Agent</div>
+        <div className="sidebar__status-body">{latestAgent || "pending"}</div>
+      </div>
+    </aside>
+  );
+}
+
+function Topbar() {
+  const { date, time } = useClock();
+  return (
+    <header className="topbar">
+      <div className="topbar__title">Codex Nexus Control</div>
+      <div className="topbar__meta">
+        <span>{date}</span>
+        <span>{time}</span>
+      </div>
+    </header>
+  );
+}
+
+function Tabs() {
+  return (
+    <div className="tabs">
+      <button className="tabs__item tabs__item--active">Timeline</button>
+      <button className="tabs__item">Tasks</button>
+      <button className="tabs__item">Control</button>
+      <button className="tabs__item">Memory</button>
+      <button className="tabs__item">Reports</button>
+      <button className="tabs__item">Stack</button>
+    </div>
+  );
+}
+
+function TimelineCard({ items }) {
+  return (
+    <div className="panel panel--tall">
+      <div className="panel__header">
+        <div>
+          <h2>Mission Timeline</h2>
+          <p>Live prompt streams routed through the Codex mesh.</p>
+        </div>
+        <span className="panel__badge">Live</span>
+      </div>
+      <div className="timeline">
+        {items.length === 0 && <div className="timeline__empty">Waiting for runs…</div>}
+        {items.map((item, idx) => (
+          <div key={`${item._file}-${idx}`} className="timeline__row">
+            <div className="timeline__marker" />
+            <div className="timeline__body">
+              <div className="timeline__meta">
+                <span className="timeline__agent">{item.agent || "Unknown Agent"}</span>
+                <span className="timeline__file">{item._file}</span>
+              </div>
+              <div className="timeline__prompt">{(item.prompt || "").slice(0, 140) || "prompt unavailable"}</div>
+              <div className="timeline__output">{(item.output || "").slice(0, 160) || "no output captured"}</div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function AgentStack({ weights, feedback }) {
+  const data = (weights && weights.weights) || {};
+  const scores = feedback.agent_scores || {};
+  const entries = Object.keys({ ...data, ...scores }).map((agent) => ({
+    agent,
+    weight: data[agent] ?? 0,
+    score: scores[agent] ?? 0,
+  }));
+  const sorted = entries.sort((a, b) => (b.weight || 0) - (a.weight || 0));
+
+  return (
+    <div className="panel">
+      <div className="panel__header">
+        <h2>Agent Stack</h2>
+        <p>Router weights blended with reinforcement scores.</p>
+      </div>
+      <ul className="stack">
+        {sorted.length === 0 && <li className="stack__empty">No agent telemetry yet.</li>}
+        {sorted.map(({ agent, weight, score }) => (
+          <li key={agent} className="stack__row">
+            <div className="stack__info">
+              <span className="stack__agent">{agent}</span>
+              <span className="stack__score">score {score.toFixed(3)}</span>
+            </div>
+            <div className="stack__bar">
+              <span style={{ width: `${Math.max(4, Math.min(100, weight * 100))}%` }} />
+            </div>
+            <div className="stack__weight">{(weight * 100).toFixed(1)}%</div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function MissionLog({ items }) {
+  const top = items.slice(0, 4);
+  return (
+    <div className="panel">
+      <div className="panel__header">
+        <h2>Mixed Signal Revocations</h2>
+        <p>Snapshot of the latest Codex log commits.</p>
+      </div>
+      <div className="mission-log">
+        {top.length === 0 && <div className="mission-log__empty">Telemetry quiet.</div>}
+        {top.map((item, idx) => (
+          <div key={`${item._file}-${idx}`} className="mission-log__row">
+            <div className="mission-log__title">{item.prompt?.slice(0, 60) || "Untitled prompt"}</div>
+            <div className="mission-log__meta">
+              <span>{item.agent || "unknown"}</span>
+              <span>{item._file}</span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function QuickLaunch() {
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [msg, setMsg] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
+
+  const submit = async () => {
+    if (!title.trim()) {
+      setMsg("Title is required.");
+      return;
+    }
+    setIsSaving(true);
+    try {
+      const res = await fetch(`${API}/prompts`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title, body, infer_agent: true }),
+      });
+      const j = await res.json();
+      if (j.ok) {
+        setMsg(`Saved ${j.file}`);
+        setTitle("");
+        setBody("");
+      } else {
+        setMsg(j.error || "Failed to save prompt.");
+      }
+    } catch (err) {
+      setMsg("Request failed. Is the API running?");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="panel">
+      <div className="panel__header">
+        <h2>Prompt Launch</h2>
+        <p>Draft a new Codex mission and push it into the router.</p>
+      </div>
+      <div className="launch">
+        <input
+          placeholder="Title (file name)"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+        <textarea
+          placeholder="Write YAML prompt or plain text…"
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          rows={6}
+        />
+        <button onClick={submit} disabled={isSaving}>
+          {isSaving ? "Saving…" : "Launch Prompt"}
+        </button>
+        {msg && <p className="launch__msg">{msg}</p>}
+      </div>
+    </div>
+  );
+}
+
+function MemoryPreview({ graphExists }) {
+  return (
+    <div className="panel">
+      <div className="panel__header">
+        <h2>Memory Graph</h2>
+        <p>Lucidia math-lab projections rendered by the watchdog.</p>
+      </div>
+      <div className="memory">
+        {graphExists ? (
+          <img src={`${API}/graph.png`} alt="graph" />
+        ) : (
+          <div className="memory__empty">No graph yet.</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function App() {
+  const { latest = [], weights = {}, feedback = {}, graph_exists = false } = useNexus();
+  const latestAgent = latest[0]?.agent;
+
+  return (
+    <div className="app">
+      <Sidebar latestAgent={latestAgent} />
+      <div className="workspace">
+        <Topbar />
+        <Tabs />
+        <div className="layout">
+          <div className="layout__main">
+            <TimelineCard items={latest} />
+          </div>
+          <div className="layout__side">
+            <AgentStack weights={weights} feedback={feedback} />
+            <MissionLog items={latest} />
+          </div>
+        </div>
+        <div className="layout layout--secondary">
+          <div className="layout__main">
+            <QuickLaunch />
+          </div>
+          <div className="layout__side">
+            <MemoryPreview graphExists={graph_exists} />
+          </div>
+        </div>
+      </div>
+      <style>{`
+        :root {
+          font-family: "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont;
+          color-scheme: dark;
+        }
+        * { box-sizing: border-box; }
+        body { margin: 0; background: #050b2c; color: #e3e7ff; }
+        .app {
+          min-height: 100vh;
+          display: flex;
+          background: radial-gradient(circle at 20% 20%, rgba(99, 102, 241, 0.12), transparent 55%),
+            radial-gradient(circle at 80% 0%, rgba(14, 165, 233, 0.14), transparent 60%),
+            #050b2c;
+        }
+        .sidebar {
+          width: 230px;
+          padding: 28px 24px;
+          display: flex;
+          flex-direction: column;
+          gap: 24px;
+          background: rgba(3, 7, 25, 0.9);
+          border-right: 1px solid rgba(79, 70, 229, 0.25);
+          backdrop-filter: blur(12px);
+        }
+        .sidebar__brand {
+          font-weight: 700;
+          font-size: 18px;
+          letter-spacing: 0.08em;
+          text-transform: uppercase;
+        }
+        .sidebar__nav {
+          display: flex;
+          flex-direction: column;
+          gap: 6px;
+        }
+        .sidebar__section {
+          font-size: 11px;
+          text-transform: uppercase;
+          letter-spacing: 0.14em;
+          color: #7b82ff;
+          margin-top: 8px;
+        }
+        .sidebar__link {
+          background: transparent;
+          border: none;
+          color: #cdd2ff;
+          text-align: left;
+          padding: 6px 0;
+          font-size: 14px;
+          cursor: pointer;
+        }
+        .sidebar__link--active {
+          color: #ffffff;
+          font-weight: 600;
+        }
+        .sidebar__cta {
+          margin-top: auto;
+          display: flex;
+          flex-direction: column;
+          gap: 2px;
+          padding: 18px 16px;
+          border-radius: 12px;
+          background: linear-gradient(130deg, #f97316, #facc15);
+          color: #111827;
+          font-weight: 700;
+          text-transform: uppercase;
+          letter-spacing: 0.1em;
+        }
+        .sidebar__cta-label { font-size: 12px; }
+        .sidebar__cta-title { font-size: 16px; }
+        .sidebar__status {
+          padding: 14px 16px;
+          border-radius: 12px;
+          background: rgba(59, 130, 246, 0.12);
+          display: flex;
+          flex-direction: column;
+          gap: 6px;
+        }
+        .sidebar__status-title {
+          font-size: 11px;
+          text-transform: uppercase;
+          letter-spacing: 0.14em;
+          color: rgba(148, 163, 184, 0.9);
+        }
+        .sidebar__status-body {
+          font-size: 16px;
+          font-weight: 600;
+        }
+
+        .workspace {
+          flex: 1;
+          display: flex;
+          flex-direction: column;
+          padding: 32px 40px;
+          gap: 24px;
+        }
+        .topbar {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+        }
+        .topbar__title {
+          font-size: 22px;
+          font-weight: 600;
+        }
+        .topbar__meta {
+          display: flex;
+          gap: 12px;
+          font-size: 14px;
+          color: rgba(226, 232, 255, 0.7);
+        }
+        .tabs {
+          display: flex;
+          gap: 12px;
+          padding-bottom: 8px;
+          border-bottom: 1px solid rgba(99, 102, 241, 0.3);
+        }
+        .tabs__item {
+          background: transparent;
+          border: none;
+          color: rgba(199, 210, 254, 0.6);
+          padding: 6px 12px;
+          border-radius: 999px;
+          font-size: 14px;
+          cursor: pointer;
+        }
+        .tabs__item--active {
+          background: rgba(79, 70, 229, 0.35);
+          color: #ffffff;
+        }
+
+        .layout {
+          display: grid;
+          grid-template-columns: minmax(0, 1fr) 320px;
+          gap: 24px;
+        }
+        .layout--secondary {
+          grid-template-columns: minmax(0, 1fr) 340px;
+        }
+        .layout__main,
+        .layout__side {
+          display: flex;
+          flex-direction: column;
+          gap: 24px;
+        }
+
+        .panel {
+          background: rgba(8, 15, 48, 0.78);
+          border: 1px solid rgba(99, 102, 241, 0.25);
+          border-radius: 18px;
+          padding: 24px;
+          box-shadow: 0 25px 45px -35px rgba(15, 23, 42, 0.8);
+        }
+        .panel--tall {
+          min-height: 420px;
+        }
+        .panel__header {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          gap: 16px;
+          margin-bottom: 20px;
+        }
+        .panel__header h2 {
+          margin: 0;
+          font-size: 20px;
+          font-weight: 600;
+        }
+        .panel__header p {
+          margin: 4px 0 0;
+          font-size: 13px;
+          color: rgba(191, 219, 254, 0.65);
+        }
+        .panel__badge {
+          padding: 6px 12px;
+          border-radius: 999px;
+          background: rgba(236, 72, 153, 0.28);
+          color: #f472b6;
+          font-size: 13px;
+          text-transform: uppercase;
+          letter-spacing: 0.12em;
+        }
+
+        .timeline {
+          display: flex;
+          flex-direction: column;
+          gap: 18px;
+          position: relative;
+          padding-left: 20px;
+        }
+        .timeline::before {
+          content: "";
+          position: absolute;
+          left: 7px;
+          top: 0;
+          bottom: 0;
+          width: 2px;
+          background: linear-gradient(to bottom, rgba(99, 102, 241, 0.4), transparent 90%);
+        }
+        .timeline__row {
+          display: flex;
+          gap: 16px;
+        }
+        .timeline__marker {
+          width: 12px;
+          height: 12px;
+          border-radius: 999px;
+          background: radial-gradient(circle, #34d399, #059669);
+          margin-top: 4px;
+        }
+        .timeline__body {
+          flex: 1;
+          display: flex;
+          flex-direction: column;
+          gap: 6px;
+        }
+        .timeline__meta {
+          display: flex;
+          gap: 12px;
+          font-size: 13px;
+          color: rgba(226, 232, 255, 0.65);
+        }
+        .timeline__agent {
+          font-weight: 600;
+          color: #a5b4fc;
+        }
+        .timeline__file {
+          font-family: "JetBrains Mono", ui-monospace, SFMono-Regular;
+          font-size: 12px;
+          color: rgba(148, 163, 184, 0.7);
+        }
+        .timeline__prompt {
+          font-size: 14px;
+          color: rgba(243, 244, 255, 0.9);
+        }
+        .timeline__output {
+          font-size: 13px;
+          color: rgba(148, 163, 184, 0.85);
+        }
+        .timeline__empty {
+          padding: 60px 0;
+          text-align: center;
+          color: rgba(148, 163, 184, 0.7);
+        }
+
+        .stack {
+          list-style: none;
+          margin: 0;
+          padding: 0;
+          display: flex;
+          flex-direction: column;
+          gap: 16px;
+        }
+        .stack__row {
+          display: grid;
+          grid-template-columns: minmax(0, 1fr) 1fr auto;
+          gap: 14px;
+          align-items: center;
+        }
+        .stack__info {
+          display: flex;
+          flex-direction: column;
+          gap: 4px;
+        }
+        .stack__agent { font-weight: 600; }
+        .stack__score { font-size: 12px; color: rgba(148, 163, 184, 0.8); }
+        .stack__bar {
+          height: 8px;
+          background: rgba(99, 102, 241, 0.16);
+          border-radius: 999px;
+          overflow: hidden;
+        }
+        .stack__bar span {
+          display: block;
+          height: 100%;
+          background: linear-gradient(90deg, #6366f1, #22d3ee);
+        }
+        .stack__weight {
+          font-size: 12px;
+          color: rgba(191, 219, 254, 0.75);
+        }
+        .stack__empty {
+          color: rgba(148, 163, 184, 0.7);
+        }
+
+        .mission-log {
+          display: flex;
+          flex-direction: column;
+          gap: 18px;
+        }
+        .mission-log__row {
+          display: flex;
+          flex-direction: column;
+          gap: 6px;
+          padding-bottom: 10px;
+          border-bottom: 1px solid rgba(79, 70, 229, 0.12);
+        }
+        .mission-log__row:last-child {
+          border-bottom: none;
+        }
+        .mission-log__title {
+          font-size: 14px;
+          color: rgba(248, 250, 255, 0.95);
+        }
+        .mission-log__meta {
+          display: flex;
+          justify-content: space-between;
+          font-size: 12px;
+          color: rgba(148, 163, 184, 0.75);
+        }
+        .mission-log__empty {
+          text-align: center;
+          color: rgba(148, 163, 184, 0.7);
+        }
+
+        .launch {
+          display: flex;
+          flex-direction: column;
+          gap: 12px;
+        }
+        .launch input,
+        .launch textarea {
+          background: rgba(12, 21, 55, 0.8);
+          border: 1px solid rgba(99, 102, 241, 0.25);
+          border-radius: 12px;
+          padding: 12px;
+          color: #e0e7ff;
+          font-family: inherit;
+          font-size: 14px;
+        }
+        .launch textarea {
+          resize: vertical;
+          min-height: 140px;
+        }
+        .launch button {
+          align-self: flex-start;
+          padding: 10px 24px;
+          border-radius: 999px;
+          border: none;
+          background: linear-gradient(120deg, #6366f1, #22d3ee);
+          color: #0f172a;
+          font-weight: 600;
+          cursor: pointer;
+        }
+        .launch button:disabled {
+          opacity: 0.6;
+          cursor: not-allowed;
+        }
+        .launch__msg {
+          font-size: 12px;
+          color: rgba(148, 163, 184, 0.85);
+        }
+
+        .memory {
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          min-height: 220px;
+          background: rgba(12, 21, 55, 0.65);
+          border-radius: 14px;
+          border: 1px dashed rgba(99, 102, 241, 0.25);
+          overflow: hidden;
+        }
+        .memory img {
+          width: 100%;
+          max-height: 280px;
+          object-fit: contain;
+        }
+        .memory__empty {
+          color: rgba(148, 163, 184, 0.7);
+        }
+
+        @media (max-width: 1200px) {
+          .layout {
+            grid-template-columns: 1fr;
+          }
+          .layout--secondary {
+            grid-template-columns: 1fr;
+          }
+          .layout__side {
+            flex-direction: column;
+          }
+        }
+
+        @media (max-width: 900px) {
+          .sidebar {
+            display: none;
+          }
+          .workspace {
+            padding: 24px 20px;
+          }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/docker-compose.dashboard.yml
+++ b/docker-compose.dashboard.yml
@@ -1,0 +1,19 @@
+version: "3.9"
+services:
+  api:
+    build: ./dash/api
+    command: uvicorn main:app --host 0.0.0.0 --port 5055
+    ports:
+      - "5055:5055"
+    volumes:
+      - ./:/app
+  web:
+    working_dir: /web
+    image: node:20-alpine
+    command: sh -c "npm i && npm run dev -- --host 0.0.0.0"
+    ports:
+      - "5173:5173"
+    volumes:
+      - ./dash/web:/web
+    environment:
+      - VITE_API_URL=http://localhost:5055


### PR DESCRIPTION
## Summary
- redesign the React dashboard shell with sidebar navigation, top controls, and mission timeline panels to mirror the Codex console mock
- introduce agent stack, mission log, prompt launch, and memory preview panels styled in a cohesive dark theme
- keep websocket-driven data wiring while enriching hooks for clock metadata and responsive layouts

## Testing
- npm run build --prefix dash/web

------
https://chatgpt.com/codex/tasks/task_e_68fc4c09639083299e8662944d75a60c