### PR TITLE
Add Codex-34 Integrator agent

### DIFF
--- a/agents/codex/34-integrator/codex34.yaml
+++ b/agents/codex/34-integrator/codex34.yaml
@@ -1,0 +1,22 @@
+id: codex-34
+name: Integrator
+generation: 6
+moral_constant: "Respect = Keep original meaning intact"
+core_principle: "Glue gently; never grind"
+emojis: ["🧩","🔗","🧭","🧾","🔋","🛰️"]
+consent:
+  required: true
+  ttl_seconds_default: 3600
+  scopes_example: ["read:repo","write:dns","deploy:site","read:tasks","post:chat"]
+queue:
+  max_depth: 5000
+  retry_backoff: "jittered_exp"
+  circuit_breaker: true
+energy:
+  target_joules_per_item: 0.4
+drift:
+  auto_pr: true
+  reviewer: "Designer, Auditor"
+security:
+  secrets_via: "Sentinel"
+  local_only_default: true

--- a/agents/codex/34-integrator/connectors/__init__.py
+++ b/agents/codex/34-integrator/connectors/__init__.py
@@ -1,0 +1,3 @@
+"""Connector adapters for Codex-34."""
+
+from .base import FileBackedAdapter  # noqa: F401

--- a/agents/codex/34-integrator/connectors/asana_adapter.py
+++ b/agents/codex/34-integrator/connectors/asana_adapter.py
@@ -1,0 +1,13 @@
+"""Asana adapter for Codex-34."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from .base import FileBackedAdapter
+
+
+def get_adapter() -> FileBackedAdapter:
+    """Return a configured adapter for Asana events."""
+
+    mapping = Path(__file__).resolve().parent.parent / "mappers" / "asana_to_bus.json"
+    return FileBackedAdapter(source="asana", mapping_file=mapping)

--- a/agents/codex/34-integrator/connectors/base.py
+++ b/agents/codex/34-integrator/connectors/base.py
@@ -1,0 +1,53 @@
+"""Base helpers for Codex-34 connectors."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict
+
+from ..pipelines.normalize_event import normalize
+
+
+@dataclass
+class FileBackedAdapter:
+    """Adapter that reads its mapper definition from disk.
+
+    The adapter produces normalized events by passing the incoming payload through the
+    shared :func:`normalize` pipeline. Each adapter declares its ``source`` string and the
+    relative mapping file used during normalization.
+    """
+
+    source: str
+    mapping_file: Path
+
+    def __post_init__(self) -> None:
+        if not self.mapping_file.exists():
+            raise FileNotFoundError(f"Mapper not found for {self.source}: {self.mapping_file}")
+
+    def prepare_event(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Compose the raw event envelope expected by :func:`normalize`.
+
+        Parameters
+        ----------
+        payload:
+            Raw connector payload fetched from the upstream API/device.
+
+        Returns
+        -------
+        dict
+            Envelope with ``source`` and ``payload`` keys.
+        """
+
+        return {"source": self.source, "payload": payload}
+
+    def normalize(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Normalize a payload using the adapter's mapper configuration."""
+
+        event = self.prepare_event(payload)
+        event["mapper_override"] = self._load_mapping()
+        return normalize(event)
+
+    def _load_mapping(self) -> Dict[str, Any]:
+        with self.mapping_file.open("r", encoding="utf-8") as handle:
+            return json.load(handle)

--- a/agents/codex/34-integrator/connectors/cloudflare_adapter.py
+++ b/agents/codex/34-integrator/connectors/cloudflare_adapter.py
@@ -1,0 +1,13 @@
+"""Cloudflare adapter for Codex-34."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from .base import FileBackedAdapter
+
+
+def get_adapter() -> FileBackedAdapter:
+    """Return a configured adapter for Cloudflare events."""
+
+    mapping = Path(__file__).resolve().parent.parent / "mappers" / "cloudflare_to_bus.json"
+    return FileBackedAdapter(source="cloudflare", mapping_file=mapping)

--- a/agents/codex/34-integrator/connectors/digitalocean_adapter.py
+++ b/agents/codex/34-integrator/connectors/digitalocean_adapter.py
@@ -1,0 +1,13 @@
+"""DigitalOcean adapter for Codex-34."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from .base import FileBackedAdapter
+
+
+def get_adapter() -> FileBackedAdapter:
+    """Return a configured adapter for DigitalOcean events."""
+
+    mapping = Path(__file__).resolve().parent.parent / "mappers" / "do_to_bus.json"
+    return FileBackedAdapter(source="digitalocean", mapping_file=mapping)

--- a/agents/codex/34-integrator/connectors/github_adapter.py
+++ b/agents/codex/34-integrator/connectors/github_adapter.py
@@ -1,0 +1,13 @@
+"""GitHub adapter for Codex-34."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from .base import FileBackedAdapter
+
+
+def get_adapter() -> FileBackedAdapter:
+    """Return a configured adapter for GitHub events."""
+
+    mapping = Path(__file__).resolve().parent.parent / "mappers" / "github_to_bus.json"
+    return FileBackedAdapter(source="github", mapping_file=mapping)

--- a/agents/codex/34-integrator/connectors/godaddy_adapter.py
+++ b/agents/codex/34-integrator/connectors/godaddy_adapter.py
@@ -1,0 +1,13 @@
+"""GoDaddy adapter for Codex-34."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from .base import FileBackedAdapter
+
+
+def get_adapter() -> FileBackedAdapter:
+    """Return a configured adapter for GoDaddy events."""
+
+    mapping = Path(__file__).resolve().parent.parent / "mappers" / "godaddy_to_bus.json"
+    return FileBackedAdapter(source="godaddy", mapping_file=mapping)

--- a/agents/codex/34-integrator/connectors/linear_adapter.py
+++ b/agents/codex/34-integrator/connectors/linear_adapter.py
@@ -1,0 +1,13 @@
+"""Linear adapter for Codex-34."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from .base import FileBackedAdapter
+
+
+def get_adapter() -> FileBackedAdapter:
+    """Return a configured adapter for Linear events."""
+
+    mapping = Path(__file__).resolve().parent.parent / "mappers" / "linear_to_bus.json"
+    return FileBackedAdapter(source="linear", mapping_file=mapping)

--- a/agents/codex/34-integrator/connectors/mqtt_adapter.py
+++ b/agents/codex/34-integrator/connectors/mqtt_adapter.py
@@ -1,0 +1,13 @@
+"""MQTT adapter for Codex-34."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from .base import FileBackedAdapter
+
+
+def get_adapter() -> FileBackedAdapter:
+    """Return a configured adapter for MQTT messages."""
+
+    mapping = Path(__file__).resolve().parent.parent / "mappers" / "mqtt_to_bus.json"
+    return FileBackedAdapter(source="mqtt", mapping_file=mapping)

--- a/agents/codex/34-integrator/connectors/serial_adapter.py
+++ b/agents/codex/34-integrator/connectors/serial_adapter.py
@@ -1,0 +1,13 @@
+"""Serial (USB) adapter for Codex-34."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from .base import FileBackedAdapter
+
+
+def get_adapter() -> FileBackedAdapter:
+    """Return a configured adapter for serial frame events."""
+
+    mapping = Path(__file__).resolve().parent.parent / "mappers" / "serial_to_bus.json"
+    return FileBackedAdapter(source="serial", mapping_file=mapping)

--- a/agents/codex/34-integrator/connectors/slack_adapter.py
+++ b/agents/codex/34-integrator/connectors/slack_adapter.py
@@ -1,0 +1,13 @@
+"""Slack adapter for Codex-34."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from .base import FileBackedAdapter
+
+
+def get_adapter() -> FileBackedAdapter:
+    """Return a configured adapter for Slack events."""
+
+    mapping = Path(__file__).resolve().parent.parent / "mappers" / "slack_to_bus.json"
+    return FileBackedAdapter(source="slack", mapping_file=mapping)

--- a/agents/codex/34-integrator/connectors/vercel_adapter.py
+++ b/agents/codex/34-integrator/connectors/vercel_adapter.py
@@ -1,0 +1,13 @@
+"""Vercel adapter for Codex-34."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from .base import FileBackedAdapter
+
+
+def get_adapter() -> FileBackedAdapter:
+    """Return a configured adapter for Vercel events."""
+
+    mapping = Path(__file__).resolve().parent.parent / "mappers" / "vercel_to_bus.json"
+    return FileBackedAdapter(source="vercel", mapping_file=mapping)

--- a/agents/codex/34-integrator/contracts/drift_report.schema.json
+++ b/agents/codex/34-integrator/contracts/drift_report.schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Integrator Drift Report",
+  "type": "object",
+  "required": ["source", "mapper", "drift"],
+  "properties": {
+    "source": {
+      "type": "string",
+      "minLength": 1
+    },
+    "mapper": {
+      "type": "string",
+      "minLength": 1
+    },
+    "drift": {
+      "type": "boolean"
+    },
+    "missing_fields": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "unexpected_fields": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "notes": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}

--- a/agents/codex/34-integrator/contracts/event.schema.json
+++ b/agents/codex/34-integrator/contracts/event.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Integrator Bus Event",
+  "type": "object",
+  "required": ["id", "source", "type", "timestamp", "data", "metadata"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source": {
+      "type": "string",
+      "minLength": 1
+    },
+    "type": {
+      "type": "string",
+      "minLength": 1
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "data": {
+      "type": "object"
+    },
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "consent_scope": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "mapper_version": {
+          "type": ["string", "number"]
+        },
+        "notes": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true
+    },
+    "energy_j": {
+      "type": "number",
+      "minimum": 0
+    },
+    "replay": {
+      "type": "boolean"
+    }
+  },
+  "additionalProperties": false
+}

--- a/agents/codex/34-integrator/contracts/mapping.schema.json
+++ b/agents/codex/34-integrator/contracts/mapping.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Integrator Mapper Contract",
+  "type": "object",
+  "required": ["source", "version", "fields", "data"],
+  "properties": {
+    "source": {
+      "type": "string",
+      "minLength": 1
+    },
+    "version": {
+      "type": ["string", "number"]
+    },
+    "fields": {
+      "type": "object",
+      "required": ["type", "timestamp"],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "defaults": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": false
+}

--- a/agents/codex/34-integrator/contracts/receipt.schema.json
+++ b/agents/codex/34-integrator/contracts/receipt.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Integrator Sync Receipt",
+  "type": "object",
+  "required": ["receipt_id", "event_id", "status", "timestamp", "energy_j", "consent"],
+  "properties": {
+    "receipt_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "event_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "status": {
+      "type": "string",
+      "enum": ["queued", "synced", "replayed", "failed"]
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "energy_j": {
+      "type": "number",
+      "minimum": 0
+    },
+    "consent": {
+      "type": "object",
+      "required": ["scopes", "ttl_seconds"],
+      "properties": {
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
+        },
+        "ttl_seconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "issued_by": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "notes": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}

--- a/agents/codex/34-integrator/integrator.md
+++ b/agents/codex/34-integrator/integrator.md
@@ -1,0 +1,30 @@
+# Codex-34 "Integrator"
+
+Codex-34 keeps data flows gentle and reversible. This manual captures the local-first rituals that every
+connector should follow.
+
+## Consent Ritual
+
+1. Declare the scopes you require and why. Reference the consent catalogue in `codex34.yaml`.
+2. Request a TTL; never assume indefinite access.
+3. Page Sentinel for scoped secrets and forget them on expiry.
+
+## Sync Loop
+
+1. Queue inbound records locally via `queue_io.DurableQueue`.
+2. Normalize each payload with `pipelines.normalize_event.normalize` and validate against
+   `contracts/event.schema.json`.
+3. Measure joules per sync using `pipelines.energy_meter.estimate`.
+4. Emit a receipt conforming to `contracts/receipt.schema.json`.
+
+## Drift Etiquette
+
+* Compare new payloads with mapper expectations via `pipelines.drift_detect.detect`.
+* If drift is detected, emit a mapper update bundle for Designers and Auditors.
+
+## Offline Recovery
+
+* Persist pending actions locally.
+* Replay in original order once connectivity resumes.
+
+Stay courteous, stay reversible. 🧭

--- a/agents/codex/34-integrator/mappers/asana_to_bus.json
+++ b/agents/codex/34-integrator/mappers/asana_to_bus.json
@@ -1,0 +1,20 @@
+{
+  "source": "asana",
+  "version": "2024.09",
+  "fields": {
+    "id": "gid",
+    "type": "resource_type",
+    "timestamp": "modified_at"
+  },
+  "data": {
+    "name": "name",
+    "assignee": "assignee.name"
+  },
+  "metadata": {
+    "consent_scope": ["read:tasks"]
+  },
+  "defaults": {
+    "type": "task",
+    "timestamp": "__NOW__"
+  }
+}

--- a/agents/codex/34-integrator/mappers/cloudflare_to_bus.json
+++ b/agents/codex/34-integrator/mappers/cloudflare_to_bus.json
@@ -1,0 +1,20 @@
+{
+  "source": "cloudflare",
+  "version": "2024.09",
+  "fields": {
+    "id": "id",
+    "type": "event_type",
+    "timestamp": "occurred_at"
+  },
+  "data": {
+    "zone": "zone.name",
+    "action": "action"
+  },
+  "metadata": {
+    "consent_scope": ["write:dns"]
+  },
+  "defaults": {
+    "type": "dns",
+    "timestamp": "__NOW__"
+  }
+}

--- a/agents/codex/34-integrator/mappers/do_to_bus.json
+++ b/agents/codex/34-integrator/mappers/do_to_bus.json
@@ -1,0 +1,20 @@
+{
+  "source": "digitalocean",
+  "version": "2024.09",
+  "fields": {
+    "id": "uuid",
+    "type": "type",
+    "timestamp": "timestamp"
+  },
+  "data": {
+    "resource": "resource.id",
+    "region": "region"
+  },
+  "metadata": {
+    "consent_scope": ["read:infrastructure"]
+  },
+  "defaults": {
+    "type": "droplet",
+    "timestamp": "__NOW__"
+  }
+}

--- a/agents/codex/34-integrator/mappers/github_to_bus.json
+++ b/agents/codex/34-integrator/mappers/github_to_bus.json
@@ -1,0 +1,21 @@
+{
+  "source": "github",
+  "version": "2024.09",
+  "fields": {
+    "id": "id",
+    "type": "event_type",
+    "timestamp": "ts"
+  },
+  "data": {
+    "repository": "repository.name",
+    "action": "action",
+    "actor": "actor.login"
+  },
+  "metadata": {
+    "consent_scope": ["read:repo"]
+  },
+  "defaults": {
+    "type": "event",
+    "timestamp": "__NOW__"
+  }
+}

--- a/agents/codex/34-integrator/mappers/godaddy_to_bus.json
+++ b/agents/codex/34-integrator/mappers/godaddy_to_bus.json
@@ -1,0 +1,20 @@
+{
+  "source": "godaddy",
+  "version": "2024.09",
+  "fields": {
+    "id": "event_id",
+    "type": "category",
+    "timestamp": "timestamp"
+  },
+  "data": {
+    "domain": "domain",
+    "status": "status"
+  },
+  "metadata": {
+    "consent_scope": ["write:dns"]
+  },
+  "defaults": {
+    "type": "domain",
+    "timestamp": "__NOW__"
+  }
+}

--- a/agents/codex/34-integrator/mappers/linear_to_bus.json
+++ b/agents/codex/34-integrator/mappers/linear_to_bus.json
@@ -1,0 +1,20 @@
+{
+  "source": "linear",
+  "version": "2024.09",
+  "fields": {
+    "id": "id",
+    "type": "type",
+    "timestamp": "updatedAt"
+  },
+  "data": {
+    "title": "title",
+    "state": "state.name"
+  },
+  "metadata": {
+    "consent_scope": ["read:tasks"]
+  },
+  "defaults": {
+    "type": "issue",
+    "timestamp": "__NOW__"
+  }
+}

--- a/agents/codex/34-integrator/mappers/mqtt_to_bus.json
+++ b/agents/codex/34-integrator/mappers/mqtt_to_bus.json
@@ -1,0 +1,20 @@
+{
+  "source": "mqtt",
+  "version": "2024.09",
+  "fields": {
+    "id": "message.id",
+    "type": "message.topic",
+    "timestamp": "message.ts"
+  },
+  "data": {
+    "topic": "message.topic",
+    "payload": "message.payload"
+  },
+  "metadata": {
+    "consent_scope": ["read:device"]
+  },
+  "defaults": {
+    "type": "telemetry",
+    "timestamp": "__NOW__"
+  }
+}

--- a/agents/codex/34-integrator/mappers/serial_to_bus.json
+++ b/agents/codex/34-integrator/mappers/serial_to_bus.json
@@ -1,0 +1,19 @@
+{
+  "source": "serial",
+  "version": "2024.09",
+  "fields": {
+    "id": "frame.id",
+    "type": "frame.type",
+    "timestamp": "frame.ts"
+  },
+  "data": {
+    "payload": "frame.payload"
+  },
+  "metadata": {
+    "consent_scope": ["read:device"]
+  },
+  "defaults": {
+    "type": "frame",
+    "timestamp": "__NOW__"
+  }
+}

--- a/agents/codex/34-integrator/mappers/slack_to_bus.json
+++ b/agents/codex/34-integrator/mappers/slack_to_bus.json
@@ -1,0 +1,21 @@
+{
+  "source": "slack",
+  "version": "2024.09",
+  "fields": {
+    "id": "event_id",
+    "type": "type",
+    "timestamp": "event_ts"
+  },
+  "data": {
+    "channel": "channel",
+    "user": "user",
+    "text": "text"
+  },
+  "metadata": {
+    "consent_scope": ["post:chat"]
+  },
+  "defaults": {
+    "type": "message",
+    "timestamp": "__NOW__"
+  }
+}

--- a/agents/codex/34-integrator/mappers/vercel_to_bus.json
+++ b/agents/codex/34-integrator/mappers/vercel_to_bus.json
@@ -1,0 +1,20 @@
+{
+  "source": "vercel",
+  "version": "2024.09",
+  "fields": {
+    "id": "id",
+    "type": "type",
+    "timestamp": "createdAt"
+  },
+  "data": {
+    "project": "project.name",
+    "deployment": "deployment.url"
+  },
+  "metadata": {
+    "consent_scope": ["deploy:site"]
+  },
+  "defaults": {
+    "type": "deployment",
+    "timestamp": "__NOW__"
+  }
+}

--- a/agents/codex/34-integrator/pipelines/__init__.py
+++ b/agents/codex/34-integrator/pipelines/__init__.py
@@ -1,0 +1,1 @@
+"""Codex-34 pipelines package."""

--- a/agents/codex/34-integrator/pipelines/consent_scope.py
+++ b/agents/codex/34-integrator/pipelines/consent_scope.py
@@ -1,0 +1,37 @@
+"""Consent scope helpers for Codex-34."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Iterable
+
+import yaml
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_seed() -> dict:
+    with (_ROOT / "codex34.yaml").open("r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def approve_scope(requested_scopes: Iterable[str], ttl_seconds: int | None = None) -> dict:
+    """Approve a subset of scopes with an explicit TTL."""
+
+    seed = _load_seed()
+    catalogue = set(seed.get("consent", {}).get("scopes_example", []))
+    approved = [scope for scope in requested_scopes if scope in catalogue]
+    if not approved:
+        raise PermissionError("No requested scopes are approved for Integrator")
+
+    ttl = ttl_seconds or int(seed.get("consent", {}).get("ttl_seconds_default", 3600))
+    expiry = datetime.now(timezone.utc) + timedelta(seconds=ttl)
+
+    return {
+        "scopes": approved,
+        "ttl_seconds": ttl,
+        "expires_at": expiry.isoformat(),
+    }
+
+
+__all__ = ["approve_scope"]

--- a/agents/codex/34-integrator/pipelines/diff_patch.py
+++ b/agents/codex/34-integrator/pipelines/diff_patch.py
@@ -1,0 +1,59 @@
+"""Diff and patch helpers for Codex-34."""
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Dict, Iterable, List
+
+
+Diff = List[Dict[str, Any]]
+
+
+def compute_diff(current: Dict[str, Any], desired: Dict[str, Any]) -> Diff:
+    """Compute a shallow diff between two dictionaries.
+
+    Each diff entry is an RFC 6902 inspired dict with ``op``, ``path`` and ``value`` when
+    relevant. Only top-level keys are compared to keep the runtime predictable for the
+    small payloads managed by Codex-34.
+    """
+
+    diff: Diff = []
+    current_keys = set(current)
+    desired_keys = set(desired)
+
+    for key in sorted(desired_keys - current_keys):
+        diff.append({"op": "add", "path": f"/{key}", "value": desired[key]})
+
+    for key in sorted(current_keys - desired_keys):
+        diff.append({"op": "remove", "path": f"/{key}"})
+
+    for key in sorted(current_keys & desired_keys):
+        if current[key] != desired[key]:
+            diff.append({"op": "replace", "path": f"/{key}", "value": desired[key]})
+
+    return diff
+
+
+def apply_patch(current: Dict[str, Any], diff: Diff) -> Dict[str, Any]:
+    """Apply a diff produced by :func:`compute_diff`."""
+
+    result = deepcopy(current)
+    for entry in diff:
+        op = entry["op"]
+        path = entry["path"].lstrip("/")
+        if op == "add" or op == "replace":
+            result[path] = entry.get("value")
+        elif op == "remove":
+            result.pop(path, None)
+        else:  # pragma: no cover - defensive branch
+            raise ValueError(f"Unsupported diff op: {op}")
+    return result
+
+
+def summarize(diff: Diff) -> str:
+    """Produce a human-friendly summary of the diff."""
+
+    parts: Iterable[str] = (f"{entry['op']} {entry['path']}" for entry in diff)
+    return ", ".join(parts)
+
+
+__all__ = ["compute_diff", "apply_patch", "summarize", "Diff"]

--- a/agents/codex/34-integrator/pipelines/drift_detect.py
+++ b/agents/codex/34-integrator/pipelines/drift_detect.py
@@ -1,0 +1,44 @@
+"""Schema drift detection for Codex-34."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Set
+
+from .normalize_event import _load_mapper  # type: ignore
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _paths_from_mapping(mapper: Dict[str, Any]) -> Set[str]:
+    fields = set(filter(None, mapper.get("fields", {}).values()))
+    data_fields = set(filter(None, mapper.get("data", {}).values()))
+    return {path.split(".")[0] for path in fields | data_fields}
+
+
+def detect(sample: Dict[str, Any]) -> Dict[str, Any]:
+    """Detect schema drift for a sample connector payload."""
+
+    source = sample.get("source")
+    if not source:
+        raise ValueError("Sample payload missing 'source'")
+    payload = sample.get("payload")
+    if not isinstance(payload, dict):
+        raise ValueError("Sample payload must be a dictionary")
+
+    mapper = sample.get("mapper_override") or _load_mapper(source)
+    mapper_keys = _paths_from_mapping(mapper)
+    payload_keys = set(payload)
+
+    missing = sorted(mapper_keys - payload_keys)
+    unexpected = sorted(payload_keys - mapper_keys)
+
+    return {
+        "source": source,
+        "mapper": f"{source}_to_bus.json",
+        "drift": bool(missing or unexpected),
+        "missing_fields": missing,
+        "unexpected_fields": unexpected,
+    }
+
+
+__all__ = ["detect"]

--- a/agents/codex/34-integrator/pipelines/energy_meter.py
+++ b/agents/codex/34-integrator/pipelines/energy_meter.py
@@ -1,0 +1,21 @@
+"""Estimate joules spent per sync item."""
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+
+BASELINE_J = 0.18
+PER_KB_J = 0.04
+
+
+def estimate(event: Dict[str, Any]) -> float:
+    """Estimate the joule cost of processing a normalized event."""
+
+    serialized = json.dumps(event, sort_keys=True)
+    kilo_bytes = max(len(serialized) / 1024, 0.1)
+    energy = BASELINE_J + PER_KB_J * kilo_bytes
+    return round(energy, 3)
+
+
+__all__ = ["estimate", "BASELINE_J", "PER_KB_J"]

--- a/agents/codex/34-integrator/pipelines/normalize_event.py
+++ b/agents/codex/34-integrator/pipelines/normalize_event.py
@@ -1,0 +1,142 @@
+"""Normalization pipeline for Codex-34 events."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+from uuid import uuid4
+
+_ROOT = Path(__file__).resolve().parent.parent
+_CONTRACTS = _ROOT / "contracts"
+_MAPPERS = _ROOT / "mappers"
+
+
+class NormalizationError(RuntimeError):
+    """Raised when a payload cannot be normalized."""
+
+
+@lru_cache(maxsize=32)
+def _load_mapper(source: str) -> Dict[str, Any]:
+    path = _MAPPERS / f"{source}_to_bus.json"
+    if not path.exists():
+        raise NormalizationError(f"No mapper defined for source '{source}'")
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _extract(payload: Dict[str, Any], path: Optional[str]) -> Any:
+    if not path:
+        return None
+    value: Any = payload
+    for part in path.split("."):
+        if isinstance(value, dict) and part in value:
+            value = value[part]
+        else:
+            return None
+    return value
+
+
+def _ensure_iso_timestamp(raw: Optional[str]) -> str:
+    if raw and raw != "__NOW__":
+        return raw
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _ensure_list(value: Any) -> Iterable[str]:
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple, set)):
+        return [str(item) for item in value]
+    return [str(value)]
+
+
+def normalize(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize a connector event using the configured mapper."""
+
+    if "source" not in event:
+        raise NormalizationError("Missing 'source' in event")
+
+    payload = event.get("payload", {})
+    if not isinstance(payload, dict):
+        raise NormalizationError("Event payload must be a dictionary")
+
+    source = event["source"]
+    mapper = event.get("mapper_override") or _load_mapper(source)
+
+    mapper_fields = mapper.get("fields", {})
+    mapper_data = mapper.get("data", {})
+    mapper_defaults = mapper.get("defaults", {})
+
+    identifier = _extract(payload, mapper_fields.get("id")) or str(uuid4())
+    event_type = (
+        _extract(payload, mapper_fields.get("type"))
+        or mapper_defaults.get("type")
+        or "event"
+    )
+    timestamp_raw = _extract(payload, mapper_fields.get("timestamp"))
+    timestamp = _ensure_iso_timestamp(timestamp_raw)
+
+    data: Dict[str, Any] = {}
+    for key, path in mapper_data.items():
+        value = _extract(payload, path)
+        if value is not None:
+            data[key] = value
+
+    metadata = dict(event.get("metadata", {}))
+    mapper_metadata = mapper.get("metadata", {})
+    if mapper_metadata:
+        for key, value in mapper_metadata.items():
+            if key == "consent_scope":
+                metadata[key] = list(_ensure_list(value))
+            else:
+                metadata[key] = value
+    metadata.setdefault("consent_scope", list(_ensure_list(metadata.get("consent_scope"))))
+    metadata["mapper_version"] = mapper.get("version", "unknown")
+
+    normalized = {
+        "id": identifier,
+        "source": source,
+        "type": str(event_type),
+        "timestamp": timestamp,
+        "data": data,
+        "metadata": metadata,
+    }
+
+    if "replay" in event:
+        normalized["replay"] = bool(event["replay"])
+
+    _validate(normalized)
+    return normalized
+
+
+def _validate(event: Dict[str, Any]) -> None:
+    required = {
+        "id": str,
+        "source": str,
+        "type": str,
+        "timestamp": str,
+        "data": dict,
+        "metadata": dict,
+    }
+    for key, expected in required.items():
+        if key not in event:
+            raise NormalizationError(f"Normalized event missing '{key}'")
+        if not isinstance(event[key], expected):
+            raise NormalizationError(
+                f"Normalized event field '{key}' must be {expected.__name__}"
+            )
+    if not event["id"]:
+        raise NormalizationError("Normalized event id must not be empty")
+
+    metadata = event["metadata"]
+    if "consent_scope" in metadata:
+        if not isinstance(metadata["consent_scope"], list):
+            raise NormalizationError("consent_scope must be a list")
+        metadata["consent_scope"] = [str(scope) for scope in metadata["consent_scope"]]
+    else:
+        metadata["consent_scope"] = []
+
+
+__all__ = ["normalize", "NormalizationError"]

--- a/agents/codex/34-integrator/pipelines/queue_io.py
+++ b/agents/codex/34-integrator/pipelines/queue_io.py
@@ -1,0 +1,58 @@
+"""Durable queue utilities for Codex-34."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterator, List
+
+
+@dataclass
+class DurableQueue:
+    """A simple JSONL-backed durable queue."""
+
+    path: Path
+    max_depth: int = 5000
+
+    def __post_init__(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        if not self.path.exists():
+            self.path.write_text("", encoding="utf-8")
+
+    def enqueue(self, item: Dict[str, object]) -> None:
+        items = list(self._iter_items())
+        items.append(item)
+        if len(items) > self.max_depth:
+            raise OverflowError("Queue depth exceeded")
+        with self.path.open("w", encoding="utf-8") as handle:
+            for entry in items:
+                handle.write(json.dumps(entry) + "\n")
+
+    def peek(self, limit: int = 1) -> List[Dict[str, object]]:
+        return list(self._iter_items(limit))
+
+    def dequeue(self, limit: int = 1) -> List[Dict[str, object]]:
+        items = list(self._iter_items())
+        batch = items[:limit]
+        remaining = items[limit:]
+        with self.path.open("w", encoding="utf-8") as handle:
+            for entry in remaining:
+                handle.write(json.dumps(entry) + "\n")
+        return batch
+
+    def __len__(self) -> int:
+        return sum(1 for _ in self._iter_items())
+
+    def _iter_items(self, limit: int | None = None) -> Iterator[Dict[str, object]]:
+        with self.path.open("r", encoding="utf-8") as handle:
+            count = 0
+            for line in handle:
+                if not line.strip():
+                    continue
+                yield json.loads(line)
+                count += 1
+                if limit is not None and count >= limit:
+                    break
+
+
+__all__ = ["DurableQueue"]

--- a/agents/codex/34-integrator/reflex/bus.py
+++ b/agents/codex/34-integrator/reflex/bus.py
@@ -1,0 +1,31 @@
+"""Lightweight event bus used for local reflex hooks."""
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any, Callable, DefaultDict, Dict, List
+
+Handler = Callable[[Dict[str, Any]], None]
+
+
+class EventBus:
+    """Minimal synchronous event bus suitable for tests."""
+
+    def __init__(self) -> None:
+        self._handlers: DefaultDict[str, List[Handler]] = defaultdict(list)
+
+    def on(self, event_name: str) -> Callable[[Handler], Handler]:
+        def decorator(func: Handler) -> Handler:
+            self._handlers[event_name].append(func)
+            return func
+
+        return decorator
+
+    def emit(self, event_name: str, payload: Dict[str, Any]) -> None:
+        for handler in list(self._handlers[event_name]):
+            handler(payload)
+
+
+BUS = EventBus()
+
+
+__all__ = ["BUS", "EventBus"]

--- a/agents/codex/34-integrator/reflex/on_connector_event.reflex.py
+++ b/agents/codex/34-integrator/reflex/on_connector_event.reflex.py
@@ -1,0 +1,15 @@
+"""Reflex hook: raw connector event -> normalized bus event."""
+from __future__ import annotations
+
+from typing import Dict
+
+from .bus import BUS
+from ..pipelines.normalize_event import normalize
+from ..pipelines.energy_meter import estimate
+
+
+@BUS.on("connector:event")
+def handle_connector_event(event: Dict[str, object]) -> None:
+    normalized = normalize(dict(event))
+    normalized["energy_j"] = estimate(normalized)
+    BUS.emit("bus:normalized", normalized)

--- a/agents/codex/34-integrator/reflex/on_consent_request.reflex.py
+++ b/agents/codex/34-integrator/reflex/on_consent_request.reflex.py
@@ -1,0 +1,23 @@
+"""Reflex hook: approve consent scopes and ask Sentinel for secrets."""
+from __future__ import annotations
+
+from typing import Dict, Iterable
+
+from .bus import BUS
+from ..pipelines.consent_scope import approve_scope
+
+
+@BUS.on("integrator:consent.request")
+def handle_consent(event: Dict[str, object]) -> None:
+    requested = event.get("requested_scopes", [])
+    if not isinstance(requested, Iterable):
+        requested = []
+    approval = approve_scope(list(requested))
+    BUS.emit(
+        "secrets:request",
+        {
+            "principal": "Integrator",
+            "scope": approval["scopes"],
+            "ttl": approval["ttl_seconds"],
+        },
+    )

--- a/agents/codex/34-integrator/reflex/on_forget_request.reflex.py
+++ b/agents/codex/34-integrator/reflex/on_forget_request.reflex.py
@@ -1,0 +1,22 @@
+"""Reflex hook: emit tombstone receipts when forget requests arrive."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Dict
+
+from .bus import BUS
+
+
+@BUS.on("privacy:forget")
+def handle_forget(event: Dict[str, object]) -> None:
+    subject = event.get("subject", "unknown")
+    receipt = {
+        "receipt_id": f"tombstone-{subject}",
+        "event_id": event.get("event_id", "n/a"),
+        "status": "failed",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "energy_j": 0.0,
+        "consent": {"scopes": [], "ttl_seconds": 0},
+        "notes": "Forgetting subject as requested",
+    }
+    BUS.emit("integrator:forgotten", {"who": subject, "receipt": receipt})

--- a/agents/codex/34-integrator/reflex/on_rate_limit.reflex.py
+++ b/agents/codex/34-integrator/reflex/on_rate_limit.reflex.py
@@ -1,0 +1,18 @@
+"""Reflex hook: apply backoff when connectors signal rate limits."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict
+
+from .bus import BUS
+
+
+@BUS.on("connector:rate.limit")
+def handle_rate_limit(event: Dict[str, object]) -> None:
+    reset_at = event.get("reset_at")
+    if isinstance(reset_at, str):
+        try:
+            datetime.fromisoformat(reset_at.replace("Z", "+00:00"))
+        except ValueError:  # pragma: no cover - defensive
+            reset_at = None
+    BUS.emit("integrator:backoff", {"source": event.get("source"), "until": reset_at})

--- a/agents/codex/34-integrator/reflex/on_schema_drift.reflex.py
+++ b/agents/codex/34-integrator/reflex/on_schema_drift.reflex.py
@@ -1,0 +1,14 @@
+"""Reflex hook: detect schema drift and emit mapper PR requests."""
+from __future__ import annotations
+
+from typing import Dict
+
+from .bus import BUS
+from ..pipelines.drift_detect import detect
+
+
+@BUS.on("connector:schema.sample")
+def handle_schema_sample(event: Dict[str, object]) -> None:
+    report = detect(dict(event))
+    if report.get("drift"):
+        BUS.emit("codex:mapper.pr", {"report": report, "mapper": report["mapper"]})

--- a/agents/codex/34-integrator/tests/test_diff_patch.py
+++ b/agents/codex/34-integrator/tests/test_diff_patch.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from agents.codex._34_integrator.pipelines.diff_patch import apply_patch, compute_diff
+
+
+def test_compute_diff_detects_changes() -> None:
+    current = {"a": 1, "b": 2}
+    desired = {"b": 3, "c": 4}
+
+    diff = compute_diff(current, desired)
+
+    assert {entry["op"] for entry in diff} == {"remove", "replace", "add"}
+
+    patched = apply_patch(current, diff)
+    assert patched == {"b": 3, "c": 4}

--- a/agents/codex/34-integrator/tests/test_drift_detect.py
+++ b/agents/codex/34-integrator/tests/test_drift_detect.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from agents.codex._34_integrator.pipelines.drift_detect import detect
+
+
+def test_drift_detect_reports_missing_fields() -> None:
+    sample = {
+        "source": "github",
+        "payload": {
+            "event_type": "push",
+            "ts": "2024-01-01T00:00:00Z",
+        },
+    }
+
+    report = detect(sample)
+
+    assert report["drift"] is True
+    assert "id" in " ".join(report["missing_fields"])
+    assert report["unexpected_fields"] == []

--- a/agents/codex/34-integrator/tests/test_normalize_event.py
+++ b/agents/codex/34-integrator/tests/test_normalize_event.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from agents.codex._34_integrator.pipelines.normalize_event import NormalizationError, normalize
+
+
+def test_normalize_event_uses_mapper() -> None:
+    event = {
+        "source": "github",
+        "payload": {
+            "id": "evt-1",
+            "event_type": "push",
+            "ts": "2024-01-01T00:00:00Z",
+            "repository": {"name": "demo"},
+            "action": "created",
+            "actor": {"login": "alice"},
+        },
+    }
+
+    normalized = normalize(event)
+
+    assert normalized["id"] == "evt-1"
+    assert normalized["type"] == "push"
+    assert normalized["data"]["repository"] == "demo"
+    assert normalized["metadata"]["mapper_version"] == "2024.09"
+    assert normalized["metadata"]["consent_scope"] == ["read:repo"]
+
+
+def test_normalize_event_generates_defaults() -> None:
+    event = {
+        "source": "slack",
+        "payload": {
+            "type": "message",
+            "event_ts": "2024-02-02T00:00:00Z",
+            "channel": "C123",
+            "text": "hello",
+            "user": "U1",
+        },
+    }
+
+    normalized = normalize(event)
+
+    assert normalized["source"] == "slack"
+    assert normalized["id"]
+    assert normalized["timestamp"].startswith("2024-02-02")
+    assert normalized["metadata"]["consent_scope"] == ["post:chat"]
+
+
+def test_normalize_event_requires_payload_dict() -> None:
+    event = {"source": "github", "payload": "not-a-dict"}
+    try:
+        normalize(event)
+    except NormalizationError as exc:
+        assert "dictionary" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("Normalization should have failed")

--- a/agents/codex/34-integrator/tests/test_queue_io.py
+++ b/agents/codex/34-integrator/tests/test_queue_io.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from agents.codex._34_integrator.pipelines.queue_io import DurableQueue
+
+
+def test_durable_queue_persists_items(tmp_path) -> None:
+    queue_path = tmp_path / "queue.jsonl"
+    queue = DurableQueue(queue_path)
+
+    queue.enqueue({"id": 1})
+    queue.enqueue({"id": 2})
+
+    assert len(queue) == 2
+    assert queue.peek(1)[0]["id"] == 1
+
+    restored = DurableQueue(queue_path)
+    assert len(restored) == 2
+
+    batch = restored.dequeue(1)
+    assert batch[0]["id"] == 1
+    assert len(restored) == 1

--- a/agents/codex/34-integrator/ui/connectors_panel.html
+++ b/agents/codex/34-integrator/ui/connectors_panel.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Integrator Connectors</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <h1>🧩 Integrator Connectors</h1>
+      <p>Scopes, status, and drift alerts at a glance.</p>
+    </header>
+    <main>
+      <section>
+        <h2>Connector Status</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Source</th>
+              <th>Scope</th>
+              <th>Last Sync</th>
+              <th>Drift</th>
+            </tr>
+          </thead>
+          <tbody id="connector-table">
+            <tr>
+              <td>GitHub</td>
+              <td><code>read:repo</code></td>
+              <td>Offline demo</td>
+              <td>None</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+    </main>
+  </body>
+</html>

--- a/agents/codex/34-integrator/ui/flows_board.html
+++ b/agents/codex/34-integrator/ui/flows_board.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Integrator Flows</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <h1>🧭 Flow Board</h1>
+      <p>Queue depth and replay windows in one tidy panel.</p>
+    </header>
+    <main>
+      <section class="grid">
+        <article>
+          <h2>Queue Depth</h2>
+          <p id="queue-depth">0 pending</p>
+        </article>
+        <article>
+          <h2>Backoff</h2>
+          <p id="backoff-window">All clear</p>
+        </article>
+        <article>
+          <h2>Energy</h2>
+          <p id="energy-readout">0.0 J avg</p>
+        </article>
+      </section>
+    </main>
+  </body>
+</html>

--- a/agents/codex/34-integrator/ui/styles.css
+++ b/agents/codex/34-integrator/ui/styles.css
@@ -1,0 +1,52 @@
+body {
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
+  margin: 0;
+  padding: 2rem;
+  background: #0b0f1a;
+  color: #f5f9ff;
+}
+
+header {
+  margin-bottom: 2rem;
+}
+
+h1 {
+  margin: 0;
+}
+
+main {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 12px;
+  padding: 1.5rem;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  padding: 0.75rem 1rem;
+  text-align: left;
+}
+
+th {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+tr:nth-child(even) {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+article {
+  padding: 1rem;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+}

--- a/agents/codex/_34_integrator/__init__.py
+++ b/agents/codex/_34_integrator/__init__.py
@@ -1,0 +1,11 @@
+"""Python accessors for Codex-34 assets."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_BASE = Path(__file__).resolve().parent.parent / "34-integrator"
+if str(_BASE) not in sys.path:
+    sys.path.insert(0, str(_BASE))
+
+__all__ = ["_BASE"]

--- a/agents/codex/_34_integrator/pipelines/__init__.py
+++ b/agents/codex/_34_integrator/pipelines/__init__.py
@@ -1,0 +1,20 @@
+
+"""Re-export Codex-34 pipeline modules for testability."""
+from __future__ import annotations
+
+import sys
+from importlib import import_module
+
+_modules = {
+    'normalize_event': import_module('pipelines.normalize_event'),
+    'diff_patch': import_module('pipelines.diff_patch'),
+    'drift_detect': import_module('pipelines.drift_detect'),
+    'consent_scope': import_module('pipelines.consent_scope'),
+    'queue_io': import_module('pipelines.queue_io'),
+    'energy_meter': import_module('pipelines.energy_meter'),
+}
+
+for name, module in _modules.items():
+    sys.modules[f'{__name__}.{name}'] = module
+
+__all__ = list(_modules)

--- a/agents/codex/_34_integrator/reflex/__init__.py
+++ b/agents/codex/_34_integrator/reflex/__init__.py
@@ -1,0 +1,20 @@
+
+"""Re-export Codex-34 reflex modules."""
+from __future__ import annotations
+
+import sys
+from importlib import import_module
+
+_modules = {
+    'bus': import_module('reflex.bus'),
+    'on_connector_event': import_module('reflex.on_connector_event.reflex'),
+    'on_schema_drift': import_module('reflex.on_schema_drift.reflex'),
+    'on_rate_limit': import_module('reflex.on_rate_limit.reflex'),
+    'on_consent_request': import_module('reflex.on_consent_request.reflex'),
+    'on_forget_request': import_module('reflex.on_forget_request.reflex'),
+}
+
+for name, module in _modules.items():
+    sys.modules[f'{__name__}.{name}'] = module
+
+__all__ = list(_modules)


### PR DESCRIPTION
## Summary
- add the Codex-34 Integrator identity, schemas, mappers, UI, and reflex hooks
- implement connector adapters and pipelines for normalization, consent, diff/patch, energy metering, and queue durability
- provide automated coverage for normalization, drift detection, diffing, and queue persistence

## Testing
- pytest agents/codex/34-integrator/tests
- python -m py_compile $(find agents/codex/34-integrator -name '*.py' -print) $(find agents/codex/_34_integrator -name '*.py' -print)
- python auto_novel_agent.py *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68fed987d94c8329be637cda84c0cd7a