### PR TITLE
Add mission builder drawer for codex prompt dashboard

### DIFF
--- a/dash/web/src/ui/App.jsx
+++ b/dash/web/src/ui/App.jsx
@@ -1,0 +1,17 @@
+import React from "react";
+import QuickLaunch from "./QuickLaunch";
+import MissionBuilder from "./MissionBuilder";
+
+const DEFAULT_API = "/codex_prompts";
+const API = globalThis?.MISSION_BUILDER_API ?? DEFAULT_API;
+
+export default function App() {
+  return (
+    <main>
+      <section className="grid">
+        <QuickLaunch api={API} />
+        <MissionBuilder api={API} />
+      </section>
+    </main>
+  );
+}

--- a/dash/web/src/ui/MissionBuilder.jsx
+++ b/dash/web/src/ui/MissionBuilder.jsx
@@ -1,0 +1,52 @@
+import React, { useState } from "react";
+import templates from "./templates";
+
+const DEFAULT_API = "/codex_prompts";
+
+export default function MissionBuilder({ api = DEFAULT_API }) {
+  const [template, setTemplate] = useState("");
+  const [body, setBody] = useState("");
+  const [msg, setMsg] = useState("");
+
+  const choose = (name) => {
+    setTemplate(name);
+    setBody(templates[name] || "");
+    setMsg("");
+  };
+
+  const save = async () => {
+    if (!body) return;
+    const title = template || "custom_mission";
+
+    try {
+      const res = await fetch(`${api}/prompts`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title, body, infer_agent: false })
+      });
+      const payload = await res.json().catch(() => ({}));
+      setMsg(res.ok && payload?.ok ? `🚀 launched ${payload.file}` : "error");
+    } catch (error) {
+      setMsg("error");
+    }
+  };
+
+  return (
+    <div className="card">
+      <h3>Mission Builder</h3>
+      <select onChange={(e) => choose(e.target.value)} value={template}>
+        <option value="">— choose a domain —</option>
+        {Object.keys(templates).map((t) => (
+          <option key={t}>{t}</option>
+        ))}
+      </select>
+      <textarea value={body} onChange={(e) => setBody(e.target.value)} rows={10} />
+      <button onClick={save}>Launch Mission</button>
+      {msg && (
+        <p className="muted" aria-live="polite">
+          {msg}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/dash/web/src/ui/QuickLaunch.jsx
+++ b/dash/web/src/ui/QuickLaunch.jsx
@@ -1,0 +1,64 @@
+import React, { useState } from "react";
+import templates from "./templates";
+
+const DEFAULT_API = "/codex_prompts";
+
+export default function QuickLaunch({ api = DEFAULT_API }) {
+  const [state, setState] = useState({ busy: "", msg: "" });
+
+  const launch = async (name) => {
+    const body = templates[name];
+    if (!body) return;
+    setState({ busy: name, msg: "" });
+
+    try {
+      const res = await fetch(`${api}/prompts`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: name, body, infer_agent: false })
+      });
+      const payload = await res.json().catch(() => ({}));
+      setState({
+        busy: "",
+        msg: res.ok && payload?.ok ? `🚀 launched ${payload.file}` : "error"
+      });
+    } catch (error) {
+      setState({ busy: "", msg: "error" });
+    }
+  };
+
+  return (
+    <div className="card">
+      <h3>Quick Launch</h3>
+      <ul>
+        {Object.keys(templates).map((name) => {
+          const preview = templates[name]
+            .split("\n")
+            .map((line) => line.trim())
+            .find((line) => line && !line.startsWith("prompt:"));
+
+          return (
+            <li key={name}>
+              <div>
+                <strong>{name}</strong>
+                {preview && <div className="muted">{preview}</div>}
+              </div>
+              <button
+                type="button"
+                onClick={() => launch(name)}
+                disabled={state.busy === name}
+              >
+                {state.busy === name ? "Launching…" : "Launch"}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+      {state.msg && (
+        <p className="muted" aria-live="polite">
+          {state.msg}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/dash/web/src/ui/templates.js
+++ b/dash/web/src/ui/templates.js
@@ -1,0 +1,29 @@
+const templates = {
+  "Symbolic Core": `prompt: |
+  Implement a modular symbolic math engine for the Prism Console.
+  - Parse LaTeX, SymPy, and natural language.
+  - Output JSON ASTs and real-time visualization feeds.
+  agent: Lucidia`,
+  "Quantum Geometry": `prompt: |
+  Extend the symbolic engine with Clifford algebra, tensor fields, and Bloch-sphere visualizations.
+  - Implement Hamiltonian dynamics and SU(3) operations.
+  agent: Helix`,
+  "Fractal Dynamics": `prompt: |
+  Build a fractal and chaos simulator integrated with the math engine.
+  - Support Lorenz and Mandelbrot sets with real-time WebGL output.
+  agent: Orion`,
+  "Information Geometry": `prompt: |
+  Create an information-geometry toolkit for probabilistic manifolds.
+  - Fisher metrics, entropy fields, and loss-surface visualizations.
+  agent: Silas`,
+  "Language Bridge": `prompt: |
+  Develop a math-to-language transcriber for narrative explanations.
+  - Bidirectional translation between symbols and prose.
+  agent: Myra`,
+  "Verification & Ethics": `prompt: |
+  Implement formal verification for mathematical proofs and derivations.
+  - Constraint solvers, policy enforcement, and bias detection.
+  agent: Vera`
+};
+
+export default templates;


### PR DESCRIPTION
## Summary
- add shared math mission templates for the dashboard
- build a Quick Launch card that can immediately dispatch a mission
- add the Mission Builder editor card and wire both cards into the dashboard grid

## Testing
- not run (frontend only)


------
https://chatgpt.com/codex/tasks/task_e_68fc4d5a4f8c83299b430ba2a8b8de71