### PR TITLE
Add scaffolding for the 10,000 step execution plan

### DIFF
--- a/data/plans/10000_step_plan.jsonl
+++ b/data/plans/10000_step_plan.jsonl
@@ -1,0 +1,1 @@
+{"schema_version":"0.1","fields":{"step_id":"string","block":"string","title":"string","theme":"string","owner":"string","status":"string","outcome":"string","dependencies":"string[]","artifacts":"string[]","evidence":"object","updated_at":"datetime"}}

--- a/docs/10000_step_plan_scaffolding.md
+++ b/docs/10000_step_plan_scaffolding.md
@@ -1,0 +1,98 @@
+# 10,000 Step Execution Plan — Scaffolding
+
+## Purpose
+- Provide a durable frame for capturing 10,000 incremental steps toward the program vision.
+- Standardize how steps, milestones, dependencies, and evidence are recorded.
+- Give product, research, operations, and finance teams a shared surface to coordinate.
+
+## Plan Architecture
+
+### Step Blocks
+Break the full sequence into 100 **blocks** of 100 steps. Each block carries a theme, a success definition, and routing to the responsible workstream. Use the table below to seed the first ten blocks; clone the structure as additional themes are defined.
+
+| Block | Step Range | Working Theme (seed) | Primary Steward | Success Signal | Status |
+| --- | --- | --- | --- | --- | --- |
+| B01 | 0001–0100 | Foundation & operating cadence | Ops Enablement | Recurring planning and retrospective ritual live | Draft |
+| B02 | 0101–0200 | Identity, access & controls | Security & IAM | Minimum access posture instrumented in dashboards | Draft |
+| B03 | 0201–0300 | Core product instrumentation | Product Analytics | Baseline funnels logging in prod | Draft |
+| B04 | 0301–0400 | Growth motion ignition | Growth | Weekly activation reviews running | Draft |
+| B05 | 0401–0500 | Treasury & finance visibility | Finance | Cash, runway, and revenue dashboards shareable | Draft |
+| B06 | 0501–0600 | Infrastructure hardening | Platform | Golden path deploys w/ rollback docs | Draft |
+| B07 | 0601–0700 | Research & knowledge loops | Research | Research backlog synced w/ publishing cadences | Draft |
+| B08 | 0701–0800 | Ecosystem & partner readiness | Partnerships | Partner intake + enablement loop ready | Draft |
+| B09 | 0801–0900 | Governance & compliance | GRC | Risk register live, review cadence assigned | Draft |
+| B10 | 0901–1000 | Marketplace & monetization | Revenue Ops | Pricing experiments instrumented | Draft |
+
+> **Extend the table**: copy the row structure through `B100` to reserve space for all 10,000 steps. Use themes like "Automation flywheel", "Support & success", or "AI assistants" as the program unfolds.
+
+### Step Definition Template
+Each step lives in Markdown in this document or in a dedicated step log (see Data Surfaces). Use this skeleton:
+
+```
+#### Step #### — <Concise Title>
+- **Outcome:** <measurable result>
+- **Owner:** <team / DRI>
+- **Dependencies:** <linked steps or external conditions>
+- **Inputs:** <docs, repos, datasets>
+- **Artifacts:** <links to PRs, dashboards, datasets>
+- **Verification:** <tests, metrics, review gates>
+- **Status:** Idea | Draft | In Progress | Blocked | Complete
+- **Notes:** <context, decisions>
+```
+
+For dense areas, nest sub-steps beneath a parent heading and reference the canonical step IDs (e.g., `Step 0245.A`).
+
+### Milestone Markers
+Every 1,000 steps, record a "checkpoint" summary capturing:
+- Objectives completed and outstanding
+- KPI deltas (activation, revenue, research throughput, etc.)
+- Risks discovered and mitigations
+- Budget/time burn vs. plan
+
+Link the checkpoint back into the relevant block row.
+
+## Data Surfaces
+
+1. **Markdown canon** — this document (and future block-specific docs) remain the human-readable source of truth.
+2. **Structured log** — create `data/plans/10000_step_plan.jsonl` capturing machine-friendly step entries with the schema below.
+3. **Snapshot views** — optional dashboards (e.g., Looker, Grafana, Notion) ingest the JSONL feed for reporting.
+
+```json
+{
+  "step_id": "0057",
+  "block": "B01",
+  "title": "Stand up weekly operating review",
+  "theme": "Foundation & operating cadence",
+  "owner": "ops",
+  "status": "draft",
+  "outcome": "Weekly review agenda agreed and calendarized",
+  "dependencies": ["0003"],
+  "artifacts": ["docs/runbooks/weekly-review.md"],
+  "evidence": {
+    "metric": "attendance_rate",
+    "target": 0.8
+  },
+  "updated_at": "2025-09-15T00:00:00Z"
+}
+```
+
+> When the structured log is created, enforce ISO-8601 timestamps and lowercase status values to simplify automation.
+
+## Operating Rituals
+- **Weekly**: Review newly proposed steps, validate dependencies, and prioritize next 10.
+- **Bi-weekly**: Demo outcomes for completed steps; archive artifacts in shared storage.
+- **Monthly**: Publish milestone checkpoint, reconcile budget/time actuals, and surface risks.
+- **Quarterly**: Re-evaluate block themes against company objectives; retire or merge blocks as strategies shift.
+
+## Governance & Controls
+- Assign a rotating editor (steward) who ensures step IDs remain unique and progression stays serial.
+- Use pull requests for updates to the plan or JSONL log; require review from at least one steward outside the originating team.
+- Capture decision logs in `docs/decisions/` with cross-links back to step IDs when major course corrections occur.
+
+## Immediate Next Actions
+1. Stand up the `data/plans/` directory with a seed JSONL file containing the schema header (no steps yet).
+2. Expand the block table through `B100` with placeholder themes/owners.
+3. Draft the first 25 steps (B01) to validate the template and catch gaps.
+4. Define automation to lint step files (ID uniqueness, required fields) and schedule it in CI.
+
+Once these four actions are complete, promote the scaffolding to the broader team for population.


### PR DESCRIPTION
## Summary
- add a scaffolding document to organize the upcoming 10,000 step execution plan
- seed a structured JSONL log to back future automation for the plan

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68fee60b4ce08329b709630e3a8afa34