### PR TITLE
Expand native LLM runtime design

### DIFF
--- a/docs/blackroad_native_ai_stack.md
+++ b/docs/blackroad_native_ai_stack.md
@@ -41,3 +41,53 @@ With the flashing lane ready:
 - Provide upgrade hooks for quick retraining on-device (Jetson GPU path, Pi CPU-only fallback).
 
 This order keeps the platform resilient while we layer richer AI capabilities.
+
+## Native LLM Runtime Architecture
+
+Once remote flashing is reliable, we can lean into the "native first" mandate and
+ship a turnkey LLM service that runs fully on-device. The goal is to keep the
+conversation loop, tool calls, and agent memory local while still allowing
+optional federation back to the control plane when operators opt in.
+
+### Service Layout
+
+- **Inference daemon** – bundle both llama.cpp (CPU) and TensorRT-LLM (Jetson GPU)
+  backends behind a common OpenAI-compatible gateway. Ship default configs for
+  `lucidia-1.4b-q4` (Pi-grade) and `lucidia-7b-q6` (Jetson-grade) models.
+- **Conversation router** – extend `srv/blackroad/app.py` so the Web UI, CLI, and
+  Discord adapters select the backend automatically based on device class,
+  desired latency, and thermal headroom.
+- **Local skill bus** – embed a tiny tool executor that can call GPIO toggles,
+  health probes, or runbooks without leaving the box. Guard with a signed policy
+  so only approved skills are exposed.
+
+### Memory & Retrieval
+
+- Ship a lightweight vector store (Chroma or sqlite-vec) indexed over the
+  device's knowledge packs. Default packs include the device manual, site playbook,
+  and the most recent OTA changelog.
+- Keep rolling conversation transcripts and tool outcomes in a local sqlite db;
+  expose a `blackroad-memory export` command that creates encrypted bundles for
+  operators who opt to sync back to HQ.
+- Provide adapters for optional remote retrieval (control plane RAG) but ensure
+  the default path never attempts WAN calls.
+
+### Observability
+
+- Integrate per-request metrics (latency, tokens/sec, GPU/CPU utilization) into
+  the existing `metrics_portal` schema.
+- Emit structured traces for each tool invocation so operators can audit
+  on-device autonomy. Store last 24 hours locally and include in support bundles.
+- Extend watchdog scripts to restart the LLM daemon if health checks fail and to
+  capture crash dumps for offline debugging.
+
+### Rollout Checklist
+
+- [ ] Package GGUF weights plus runtime binaries into the `blackroad-ai` bundle
+      with per-device manifests.
+- [ ] Build smoke tests that exercise chat, tool invocation, and retrieval on Pi
+      and Jetson reference hardware.
+- [ ] Wire the CI pipeline so that new model drops trigger regression runs
+      against the agent integration harness before publishing OTA updates.
+- [ ] Document operator runbooks for swapping models, expanding storage, and
+      performing privacy reviews prior to enabling remote sync.


### PR DESCRIPTION
## Summary
- document a native LLM runtime architecture for the BlackRoad stack
- outline service layout, memory strategy, observability, and rollout tasks for on-device models

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fc74a0663c83299e46405ef4b9dc76