### PR TITLE
Add Storyteller datasets and episode rendering upgrades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,8 @@ benchmarks/
 # Lucidia artifacts
 secrets/*
 datasets/
+!agents/codex/24-storyteller/datasets/
+!agents/codex/24-storyteller/datasets/*.json
 models/
 !br-dbt/models/
 !br-dbt/models/**

--- a/agents/codex/24-storyteller/datasets/canon_timeline.json
+++ b/agents/codex/24-storyteller/datasets/canon_timeline.json
@@ -1,0 +1,9 @@
+[
+  {
+    "date": "2025-01-03",
+    "episode_id": "E-2025-01-03-kindness-loop",
+    "title": "When Roadie Remembered the Repair",
+    "summary": "Guardian flagged a brittle deploy and the crew rebuilt the ritual around care.",
+    "next_door": "E-2025-01-05-painter-light"
+  }
+]

--- a/agents/codex/24-storyteller/datasets/motifs.json
+++ b/agents/codex/24-storyteller/datasets/motifs.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "kindness-loop",
+    "symbol": "\ud83e\udde6",
+    "description": "care \u2192 action \u2192 repair \u2192 care",
+    "first_appearance": "E-2025-01-03-kindness-loop",
+    "notes": "Reminds every agent that care is the fuel for resilient systems."
+  },
+  {
+    "id": "receipt-song",
+    "symbol": "\ud83d\udcc4",
+    "description": "Stories back their wonder with receipts.",
+    "first_appearance": "E-2025-02-11-guardian-proof",
+    "notes": "Whenever Storyteller cites a source, the choir hums this motif."
+  }
+]

--- a/agents/codex/24-storyteller/pipelines/render_episode.py
+++ b/agents/codex/24-storyteller/pipelines/render_episode.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Iterable, List
 import json
 import textwrap
+from datetime import datetime
 
 from .persona_style import get_tone
 
@@ -20,9 +21,14 @@ class Episode:
     audience: str
     lessons: list[str]
     next_door: str
+    citations: list[str]
+    a_b_tests: list[dict[str, str]]
 
 
 TEMPLATE_HEADER = """# {title}\n\n> Episode ID: {episode_id}\n> Audience: {audience_title}\n"""
+
+DATASETS_DIR = Path(__file__).resolve().parent.parent / "datasets"
+CANON_TIMELINE_PATH = DATASETS_DIR / "canon_timeline.json"
 
 
 def render_markdown(episode: Episode) -> str:
@@ -30,6 +36,14 @@ def render_markdown(episode: Episode) -> str:
 
     tone = get_tone(episode.audience)
     lesson_block = "\n".join(f"- {lesson}" for lesson in episode.lessons)
+    citations_block = "\n".join(f"- {cite}" for cite in episode.citations)
+    if episode.a_b_tests:
+        experiments_block = "\n".join(
+            f"- {test.get('hypothesis', 'Hypothesis')} → {test.get('result', 'Result')}"
+            for test in episode.a_b_tests
+        )
+    else:
+        experiments_block = "_No experiments logged this time. Add one?_"
     body = textwrap.dedent(
         f"""
         ## {tone.headline}
@@ -37,6 +51,12 @@ def render_markdown(episode: Episode) -> str:
 
         ### Lessons
         {lesson_block}
+
+        ### Citations
+        {citations_block}
+
+        ### Experiments
+        {experiments_block}
 
         ### Next Door
         {episode.next_door}
@@ -49,21 +69,72 @@ def render_markdown(episode: Episode) -> str:
     ) + "\n\n" + body + "\n"
 
 
+def _load_json_list(path: Path) -> List[dict[str, Any]]:
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(data, list):
+            return [item for item in data if isinstance(item, dict)]
+    except json.JSONDecodeError:
+        pass
+    return []
+
+
+def _write_json(path: Path, data: Iterable[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(list(data), indent=2), encoding="utf-8")
+
+
+def _update_canon_timeline(entry: Dict[str, Any], path: Path = CANON_TIMELINE_PATH) -> None:
+    timeline = _load_json_list(path)
+    filtered = [item for item in timeline if item.get("episode_id") != entry.get("episode_id")]
+    filtered.append(entry)
+
+    def sort_key(item: dict[str, Any]) -> tuple[str, str]:
+        date_str = str(item.get("date", ""))
+        try:
+            dt = datetime.fromisoformat(date_str)
+            return (dt.isoformat(), item.get("episode_id", ""))
+        except ValueError:
+            return (date_str, item.get("episode_id", ""))
+
+    filtered.sort(key=sort_key)
+    _write_json(path, filtered)
+
+
 def render_from_pr(pr_event: Dict[str, Any]) -> Path:
     """Render an episode stub from a merged PR event."""
 
     output_dir = Path(pr_event.get("output_dir", "codex_episodes"))
     output_dir.mkdir(parents=True, exist_ok=True)
+    citations = pr_event.get("citations") or [
+        pr_event.get("url")
+        or f"PR #{pr_event.get('number', 'unknown')}"
+        or "Citation pending"
+    ]
+    episode_tests = [test for test in pr_event.get("a_b_tests", []) if isinstance(test, dict)]
     episode = Episode(
         episode_id=pr_event["episode_id"],
         title=pr_event["title"],
         audience=pr_event.get("audience", "engineers"),
         lessons=pr_event.get("lessons", ["Document the change." ]),
         next_door=pr_event.get("next_door", "TBD"),
+        citations=[str(cite) for cite in citations if cite],
+        a_b_tests=episode_tests,
     )
     markdown = render_markdown(episode)
     output_path = output_dir / f"{episode.episode_id}.md"
     output_path.write_text(markdown, encoding="utf-8")
     metadata_path = output_dir / f"{episode.episode_id}.json"
     metadata_path.write_text(json.dumps(pr_event, indent=2), encoding="utf-8")
+    _update_canon_timeline(
+        {
+            "date": pr_event.get("merged_at", ""),
+            "episode_id": episode.episode_id,
+            "title": episode.title,
+            "summary": pr_event.get("summary", ""),
+            "next_door": episode.next_door,
+        }
+    )
     return output_path


### PR DESCRIPTION
## Summary
- add tracked datasets for Storyteller motifs and canon timeline
- teach the Storyteller renderer to capture citations, experiments, and update the canon timeline
- allow the dataset folder to bypass the global datasets ignore rule

## Testing
- python -m py_compile __init__.py
- python -m py_compile pipelines/*.py
- python -m py_compile hooks/*.py
- python agents/auto_novel_agent.py *(fails: ValueError: Unsupported engine. Choose one of: unity, unreal.)*

------
https://chatgpt.com/codex/tasks/task_e_68fe5b78342083299763b2c5338b2972