### PR TITLE
Fix duplicate exports in chat and artifact viewer components

### DIFF
--- a/sites/blackroad/src/components/ArtifactViewer/index.jsx
+++ b/sites/blackroad/src/components/ArtifactViewer/index.jsx
@@ -137,30 +137,5 @@ export default function ArtifactViewer({ jobId, artifacts: initialArtifacts, onS
         </div>
       )}
     </div>
-export default function ArtifactViewer({ job }) {
-  const artifacts = job?.artifacts ?? [];
-  return (
-    <section className="flex-1 rounded-2xl border border-white/10 bg-white/5 p-4">
-      <header className="flex items-center justify-between">
-        <h2 className="text-sm font-semibold uppercase tracking-wide opacity-70">Artifact Viewer</h2>
-        <span className="text-[10px] uppercase opacity-50">{job?.id ?? "idle"}</span>
-      </header>
-      {artifacts.length === 0 ? (
-        <p className="mt-4 text-xs opacity-60">Artifacts will appear once a job completes.</p>
-      ) : (
-        <ul className="mt-4 space-y-2 text-xs">
-          {artifacts.map((artifact) => (
-            <li key={artifact.id} className="rounded border border-white/10 bg-black/30 p-3">
-              <div className="flex items-center justify-between">
-                <span className="font-semibold">{artifact.description ?? artifact.path}</span>
-                <span className="rounded-full bg-white/10 px-2 py-1 text-[10px] uppercase">{artifact.type}</span>
-              </div>
-              <div className="mt-1 font-mono text-[10px] opacity-60">{artifact.path}</div>
-              <div className="font-mono text-[10px] opacity-60">sha256 {artifact.sha256}</div>
-            </li>
-          ))}
-        </ul>
-      )}
-    </section>
   );
 }

--- a/sites/blackroad/src/components/ChatPanel/index.jsx
+++ b/sites/blackroad/src/components/ChatPanel/index.jsx
@@ -128,55 +128,5 @@ export default function ChatPanel({ jobId, protocol = 'graphql', baseUrl = '', p
         </div>
       </form>
     </div>
-import { useState } from "react";
-
-export default function ChatPanel({ jobId, events }) {
-  const [draft, setDraft] = useState("");
-  const [notes, setNotes] = useState([]);
-
-  const addNote = () => {
-    if (!draft.trim()) return;
-    setNotes((prev) => [...prev, { id: `note-${prev.length}`, text: draft, ts: new Date().toISOString() }]);
-    setDraft("");
-  };
-
-  return (
-    <section className="flex flex-1 flex-col rounded-2xl border border-white/10 bg-white/5 p-4">
-      <header className="mb-3 flex items-center justify-between">
-        <h2 className="text-sm font-semibold uppercase tracking-wide opacity-70">Chat Panel</h2>
-        <span className="text-[10px] uppercase opacity-50">job {jobId ?? "idle"}</span>
-      </header>
-      <div className="flex-1 space-y-2 overflow-y-auto rounded bg-black/30 p-3 text-xs">
-        {(events ?? []).map((event) => (
-          <div key={event.id} className="flex items-start gap-2">
-            <span>{event.emoji}</span>
-            <div>
-              <div className="font-semibold">{event.text}</div>
-              <div className="text-[10px] opacity-50">{new Date(event.ts).toLocaleTimeString()}</div>
-            </div>
-          </div>
-        ))}
-        {notes.map((note) => (
-          <div key={note.id} className="flex items-start gap-2">
-            <span>💬</span>
-            <div>
-              <div className="font-semibold">{note.text}</div>
-              <div className="text-[10px] opacity-50">{new Date(note.ts).toLocaleTimeString()}</div>
-            </div>
-          </div>
-        ))}
-      </div>
-      <div className="mt-3 flex gap-2">
-        <input
-          className="flex-1 rounded bg-black/40 px-2 py-1 text-xs"
-          placeholder="Add a note for this job"
-          value={draft}
-          onChange={(e) => setDraft(e.target.value)}
-        />
-        <button className="rounded bg-blue-500/30 px-3 py-1 text-xs hover:bg-blue-500/40" onClick={addNote}>
-          Save
-        </button>
-      </div>
-    </section>
   );
 }


### PR DESCRIPTION
## Summary
- remove duplicate fallback definitions from the chat panel component so only the realtime version exports
- remove duplicate fallback implementation from the artifact viewer component and keep the interactive viewer

## Testing
- npm test --prefix sites/blackroad

------
https://chatgpt.com/codex/tasks/task_e_68febb8da5e88329ba1d17802e53939f