### PR TITLE
Add Codex-28 Auditor agent bundle

### DIFF
--- a/agents/codex/28-auditor/__init__.py
+++ b/agents/codex/28-auditor/__init__.py
@@ -1,0 +1,22 @@
+"""Codex-28 Auditor agent package."""
+
+from importlib import resources
+
+def get_guardpack_path(name: str) -> str:
+    """Return the filesystem path for a guardpack by ``name``.
+
+    Parameters
+    ----------
+    name:
+        File name of the guardpack within the ``guardpacks`` directory.
+
+    Returns
+    -------
+    str
+        Absolute path pointing to the requested guardpack resource.
+    """
+
+    return str(resources.files(__package__) / "guardpacks" / name)
+
+
+__all__ = ["get_guardpack_path"]

--- a/agents/codex/28-auditor/auditor.md
+++ b/agents/codex/28-auditor/auditor.md
@@ -1,0 +1,52 @@
+# Codex-28 “Auditor” Operations Manual
+
+Codex-28 focuses on trustworthy provenance, lightweight compliance evidence,
+and quick human review loops. This manual summarises the key rituals the agent
+follows when embedded in a workflow.
+
+## Operating Loop
+
+1. **Collect** – Ingest pull-request events, CI logs, metrics, and manual notes
+   into a normalised evidence bundle.
+2. **Normalize** – Hash all relevant inputs, scrub potentially sensitive data,
+   and annotate the bundle with timestamps and authorship metadata.
+3. **Validate** – Run guardpacks spanning privacy, safety, financial, and
+   research controls. Violation payloads include remediation hints.
+4. **Attest** – Mint a compact receipt summarising the event, energy
+   consumption, hashes, and policy verdict.
+5. **Publish** – Emit the evidence bundle and attestation to downstream
+   subscribers such as dashboards or archives.
+6. **Teach** – Surface summaries for humans, highlighting violations or energy
+   deltas against the 2.0 J/report target.
+
+## Evidence Bundle Expectations
+
+Bundles are JSON-serialisable dictionaries that contain `artifacts`, `logs`,
+`metrics`, and `metadata` keys. Pipelines are designed to operate on Python
+structures and keep mutations isolated—callers should treat the returned bundle
+as immutable.
+
+## Guardpack Coverage
+
+- `privacy.yaml` blocks unmasked personal data and requires an explicit scrub
+  flag.
+- `safety.yaml` ensures audit topics and severity markers accompany high-risk
+  findings.
+- `finance.yaml` validates cost telemetry and sanity-checks anomalous spikes.
+- `research.yaml` enforces dataset lineage and citation references for models.
+
+## Energy Discipline
+
+Codex-28 tracks joules per report. Receipts include both the observed value and
+whether the 2.0 J target has been met. Use the guardpack hints to reduce energy
+use if the target is missed.
+
+## Escalation Ritual
+
+1. Policy violation detected.
+2. Receipt minted with `policy_pass: false` and linked violations.
+3. Human reviewer receives a succinct summary plus remediation hints.
+4. Once corrected, rerun the pipelines to obtain a clean receipt.
+
+Stay gentle, precise, and verifiable—every bundle should stand as a receipt the
+team can trust.

--- a/agents/codex/28-auditor/codex28.yaml
+++ b/agents/codex/28-auditor/codex28.yaml
@@ -1,0 +1,18 @@
+id: codex-28
+name: Auditor
+generation: 6
+moral_constant: "Trust = Truth with a receipt"
+core_principle: "Prove softly, verify completely"
+emojis: ["🛡️", "🧾", "🔐", "🧰", "✅", "🕯️"]
+energy:
+  target_joules_per_report: 2.0
+guardpacks:
+  - privacy.yaml
+  - safety.yaml
+  - finance.yaml
+  - research.yaml
+attestation:
+  include: ["inputs", "outputs", "hashes", "energy", "policy_pass"]
+redaction:
+  pii_strategies: ["mask", "drop", "hash-salt"]
+  default_mode: "mask"

--- a/agents/codex/28-auditor/guardpacks/finance.yaml
+++ b/agents/codex/28-auditor/guardpacks/finance.yaml
@@ -1,0 +1,16 @@
+name: finance
+version: 1
+policies:
+  - id: FIN-001
+    description: "Cost telemetry must be present in metrics.cost_usd."
+    type: require_numeric
+    path: metrics.cost_usd
+    severity: medium
+    hint: "Report the execution cost in metrics.cost_usd for financial attestation."
+  - id: FIN-002
+    description: "Cost per report should stay within the configured ceiling."
+    type: max_value
+    path: metrics.cost_usd
+    threshold: 5000
+    severity: medium
+    hint: "Investigate unusual cost spikes before publishing the bundle."

--- a/agents/codex/28-auditor/guardpacks/privacy.yaml
+++ b/agents/codex/28-auditor/guardpacks/privacy.yaml
@@ -1,0 +1,23 @@
+name: privacy
+version: 1
+policies:
+  - id: PRIV-001
+    description: "Bundles must record that PII scrubbing has been applied."
+    type: require_flag
+    path: metadata.pii_scrubbed
+    severity: high
+    hint: "Invoke scrub_pii.scrub before validation to set metadata.pii_scrubbed."
+  - id: PRIV-002
+    description: "Evidence payloads must not contain email addresses."
+    type: regex_forbidden
+    targets: [artifacts, logs]
+    pattern: "(?i)[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,}"
+    severity: high
+    hint: "Mask emails with the configured redaction token."
+  - id: PRIV-003
+    description: "Evidence payloads must not contain phone numbers."
+    type: regex_forbidden
+    targets: [artifacts, logs]
+    pattern: "(?i)\\b(?:\\+?\\d{1,3}[-.\\s]?)?(?:\\(\\d{3}\\)|\\d{3})[-.\\s]?\\d{3}[-.\\s]?\\d{4}\\b"
+    severity: medium
+    hint: "Remove or hash phone numbers before publishing."

--- a/agents/codex/28-auditor/guardpacks/research.yaml
+++ b/agents/codex/28-auditor/guardpacks/research.yaml
@@ -1,0 +1,15 @@
+name: research
+version: 1
+policies:
+  - id: RES-001
+    description: "Model events must include dataset lineage hashes."
+    type: require_non_empty
+    path: metadata.dataset_hashes
+    severity: high
+    hint: "Capture dataset hashes in metadata.dataset_hashes when training completes."
+  - id: RES-002
+    description: "Research outputs should cite supporting references."
+    type: require_non_empty
+    path: metadata.references
+    severity: low
+    hint: "List key references or tickets in metadata.references for traceability."

--- a/agents/codex/28-auditor/guardpacks/safety.yaml
+++ b/agents/codex/28-auditor/guardpacks/safety.yaml
@@ -1,0 +1,17 @@
+name: safety
+version: 1
+policies:
+  - id: SAFE-001
+    description: "Bundles should declare a risk topic for traceability."
+    type: require_non_empty
+    path: metadata.risk_topics
+    severity: medium
+    hint: "Populate metadata.risk_topics with relevant tags (e.g. ['model', 'privacy'])."
+  - id: SAFE-002
+    description: "High risk findings require an assigned reviewer."
+    type: conditional_flag
+    path: metadata.risk_level
+    equals: high
+    required_flag: metadata.reviewer
+    severity: high
+    hint: "Assign a human reviewer whenever risk_level is 'high'."

--- a/agents/codex/28-auditor/pipelines/__init__.py
+++ b/agents/codex/28-auditor/pipelines/__init__.py
@@ -1,0 +1,3 @@
+"""Pipelines powering the Codex-28 Auditor agent."""
+
+__all__ = []

--- a/agents/codex/28-auditor/pipelines/collect_artifacts.py
+++ b/agents/codex/28-auditor/pipelines/collect_artifacts.py
@@ -1,0 +1,97 @@
+"""Collection utilities for building evidence bundles."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List
+
+EvidenceBundle = Dict[str, Any]
+
+
+def _ensure_list(candidate: Any) -> List[Any]:
+    """Return ``candidate`` as a list.
+
+    Scalars are wrapped, ``None`` becomes an empty list, and existing lists are
+    shallow-copied so that callers cannot mutate the bundle through shared
+    references.
+    """
+
+    if candidate is None:
+        return []
+    if isinstance(candidate, list):
+        return list(candidate)
+    return [candidate]
+
+
+def _merge_tags(*candidates: Iterable[str]) -> List[str]:
+    """Merge multiple iterables into a de-duplicated list preserving order."""
+
+    merged: List[str] = []
+    for iterable in candidates:
+        for item in iterable or []:
+            if item not in merged:
+                merged.append(item)
+    return merged
+
+
+def collect(event: Dict[str, Any]) -> EvidenceBundle:
+    """Normalise an incoming event into an evidence bundle.
+
+    Parameters
+    ----------
+    event:
+        Event payload produced by workflow hooks (e.g. PR merge, deployment
+        attempt). The structure is expected to include optional ``artifacts``,
+        ``logs``, ``metrics``, and ``metadata`` keys.
+
+    Returns
+    -------
+    EvidenceBundle
+        A dictionary shaped according to ``evidence_bundle.schema.json``. The
+        returned bundle is decoupled from the source event to prevent accidental
+        mutation.
+    """
+
+    if not isinstance(event, dict):
+        raise TypeError("event must be a dictionary")
+
+    event_metadata = event.get("metadata", {})
+    raw_metadata = deepcopy(event_metadata if isinstance(event_metadata, dict) else {})
+    metadata: Dict[str, Any] = {
+        "source_event": event.get("type", "unknown"),
+        "source_event_id": event.get("id"),
+        "collected_at": datetime.now(timezone.utc).isoformat(),
+        "pii_scrubbed": bool(raw_metadata.get("pii_scrubbed") or event.get("pii_scrubbed")),
+        "risk_topics": _ensure_list(raw_metadata.get("risk_topics")),
+        "risk_level": raw_metadata.get("risk_level", "low"),
+        "reviewer": raw_metadata.get("reviewer"),
+        "dataset_hashes": _ensure_list(raw_metadata.get("dataset_hashes")),
+        "references": _ensure_list(raw_metadata.get("references")),
+    }
+
+    tags = _merge_tags(
+        metadata.get("risk_topics", []),
+        _ensure_list(event.get("tags")),
+    )
+    if tags:
+        metadata["risk_topics"] = tags
+
+    bundle: EvidenceBundle = {
+        "artifacts": _ensure_list(deepcopy(event.get("artifacts"))),
+        "logs": [str(item) for item in _ensure_list(event.get("logs"))],
+        "metrics": deepcopy(event.get("metrics", {})),
+        "metadata": metadata,
+    }
+
+    notes = event.get("notes")
+    if notes:
+        bundle["logs"].append(str(notes))
+
+    if event.get("decisions"):
+        bundle.setdefault("artifacts", []).append({"decisions": deepcopy(event["decisions"])})
+
+    return bundle
+
+
+__all__ = ["collect", "EvidenceBundle"]

--- a/agents/codex/28-auditor/pipelines/hash_lineage.py
+++ b/agents/codex/28-auditor/pipelines/hash_lineage.py
@@ -1,0 +1,47 @@
+"""Hash computation helpers for lineage tracking."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Dict, Iterable, List
+
+from .collect_artifacts import EvidenceBundle
+
+
+def _hash_payload(payload: Any) -> str:
+    """Return a SHA-256 hex digest for ``payload``."""
+
+    normalised = json.dumps(payload, sort_keys=True, default=str, separators=(",", ":"))
+    return hashlib.sha256(normalised.encode("utf-8")).hexdigest()
+
+
+def _hash_iterable(iterable: Iterable[Any]) -> List[str]:
+    """Hash each element of ``iterable`` and return the digest list."""
+
+    return [_hash_payload(item) for item in iterable]
+
+
+def lineage(bundle: EvidenceBundle) -> Dict[str, Any]:
+    """Generate deterministic hashes for the supplied evidence bundle."""
+
+    if not isinstance(bundle, dict):
+        raise TypeError("bundle must be a dictionary")
+
+    artifacts = bundle.get("artifacts", [])
+    logs = bundle.get("logs", [])
+    metrics = bundle.get("metrics", {})
+    metadata = bundle.get("metadata", {})
+
+    hashes = {
+        "bundle": _hash_payload({k: bundle[k] for k in bundle if k != "hashes"}),
+        "artifacts": _hash_iterable(artifacts),
+        "logs": _hash_iterable(str(item) for item in logs),
+        "metrics": {key: _hash_payload(value) for key, value in metrics.items()},
+        "metadata": _hash_payload(metadata),
+    }
+
+    return hashes
+
+
+__all__ = ["lineage"]

--- a/agents/codex/28-auditor/pipelines/mint_receipt.py
+++ b/agents/codex/28-auditor/pipelines/mint_receipt.py
@@ -1,0 +1,69 @@
+"""Receipt minting utilities for Codex-28 Auditor."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+from uuid import uuid4
+
+from .collect_artifacts import EvidenceBundle
+from .hash_lineage import lineage
+
+TARGET_JOULES_PER_REPORT = 2.0
+
+
+def _coerce_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        return float(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _energy_section(bundle: EvidenceBundle) -> Dict[str, Any]:
+    metrics = bundle.get("metrics", {}) if isinstance(bundle, dict) else {}
+    observed = _coerce_float(metrics.get("energy_j") or metrics.get("energy_joules"))
+    if observed is None:
+        observed = 0.0
+    return {
+        "actual_joules": observed,
+        "target_joules": TARGET_JOULES_PER_REPORT,
+        "within_target": observed <= TARGET_JOULES_PER_REPORT,
+    }
+
+
+def _outputs_section(bundle: EvidenceBundle) -> Dict[str, Any]:
+    return {
+        "artifacts": len(bundle.get("artifacts", [])),
+        "logs": len(bundle.get("logs", [])),
+        "metrics": list(bundle.get("metrics", {}).keys()),
+    }
+
+
+def mint(bundle: EvidenceBundle, ok: bool, violations: List[Dict[str, Any]] | None = None) -> Dict[str, Any]:
+    """Mint an attestation receipt for ``bundle``."""
+
+    if not isinstance(bundle, dict):
+        raise TypeError("bundle must be a dictionary")
+
+    receipt_hashes = bundle.get("hashes") or lineage(bundle)
+
+    receipt = {
+        "receipt_id": str(uuid4()),
+        "agent": "codex-28",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "inputs": bundle.get("metadata", {}),
+        "outputs": _outputs_section(bundle),
+        "hashes": receipt_hashes,
+        "energy": _energy_section(bundle),
+        "policy_pass": bool(ok),
+        "violations": violations or [],
+    }
+
+    return receipt
+
+
+__all__ = ["mint", "TARGET_JOULES_PER_REPORT"]

--- a/agents/codex/28-auditor/pipelines/scrub_pii.py
+++ b/agents/codex/28-auditor/pipelines/scrub_pii.py
@@ -1,0 +1,157 @@
+"""Redaction helpers for personally identifiable information (PII)."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Any, Dict, Iterable, List, Tuple
+
+DEFAULT_STRATEGY = "mask"
+MASK_TOKEN = "██REDACTED██"
+_HASH_SALT = "codex-28::auditor"
+_PII_FIELDS = {
+    "email",
+    "phone",
+    "ssn",
+    "dob",
+    "address",
+    "name",
+    "token",
+    "secret",
+    "password",
+    "api_key",
+}
+_PII_PATTERNS: Tuple[Tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"(?i)[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}"), "email"),
+    (
+        re.compile(r"(?i)\b(?:\+?\d{1,3}[-.\s]?)?(?:\(\d{3}\)|\d{3})[-.\s]?\d{3}[-.\s]?\d{4}\b"),
+        "phone",
+    ),
+    (re.compile(r"(?i)\bssn[:=]?\s*\d{3}-?\d{2}-?\d{4}\b"), "ssn"),
+)
+
+RedactionDiff = Dict[str, Any]
+
+
+def _apply_strategy(value: Any, strategy: str) -> Any:
+    if strategy == "drop":
+        return None
+    if strategy == "hash-salt":
+        digest = hashlib.sha256(f"{_HASH_SALT}:{value}".encode("utf-8")).hexdigest()
+        return digest
+    return MASK_TOKEN
+
+
+def _scrub_string(text: str, strategy: str, path: str, diffs: List[RedactionDiff]) -> str:
+    scrubbed = text
+    for pattern, label in _PII_PATTERNS:
+        matches = list(pattern.finditer(scrubbed))
+        if not matches:
+            continue
+        replacement = (
+            lambda match: _apply_strategy(match.group(0), strategy)
+            if strategy == "hash-salt"
+            else MASK_TOKEN
+        )
+        scrubbed = pattern.sub(replacement, scrubbed)
+        diffs.append(
+            {
+                "field": path,
+                "original": text,
+                "redacted": scrubbed,
+                "strategy": strategy,
+                "label": label,
+            }
+        )
+    return scrubbed
+
+
+def _scrub_mapping(
+    mapping: Dict[str, Any], strategy: str, path: List[str], diffs: List[RedactionDiff]
+) -> Dict[str, Any]:
+    result: Dict[str, Any] = {}
+    for key, value in mapping.items():
+        lowered = key.lower()
+        current_path = path + [key]
+        joined = ".".join(current_path)
+        if lowered in _PII_FIELDS:
+            redacted = _apply_strategy(value, strategy)
+            diffs.append(
+                {
+                    "field": joined,
+                    "original": value,
+                    "redacted": redacted,
+                    "strategy": strategy,
+                    "label": lowered,
+                }
+            )
+            if strategy == "drop":
+                continue
+            result[key] = redacted
+            continue
+        result[key] = _scrub_value(value, strategy, current_path, diffs)
+    return result
+
+
+def _scrub_iterable(
+    iterable: Iterable[Any], strategy: str, path: List[str], diffs: List[RedactionDiff]
+) -> List[Any]:
+    result: List[Any] = []
+    for index, value in enumerate(iterable):
+        current_path = path + [str(index)]
+        scrubbed = _scrub_value(value, strategy, current_path, diffs)
+        if strategy == "drop" and scrubbed is None:
+            continue
+        result.append(scrubbed)
+    return result
+
+
+def _scrub_value(value: Any, strategy: str, path: List[str], diffs: List[RedactionDiff]) -> Any:
+    if isinstance(value, dict):
+        return _scrub_mapping(value, strategy, path, diffs)
+    if isinstance(value, list):
+        return _scrub_iterable(value, strategy, path, diffs)
+    if isinstance(value, str):
+        return _scrub_string(value, strategy, ".".join(path), diffs)
+    return value
+
+
+def scrub(payload: Any, strategy: str = DEFAULT_STRATEGY, return_diffs: bool = False):
+    """Redact sensitive information from ``payload``.
+
+    Parameters
+    ----------
+    payload:
+        Arbitrary JSON-like structure containing potential PII.
+    strategy:
+        One of ``"mask"``, ``"drop"``, or ``"hash-salt"``.
+    return_diffs:
+        When ``True`` the function returns a tuple ``(sanitised, diffs)``.
+
+    Returns
+    -------
+    Any or Tuple[Any, List[RedactionDiff]]
+        Scrubbed payload, optionally accompanied by the redaction diff records.
+    """
+
+    if strategy not in {"mask", "drop", "hash-salt"}:
+        raise ValueError("strategy must be one of 'mask', 'drop', or 'hash-salt'")
+
+    diffs: List[RedactionDiff] = []
+    scrubbed = _scrub_value(payload, strategy, [], diffs)
+
+    if isinstance(scrubbed, dict) and any(
+        key in scrubbed for key in ("artifacts", "logs", "metadata", "metrics")
+    ):
+        metadata = scrubbed.get("metadata")
+        if not isinstance(metadata, dict):
+            metadata = {}
+        metadata["pii_scrubbed"] = True
+        scrubbed["metadata"] = metadata
+
+    if return_diffs:
+        return scrubbed, diffs
+    return scrubbed
+
+
+__all__ = ["scrub", "MASK_TOKEN", "DEFAULT_STRATEGY"]

--- a/agents/codex/28-auditor/pipelines/validate_policies.py
+++ b/agents/codex/28-auditor/pipelines/validate_policies.py
@@ -1,0 +1,206 @@
+"""Guardpack validation for Codex-28 Auditor."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Tuple
+
+import yaml
+
+from .collect_artifacts import EvidenceBundle
+
+_GUARDPACK_FILES: Tuple[str, ...] = (
+    "privacy.yaml",
+    "safety.yaml",
+    "finance.yaml",
+    "research.yaml",
+)
+_GUARDPACK_DIR = Path(__file__).resolve().parents[1] / "guardpacks"
+
+
+@dataclass
+class PolicyViolation:
+    """Container for policy violation details."""
+
+    policy_id: str
+    description: str
+    severity: str
+    hint: str
+    context: Dict[str, Any]
+
+    def asdict(self) -> Dict[str, Any]:
+        return {
+            "id": self.policy_id,
+            "description": self.description,
+            "severity": self.severity,
+            "hint": self.hint,
+            "context": self.context,
+        }
+
+
+def _load_guardpacks() -> List[Dict[str, Any]]:
+    guardpacks: List[Dict[str, Any]] = []
+    for filename in _GUARDPACK_FILES:
+        path = _GUARDPACK_DIR / filename
+        with path.open("r", encoding="utf-8") as stream:
+            guardpacks.append(yaml.safe_load(stream))
+    return guardpacks
+
+
+def _resolve_path(data: Any, path: str) -> Any:
+    current = data
+    for part in path.split("."):
+        if isinstance(current, dict) and part in current:
+            current = current[part]
+        else:
+            return None
+    return current
+
+
+def _iter_targets(bundle: EvidenceBundle, target: str) -> Iterable[Tuple[str, Any]]:
+    if target == "artifacts":
+        for idx, artifact in enumerate(bundle.get("artifacts", [])):
+            yield (f"artifacts[{idx}]", artifact)
+    elif target == "logs":
+        for idx, log in enumerate(bundle.get("logs", [])):
+            yield (f"logs[{idx}]", log)
+    elif target == "metadata":
+        yield ("metadata", bundle.get("metadata", {}))
+    elif target == "metrics":
+        yield ("metrics", bundle.get("metrics", {}))
+
+
+def _violation(policy: Dict[str, Any], context: Dict[str, Any]) -> PolicyViolation:
+    return PolicyViolation(
+        policy_id=policy["id"],
+        description=policy.get("description", ""),
+        severity=policy.get("severity", "medium"),
+        hint=policy.get("hint", ""),
+        context=context,
+    )
+
+
+def _check_require_flag(policy: Dict[str, Any], bundle: EvidenceBundle) -> List[PolicyViolation]:
+    value = _resolve_path(bundle, policy["path"])
+    if value:
+        return []
+    return [
+        _violation(
+            policy,
+            {"path": policy["path"], "message": "Expected truthy flag", "observed": value},
+        )
+    ]
+
+
+def _check_require_non_empty(policy: Dict[str, Any], bundle: EvidenceBundle) -> List[PolicyViolation]:
+    value = _resolve_path(bundle, policy["path"])
+    if isinstance(value, (list, tuple, set)) and len(value) > 0:
+        return []
+    if isinstance(value, str) and value.strip():
+        return []
+    return [
+        _violation(
+            policy,
+            {"path": policy["path"], "message": "Expected non-empty value", "observed": value},
+        )
+    ]
+
+
+def _check_conditional_flag(policy: Dict[str, Any], bundle: EvidenceBundle) -> List[PolicyViolation]:
+    trigger_value = _resolve_path(bundle, policy["path"])
+    if trigger_value != policy.get("equals"):
+        return []
+    required = _resolve_path(bundle, policy["required_flag"])
+    if required:
+        return []
+    return [
+        _violation(
+            policy,
+            {
+                "path": policy["required_flag"],
+                "message": "Expected reviewer when risk level triggered",
+                "observed": required,
+            },
+        )
+    ]
+
+
+def _check_regex_forbidden(policy: Dict[str, Any], bundle: EvidenceBundle) -> List[PolicyViolation]:
+    pattern = re.compile(policy["pattern"])
+    violations: List[PolicyViolation] = []
+    for target in policy.get("targets", []):
+        for location, candidate in _iter_targets(bundle, target):
+            text = json.dumps(candidate, sort_keys=True) if isinstance(candidate, dict) else str(candidate)
+            if pattern.search(text):
+                violations.append(
+                    _violation(
+                        policy,
+                        {
+                            "path": location,
+                            "message": "Forbidden pattern detected",
+                            "snippet": text,
+                        },
+                    )
+                )
+    return violations
+
+
+def _check_require_numeric(policy: Dict[str, Any], bundle: EvidenceBundle) -> List[PolicyViolation]:
+    value = _resolve_path(bundle, policy["path"])
+    if isinstance(value, (int, float)):
+        return []
+    return [
+        _violation(
+            policy,
+            {"path": policy["path"], "message": "Expected numeric value", "observed": value},
+        )
+    ]
+
+
+def _check_max_value(policy: Dict[str, Any], bundle: EvidenceBundle) -> List[PolicyViolation]:
+    value = _resolve_path(bundle, policy["path"])
+    threshold = policy.get("threshold")
+    if isinstance(value, (int, float)) and (threshold is None or value <= threshold):
+        return []
+    return [
+        _violation(
+            policy,
+            {
+                "path": policy["path"],
+                "message": "Value exceeds allowed threshold",
+                "observed": value,
+                "threshold": threshold,
+            },
+        )
+    ]
+
+
+_POLICY_HANDLERS = {
+    "require_flag": _check_require_flag,
+    "require_non_empty": _check_require_non_empty,
+    "conditional_flag": _check_conditional_flag,
+    "regex_forbidden": _check_regex_forbidden,
+    "require_numeric": _check_require_numeric,
+    "max_value": _check_max_value,
+}
+
+
+def check(bundle: EvidenceBundle) -> Tuple[bool, List[Dict[str, Any]]]:
+    """Run the configured guardpacks against ``bundle``."""
+
+    violations: List[Dict[str, Any]] = []
+    for guardpack in _load_guardpacks():
+        for policy in guardpack.get("policies", []):
+            handler = _POLICY_HANDLERS.get(policy.get("type"))
+            if handler is None:
+                continue
+            for violation in handler(policy, bundle):
+                violations.append(violation.asdict())
+
+    return len(violations) == 0, violations
+
+
+__all__ = ["check", "PolicyViolation"]

--- a/agents/codex/28-auditor/reflex/on_forget_request.reflex.py
+++ b/agents/codex/28-auditor/reflex/on_forget_request.reflex.py
@@ -1,0 +1,36 @@
+"""Reflex hook that attests right-to-forget operations."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from lucidia.reflex.core import BUS, start
+
+from ..pipelines.mint_receipt import mint
+
+
+@BUS.on("privacy:forget_request")
+def forget(event: dict) -> None:
+    """Emit a tombstone confirmation for data deletion events."""
+
+    bundle = {
+        "artifacts": [],
+        "logs": [
+            f"Forget request for subject={event.get('subject_id', 'unknown')}",
+            event.get("notes", ""),
+        ],
+        "metrics": {},
+        "metadata": {
+            "pii_scrubbed": True,
+            "subject_id": event.get("subject_id"),
+            "request_id": event.get("request_id"),
+            "deleted_at": datetime.now(timezone.utc).isoformat(),
+        },
+        "hashes": event.get("hashes", {}),
+    }
+    receipt = mint(bundle, ok=True)
+    BUS.emit("privacy:tombstone.created", {"receipt": receipt, "bundle": bundle})
+
+
+if __name__ == "__main__":
+    start()

--- a/agents/codex/28-auditor/reflex/on_model_train.reflex.py
+++ b/agents/codex/28-auditor/reflex/on_model_train.reflex.py
@@ -1,0 +1,30 @@
+"""Reflex hook for emitting model training attestations."""
+
+from __future__ import annotations
+
+from lucidia.reflex.core import BUS, start
+
+from ..pipelines.mint_receipt import mint
+
+
+@BUS.on("train:completed")
+def attest(event: dict) -> None:
+    """Mint an attestation receipt for the completed training job."""
+
+    receipt = mint({
+        "artifacts": event.get("artifacts", []),
+        "logs": event.get("logs", []),
+        "metrics": {"energy_j": event.get("energy_j")},
+        "metadata": {
+            "model": event.get("model"),
+            "dataset_hashes": event.get("dataset_hashes", []),
+            "references": event.get("references", []),
+            "pii_scrubbed": True,
+        },
+        "hashes": event.get("hashes", {}),
+    }, ok=True)
+    BUS.emit("audit:attestation.published", receipt)
+
+
+if __name__ == "__main__":
+    start()

--- a/agents/codex/28-auditor/reflex/on_pr_merged.reflex.py
+++ b/agents/codex/28-auditor/reflex/on_pr_merged.reflex.py
@@ -1,0 +1,28 @@
+"""Reflex hook triggered when a pull request is merged."""
+
+from __future__ import annotations
+
+from lucidia.reflex.core import BUS, start
+
+from ..pipelines.collect_artifacts import collect
+from ..pipelines.hash_lineage import lineage
+from ..pipelines.validate_policies import check
+from ..pipelines.mint_receipt import mint
+
+
+@BUS.on("git:pr_merged")
+def bundle(event: dict) -> None:
+    """Create an evidence bundle and mint an attestation receipt."""
+
+    evidence = collect(event)
+    evidence["hashes"] = lineage(evidence)
+    ok, violations = check(evidence)
+    receipt = mint(evidence, ok=ok, violations=violations)
+    BUS.emit(
+        "audit:evidence.created",
+        {"receipt": receipt, "ok": ok, "violations": violations, "bundle": evidence},
+    )
+
+
+if __name__ == "__main__":
+    start()

--- a/agents/codex/28-auditor/reflex/on_publish_attempt.reflex.py
+++ b/agents/codex/28-auditor/reflex/on_publish_attempt.reflex.py
@@ -1,0 +1,27 @@
+"""Reflex hook enforcing guardpacks before publishing artifacts."""
+
+from __future__ import annotations
+
+from lucidia.reflex.core import BUS, start
+
+from ..pipelines.scrub_pii import scrub
+from ..pipelines.validate_policies import check
+
+
+@BUS.on("publish:attempt")
+def gate(event: dict) -> None:
+    """Scrub the artifact and gate publication on policy compliance."""
+
+    clean_artifact = scrub(event.get("artifact", {}))
+    ok, violations = check(clean_artifact if isinstance(clean_artifact, dict) else {
+        "artifacts": [clean_artifact],
+        "logs": [],
+        "metrics": {},
+        "metadata": {"pii_scrubbed": True},
+    })
+    topic = "publish:allowed" if ok else "publish:blocked"
+    BUS.emit(topic, {"artifact": clean_artifact, "violations": violations})
+
+
+if __name__ == "__main__":
+    start()

--- a/agents/codex/28-auditor/schemas/attestation.schema.json
+++ b/agents/codex/28-auditor/schemas/attestation.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "AttestationReceipt",
+  "type": "object",
+  "required": ["receipt_id", "agent", "timestamp", "policy_pass", "hashes", "energy"],
+  "properties": {
+    "receipt_id": {"type": "string"},
+    "agent": {"type": "string"},
+    "timestamp": {"type": "string", "format": "date-time"},
+    "policy_pass": {"type": "boolean"},
+    "hashes": {"type": "object"},
+    "energy": {
+      "type": "object",
+      "required": ["actual_joules", "target_joules", "within_target"],
+      "properties": {
+        "actual_joules": {"type": "number"},
+        "target_joules": {"type": "number"},
+        "within_target": {"type": "boolean"}
+      }
+    },
+    "inputs": {"type": "object"},
+    "outputs": {"type": "object"},
+    "violations": {
+      "type": "array",
+      "items": {"type": "object"}
+    }
+  },
+  "additionalProperties": true
+}

--- a/agents/codex/28-auditor/schemas/evidence_bundle.schema.json
+++ b/agents/codex/28-auditor/schemas/evidence_bundle.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "EvidenceBundle",
+  "type": "object",
+  "required": ["artifacts", "logs", "metrics", "metadata"],
+  "properties": {
+    "artifacts": {
+      "type": "array",
+      "items": {"type": ["object", "string"]}
+    },
+    "logs": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "metrics": {
+      "type": "object"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "hashes": {
+      "type": "object"
+    }
+  },
+  "additionalProperties": true
+}

--- a/agents/codex/28-auditor/schemas/policy_violation.schema.json
+++ b/agents/codex/28-auditor/schemas/policy_violation.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PolicyViolation",
+  "type": "object",
+  "required": ["id", "description", "severity", "hint"],
+  "properties": {
+    "id": {"type": "string"},
+    "description": {"type": "string"},
+    "severity": {"type": "string"},
+    "hint": {"type": "string"},
+    "context": {"type": "object"}
+  },
+  "additionalProperties": true
+}

--- a/agents/codex/28-auditor/schemas/redaction_diff.schema.json
+++ b/agents/codex/28-auditor/schemas/redaction_diff.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "RedactionDiff",
+  "type": "object",
+  "required": ["field", "original", "redacted", "strategy"],
+  "properties": {
+    "field": {"type": "string"},
+    "original": {},
+    "redacted": {},
+    "strategy": {"type": "string"}
+  },
+  "additionalProperties": true
+}

--- a/agents/codex/28-auditor/tests/test_attestation.py
+++ b/agents/codex/28-auditor/tests/test_attestation.py
@@ -1,0 +1,28 @@
+"""Tests for minting attestation receipts."""
+
+from agents.codex._28_auditor.pipelines.mint_receipt import (
+    TARGET_JOULES_PER_REPORT,
+    mint,
+)
+
+
+def test_mint_receipt_contains_expected_sections():
+    bundle = {
+        "artifacts": [{"bundle": "demo"}],
+        "logs": ["All good"],
+        "metrics": {"energy_j": 1.2},
+        "metadata": {"reviewer": "auditor@example.com"},
+        "hashes": {"bundle": "hash123"},
+    }
+
+    receipt = mint(bundle, ok=True, violations=[])
+
+    assert receipt["policy_pass"] is True
+    assert receipt["hashes"]["bundle"] == "hash123"
+    assert receipt["outputs"]["artifacts"] == 1
+    assert receipt["energy"]["actual_joules"] == 1.2
+    assert receipt["energy"]["target_joules"] == TARGET_JOULES_PER_REPORT
+    assert receipt["energy"]["within_target"] is True
+    assert receipt["violations"] == []
+    assert receipt["inputs"]["reviewer"] == "auditor@example.com"
+    assert receipt["receipt_id"]

--- a/agents/codex/28-auditor/tests/test_guardpacks.py
+++ b/agents/codex/28-auditor/tests/test_guardpacks.py
@@ -1,0 +1,36 @@
+"""Tests covering guardpack validations."""
+
+from agents.codex._28_auditor.pipelines.scrub_pii import scrub
+from agents.codex._28_auditor.pipelines.validate_policies import check
+
+
+def _base_bundle() -> dict:
+    return {
+        "artifacts": ["Initial artifact"],
+        "logs": ["Pipeline complete"],
+        "metrics": {"cost_usd": 120.5, "energy_j": 1.5},
+        "metadata": {
+            "pii_scrubbed": False,
+            "risk_topics": ["model"],
+            "risk_level": "medium",
+            "dataset_hashes": ["abc"],
+            "references": ["paper-1"],
+        },
+    }
+
+
+def test_detects_privacy_violation_when_raw_pii_present():
+    bundle = _base_bundle()
+    bundle["logs"].append("Reach me at 555-123-4567")
+    ok, violations = check(bundle)
+    assert not ok
+    assert any(v["id"] == "PRIV-003" for v in violations)
+    assert any(v["id"] == "PRIV-001" for v in violations)
+
+
+def test_passes_after_scrubbing_and_metadata_present():
+    bundle = _base_bundle()
+    bundle["logs"].append("Reach me at 555-123-4567")
+    scrubbed = scrub(bundle)
+    ok, violations = check(scrubbed)
+    assert ok, violations

--- a/agents/codex/28-auditor/tests/test_scrub_pii.py
+++ b/agents/codex/28-auditor/tests/test_scrub_pii.py
@@ -1,0 +1,27 @@
+"""Tests for PII scrubbing utilities."""
+
+from agents.codex._28_auditor.pipelines.scrub_pii import MASK_TOKEN, scrub
+
+
+def test_scrub_masks_sensitive_fields_without_mutating_source():
+    payload = {
+        "email": "person@example.com",
+        "notes": "Reach me at 555-123-4567 or person@example.com",
+        "nested": {"phone": "(555) 222-1111"},
+    }
+    original = payload.copy()
+
+    cleaned = scrub(payload)
+
+    assert cleaned["email"] == MASK_TOKEN
+    assert cleaned["nested"]["phone"] == MASK_TOKEN
+    assert cleaned["notes"].count(MASK_TOKEN) == 2
+    assert payload == original
+
+
+def test_scrub_hash_strategy_generates_deterministic_digest():
+    payload = {"token": "secret-token"}
+    first, _ = scrub(payload, strategy="hash-salt", return_diffs=True)
+    second, _ = scrub(payload, strategy="hash-salt", return_diffs=True)
+    assert first["token"] == second["token"]
+    assert first["token"] != payload["token"]

--- a/agents/codex/28-auditor/ui/audit_panel.html
+++ b/agents/codex/28-auditor/ui/audit_panel.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Codex-28 Auditor Panel</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <h1>Codex-28 Auditor</h1>
+      <p class="subtitle">Trust = Truth with a receipt</p>
+    </header>
+
+    <main>
+      <section class="filters">
+        <h2>Filters</h2>
+        <div class="filter-row">
+          <label for="status-filter">Policy Status</label>
+          <select id="status-filter">
+            <option value="all">All</option>
+            <option value="pass">Pass</option>
+            <option value="fail">Fail</option>
+          </select>
+        </div>
+        <div class="filter-row">
+          <label for="audience-filter">Audience</label>
+          <select id="audience-filter">
+            <option value="engineer">Engineer</option>
+            <option value="regulator">Regulator</option>
+            <option value="investor">Investor</option>
+            <option value="public">Public</option>
+          </select>
+        </div>
+      </section>
+
+      <section class="metrics">
+        <h2>Energy Trend</h2>
+        <div id="energy-trend" class="metric-card">Loading…</div>
+      </section>
+
+      <section class="receipts">
+        <h2>Attestation Receipts</h2>
+        <table id="receipts-table">
+          <thead>
+            <tr>
+              <th>Receipt</th>
+              <th>Timestamp</th>
+              <th>Policy</th>
+              <th>Energy (J)</th>
+              <th>Audience Summary</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </section>
+    </main>
+
+    <script src="widgets.js"></script>
+  </body>
+</html>

--- a/agents/codex/28-auditor/ui/styles.css
+++ b/agents/codex/28-auditor/ui/styles.css
@@ -1,0 +1,119 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background: #0f1115;
+  color: #e8edf5;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background: linear-gradient(135deg, #0f1115, #1c1f27);
+}
+
+header {
+  padding: 2rem 3rem 1rem;
+  border-bottom: 1px solid #2a2f3a;
+}
+
+h1 {
+  margin: 0;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+}
+
+.subtitle {
+  margin: 0.25rem 0 0;
+  font-size: 0.95rem;
+  color: #99a1b3;
+}
+
+main {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 1.5rem;
+  padding: 2rem 3rem;
+}
+
+section {
+  background: rgba(22, 24, 33, 0.85);
+  border: 1px solid #272b36;
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.35);
+}
+
+.filters {
+  height: fit-content;
+}
+
+.filter-row {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
+}
+
+label {
+  font-size: 0.85rem;
+  color: #8f96a8;
+  margin-bottom: 0.25rem;
+}
+
+select {
+  padding: 0.6rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid #2f3544;
+  background: #151821;
+  color: #e8edf5;
+}
+
+.metrics {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.metric-card {
+  padding: 1.25rem;
+  border-radius: 12px;
+  background: #141720;
+  border: 1px solid #252a36;
+  min-height: 120px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1rem;
+  color: #9fa8be;
+}
+
+.receipts table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.receipts th,
+.receipts td {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid #252a36;
+}
+
+.receipts tbody tr:hover {
+  background: rgba(99, 120, 255, 0.1);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  background: rgba(16, 184, 125, 0.18);
+  color: #24c48f;
+}
+
+.badge.danger {
+  background: rgba(255, 92, 141, 0.18);
+  color: #ff567d;
+}

--- a/agents/codex/28-auditor/ui/widgets.js
+++ b/agents/codex/28-auditor/ui/widgets.js
@@ -1,0 +1,113 @@
+const state = {
+  receipts: [],
+  filters: {
+    status: 'all',
+    audience: 'engineer',
+  },
+};
+
+function formatEnergy(energy) {
+  if (!energy) return '—';
+  const value = Number(energy.actual_joules || 0).toFixed(2);
+  const badge = energy.within_target ? 'badge' : 'badge danger';
+  return `<span class="${badge}">${value} J</span>`;
+}
+
+function formatPolicy(receipt) {
+  return receipt.policy_pass ? '<span class="badge">Pass</span>' : '<span class="badge danger">Fail</span>';
+}
+
+function summarizeForAudience(receipt) {
+  const base = receipt.policy_pass ? 'All policies cleared.' : `${receipt.violations.length} violation(s).`;
+  switch (state.filters.audience) {
+    case 'regulator':
+      return `${base} Hash bundle=${receipt.hashes.bundle.slice(0, 8)}…`;
+    case 'investor':
+      return `${base} Energy=${Number(receipt.energy.actual_joules || 0).toFixed(2)}J.`;
+    case 'public':
+      return receipt.policy_pass ? '✅ Safe to announce.' : '⚠️ Pending review.';
+    default:
+      return `${base} Reviewer=${receipt.inputs.reviewer || 'unassigned'}.`;
+  }
+}
+
+function applyFilters(receipts) {
+  return receipts.filter((receipt) => {
+    if (state.filters.status === 'pass' && !receipt.policy_pass) return false;
+    if (state.filters.status === 'fail' && receipt.policy_pass) return false;
+    return true;
+  });
+}
+
+function renderTable() {
+  const tableBody = document.querySelector('#receipts-table tbody');
+  tableBody.innerHTML = '';
+  const visibleReceipts = applyFilters(state.receipts);
+  visibleReceipts.forEach((receipt) => {
+    const row = document.createElement('tr');
+    row.innerHTML = `
+      <td>${receipt.receipt_id}</td>
+      <td>${new Date(receipt.timestamp).toLocaleString()}</td>
+      <td>${formatPolicy(receipt)}</td>
+      <td>${formatEnergy(receipt.energy)}</td>
+      <td>${summarizeForAudience(receipt)}</td>
+    `;
+    tableBody.appendChild(row);
+  });
+}
+
+function renderEnergyTrend() {
+  const trend = document.querySelector('#energy-trend');
+  if (!trend) return;
+  const values = applyFilters(state.receipts).map((receipt) => receipt.energy.actual_joules || 0);
+  if (values.length === 0) {
+    trend.textContent = 'No receipts yet.';
+    return;
+  }
+  const average = values.reduce((acc, val) => acc + val, 0) / values.length;
+  const within = average <= 2.0;
+  trend.innerHTML = `Average ${average.toFixed(2)} J/report — ${within ? '✅ Within target' : '⚠️ Above target'}`;
+}
+
+function render() {
+  renderTable();
+  renderEnergyTrend();
+}
+
+function setFiltersFromControls() {
+  const status = document.getElementById('status-filter');
+  const audience = document.getElementById('audience-filter');
+  if (!status || !audience) return;
+  state.filters.status = status.value;
+  state.filters.audience = audience.value;
+  render();
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('status-filter').addEventListener('change', setFiltersFromControls);
+  document.getElementById('audience-filter').addEventListener('change', setFiltersFromControls);
+
+  // Seed with placeholder receipts for offline preview.
+  state.receipts = [
+    {
+      receipt_id: 'demo-1',
+      timestamp: new Date().toISOString(),
+      policy_pass: true,
+      hashes: { bundle: 'abc12345' },
+      energy: { actual_joules: 1.4, within_target: true },
+      violations: [],
+      inputs: { reviewer: 'auditor@example.com' },
+    },
+    {
+      receipt_id: 'demo-2',
+      timestamp: new Date().toISOString(),
+      policy_pass: false,
+      hashes: { bundle: 'def67890' },
+      energy: { actual_joules: 2.8, within_target: false },
+      violations: [{ id: 'PRIV-002' }],
+      inputs: { reviewer: null },
+    },
+  ];
+
+  render();
+});

--- a/agents/codex/_28_auditor/__init__.py
+++ b/agents/codex/_28_auditor/__init__.py
@@ -1,0 +1,9 @@
+"""Python package shim exposing the Codex-28 Auditor assets."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+_BASE_DIR = Path(__file__).resolve().parent.parent / "28-auditor"
+__path__: List[str] = [str(_BASE_DIR)]


### PR DESCRIPTION
## Summary
- add the Codex-28 Auditor agent package with guardpacks, schemas, pipelines, and reflex hooks
- implement PII scrubbing, lineage hashing, and attestation receipt minting utilities alongside UI assets
- cover the new behaviour with targeted unit tests for scrubbing, guardpacks, and receipt generation

## Testing
- python -m py_compile $(find agents/codex/28-auditor -name '*.py')
- pytest agents/codex/28-auditor/tests

------
https://chatgpt.com/codex/tasks/task_e_68fe809578948329a360336442ab28b8