### PR TITLE
Add Grafana and Loki observability stack to OS overlay

### DIFF
--- a/os/brctl
+++ b/os/brctl
@@ -179,6 +179,15 @@ main() {
     info) cmd_info "$@" ;;
     kiosk) cmd_kiosk "$@" ;;
     upgrade) cmd_upgrade "$@" ;;
+    metrics)
+      echo "Grafana:    http://$(hostname -I | awk '{print $1}')/grafana  (${GRAFANA_ADMIN_USER:-admin}/${GRAFANA_ADMIN_PASSWORD:-admin})"
+      echo "Loki:       internal at http://loki:3100"
+      echo "Promtail:   scrapes docker logs via docker_sd"
+      echo
+      echo "Sample LogQL:"
+      echo '  {job="docker-logs"} |= "ERROR"'
+      echo '  {service="blackroad-api"} | json | line_format "{{.message}}"'
+      ;;
     help|-h|--help) usage ;;
     *)
       echo "Unknown command: ${cmd}" >&2
@@ -206,6 +215,15 @@ case "${1:-}" in
     echo "== Compose =="; docker compose version
     echo "== Ports =="; ss -lntp | grep -E ':80 |:443 |:5000|:7000|:8000|:8001|:9000' || true
     ;;
+  metrics)
+    echo "Grafana:    http://$(hostname -I | awk '{print $1}')/grafana  (${GRAFANA_ADMIN_USER:-admin}/${GRAFANA_ADMIN_PASSWORD:-admin})"
+    echo "Loki:       internal at http://loki:3100"
+    echo "Promtail:   scrapes docker logs via docker_sd"
+    echo
+    echo "Sample LogQL:"
+    echo '  {job="docker-logs"} |= "ERROR"'
+    echo '  {service="blackroad-api"} | json | line_format "{{.message}}"'
+    ;;
   "kiosk") shift
     case "${1:-}" in
       on)  systemctl --user enable --now blackroad-kiosk.service || true ;;
@@ -214,5 +232,5 @@ case "${1:-}" in
     esac
     ;;
   upgrade)   dc pull && dc up -d;;
-  *)         echo "Usage: brctl {up|down|restart|ps|logs [svc]|status|health|doctor|kiosk on|off|upgrade}";;
+  *)         echo "Usage: brctl {up|down|restart|ps|logs [svc]|status|health|doctor|metrics|kiosk on|off|upgrade}";;
 esac

--- a/os/docker/.env.example
+++ b/os/docker/.env.example
@@ -38,3 +38,7 @@ BR_API_KEY=changeme
 # --- MQTT / Redis ---
 MQTT_URL=mqtt://mqtt:1883
 REDIS_URL=redis://redis:6379/0
+
+# --- Grafana (defaults; change in real env) ---
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=admin

--- a/os/docker/docker-compose.yml
+++ b/os/docker/docker-compose.yml
@@ -258,6 +258,47 @@ services:
       retries: 30
     restart: unless-stopped
 
+  loki:
+    image: grafana/loki:2.9.4
+    command: [ "-config.file=/etc/loki/loki.yml" ]
+    volumes:
+      - loki-data:/loki
+      - ../obsv/loki-config.yml:/etc/loki/loki.yml:ro
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD","wget","-qO-","http://localhost:3100/ready"]
+      interval: 10s
+      timeout: 3s
+      retries: 20
+
+  promtail:
+    image: grafana/promtail:2.9.4
+    command: [ "-config.file=/etc/promtail/promtail.yml" ]
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ../obsv/promtail-config.yml:/etc/promtail/promtail.yml:ro
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:10.4.3
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD}
+      GF_SERVER_ROOT_URL: "%(protocol)s://%(domain)s/grafana"
+      GF_SERVER_SERVE_FROM_SUB_PATH: "true"
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ../obsv/grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
+      - ../obsv/grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards:ro
+      - ../obsv/grafana/dashboards:/var/lib/grafana/dashboards:ro
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.grafana.rule=PathPrefix(`/grafana`)
+      - traefik.http.services.grafana.loadbalancer.server.port=3000
+    restart: unless-stopped
+
 volumes:
   mosq-data:
   mosq-conf:
+  grafana-data:
+  loki-data:

--- a/os/docker/obsv/grafana/dashboards/README.txt
+++ b/os/docker/obsv/grafana/dashboards/README.txt
@@ -1,0 +1,3 @@
+Drop exported JSON dashboards in this directory.
+Suggested: "Docker Logs" (ID 15158) and "Loki Logs Overview" from Grafana.com.
+They will appear under folder "BlackRoad" after Grafana starts.

--- a/os/docker/obsv/grafana/provisioning/dashboards/dashboards.yml
+++ b/os/docker/obsv/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+providers:
+  - name: BlackRoad
+    orgId: 1
+    folder: "BlackRoad"
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/os/docker/obsv/grafana/provisioning/datasources/loki.yml
+++ b/os/docker/obsv/grafana/provisioning/datasources/loki.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+datasources:
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    isDefault: true
+    jsonData:
+      maxLines: 1000

--- a/os/docker/obsv/loki-config.yml
+++ b/os/docker/obsv/loki-config.yml
@@ -1,0 +1,39 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+ruler:
+  alertmanager_url: http://localhost:9093
+
+limits_config:
+  allow_structured_metadata: true
+  retention_period: 168h   # 7 days (tune for your SD card)
+
+compactor:
+  working_directory: /loki/compactor
+  compaction_interval: 10m

--- a/os/docker/obsv/promtail-config.yml
+++ b/os/docker/obsv/promtail-config.yml
@@ -1,0 +1,28 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+    relabel_configs:
+      - source_labels: ['__meta_docker_container_name']
+        target_label: 'container'
+      - source_labels: ['__meta_docker_container_label_com_docker_compose_service']
+        target_label: 'service'
+      - source_labels: ['__meta_docker_container_label_com_docker_compose_project']
+        target_label: 'stack'
+      - source_labels: ['__meta_docker_container_label_traefik_http_routers_0_rule']
+        target_label: 'traefik_rule'
+      - source_labels: ['__meta_docker_container_log_stream']
+        target_label: 'stream'
+      - target_label: 'job'
+        replacement: 'docker-logs'

--- a/os/docs/ARCHITECTURE.md
+++ b/os/docs/ARCHITECTURE.md
@@ -74,3 +74,4 @@ BlackRoad OS provides a Raspberry Pi focused deployment for the Prism Console. T
 - **Kiosk unit (optional)** – launches Chromium in kiosk mode pointed at the local web UI.
 
 See `os/docs/TROUBLESHOOTING.md` for operational guidance.
+See `os/docs/OBSERVABILITY.md` for Grafana, Loki, and Promtail usage.

--- a/os/docs/OBSERVABILITY.md
+++ b/os/docs/OBSERVABILITY.md
@@ -1,0 +1,18 @@
+# Observability (Grafana + Loki + Promtail)
+
+## Access
+- Grafana: `http://<pi-ip>/grafana` (default admin/admin — change in `.env`)
+- Loki is internal; Grafana uses it via the provisioned datasource.
+
+## What you get
+- Container logs for every service, labeled by `{stack,service,container,stream}`.
+- Filter errors: `{job="docker-logs"} |= "ERROR"`
+- Focus one service: `{service="blackroad-api"}`
+
+## Dashboards
+- Import community dashboards (e.g., ID **15158** "Docker Logs").
+- Place JSON under `os/docker/obsv/grafana/dashboards/` → auto-loaded at startup.
+
+## Tips
+- Retention is 7d by default in `loki-config.yml` (tune for SD wear).
+- All apps should log to stdout; Promtail scrapes Docker logs automatically.

--- a/os/tests/smoke.sh
+++ b/os/tests/smoke.sh
@@ -53,4 +53,9 @@ for u in "${urls[@]}"; do
   echo "Checking $u"
   if curl -fsS "$u" >/dev/null; then echo "OK $u"; ((ok++)); else echo "FAIL $u"; fi
 done
+if curl -fsS http://localhost/grafana/login >/dev/null; then
+  echo "OK grafana"
+else
+  echo "WARN grafana"
+fi
 test "$ok" -ge 3 || (echo "Smoke failed"; exit 1)


### PR DESCRIPTION
## Summary
- add Grafana, Loki, and Promtail services and volumes to the OS docker compose stack
- provide zero-secret defaults, provisioning, and dashboards directories for observability assets
- document observability access, expose metrics helper in brctl, and link from architecture docs
- extend smoke test to cover Grafana availability endpoint

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fe7a0f4fe88329b7eb8d3c16b380ce