### PR TITLE
Fix brctl dispatcher init

### DIFF
--- a/os/brctl
+++ b/os/brctl
@@ -239,6 +239,8 @@ cmd_url() {
 }
 
 main() {
+  load_env
+
   if [[ $# -lt 1 ]]; then
     usage
     exit 1
@@ -271,6 +273,5 @@ main() {
   esac
 }
 
-load_env
 main "$@"
 exit 0


### PR DESCRIPTION
## Summary
- load the compose environment inside the brctl main dispatcher before handling commands

## Testing
- bash -n os/brctl

------
https://chatgpt.com/codex/tasks/task_e_68fee62bba848329b764f99db18d862c