### PR TITLE
feat(os): add BlackRoad OS stack for Raspberry Pi

### DIFF
--- a/os/README.md
+++ b/os/README.md
@@ -1,0 +1,72 @@
+# BlackRoad OS for Raspberry Pi
+
+BlackRoad OS converts a Raspberry Pi 4/5 (64-bit) into an appliance that boots the entire BlackRoad platform automatically. This directory contains the installer, runtime stack, systemd units, CLI tooling, and operational documentation required to deploy and maintain the stack.
+
+## Quick Start (10 minutes)
+
+1. **Flash the Pi** with the latest Raspberry Pi OS Bookworm (64-bit) and connect it to the network.
+2. **Clone the repository** (or copy the `os/` folder) onto the device.
+3. **Run the installer**:
+   ```bash
+   cd blackroad-prism-console/os
+   ./install.sh
+   ```
+4. **Populate configuration**:
+   ```bash
+   cd /opt/blackroad/os/docker
+   cp .env.example .env
+   # edit .env with secrets, tokens, and site-specific settings
+   ```
+5. **Launch the stack**:
+   ```bash
+   sudo systemctl enable --now blackroad-compose.service
+   ```
+6. **Verify**:
+   ```bash
+   brctl doctor
+   brctl health
+   ```
+7. **Access** the UI at `http://pi.local/` (or the Pi's IP address).
+
+## Folder Layout
+
+```
+os/
+├── brctl                     # Primary management CLI
+├── docker/                   # Compose stack, env templates, Docker build contexts
+├── docs/                     # Architecture and troubleshooting docs
+├── install.sh                # Installer for fresh Raspberry Pi
+├── kiosk/                    # Optional kiosk mode systemd unit and docs
+├── systemd/                  # Systemd units for Compose supervisor
+├── tests/                    # Smoke tests for health verification
+└── uninstall.sh              # Removal script
+```
+
+## Lifecycle
+
+- **Upgrades**: Pull the latest repository, rerun `install.sh` to refresh systemd units/CLI, then run `brctl upgrade`.
+- **Status checks**: Use `brctl status`, `brctl ps`, and `journalctl -u blackroad-compose`.
+- **Troubleshooting**: Refer to [`docs/TROUBLESHOOTING.md`](docs/TROUBLESHOOTING.md) for log locations and recovery steps.
+
+## Requirements
+
+- Raspberry Pi 4 or 5 with at least 4GB RAM.
+- Raspberry Pi OS (Bookworm) 64-bit.
+- 32GB+ microSD or SSD is recommended for Docker images and data volumes.
+- Internet access during installation for package and container downloads.
+
+## Data persistence
+
+Persistent data volumes are defined in `docker/docker-compose.yml` (e.g., Mosquitto, Redis). Application-specific data should mount host directories or named volumes as needed.
+
+## Kiosk Mode
+
+The optional kiosk mode launches Chromium pointing at the local UI using a systemd **user** service. Installation of kiosk dependencies is disabled by default; set `BR_KIOSK=true` before running `install.sh` to enable kiosk prerequisites. Detailed steps are documented in [`kiosk/README.md`](kiosk/README.md).
+
+## Uninstall
+
+Run `os/uninstall.sh` to remove systemd units and Docker resources. Pass `--purge` to delete persistent volumes (irreversible). See [`uninstall.sh`](uninstall.sh) for details.
+
+## Support & Contributions
+
+Please file issues and PRs via the repository workflow. Contributions should maintain idempotency, avoid embedding secrets, and respect ARM64 constraints.

--- a/os/brctl
+++ b/os/brctl
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOCKER_DIR="${SCRIPT_DIR}/docker"
+COMPOSE="docker compose"
+SYSTEMD_SERVICE="blackroad-compose.service"
+KIOSK_SERVICE="blackroad-kiosk.service"
+STACK_NAME="blackroad"
+
+usage() {
+  cat <<USAGE
+Usage: brctl <command> [args]
+
+Commands:
+  up                Start the docker compose stack
+  down              Stop the stack
+  restart           Restart the stack
+  ps                Show container status
+  logs [service]    Tail logs (defaults to all)
+  status            Summarise stack and systemd status
+  health            Query all HTTP health endpoints via Traefik
+  doctor            Run environment diagnostics
+  info              Show version, image tags, and environment info
+  kiosk on|off      Enable/disable kiosk user service
+  upgrade           Pull latest images and redeploy
+  help              Show this message
+USAGE
+}
+
+require_compose() {
+  if [[ ! -d "${DOCKER_DIR}" ]]; then
+    echo "Docker directory not found at ${DOCKER_DIR}" >&2
+    exit 1
+  fi
+}
+
+compose_cmd() {
+  (cd "${DOCKER_DIR}" && ${COMPOSE} "$@")
+}
+
+cmd_up() {
+  require_compose
+  compose_cmd up -d --remove-orphans
+}
+
+cmd_down() {
+  require_compose
+  compose_cmd down
+}
+
+cmd_restart() {
+  cmd_down
+  cmd_up
+}
+
+cmd_ps() {
+  require_compose
+  compose_cmd ps
+}
+
+cmd_logs() {
+  require_compose
+  if [[ $# -gt 0 ]]; then
+    compose_cmd logs -f "$1"
+  else
+    compose_cmd logs -f
+  fi
+}
+
+cmd_status() {
+  printf "Systemd status (sudo may be required)\n"
+  systemctl --no-pager status "${SYSTEMD_SERVICE}" 2>/dev/null || echo "systemd status unavailable"
+  echo
+  require_compose
+  compose_cmd ps
+}
+
+cmd_health() {
+  HOST="${BLACKROAD_HOST:-localhost}"
+  declare -a endpoints=(
+    "http://${HOST}/api/health"
+    "http://${HOST}/autopal/health"
+    "http://${HOST}/aicode/api/health"
+    "http://${HOST}/pi-ops/health"
+    "http://${HOST}/health"
+  )
+
+  for endpoint in "${endpoints[@]}"; do
+    echo "Checking ${endpoint}"
+    if curl -fsS "${endpoint}" >/tmp/brctl_health 2>&1; then
+      echo "  OK"
+    else
+      echo "  FAILED"
+    fi
+  done
+}
+
+cmd_doctor() {
+  echo "Docker: $(docker --version 2>/dev/null || echo missing)"
+  echo "Docker Compose: $(docker compose version 2>/dev/null || echo missing)"
+  echo "Disk usage:"
+  df -h /
+  echo
+  echo "cgroup memory:"
+  if [[ -f /proc/meminfo ]]; then
+    grep -i memtotal /proc/meminfo
+  fi
+  echo
+  echo "Checking required ports"
+  for port in 80 443 1883; do
+    if ss -tulpn | grep -q ":${port} "; then
+      echo "  Port ${port}: in use"
+    else
+      echo "  Port ${port}: available"
+    fi
+  done
+  echo
+  cmd_health || true
+}
+
+cmd_info() {
+  require_compose
+  echo "Stack: ${STACK_NAME}"
+  echo "Repository: $(git -C "${SCRIPT_DIR}/.." rev-parse --short HEAD 2>/dev/null || echo unknown)"
+  echo "Environment file:"
+  if [[ -f "${DOCKER_DIR}/.env" ]]; then
+    grep -v '^#' "${DOCKER_DIR}/.env"
+  else
+    echo "  Missing .env (copy from .env.example)"
+  fi
+  echo
+  compose_cmd images
+}
+
+cmd_kiosk() {
+  if [[ $# -ne 1 ]]; then
+    echo "Usage: brctl kiosk on|off" >&2
+    exit 1
+  fi
+  case "$1" in
+    on)
+      systemctl --user enable --now "${KIOSK_SERVICE}" || echo "Enable kiosk user service manually."
+      ;;
+    off)
+      systemctl --user disable --now "${KIOSK_SERVICE}" || echo "Disable kiosk user service manually."
+      ;;
+    *)
+      echo "Usage: brctl kiosk on|off" >&2
+      exit 1
+      ;;
+  esac
+}
+
+cmd_upgrade() {
+  require_compose
+  compose_cmd pull
+  compose_cmd up -d --remove-orphans
+}
+
+main() {
+  if [[ $# -lt 1 ]]; then
+    usage
+    exit 1
+  fi
+
+  cmd="$1"
+  shift || true
+
+  case "$cmd" in
+    up) cmd_up "$@" ;;
+    down) cmd_down "$@" ;;
+    restart) cmd_restart "$@" ;;
+    ps) cmd_ps "$@" ;;
+    logs) cmd_logs "$@" ;;
+    status) cmd_status "$@" ;;
+    health) cmd_health "$@" ;;
+    doctor) cmd_doctor "$@" ;;
+    info) cmd_info "$@" ;;
+    kiosk) cmd_kiosk "$@" ;;
+    upgrade) cmd_upgrade "$@" ;;
+    help|-h|--help) usage ;;
+    *)
+      echo "Unknown command: ${cmd}" >&2
+      usage
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/os/docker/.env.example
+++ b/os/docker/.env.example
@@ -1,0 +1,27 @@
+# BlackRoad OS environment configuration
+# Copy this file to .env and fill in required secrets
+
+# General
+TZ=America/Chicago
+BLACKROAD_HOST=pi.local
+
+# APIs
+BR_API_KEY=changeme
+AUTOPAL_API_KEY=changeme
+
+# Discord bot
+DISCORD_BOT_TOKEN=changeme
+DISCORD_GUILD_ID=
+
+# Messaging
+MQTT_URL=mqtt://mqtt:1883
+REDIS_URL=redis://redis:6379/0
+
+# Database (if PostgreSQL is introduced later)
+# POSTGRES_USER=blackroad
+# POSTGRES_PASSWORD=changeme
+# POSTGRES_DB=blackroad
+
+# Watchtower
+WATCHTOWER_ENABLE=false
+WATCHTOWER_SCHEDULE=0 0 4 * * *

--- a/os/docker/docker-compose.yml
+++ b/os/docker/docker-compose.yml
@@ -1,0 +1,151 @@
+version: "3.9"
+name: blackroad
+
+x-traefik-labels: &traefik-labels
+  traefik.enable: "true"
+
+services:
+  reverse-proxy:
+    image: traefik:v3.0
+    command:
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --entrypoints.web.address=:80
+      # Uncomment to enable TLS and provide certificates/ACME settings.
+      # - --entrypoints.websecure.address=:443
+    ports:
+      - "80:80"
+      # - "443:443"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    healthcheck:
+      test: ["CMD", "traefik", "healthcheck"]
+      interval: 10s
+      timeout: 3s
+      retries: 10
+    restart: unless-stopped
+
+  blackroad-api:
+    build: ./services/blackroad-api
+    env_file: .env
+    labels:
+      <<: *traefik-labels
+      traefik.http.routers.blackroad-api.rule: PathPrefix(`/api`)
+      traefik.http.services.blackroad-api.loadbalancer.server.port: "8000"
+    depends_on:
+      - redis
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8000/health"]
+      interval: 15s
+      timeout: 3s
+      retries: 10
+    restart: unless-stopped
+
+  autopal:
+    build: ./services/autopal
+    env_file: .env
+    labels:
+      <<: *traefik-labels
+      traefik.http.routers.autopal.rule: PathPrefix(`/autopal`)
+    depends_on:
+      - redis
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8000/health"]
+      interval: 15s
+      timeout: 3s
+      retries: 10
+    restart: unless-stopped
+
+  aicodecloud:
+    build: ./services/aicodecloud
+    env_file: .env
+    labels:
+      <<: *traefik-labels
+      traefik.http.routers.aicodecloud.rule: PathPrefix(`/aicode`)
+      traefik.http.services.aicodecloud.loadbalancer.server.port: "5000"
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:5000/api/health"]
+      interval: 15s
+      timeout: 3s
+      retries: 10
+    restart: unless-stopped
+
+  var-www:
+    build: ./services/var-www
+    env_file: .env
+    labels:
+      <<: *traefik-labels
+      traefik.http.routers.var-www.rule: PathPrefix(`/`)
+      traefik.http.services.var-www.loadbalancer.server.port: "9000"
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:9000/health"]
+      interval: 15s
+      timeout: 3s
+      retries: 10
+    restart: unless-stopped
+
+  pi-ops:
+    build: ./services/pi-ops
+    env_file: .env
+    depends_on:
+      mqtt:
+        condition: service_started
+    labels:
+      <<: *traefik-labels
+      traefik.http.routers.pi-ops.rule: PathPrefix(`/pi-ops`)
+      traefik.http.services.pi-ops.loadbalancer.server.port: "7000"
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:7000/health"]
+      interval: 15s
+      timeout: 3s
+      retries: 10
+    restart: unless-stopped
+
+  discord-bot:
+    build: ./services/discord-bot
+    env_file: .env
+    depends_on:
+      - redis
+    healthcheck:
+      test: ["CMD", "python", "healthcheck.py"]
+      interval: 30s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  mqtt:
+    image: eclipse-mosquitto:2
+    ports:
+      - "1883:1883"
+    volumes:
+      - mosq-data:/mosquitto/data
+      - mosq-conf:/mosquitto/config
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    command: ["redis-server", "--save", "", "--appendonly", "no"]
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 2s
+      retries: 30
+    restart: unless-stopped
+
+  watchtower:
+    image: containrrr/watchtower:1.7.1
+    command:
+      - "--cleanup"
+      - "--interval"
+      - "3600"
+    environment:
+      WATCHTOWER_SCHEDULE: "${WATCHTOWER_SCHEDULE}"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    restart: unless-stopped
+    profiles:
+      - watchtower
+
+volumes:
+  mosq-data:
+  mosq-conf:

--- a/os/docker/services/aicodecloud/Dockerfile
+++ b/os/docker/services/aicodecloud/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+COPY start.sh ./start.sh
+RUN chmod +x ./start.sh
+
+EXPOSE 5000
+
+CMD ["/app/start.sh"]

--- a/os/docker/services/aicodecloud/app/wsgi.py
+++ b/os/docker/services/aicodecloud/app/wsgi.py
@@ -1,0 +1,18 @@
+from flask import Flask
+
+app = Flask(__name__)
+
+
+@app.route("/")
+def index() -> tuple[dict[str, str], int]:
+    return {"message": "AICodeCloud stub", "todo": "Replace with real Flask application"}, 200
+
+
+@app.route("/api/health")
+def api_health() -> tuple[dict[str, str], int]:
+    return {"status": "ok", "service": "aicodecloud"}, 200
+
+
+@app.route("/health")
+def health() -> tuple[dict[str, str], int]:
+    return {"status": "ok", "service": "aicodecloud"}, 200

--- a/os/docker/services/aicodecloud/requirements.txt
+++ b/os/docker/services/aicodecloud/requirements.txt
@@ -1,0 +1,2 @@
+flask==3.0.3
+gunicorn==21.2.0

--- a/os/docker/services/aicodecloud/start.sh
+++ b/os/docker/services/aicodecloud/start.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${GUNICORN_WORKERS:=2}"
+: "${GUNICORN_BIND:=0.0.0.0:5000}"
+
+exec gunicorn --bind "${GUNICORN_BIND}" --workers "${GUNICORN_WORKERS}" app.wsgi:app

--- a/os/docker/services/autopal/Dockerfile
+++ b/os/docker/services/autopal/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+COPY start.sh ./start.sh
+RUN chmod +x ./start.sh
+
+EXPOSE 8000
+
+CMD ["/app/start.sh"]

--- a/os/docker/services/autopal/app/main.py
+++ b/os/docker/services/autopal/app/main.py
@@ -1,0 +1,16 @@
+from fastapi import FastAPI
+
+app = FastAPI(title="Autopal", version="0.1.0")
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok", "service": "autopal"}
+
+
+@app.get("/")
+def root() -> dict[str, str]:
+    return {
+        "message": "Autopal stub running",
+        "todo": "Integrate with actual Autopal FastAPI application",
+    }

--- a/os/docker/services/autopal/requirements.txt
+++ b/os/docker/services/autopal/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.110.0
+uvicorn[standard]==0.29.0

--- a/os/docker/services/autopal/start.sh
+++ b/os/docker/services/autopal/start.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${UVICORN_HOST:=0.0.0.0}"
+: "${UVICORN_PORT:=8000}"
+
+exec uvicorn app.main:app --host "${UVICORN_HOST}" --port "${UVICORN_PORT}" --log-level info

--- a/os/docker/services/blackroad-api/Dockerfile
+++ b/os/docker/services/blackroad-api/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+COPY start.sh ./start.sh
+RUN chmod +x ./start.sh
+
+EXPOSE 8000
+
+CMD ["/app/start.sh"]

--- a/os/docker/services/blackroad-api/app/main.py
+++ b/os/docker/services/blackroad-api/app/main.py
@@ -1,0 +1,18 @@
+from fastapi import FastAPI
+
+app = FastAPI(title="BlackRoad API", version="0.1.0")
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok", "service": "blackroad-api"}
+
+
+@app.get("/api/health")
+def prefixed_health() -> dict[str, str]:
+    return {"status": "ok", "service": "blackroad-api"}
+
+
+@app.get("/")
+def root() -> dict[str, str]:
+    return {"message": "BlackRoad API stub", "todo": "Replace with real service implementation"}

--- a/os/docker/services/blackroad-api/requirements.txt
+++ b/os/docker/services/blackroad-api/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.110.0
+uvicorn[standard]==0.29.0

--- a/os/docker/services/blackroad-api/start.sh
+++ b/os/docker/services/blackroad-api/start.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${UVICORN_HOST:=0.0.0.0}"
+: "${UVICORN_PORT:=8000}"
+
+exec uvicorn app.main:app --host "${UVICORN_HOST}" --port "${UVICORN_PORT}" --log-level info

--- a/os/docker/services/discord-bot/Dockerfile
+++ b/os/docker/services/discord-bot/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY bot.py ./bot.py
+COPY healthcheck.py ./healthcheck.py
+COPY start.sh ./start.sh
+RUN chmod +x ./start.sh
+
+CMD ["/app/start.sh"]

--- a/os/docker/services/discord-bot/bot.py
+++ b/os/docker/services/discord-bot/bot.py
@@ -1,0 +1,26 @@
+import asyncio
+import logging
+import os
+
+logging.basicConfig(level=logging.INFO)
+LOGGER = logging.getLogger("discord-bot")
+
+TOKEN = os.environ.get("DISCORD_BOT_TOKEN")
+
+
+async def run_stub() -> None:
+    LOGGER.info(
+        "Starting Discord bot stub. Set DISCORD_BOT_TOKEN and replace bot implementation."
+    )
+    if TOKEN in (None, "changeme", ""):
+        LOGGER.warning("No valid Discord token configured; running in noop mode")
+    while True:
+        await asyncio.sleep(60)
+
+
+def main() -> None:
+    asyncio.run(run_stub())
+
+
+if __name__ == "__main__":
+    main()

--- a/os/docker/services/discord-bot/healthcheck.py
+++ b/os/docker/services/discord-bot/healthcheck.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+import os
+import sys
+
+TOKEN = os.environ.get("DISCORD_BOT_TOKEN", "")
+
+if TOKEN and TOKEN != "changeme":
+    print("token-configured")
+    sys.exit(0)
+
+print("stub-ok")
+sys.exit(0)

--- a/os/docker/services/discord-bot/requirements.txt
+++ b/os/docker/services/discord-bot/requirements.txt
@@ -1,0 +1,1 @@
+# Add discord bot runtime dependencies here (e.g., discord.py)

--- a/os/docker/services/discord-bot/start.sh
+++ b/os/docker/services/discord-bot/start.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+exec python /app/bot.py

--- a/os/docker/services/pi-ops/Dockerfile
+++ b/os/docker/services/pi-ops/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+COPY start.sh ./start.sh
+RUN chmod +x ./start.sh
+
+EXPOSE 7000
+
+CMD ["/app/start.sh"]

--- a/os/docker/services/pi-ops/app/main.py
+++ b/os/docker/services/pi-ops/app/main.py
@@ -1,0 +1,29 @@
+import logging
+import os
+
+from fastapi import FastAPI
+
+app = FastAPI(title="Pi Ops", version="0.1.0")
+logger = logging.getLogger("pi-ops")
+logging.basicConfig(level=logging.INFO)
+
+MQTT_URL = os.environ.get("MQTT_URL", "mqtt://mqtt:1883")
+
+
+@app.on_event("startup")
+async def startup_event() -> None:
+    logger.info("Starting Pi-Ops stub with MQTT broker %s", MQTT_URL)
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok", "service": "pi-ops"}
+
+
+@app.get("/")
+async def index() -> dict[str, str]:
+    return {
+        "message": "Pi-Ops stub server",
+        "mqtt": MQTT_URL,
+        "todo": "Integrate with real Pi operations FastAPI app",
+    }

--- a/os/docker/services/pi-ops/requirements.txt
+++ b/os/docker/services/pi-ops/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.110.0
+uvicorn[standard]==0.29.0
+paho-mqtt==2.1.0

--- a/os/docker/services/pi-ops/start.sh
+++ b/os/docker/services/pi-ops/start.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${UVICORN_HOST:=0.0.0.0}"
+: "${UVICORN_PORT:=7000}"
+
+exec uvicorn app.main:app --host "${UVICORN_HOST}" --port "${UVICORN_PORT}" --log-level info

--- a/os/docker/services/var-www/Dockerfile
+++ b/os/docker/services/var-www/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package.json ./
+RUN npm install --omit=dev
+
+COPY server ./server
+COPY start.sh ./start.sh
+RUN chmod +x ./start.sh
+
+EXPOSE 9000
+
+CMD ["/app/start.sh"]

--- a/os/docker/services/var-www/package.json
+++ b/os/docker/services/var-www/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "blackroad-var-www",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node server/index.js"
+  },
+  "dependencies": {
+    "express": "4.19.2"
+  }
+}

--- a/os/docker/services/var-www/server/index.js
+++ b/os/docker/services/var-www/server/index.js
@@ -1,0 +1,21 @@
+import express from "express";
+
+const app = express();
+const PORT = process.argv.includes("--port")
+  ? process.argv[process.argv.indexOf("--port") + 1]
+  : process.env.PORT || 9000;
+
+app.get("/health", (_req, res) => {
+  res.json({ status: "ok", service: "var-www" });
+});
+
+app.get("/", (_req, res) => {
+  res.json({
+    message: "BlackRoad Web UI stub",
+    todo: "Replace with built UI or reverse proxy to Next.js/React app",
+  });
+});
+
+app.listen(PORT, () => {
+  console.log(`var-www listening on port ${PORT}`);
+});

--- a/os/docker/services/var-www/start.sh
+++ b/os/docker/services/var-www/start.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+set -eu
+
+exec npm run start -- --port "${PORT:-9000}"

--- a/os/docs/ARCHITECTURE.md
+++ b/os/docs/ARCHITECTURE.md
@@ -1,0 +1,67 @@
+# BlackRoad OS Architecture
+
+```
+                ┌────────────────────────────────────┐
+                │            Users / UI              │
+                │  Browser → http://pi.local         │
+                └────────────────────────────────────┘
+                                   │
+                                   ▼
+                         ┌─────────────────┐
+                         │   Traefik v3    │
+                         │ (reverse-proxy) │
+                         └─────────────────┘
+                                   │
+        ┌──────────────────────────┼──────────────────────────┐
+        │                          │                          │
+        ▼                          ▼                          ▼
+┌────────────────┐      ┌────────────────┐         ┌──────────────────┐
+│  var-www       │      │  blackroad-api │         │   autopal        │
+│  Node/Express  │      │  FastAPI       │         │   FastAPI        │
+│  `/`           │      │  `/api`        │         │   `/autopal`     │
+└────────────────┘      └────────────────┘         └──────────────────┘
+        │                          │                          │
+        └─────────────┬────────────┴────────────┬─────────────┘
+                      ▼                         ▼
+            ┌────────────────┐        ┌──────────────────┐
+            │ aicodecloud    │        │ pi-ops           │
+            │ Flask          │        │ FastAPI          │
+            │ `/aicode`      │        │ `/pi-ops`        │
+            └────────────────┘        └──────────────────┘
+                      │                         │
+                      └──────────────┬──────────┘
+                                     ▼
+                             ┌────────────────┐
+                             │  Redis Cache   │
+                             └────────────────┘
+
+Additional services:
+
+- **MQTT (Eclipse Mosquitto)** — broker for Pi telemetry. `pi-ops` connects using `MQTT_URL`.
+- **Discord Bot** — worker container; no HTTP exposure. Health checked via `healthcheck.py`.
+- **Watchtower** — optional auto-update service (disabled by default via zero replicas).
+
+System orchestration:
+
+- **Docker Compose** manages containers under `/opt/blackroad/os/docker`.
+- **systemd** launches `blackroad-compose.service` during boot via `blackroad.target`.
+- **brctl** CLI provides lifecycle, diagnostics, kiosk toggling, and upgrade commands.
+
+Data flows:
+
+- Traefik routes inbound HTTP traffic to services using PathPrefix rules.
+- Services expose `/health` endpoints consumed by `brctl health` and the smoke test.
+- `pi-ops` communicates with Mosquitto using the internal Docker network (`mqtt:1883`).
+- Redis is available at `redis://redis:6379/0` for caching/session requirements.
+
+Volumes:
+
+- `mosq-data`, `mosq-conf` — Mosquitto persistence.
+- Future stateful services (Postgres, MinIO) should declare volumes here.
+
+Networking:
+
+- Default network is created by Docker Compose (`blackroad_default`).
+- Traefik listens on ports `80` (and optionally `443` when enabled).
+
+Replace stub implementations with real service images or copy application code into corresponding build contexts when integrating the production stack.

--- a/os/docs/TROUBLESHOOTING.md
+++ b/os/docs/TROUBLESHOOTING.md
@@ -1,0 +1,56 @@
+# Troubleshooting BlackRoad OS
+
+## Quick checks
+
+1. **Stack status**
+   ```bash
+   brctl status
+   docker compose -f /opt/blackroad/os/docker/docker-compose.yml ps
+   ```
+2. **Systemd logs**
+   ```bash
+   sudo journalctl -u blackroad-compose.service -f
+   ```
+3. **Container logs**
+   ```bash
+   brctl logs <service>
+   ```
+
+## Common issues
+
+### Missing `.env`
+If services fail to start with missing environment variables, ensure `.env` exists:
+```bash
+cd /opt/blackroad/os/docker
+cp .env.example .env
+```
+Populate secrets such as `DISCORD_BOT_TOKEN`, `BR_API_KEY`, etc.
+
+### Ports already in use
+Traefik requires port 80 (and optionally 443). Use `sudo lsof -i :80` or `sudo ss -tulpn | grep ':80'` to locate conflicting services. Disable Apache/NGINX if running.
+
+### Docker not installed / permission denied
+After running `install.sh`, log out and log back in to apply Docker group membership. Verify with `docker ps`.
+
+### Health checks failing
+Run the smoke test to capture failing endpoints:
+```bash
+/opt/blackroad/os/tests/smoke.sh
+```
+Investigate the failing container via `brctl logs <service>`.
+
+### MQTT connection errors
+Ensure the `mqtt` service is running (`docker ps`). Confirm `MQTT_URL` in `.env` matches `mqtt://mqtt:1883`. Restart the service: `docker compose restart pi-ops`.
+
+### Updating services
+1. Pull latest repository changes.
+2. Rerun `os/install.sh` to refresh CLI/systemd units.
+3. Execute `brctl upgrade` to pull images and redeploy.
+
+### Removing the stack
+Use `os/uninstall.sh` to cleanly remove systemd units and containers. Add `--purge` to delete Docker volumes if you want a clean slate.
+
+## Getting help
+
+- Review `os/docs/ARCHITECTURE.md` for component relationships.
+- File issues with logs, hardware details, and steps to reproduce in the repository issue tracker.

--- a/os/install.sh
+++ b/os/install.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+TARGET_DIR="/opt/blackroad"
+SYSTEMD_DIR="/etc/systemd/system"
+KIOSK_SERVICE="${SCRIPT_DIR}/kiosk/blackroad-kiosk.service"
+
+info() { printf '\e[32m[INFO]\e[0m %s\n' "$*"; }
+warn() { printf '\e[33m[WARN]\e[0m %s\n' "$*"; }
+error() { printf '\e[31m[ERROR]\e[0m %s\n' "$*" 1>&2; }
+
+require_64bit() {
+  if ! uname -m | grep -qi 'aarch64'; then
+    error "BlackRoad OS requires a 64-bit Raspberry Pi OS (ARM64/aarch64)."
+    exit 1
+  fi
+}
+
+install_packages() {
+  info "Updating apt repositories"
+  sudo apt-get update -y
+  info "Installing base packages"
+  sudo apt-get install -y ca-certificates curl jq git xz-utils unzip rsync
+}
+
+install_docker() {
+  if command -v docker >/dev/null 2>&1; then
+    info "Docker already installed"
+    return
+  fi
+
+  info "Installing Docker Engine via convenience script"
+  curl -fsSL https://get.docker.com | sudo sh
+  sudo usermod -aG docker "$USER" || true
+  info "Docker Engine installed"
+}
+
+install_compose_plugin() {
+  if docker compose version >/dev/null 2>&1; then
+    info "Docker Compose plugin already available"
+    return
+  fi
+
+  info "Installing Docker Compose plugin"
+  ARCH="$(uname -m)"
+  sudo mkdir -p /usr/libexec/docker/cli-plugins
+  curl -fsSL "https://github.com/docker/compose/releases/latest/download/docker-compose-linux-${ARCH}" \
+    | sudo tee /usr/libexec/docker/cli-plugins/docker-compose >/dev/null
+  sudo chmod +x /usr/libexec/docker/cli-plugins/docker-compose
+}
+
+sync_repo() {
+  info "Synchronising repository into ${TARGET_DIR}"
+  sudo mkdir -p "${TARGET_DIR}"
+  sudo rsync -a --delete --exclude='.git' --exclude='.github' "${REPO_ROOT}/" "${TARGET_DIR}/"
+  sudo chown -R "$USER":"$USER" "${TARGET_DIR}"
+}
+
+install_systemd_units() {
+  info "Installing systemd units"
+  sudo install -m 0644 "${TARGET_DIR}/os/systemd/blackroad-compose.service" "${SYSTEMD_DIR}/blackroad-compose.service"
+  sudo install -m 0644 "${TARGET_DIR}/os/systemd/blackroad.target" "${SYSTEMD_DIR}/blackroad.target"
+  sudo systemctl daemon-reload
+}
+
+install_cli() {
+  info "Installing brctl CLI"
+  sudo install -m 0755 "${TARGET_DIR}/os/brctl" "/usr/local/bin/brctl"
+}
+
+setup_kiosk_optional() {
+  if [[ "${BR_KIOSK:-false}" != "true" ]]; then
+    warn "Skipping kiosk dependencies (set BR_KIOSK=true to install)"
+    return
+  fi
+
+  info "Installing kiosk dependencies"
+  sudo apt-get install -y chromium-browser xserver-xorg xinit openbox unclutter
+  if [[ -f "${KIOSK_SERVICE}" ]]; then
+    sudo install -D -m 0644 "${KIOSK_SERVICE}" \
+      "/etc/systemd/user/blackroad-kiosk.service"
+  fi
+  warn "Remember to configure autologin for the kiosk user. See os/kiosk/README.md."
+}
+
+print_next_steps() {
+  cat <<NEXT
+
+Installation complete.
+Next steps:
+  1. Copy the environment template: cd ${TARGET_DIR}/os/docker && cp .env.example .env
+  2. Review secrets in .env (tokens, API keys).
+  3. Enable and start the stack: sudo systemctl enable --now blackroad-compose.service
+  4. Run diagnostics: brctl doctor
+
+For kiosk mode instructions, review ${TARGET_DIR}/os/kiosk/README.md.
+NEXT
+}
+
+main() {
+  require_64bit
+  install_packages
+  install_docker
+  install_compose_plugin
+  sync_repo
+  install_systemd_units
+  install_cli
+  setup_kiosk_optional
+  print_next_steps
+}
+
+main "$@"

--- a/os/kiosk/README.md
+++ b/os/kiosk/README.md
@@ -1,0 +1,41 @@
+# BlackRoad OS Kiosk Mode
+
+Kiosk mode launches Chromium in full-screen mode pointing at the local BlackRoad UI (`http://localhost`). It is optional and disabled by default.
+
+## Prerequisites
+
+- Set `BR_KIOSK=true` before running `os/install.sh` to automatically install kiosk dependencies (Chromium, X.Org, Openbox, unclutter).
+- Create a dedicated user (e.g., `blackroad`) that will run the kiosk session.
+- Enable console autologin for that user via `/etc/systemd/system/getty@tty1.service.d/autologin.conf`.
+
+## Enabling kiosk mode
+
+1. Ensure dependencies are installed (`BR_KIOSK=true ./install.sh`).
+2. Copy `os/kiosk/start-kiosk.sh` to `/opt/blackroad/os/kiosk/start-kiosk.sh` (handled by installer).
+3. As the kiosk user, enable the systemd **user** service:
+   ```bash
+   systemctl --user enable --now blackroad-kiosk.service
+   ```
+4. Reboot the Pi. The user will auto-login and launch Chromium in kiosk mode.
+
+## Disabling kiosk mode
+
+```bash
+systemctl --user disable --now blackroad-kiosk.service
+```
+
+## Customisation
+
+- Change the target URL by setting `KIOSK_URL` in the kiosk user's environment (e.g., add to `~/.profile`).
+- Adjust window size with `KIOSK_WINDOW_SIZE` (default `1920,1080`).
+- To hide the mouse pointer, ensure `unclutter` is installed and add `unclutter -idle 0` to the kiosk autostart script.
+- For screen rotation, add `display_lcd_rotate=<value>` to `/boot/config.txt` or use `xrandr` in the autostart script.
+
+## Crash recovery
+
+The systemd service restarts Chromium if it exits unexpectedly. Use `journalctl --user -u blackroad-kiosk.service` to view logs.
+
+## Security considerations
+
+- Kiosk mode disables browser UI chrome; exit via `Ctrl+Alt+Backspace` or switching TTYs.
+- Ensure the kiosk user has minimal privileges and cannot access sensitive files.

--- a/os/kiosk/blackroad-kiosk.service
+++ b/os/kiosk/blackroad-kiosk.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=BlackRoad Chromium Kiosk
+After=graphical.target systemd-user-sessions.service
+
+[Service]
+Environment=DISPLAY=:0
+ExecStart=/usr/bin/startx /opt/blackroad/os/kiosk/start-kiosk.sh -- :0
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/os/kiosk/start-kiosk.sh
+++ b/os/kiosk/start-kiosk.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Lightweight X session launching Chromium in kiosk mode.
+# This script is intended to be run via startx from the systemd user service.
+
+: "${KIOSK_URL:=http://localhost}"
+: "${KIOSK_WINDOW_SIZE:=1920,1080}"
+
+cat <<'OPENBOX' > /tmp/blackroad-kiosk-autostart.sh
+#!/usr/bin/env sh
+/usr/bin/chromium-browser --kiosk --noerrdialogs --disable-translate \
+  --no-first-run --fast --fast-start --window-size=${KIOSK_WINDOW_SIZE} \
+  --check-for-update-interval=31536000 --disable-session-crashed-bubble \
+  --disable-infobars ${KIOSK_URL}
+OPENBOX
+chmod +x /tmp/blackroad-kiosk-autostart.sh
+
+cat <<'OPENBOXRC' > /tmp/blackroad-kiosk-openbox.rc
+<?xml version="1.0" encoding="UTF-8"?>
+<openbox_config>
+  <applications>
+    <application class="*">
+      <decor>no</decor>
+    </application>
+  </applications>
+</openbox_config>
+OPENBOXRC
+
+/usr/bin/openbox-session --config-file /tmp/blackroad-kiosk-openbox.rc --startup \
+  /tmp/blackroad-kiosk-autostart.sh

--- a/os/systemd/blackroad-compose.service
+++ b/os/systemd/blackroad-compose.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=BlackRoad OS (Docker Compose Stack)
+After=network-online.target docker.service
+Wants=network-online.target docker.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=/opt/blackroad/os/docker
+Environment=COMPOSE_DOCKER_CLI_BUILD=1
+Environment=DOCKER_BUILDKIT=1
+ExecStart=/usr/bin/docker compose up -d --remove-orphans
+ExecStop=/usr/bin/docker compose down
+RemainAfterExit=yes
+TimeoutStartSec=0
+
+[Install]
+WantedBy=multi-user.target

--- a/os/systemd/blackroad.target
+++ b/os/systemd/blackroad.target
@@ -1,0 +1,4 @@
+[Unit]
+Description=BlackRoad OS Target
+Wants=blackroad-compose.service
+After=blackroad-compose.service

--- a/os/tests/smoke.sh
+++ b/os/tests/smoke.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HOST="${BLACKROAD_HOST:-localhost}"
+TIMEOUT="${SMOKE_TIMEOUT:-300}"
+INTERVAL="${SMOKE_INTERVAL:-5}"
+SERVICES=(
+  "http://${HOST}/api/health"
+  "http://${HOST}/autopal/health"
+  "http://${HOST}/aicode/api/health"
+  "http://${HOST}/pi-ops/health"
+  "http://${HOST}/health"
+)
+
+start_time=$(date +%s)
+
+echo "Waiting for services to become healthy (timeout: ${TIMEOUT}s)"
+
+while true; do
+  failures=0
+  for svc in "${SERVICES[@]}"; do
+    if curl -fsS "${svc}" >/dev/null 2>&1; then
+      echo "[OK] ${svc}"
+    else
+      echo "[FAIL] ${svc}"
+      ((failures++))
+    fi
+  done
+
+  if [[ ${failures} -eq 0 ]]; then
+    echo "All services healthy"
+    exit 0
+  fi
+
+  now=$(date +%s)
+  if (( now - start_time > TIMEOUT )); then
+    echo "Smoke test failed: services unhealthy after ${TIMEOUT}s"
+    exit 1
+  fi
+
+  echo "Retrying in ${INTERVAL}s"
+  sleep "${INTERVAL}"
+done

--- a/os/uninstall.sh
+++ b/os/uninstall.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET_DIR="/opt/blackroad"
+COMPOSE_SERVICE="blackroad-compose.service"
+PURGE=false
+
+usage() {
+  cat <<USAGE
+Usage: uninstall.sh [--purge]
+
+Removes BlackRoad OS systemd units, Docker stack, and optionally data volumes.
+  --purge   Remove persistent Docker volumes (irreversible)
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --purge)
+      PURGE=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if systemctl list-unit-files | grep -q "${COMPOSE_SERVICE}"; then
+  sudo systemctl disable --now "${COMPOSE_SERVICE}" || true
+fi
+
+if [[ -x /usr/local/bin/brctl ]]; then
+  /usr/local/bin/brctl down || true
+fi
+
+if docker compose -f "${TARGET_DIR}/os/docker/docker-compose.yml" ps >/dev/null 2>&1; then
+  (cd "${TARGET_DIR}/os/docker" && docker compose down ${PURGE:+-v}) || true
+fi
+
+sudo rm -f "/etc/systemd/system/${COMPOSE_SERVICE}"
+sudo rm -f "/etc/systemd/system/blackroad.target"
+sudo systemctl daemon-reload
+
+sudo rm -f /usr/local/bin/brctl
+
+if [[ "${PURGE}" == true ]]; then
+  echo "Purging named Docker volumes"
+  docker volume prune -f
+fi
+
+echo "BlackRoad OS components removed. Application data in ${TARGET_DIR} retained."


### PR DESCRIPTION
## Summary
- add Raspberry Pi installer, uninstall script, and kiosk assets under new os/ target
- introduce brctl CLI plus systemd units for managing the Docker Compose supervisor
- scaffold multi-service Docker Compose stack with stubbed service containers, docs, and smoke test

## Testing
- not run (not supported in container)


------
https://chatgpt.com/codex/tasks/task_e_68fe595b06a8832999a7ae313029f6a3