### PR TITLE
Fix Zod validation and contract tests for API Gateway

### DIFF
--- a/services/api-gateway/src/app.ts
+++ b/services/api-gateway/src/app.ts
@@ -1,0 +1,127 @@
+import { createRequire } from 'node:module';
+import Fastify from 'fastify';
+import swagger from '@fastify/swagger';
+import swaggerUi from '@fastify/swagger-ui';
+import {
+  ZodTypeProvider,
+  jsonSchemaTransform,
+  serializerCompiler,
+  validatorCompiler
+} from 'fastify-type-provider-zod';
+import { env } from './config/env.js';
+import { loadRoutes } from './config/routes.js';
+import validationPlugin from './plugins/validation.js';
+import correlationPlugin from './plugins/correlation.js';
+import loggingPlugin from './plugins/logging.js';
+import metricsPlugin from './plugins/metrics.js';
+import tracingPlugin from './plugins/tracing.js';
+import securityPlugin from './plugins/security.js';
+import authPlugin from './plugins/auth.js';
+import proxyPlugin from './plugins/proxy.js';
+import metaRoutes from './routes/meta.js';
+import authRoutes from './routes/auth.js';
+import searchRoutes from './routes/search.js';
+import automationRoutes from './routes/automation.js';
+import consoleRoutes from './routes/console.js';
+
+const require = createRequire(import.meta.url);
+const pkg = require('../package.json') as { version: string };
+
+const GENERIC_PREFIXES = new Set(['/automation', '/console', '/search']);
+
+export async function buildServer() {
+  const fastify = Fastify({
+    logger: {
+      level: env.GATEWAY_LOG_LEVEL,
+      transport: env.isDev
+        ? {
+            target: 'pino-pretty',
+            options: {
+              colorize: true,
+              translateTime: 'SYS:standard'
+            }
+          }
+        : undefined
+    },
+    trustProxy: true,
+    bodyLimit: 1_048_576,
+    disableRequestLogging: true
+  }).withTypeProvider<ZodTypeProvider>();
+
+  fastify.setValidatorCompiler(validatorCompiler);
+  fastify.setSerializerCompiler(serializerCompiler);
+
+  await fastify.register(validationPlugin);
+  await fastify.register(correlationPlugin);
+  await fastify.register(loggingPlugin);
+  await fastify.register(metricsPlugin);
+  await fastify.register(tracingPlugin);
+  await fastify.register(securityPlugin);
+  await fastify.register(authPlugin);
+  await fastify.register(proxyPlugin);
+
+  await fastify.register(swagger, {
+    openapi: {
+      info: {
+        title: 'BlackRoad API Gateway',
+        version: pkg.version,
+        description: 'Secure entry point for BlackRoad services'
+      }
+    },
+    transform: jsonSchemaTransform
+  });
+
+  if (env.isDev) {
+    await fastify.register(swaggerUi, {
+      routePrefix: '/docs',
+      uiConfig: {
+        docExpansion: 'list'
+      }
+    });
+  }
+
+  await fastify.register(metaRoutes);
+  await fastify.register(authRoutes);
+  await fastify.register(searchRoutes);
+  await fastify.register(automationRoutes);
+  await fastify.register(consoleRoutes);
+
+  const routes = await loadRoutes();
+
+  for (const route of routes) {
+    const baseUrl = (process.env[route.target] ?? (env as Record<string, unknown>)[route.target]) as string | undefined;
+    if (!baseUrl) {
+      fastify.log.warn({ route }, 'Skipping route registration because backend URL missing');
+      continue;
+    }
+    fastify.proxy.registerBackend(route.target, baseUrl);
+
+    if (GENERIC_PREFIXES.has(route.prefix)) {
+      continue;
+    }
+
+    const handler = fastify.proxy.handler(route.target, { stripPrefix: route.prefix });
+
+    fastify.register(
+      (instance, _opts, done) => {
+        if (route.auth === 'required') {
+          instance.addHook('preHandler', async (request, reply) => {
+            await fastify.auth.required(request, reply);
+          });
+        } else {
+          instance.addHook('preHandler', async (request, reply) => {
+            await fastify.auth.optional(request, reply);
+          });
+        }
+
+        instance.all('/*', async (request, reply) => {
+          await handler(request, reply);
+        });
+        done();
+      },
+      { prefix: route.prefix }
+    );
+  }
+
+  return fastify;
+}

--- a/services/api-gateway/src/config/env.ts
+++ b/services/api-gateway/src/config/env.ts
@@ -1,17 +1,57 @@
 import { z } from 'zod';
 
+const booleanSchema = z
+  .union([z.string(), z.boolean()])
+  .optional()
+  .transform((value) => {
+    if (value === undefined) return undefined;
+    if (typeof value === 'boolean') return value;
+    if (value === 'true' || value === '1') return true;
+    if (value === 'false' || value === '0') return false;
+    return undefined;
+  });
+
 const envSchema = z.object({
-  PORT: z.coerce.number().default(8080),
-  AUTH_SERVICE_URL: z.string().url(),
-  BLACKROAD_API_URL: z.string().url(),
-  SERVICE_TOKEN: z.string().min(1)
+  GATEWAY_PORT: z.coerce.number().int().nonnegative().default(8081),
+  GATEWAY_ENV: z.enum(['dev', 'test', 'prod']).default('dev'),
+  GATEWAY_LOG_LEVEL: z.string().default('info'),
+  GATEWAY_CORS_ORIGINS: z
+    .string()
+    .optional()
+    .transform((value) => value?.split(',').map((origin) => origin.trim()).filter(Boolean) ?? []),
+  GATEWAY_RATE_LIMIT_RPM: z.coerce.number().int().positive().default(120),
+  AUTH_BASE_URL: z.string().url(),
+  AUTH_PUBLIC_CACHE_TTL_MS: z.coerce.number().int().nonnegative().default(60_000),
+  OTEL_EXPORTER_OTLP_ENDPOINT: z.string().url().optional(),
+  METRICS_ENABLED: booleanSchema,
+  ROADGLITCH_BASE_URL: z.string().url().optional(),
+  CONSOLE_BASE_URL: z.string().url().optional(),
+  SEARCH_BASE_URL: z.string().url().optional()
 });
 
-type Env = z.infer<typeof envSchema>;
+export type Env = z.infer<typeof envSchema> & {
+  corsOrigins: string[];
+  isDev: boolean;
+};
 
-export const env: Env = envSchema.parse({
-  PORT: process.env.PORT,
-  AUTH_SERVICE_URL: process.env.AUTH_SERVICE_URL,
-  BLACKROAD_API_URL: process.env.BLACKROAD_API_URL,
-  SERVICE_TOKEN: process.env.SERVICE_TOKEN
+const parsed = envSchema.parse({
+  GATEWAY_PORT: process.env.GATEWAY_PORT,
+  GATEWAY_ENV: process.env.GATEWAY_ENV,
+  GATEWAY_LOG_LEVEL: process.env.GATEWAY_LOG_LEVEL,
+  GATEWAY_CORS_ORIGINS: process.env.GATEWAY_CORS_ORIGINS,
+  GATEWAY_RATE_LIMIT_RPM: process.env.GATEWAY_RATE_LIMIT_RPM,
+  AUTH_BASE_URL: process.env.AUTH_BASE_URL,
+  AUTH_PUBLIC_CACHE_TTL_MS: process.env.AUTH_PUBLIC_CACHE_TTL_MS,
+  OTEL_EXPORTER_OTLP_ENDPOINT: process.env.OTEL_EXPORTER_OTLP_ENDPOINT,
+  METRICS_ENABLED: process.env.METRICS_ENABLED,
+  ROADGLITCH_BASE_URL: process.env.ROADGLITCH_BASE_URL,
+  CONSOLE_BASE_URL: process.env.CONSOLE_BASE_URL,
+  SEARCH_BASE_URL: process.env.SEARCH_BASE_URL
 });
+
+export const env: Env = {
+  ...parsed,
+  corsOrigins: parsed.GATEWAY_CORS_ORIGINS,
+  isDev: parsed.GATEWAY_ENV !== 'prod',
+  METRICS_ENABLED: parsed.METRICS_ENABLED ?? true
+};

--- a/services/api-gateway/src/config/routes.ts
+++ b/services/api-gateway/src/config/routes.ts
@@ -1,0 +1,23 @@
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { z } from 'zod';
+
+const routeSchema = z.object({
+  prefix: z.string().min(1),
+  target: z.string().min(1),
+  auth: z.enum(['required', 'public']).default('required')
+});
+
+const routesSchema = z.object({
+  routes: z.array(routeSchema)
+});
+
+export type GatewayRoute = z.infer<typeof routeSchema>;
+
+const defaultRoutesPath = fileURLToPath(new URL('../../config/routes.json', import.meta.url));
+
+export async function loadRoutes(filePath = defaultRoutesPath) {
+  const raw = await readFile(filePath, 'utf8');
+  const parsed = routesSchema.parse(JSON.parse(raw));
+  return parsed.routes;
+}

--- a/services/api-gateway/src/plugins/validation.ts
+++ b/services/api-gateway/src/plugins/validation.ts
@@ -1,0 +1,71 @@
+import fp from 'fastify-plugin';
+import { ZodTypeProvider, serializerCompiler, validatorCompiler } from 'fastify-type-provider-zod';
+import { ZodError } from 'zod';
+import { env } from '../config/env.js';
+import { notFound, problem, replyWithProblem } from '../utils/errors.js';
+
+interface ValidationConfig {
+  responseSchema?: {
+    parse: (payload: unknown) => unknown;
+    safeParse: (payload: unknown) => { success: boolean; data?: unknown; error?: ZodError };
+  };
+}
+
+declare module 'fastify' {
+  interface FastifyContextConfig extends ValidationConfig {}
+}
+
+export default fp(async (fastify) => {
+  fastify.withTypeProvider<ZodTypeProvider>();
+  fastify.setValidatorCompiler(validatorCompiler);
+  fastify.setSerializerCompiler(serializerCompiler);
+  fastify.setErrorHandler((error, request, reply) => {
+    if (error instanceof ZodError) {
+      return replyWithProblem(
+        reply,
+        problem({
+          type: 'https://blackroad.io/problems/validation-error',
+          title: 'Validation failed',
+          status: 400,
+          detail: error.issues.map((issue) => issue.message).join(', '),
+          instance: request.url
+        })
+      );
+    }
+
+    const status = (error as any).statusCode ?? 500;
+    const detail = (error as any).detail ?? error.message;
+    return replyWithProblem(
+      reply,
+      problem({
+        type: 'about:blank',
+        title: error.name || 'Internal Server Error',
+        status,
+        detail,
+        instance: request.url
+      })
+    );
+  });
+
+  fastify.setNotFoundHandler((request, reply) => {
+    return replyWithProblem(reply, notFound(request));
+  });
+
+  if (env.isDev) {
+    fastify.addHook('preSerialization', async (request, reply, payload) => {
+      const config = reply.context.config as ValidationConfig;
+      if (!config.responseSchema) {
+        return payload;
+      }
+
+      const result = config.responseSchema.safeParse(payload);
+      if (!result.success) {
+        const error = new Error('backend schema drift detected');
+        (error as any).statusCode = 502;
+        (error as any).detail = 'backend schema drift detected';
+        throw error;
+      }
+      return payload;
+    });
+  }
+});

--- a/services/api-gateway/tests/contract/openapi.spec.ts
+++ b/services/api-gateway/tests/contract/openapi.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest';
+
+describe('OpenAPI contract', () => {
+  it('includes core routes', async () => {
+    vi.resetModules();
+    process.env.GATEWAY_PORT = '0';
+    process.env.GATEWAY_ENV = 'test';
+    process.env.GATEWAY_LOG_LEVEL = 'silent';
+    process.env.AUTH_BASE_URL = 'http://auth.test';
+    process.env.ROADGLITCH_BASE_URL = 'http://roadglitch.test';
+    process.env.CONSOLE_BASE_URL = 'http://console.test';
+    process.env.SEARCH_BASE_URL = 'http://search.test';
+    process.env.METRICS_ENABLED = 'false';
+
+    const { buildServer } = await import('../../src/app.js');
+    const app = await buildServer();
+    await app.ready();
+    const doc = app.swagger();
+
+    expect(doc.paths['/health']).toBeDefined();
+    expect(doc.paths['/automation/runs']).toBeDefined();
+    expect(doc.paths['/console/mobile/dashboard']).toBeDefined();
+    await app.close();
+  });
+});

--- a/services/api-gateway/tests/e2e/gateway.e2e.spec.ts
+++ b/services/api-gateway/tests/e2e/gateway.e2e.spec.ts
@@ -1,0 +1,114 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { MockAgent, setGlobalDispatcher } from 'undici';
+import type { FastifyInstance } from 'fastify';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe('gateway e2e', () => {
+  let mockAgent: MockAgent;
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    vi.resetModules();
+    process.env.GATEWAY_PORT = '0';
+    process.env.GATEWAY_ENV = 'test';
+    process.env.GATEWAY_LOG_LEVEL = 'silent';
+    process.env.GATEWAY_RATE_LIMIT_RPM = '5';
+    process.env.METRICS_ENABLED = 'true';
+    process.env.AUTH_BASE_URL = 'http://auth.test';
+    process.env.ROADGLITCH_BASE_URL = 'http://roadglitch.test';
+    process.env.CONSOLE_BASE_URL = 'http://console.test';
+    process.env.SEARCH_BASE_URL = 'http://search.test';
+
+    mockAgent = new MockAgent();
+    mockAgent.disableNetConnect();
+    setGlobalDispatcher(mockAgent);
+
+    const authMock = mockAgent.get('http://auth.test');
+    authMock
+      .intercept({ path: '/tokens/verify', method: 'POST' })
+      .reply(200, { sub: 'user-abc', scope: 'automation:run' })
+      .times(1);
+
+    const roadglitch = mockAgent.get('http://roadglitch.test');
+    roadglitch
+      .intercept({ path: '/runs', method: 'POST' })
+      .reply(200, { id: 'run-1' })
+      .times(1);
+
+    const consoleApi = mockAgent.get('http://console.test');
+    consoleApi
+      .intercept({ path: '/mobile/dashboard', method: 'GET' })
+      .reply(200, {
+        summary: { incidents: 1, automationSuccessRate: 0.9, activeAlerts: 0 },
+        widgets: []
+      })
+      .times(1);
+
+    const searchApi = mockAgent.get('http://search.test');
+    searchApi
+      .intercept({ path: '/search?q=lucidia', method: 'GET' })
+      .reply(200, { results: [], nextCursor: null })
+      .times(1);
+
+    const { buildServer } = await import('../../src/app.js');
+    app = await buildServer();
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+    mockAgent.assertNoPendingInterceptors();
+    await mockAgent.close();
+  });
+
+  it('reports health status with backends', async () => {
+    const response = await app.inject({ method: 'GET', url: '/health' });
+    expect(response.statusCode).toBe(200);
+    const payload = response.json();
+    expect(payload.status).toBe('ok');
+    expect(Array.isArray(payload.backends)).toBe(true);
+  });
+
+  it('enforces auth on automation routes', async () => {
+    const unauthorized = await app.inject({ method: 'POST', url: '/automation/runs' });
+    expect(unauthorized.statusCode).toBe(401);
+
+    const authorized = await app.inject({
+      method: 'POST',
+      url: '/automation/runs',
+      headers: { Authorization: 'Bearer valid-token' },
+      payload: { job: 'deploy' }
+    });
+    expect(authorized.statusCode).toBe(200);
+    expect(authorized.json().id).toBe('run-1');
+  });
+
+  it('validates console responses', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/console/mobile/dashboard',
+      headers: { Authorization: 'Bearer valid-token' }
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().summary.incidents).toBe(1);
+  });
+
+  it('allows public search', async () => {
+    const response = await app.inject({ method: 'GET', url: '/search?q=lucidia' });
+    expect(response.statusCode).toBe(200);
+  });
+
+  it('applies rate limiting', async () => {
+    const hits = await Promise.all(
+      Array.from({ length: 6 }).map(() => app.inject({ method: 'GET', url: '/health' }))
+    );
+
+    const tooMany = hits.find((r) => r.statusCode === 429);
+    expect(tooMany).toBeDefined();
+    expect(tooMany?.headers['retry-after']).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- enable the validation plugin and Fastify app to register zod compilers and expose swagger schemas so the search route mounts correctly
- load the route map relative to the source tree, allow port 0 in tests, and wire swagger's zod transform for OpenAPI output
- update gateway e2e and contract tests to avoid worker chdir issues and align Undici intercept expectations

## Testing
- npm run test:unit
- npm run test:e2e
- npm run test
- npm run openapi:export
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fd08d00ecc83298ccdc57bcf130f6f