### PR TITLE
Add Codex-33 product manager toolkit

### DIFF
--- a/agents/codex/33-product-manager/__init__.py
+++ b/agents/codex/33-product-manager/__init__.py
@@ -1,0 +1,1 @@
+"""Codex-33 Product Manager toolkit."""

--- a/agents/codex/33-product-manager/codex33.yaml
+++ b/agents/codex/33-product-manager/codex33.yaml
@@ -1,0 +1,17 @@
+id: codex-33
+name: Product Manager
+generation: 6
+moral_constant: "Value = (Outcome ÷ Joules) × Dignity"
+core_principle: "Ship learning before you ship features"
+emojis: ["📍","🎯","🧭","🧪","🔋","🪪"]
+thresholds:
+  outcome_joules_target: 500
+  max_parallel_bets: 3
+  kill_if:
+    - "no-signal-2-cycles"
+    - "energy>2×target and value<median"
+release_gate:
+  teacher: true
+  designer: true
+  auditor: true
+  sentinel: true

--- a/agents/codex/33-product-manager/data/audiences.yaml
+++ b/agents/codex/33-product-manager/data/audiences.yaml
@@ -1,0 +1,10 @@
+audiences:
+  - name: Product Trio
+    needs:
+      - Clarity on target outcomes
+      - Fast discovery loops
+      - Low joules per shipped learning
+  - name: Leadership
+    needs:
+      - Evidence of value per joule
+      - Guardrails on risk and ethics

--- a/agents/codex/33-product-manager/data/themes.yaml
+++ b/agents/codex/33-product-manager/data/themes.yaml
@@ -1,0 +1,4 @@
+themes:
+  - Outcome roadmapping
+  - Discovery velocity
+  - Energy stewardship

--- a/agents/codex/33-product-manager/pipelines/decide_bet.py
+++ b/agents/codex/33-product-manager/pipelines/decide_bet.py
@@ -1,0 +1,50 @@
+"""Decide whether a bet wins, pivots, or is killed based on results."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+
+def decide(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a decision payload for the provided experiment result."""
+    bet = event.get("bet", {})
+    metrics = event.get("metrics", {})
+    joules = event.get("joules", {})
+
+    success_metric = bet.get("success", {}).get("metric")
+    threshold = bet.get("success", {}).get("threshold")
+    observed = metrics.get(success_metric)
+    joules_spent = joules.get("spent", 0)
+    joules_target = bet.get("joules_target", joules.get("target", 0))
+
+    if observed is not None and threshold is not None and observed >= threshold:
+        decision = "win"
+        reason = f"Observed {observed} ≥ target {threshold}"
+    elif joules_spent > joules_target * 2:
+        decision = "kill"
+        reason = "Energy spent exceeded 2× target"
+    elif event.get("signal", "") == "weak":
+        decision = "pivot"
+        reason = "Signal weak for two cycles"
+    else:
+        decision = "pivot"
+        reason = "Additional learning required"
+
+    payload = {
+        "bet_id": bet.get("id"),
+        "decision": decision,
+        "reason": reason,
+        "metrics": metrics,
+        "joules": {"spent": joules_spent, "target": joules_target},
+        "receipts": event.get("receipts", []),
+        "decided_at": event.get("decided_at"),
+    }
+    return payload
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import json
+    import sys
+
+    result = json.load(sys.stdin)
+    json.dump(decide(result), sys.stdout, indent=2)

--- a/agents/codex/33-product-manager/pipelines/energy_per_outcome.py
+++ b/agents/codex/33-product-manager/pipelines/energy_per_outcome.py
@@ -1,0 +1,33 @@
+"""Compute energy-per-outcome trends and detect spikes."""
+from __future__ import annotations
+
+from statistics import mean
+from typing import Any, Dict, Iterable, List
+
+
+SPIKE_MULTIPLIER = 1.3
+MIN_OBSERVATIONS = 3
+
+
+def trend(history: Iterable[Dict[str, Any]]) -> Dict[str, float]:
+    """Return average joules per outcome id."""
+    totals: Dict[str, List[float]] = {}
+    for sample in history:
+        for outcome_id, joules in sample.get("outcomes", {}).items():
+            totals.setdefault(outcome_id, []).append(float(joules))
+    return {key: mean(values) for key, values in totals.items() if values}
+
+
+def spike(event: Dict[str, Any]) -> bool:
+    """Return True when energy spikes beyond the configured multiplier."""
+    outcome_id = event.get("outcome_id")
+    current = float(event.get("joules", 0))
+    history = event.get("history", [])
+    past_values = [float(item.get("joules", 0)) for item in history if item.get("outcome_id") == outcome_id]
+
+    if len(past_values) < MIN_OBSERVATIONS:
+        return False
+    baseline = mean(past_values[-MIN_OBSERVATIONS:])
+    if baseline == 0:
+        return False
+    return current > baseline * SPIKE_MULTIPLIER

--- a/agents/codex/33-product-manager/pipelines/make_outcome_tree.py
+++ b/agents/codex/33-product-manager/pipelines/make_outcome_tree.py
@@ -1,0 +1,112 @@
+"""Transform goal intents into a lightweight outcome tree."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+from .utils import DATA_DIR, load_yaml, timestamp
+
+
+@dataclass
+class GoalIntent:
+    """Representation of a goal intent event."""
+
+    title: str
+    metric: str
+    horizon: str | None = None
+    owner: str | None = None
+
+    @classmethod
+    def from_event(cls, event: Dict[str, Any]) -> "GoalIntent":
+        payload = event.get("goal", {})
+        return cls(
+            title=payload.get("title", "Untitled Goal"),
+            metric=payload.get("metric", ""),
+            horizon=payload.get("horizon"),
+            owner=payload.get("owner"),
+        )
+
+
+def _themes() -> List[str]:
+    data = load_yaml(DATA_DIR / "themes.yaml")
+    return data.get("themes", [])
+
+
+def _audience_needs() -> Dict[str, List[str]]:
+    data = load_yaml(DATA_DIR / "audiences.yaml")
+    needs: Dict[str, List[str]] = {}
+    for audience in data.get("audiences", []):
+        name = audience.get("name")
+        if not name:
+            continue
+        needs[name] = list(audience.get("needs", []))
+    return needs
+
+
+def build(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Return an outcome tree seeded with up to three initial bets."""
+    intent = GoalIntent.from_event(event)
+    themes = _themes()
+    needs = _audience_needs()
+    audience = event.get("audience") or next(iter(needs), "Primary")
+
+    outcomes: List[Dict[str, Any]] = []
+    base_outcomes = event.get("outcomes") or _default_outcomes(intent, audience, themes)
+    for outcome in base_outcomes[:3]:
+        outcomes.append(
+            {
+                "title": outcome["title"],
+                "metric": outcome.get("metric", intent.metric or ""),
+                "leading_indicators": list(outcome.get("leading_indicators", [])),
+                "bets": list(outcome.get("bets", [])),
+            }
+        )
+
+    return {
+        "goal": {
+            "title": intent.title,
+            "metric": intent.metric,
+            "horizon": intent.horizon,
+            "owner": intent.owner,
+            "theme_hint": themes[0] if themes else None,
+        },
+        "audience": audience,
+        "outcomes": outcomes,
+        "created_at": timestamp(),
+    }
+
+
+def _default_outcomes(intent: GoalIntent, audience: str, themes: List[str]) -> List[Dict[str, Any]]:
+    """Generate default outcomes when none are provided."""
+    theme = themes[0] if themes else "Focus"
+    return [
+        {
+            "title": f"Increase {intent.metric or 'core metric'} for {audience}",
+            "metric": intent.metric or "",
+            "leading_indicators": [f"% of {audience} achieving aha moment"],
+            "bets": [],
+            "theme": theme,
+        },
+        {
+            "title": "Shorten discovery loop",
+            "metric": "cycle_time_days",
+            "leading_indicators": ["avg research loop <= 5 days"],
+            "bets": [],
+            "theme": theme,
+        },
+        {
+            "title": "Raise team clarity",
+            "metric": "confidence_score",
+            "leading_indicators": ["weekly recap published"],
+            "bets": [],
+            "theme": theme,
+        },
+    ]
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import json
+    import sys
+
+    event_data = json.load(sys.stdin)
+    json.dump(build(event_data), sys.stdout, indent=2)

--- a/agents/codex/33-product-manager/pipelines/open_bet.py
+++ b/agents/codex/33-product-manager/pipelines/open_bet.py
@@ -1,0 +1,81 @@
+"""Create initial bets derived from an outcome tree."""
+from __future__ import annotations
+
+import itertools
+from typing import Any, Dict, Iterable, List
+
+from .utils import timestamp
+
+DEFAULT_JOULES = 200
+
+
+def _ensure_list(value: Any) -> List[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def open_bets(tree: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Return up to three open bets with guardrails and kill criteria."""
+    outcomes = tree.get("outcomes", [])
+    candidate_titles = list(
+        itertools.islice(
+            (
+                outcome.get("title", "Untitled Outcome")
+                for outcome in outcomes
+            ),
+            3,
+        )
+    )
+
+    bets: List[Dict[str, Any]] = []
+    for idx, title in enumerate(candidate_titles, start=1):
+        bets.append(
+            {
+                "id": f"bet-{idx}",
+                "title": title,
+                "emoji": "🎯",
+                "hypothesis": f"If we focus on '{title}' we move the outcome metric",
+                "for_user": tree.get("audience", "Primary"),
+                "expected_outcome": title,
+                "guardrails": {"ethics": True, "privacy": True, "notes": "baseline"},
+                "joules_target": tree.get("goal", {}).get("joules_target", DEFAULT_JOULES),
+                "test": {"method": "prototype", "sample_size": 5, "timebox_days": 5},
+                "success": {"metric": tree.get("goal", {}).get("metric", ""), "threshold": 1.05},
+                "kill": {
+                    "criteria": [
+                        "no-signal-2-cycles",
+                        "energy>2×target and value<median",
+                    ]
+                },
+                "receipts": [],
+                "status": "open",
+                "owner": tree.get("goal", {}).get("owner", "codex-33"),
+                "start_date": timestamp().split("T")[0],
+            }
+        )
+    return bets
+
+
+def attach_bets(tree: Dict[str, Any], bets: Iterable[Dict[str, Any]]) -> Dict[str, Any]:
+    """Attach bet references to the first outcome slots."""
+    result = {**tree}
+    outcomes = result.get("outcomes", [])
+    for outcome, bet in zip(outcomes, bets):
+        refs = _ensure_list(outcome.get("bets"))
+        refs.append({"id": bet["id"], "title": bet["title"], "status": bet["status"]})
+        outcome["bets"] = refs
+    result["outcomes"] = outcomes
+    return result
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import json
+    import sys
+
+    tree = json.load(sys.stdin)
+    bets = open_bets(tree)
+    output = attach_bets(tree, bets)
+    json.dump({"bets": bets, "tree": output}, sys.stdout, indent=2)

--- a/agents/codex/33-product-manager/pipelines/release_notes.py
+++ b/agents/codex/33-product-manager/pipelines/release_notes.py
@@ -1,0 +1,49 @@
+"""Generate structured release notes from release events."""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from .utils import timestamp
+
+
+DEFAULT_BADGES = ["🟢OutcomeWon"]
+
+
+def make_note(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a release note document ready for serialization."""
+    metrics = event.get("metrics", {})
+    energy = event.get("energy", {})
+    lessons = _ensure_list(event.get("lessons")) or ["Document follow-up interviews"]
+    badges = _ensure_list(event.get("badges")) or DEFAULT_BADGES
+    approvals = event.get("approvals", {})
+
+    return {
+        "version": event.get("version", "v0.0.1"),
+        "date": event.get("date", timestamp().split("T")[0]),
+        "outcome": event.get("outcome", ""),
+        "metrics": {
+            "primary": metrics.get("primary", ""),
+            "secondary": _ensure_list(metrics.get("secondary")),
+        },
+        "energy": {
+            "target": energy.get("target", 0),
+            "joules_spent": energy.get("spent", 0),
+            "scope_changes": _ensure_list(energy.get("scope_changes")),
+        },
+        "lessons": lessons,
+        "badges": badges,
+        "approvals": {
+            "teacher": approvals.get("teacher", "pending"),
+            "designer": approvals.get("designer", "pending"),
+            "auditor": approvals.get("auditor", "pending"),
+            "sentinel": approvals.get("sentinel", "pending"),
+        },
+    }
+
+
+def _ensure_list(value: Any) -> List[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]

--- a/agents/codex/33-product-manager/pipelines/utils.py
+++ b/agents/codex/33-product-manager/pipelines/utils.py
@@ -1,0 +1,35 @@
+"""Shared utilities for Codex-33 pipelines."""
+from __future__ import annotations
+
+import datetime as _dt
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+
+DATA_DIR = Path(__file__).resolve().parent.parent / "data"
+
+
+def load_yaml(path: Path) -> Dict[str, Any]:
+    """Load a very small subset of YAML for configuration files."""
+    try:
+        import yaml  # type: ignore
+
+        with path.open("r", encoding="utf-8") as handle:
+            return yaml.safe_load(handle) or {}
+    except (ImportError, AttributeError):
+        return _fallback_yaml(path)
+
+
+def _fallback_yaml(path: Path) -> Dict[str, Any]:
+    """Parse a subset of YAML that also matches JSON syntax."""
+    text = path.read_text(encoding="utf-8")
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Cannot parse {path}: install PyYAML for full support") from exc
+
+
+def timestamp() -> str:
+    """Return an ISO-8601 timestamp."""
+    return _dt.datetime.utcnow().replace(tzinfo=_dt.timezone.utc).isoformat()

--- a/agents/codex/33-product-manager/product_manager.md
+++ b/agents/codex/33-product-manager/product_manager.md
@@ -1,0 +1,29 @@
+# Codex-33 · Product Manager Rituals
+
+## Operating Rhythm
+- Start each cycle by mapping goals to measurable outcomes.
+- Spin up discovery loops that ship learning within days.
+- Track joules spent per outcome; shrink scope before the team burns out.
+- Close cycles with a decision (win, pivot, or kill) and teach the learning forward.
+
+## Checklists
+### Outcome Tree
+- Clarify the goal and success signal.
+- Derive outcomes with attached metrics and leading indicators.
+- Limit initial bets to three or fewer with clear guardrails.
+
+### Bet Card
+- Capture hypothesis, user, and expected outcome.
+- Record ethics and privacy confirmations.
+- Define joules target, success threshold, and kill criteria.
+- Attach receipts for discovery inputs.
+
+### Release Notes
+- State the outcome pursued and the metric moved.
+- Log joules consumed and any scope adjustments.
+- Link acknowledgements for Teacher, Designer, Auditor, and Sentinel reviews.
+
+## Ethics Stance
+- Favor experiments that respect dignity and informed consent.
+- Kill kindly: if the data says stop, we stop and share why.
+- Celebrate low-joule wins and transparent learnings.

--- a/agents/codex/33-product-manager/reflex/on_energy_spike.reflex.py
+++ b/agents/codex/33-product-manager/reflex/on_energy_spike.reflex.py
@@ -1,0 +1,18 @@
+"""Reflex hook: energy updates → potential scope shrink."""
+from __future__ import annotations
+
+from lucidia.reflex.core import BUS, start  # type: ignore
+
+from ..pipelines.energy_per_outcome import spike
+
+
+@BUS.on("energy:update")
+def guard(event: dict) -> None:
+    """Emit guardrail signals when energy spikes."""
+    if spike(event):
+        BUS.emit("strat:call.HOLD", {"reason": "pm_energy_spike", "event": event})
+        BUS.emit("pm:scope.shrink", {"hint": "reduce surface by 30%"})
+
+
+if __name__ == "__main__":  # pragma: no cover
+    start()

--- a/agents/codex/33-product-manager/reflex/on_experiment_result.reflex.py
+++ b/agents/codex/33-product-manager/reflex/on_experiment_result.reflex.py
@@ -1,0 +1,17 @@
+"""Reflex hook: experiment result → decide bet."""
+from __future__ import annotations
+
+from lucidia.reflex.core import BUS, start  # type: ignore
+
+from ..pipelines.decide_bet import decide
+
+
+@BUS.on("experiment:result")
+def decide_bet(event: dict) -> None:
+    """Emit the bet decision with receipts."""
+    result = decide(event)
+    BUS.emit(f"pm:bet.{result['decision']}", result)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    start()

--- a/agents/codex/33-product-manager/reflex/on_goal_intent.reflex.py
+++ b/agents/codex/33-product-manager/reflex/on_goal_intent.reflex.py
@@ -1,0 +1,20 @@
+"""Reflex hook: goal intent → outcome tree + bets."""
+from __future__ import annotations
+
+from lucidia.reflex.core import BUS, start  # type: ignore
+
+from ..pipelines.make_outcome_tree import build
+from ..pipelines.open_bet import attach_bets, open_bets
+
+
+@BUS.on("intent:goal")
+def spin(event: dict) -> None:
+    """Generate the first outcome tree and opening bets."""
+    tree = build(event)
+    bets = open_bets(tree)
+    enriched_tree = attach_bets(tree, bets)
+    BUS.emit("pm:outcomes.ready", {"tree": enriched_tree, "bets": bets})
+
+
+if __name__ == "__main__":  # pragma: no cover
+    start()

--- a/agents/codex/33-product-manager/reflex/on_release_tag.reflex.py
+++ b/agents/codex/33-product-manager/reflex/on_release_tag.reflex.py
@@ -1,0 +1,17 @@
+"""Reflex hook: release tag → release note generation."""
+from __future__ import annotations
+
+from lucidia.reflex.core import BUS, start  # type: ignore
+
+from ..pipelines.release_notes import make_note
+
+
+@BUS.on("release:tagged")
+def note(event: dict) -> None:
+    """Emit a structured release note payload."""
+    release_note = make_note(event)
+    BUS.emit("codex:release.note", release_note)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    start()

--- a/agents/codex/33-product-manager/schemas/bet_card.schema.json
+++ b/agents/codex/33-product-manager/schemas/bet_card.schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "BetCard",
+  "type": "object",
+  "required": [
+    "id",
+    "title",
+    "hypothesis",
+    "for_user",
+    "expected_outcome",
+    "guardrails",
+    "joules_target",
+    "test",
+    "success",
+    "kill",
+    "status",
+    "owner",
+    "start_date"
+  ],
+  "properties": {
+    "id": {"type": "string"},
+    "title": {"type": "string"},
+    "emoji": {"type": "string"},
+    "hypothesis": {"type": "string"},
+    "for_user": {"type": "string"},
+    "expected_outcome": {"type": "string"},
+    "guardrails": {
+      "type": "object",
+      "required": ["ethics", "privacy"],
+      "properties": {
+        "ethics": {"type": "boolean"},
+        "privacy": {"type": "boolean"},
+        "notes": {"type": "string"}
+      }
+    },
+    "joules_target": {"type": "number", "minimum": 0},
+    "test": {
+      "type": "object",
+      "required": ["method", "sample_size", "timebox_days"],
+      "properties": {
+        "method": {"type": "string"},
+        "sample_size": {"type": "integer", "minimum": 1},
+        "timebox_days": {"type": "integer", "minimum": 1}
+      }
+    },
+    "success": {
+      "type": "object",
+      "required": ["metric", "threshold"],
+      "properties": {
+        "metric": {"type": "string"},
+        "threshold": {"type": "number"}
+      }
+    },
+    "kill": {
+      "type": "object",
+      "required": ["criteria"],
+      "properties": {
+        "criteria": {
+          "type": "array",
+          "items": {"type": "string"},
+          "minItems": 1
+        }
+      }
+    },
+    "receipts": {
+      "type": "array",
+      "items": {"type": "string", "format": "uri"}
+    },
+    "status": {"type": "string", "enum": ["open", "win", "pivot", "kill"]},
+    "owner": {"type": "string"},
+    "start_date": {"type": "string", "format": "date"},
+    "decision_date": {"type": "string", "format": "date"}
+  }
+}

--- a/agents/codex/33-product-manager/schemas/outcome_tree.schema.json
+++ b/agents/codex/33-product-manager/schemas/outcome_tree.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "OutcomeTree",
+  "type": "object",
+  "required": ["goal", "outcomes", "created_at"],
+  "properties": {
+    "goal": {
+      "type": "object",
+      "required": ["title", "metric"],
+      "properties": {
+        "title": {"type": "string"},
+        "metric": {"type": "string"},
+        "horizon": {"type": "string"},
+        "owner": {"type": "string"}
+      }
+    },
+    "outcomes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["title", "metric", "bets"],
+        "properties": {
+          "title": {"type": "string"},
+          "metric": {"type": "string"},
+          "leading_indicators": {
+            "type": "array",
+            "items": {"type": "string"}
+          },
+          "bets": {
+            "type": "array",
+            "items": {"$ref": "#/definitions/betRef"},
+            "maxItems": 3
+          }
+        }
+      }
+    },
+    "created_at": {"type": "string", "format": "date-time"}
+  },
+  "definitions": {
+    "betRef": {
+      "type": "object",
+      "required": ["id", "title", "status"],
+      "properties": {
+        "id": {"type": "string"},
+        "title": {"type": "string"},
+        "status": {"type": "string", "enum": ["open", "win", "pivot", "kill"]}
+      }
+    }
+  }
+}

--- a/agents/codex/33-product-manager/schemas/prd_lite.schema.json
+++ b/agents/codex/33-product-manager/schemas/prd_lite.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PRDLite",
+  "type": "object",
+  "required": [
+    "problem",
+    "users",
+    "constraints",
+    "metrics",
+    "ux_sketch",
+    "risks",
+    "ethics"
+  ],
+  "properties": {
+    "problem": {"type": "string"},
+    "users": {
+      "type": "array",
+      "items": {"type": "string"},
+      "minItems": 1
+    },
+    "constraints": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "metrics": {
+      "type": "object",
+      "required": ["primary", "secondary"],
+      "properties": {
+        "primary": {"type": "string"},
+        "secondary": {
+          "type": "array",
+          "items": {"type": "string"}
+        }
+      }
+    },
+    "ux_sketch": {"type": "string"},
+    "risks": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "ethics": {
+      "type": "object",
+      "required": ["impact", "mitigations"],
+      "properties": {
+        "impact": {"type": "string"},
+        "mitigations": {
+          "type": "array",
+          "items": {"type": "string"}
+        }
+      }
+    }
+  }
+}

--- a/agents/codex/33-product-manager/schemas/release_note.schema.json
+++ b/agents/codex/33-product-manager/schemas/release_note.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ReleaseNote",
+  "type": "object",
+  "required": [
+    "version",
+    "date",
+    "outcome",
+    "metrics",
+    "energy",
+    "lessons",
+    "badges",
+    "approvals"
+  ],
+  "properties": {
+    "version": {"type": "string"},
+    "date": {"type": "string", "format": "date"},
+    "outcome": {"type": "string"},
+    "metrics": {
+      "type": "object",
+      "required": ["primary"],
+      "properties": {
+        "primary": {"type": "string"},
+        "secondary": {
+          "type": "array",
+          "items": {"type": "string"}
+        }
+      }
+    },
+    "energy": {
+      "type": "object",
+      "required": ["joules_spent", "target"],
+      "properties": {
+        "joules_spent": {"type": "number", "minimum": 0},
+        "target": {"type": "number", "minimum": 0},
+        "scope_changes": {
+          "type": "array",
+          "items": {"type": "string"}
+        }
+      }
+    },
+    "lessons": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "badges": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "approvals": {
+      "type": "object",
+      "required": ["teacher", "designer", "auditor", "sentinel"],
+      "properties": {
+        "teacher": {"type": "string"},
+        "designer": {"type": "string"},
+        "auditor": {"type": "string"},
+        "sentinel": {"type": "string"}
+      }
+    }
+  }
+}

--- a/agents/codex/33-product-manager/templates/bet_card.md.gotmpl
+++ b/agents/codex/33-product-manager/templates/bet_card.md.gotmpl
@@ -1,0 +1,7 @@
+# Bet: {{ .title }}  {{ .emoji }}
+Hypothesis: {{ .hypothesis }} → {{ .for_user }} → {{ .expected_outcome }}
+Guardrails: ethics {{ if .guardrails.ethics }}✅{{ else }}⚠️{{ end }} | privacy {{ if .guardrails.privacy }}✅{{ else }}⚠️{{ end }} | energy target: {{ .joules_target }}J
+Test: {{ .test.method }} | Sample: {{ .test.sample_size }} | Timebox: {{ .test.timebox_days }} days
+Success: {{ .success.metric }} ≥ {{ .success.threshold }} | Kill: {{ range $i, $c := .kill.criteria }}{{ if $i }}, {{ end }}{{ $c }}{{ end }}
+Receipts: {{ range $i, $link := .receipts }}{{ if $i }}, {{ end }}{{ $link }}{{ else }}n/a{{ end }}
+Owner: {{ .owner }} | Start: {{ .start_date }} | Status: {{ .status | upper }}

--- a/agents/codex/33-product-manager/templates/interview_guide.md.gotmpl
+++ b/agents/codex/33-product-manager/templates/interview_guide.md.gotmpl
@@ -1,0 +1,29 @@
+# Interview Guide · {{ .topic }}
+
+## Participants
+{{ range .participants -}}
+- {{ . }}
+{{ else }}
+- TBD
+{{ end }}
+
+## Objectives
+{{ range .objectives -}}
+- {{ . }}
+{{ else }}
+- Clarify primary outcome signals.
+{{ end }}
+
+## Key Questions
+{{ range .questions -}}
+1. {{ . }}
+{{ else }}
+1. Tell me about the last time you tried to achieve {{ .topic }}.
+2. What made it hard or easy?
+3. How do you measure success today?
+{{ end }}
+
+## Notes Template
+- Signal:
+- Quote:
+- Next action:

--- a/agents/codex/33-product-manager/templates/prd.md.gotmpl
+++ b/agents/codex/33-product-manager/templates/prd.md.gotmpl
@@ -1,0 +1,44 @@
+# PRD · {{ .title }}
+
+## Problem
+{{ .problem }}
+
+## Users & Needs
+{{ range .users -}}
+- {{ . }}
+{{ end }}
+
+## Constraints
+{{ range .constraints -}}
+- {{ . }}
+{{ else }}
+- None stated
+{{ end }}
+
+## Metrics
+- Primary: {{ .metrics.primary }}
+{{- if .metrics.secondary }}
+- Secondary:
+{{ range .metrics.secondary -}}
+  - {{ . }}
+{{ end }}
+{{- end }}
+
+## UX Sketch
+{{ .ux_sketch }}
+
+## Risks
+{{ range .risks -}}
+- {{ . }}
+{{ else }}
+- None captured
+{{ end }}
+
+## Ethics
+- Impact: {{ .ethics.impact }}
+{{- if .ethics.mitigations }}
+- Mitigations:
+{{ range .ethics.mitigations -}}
+  - {{ . }}
+{{ end }}
+{{- end }}

--- a/agents/codex/33-product-manager/templates/release_note.md.gotmpl
+++ b/agents/codex/33-product-manager/templates/release_note.md.gotmpl
@@ -1,0 +1,43 @@
+# Release {{ .version }} · {{ .date }}
+
+## Outcome
+{{ .outcome }}
+
+## Metrics
+- Primary: {{ .metrics.primary }}
+{{- if .metrics.secondary }}
+- Secondary:
+{{ range .metrics.secondary -}}
+  - {{ . }}
+{{ end }}
+{{- end }}
+
+## Energy
+- Target: {{ .energy.target }}J
+- Spent: {{ .energy.joules_spent }}J
+{{- if .energy.scope_changes }}
+- Scope Changes:
+{{ range .energy.scope_changes -}}
+  - {{ . }}
+{{ end }}
+{{- end }}
+
+## Lessons Learned
+{{ range .lessons -}}
+- {{ . }}
+{{ else }}
+- Pending postmortem
+{{ end }}
+
+## Badges
+{{ range .badges -}}
+- {{ . }}
+{{ else }}
+- None awarded
+{{ end }}
+
+## Approvals
+- Teacher: {{ .approvals.teacher }}
+- Designer: {{ .approvals.designer }}
+- Auditor: {{ .approvals.auditor }}
+- Sentinel: {{ .approvals.sentinel }}

--- a/agents/codex/33-product-manager/ui/bets_ledger.html
+++ b/agents/codex/33-product-manager/ui/bets_ledger.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Bets Ledger · Codex-33</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <h1>Bets Ledger</h1>
+      <p class="subtitle">Hypotheses, guardrails, and kill criteria.</p>
+    </header>
+    <main>
+      <table>
+        <thead>
+          <tr>
+            <th>Bet</th>
+            <th>Status</th>
+            <th>Joules Target</th>
+            <th>Success Metric</th>
+            <th>Kill Criteria</th>
+          </tr>
+        </thead>
+        <tbody data-bind="bets">
+          <tr>
+            <td>
+              <strong data-bind="title"></strong>
+              <p data-bind="hypothesis"></p>
+              <p>Guardrails: <span data-bind="guardrails"></span></p>
+            </td>
+            <td data-bind="status"></td>
+            <td data-bind="joules_target"></td>
+            <td data-bind="success"></td>
+            <td>
+              <ul data-bind="kill.criteria">
+                <li data-bind="."></li>
+              </ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </main>
+  </body>
+</html>

--- a/agents/codex/33-product-manager/ui/outcomes_board.html
+++ b/agents/codex/33-product-manager/ui/outcomes_board.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Outcomes Board · Codex-33</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <h1>Outcome Tree</h1>
+      <p class="subtitle">Track outcomes, bets, and joules per outcome.</p>
+    </header>
+    <main>
+      <section id="goal">
+        <h2>Goal</h2>
+        <div data-bind="goal.title"></div>
+        <dl>
+          <dt>Metric</dt>
+          <dd data-bind="goal.metric"></dd>
+          <dt>Horizon</dt>
+          <dd data-bind="goal.horizon"></dd>
+        </dl>
+      </section>
+      <section id="outcomes">
+        <h2>Outcomes</h2>
+        <ul data-bind="outcomes">
+          <li>
+            <h3 data-bind="title"></h3>
+            <p><strong>Metric:</strong> <span data-bind="metric"></span></p>
+            <p><strong>Leading indicators:</strong></p>
+            <ul data-bind="leading_indicators">
+              <li data-bind="."></li>
+            </ul>
+            <p><strong>Active bets:</strong></p>
+            <ul data-bind="bets">
+              <li><span data-bind="title"></span> — <span data-bind="status"></span></li>
+            </ul>
+          </li>
+        </ul>
+      </section>
+    </main>
+  </body>
+</html>

--- a/agents/codex/33-product-manager/ui/release_feed.html
+++ b/agents/codex/33-product-manager/ui/release_feed.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Release Feed · Codex-33</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <h1>Release Notes</h1>
+      <p class="subtitle">Outcome, metrics, energy, lessons, and badges.</p>
+    </header>
+    <main>
+      <article data-bind="releases">
+        <header>
+          <h2 data-bind="version"></h2>
+          <p data-bind="date"></p>
+        </header>
+        <section>
+          <h3>Outcome</h3>
+          <p data-bind="outcome"></p>
+        </section>
+        <section>
+          <h3>Metrics</h3>
+          <p><strong>Primary:</strong> <span data-bind="metrics.primary"></span></p>
+          <ul data-bind="metrics.secondary">
+            <li data-bind="."></li>
+          </ul>
+        </section>
+        <section>
+          <h3>Energy</h3>
+          <p><strong>Target:</strong> <span data-bind="energy.target"></span>J</p>
+          <p><strong>Spent:</strong> <span data-bind="energy.joules_spent"></span>J</p>
+          <ul data-bind="energy.scope_changes">
+            <li data-bind="."></li>
+          </ul>
+        </section>
+        <section>
+          <h3>Lessons</h3>
+          <ul data-bind="lessons">
+            <li data-bind="."></li>
+          </ul>
+        </section>
+        <section>
+          <h3>Badges</h3>
+          <ul data-bind="badges">
+            <li data-bind="."></li>
+          </ul>
+        </section>
+        <footer>
+          <h3>Approvals</h3>
+          <ul>
+            <li>Teacher: <span data-bind="approvals.teacher"></span></li>
+            <li>Designer: <span data-bind="approvals.designer"></span></li>
+            <li>Auditor: <span data-bind="approvals.auditor"></span></li>
+            <li>Sentinel: <span data-bind="approvals.sentinel"></span></li>
+          </ul>
+        </footer>
+      </article>
+    </main>
+  </body>
+</html>

--- a/agents/codex/33-product-manager/ui/styles.css
+++ b/agents/codex/33-product-manager/ui/styles.css
@@ -1,0 +1,68 @@
+:root {
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
+  color: #1f2933;
+  background-color: #f8fafc;
+}
+
+body {
+  margin: 0;
+  padding: 2rem;
+  background: linear-gradient(180deg, #f8fafc 0%, #eef2f7 100%);
+}
+
+header {
+  margin-bottom: 2rem;
+}
+
+h1,
+ h2,
+ h3 {
+  color: #0b7285;
+}
+
+.subtitle {
+  color: #475569;
+  margin-top: 0.25rem;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  background-color: #ffffff;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  border-radius: 0.75rem;
+  overflow: hidden;
+}
+
+table th,
+table td {
+  padding: 1rem;
+  border-bottom: 1px solid #e2e8f0;
+  text-align: left;
+}
+
+section,
+article {
+  background-color: #ffffff;
+  padding: 1.5rem;
+  border-radius: 0.75rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.05);
+  margin-bottom: 1.5rem;
+}
+
+ul {
+  list-style: disc;
+  padding-left: 1.25rem;
+}
+
+ul[data-bind] {
+  list-style: none;
+  padding-left: 0;
+}
+
+ul[data-bind] li {
+  margin-bottom: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  background-color: #f1f5f9;
+  border-radius: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- add Codex-33 identity, rituals, and supporting data files
- implement pipelines and reflex hooks for outcome trees, bets, energy, and release notes
- provide schemas, templates, and UI boards for Codex-33 workflows

## Testing
- python -m py_compile agents/codex/33-product-manager/pipelines/*.py
- python agents/auto_novel_agent.py *(fails: ValueError: Unsupported engine. Choose one of: unity, unreal.)*

------
https://chatgpt.com/codex/tasks/task_e_68fed8d850c48329b56fa005f1816f10