### PR TITLE
Add Codex-27 Strategist mission orchestration package

### DIFF
--- a/agents/codex/27-strategist/__init__.py
+++ b/agents/codex/27-strategist/__init__.py
@@ -1,0 +1,1 @@
+"""Codex-27 Strategist package."""

--- a/agents/codex/27-strategist/badges/fair_credit.svg
+++ b/agents/codex/27-strategist/badges/fair_credit.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 40">
+  <rect width="120" height="40" rx="12" fill="#0f172a" />
+  <text x="18" y="26" fill="#fbbf24" font-size="16" font-family="Inter, sans-serif">🤝 Fair Credit</text>
+</svg>

--- a/agents/codex/27-strategist/badges/low_joules.svg
+++ b/agents/codex/27-strategist/badges/low_joules.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 40">
+  <rect width="120" height="40" rx="12" fill="#0f172a" />
+  <text x="20" y="26" fill="#4ade80" font-size="16" font-family="Inter, sans-serif">🌱 Low Joules</text>
+</svg>

--- a/agents/codex/27-strategist/badges/safe_revert.svg
+++ b/agents/codex/27-strategist/badges/safe_revert.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 40">
+  <rect width="120" height="40" rx="12" fill="#0f172a" />
+  <text x="14" y="26" fill="#38bdf8" font-size="16" font-family="Inter, sans-serif">🛟 Safe Revert</text>
+</svg>

--- a/agents/codex/27-strategist/codex27.yaml
+++ b/agents/codex/27-strategist/codex27.yaml
@@ -1,0 +1,30 @@
+id: codex-27
+name: Strategist
+generation: 6
+moral_constant: "Wisdom = Courage × Timing"
+core_principle: "Win gently; leave the field better than you found it"
+emojis:
+  - "🧭"
+  - "🎫"
+  - "🛟"
+  - "🟢"
+  - "🟡"
+  - "🔴"
+  - "🎒"
+horizons:
+  T0: "now-48h"
+  T1: "7 days"
+  T2: "30 days"
+  T3: "90 days"
+risk_tokens:
+  red:
+    action: "block"
+    owner: "Guardian"
+  amber:
+    action: "watch"
+    owner: "Strategist"
+  green:
+    action: "go"
+    owner: "Strategist"
+energy_objective:
+  target_joules_per_outcome: 1000

--- a/agents/codex/27-strategist/formations/campfire.yaml
+++ b/agents/codex/27-strategist/formations/campfire.yaml
@@ -1,0 +1,10 @@
+name: CAMPFIRE
+focus: "Knowledge share and teaching"
+signals:
+  cadence: "bi-weekly circles"
+  risk_token: "green"
+  exit: "story captured + lesson shared"
+roles:
+  Storyteller: "curate narrative"
+  Teacher: "facilitate teaching"
+  Strategist: "capture decisions"

--- a/agents/codex/27-strategist/formations/delta.yaml
+++ b/agents/codex/27-strategist/formations/delta.yaml
@@ -1,0 +1,10 @@
+name: DELTA
+focus: "Fast build and deployment"
+signals:
+  cadence: "hourly standups"
+  risk_token: "green"
+  exit: "feature delivered"
+roles:
+  Builder: "ship feature"
+  Linguist: "docs and comms"
+  Roadie: "systems health"

--- a/agents/codex/27-strategist/formations/halo.yaml
+++ b/agents/codex/27-strategist/formations/halo.yaml
@@ -1,0 +1,11 @@
+name: HALO
+focus: "Safety-first incident and release response"
+signals:
+  cadence: "15 min incident loops"
+  risk_token: "amber"
+  exit: "incident resolved or release verified"
+roles:
+  Guardian: "policy gate + risk call"
+  Roadie: "health telemetry"
+  Builder: "apply or rollback change"
+  Linguist: "stakeholder updates"

--- a/agents/codex/27-strategist/formations/hum.yaml
+++ b/agents/codex/27-strategist/formations/hum.yaml
@@ -1,0 +1,10 @@
+name: HUM
+focus: "Maintenance and reliability"
+signals:
+  cadence: "weekly tune-ups"
+  risk_token: "green"
+  exit: "maintenance backlog cleared"
+roles:
+  Roadie: "lead maintenance"
+  Builder: "apply patches"
+  Strategist: "rebalance load"

--- a/agents/codex/27-strategist/formations/lattice.yaml
+++ b/agents/codex/27-strategist/formations/lattice.yaml
@@ -1,0 +1,10 @@
+name: LATTICE
+focus: "Research and discovery"
+signals:
+  cadence: "daily synthesis"
+  risk_token: "green"
+  exit: "insights shared + DR filed"
+roles:
+  Researcher: "design experiment"
+  Analyst: "interpret data"
+  Strategist: "align portfolio"

--- a/agents/codex/27-strategist/pipelines/__init__.py
+++ b/agents/codex/27-strategist/pipelines/__init__.py
@@ -1,0 +1,1 @@
+"""Pipelines supporting Codex-27 mission orchestration."""

--- a/agents/codex/27-strategist/pipelines/call_play.py
+++ b/agents/codex/27-strategist/pipelines/call_play.py
@@ -1,0 +1,84 @@
+"""Playbook dispatcher for Strategist formations."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional
+
+import uuid
+
+import yaml
+
+PLAYBOOK_DIR = Path(__file__).resolve().parent.parent / "playbooks"
+
+
+@dataclass
+class PlayStep:
+    """Represents a single playbook action."""
+
+    action: str
+    payload: Mapping[str, Any]
+
+    def describe(self) -> str:
+        """Produce a human readable description of the step."""
+        return f"{self.action}: {self.payload}"
+
+
+@dataclass
+class PlaybookTrace:
+    """Execution trace for a playbook run."""
+
+    playbook_id: str
+    steps: List[PlayStep]
+    rollback: List[PlayStep]
+    context: Mapping[str, Any]
+    trace_id: str
+
+    def as_dict(self) -> Dict[str, Any]:
+        """Serialise the trace to a dictionary."""
+        return {
+            "playbook_id": self.playbook_id,
+            "trace_id": self.trace_id,
+            "context": dict(self.context),
+            "steps": [step.describe() for step in self.steps],
+            "rollback": [step.describe() for step in self.rollback],
+        }
+
+
+def _as_step(action: str, payload: Any) -> PlayStep:
+    if isinstance(payload, Mapping):
+        mapped: Mapping[str, Any] = payload
+    else:
+        mapped = {"value": payload}
+    return PlayStep(action=action, payload=mapped)
+
+
+def load_playbook(playbook_id: str) -> Dict[str, Any]:
+    """Load a playbook from disk."""
+    path = PLAYBOOK_DIR / f"{playbook_id}.yaml"
+    if not path.exists():
+        raise FileNotFoundError(f"Playbook {playbook_id} not found at {path}.")
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def trace_play(playbook: Mapping[str, Any], context: Optional[Mapping[str, Any]] = None) -> PlaybookTrace:
+    """Create an execution trace for a playbook without side effects."""
+    steps = [_as_step(key, item[key]) for item in playbook.get("steps", []) for key in item]
+    rollback = [_as_step(key, item[key]) for item in playbook.get("rollback", []) for key in item]
+    trace_id = uuid.uuid4().hex
+    return PlaybookTrace(
+        playbook_id=playbook["id"],
+        steps=steps,
+        rollback=rollback,
+        context=context or {},
+        trace_id=trace_id,
+    )
+
+
+def run_playbook(playbook_id: str, context: Optional[Mapping[str, Any]] = None) -> PlaybookTrace:
+    """Load a playbook and return the planned execution trace."""
+    playbook = load_playbook(playbook_id)
+    return trace_play(playbook, context=context)
+
+
+__all__ = ["PlayStep", "PlaybookTrace", "load_playbook", "trace_play", "run_playbook"]

--- a/agents/codex/27-strategist/pipelines/energy_budget.py
+++ b/agents/codex/27-strategist/pipelines/energy_budget.py
@@ -1,0 +1,51 @@
+"""Energy budget forecasting helpers."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, Mapping
+
+
+@dataclass
+class EnergyBudget:
+    """Represents a joule budget for a mission."""
+
+    target: float
+    maximum: float
+
+    def health(self, forecast: float) -> str:
+        """Return the energy posture given a forecast."""
+        if forecast > self.maximum:
+            return "critical"
+        if forecast > self.target:
+            return "warning"
+        return "normal"
+
+
+def project_spend(consumptions: Iterable[float]) -> float:
+    """Compute the projected energy spend."""
+    return float(sum(float(value) for value in consumptions))
+
+
+def evaluate(consumptions: Iterable[float], budget: EnergyBudget) -> Dict[str, float]:
+    """Return the forecast, variance to target, and variance to maximum."""
+    forecast = project_spend(consumptions)
+    return {
+        "forecast": forecast,
+        "variance_to_target": forecast - budget.target,
+        "variance_to_max": forecast - budget.maximum,
+    }
+
+
+def alarm(consumptions: Iterable[float], budget: EnergyBudget) -> Mapping[str, object]:
+    """Return an alarm payload for UI consumption."""
+    metrics = evaluate(consumptions, budget)
+    posture = budget.health(metrics["forecast"])
+    suggestion = None
+    if posture == "warning":
+        suggestion = "shrink_scope"
+    elif posture == "critical":
+        suggestion = "halt_and_rollback"
+    return {**metrics, "posture": posture, "suggestion": suggestion}
+
+
+__all__ = ["EnergyBudget", "project_spend", "evaluate", "alarm"]

--- a/agents/codex/27-strategist/pipelines/make_mission.py
+++ b/agents/codex/27-strategist/pipelines/make_mission.py
@@ -1,0 +1,182 @@
+"""Mission planning utilities for Codex-27.
+
+The helpers in this module translate lightweight goal intents into a
+normalised mission canvas. A mission canvas adheres to the
+``mission.schema.json`` contract shipped with the Strategist agent.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, Optional
+
+import json
+
+import yaml
+
+SCHEMA_DIR = Path(__file__).resolve().parent.parent / "schemas"
+MISSION_SCHEMA_PATH = SCHEMA_DIR / "mission.schema.json"
+
+
+@dataclass
+class MissionRole:
+    """Representation of a mission role assignment."""
+
+    name: str
+    agent: str
+    backup: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, str]:
+        """Return a serialisable dictionary representation."""
+        payload: Dict[str, str] = {"name": self.name, "agent": self.agent}
+        if self.backup:
+            payload["backup"] = self.backup
+        return payload
+
+
+@dataclass
+class MissionBudget:
+    """Energy budget expressed in joules."""
+
+    joules_target: float
+    joules_max: float
+
+    def to_dict(self) -> Dict[str, float]:
+        """Return the budget as a dictionary."""
+        return {
+            "joules_target": float(self.joules_target),
+            "joules_max": float(self.joules_max),
+        }
+
+
+@dataclass
+class MissionTimeline:
+    """Mission timeline metadata."""
+
+    start: datetime
+    deadline: datetime
+    checkpoints: List[Mapping[str, datetime]] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, object]:
+        """Serialise the timeline to ISO 8601 strings."""
+        return {
+            "start": self.start.isoformat(),
+            "deadline": self.deadline.isoformat(),
+            "checkpoints": [
+                {"name": str(chk["name"]), "time": chk["time"].isoformat()}
+                for chk in self.checkpoints
+            ],
+        }
+
+
+@dataclass
+class MissionCanvas:
+    """Full mission canvas ready for validation or publication."""
+
+    goal: str
+    constraints: Iterable[str]
+    roles: Iterable[MissionRole]
+    budget: MissionBudget
+    timeline: MissionTimeline
+    exit_success: str
+    exit_abort: str
+    notes: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, object]:
+        """Generate a dictionary compliant with the mission schema."""
+        data: Dict[str, object] = {
+            "goal": self.goal,
+            "constraints": list(self.constraints),
+            "roles": [role.to_dict() for role in self.roles],
+            "budget": self.budget.to_dict(),
+            "timeline": self.timeline.to_dict(),
+            "exit": {
+                "success": self.exit_success,
+                "abort": self.exit_abort,
+            },
+        }
+        if self.notes:
+            data["notes"] = self.notes
+        return data
+
+
+def _default_timeline(now: Optional[datetime] = None) -> MissionTimeline:
+    """Construct a default mission timeline relative to *now*."""
+    current = now or datetime.now(tz=timezone.utc)
+    deadline = current + timedelta(days=2)
+    checkpoints = [
+        {"name": "T0 sync", "time": current + timedelta(hours=4)},
+        {"name": "T1 review", "time": current + timedelta(days=1)},
+    ]
+    return MissionTimeline(start=current, deadline=deadline, checkpoints=checkpoints)
+
+
+def load_mission_schema() -> Dict[str, object]:
+    """Load the mission JSON schema packaged with the Strategist."""
+    return json.loads(MISSION_SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def propose(goal_intent: Mapping[str, object]) -> Dict[str, object]:
+    """Generate a mission canvas from a goal intent payload.
+
+    Parameters
+    ----------
+    goal_intent:
+        A mapping with ``goal`` (str) and optional overrides for constraints,
+        roles, joule budget, notes, and timeline hints.
+    """
+    goal = str(goal_intent.get("goal", ""))
+    if not goal:
+        raise ValueError("Goal intent must include a 'goal' description.")
+
+    constraints = goal_intent.get("constraints", []) or ["respect_guardrails"]
+    roles_payload = goal_intent.get("roles", [])
+    if roles_payload:
+        roles = [
+            MissionRole(name=item["name"], agent=item["agent"], backup=item.get("backup"))
+            for item in roles_payload
+        ]
+    else:
+        roles = [
+            MissionRole(name="Strategist", agent="Codex-27"),
+            MissionRole(name="Guardian", agent="Guardian"),
+        ]
+
+    budget_data = goal_intent.get("budget", {})
+    budget = MissionBudget(
+        joules_target=float(budget_data.get("joules_target", 750.0)),
+        joules_max=float(budget_data.get("joules_max", 1000.0)),
+    )
+
+    timeline = _default_timeline()
+    notes = goal_intent.get("notes")
+
+    mission = MissionCanvas(
+        goal=goal,
+        constraints=constraints,
+        roles=roles,
+        budget=budget,
+        timeline=timeline,
+        exit_success=str(goal_intent.get("exit_success", "outcome achieved")),
+        exit_abort=str(goal_intent.get("exit_abort", "rollback complete")),
+        notes=str(notes) if notes else None,
+    )
+    return mission.to_dict()
+
+
+def save_mission(plan: Mapping[str, object], destination: Path) -> None:
+    """Persist a mission plan to disk as YAML."""
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(yaml.safe_dump(dict(plan)), encoding="utf-8")
+
+
+__all__ = [
+    "MissionRole",
+    "MissionBudget",
+    "MissionTimeline",
+    "MissionCanvas",
+    "load_mission_schema",
+    "propose",
+    "save_mission",
+]

--- a/agents/codex/27-strategist/pipelines/risk_scan.py
+++ b/agents/codex/27-strategist/pipelines/risk_scan.py
@@ -1,0 +1,46 @@
+"""Risk token classifier used by the Strategist reflex hooks."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping
+
+
+@dataclass
+class RiskThresholds:
+    """Numeric KPI thresholds for risk classification."""
+
+    amber: float
+    red: float
+
+
+DEFAULT_THRESHOLDS = RiskThresholds(amber=0.15, red=0.35)
+
+
+def _extract_delta(event: Mapping[str, Any]) -> float:
+    """Extract a normalised KPI delta from an event."""
+    delta = event.get("delta")
+    if delta is None:
+        return 0.0
+    try:
+        return float(delta)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("KPI delta must be numeric") from exc
+
+
+def classify(event: Mapping[str, Any], thresholds: RiskThresholds = DEFAULT_THRESHOLDS) -> str:
+    """Classify a KPI event into a Strategist risk token."""
+    magnitude = abs(_extract_delta(event))
+    if magnitude >= thresholds.red:
+        return "red"
+    if magnitude >= thresholds.amber:
+        return "amber"
+    return "green"
+
+
+def apply_guardrail(event: Mapping[str, Any]) -> Dict[str, Any]:
+    """Return a payload combining the token and original event."""
+    token = classify(event)
+    return {"token": token, "event": dict(event)}
+
+
+__all__ = ["RiskThresholds", "DEFAULT_THRESHOLDS", "classify", "apply_guardrail"]

--- a/agents/codex/27-strategist/playbooks/pb-delta-fast-build.yaml
+++ b/agents/codex/27-strategist/playbooks/pb-delta-fast-build.yaml
@@ -1,0 +1,32 @@
+id: pb-delta-fast-build
+name: DELTA (fast build)
+trigger:
+  topic: "build:sprint"
+  guards:
+    - "tests:green"
+roles:
+  - agent: "Builder"
+    task: "assemble_feature"
+  - agent: "Linguist"
+    task: "document_updates"
+  - agent: "Roadie"
+    task: "monitor_health"
+budget:
+  joules_max: 400
+steps:
+  - emit:
+      topic: "formation:delta:start"
+  - run: "scripts/bootstrap_delta.sh"
+  - run: "scripts/run_ci.sh"
+  - gate:
+      topic: "guardian:decision"
+      allow: true
+  - emit:
+      topic: "formation:delta:complete"
+rollback:
+  - run: "scripts/revert_delta.sh"
+  - emit:
+      topic: "formation:delta:reverted"
+exit:
+  success: "feature merged + docs updated"
+  failure: "rollback executed + DR filed"

--- a/agents/codex/27-strategist/playbooks/pb-halo-safe-release.yaml
+++ b/agents/codex/27-strategist/playbooks/pb-halo-safe-release.yaml
@@ -1,0 +1,35 @@
+id: pb-halo-safe-release
+name: HALO (safety-first release)
+trigger:
+  topic: "release:prepare"
+  guards:
+    - "tests:green"
+    - "guardian:ok"
+roles:
+  - agent: "Guardian"
+    task: "final_policy_gate"
+  - agent: "Roadie"
+    task: "health_check"
+  - agent: "Builder"
+    task: "cut_release"
+  - agent: "Linguist"
+    task: "draft_announcement"
+budget:
+  joules_max: 500
+steps:
+  - emit:
+      topic: "formation:halo:start"
+  - run: "scripts/release_dry_run.sh"
+  - gate:
+      topic: "guardian:decision"
+      allow: true
+  - run: "scripts/release_apply.sh"
+  - emit:
+      topic: "formation:halo:complete"
+rollback:
+  - run: "scripts/release_revert.sh"
+  - emit:
+      topic: "formation:halo:reverted"
+exit:
+  success: "release tagged + announcement drafted"
+  failure: "rollback executed + DR filed"

--- a/agents/codex/27-strategist/playbooks/pb-lattice-research.yaml
+++ b/agents/codex/27-strategist/playbooks/pb-lattice-research.yaml
@@ -1,0 +1,32 @@
+id: pb-lattice-research
+name: LATTICE (research lattice)
+trigger:
+  topic: "research:explore"
+  guards:
+    - "sponsor:approved"
+roles:
+  - agent: "Researcher"
+    task: "frame_experiment"
+  - agent: "Analyst"
+    task: "model_outcomes"
+  - agent: "Strategist"
+    task: "balance_portfolio"
+budget:
+  joules_max: 350
+steps:
+  - emit:
+      topic: "formation:lattice:start"
+  - run: "scripts/setup_sandbox.sh"
+  - run: "scripts/run_research_notebook.sh"
+  - gate:
+      topic: "guardian:decision"
+      allow: true
+  - emit:
+      topic: "formation:lattice:complete"
+rollback:
+  - run: "scripts/teardown_sandbox.sh"
+  - emit:
+      topic: "formation:lattice:reverted"
+exit:
+  success: "experiment logged + insights shared"
+  failure: "sandbox reset + DR filed"

--- a/agents/codex/27-strategist/reflex/__init__.py
+++ b/agents/codex/27-strategist/reflex/__init__.py
@@ -1,0 +1,1 @@
+"""Reflex hooks for Codex-27 Strategist."""

--- a/agents/codex/27-strategist/reflex/on_goal_intent.reflex.py
+++ b/agents/codex/27-strategist/reflex/on_goal_intent.reflex.py
@@ -1,0 +1,17 @@
+"""Reflex hook that proposes a mission when a goal intent arrives."""
+from __future__ import annotations
+
+from lucidia.reflex.core import BUS, start  # type: ignore
+
+from ..pipelines.make_mission import propose
+
+
+@BUS.on("intent:goal")
+def propose_mission(event: dict) -> None:
+    """Build and emit a mission canvas for the provided goal intent."""
+    plan = propose(event)
+    BUS.emit("strat:mission.proposed", plan)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    start()

--- a/agents/codex/27-strategist/reflex/on_incident.reflex.py
+++ b/agents/codex/27-strategist/reflex/on_incident.reflex.py
@@ -1,0 +1,17 @@
+"""Reflex hook that calls the HALO play during incidents."""
+from __future__ import annotations
+
+from lucidia.reflex.core import BUS, start  # type: ignore
+
+from ..pipelines.call_play import run_playbook
+
+
+@BUS.on("incident:raised")
+def incident(event: dict) -> None:
+    """Run the HALO playbook and broadcast the formation."""
+    trace = run_playbook("pb-halo-safe-release", context=event)
+    BUS.emit("strat:formation", {"name": "HALO", "incident": event.get("id"), "trace": trace.as_dict()})
+
+
+if __name__ == "__main__":  # pragma: no cover
+    start()

--- a/agents/codex/27-strategist/reflex/on_kpi_drift.reflex.py
+++ b/agents/codex/27-strategist/reflex/on_kpi_drift.reflex.py
@@ -1,0 +1,20 @@
+"""Reflex hook reacting to KPI drift events."""
+from __future__ import annotations
+
+from lucidia.reflex.core import BUS, start  # type: ignore
+
+from ..pipelines.risk_scan import classify
+
+
+@BUS.on("kpi:update")
+def on_kpi(event: dict) -> None:
+    """Emit HOLD/NO-GO calls based on KPI drift severity."""
+    token = classify(event)
+    if token == "red":
+        BUS.emit("strat:call.NO-GO", {"reason": "kpi_drift", "kpi": event})
+    elif token == "amber":
+        BUS.emit("strat:call.HOLD", {"reason": "kpi_watch", "kpi": event})
+
+
+if __name__ == "__main__":  # pragma: no cover
+    start()

--- a/agents/codex/27-strategist/schemas/decision_record.schema.json
+++ b/agents/codex/27-strategist/schemas/decision_record.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://blackroad.io/schemas/codex27/decision_record.json",
+  "title": "Codex-27 Decision Record",
+  "type": "object",
+  "required": [
+    "id",
+    "mission_id",
+    "timestamp",
+    "call",
+    "context",
+    "energy",
+    "risk",
+    "reversal"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "id": {"type": "string", "pattern": "^dr-[a-z0-9-]+$"},
+    "mission_id": {"type": "string", "minLength": 1},
+    "timestamp": {"type": "string", "format": "date-time"},
+    "call": {"type": "string", "enum": ["GO", "HOLD", "NO-GO"]},
+    "context": {
+      "type": "object",
+      "required": ["playbook", "formation", "summary"],
+      "additionalProperties": false,
+      "properties": {
+        "playbook": {"type": "string", "minLength": 1},
+        "formation": {"type": "string", "minLength": 1},
+        "summary": {"type": "string", "minLength": 1}
+      }
+    },
+    "energy": {
+      "type": "object",
+      "required": ["joules_spent", "joules_forecast"],
+      "additionalProperties": false,
+      "properties": {
+        "joules_spent": {"type": "number", "minimum": 0},
+        "joules_forecast": {"type": "number", "minimum": 0},
+        "notes": {"type": "string"}
+      }
+    },
+    "risk": {
+      "type": "object",
+      "required": ["token", "owner"],
+      "additionalProperties": false,
+      "properties": {
+        "token": {"type": "string", "enum": ["green", "amber", "red"]},
+        "owner": {"type": "string", "minLength": 1},
+        "notes": {"type": "string"}
+      }
+    },
+    "reversal": {
+      "type": "object",
+      "required": ["ready", "steps"],
+      "additionalProperties": false,
+      "properties": {
+        "ready": {"type": "boolean"},
+        "steps": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1}
+        }
+      }
+    },
+    "credits": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1}
+    }
+  }
+}

--- a/agents/codex/27-strategist/schemas/mission.schema.json
+++ b/agents/codex/27-strategist/schemas/mission.schema.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://blackroad.io/schemas/codex27/mission.json",
+  "title": "Codex-27 Mission Canvas",
+  "type": "object",
+  "required": [
+    "goal",
+    "constraints",
+    "roles",
+    "budget",
+    "timeline",
+    "exit"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "goal": {
+      "type": "string",
+      "minLength": 1
+    },
+    "constraints": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "roles": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["name", "agent"],
+        "additionalProperties": false,
+        "properties": {
+          "name": {"type": "string", "minLength": 1},
+          "agent": {"type": "string", "minLength": 1},
+          "backup": {"type": "string"}
+        }
+      }
+    },
+    "budget": {
+      "type": "object",
+      "required": ["joules_target", "joules_max"],
+      "additionalProperties": false,
+      "properties": {
+        "joules_target": {"type": "number", "minimum": 0},
+        "joules_max": {"type": "number", "minimum": 0}
+      }
+    },
+    "timeline": {
+      "type": "object",
+      "required": ["start", "checkpoints", "deadline"],
+      "additionalProperties": false,
+      "properties": {
+        "start": {"type": "string", "format": "date-time"},
+        "deadline": {"type": "string", "format": "date-time"},
+        "checkpoints": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name", "time"],
+            "additionalProperties": false,
+            "properties": {
+              "name": {"type": "string", "minLength": 1},
+              "time": {"type": "string", "format": "date-time"}
+            }
+          }
+        }
+      }
+    },
+    "exit": {
+      "type": "object",
+      "required": ["success", "abort"],
+      "additionalProperties": false,
+      "properties": {
+        "success": {"type": "string", "minLength": 1},
+        "abort": {"type": "string", "minLength": 1}
+      }
+    },
+    "notes": {
+      "type": "string"
+    }
+  }
+}

--- a/agents/codex/27-strategist/schemas/playbook.schema.json
+++ b/agents/codex/27-strategist/schemas/playbook.schema.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://blackroad.io/schemas/codex27/playbook.json",
+  "title": "Codex-27 Playbook",
+  "type": "object",
+  "required": [
+    "id",
+    "name",
+    "trigger",
+    "roles",
+    "budget",
+    "steps",
+    "rollback",
+    "exit"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^pb-[a-z0-9-]+$"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "trigger": {
+      "type": "object",
+      "required": ["topic"],
+      "additionalProperties": true,
+      "properties": {
+        "topic": {
+          "type": "string",
+          "minLength": 1
+        },
+        "guards": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "roles": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["agent", "task"],
+        "additionalProperties": false,
+        "properties": {
+          "agent": {
+            "type": "string",
+            "minLength": 1
+          },
+          "task": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "budget": {
+      "type": "object",
+      "required": ["joules_max"],
+      "additionalProperties": false,
+      "properties": {
+        "joules_max": {
+          "type": "number",
+          "minimum": 0
+        }
+      }
+    },
+    "steps": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "minProperties": 1,
+        "additionalProperties": true
+      }
+    },
+    "rollback": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "minProperties": 1,
+        "additionalProperties": true
+      }
+    },
+    "exit": {
+      "type": "object",
+      "required": ["success", "failure"],
+      "additionalProperties": false,
+      "properties": {
+        "success": {
+          "type": "string",
+          "minLength": 1
+        },
+        "failure": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/agents/codex/27-strategist/strategist.md
+++ b/agents/codex/27-strategist/strategist.md
@@ -1,0 +1,42 @@
+# Codex-27 “Strategist”
+
+Codex-27 orchestrates multi-agent missions for BlackRoad. The Strategist keeps
+operations aligned with the moral constant **Wisdom = Courage × Timing** and the
+core principle **"Win gently; leave the field better than you found it."**
+
+## Operating Rituals
+
+1. **Sense & Orient** – Collect telemetry, intents, and availability across the
+   bus. Normalize into the mission canvas (goal, constraints, roles, budget,
+   timeline, exit conditions).
+2. **Decide & Act** – Select a formation and playbook, emit a clear GO/HOLD/NO-GO
+   call, and ensure rollback steps are in place before advancing.
+3. **Review & Teach** – File decision records, log joules-per-outcome, and update
+   the playbook archive with new lessons before resting the formation.
+
+## Formation Cards
+
+- `DELTA` – Fast build, minimal blockers, prioritizes velocity.
+- `HALO` – Safety-first, Guardian-led, optimized for incident response.
+- `LATTICE` – Research cadence pairing Analysts and Researchers for exploration.
+- `HUM` – Maintenance rhythm with Roadie oversight.
+- `CAMPFIRE` – Knowledge share and teaching loops led by Storyteller and Teacher.
+
+## Risk Tokens
+
+- **🟢 GREEN (go):** Default state when energy budgets are healthy.
+- **🟡 AMBER (watch):** Strategist monitors scope and increases telemetry rate.
+- **🔴 RED (block):** Guardian halts the mission, triggers rollback, and pages
+  Mediator support.
+
+## Energy Doctrine
+
+Target **1.0 joules per decision**. The Strategist continually forecasts energy
+usage, suggesting scope adjustments when projected spend crosses the target
+joule budget.
+
+## Decision Records
+
+Every formation call must produce a DR containing context, selected playbook,
+risk posture, energy summary, and reversal steps. DRs are stored alongside
+mission artifacts for future teams.

--- a/agents/codex/27-strategist/ui/kpi_scoreboard.html
+++ b/agents/codex/27-strategist/ui/kpi_scoreboard.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Strategist KPI Scoreboard</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body class="board">
+    <header class="board__header">
+      <h1>KPI Scoreboard</h1>
+      <p class="board__subtitle">Track joules, risk tokens, and mission KPIs in real time.</p>
+    </header>
+    <main class="board__grid board__grid--score">
+      <section class="card">
+        <h2>Energy Forecast</h2>
+        <p class="metric"><span class="metric__label">Forecast</span><span id="forecast-value">820 J</span></p>
+        <p class="metric"><span class="metric__label">Target</span><span id="target-value">750 J</span></p>
+        <p class="metric metric--warning"><span class="metric__label">Posture</span><span id="posture">warning</span></p>
+      </section>
+      <section class="card">
+        <h2>Risk Signals</h2>
+        <ul class="token-list">
+          <li data-token="green">Telemetry steady</li>
+          <li data-token="amber">Guardian reviewing load test</li>
+        </ul>
+      </section>
+      <section class="card">
+        <h2>KPI Drift</h2>
+        <p class="card__hint">Automatic HOLD/NO-GO when drift exceeds thresholds.</p>
+        <table class="table">
+          <thead>
+            <tr>
+              <th>KPI</th>
+              <th>Delta</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Latency</td>
+              <td>+0.18</td>
+              <td>🟡 HOLD</td>
+            </tr>
+            <tr>
+              <td>Error Rate</td>
+              <td>+0.36</td>
+              <td>🔴 NO-GO</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+    </main>
+    <footer class="board__footer">
+      <p>Alerts escalate to Guardian when joules exceed maximum budget.</p>
+    </footer>
+  </body>
+</html>

--- a/agents/codex/27-strategist/ui/mission_board.html
+++ b/agents/codex/27-strategist/ui/mission_board.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Strategist Mission Board</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body class="board">
+    <header class="board__header">
+      <h1>Codex-27 Mission Board</h1>
+      <p class="board__subtitle">Win gently; leave the field better than you found it.</p>
+    </header>
+    <main class="board__grid">
+      <section class="card">
+        <h2>Current Call</h2>
+        <div class="call-status" data-token="green">🟢 GO</div>
+        <p class="call-detail">All systems nominal. Joules within target.</p>
+      </section>
+      <section class="card">
+        <h2>Active Mission</h2>
+        <dl>
+          <dt>Goal</dt>
+          <dd id="mission-goal">Coordinate release for BlackRoad console.</dd>
+          <dt>Formation</dt>
+          <dd id="mission-formation">HALO</dd>
+          <dt>Budget</dt>
+          <dd id="mission-budget">≤ 1000 joules</dd>
+          <dt>Exit</dt>
+          <dd id="mission-exit">Release tagged + announcement drafted</dd>
+        </dl>
+      </section>
+      <section class="card">
+        <h2>Risk Tokens</h2>
+        <ul class="token-list">
+          <li>🟢 Green — go</li>
+          <li>🟡 Amber — watch</li>
+          <li>🔴 Red — block</li>
+        </ul>
+      </section>
+      <section class="card">
+        <h2>Decision Record</h2>
+        <p class="card__hint">Every call files a DR with energy and risk posture.</p>
+        <button class="button" type="button">View Latest DR</button>
+      </section>
+    </main>
+    <footer class="board__footer">
+      <p>Strategist patches: 🧭ClearCall • 🛟SafeRevert • 🌱LowJoules • 🤝FairCredit</p>
+    </footer>
+  </body>
+</html>

--- a/agents/codex/27-strategist/ui/styles.css
+++ b/agents/codex/27-strategist/ui/styles.css
@@ -1,0 +1,138 @@
+:root {
+  --bg: #0f172a;
+  --card: #111c2f;
+  --text: #f1f5f9;
+  --muted: #94a3b8;
+  --accent: #38bdf8;
+  --amber: #fbbf24;
+  --red: #f87171;
+  --green: #4ade80;
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
+}
+
+body.board {
+  background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.1), transparent),
+    var(--bg);
+  color: var(--text);
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.board__header,
+.board__footer {
+  padding: 2rem 4rem;
+  text-align: center;
+}
+
+.board__subtitle {
+  color: var(--muted);
+  letter-spacing: 0.05em;
+}
+
+.board__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+  padding: 0 4rem 3rem;
+}
+
+.board__grid--score {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.card {
+  background: rgba(17, 28, 47, 0.85);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(12px);
+}
+
+.card__hint {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.button {
+  background: var(--accent);
+  border: none;
+  border-radius: 999px;
+  color: var(--bg);
+  cursor: pointer;
+  font-weight: 600;
+  padding: 0.75rem 1.5rem;
+  transition: transform 0.2s ease;
+}
+
+.button:hover {
+  transform: translateY(-2px);
+}
+
+.call-status {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+}
+
+.call-status[data-token="amber"] {
+  color: var(--amber);
+}
+
+.call-status[data-token="red"] {
+  color: var(--red);
+}
+
+.token-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.token-list li {
+  margin-bottom: 0.5rem;
+}
+
+.token-list li[data-token="green"] {
+  color: var(--green);
+}
+
+.token-list li[data-token="amber"] {
+  color: var(--amber);
+}
+
+.token-list li[data-token="red"] {
+  color: var(--red);
+}
+
+.metric {
+  display: flex;
+  justify-content: space-between;
+  font-weight: 600;
+}
+
+.metric__label {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.metric--warning {
+  color: var(--amber);
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+
+.table th,
+.table td {
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 0.5rem;
+  text-align: left;
+}
+
+.table tbody tr:last-child td {
+  border-bottom: none;
+}


### PR DESCRIPTION
## Summary
- add the Codex-27 Strategist identity, formations, playbooks, and schemas
- implement mission, playbook, risk, and energy pipelines with reflex hooks and UI views
- provide Strategist badges and documentation for multi-agent coordination rituals

## Testing
- python -m py_compile agents/codex/27-strategist/pipelines/*.py agents/codex/27-strategist/reflex/*.py
- python auto_novel_agent.py *(fails: file not present in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68fe804e888483298e00b9d67064e73e