### PR TITLE
Add Nexus console experience page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -297,6 +297,7 @@ export default function App(){
     { key: 'manifesto', to: '/manifesto', text: 'Manifesto', icon: <BookOpen size={18} /> },
     { key: 'git', to: '/git', text: 'Git', icon: <GitCommit size={18} /> },
     { key: 'subscribe', href: '/subscribe', text: 'Subscribe', icon: <Rocket size={18} /> },
+    { key: 'nexus', href: '/nexus', text: 'Nexus Console', icon: <LayoutGrid size={18} /> },
     { key: 'novelty', to: '/novelty', text: 'Novelty Dashboard', icon: <Sparkles size={18} /> },
   ]
   if (isSubscribe) {

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -3,12 +3,14 @@ import { createRoot } from 'react-dom/client'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import App from './App.jsx'
 import Novelty from './pages/Novelty.jsx'
+import Nexus from './pages/Nexus.jsx'
 import './index.css'
 
 createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <BrowserRouter>
       <Routes>
+        <Route path="/nexus" element={<Nexus />} />
         <Route path="/novelty" element={<Novelty />} />
         <Route path="*" element={<App />} />
       </Routes>

--- a/frontend/src/pages/Nexus.css
+++ b/frontend/src/pages/Nexus.css
@@ -1,0 +1,705 @@
+.nexus-page {
+  --nexus-bg: #0a0a0f;
+  --nexus-bg-secondary: #13131a;
+  --nexus-bg-tertiary: #1a1a24;
+  --nexus-bg-elevated: #202030;
+  --nexus-border: rgba(255, 255, 255, 0.08);
+  --nexus-text: #ffffff;
+  --nexus-text-secondary: rgba(255, 255, 255, 0.7);
+  --nexus-text-tertiary: rgba(255, 255, 255, 0.5);
+  --nexus-gradient: linear-gradient(
+    135deg,
+    #fdba2d 0%,
+    #ff6b35 20%,
+    #ff4fd8 45%,
+    #c753ff 65%,
+    #6366f1 85%,
+    #3b82f6 100%
+  );
+  --nexus-accent-yellow: #fdba2d;
+  --nexus-accent-orange: #ff6b35;
+  --nexus-accent-pink: #ff4fd8;
+  --nexus-accent-purple: #c753ff;
+  --nexus-accent-indigo: #6366f1;
+  --nexus-accent-blue: #3b82f6;
+  --nexus-success: #22c55e;
+  --nexus-warning: #f59e0b;
+  --nexus-error: #ef4444;
+
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Inter',
+    sans-serif;
+  background: var(--nexus-bg);
+  color: var(--nexus-text);
+  min-height: 100vh;
+  height: 100vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.nexus-page * {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+.nexus-page .header {
+  height: 64px;
+  background: var(--nexus-bg-secondary);
+  border-bottom: 1px solid var(--nexus-border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 24px;
+  position: relative;
+  z-index: 1000;
+}
+
+.nexus-page .logo {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.nexus-page .logo-icon {
+  width: 40px;
+  height: 40px;
+  background: var(--nexus-gradient);
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 900;
+  font-size: 20px;
+  color: #000;
+  box-shadow: 0 0 20px rgba(255, 79, 216, 0.3);
+}
+
+.nexus-page .logo-text {
+  font-size: 1.3rem;
+  font-weight: 700;
+  background: var(--nexus-gradient);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.nexus-page .header-center {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.nexus-page .model-selector {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 16px;
+  background: var(--nexus-bg-tertiary);
+  border: 1px solid var(--nexus-border);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.nexus-page .model-selector:hover {
+  border-color: var(--nexus-accent-pink);
+  background: var(--nexus-bg-elevated);
+}
+
+.nexus-page .model-status {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--nexus-success);
+  box-shadow: 0 0 8px var(--nexus-success);
+}
+
+.nexus-page .header-right {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.nexus-page .header-button {
+  padding: 8px 16px;
+  background: var(--nexus-bg-tertiary);
+  border: 1px solid var(--nexus-border);
+  border-radius: 8px;
+  color: var(--nexus-text-secondary);
+  cursor: pointer;
+  transition: all 0.2s;
+  font-size: 0.9rem;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.nexus-page .header-button:hover {
+  border-color: var(--nexus-accent-blue);
+  color: var(--nexus-text);
+}
+
+.nexus-page .header-button.active {
+  background: rgba(255, 79, 216, 0.15);
+  border-color: var(--nexus-accent-pink);
+  color: var(--nexus-text);
+}
+
+.nexus-page .main-container {
+  display: flex;
+  height: calc(100vh - 64px);
+  overflow: hidden;
+}
+
+.nexus-page .sidebar {
+  width: 280px;
+  background: var(--nexus-bg-secondary);
+  border-right: 1px solid var(--nexus-border);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.nexus-page .sidebar-tabs {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  border-bottom: 1px solid var(--nexus-border);
+  background: var(--nexus-bg-tertiary);
+}
+
+.nexus-page .sidebar-tab {
+  padding: 12px;
+  text-align: center;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  transition: all 0.2s;
+  font-size: 0.85rem;
+  color: var(--nexus-text-secondary);
+  background: transparent;
+  border: none;
+  font-family: inherit;
+}
+
+.nexus-page .sidebar-tab:hover {
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--nexus-text);
+}
+
+.nexus-page .sidebar-tab.active {
+  border-bottom-color: var(--nexus-accent-pink);
+  color: var(--nexus-text);
+}
+
+.nexus-page .sidebar-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+}
+
+.nexus-page .integration-section {
+  margin-bottom: 24px;
+}
+
+.nexus-page .section-title {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--nexus-text-tertiary);
+  margin-bottom: 12px;
+  font-weight: 600;
+}
+
+.nexus-page .integration-card {
+  background: var(--nexus-bg-tertiary);
+  border: 1px solid var(--nexus-border);
+  border-radius: 8px;
+  padding: 12px;
+  margin-bottom: 8px;
+  cursor: pointer;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.nexus-page .integration-card:hover {
+  border-color: var(--nexus-accent-pink);
+  background: var(--nexus-bg-elevated);
+  transform: translateX(4px);
+}
+
+.nexus-page .integration-card.connected {
+  border-color: var(--nexus-success);
+}
+
+.nexus-page .integration-icon {
+  width: 36px;
+  height: 36px;
+  background: var(--nexus-gradient);
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+  flex-shrink: 0;
+}
+
+.nexus-page .integration-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.nexus-page .integration-name {
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin-bottom: 2px;
+}
+
+.nexus-page .integration-status {
+  font-size: 0.75rem;
+  color: var(--nexus-text-tertiary);
+}
+
+.nexus-page .integration-status.connected {
+  color: var(--nexus-success);
+}
+
+.nexus-page .connection-indicator {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--nexus-text-tertiary);
+  flex-shrink: 0;
+}
+
+.nexus-page .connection-indicator.connected {
+  background: var(--nexus-success);
+  box-shadow: 0 0 8px var(--nexus-success);
+}
+
+.nexus-page .sidebar-placeholder {
+  color: var(--nexus-text-tertiary);
+  font-size: 0.85rem;
+  line-height: 1.6;
+}
+
+.nexus-page .content-area {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.nexus-page .chat-container {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.nexus-page .messages-area {
+  flex: 1;
+  overflow-y: auto;
+  padding: 24px;
+}
+
+.nexus-page .message {
+  margin-bottom: 24px;
+  display: flex;
+  gap: 12px;
+}
+
+.nexus-page .message-avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--nexus-gradient);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  font-weight: 700;
+  color: #000;
+  flex-shrink: 0;
+}
+
+.nexus-page .message-avatar.user {
+  background: var(--nexus-bg-tertiary);
+  color: var(--nexus-text);
+  border: 1px solid var(--nexus-border);
+}
+
+.nexus-page .message-content {
+  flex: 1;
+}
+
+.nexus-page .message-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.nexus-page .message-author {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.nexus-page .message-time {
+  font-size: 0.75rem;
+  color: var(--nexus-text-tertiary);
+}
+
+.nexus-page .message-text {
+  line-height: 1.6;
+  color: var(--nexus-text-secondary);
+  font-size: 0.95rem;
+}
+
+.nexus-page .message-list {
+  margin-top: 8px;
+  padding-left: 20px;
+  line-height: 2;
+}
+
+.nexus-page .code-block {
+  background: var(--nexus-bg-tertiary);
+  border: 1px solid var(--nexus-border);
+  border-radius: 8px;
+  margin: 12px 0;
+  overflow: hidden;
+}
+
+.nexus-page .code-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--nexus-border);
+  background: var(--nexus-bg-secondary);
+}
+
+.nexus-page .code-language {
+  font-size: 0.8rem;
+  color: var(--nexus-text-secondary);
+  font-family: monospace;
+}
+
+.nexus-page .code-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.nexus-page .code-action-btn {
+  padding: 4px 12px;
+  background: transparent;
+  border: 1px solid var(--nexus-border);
+  border-radius: 4px;
+  color: var(--nexus-text-secondary);
+  cursor: pointer;
+  font-size: 0.75rem;
+  transition: all 0.2s;
+}
+
+.nexus-page .code-action-btn:hover {
+  background: var(--nexus-bg-elevated);
+  border-color: var(--nexus-accent-pink);
+  color: var(--nexus-text);
+}
+
+.nexus-page .code-content {
+  padding: 16px;
+  font-family: 'Monaco', 'Menlo', monospace;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  overflow-x: auto;
+  white-space: pre;
+}
+
+.nexus-page .execution-result {
+  background: var(--nexus-bg-secondary);
+  border: 1px solid var(--nexus-border);
+  border-left: 3px solid var(--nexus-success);
+  border-radius: 8px;
+  padding: 12px 16px;
+  margin: 12px 0;
+  font-family: monospace;
+  font-size: 0.85rem;
+  line-height: 1.6;
+}
+
+.nexus-page .execution-result.error {
+  border-left-color: var(--nexus-error);
+}
+
+.nexus-page .input-area {
+  border-top: 1px solid var(--nexus-border);
+  background: var(--nexus-bg-secondary);
+  padding: 20px 24px;
+}
+
+.nexus-page .input-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.nexus-page .input-toolbar {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.nexus-page .tool-button {
+  padding: 6px 12px;
+  background: var(--nexus-bg-tertiary);
+  border: 1px solid var(--nexus-border);
+  border-radius: 6px;
+  color: var(--nexus-text-secondary);
+  cursor: pointer;
+  font-size: 0.8rem;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.nexus-page .tool-button:hover {
+  border-color: var(--nexus-accent-blue);
+  color: var(--nexus-text);
+}
+
+.nexus-page .tool-button.active {
+  background: rgba(255, 79, 216, 0.15);
+  border-color: var(--nexus-accent-pink);
+  color: var(--nexus-text);
+}
+
+.nexus-page .input-box {
+  display: flex;
+  gap: 12px;
+  align-items: flex-end;
+}
+
+.nexus-page .input-field {
+  flex: 1;
+  min-height: 60px;
+  max-height: 200px;
+  padding: 12px 16px;
+  background: var(--nexus-bg-tertiary);
+  border: 1px solid var(--nexus-border);
+  border-radius: 12px;
+  color: var(--nexus-text);
+  font-size: 0.95rem;
+  line-height: 1.5;
+  resize: vertical;
+  outline: none;
+  transition: border-color 0.2s;
+  font-family: inherit;
+}
+
+.nexus-page .input-field:focus {
+  border-color: var(--nexus-accent-pink);
+}
+
+.nexus-page .send-button {
+  padding: 12px 24px;
+  background: var(--nexus-gradient);
+  border: none;
+  border-radius: 12px;
+  color: #000;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-size: 0.95rem;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.nexus-page .send-button:hover {
+  transform: scale(1.02);
+  box-shadow: 0 0 24px rgba(255, 79, 216, 0.5);
+}
+
+.nexus-page .send-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.nexus-page .right-panel {
+  width: 360px;
+  background: var(--nexus-bg-secondary);
+  border-left: 1px solid var(--nexus-border);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.nexus-page .panel-tabs {
+  display: flex;
+  border-bottom: 1px solid var(--nexus-border);
+}
+
+.nexus-page .panel-tab {
+  flex: 1;
+  padding: 12px;
+  text-align: center;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  transition: all 0.2s;
+  font-size: 0.85rem;
+  color: var(--nexus-text-secondary);
+  background: transparent;
+  border: none;
+  font-family: inherit;
+}
+
+.nexus-page .panel-tab:hover {
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--nexus-text);
+}
+
+.nexus-page .panel-tab.active {
+  border-bottom-color: var(--nexus-accent-pink);
+  color: var(--nexus-text);
+}
+
+.nexus-page .panel-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+}
+
+.nexus-page .activity-item,
+.nexus-page .context-item,
+.nexus-page .stat-card {
+  background: var(--nexus-bg-tertiary);
+  border: 1px solid var(--nexus-border);
+  border-radius: 8px;
+  padding: 12px;
+  margin-bottom: 12px;
+}
+
+.nexus-page .activity-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.nexus-page .activity-icon {
+  width: 28px;
+  height: 28px;
+  background: var(--nexus-gradient);
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+}
+
+.nexus-page .activity-title {
+  font-size: 0.9rem;
+  font-weight: 600;
+  flex: 1;
+}
+
+.nexus-page .activity-time {
+  font-size: 0.7rem;
+  color: var(--nexus-text-tertiary);
+}
+
+.nexus-page .activity-description {
+  font-size: 0.85rem;
+  color: var(--nexus-text-secondary);
+  line-height: 1.5;
+}
+
+.nexus-page .context-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--nexus-text-tertiary);
+  margin-bottom: 8px;
+}
+
+.nexus-page .context-value {
+  font-size: 0.9rem;
+  color: var(--nexus-text-secondary);
+  line-height: 1.5;
+}
+
+.nexus-page .stat-label {
+  font-size: 0.75rem;
+  color: var(--nexus-text-tertiary);
+  margin-bottom: 4px;
+}
+
+.nexus-page .stat-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  background: var(--nexus-gradient);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.nexus-page .progress-bar {
+  height: 4px;
+  background: var(--nexus-bg-secondary);
+  border-radius: 2px;
+  margin-top: 8px;
+  overflow: hidden;
+}
+
+.nexus-page .progress-fill {
+  height: 100%;
+  background: var(--nexus-gradient);
+  transition: width 0.3s;
+}
+
+.nexus-page ::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+.nexus-page ::-webkit-scrollbar-track {
+  background: var(--nexus-bg);
+}
+
+.nexus-page ::-webkit-scrollbar-thumb {
+  background: var(--nexus-bg-tertiary);
+  border-radius: 4px;
+}
+
+.nexus-page ::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 79, 216, 0.3);
+}
+
+.nexus-page .loading {
+  animation: nexus-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes nexus-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
+.nexus-page .sidebar-placeholder strong {
+  color: var(--nexus-text-secondary);
+}
+
+.nexus-page .panel-placeholder {
+  color: var(--nexus-text-tertiary);
+  font-size: 0.85rem;
+  line-height: 1.6;
+}

--- a/frontend/src/pages/Nexus.jsx
+++ b/frontend/src/pages/Nexus.jsx
@@ -1,0 +1,527 @@
+import React, { useMemo, useState } from 'react'
+import './Nexus.css'
+
+const sidebarTabs = ['Integrations', 'Models', 'Projects']
+const panelTabs = ['Activity', 'Context', 'Stats']
+const toolButtons = [
+  { label: 'Python', icon: '🐍' },
+  { label: 'JavaScript', icon: '📜' },
+  { label: 'Shell', icon: '🔧' },
+  { label: 'Attach Files', icon: '📁' },
+  { label: 'Web Scrape', icon: '🌐' },
+  { label: 'Visualize', icon: '📊' },
+  { label: 'Deploy', icon: '🚀' },
+]
+
+const integrationSections = [
+  {
+    title: 'Cloud & Infrastructure',
+    items: [
+      {
+        icon: '🌊',
+        name: 'DigitalOcean',
+        status: 'Connected • 3 droplets',
+        connected: true,
+      },
+      {
+        icon: '🐳',
+        name: 'Docker',
+        status: 'Connected • 7 containers',
+        connected: true,
+      },
+      {
+        icon: '🥧',
+        name: 'Raspberry Pi',
+        status: '3 devices online',
+        connected: true,
+      },
+      {
+        icon: '⚡',
+        name: 'Termius',
+        status: 'Click to connect',
+        connected: false,
+      },
+    ],
+  },
+  {
+    title: 'AI & ML Models',
+    items: [
+      {
+        icon: '🤗',
+        name: 'HuggingFace',
+        status: '12 models loaded',
+        connected: true,
+      },
+      {
+        icon: '🟢',
+        name: 'OpenAI',
+        status: 'GPT-4 ready',
+        connected: true,
+      },
+      {
+        icon: '🎭',
+        name: 'Claude API',
+        status: 'Sonnet 4.5 active',
+        connected: true,
+      },
+    ],
+  },
+  {
+    title: 'Development Tools',
+    items: [
+      {
+        icon: '📁',
+        name: 'GitHub',
+        status: '42 repositories',
+        connected: true,
+      },
+      {
+        icon: '💻',
+        name: 'VS Code',
+        status: 'Remote enabled',
+        connected: true,
+      },
+      {
+        icon: '✅',
+        name: 'Asana',
+        status: '8 active tasks',
+        connected: true,
+      },
+    ],
+  },
+  {
+    title: 'Engines & Tools',
+    items: [
+      {
+        icon: '🎮',
+        name: 'Unity',
+        status: 'Click to connect',
+        connected: false,
+      },
+      {
+        icon: '🎯',
+        name: 'Unreal Engine',
+        status: 'Click to connect',
+        connected: false,
+      },
+      {
+        icon: '📊',
+        name: 'Desmos',
+        status: 'Math engine ready',
+        connected: true,
+      },
+    ],
+  },
+]
+
+const activityFeed = [
+  {
+    icon: '✅',
+    title: 'Task Created',
+    time: '1m ago',
+    description: 'Created 3 Asana tasks for stale repositories',
+  },
+  {
+    icon: '▶️',
+    title: 'Code Executed',
+    time: '1m ago',
+    description: 'Ran stale_repos_tracker.py successfully',
+  },
+  {
+    icon: '📁',
+    title: 'Saved to GitHub',
+    time: '2m ago',
+    description: 'Committed scripts/stale-repos-tracker.py',
+  },
+  {
+    icon: '🔗',
+    title: 'API Connected',
+    time: '5m ago',
+    description: 'Connected to GitHub & Asana APIs',
+  },
+  {
+    icon: '🐳',
+    title: 'Container Started',
+    time: '15m ago',
+    description: 'Started postgres:14 on droplet-prod-01',
+  },
+  {
+    icon: '🥧',
+    title: 'Pi Status Check',
+    time: '30m ago',
+    description: 'All 3 Raspberry Pi devices online and healthy',
+  },
+]
+
+const contextItems = [
+  { label: 'Active Model', value: 'Llama 3.2 90B Instruct (HuggingFace)' },
+  { label: 'Working Directory', value: '/home/user/blackroad-projects' },
+  { label: 'Current Branch', value: 'main • blackroad/nexus-core' },
+  { label: 'Connected Services', value: '12 integrations active' },
+]
+
+const statCards = [
+  { label: 'Code Executions Today', value: '47', progress: 75 },
+  { label: 'API Calls', value: '1,284', progress: 45 },
+  { label: 'Tokens Used', value: '89K', progress: 30 },
+]
+
+const pythonCode = `import requests
+from datetime import datetime, timedelta
+import os
+
+# Configuration
+GITHUB_TOKEN = os.environ.get('GITHUB_TOKEN')
+ASANA_TOKEN = os.environ.get('ASANA_TOKEN')
+ASANA_WORKSPACE = 'your_workspace_id'
+
+def get_stale_repos():
+    """Fetch GitHub repos not updated in 30+ days"""
+    headers = {'Authorization': f'token {GITHUB_TOKEN}'}
+    response = requests.get(
+        'https://api.github.com/user/repos',
+        headers=headers
+    )
+    repos = response.json()
+
+    stale_repos = []
+    cutoff_date = datetime.now() - timedelta(days=30)
+
+    for repo in repos:
+        updated = datetime.strptime(
+            repo['updated_at'],
+            '%Y-%m-%dT%H:%M:%SZ'
+        )
+        if updated < cutoff_date:
+            stale_repos.append(repo)
+
+    return stale_repos
+
+def create_asana_task(repo):
+    """Create Asana task for stale repo"""
+    headers = {
+        'Authorization': f'Bearer {ASANA_TOKEN}',
+        'Content-Type': 'application/json'
+    }
+
+    task_data = {
+        'data': {
+            'name': f'Update stale repo: {repo["name"]}',
+            'notes': f'Repo URL: {repo["html_url"]}\\n'
+                     f'Last updated: {repo["updated_at"]}\\n'
+                     f'Description: {repo["description"]}',
+            'workspace': ASANA_WORKSPACE
+        }
+    }
+
+    response = requests.post(
+        'https://app.asana.com/api/1.0/tasks',
+        headers=headers,
+        json=task_data
+    )
+    return response.json()
+
+# Main execution
+if __name__ == '__main__':
+    stale_repos = get_stale_repos()
+    print(f'Found {len(stale_repos)} stale repositories')
+
+    for repo in stale_repos:
+        result = create_asana_task(repo)
+        print(f'Created task for: {repo["name"]}')
+`
+
+const executionResult = `$ python stale_repos_tracker.py
+Found 3 stale repositories
+Created task for: old-project-2023
+Created task for: archived-experiments
+Created task for: legacy-dashboard
+
+✓ Successfully created 3 Asana tasks
+⏱ Execution time: 1.2s`
+
+export default function Nexus(){
+  const [activeSidebarTab, setActiveSidebarTab] = useState(sidebarTabs[0])
+  const [activePanelTab, setActivePanelTab] = useState(panelTabs[0])
+  const [activeTools, setActiveTools] = useState([toolButtons[0].label])
+  const [message, setMessage] = useState('')
+
+  const sidebarContent = useMemo(() => {
+    if(activeSidebarTab !== 'Integrations'){
+      return (
+        <div className="sidebar-placeholder">
+          <strong>{activeSidebarTab}</strong> workspace views are coming soon. You’ll be able to curate model catalogs and cross-project resource maps here.
+        </div>
+      )
+    }
+
+    return integrationSections.map(section => (
+      <div className="integration-section" key={section.title}>
+        <div className="section-title">{section.title}</div>
+        {section.items.map(item => (
+          <div
+            key={item.name}
+            className={`integration-card${item.connected ? ' connected' : ''}`}
+            role="button"
+            tabIndex={0}
+          >
+            <div className="integration-icon" aria-hidden>{item.icon}</div>
+            <div className="integration-info">
+              <div className="integration-name">{item.name}</div>
+              <div className={`integration-status${item.connected ? ' connected' : ''}`}>
+                {item.status}
+              </div>
+            </div>
+            <div className={`connection-indicator${item.connected ? ' connected' : ''}`} aria-hidden />
+          </div>
+        ))}
+      </div>
+    ))
+  }, [activeSidebarTab])
+
+  const panelContent = useMemo(() => {
+    if(activePanelTab === 'Context'){
+      return contextItems.map(item => (
+        <div className="context-item" key={item.label}>
+          <div className="context-label">{item.label}</div>
+          <div className="context-value">{item.value}</div>
+        </div>
+      ))
+    }
+
+    if(activePanelTab === 'Stats'){
+      return statCards.map(card => (
+        <div className="stat-card" key={card.label}>
+          <div className="stat-label">{card.label}</div>
+          <div className="stat-value">{card.value}</div>
+          <div className="progress-bar">
+            <div className="progress-fill" style={{ width: `${card.progress}%` }} />
+          </div>
+        </div>
+      ))
+    }
+
+    return activityFeed.map(item => (
+      <div className="activity-item" key={`${item.title}-${item.time}`}>
+        <div className="activity-header">
+          <div className="activity-icon" aria-hidden>{item.icon}</div>
+          <div className="activity-title">{item.title}</div>
+          <div className="activity-time">{item.time}</div>
+        </div>
+        <div className="activity-description">{item.description}</div>
+      </div>
+    ))
+  }, [activePanelTab])
+
+  const toggleTool = (label) => {
+    setActiveTools(prev => (
+      prev.includes(label)
+        ? prev.filter(item => item !== label)
+        : [...prev, label]
+    ))
+  }
+
+  const handleCopy = () => {
+    if(typeof navigator !== 'undefined' && navigator.clipboard?.writeText){
+      navigator.clipboard.writeText(pythonCode)
+    }
+  }
+
+  const handleSend = () => {
+    const trimmed = message.trim()
+    if(!trimmed){
+      return
+    }
+    if(typeof window !== 'undefined'){
+      window.alert('In a full implementation this would send your message to the AI backend!')
+    }
+    setMessage('')
+  }
+
+  return (
+    <div className="nexus-page">
+      <header className="header">
+        <div className="logo">
+          <div className="logo-icon">K3</div>
+          <div className="logo-text">BlackRoad Nexus</div>
+        </div>
+        <div className="header-center">
+          <button className="model-selector" type="button">
+            <div className="model-status" />
+            <span>Llama 3.2 90B (HuggingFace)</span>
+            <span aria-hidden>▼</span>
+          </button>
+        </div>
+        <div className="header-right">
+          <button className="header-button" type="button">
+            <span aria-hidden>⚡</span>
+            <span>Quick Actions</span>
+          </button>
+          <button className="header-button active" type="button">
+            <span aria-hidden>🔗</span>
+            <span>Connected: 12</span>
+          </button>
+        </div>
+      </header>
+
+      <div className="main-container">
+        <aside className="sidebar">
+          <div className="sidebar-tabs">
+            {sidebarTabs.map(tab => (
+              <button
+                key={tab}
+                type="button"
+                className={`sidebar-tab${activeSidebarTab === tab ? ' active' : ''}`}
+                onClick={() => setActiveSidebarTab(tab)}
+              >
+                {tab}
+              </button>
+            ))}
+          </div>
+          <div className="sidebar-content">
+            {sidebarContent}
+          </div>
+        </aside>
+
+        <main className="content-area">
+          <div className="chat-container">
+            <div className="messages-area">
+              <div className="message">
+                <div className="message-avatar">K3</div>
+                <div className="message-content">
+                  <div className="message-header">
+                    <span className="message-author">BlackRoad Nexus</span>
+                    <span className="message-time">Just now</span>
+                  </div>
+                  <div className="message-text">
+                    <p>
+                      Welcome to BlackRoad Nexus! I'm your AI development assistant with native code execution and seamless integration across your entire development ecosystem.
+                    </p>
+                    <p>🚀 <strong>What I can do:</strong></p>
+                    <ul className="message-list">
+                      <li>Write, run, and debug code in Python, JavaScript, C++, and more</li>
+                      <li>Deploy directly to DigitalOcean, manage Docker containers</li>
+                      <li>Create and manage GitHub repos, commit changes</li>
+                      <li>Control your Raspberry Pi devices remotely</li>
+                      <li>Generate math visualizations with Desmos</li>
+                      <li>Manage tasks in Asana, open files in VS Code</li>
+                      <li>Access multiple AI models (GPT-4, Claude, Llama, etc.)</li>
+                    </ul>
+                    <p>
+                      Try: <em>"Create a Python script that monitors my DigitalOcean droplets"</em> or <em>"Deploy a Docker container to my Raspberry Pi"</em>
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              <div className="message">
+                <div className="message-avatar user">U</div>
+                <div className="message-content">
+                  <div className="message-header">
+                    <span className="message-author">You</span>
+                    <span className="message-time">2 minutes ago</span>
+                  </div>
+                  <div className="message-text">
+                    Write a Python script that fetches my GitHub repos and creates a new Asana task for each repo that hasn't been updated in 30 days
+                  </div>
+                </div>
+              </div>
+
+              <div className="message">
+                <div className="message-avatar">K3</div>
+                <div className="message-content">
+                  <div className="message-header">
+                    <span className="message-author">BlackRoad Nexus</span>
+                    <span className="message-time">Just now</span>
+                  </div>
+                  <div className="message-text">
+                    I'll create a Python script that integrates with both GitHub and Asana APIs to accomplish this. Here's the solution:
+                  </div>
+
+                  <div className="code-block">
+                    <div className="code-header">
+                      <span className="code-language">Python</span>
+                      <div className="code-actions">
+                        <button className="code-action-btn" type="button" onClick={handleCopy}>Copy</button>
+                        <button className="code-action-btn" type="button">Run</button>
+                        <button className="code-action-btn" type="button">Save to GitHub</button>
+                      </div>
+                    </div>
+                    <pre className="code-content">
+                      <code>{pythonCode}</code>
+                    </pre>
+                  </div>
+
+                  <div className="execution-result">
+                    <code>{executionResult}</code>
+                  </div>
+
+                  <div className="message-text" style={{ marginTop: 12 }}>
+                    ✅ Script executed successfully! I've created 3 Asana tasks for your stale repositories. The script has been saved to your GitHub at <code>scripts/stale-repos-tracker.py</code>.
+                    <br />
+                    <br />
+                    Would you like me to set up a cron job to run this automatically every week?
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div className="input-area">
+              <div className="input-wrapper">
+                <div className="input-toolbar">
+                  {toolButtons.map(({ label, icon }) => (
+                    <button
+                      key={label}
+                      type="button"
+                      className={`tool-button${activeTools.includes(label) ? ' active' : ''}`}
+                      onClick={() => toggleTool(label)}
+                    >
+                      <span aria-hidden>{icon}</span>
+                      <span>{label}</span>
+                    </button>
+                  ))}
+                </div>
+
+                <div className="input-box">
+                  <textarea
+                    className="input-field"
+                    placeholder="Ask me to code, deploy, analyze, or integrate anything... I can execute code natively and connect to all your services."
+                    value={message}
+                    onChange={event => setMessage(event.target.value)}
+                  />
+                  <button
+                    className="send-button"
+                    type="button"
+                    onClick={handleSend}
+                    disabled={!message.trim()}
+                  >
+                    <span>Send</span>
+                    <span aria-hidden>⚡</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </main>
+
+        <aside className="right-panel">
+          <div className="panel-tabs">
+            {panelTabs.map(tab => (
+              <button
+                key={tab}
+                type="button"
+                className={`panel-tab${activePanelTab === tab ? ' active' : ''}`}
+                onClick={() => setActivePanelTab(tab)}
+              >
+                {tab}
+              </button>
+            ))}
+          </div>
+          <div className="panel-content">
+            {panelContent}
+          </div>
+        </aside>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add a dedicated Nexus console page that recreates the immersive co-coding view with sidebar tabs, chat feed, and tool controls
- scope Nexus-specific theming and layout styles for the new experience
- expose the experience at `/nexus` and surface it from the primary navigation for quick access

## Testing
- npm --prefix frontend ci *(fails: frontend/package.json is not valid JSON)*

------
https://chatgpt.com/codex/tasks/task_e_68fe950097c083298ff9783e4aaf9f66