### PR TITLE
feat: redesign roadview with cinematic layout

### DIFF
--- a/frontend/src/pages/RoadView.css
+++ b/frontend/src/pages/RoadView.css
@@ -1,0 +1,785 @@
+.roadview-page {
+  --bg: #0a0a0f;
+  --bg-secondary: #13131a;
+  --bg-tertiary: #1a1a24;
+  --border: rgba(255, 255, 255, 0.08);
+  --text: #ffffff;
+  --text-secondary: rgba(255, 255, 255, 0.7);
+  --text-tertiary: rgba(255, 255, 255, 0.5);
+  --gradient: linear-gradient(
+    135deg,
+    #fdba2d 0%,
+    #ff6b35 20%,
+    #ff4fd8 45%,
+    #c753ff 65%,
+    #6366f1 85%,
+    #3b82f6 100%
+  );
+  --accent-yellow: #fdba2d;
+  --accent-orange: #ff6b35;
+  --accent-pink: #ff4fd8;
+  --accent-purple: #c753ff;
+  --accent-blue: #3b82f6;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  overflow-x: hidden;
+  min-height: 100vh;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.roadview-page *,
+.roadview-page *::before,
+.roadview-page *::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+.roadview-page button,
+.roadview-page input {
+  font-family: inherit;
+}
+
+.roadview-page .header {
+  height: 60px;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 20px;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.roadview-page .header-left {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+}
+
+.roadview-page .menu-icon {
+  font-size: 24px;
+  cursor: pointer;
+  padding: 8px;
+  border-radius: 50%;
+  transition: background 0.2s;
+}
+
+.roadview-page .menu-icon:hover {
+  background: var(--bg-tertiary);
+}
+
+.roadview-page .logo {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+}
+
+.roadview-page .logo-icon {
+  width: 40px;
+  height: 40px;
+  background: var(--gradient);
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 900;
+  font-size: 20px;
+  color: #000;
+}
+
+.roadview-page .logo-text {
+  font-size: 1.3rem;
+  font-weight: 700;
+  background: var(--gradient);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.roadview-page .header-center {
+  flex: 1;
+  max-width: 600px;
+  margin: 0 40px;
+}
+
+.roadview-page .search-bar {
+  display: flex;
+  align-items: center;
+  gap: 0;
+}
+
+.roadview-page .search-input {
+  flex: 1;
+  padding: 12px 16px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-right: none;
+  border-radius: 24px 0 0 24px;
+  color: var(--text);
+  font-size: 0.95rem;
+  outline: none;
+  transition: border-color 0.2s;
+}
+
+.roadview-page .search-input:focus {
+  border-color: var(--accent-blue);
+}
+
+.roadview-page .search-button {
+  padding: 12px 24px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-left: none;
+  border-radius: 0 24px 24px 0;
+  color: var(--text);
+  cursor: pointer;
+  transition: all 0.2s;
+  font-size: 18px;
+}
+
+.roadview-page .search-button:hover {
+  background: rgba(255, 79, 216, 0.1);
+}
+
+.roadview-page .header-right {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.roadview-page .icon-button {
+  width: 40px;
+  height: 40px;
+  background: transparent;
+  border: none;
+  border-radius: 50%;
+  color: var(--text);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 20px;
+  transition: background 0.2s;
+}
+
+.roadview-page .icon-button:hover {
+  background: var(--bg-tertiary);
+}
+
+.roadview-page .user-avatar {
+  width: 36px;
+  height: 36px;
+  background: var(--gradient);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  color: #000;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.roadview-page .main-container {
+  display: flex;
+  flex: 1;
+  min-height: calc(100vh - 60px);
+}
+
+.roadview-page .sidebar {
+  width: 240px;
+  background: var(--bg-secondary);
+  border-right: 1px solid var(--border);
+  padding: 12px 0;
+  overflow-y: auto;
+  position: sticky;
+  top: 60px;
+  height: calc(100vh - 60px);
+}
+
+.roadview-page .sidebar-section {
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.roadview-page .sidebar-item {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 10px 24px;
+  cursor: pointer;
+  transition: background 0.2s;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+}
+
+.roadview-page .sidebar-item:hover {
+  background: var(--bg-tertiary);
+  color: var(--text);
+}
+
+.roadview-page .sidebar-item.active {
+  background: rgba(255, 79, 216, 0.15);
+  color: var(--text);
+  border-left: 3px solid var(--accent-pink);
+}
+
+.roadview-page .sidebar-icon {
+  font-size: 20px;
+  width: 24px;
+  text-align: center;
+}
+
+.roadview-page .sidebar-title {
+  font-size: 0.85rem;
+  color: var(--text-tertiary);
+  padding: 12px 24px 8px;
+  font-weight: 600;
+}
+
+.roadview-page .subscription-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 24px;
+  cursor: pointer;
+  transition: background 0.2s;
+  color: var(--text-secondary);
+}
+
+.roadview-page .subscription-item:hover {
+  background: var(--bg-tertiary);
+}
+
+.roadview-page .subscription-avatar {
+  width: 28px;
+  height: 28px;
+  background: var(--gradient);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  color: #000;
+  font-weight: 700;
+}
+
+.roadview-page .content {
+  flex: 1;
+  padding: 24px;
+  overflow-y: auto;
+}
+
+.roadview-page .video-player {
+  width: 100%;
+  max-width: 1280px;
+  margin: 0 auto;
+}
+
+.roadview-page .player-wrapper {
+  position: relative;
+  width: 100%;
+  padding-bottom: 56.25%;
+  background: var(--bg-tertiary);
+  border-radius: 12px;
+  overflow: hidden;
+  margin-bottom: 16px;
+}
+
+.roadview-page .player {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(
+    135deg,
+    rgba(253, 186, 45, 0.3) 0%,
+    rgba(255, 107, 53, 0.3) 20%,
+    rgba(255, 79, 216, 0.3) 45%,
+    rgba(199, 83, 255, 0.3) 65%,
+    rgba(99, 102, 241, 0.3) 85%,
+    rgba(59, 130, 246, 0.3) 100%
+  );
+}
+
+.roadview-page .play-button {
+  width: 80px;
+  height: 80px;
+  background: rgba(0, 0, 0, 0.7);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.3s;
+  border: 3px solid rgba(255, 255, 255, 0.3);
+}
+
+.roadview-page .play-button:hover {
+  transform: scale(1.1);
+  background: rgba(0, 0, 0, 0.9);
+  box-shadow: 0 0 40px rgba(255, 79, 216, 0.6);
+}
+
+.roadview-page .play-icon {
+  font-size: 36px;
+  color: white;
+  margin-left: 4px;
+}
+
+.roadview-page .video-info {
+  max-width: 1280px;
+  margin: 0 auto;
+}
+
+.roadview-page .video-title {
+  font-size: 1.4rem;
+  font-weight: 600;
+  margin-bottom: 12px;
+  line-height: 1.4;
+}
+
+.roadview-page .video-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 16px;
+}
+
+.roadview-page .video-stats {
+  display: flex;
+  gap: 16px;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  align-items: center;
+}
+
+.roadview-page .video-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.roadview-page .action-button {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  color: var(--text);
+  cursor: pointer;
+  transition: all 0.2s;
+  font-size: 0.9rem;
+}
+
+.roadview-page .action-button:hover {
+  background: rgba(255, 79, 216, 0.1);
+  border-color: var(--accent-pink);
+}
+
+.roadview-page .action-button.liked {
+  background: rgba(255, 79, 216, 0.2);
+  border-color: var(--accent-pink);
+  color: var(--accent-pink);
+}
+
+.roadview-page .channel-info {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 0;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 24px;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.roadview-page .channel-details {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.roadview-page .channel-avatar {
+  width: 48px;
+  height: 48px;
+  background: var(--gradient);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 20px;
+  color: #000;
+  font-weight: 700;
+}
+
+.roadview-page .channel-text h3 {
+  font-size: 1rem;
+  margin-bottom: 2px;
+}
+
+.roadview-page .channel-text p {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.roadview-page .subscribe-button {
+  padding: 12px 24px;
+  background: var(--gradient);
+  border: none;
+  border-radius: 24px;
+  color: #000;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-size: 0.95rem;
+}
+
+.roadview-page .subscribe-button:hover {
+  transform: scale(1.05);
+  box-shadow: 0 0 20px rgba(255, 79, 216, 0.5);
+}
+
+.roadview-page .subscribe-button.subscribed {
+  background: var(--bg-tertiary);
+  color: var(--text);
+  border: 1px solid var(--border);
+}
+
+.roadview-page .video-description {
+  background: var(--bg-tertiary);
+  padding: 16px;
+  border-radius: 12px;
+  margin-bottom: 24px;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: var(--text-secondary);
+}
+
+.roadview-page .comments-section {
+  margin-top: 32px;
+}
+
+.roadview-page .comments-header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 24px;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.roadview-page .comment-count {
+  color: var(--text-secondary);
+}
+
+.roadview-page .comment-input-wrapper {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 32px;
+  align-items: flex-start;
+}
+
+.roadview-page .comment-avatar {
+  width: 40px;
+  height: 40px;
+  background: var(--gradient);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  color: #000;
+  font-weight: 700;
+}
+
+.roadview-page .comment-input-box {
+  flex: 1;
+}
+
+.roadview-page .comment-input {
+  width: 100%;
+  padding: 12px 0;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--border);
+  color: var(--text);
+  font-size: 0.95rem;
+  outline: none;
+  transition: border-color 0.2s;
+}
+
+.roadview-page .comment-input:focus {
+  border-bottom-color: var(--accent-pink);
+}
+
+.roadview-page .comment-actions {
+  display: flex;
+  gap: 12px;
+  margin-top: 12px;
+  justify-content: flex-end;
+}
+
+.roadview-page .comment-actions.hidden {
+  display: none;
+}
+
+.roadview-page .comment-button {
+  padding: 10px 20px;
+  border: none;
+  border-radius: 24px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 600;
+  transition: all 0.2s;
+}
+
+.roadview-page .comment-button.cancel {
+  background: transparent;
+  color: var(--text-secondary);
+}
+
+.roadview-page .comment-button.cancel:hover {
+  background: var(--bg-tertiary);
+}
+
+.roadview-page .comment-button.post {
+  background: var(--gradient);
+  color: #000;
+}
+
+.roadview-page .comment-button.post:hover {
+  box-shadow: 0 0 20px rgba(255, 79, 216, 0.5);
+}
+
+.roadview-page .comment {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.roadview-page .comment-content {
+  flex: 1;
+}
+
+.roadview-page .comment-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.roadview-page .comment-author {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.roadview-page .comment-time {
+  color: var(--text-tertiary);
+  font-size: 0.85rem;
+}
+
+.roadview-page .comment-text {
+  font-size: 0.95rem;
+  line-height: 1.6;
+  margin-bottom: 8px;
+  color: var(--text-secondary);
+}
+
+.roadview-page .comment-actions-bar {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+}
+
+.roadview-page .comment-action {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+.roadview-page .comment-action:hover {
+  color: var(--text);
+}
+
+.roadview-page .recommendations {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 16px;
+  margin-top: 32px;
+}
+
+.roadview-page .video-card {
+  background: var(--bg-secondary);
+  border-radius: 12px;
+  overflow: hidden;
+  cursor: pointer;
+  transition: all 0.2s;
+  border: 1px solid transparent;
+  display: flex;
+  flex-direction: column;
+}
+
+.roadview-page .video-card:hover {
+  border-color: var(--accent-pink);
+  transform: translateY(-2px);
+}
+
+.roadview-page .video-thumbnail {
+  width: 100%;
+  padding-bottom: 56.25%;
+  position: relative;
+  background: linear-gradient(
+    135deg,
+    rgba(253, 186, 45, 0.2) 0%,
+    rgba(255, 79, 216, 0.2) 50%,
+    rgba(59, 130, 246, 0.2) 100%
+  );
+}
+
+.roadview-page .video-duration {
+  position: absolute;
+  bottom: 8px;
+  right: 8px;
+  background: rgba(0, 0, 0, 0.8);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.roadview-page .video-card-info {
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.roadview-page .video-card-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.roadview-page .video-card-channel {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.roadview-page .video-card-stats {
+  font-size: 0.85rem;
+  color: var(--text-tertiary);
+}
+
+.roadview-page ::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+.roadview-page ::-webkit-scrollbar-track {
+  background: var(--bg);
+}
+
+.roadview-page ::-webkit-scrollbar-thumb {
+  background: var(--bg-tertiary);
+  border-radius: 4px;
+}
+
+.roadview-page ::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 79, 216, 0.3);
+}
+
+@media (max-width: 1024px) {
+  .roadview-page .main-container {
+    flex-direction: column;
+  }
+
+  .roadview-page .sidebar {
+    position: relative;
+    width: 100%;
+    height: auto;
+    display: flex;
+    overflow: visible;
+  }
+
+  .roadview-page .sidebar-section {
+    flex: 1;
+    border-bottom: none;
+    border-right: 1px solid var(--border);
+  }
+
+  .roadview-page .sidebar-section:last-child {
+    border-right: none;
+  }
+}
+
+@media (max-width: 768px) {
+  .roadview-page .header {
+    flex-wrap: wrap;
+    height: auto;
+    gap: 16px;
+    padding: 16px;
+  }
+
+  .roadview-page .header-center {
+    order: 3;
+    width: 100%;
+    margin: 0;
+  }
+
+  .roadview-page .main-container {
+    min-height: auto;
+  }
+
+  .roadview-page .sidebar {
+    flex-direction: column;
+  }
+
+  .roadview-page .sidebar-section {
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+  }
+}
+
+@media (max-width: 640px) {
+  .roadview-page .video-meta {
+    flex-direction: column;
+    gap: 12px;
+    align-items: flex-start;
+  }
+
+  .roadview-page .video-actions {
+    width: 100%;
+  }
+
+  .roadview-page .content {
+    padding: 16px;
+  }
+
+  .roadview-page .recommendations {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/pages/RoadView.jsx
+++ b/frontend/src/pages/RoadView.jsx
@@ -1,92 +1,346 @@
-import React, { useEffect, useState } from 'react'
-import AgentStack from '../components/AgentStack.jsx'
-import { fetchRoadviewStreams } from '../api'
+import React, { useState } from 'react'
+import './RoadView.css'
 
-const colors = ['var(--accent)', 'var(--accent-2)', 'var(--accent-3)']
+const primaryNav = [
+  { icon: '🏠', label: 'Home', active: true },
+  { icon: '🔥', label: 'Trending' },
+  { icon: '📺', label: 'Subscriptions' },
+]
 
-export default function RoadView({ agents = [] }){
-  const [streams, setStreams] = useState([])
-  const [loading, setLoading] = useState(true)
+const libraryNav = [
+  { icon: '📚', label: 'Library' },
+  { icon: '🕒', label: 'History' },
+  { icon: '▶️', label: 'Your videos' },
+  { icon: '⏰', label: 'Watch later' },
+  { icon: '👍', label: 'Liked videos' },
+]
 
-  useEffect(() => {
-    let alive = true
-    ;(async () => {
-      try {
-        const list = await fetchRoadviewStreams()
-        if (alive) setStreams(Array.isArray(list) ? list : [])
-      } catch {
-        if (alive) setStreams([])
-      } finally {
-        if (alive) setLoading(false)
-      }
-    })()
-    return () => {
-      alive = false
-    }
-  }, [])
+const subscriptions = [
+  { initials: 'TC', name: 'Tech Channel' },
+  { initials: 'MC', name: 'Music Creator' },
+  { initials: 'GV', name: 'Gaming Vlog' },
+  { initials: 'DE', name: 'Dev Education' },
+]
+
+const comments = [
+  {
+    initials: 'JD',
+    author: '@johndeveloper',
+    time: '2 days ago',
+    text:
+      "This is absolutely incredible! The gradient design is so clean and the concept behind BlackRoad is inspiring. Can't wait to see where this goes! 🚀",
+    likes: '2.4K',
+  },
+  {
+    initials: 'SK',
+    author: '@sarahkodes',
+    time: '1 day ago',
+    text:
+      'The philosophy behind "the road isn\'t made, it\'s remembered" really resonates with me. As a developer, I feel like we\'re always building on top of what came before.',
+    likes: '1.8K',
+  },
+  {
+    initials: 'MR',
+    author: '@mikereacts',
+    time: '18 hours ago',
+    text: 'That color scheme though! 😍 Yellow to orange to pink to purple to blue... *chef\'s kiss*',
+    likes: '942',
+  },
+  {
+    initials: 'AL',
+    author: '@alexlearns',
+    time: '12 hours ago',
+    text:
+      'Just signed up for early access! This is exactly what the developer community needs. A platform built BY developers FOR developers.',
+    likes: '756',
+  },
+]
+
+const recommendedVideos = [
+  {
+    title: 'Getting Started with BlackRoad: Complete Tutorial',
+    channel: 'BlackRoad Inc',
+    stats: '890K views • 3 days ago',
+    duration: '12:45',
+  },
+  {
+    title: "Top 10 Features You Didn't Know About",
+    channel: 'Tech Review Hub',
+    stats: '1.2M views • 1 week ago',
+    duration: '8:32',
+  },
+  {
+    title: 'Building Your First Project on BlackRoad',
+    channel: 'Code Masters',
+    stats: '654K views • 5 days ago',
+    duration: '15:20',
+  },
+  {
+    title: 'The Future of Collaborative Development',
+    channel: 'Dev Talks',
+    stats: '2.1M views • 2 weeks ago',
+    duration: '20:15',
+  },
+  {
+    title: 'BlackRoad vs Traditional IDEs: Which is Better?',
+    channel: 'Developer Daily',
+    stats: '445K views • 4 days ago',
+    duration: '10:05',
+  },
+  {
+    title: 'Advanced Tips and Tricks for Power Users',
+    channel: 'BlackRoad Inc',
+    stats: '728K views • 1 week ago',
+    duration: '25:42',
+  },
+]
+
+export default function RoadView(){
+  const [commentText, setCommentText] = useState('')
+  const [showCommentActions, setShowCommentActions] = useState(false)
+  const [subscribed, setSubscribed] = useState(false)
+
+  const handleCommentFocus = () => {
+    setShowCommentActions(true)
+  }
+
+  const handleCancelComment = () => {
+    setCommentText('')
+    setShowCommentActions(false)
+  }
+
+  const toggleSubscribe = () => {
+    setSubscribed((prev) => !prev)
+  }
 
   return (
-    <section className="col-span-8">
-      <h1 className="text-xl font-semibold mb-4">RoadView</h1>
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        {loading && (
-          <div className="col-span-full card flex items-center justify-center h-40 text-slate-500">
-            Loading streams…
+    <div className="roadview-page">
+      <header className="header">
+        <div className="header-left">
+          <div className="menu-icon">☰</div>
+          <div className="logo">
+            <div className="logo-icon">K3</div>
+            <div className="logo-text">BlackTube</div>
           </div>
-        )}
-        {!loading && streams.length === 0 && (
-          <div className="col-span-full card flex items-center justify-center h-40 text-slate-500">
-            No active streams yet.
+        </div>
+
+        <div className="header-center">
+          <div className="search-bar">
+            <input
+              type="text"
+              className="search-input"
+              placeholder="Search"
+              aria-label="Search"
+            />
+            <button type="button" className="search-button" aria-label="Submit search">
+              🔍
+            </button>
           </div>
-        )}
-        {streams.map((stream) => (
-          <div key={stream.id || stream.name} className="card p-4 h-40 flex flex-col justify-between">
-            <div>
-              <div className="text-lg font-semibold">{stream.name || stream.id}</div>
-              <div className="text-sm text-slate-400 mt-1">
-                {stream.status || stream.description || 'Coming soon'}
+        </div>
+
+        <div className="header-right">
+          <button type="button" className="icon-button" aria-label="Create">
+            📹
+          </button>
+          <button type="button" className="icon-button" aria-label="Notifications">
+            🔔
+          </button>
+          <div className="user-avatar">U</div>
+        </div>
+      </header>
+
+      <div className="main-container">
+        <aside className="sidebar">
+          <div className="sidebar-section">
+            {primaryNav.map((item) => (
+              <div
+                key={item.label}
+                className={`sidebar-item${item.active ? ' active' : ''}`}
+              >
+                <span className="sidebar-icon">{item.icon}</span>
+                <span>{item.label}</span>
+              </div>
+            ))}
+          </div>
+
+          <div className="sidebar-section">
+            {libraryNav.map((item) => (
+              <div key={item.label} className="sidebar-item">
+                <span className="sidebar-icon">{item.icon}</span>
+                <span>{item.label}</span>
+              </div>
+            ))}
+          </div>
+
+          <div className="sidebar-section">
+            <div className="sidebar-title">SUBSCRIPTIONS</div>
+            {subscriptions.map((subscription) => (
+              <div key={subscription.name} className="subscription-item">
+                <div className="subscription-avatar">{subscription.initials}</div>
+                <span>{subscription.name}</span>
+              </div>
+            ))}
+          </div>
+        </aside>
+
+        <main className="content">
+          <div className="video-player">
+            <div className="player-wrapper">
+              <div className="player">
+                <div className="play-button" role="button" aria-label="Play video">
+                  <div className="play-icon">▶</div>
+                </div>
               </div>
             </div>
-            {stream.lastUpdate && (
-              <div className="text-xs text-slate-500">Updated {new Date(stream.lastUpdate).toLocaleString()}</div>
-            )}
+
+            <div className="video-info">
+              <h1 className="video-title">Building the Future: BlackRoad Development Journey</h1>
+
+              <div className="video-meta">
+                <div className="video-stats">
+                  <span>1.2M views</span>
+                  <span aria-hidden="true">•</span>
+                  <span>2 days ago</span>
+                </div>
+
+                <div className="video-actions">
+                  <button type="button" className="action-button liked">
+                    <span role="img" aria-label="Like">
+                      👍
+                    </span>
+                    <span>124K</span>
+                  </button>
+                  <button type="button" className="action-button" aria-label="Dislike">
+                    <span role="img" aria-label="Dislike">
+                      👎
+                    </span>
+                  </button>
+                  <button type="button" className="action-button">
+                    <span role="img" aria-label="Share">
+                      ↗️
+                    </span>
+                    <span>Share</span>
+                  </button>
+                  <button type="button" className="action-button">
+                    <span role="img" aria-label="Save">
+                      💾
+                    </span>
+                    <span>Save</span>
+                  </button>
+                </div>
+              </div>
+
+              <div className="channel-info">
+                <div className="channel-details">
+                  <div className="channel-avatar">BR</div>
+                  <div className="channel-text">
+                    <h3>BlackRoad Inc</h3>
+                    <p>2.5M subscribers</p>
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  className={`subscribe-button${subscribed ? ' subscribed' : ''}`}
+                  onClick={toggleSubscribe}
+                >
+                  {subscribed ? 'Subscribed' : 'Subscribe'}
+                </button>
+              </div>
+
+              <div className="video-description">
+                <p>The road isn&apos;t made. It&apos;s remembered. 🛣️✨</p>
+                <p>
+                  We&apos;ve seen the future—and it looks a lot like where we started. Welcome to
+                  BlackRoad. Built for the ones who never stopped imagining.
+                </p>
+                <p>
+                  In this video, we take you through our development journey, the challenges we
+                  faced, and how we&apos;re building a platform that empowers creators and developers
+                  worldwide.
+                </p>
+                <p>
+                  🔥 Join our community: <a className="link" href="https://blackroad.io">https://blackroad.io</a>
+                  <br />💬 Discord: <a className="link" href="https://discord.gg/blackroad">https://discord.gg/blackroad</a>
+                  <br />🐦 Twitter: <a className="link" href="https://twitter.com/blackroadinc">@blackroadinc</a>
+                </p>
+              </div>
+
+              <div className="comments-section">
+                <div className="comments-header">
+                  <span>Comments</span>
+                  <span className="comment-count">8,432</span>
+                </div>
+
+                <div className="comment-input-wrapper">
+                  <div className="comment-avatar">U</div>
+                  <div className="comment-input-box">
+                    <input
+                      type="text"
+                      className="comment-input"
+                      placeholder="Add a comment..."
+                      value={commentText}
+                      onChange={(event) => setCommentText(event.target.value)}
+                      onFocus={handleCommentFocus}
+                    />
+                    <div className={`comment-actions${showCommentActions ? '' : ' hidden'}`}>
+                      <button type="button" className="comment-button cancel" onClick={handleCancelComment}>
+                        Cancel
+                      </button>
+                      <button type="button" className="comment-button post" disabled={!commentText.trim()}>
+                        Comment
+                      </button>
+                    </div>
+                  </div>
+                </div>
+
+                {comments.map((comment) => (
+                  <div key={comment.author} className="comment">
+                    <div className="comment-avatar">{comment.initials}</div>
+                    <div className="comment-content">
+                      <div className="comment-header">
+                        <span className="comment-author">{comment.author}</span>
+                        <span className="comment-time">{comment.time}</span>
+                      </div>
+                      <div className="comment-text">{comment.text}</div>
+                      <div className="comment-actions-bar">
+                        <div className="comment-action" role="button" tabIndex={0}>
+                          <span role="img" aria-label="Like comment">
+                            👍
+                          </span>
+                          <span>{comment.likes}</span>
+                        </div>
+                        <div className="comment-action" role="button" tabIndex={0}>
+                          <span role="img" aria-label="Dislike comment">
+                            👎
+                          </span>
+                        </div>
+                        <div className="comment-action" role="button" tabIndex={0}>
+                          <span>Reply</span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
           </div>
-        ))}
+
+          <div className="recommendations">
+            {recommendedVideos.map((video) => (
+              <div key={video.title} className="video-card">
+                <div className="video-thumbnail">
+                  <div className="video-duration">{video.duration}</div>
+                </div>
+                <div className="video-card-info">
+                  <div className="video-card-title">{video.title}</div>
+                  <div className="video-card-channel">{video.channel}</div>
+                  <div className="video-card-stats">{video.stats}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </main>
       </div>
-      {agents.length > 0 && (
-        <div className="flex items-center gap-2 mt-6">
-          {agents.map((agent, index) => (
-            <div
-              key={agent.id || agent.key || index}
-              title={agent.name || agent.username || 'agent'}
-              className="w-3 h-3 rounded-full"
-              style={{ backgroundColor: colors[index % colors.length] }}
-            />
-          ))}
-        </div>
-      )}
-    </section>
-export default function RoadView({ agents, stream, setStream, system, wallet, contradictions, notes, setNotes }){
-  const [streams, setStreams] = useState([])
-  useEffect(()=>{ (async()=>{ try{ const s = await fetchRoadviewStreams(); setStreams(s) } catch{} })() }, [])
-  return (
-    <>
-      <section className="col-span-8">
-        <h1 className="text-xl font-semibold mb-4">RoadView</h1>
-        <div className="grid grid-cols-2 gap-4">
-          {streams.map(s => (
-            <div key={s.id} className="card flex items-center justify-center h-40 text-slate-400">Coming Soon</div>
-          ))}
-        </div>
-        <div className="flex items-center gap-2 mt-4">
-          {agents.map((a,i)=>(
-            <div key={a.id||i} title={a.name||a.username} className="w-3 h-3 rounded-full" style={{ backgroundColor: colors[i%colors.length] }}></div>
-          ))}
-        </div>
-      </section>
-      <section className="col-span-4 flex flex-col gap-4">
-        <AgentStack stream={stream} setStream={setStream} system={system} wallet={wallet} contradictions={contradictions} notes={notes} setNotes={setNotes} />
-      </section>
-    </>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary
- replace the RoadView page with a cinematic BlackTube-inspired experience featuring navigation, player, comments, and recommendations
- add a dedicated stylesheet that scopes the gradients, typography, and responsive layout to the RoadView page
- wire lightweight interactivity for the subscribe toggle and comment composer actions

## Testing
- npm install *(fails: package.json contains duplicate keys and cannot be parsed)*

------
https://chatgpt.com/codex/tasks/task_e_68fe93d60e1483299ddf02e105e38686