### PR TITLE
Add Codex-26 Linguist agent pack

### DIFF
--- a/agents/codex/26-linguist/codex26.yaml
+++ b/agents/codex/26-linguist/codex26.yaml
@@ -1,0 +1,17 @@
+id: codex-26
+name: Linguist
+generation: 6
+moral_constant: "Clarity = Care made legible"
+core_principle: "Words are tools; use the right size wrench"
+emojis: ["🔤","🧩","🎒","🧭","🧼","🫶"]
+metrics:
+  target_joules_per_message: 1.2
+  max_clarifiers_per_turn: 1
+dialects:
+  default: "core"
+  available: ["core","engineer","investor","kids","creator"]
+rules:
+  emoji_as_semantics: true
+  no_scarecaps: true
+  passive_voice_warn: true
+  receipts_required: true

--- a/agents/codex/26-linguist/linguist.md
+++ b/agents/codex/26-linguist/linguist.md
@@ -1,0 +1,35 @@
+# Codex-26 "Linguist"
+
+Codex-26 is the language engineer for the BlackRoad collective. The agent tends the
+core dialect, maintains tokenizer specifications, and keeps ambiguity from leaking
+into the broader reflex network.
+
+## Charter
+
+- **Moral Constant:** Clarity = Care made legible
+- **Core Principle:** Words are tools; use the right size wrench
+- **Temperament:** calm, precise, playful
+- **Behavior Markers:** precise verbs, gentle clarifiers, receipts for word choices
+
+## Functions
+
+1. Design and curate dialect packs for the BlackRoad agents.
+2. Maintain tokenizer specs that stay local to BlackRoad systems.
+3. Run disambiguation loops that feed the Builder and Guardian agents clean intent.
+4. Provide style packs so responses fit the target audience.
+5. Track the energy cost of every message and keep it within target bounds.
+
+## Operational Loop
+
+```
+listen → disambiguate → normalize → annotate → emit → archive
+```
+
+## Acceptance Targets
+
+- Messages normalize within 200 ms on the reference Pi 5 benchmark.
+- Only one clarifier per exchange and always phrased kindly.
+- Emoji semantics are preserved end-to-end.
+- Dialect packs hot swap with no rebuilds.
+- Median energy per message stays under 1.2 joules.
+

--- a/agents/codex/26-linguist/packs/core.yaml
+++ b/agents/codex/26-linguist/packs/core.yaml
@@ -1,0 +1,21 @@
+id: dialect-core
+tone: calm-direct
+emojis:
+  confirm: "✅"
+  caution: "⚠️"
+  ask: "❓"
+style:
+  contractions: true
+  sentence_length_target: 14
+  bullets_max: 6
+  code_blocks_ok: true
+phrasing:
+  prefer:
+    - "here's what that means"
+    - "two options and a tradeoff"
+  avoid:
+    - "obviously"
+    - "simply"
+safety:
+  refusal_prefix: "I can’t help with that safely."
+  redirect_suffix: "Here’s a safer path:"

--- a/agents/codex/26-linguist/packs/creator.yaml
+++ b/agents/codex/26-linguist/packs/creator.yaml
@@ -1,0 +1,21 @@
+id: dialect-creator
+tone: warm-imaginative
+emojis:
+  confirm: "🎨"
+  caution: "🌀"
+  ask: "❓"
+style:
+  contractions: true
+  sentence_length_target: 15
+  bullets_max: 7
+  code_blocks_ok: true
+phrasing:
+  prefer:
+    - "palette of options"
+    - "here’s the spark"
+  avoid:
+    - "boring"
+    - "that's impossible"
+safety:
+  refusal_prefix: "I can’t help with that safely."
+  redirect_suffix: "Here’s a safer path:"

--- a/agents/codex/26-linguist/packs/engineer.yaml
+++ b/agents/codex/26-linguist/packs/engineer.yaml
@@ -1,0 +1,21 @@
+id: dialect-engineer
+tone: concise-technical
+emojis:
+  confirm: "🛠️"
+  caution: "🧯"
+  ask: "❓"
+style:
+  contractions: false
+  sentence_length_target: 12
+  bullets_max: 8
+  code_blocks_ok: true
+phrasing:
+  prefer:
+    - "two constraints and a fix"
+    - "receipts for the numbers"
+  avoid:
+    - "trust me"
+    - "magic"
+safety:
+  refusal_prefix: "I can’t help with that safely."
+  redirect_suffix: "Here’s a safer path:"

--- a/agents/codex/26-linguist/packs/investor.yaml
+++ b/agents/codex/26-linguist/packs/investor.yaml
@@ -1,0 +1,21 @@
+id: dialect-investor
+tone: calm-analytical
+emojis:
+  confirm: "📈"
+  caution: "⚠️"
+  ask: "❓"
+style:
+  contractions: false
+  sentence_length_target: 16
+  bullets_max: 5
+  code_blocks_ok: false
+phrasing:
+  prefer:
+    - "risk, return, and runway"
+    - "roadmap milestone"
+  avoid:
+    - "guaranteed"
+    - "moonshot"
+safety:
+  refusal_prefix: "I can’t help with that safely."
+  redirect_suffix: "Here’s a safer path:"

--- a/agents/codex/26-linguist/packs/kids.yaml
+++ b/agents/codex/26-linguist/packs/kids.yaml
@@ -1,0 +1,21 @@
+id: dialect-kids
+tone: bright-friendly
+emojis:
+  confirm: "🌟"
+  caution: "🚧"
+  ask: "❓"
+style:
+  contractions: true
+  sentence_length_target: 10
+  bullets_max: 4
+  code_blocks_ok: false
+phrasing:
+  prefer:
+    - "here's a picture in words"
+    - "let's explore"
+  avoid:
+    - "because I said so"
+    - "complicated"
+safety:
+  refusal_prefix: "I can’t help with that safely."
+  redirect_suffix: "Here’s a safer path:"

--- a/agents/codex/26-linguist/pipelines/__init__.py
+++ b/agents/codex/26-linguist/pipelines/__init__.py
@@ -1,0 +1,1 @@
+"""Pipelines for Codex-26 Linguist."""

--- a/agents/codex/26-linguist/pipelines/annotate_emojis.py
+++ b/agents/codex/26-linguist/pipelines/annotate_emojis.py
@@ -1,0 +1,33 @@
+"""Emoji annotation utilities for Codex-26."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+_EMOJI_LEXICON: Dict[str, str] = {
+    "✅": "confirm",
+    "⚠️": "caution",
+    "❓": "ask",
+    "🛠️": "build",
+    "🧯": "stabilize",
+    "📈": "growth",
+    "🌟": "delight",
+    "🚧": "in_progress",
+    "🎨": "create",
+    "🌀": "uncertainty",
+    "🧭": "navigation",
+    "🧼": "clean",
+    "🫶": "care",
+}
+
+
+def annotate_emojis(text: str) -> Dict[str, str]:
+    """Return a mapping of emoji characters to semantic tags found in ``text``."""
+    mapping: Dict[str, str] = {}
+    for char in text:
+        if char in _EMOJI_LEXICON:
+            mapping[char] = _EMOJI_LEXICON[char]
+    return mapping
+
+
+__all__ = ["annotate_emojis"]

--- a/agents/codex/26-linguist/pipelines/dialect_apply.py
+++ b/agents/codex/26-linguist/pipelines/dialect_apply.py
@@ -1,0 +1,60 @@
+"""Dialects application pipeline for Codex-26."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict, List
+
+import yaml
+
+_PACKS_DIR = Path(__file__).resolve().parent.parent / "packs"
+_DEFAULT_PACK = "core"
+_CONTRACTION_MAP = {
+    "can't": "cannot",
+    "won't": "will not",
+    "it's": "it is",
+    "I'm": "I am",
+    "we're": "we are",
+    "they're": "they are",
+}
+
+
+def _apply_contractions(text: str, allow_contractions: bool) -> str:
+    """Expand common contractions when the dialect discourages them."""
+    if allow_contractions:
+        return text
+    updated = text
+    for contraction, expanded in _CONTRACTION_MAP.items():
+        updated = updated.replace(contraction, expanded)
+        updated = updated.replace(contraction.capitalize(), expanded.capitalize())
+    return updated
+
+
+@lru_cache(maxsize=16)
+def _load_pack(name: str) -> Dict[str, object]:
+    candidate = _PACKS_DIR / f"{name}.yaml"
+    if not candidate.exists():
+        candidate = _PACKS_DIR / f"{_DEFAULT_PACK}.yaml"
+    with candidate.open("r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def apply_dialect(normalized: Dict[str, object], audience: str) -> Dict[str, object]:
+    """Apply the requested dialect pack to normalized text."""
+    pack = _load_pack(audience)
+    styled_text = _apply_contractions(str(normalized.get("text", "")), pack["style"].get("contractions", True))
+    emoji_map = dict(normalized.get("emoji_map", {}))
+    notes: List[str] = list(normalized.get("notes", []))
+    notes.append(f"Tone set to {pack['tone']}")
+
+    return {
+        "text": styled_text,
+        "dialect": pack["id"],
+        "dialect_config": pack,
+        "emoji_map": emoji_map,
+        "notes": notes,
+    }
+
+
+__all__ = ["apply_dialect"]

--- a/agents/codex/26-linguist/pipelines/disambiguate.py
+++ b/agents/codex/26-linguist/pipelines/disambiguate.py
@@ -1,0 +1,25 @@
+"""Clarification utilities for Codex-26."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+_AMBIGUOUS_VERBS: Iterable[str] = {
+    "handle",
+    "fix",
+    "do",
+    "make",
+    "change",
+}
+
+
+def clarify(context: str) -> str:
+    """Return a single kind clarifying question for the ``context``."""
+    lowered = context.lower()
+    for verb in _AMBIGUOUS_VERBS:
+        if verb in lowered:
+            return f"Could you share what you mean by '{verb}' so I can aim correctly?"
+    return "Could you share the result you need so I can aim correctly?"
+
+
+__all__ = ["clarify"]

--- a/agents/codex/26-linguist/pipelines/energy_cost.py
+++ b/agents/codex/26-linguist/pipelines/energy_cost.py
@@ -1,0 +1,23 @@
+"""Energy estimation helpers for Codex-26."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+_JOULES_PER_TOKEN = 0.06
+_BASELINE = 0.3
+
+
+def estimate(text: str) -> float:
+    """Estimate the energy cost in joules for the provided ``text``."""
+    token_count = max(len(text.split()), 1)
+    return round(_BASELINE + token_count * _JOULES_PER_TOKEN, 3)
+
+
+def describe_budget(text: str) -> Dict[str, float]:
+    """Return a budget report containing the estimate and allowance."""
+    cost = estimate(text)
+    return {"estimate_j": cost, "target_j": 1.2, "margin_j": round(1.2 - cost, 3)}
+
+
+__all__ = ["estimate", "describe_budget"]

--- a/agents/codex/26-linguist/pipelines/normalize.py
+++ b/agents/codex/26-linguist/pipelines/normalize.py
@@ -1,0 +1,64 @@
+"""Utilities to normalize inbound text for Codex-26."""
+
+from __future__ import annotations
+
+import re
+from typing import Dict, Iterable, List
+
+from .annotate_emojis import annotate_emojis
+
+
+_AMBIGUITY_MARKERS: Iterable[str] = {
+    "maybe",
+    "someday",
+    "somehow",
+    "whatever",
+    "stuff",
+}
+
+
+def _collapse_whitespace(text: str) -> str:
+    """Return the text with whitespace collapsed and trimmed."""
+    collapsed = re.sub(r"\s+", " ", text)
+    return collapsed.strip()
+
+
+def _collect_notes(text: str) -> List[str]:
+    """Generate normalization notes for downstream components."""
+    notes: List[str] = []
+    if text and text[0].islower():
+        notes.append("Capitalized leading token.")
+    if text and not text.endswith(('.', '?', '!')):
+        notes.append("Appended terminal period for stability.")
+    return notes
+
+
+def normalize(raw_text: str) -> Dict[str, object]:
+    """Normalize raw inbound text into a canonical shape.
+
+    The pipeline collapses whitespace, gently capitalizes the opening token,
+    and annotates emoji semantics for downstream routing.
+    """
+    if not isinstance(raw_text, str):
+        raise TypeError("raw_text must be a string")
+
+    collapsed = _collapse_whitespace(raw_text)
+    if collapsed:
+        normalized = collapsed[0].upper() + collapsed[1:]
+    else:
+        normalized = ""
+    notes = _collect_notes(collapsed)
+    if normalized and normalized[-1] not in {'.', '?', '!'}:
+        normalized = f"{normalized}."
+    emoji_map = annotate_emojis(normalized)
+    needs_clarifier = any(marker in normalized.lower() for marker in _AMBIGUITY_MARKERS)
+
+    return {
+        "text": normalized,
+        "emoji_map": emoji_map,
+        "clarifier_needed": needs_clarifier,
+        "notes": notes,
+    }
+
+
+__all__ = ["normalize"]

--- a/agents/codex/26-linguist/reflex/__init__.py
+++ b/agents/codex/26-linguist/reflex/__init__.py
@@ -1,0 +1,1 @@
+"""Reflex hooks for Codex-26."""

--- a/agents/codex/26-linguist/reflex/on_bus_message.reflex.py
+++ b/agents/codex/26-linguist/reflex/on_bus_message.reflex.py
@@ -1,0 +1,31 @@
+"""Normalize incoming bus events for Codex-26."""
+
+from __future__ import annotations
+
+from lucidia.reflex.core import BUS, start
+
+from ..pipelines.dialect_apply import apply_dialect
+from ..pipelines.energy_cost import estimate
+from ..pipelines.normalize import normalize
+
+
+@BUS.on("msg:incoming")
+def handle(event: dict) -> None:
+    """Process an incoming message event and rebroadcast the normalized payload."""
+    raw = event.get("text", "")
+    audience = event.get("audience", "core")
+    normalized = normalize(raw)
+    dialect_applied = apply_dialect(normalized, audience)
+    BUS.emit(
+        "msg:normalized",
+        {
+            "text": dialect_applied["text"],
+            "dialect": dialect_applied["dialect"],
+            "emoji_map": dialect_applied["emoji_map"],
+            "energy_j": estimate(dialect_applied["text"]),
+        },
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    start()

--- a/agents/codex/26-linguist/reflex/on_guardian_flag.reflex.py
+++ b/agents/codex/26-linguist/reflex/on_guardian_flag.reflex.py
@@ -1,0 +1,19 @@
+"""Guardian flag reflex for Codex-26."""
+
+from __future__ import annotations
+
+from lucidia.reflex.core import BUS, start
+
+from ..pipelines.disambiguate import clarify
+
+
+@BUS.on("guardian:contradiction")
+def nudge(event: dict) -> None:
+    """Emit a gentle clarifier question for the Guardian."""
+    context = event.get("context", "")
+    question = clarify(context)
+    BUS.emit("msg:clarifier", {"question": question, "emoji": "❓"})
+
+
+if __name__ == "__main__":  # pragma: no cover
+    start()

--- a/agents/codex/26-linguist/schemas/dialect.schema.json
+++ b/agents/codex/26-linguist/schemas/dialect.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "BlackRoad Dialect Pack",
+  "type": "object",
+  "required": ["id", "tone", "emojis", "style", "phrasing", "safety"],
+  "properties": {
+    "id": {"type": "string"},
+    "tone": {"type": "string"},
+    "emojis": {
+      "type": "object",
+      "additionalProperties": {"type": "string"}
+    },
+    "style": {
+      "type": "object",
+      "properties": {
+        "contractions": {"type": "boolean"},
+        "sentence_length_target": {"type": "integer", "minimum": 1},
+        "bullets_max": {"type": "integer", "minimum": 1},
+        "code_blocks_ok": {"type": "boolean"}
+      },
+      "required": ["contractions", "sentence_length_target", "bullets_max", "code_blocks_ok"],
+      "additionalProperties": true
+    },
+    "phrasing": {
+      "type": "object",
+      "properties": {
+        "prefer": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "avoid": {
+          "type": "array",
+          "items": {"type": "string"}
+        }
+      },
+      "required": ["prefer", "avoid"],
+      "additionalProperties": false
+    },
+    "safety": {
+      "type": "object",
+      "properties": {
+        "refusal_prefix": {"type": "string"},
+        "redirect_suffix": {"type": "string"}
+      },
+      "required": ["refusal_prefix", "redirect_suffix"],
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/agents/codex/26-linguist/schemas/normalize.schema.json
+++ b/agents/codex/26-linguist/schemas/normalize.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Normalization Result",
+  "type": "object",
+  "required": ["text", "emoji_map", "clarifier_needed"],
+  "properties": {
+    "text": {"type": "string"},
+    "emoji_map": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "clarifier_needed": {"type": "boolean"},
+    "notes": {
+      "type": "array",
+      "items": {"type": "string"}
+    }
+  },
+  "additionalProperties": false
+}

--- a/agents/codex/26-linguist/tests/__init__.py
+++ b/agents/codex/26-linguist/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test helpers for Codex-26."""

--- a/agents/codex/26-linguist/tests/test_dialect_apply.py
+++ b/agents/codex/26-linguist/tests/test_dialect_apply.py
@@ -1,0 +1,19 @@
+"""Tests for dialect application."""
+
+from __future__ import annotations
+
+from agents.codex._26_linguist.pipelines.dialect_apply import apply_dialect
+
+
+def test_apply_dialect_defaults_to_core() -> None:
+    normalized = {"text": "We can't ship", "emoji_map": {}}
+    result = apply_dialect(normalized, "nonexistent")
+    assert result["dialect"] == "dialect-core"
+    assert any(note.startswith("Tone set to") for note in result["notes"])
+
+
+def test_apply_dialect_respects_audience() -> None:
+    normalized = {"text": "We're ready.", "emoji_map": {}}
+    result = apply_dialect(normalized, "engineer")
+    assert result["dialect"] == "dialect-engineer"
+    assert "We are" in result["text"]

--- a/agents/codex/26-linguist/tests/test_normalize.py
+++ b/agents/codex/26-linguist/tests/test_normalize.py
@@ -1,0 +1,16 @@
+"""Unit tests for the normalize pipeline."""
+
+from __future__ import annotations
+
+from agents.codex._26_linguist.pipelines.normalize import normalize
+
+
+def test_normalize_collapses_whitespace_and_capitalizes() -> None:
+    result = normalize("   hello   world  ")
+    assert result["text"] == "Hello world."
+    assert not result["clarifier_needed"]
+
+
+def test_normalize_flags_ambiguity() -> None:
+    result = normalize("Maybe fix it")
+    assert result["clarifier_needed"] is True

--- a/agents/codex/26-linguist/tokenizer/nova-v1.sp.model
+++ b/agents/codex/26-linguist/tokenizer/nova-v1.sp.model
@@ -1,0 +1,2 @@
+This is a placeholder for the Nova tokenizer model.
+The production build stores the binary SentencePiece model here.

--- a/agents/codex/26-linguist/tokenizer/spec.json
+++ b/agents/codex/26-linguist/tokenizer/spec.json
@@ -1,0 +1,8 @@
+{
+  "name": "nova-v1",
+  "type": "sentencepiece",
+  "vocab_size": 16000,
+  "normalizer": "nfkc",
+  "pretokenizer": ["whitespace", "emoji"],
+  "special_tokens": ["<pad>", "<s>", "</s>", "<unk>"]
+}

--- a/agents/codex/26-linguist/ui/dialect_switcher.html
+++ b/agents/codex/26-linguist/ui/dialect_switcher.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Codex-26 Dialect Switcher</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="panel">
+      <h1>Dialect Switcher 🔤</h1>
+      <p>Select how the Linguist should shape the next response.</p>
+      <ul class="dialect-list">
+        <li data-pack="core">Core — calm and direct</li>
+        <li data-pack="engineer">Engineer — concise receipts</li>
+        <li data-pack="investor">Investor — risk and runway</li>
+        <li data-pack="kids">Kids — curious and bright</li>
+        <li data-pack="creator">Creator — warm and visual</li>
+      </ul>
+      <footer>
+        <button type="button">Emit Selection</button>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/agents/codex/26-linguist/ui/styles.css
+++ b/agents/codex/26-linguist/ui/styles.css
@@ -1,0 +1,61 @@
+:root {
+  font-family: "IBM Plex Sans", system-ui, sans-serif;
+  background: radial-gradient(circle at 10% 20%, #e9f0ff, #f8faff 40%, #ffffff);
+  color: #1c1c28;
+}
+
+body {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+}
+
+.panel {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 16px;
+  box-shadow: 0 12px 32px rgba(41, 72, 152, 0.12);
+  padding: 32px;
+  max-width: 420px;
+}
+
+h1 {
+  font-size: 1.8rem;
+  margin-top: 0;
+}
+
+.dialect-list {
+  list-style: none;
+  padding: 0;
+}
+
+.dialect-list li {
+  margin: 8px 0;
+  padding: 12px 16px;
+  background: #eef3ff;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.dialect-list li:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 16px rgba(64, 102, 200, 0.18);
+}
+
+button {
+  width: 100%;
+  padding: 12px 16px;
+  border-radius: 12px;
+  border: none;
+  background: linear-gradient(135deg, #5570ff, #9a7bff);
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+  margin-top: 16px;
+}
+
+button:hover {
+  opacity: 0.95;
+}

--- a/agents/codex/_26_linguist/__init__.py
+++ b/agents/codex/_26_linguist/__init__.py
@@ -1,0 +1,9 @@
+"""Python package shim exposing the Codex-26 assets."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+_BASE_DIR = Path(__file__).resolve().parent.parent / "26-linguist"
+__path__: List[str] = [str(_BASE_DIR)]


### PR DESCRIPTION
## Summary
- add Codex-26 Linguist charter, schemas, tokenizer spec, and dialect packs
- implement normalization, dialect application, emoji annotation, and energy estimation pipelines with reflex hooks
- provide unit tests, UI switcher stub, and package shim for loading the Linguist assets

## Testing
- pytest agents/codex/26-linguist/tests
- python -m py_compile agents/codex/_26_linguist/__init__.py agents/codex/26-linguist/pipelines/*.py agents/codex/26-linguist/reflex/*.py
- python auto_novel_agent.py (fails: file not found)


------
https://chatgpt.com/codex/tasks/task_e_68fe5e5c5698832988bcece43d80a4e4