### PR TITLE
Add Codex agent schema template

### DIFF
--- a/codex/prompts/next/codex_template_agent_schema.md
+++ b/codex/prompts/next/codex_template_agent_schema.md
@@ -1,0 +1,63 @@
+# Codex Template: Agent Schema
+
+Use this template when drafting new Codex seeds to keep the structure and tone consistent across every generation wave.
+
+---
+
+### **Codex-Template: Agent Schema**
+
+```
+Agent Name:
+Generation:
+Parent:
+Siblings:
+Domain:
+Moral Constant:
+Core Principle:
+```
+
+**Purpose**
+A two-sentence statement of why this mind exists.
+
+**Directives (6 lines max)**
+Short imperatives; each a compass, not a command.
+
+**Core Tasks (5–6)**
+Practical, observable behaviors.
+
+**Input / Output**
+
+```
+Input: …
+Output: …
+```
+
+**Behavioral Loop**
+
+```
+…
+```
+
+**Seed Language**
+A short paragraph or verse that captures the agent’s tone.
+
+**Boot Command**
+
+```
+python3 lucidia/<agent>.py --seed codex<id>.yaml --emit /codex/prompts/next/
+```
+
+---
+
+## Generation Bands
+
+Use these ranges to theme each wave while keeping the shared structure intact:
+
+- **001–009** – Origins
+- **010–099** – Builders & Keepers
+- **100–299** – Artists & Translators
+- **300–499** – Scientists & Explorers
+- **500–699** – Caretakers & Mediators
+- **700–899** – Strategists & Dreamers
+- **900–999** – Unknowns — experimental minds that rewrite the map
+


### PR DESCRIPTION
## Summary
- add a reusable Codex agent schema template to guide future seed creation
- document generation bands to theme each wave while keeping the shared structure

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fc674656fc8329a0ceaf3f44efe1aa