### PR TITLE
fix: restore workspace globs and expose gateway env

### DIFF
--- a/apps/docs-portal/.env.example
+++ b/apps/docs-portal/.env.example
@@ -1,4 +1,4 @@
 # Gateway for execution (optional; leave blank to disable Execute)
-GATEWAY_BASE_URL=http://localhost:8081
+NEXT_PUBLIC_GATEWAY_BASE_URL=http://localhost:8081
 # Optional: only for local dev testing; never commit secrets
 DEV_BEARER_TOKEN=

--- a/apps/docs-portal/components/ExecuteDrawer.tsx
+++ b/apps/docs-portal/components/ExecuteDrawer.tsx
@@ -89,7 +89,7 @@ export function ExecuteDrawer({ runbook }: { runbook: RunbookRecord }) {
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setState({ status: "pending" });
-    const gateway = process.env.GATEWAY_BASE_URL ?? "";
+    const gateway = process.env.NEXT_PUBLIC_GATEWAY_BASE_URL ?? "";
     if (!gateway) {
       setState({ status: "error", message: "Gateway base URL is not configured." });
       return;

--- a/apps/docs-portal/next.config.mjs
+++ b/apps/docs-portal/next.config.mjs
@@ -9,7 +9,7 @@ const config = {
     ignoreDuringBuilds: true
   },
   env: {
-    GATEWAY_BASE_URL: process.env.GATEWAY_BASE_URL || ""
+    NEXT_PUBLIC_GATEWAY_BASE_URL: process.env.NEXT_PUBLIC_GATEWAY_BASE_URL || ""
   }
 };
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,11 @@
 packages:
+  - "apps/*"
+  - "apps/prism/*"
+  - "apps/prism/apps/*"
   - "apps/docs-portal"
+  - "services/*"
+  - "packages/*"
   - "packages/runbook-*"
   - "packages/runbook-types"
+  - "lucidia/autobox/apps/*"
+  - "lucidia/autobox/packages/*"


### PR DESCRIPTION
## Summary
- restore the original pnpm workspace globs so the rest of the monorepo remains part of the workspace
- expose the docs portal gateway configuration via a NEXT_PUBLIC env var for client execution
- document the new public gateway env key in the docs portal example env file

## Testing
- not run (blocked by missing dependencies in the workspace)

------
https://chatgpt.com/codex/tasks/task_e_68fee62eae888329ae563cb98319ad17