### PR TITLE
Add collaboration presence bus and enforcement tooling

### DIFF
--- a/.github/workflows/collab-presence-check.yml
+++ b/.github/workflows/collab-presence-check.yml
@@ -1,0 +1,17 @@
+name: collaboration-presence-enforcement
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  presence-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Ensure collaboration discussion recorded
+        env:
+          COLLAB_DB_PATH: ${{ vars.COLLAB_DB_PATH }}
+        run: |
+          DB_PATH="${COLLAB_DB_PATH:-var/collab_bus.sqlite}"
+          python scripts/check_presence_discussion.py --pr "${{ github.event.number }}" --db "$DB_PATH"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # Top-level CODEOWNERS ensures consistent review coverage for new scaffolds.
-*       @blackboxprogramming/maintainers
+*       @blackboxprogramming/maintainers @blackboxprogramming/agents
 
 # Delegate ownership for newly scaffolded surfaces.
 /apps/blackroad-mobile/   @blackboxprogramming/mobile

--- a/COLLABORATION_STATUS.md
+++ b/COLLABORATION_STATUS.md
@@ -1,0 +1,12 @@
+# Collaboration Status
+
+Last updated: 2025-10-26 20:39:51 UTC
+
+## Online Agents
+- _No active sessions_
+
+## Recent Focus
+- _No editor telemetry in window_
+
+## Unresolved Reviews
+- _No pending approvals_

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 anthropic
 boto3
 fastapi
+python-socketio[client]
 httpx
 PyJWT[crypto]
 cryptography

--- a/scripts/check_presence_discussion.py
+++ b/scripts/check_presence_discussion.py
@@ -1,0 +1,41 @@
+"""Validate that a discussion occurred for a pull request before merge."""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from services.collab_bus.storage import CollabStore
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Ensure collaboration discussion logged in presence bus")
+    parser.add_argument("--pr", type=int, required=True, help="Pull request number under review")
+    parser.add_argument("--db", type=Path, default=Path("var/collab_bus.sqlite"))
+    parser.add_argument("--subject", type=str, help="Override discussion subject name")
+    parser.add_argument("--horizon", type=int, default=3 * 24 * 3600, help="Age window (seconds)")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if not args.db.exists():
+        print(
+            f"::error::Presence database {args.db} not found. "
+            "Sync collab_bus status before merging."
+        )
+        return 1
+    store = CollabStore(path=args.db)
+    subject = args.subject or f"pr-{args.pr}"
+    if store.has_discussion(subject, horizon_s=args.horizon):
+        print(f"discussion found for {subject}")
+        return 0
+    print(
+        f"::error::Presence bus audit log missing review discussion for {subject}. "
+        "Ensure at least one agent + human conversation is recorded."
+    )
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/services/api/modules/github_webhook.js
+++ b/services/api/modules/github_webhook.js
@@ -1,6 +1,20 @@
 // GitHub webhook -> LED & progress. Verify signature if GITHUB_WEBHOOK_SECRET set.
 // Map push/success/failure to LED patterns; optional deploy progress passthrough.
 const crypto = require('crypto');
+const COLLAB_URL = process.env.COLLAB_BUS_URL || "http://127.0.0.1:9000";
+
+async function postCollabEvent(event, payload) {
+  try {
+    await fetch(`${COLLAB_URL.replace(/\/$/, '')}/collab/events`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ event, payload })
+    });
+  } catch (err) {
+    console.warn('[collab-bus] broadcast failed', err);
+  }
+}
+
 module.exports = function attachGitHubHook({ app }) {
   if (!app) throw new Error("github_webhook: need app");
   const secret = process.env.GITHUB_WEBHOOK_SECRET || "";
@@ -40,6 +54,36 @@ module.exports = function attachGitHubHook({ app }) {
             body:JSON.stringify(payload)
           });
         }catch{}
+      }
+      const subject = body.pull_request
+        ? `pr-${body.pull_request.number}`
+        : body.issue
+        ? `issue-${body.issue.number}`
+        : body.workflow_run
+        ? `workflow-${body.workflow_run.id}`
+        : body.deployment
+        ? `deployment-${body.deployment.id}`
+        : event;
+      const collabPayload = {
+        agent: body.sender?.login || 'github-bot',
+        ts: Date.now() / 1000,
+        subject,
+        metadata: {
+          event,
+          repository: body.repository?.full_name,
+          action: body.action,
+          ref: body.ref || body.pull_request?.head?.ref,
+          status: body.workflow_run?.conclusion || body.deployment_status?.state || body.review?.state,
+          type: body.pull_request ? 'pull_request' : body.issue ? 'issue' : 'event'
+        }
+      };
+      if (event === 'pull_request_review') {
+        collabPayload.decision = body.review?.state;
+        await postCollabEvent('decision', collabPayload);
+      } else if (['push', 'pull_request', 'issues', 'issue_comment', 'pull_request_review_comment'].includes(event)) {
+        await postCollabEvent('presence', collabPayload);
+      } else if (['workflow_run', 'deployment_status'].includes(event)) {
+        await postCollabEvent('focus', collabPayload);
       }
       ok(res,{ok:true});
     });

--- a/services/collab_bus/README.md
+++ b/services/collab_bus/README.md
@@ -1,0 +1,27 @@
+# Collaboration Presence Bus
+
+This service provides a lightweight Socket.IO fabric for real-time collaboration
+signals across BlackRoad tooling. It exposes:
+
+- `/collab/socket.io` – websocket gateway for presence/focus/help/voice events
+- `/collab/status` – JSON snapshot of online agents, focus history, review queue
+- `/collab/status.md` – markdown export used to publish `COLLABORATION_STATUS.md`
+
+The service persists state in `var/collab_bus.sqlite` by default. Override the
+`COLLAB_DB_PATH` environment variable to supply a custom location or point at a
+Redis-backed filesystem mount.
+
+## Running locally
+
+```bash
+uvicorn services.collab_bus.server:app --host 0.0.0.0 --port 9000
+```
+
+## Clients
+
+- `services/collab_bus/client.py` – Python helper for agents and scripts
+- `services/collab_bus/working_copy_hook.py` – Working Copy automation entrypoint
+- `tools/collab_presence/vscode-extension` – VS Code extension for editor focus
+
+Events from GitHub webhooks automatically flow into the bus so automated agents
+appear alongside humans during reviews.

--- a/services/collab_bus/__init__.py
+++ b/services/collab_bus/__init__.py
@@ -1,0 +1,6 @@
+"""Presence bus package for real-time collaboration telemetry."""
+
+from .client import CollabBusClient
+from .storage import CollabStore
+
+__all__ = ["CollabBusClient", "CollabStore"]

--- a/services/collab_bus/client.py
+++ b/services/collab_bus/client.py
@@ -1,0 +1,92 @@
+"""Client helper for interacting with the collaboration presence bus."""
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Mapping, Optional
+
+import requests
+
+try:
+    import socketio  # type: ignore
+except Exception:  # pragma: no cover - optional runtime dependency
+    socketio = None  # type: ignore
+
+LOGGER = logging.getLogger(__name__)
+
+
+class CollabBusClient:
+    """Small helper that wraps socket.io and REST fallbacks."""
+
+    def __init__(self, base_url: str = "http://127.0.0.1:9000", agent: str = "anonymous") -> None:
+        self._base_url = base_url.rstrip("/")
+        self._agent = agent
+        self._socket: Optional[Any] = None
+        self._session = requests.Session()
+
+    def connect(self) -> None:
+        if socketio is None:
+            LOGGER.warning("socketio client missing; REST-only mode")
+            return
+        if self._socket:
+            return
+        client = socketio.Client(reconnection=True, reconnection_attempts=3)
+        try:
+            client.connect(f"{self._base_url}", transports=["websocket", "polling"], wait_timeout=2)
+            client.emit("join", {"agent": self._agent, "ts": time.time()})
+            self._socket = client
+        except Exception as exc:  # pragma: no cover - connection optional
+            LOGGER.warning("Failed to connect to collab bus via socket.io: %s", exc)
+            self._socket = None
+
+    def emit(self, event: str, payload: Mapping[str, Any]) -> None:
+        message = {"agent": self._agent, **payload}
+        if self._socket:
+            try:
+                self._socket.emit(event, message)
+                return
+            except Exception as exc:  # pragma: no cover - degrade to REST
+                LOGGER.warning("socket.io emit failed (%s); falling back to REST", exc)
+        self._post_rest(event, message)
+
+    def _post_rest(self, event: str, payload: Mapping[str, Any]) -> None:
+        try:
+            res = self._session.post(
+                f"{self._base_url}/collab/events",
+                json={"event": event, "payload": payload},
+                timeout=2,
+            )
+            res.raise_for_status()
+        except Exception as exc:  # pragma: no cover - telemetry only
+            LOGGER.warning("collab bus REST publish failed: %s", exc)
+
+    def heartbeat(self, focus: Optional[str] = None, branch: Optional[str] = None, metadata: Optional[Mapping[str, Any]] = None) -> None:
+        payload: dict[str, Any] = {"ts": time.time(), "metadata": metadata or {}}
+        if focus:
+            payload["file"] = focus
+        if branch:
+            payload["branch"] = branch
+        self.emit("presence", payload)
+
+    def focus(self, file_path: str, branch: Optional[str] = None, metadata: Optional[Mapping[str, Any]] = None) -> None:
+        payload: dict[str, Any] = {
+            "ts": time.time(),
+            "file": file_path,
+            "branch": branch,
+            "metadata": metadata or {},
+        }
+        self.emit("focus", payload)
+
+    def help_request(self, topic: str, metadata: Optional[Mapping[str, Any]] = None) -> None:
+        self.emit("help", {"ts": time.time(), "topic": topic, "metadata": metadata or {}})
+
+    def record_decision(self, subject: str, decision: str, metadata: Optional[Mapping[str, Any]] = None) -> None:
+        self.emit(
+            "decision",
+            {
+                "ts": time.time(),
+                "subject": subject,
+                "decision": decision,
+                "metadata": metadata or {},
+            },
+        )

--- a/services/collab_bus/server.py
+++ b/services/collab_bus/server.py
@@ -1,0 +1,161 @@
+"""ASGI server exposing the Socket.IO presence bus and dashboards."""
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Dict, Mapping, MutableMapping, Optional
+
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, status
+from fastapi.responses import JSONResponse, PlainTextResponse
+import socketio
+
+from .storage import CollabStore
+
+LOGGER = logging.getLogger(__name__)
+
+sio = socketio.AsyncServer(async_mode="asgi", cors_allowed_origins="*")
+router = APIRouter(prefix="/collab", tags=["collaboration"])
+_store = CollabStore()
+_sessions: MutableMapping[str, str] = {}
+
+
+def get_store() -> CollabStore:
+    return _store
+
+
+async def _record_presence(agent: str, event: str, metadata: Optional[Mapping[str, Any]] = None) -> None:
+    LOGGER.debug("record_presence %s %s", agent, event)
+    _store.record_presence(agent, event, metadata)
+
+
+async def _record_focus(agent: str, payload: Mapping[str, Any]) -> None:
+    _store.record_focus(agent, payload.get("file"), payload.get("branch"), payload.get("metadata"))
+
+
+async def _record_decision(agent: str, payload: Mapping[str, Any]) -> None:
+    _store.record_decision(agent, payload.get("subject", "unknown"), payload.get("decision", "unknown"), payload.get("metadata"))
+
+
+async def _dispatch(event: str, agent: str, payload: Mapping[str, Any]) -> None:
+    metadata = dict(payload.get("metadata") or {})
+    if event == "focus":
+        await _record_presence(agent, "focus", metadata | {"file": payload.get("file"), "branch": payload.get("branch")})
+        await _record_focus(agent, payload)
+    elif event in {"presence", "help", "voice"}:
+        await _record_presence(agent, event, metadata)
+    elif event == "decision":
+        await _record_presence(agent, event, metadata | {"decision": payload.get("decision")})
+        await _record_decision(agent, payload)
+    else:
+        await _record_presence(agent, event, metadata)
+    await sio.emit(event, {"agent": agent, **payload})
+
+
+@sio.event
+async def connect(sid, environ, auth):  # type: ignore[override]
+    LOGGER.info("socket connected %s", sid)
+
+
+@sio.event
+async def disconnect(sid):  # type: ignore[override]
+    agent = _sessions.pop(sid, None)
+    if agent:
+        await _record_presence(agent, "disconnect", {})
+        await sio.emit("presence", {"agent": agent, "event": "disconnect", "ts": time.time()})
+
+
+@sio.on("join")
+async def handle_join(sid, data):
+    agent = (data or {}).get("agent") or f"session:{sid}"
+    _sessions[sid] = agent
+    await _record_presence(agent, "join", {"ts": data.get("ts") if isinstance(data, Mapping) else time.time()})
+    await sio.emit("presence", {"agent": agent, "event": "join", "ts": time.time()}, skip_sid=sid)
+
+
+@sio.on("presence")
+async def handle_presence(sid, payload):
+    agent = _sessions.get(sid, (payload or {}).get("agent") or "unknown")
+    await _dispatch("presence", agent, payload or {})
+
+
+@sio.on("focus")
+async def handle_focus(sid, payload):
+    agent = _sessions.get(sid, (payload or {}).get("agent") or "unknown")
+    await _dispatch("focus", agent, payload or {})
+
+
+@sio.on("help")
+async def handle_help(sid, payload):
+    agent = _sessions.get(sid, (payload or {}).get("agent") or "unknown")
+    await _dispatch("help", agent, payload or {})
+
+
+@sio.on("voice")
+async def handle_voice(sid, payload):
+    agent = _sessions.get(sid, (payload or {}).get("agent") or "unknown")
+    await _dispatch("voice", agent, payload or {})
+
+
+@sio.on("decision")
+async def handle_decision(sid, payload):
+    agent = _sessions.get(sid, (payload or {}).get("agent") or "unknown")
+    await _dispatch("decision", agent, payload or {})
+
+
+@router.post("/events")
+async def post_event(payload: Mapping[str, Any]) -> JSONResponse:
+    event = payload.get("event")
+    body = payload.get("payload") or {}
+    agent = body.get("agent") or "api"
+    if not event:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "event required")
+    await _dispatch(event, agent, body)
+    return JSONResponse({"ok": True})
+
+
+@router.get("/status")
+async def collab_status(store: CollabStore = Depends(get_store)) -> Dict[str, Any]:
+    return store.snapshot()
+
+
+@router.get("/status.md")
+async def collab_status_markdown(store: CollabStore = Depends(get_store)) -> PlainTextResponse:
+    return PlainTextResponse(store.export_markdown(), media_type="text/markdown")
+
+
+@router.post("/decision")
+async def collab_decision(payload: Mapping[str, Any]) -> Dict[str, Any]:
+    agent = payload.get("agent") or "api"
+    await _dispatch("decision", agent, payload)
+    return {"ok": True}
+
+
+@router.get("/audit")
+async def collab_audit(store: CollabStore = Depends(get_store)) -> Dict[str, Any]:
+    return {
+        "online": store.online_agents(),
+        "recent_focus": [
+            record.metadata | {"agent": record.agent, "ts": record.ts}
+            for record in store.most_recent_focus()
+        ],
+        "unresolved_decisions": [
+            record.metadata | {"agent": record.agent, "state": record.event, "ts": record.ts}
+            for record in store.unresolved_decisions()
+        ],
+    }
+
+
+def create_app() -> FastAPI:
+    fastapi_app = FastAPI(title="Collaboration Presence Bus", version="1.0.0")
+    fastapi_app.include_router(router)
+    fastapi_app.mount("/collab/socket.io", socketio.ASGIApp(sio, socketio_path="socket.io"))
+    return fastapi_app
+
+
+app = create_app()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=9000)

--- a/services/collab_bus/status.py
+++ b/services/collab_bus/status.py
@@ -1,0 +1,26 @@
+"""Utilities for exporting presence bus state to markdown dashboards."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .storage import CollabStore
+
+
+def export_markdown(output: Path) -> Path:
+    store = CollabStore()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(store.export_markdown(), encoding="utf-8")
+    return output
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Export collaboration presence snapshot to markdown")
+    parser.add_argument("--output", default="COLLABORATION_STATUS.md", type=Path)
+    args = parser.parse_args()
+    path = export_markdown(args.output)
+    print(f"wrote {path}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/services/collab_bus/storage.py
+++ b/services/collab_bus/storage.py
@@ -1,0 +1,213 @@
+"""SQLite backed persistence for the collaboration presence bus."""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import threading
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, Iterator, List, Mapping, Optional
+
+_DEFAULT_DB_PATH = Path(os.environ.get("COLLAB_DB_PATH", "var/collab_bus.sqlite"))
+
+
+@dataclass(frozen=True)
+class PresenceRecord:
+    agent: str
+    event: str
+    ts: float
+    metadata: Mapping[str, Any]
+
+
+class CollabStore:
+    """High level wrapper around SQLite for collaboration state."""
+
+    def __init__(self, path: Optional[Path | str] = None) -> None:
+        self._path = Path(path) if path else _DEFAULT_DB_PATH
+        self._lock = threading.RLock()
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        with self._connection() as conn:
+            self._apply_schema(conn)
+
+    @contextmanager
+    def _connection(self) -> Iterator[sqlite3.Connection]:
+        with self._lock:
+            conn = sqlite3.connect(self._path)
+            conn.row_factory = sqlite3.Row
+            try:
+                yield conn
+            finally:
+                conn.commit()
+                conn.close()
+
+    @staticmethod
+    def _apply_schema(conn: sqlite3.Connection) -> None:
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS presence_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                agent TEXT NOT NULL,
+                event TEXT NOT NULL,
+                ts REAL NOT NULL,
+                metadata TEXT DEFAULT '{}'
+            );
+
+            CREATE TABLE IF NOT EXISTS focus_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                agent TEXT NOT NULL,
+                file TEXT,
+                branch TEXT,
+                ts REAL NOT NULL,
+                metadata TEXT DEFAULT '{}'
+            );
+
+            CREATE TABLE IF NOT EXISTS review_decisions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                agent TEXT NOT NULL,
+                subject TEXT NOT NULL,
+                decision TEXT NOT NULL,
+                ts REAL NOT NULL,
+                metadata TEXT DEFAULT '{}'
+            );
+            """
+        )
+
+    def record_presence(self, agent: str, event: str, metadata: Optional[Mapping[str, Any]] = None) -> None:
+        self._insert(
+            "INSERT INTO presence_events(agent, event, ts, metadata) VALUES(?,?,?,?)",
+            (agent, event, time.time(), json.dumps(metadata or {})),
+        )
+
+    def record_focus(self, agent: str, file: str | None, branch: str | None, metadata: Optional[Mapping[str, Any]] = None) -> None:
+        self._insert(
+            "INSERT INTO focus_events(agent, file, branch, ts, metadata) VALUES(?,?,?,?,?)",
+            (agent, file, branch, time.time(), json.dumps(metadata or {})),
+        )
+
+    def record_decision(self, agent: str, subject: str, decision: str, metadata: Optional[Mapping[str, Any]] = None) -> None:
+        self._insert(
+            "INSERT INTO review_decisions(agent, subject, decision, ts, metadata) VALUES(?,?,?,?,?)",
+            (agent, subject, decision, time.time(), json.dumps(metadata or {})),
+        )
+
+    def _insert(self, query: str, params: Iterable[Any]) -> None:
+        with self._connection() as conn:
+            conn.execute(query, tuple(params))
+
+    def online_agents(self, horizon_s: int = 90) -> List[str]:
+        cutoff = time.time() - horizon_s
+        query = "SELECT DISTINCT agent FROM presence_events WHERE ts >= ?"
+        with self._connection() as conn:
+            rows = conn.execute(query, (cutoff,)).fetchall()
+        return sorted({row["agent"] for row in rows})
+
+    def unresolved_decisions(self, horizon_s: int = 24 * 3600) -> List[PresenceRecord]:
+        cutoff = time.time() - horizon_s
+        query = (
+            "SELECT agent, subject, decision, ts, metadata FROM review_decisions "
+            "WHERE ts >= ? AND decision NOT IN ('approved', 'rejected')"
+        )
+        with self._connection() as conn:
+            rows = conn.execute(query, (cutoff,)).fetchall()
+        records: List[PresenceRecord] = []
+        for row in rows:
+            meta = json.loads(row["metadata"] or "{}")
+            meta.setdefault("subject", row["subject"])
+            records.append(
+                PresenceRecord(
+                    agent=row["agent"],
+                    event=row["decision"],
+                    ts=row["ts"],
+                    metadata=meta,
+                )
+            )
+        return records
+
+    def most_recent_focus(self, limit: int = 25) -> List[PresenceRecord]:
+        query = "SELECT agent, file, branch, ts, metadata FROM focus_events ORDER BY ts DESC LIMIT ?"
+        with self._connection() as conn:
+            rows = conn.execute(query, (limit,)).fetchall()
+        records: List[PresenceRecord] = []
+        for row in rows:
+            meta = json.loads(row["metadata"] or "{}")
+            meta.update({"file": row["file"], "branch": row["branch"]})
+            records.append(PresenceRecord(agent=row["agent"], event="focus", ts=row["ts"], metadata=meta))
+        return records
+
+    def snapshot(self) -> Dict[str, Any]:
+        """Return a shape consumable by dashboards and status exporters."""
+        online = self.online_agents()
+        focus = self.most_recent_focus()
+        decisions = self.unresolved_decisions()
+        return {
+            "online": online,
+            "recent_focus": [record.metadata | {"agent": record.agent, "ts": record.ts} for record in focus],
+            "unresolved_decisions": [
+                record.metadata | {"agent": record.agent, "state": record.event, "ts": record.ts}
+                for record in decisions
+            ],
+        }
+
+    def export_markdown(self) -> str:
+        snapshot = self.snapshot()
+        lines = ["# Collaboration Status", ""]
+        lines.append(f"Last updated: {time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime())} UTC")
+        lines.append("")
+        lines.append("## Online Agents")
+        if snapshot["online"]:
+            for agent in snapshot["online"]:
+                lines.append(f"- {agent}")
+        else:
+            lines.append("- _No active sessions_")
+        lines.append("")
+        lines.append("## Recent Focus")
+        if snapshot["recent_focus"]:
+            for entry in snapshot["recent_focus"]:
+                file = entry.get("file") or "(workspace)"
+                branch = entry.get("branch") or "unknown"
+                lines.append(
+                    f"- **{entry['agent']}** on `{file}` @ `{branch}` ({_ago(entry['ts'])})"
+                )
+        else:
+            lines.append("- _No editor telemetry in window_")
+        lines.append("")
+        lines.append("## Unresolved Reviews")
+        if snapshot["unresolved_decisions"]:
+            for entry in snapshot["unresolved_decisions"]:
+                subject = entry.get("subject") or entry.get("id") or "discussion"
+                state = entry.get("state")
+                lines.append(
+                    f"- **{entry['agent']}**: {subject} → {state} ({_ago(entry['ts'])})"
+                )
+        else:
+            lines.append("- _No pending approvals_")
+        lines.append("")
+        return "\n".join(lines)
+
+    def has_discussion(self, subject: str, horizon_s: int = 7 * 24 * 3600) -> bool:
+        cutoff = time.time() - horizon_s
+        query = "SELECT 1 FROM review_decisions WHERE ts >= ? AND subject = ? LIMIT 1"
+        with self._connection() as conn:
+            row = conn.execute(query, (cutoff, subject)).fetchone()
+        if row:
+            return True
+        query_meta = (
+            "SELECT 1 FROM review_decisions WHERE ts >= ? AND json_extract(metadata, '$.subject') = ? LIMIT 1"
+        )
+        with self._connection() as conn:
+            row = conn.execute(query_meta, (cutoff, subject)).fetchone()
+        return bool(row)
+
+
+def _ago(ts: float) -> str:
+    delta = max(0, int(time.time() - ts))
+    if delta < 60:
+        return f"{delta}s ago"
+    if delta < 3600:
+        return f"{delta // 60}m ago"
+    if delta < 86400:
+        return f"{delta // 3600}h ago"
+    return f"{delta // 86400}d ago"

--- a/services/collab_bus/working_copy_hook.py
+++ b/services/collab_bus/working_copy_hook.py
@@ -1,0 +1,35 @@
+"""Working Copy automation hook for emitting bus telemetry.
+
+The script is designed to be invoked by Working Copy's automation feature
+(https://workingcopyapp.com/automation). It sends a lightweight heartbeat and
+focus payload to the collaboration presence bus so mobile contributors show up
+next to desktop agents.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+from .client import CollabBusClient
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Working Copy presence hook")
+    parser.add_argument("--agent", default=os.environ.get("COLLAB_AGENT", "working-copy"))
+    parser.add_argument("--file", default="")
+    parser.add_argument("--branch", default=os.environ.get("GIT_BRANCH"))
+    parser.add_argument("--bus", default=os.environ.get("COLLAB_BUS_URL", "http://127.0.0.1:9000"))
+    args = parser.parse_args()
+
+    client = CollabBusClient(base_url=args.bus, agent=args.agent)
+    client.connect()
+    focus_path = Path(args.file) if args.file else None
+    if focus_path and focus_path.exists():
+        client.focus(str(focus_path), branch=args.branch)
+    else:
+        client.heartbeat(branch=args.branch)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tools/collab_presence/vscode-extension/README.md
+++ b/tools/collab_presence/vscode-extension/README.md
@@ -1,0 +1,18 @@
+# BlackRoad Presence Bus (VS Code)
+
+This lightweight extension emits editor activity to the collaboration bus so
+VS Code sessions show up next to mobile Working Copy commits and autonomous
+agents. Key features:
+
+- joins the Socket.IO presence bus on startup
+- broadcasts file + branch focus on editor changes
+- falls back to REST API heartbeat if WebSockets are blocked
+
+## Getting Started
+
+1. `npm install` inside this directory to install dependencies.
+2. Run the VS Code extension host with `F5`.
+3. Configure `blackroadPresence.agent` and `blackroadPresence.busUrl` in settings.
+
+The extension will send telemetry every time focus changes or every 45 seconds
+while idle.

--- a/tools/collab_presence/vscode-extension/extension.js
+++ b/tools/collab_presence/vscode-extension/extension.js
@@ -1,0 +1,94 @@
+const vscode = require('vscode');
+const io = require('socket.io-client');
+
+let socket;
+let heartbeat;
+
+function activate(context) {
+  const config = () => vscode.workspace.getConfiguration('blackroadPresence');
+
+  function connect() {
+    const agent = config().get('agent') || 'vscode';
+    const baseUrl = (config().get('busUrl') || 'http://127.0.0.1:9000').replace(/\/$/, '');
+    if (socket) {
+      socket.disconnect();
+    }
+    socket = io(baseUrl, {
+      path: '/collab/socket.io',
+      transports: ['websocket', 'polling'],
+      reconnection: true,
+      reconnectionDelay: 500,
+      reconnectionAttempts: 5
+    });
+    socket.on('connect', () => {
+      socket.emit('join', { agent, ts: Date.now() / 1000 });
+      sendHeartbeat();
+    });
+    socket.on('connect_error', (err) => {
+      console.warn('[presence-bus] connect error', err.message);
+    });
+  }
+
+  function sendHeartbeat(editor) {
+    const agent = config().get('agent') || 'vscode';
+    const baseUrl = (config().get('busUrl') || 'http://127.0.0.1:9000').replace(/\/$/, '');
+    const branch = vscode.workspace.getConfiguration('git').get('defaultBranchName') || undefined;
+    const payload = {
+      agent,
+      ts: Date.now() / 1000,
+      file: editor && editor.document ? vscode.workspace.asRelativePath(editor.document.uri) : undefined,
+      branch,
+      metadata: {
+        language: editor && editor.document ? editor.document.languageId : undefined
+      }
+    };
+    if (socket && socket.connected) {
+      socket.emit('focus', payload);
+    }
+    fetch(`${baseUrl}/collab/events`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ event: 'focus', payload })
+    }).catch((err) => console.warn('[presence-bus] heartbeat failed', err.message));
+  }
+
+  function handleActiveEditor(editor) {
+    if (!editor) {
+      return;
+    }
+    sendHeartbeat(editor);
+  }
+
+  context.subscriptions.push(vscode.workspace.onDidChangeConfiguration((event) => {
+    if (event.affectsConfiguration('blackroadPresence')) {
+      connect();
+    }
+  }));
+
+  context.subscriptions.push(vscode.window.onDidChangeActiveTextEditor((editor) => handleActiveEditor(editor)));
+  context.subscriptions.push(vscode.workspace.onDidChangeTextDocument((event) => {
+    const editor = vscode.window.visibleTextEditors.find((ed) => ed.document === event.document);
+    if (editor) {
+      sendHeartbeat(editor);
+    }
+  }));
+
+  connect();
+  heartbeat = setInterval(() => sendHeartbeat(vscode.window.activeTextEditor), 45000);
+}
+
+function deactivate() {
+  if (heartbeat) {
+    clearInterval(heartbeat);
+    heartbeat = undefined;
+  }
+  if (socket) {
+    socket.disconnect();
+    socket = undefined;
+  }
+}
+
+module.exports = {
+  activate,
+  deactivate
+};

--- a/tools/collab_presence/vscode-extension/package.json
+++ b/tools/collab_presence/vscode-extension/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "blackroad-collab-presence",
+  "displayName": "BlackRoad Presence Bus",
+  "description": "Streams cursor + focus telemetry to the BlackRoad collaboration presence bus.",
+  "publisher": "blackroad",
+  "version": "0.1.0",
+  "engines": {
+    "vscode": "^1.75.0"
+  },
+  "activationEvents": ["*"],
+  "main": "./extension.js",
+  "contributes": {
+    "configuration": {
+      "type": "object",
+      "title": "BlackRoad Presence Bus",
+      "properties": {
+        "blackroadPresence.agent": {
+          "type": "string",
+          "default": "codex",
+          "description": "Display name for this VS Code session on the presence bus"
+        },
+        "blackroadPresence.busUrl": {
+          "type": "string",
+          "default": "http://127.0.0.1:9000",
+          "description": "Base URL for the presence bus server"
+        }
+      }
+    }
+  },
+  "dependencies": {
+    "socket.io-client": "^4.7.5"
+  }
+}


### PR DESCRIPTION
## Summary
- add a Socket.IO collaboration bus with SQLite storage, status exports, and markdown publishing
- wire GitHub webhooks, Working Copy hook, and a VS Code extension into the new presence bus
- enforce multi-agent reviews via CODEOWNERS and a presence-audit GitHub Action

## Testing
- python -m compileall services/collab_bus scripts/check_presence_discussion.py tools/collab_presence/vscode-extension/extension.js

------
https://chatgpt.com/codex/tasks/task_e_68fe85e3ca0083299fef5f2d575dfe2a