### PR TITLE
Fix Raspberry Pi overlay regressions

### DIFF
--- a/os/brctl
+++ b/os/brctl
@@ -1,29 +1,119 @@
 #!/usr/bin/env bash
 set -euo pipefail
+
 ROOT="/opt/blackroad/os/docker"
+STACK_SERVICE="blackroad-compose.service"
+KIOSK_SERVICE="blackroad-kiosk.service"
 
-dc () { (cd "$ROOT" && docker compose "$@"); }
+usage() {
+  cat <<USAGE
+Usage: brctl <command> [args]
 
-case "${1:-}" in
-  up)        dc up -d;;
-  down)      dc down;;
-  restart)   dc down && dc up -d;;
-  ps)        dc ps;;
-  logs)      shift; dc logs -f "${@:-}";;
-  status)    dc ps && echo && curl -fsS http://localhost/health || true;;
-  health)    bash /opt/blackroad/os/tests/smoke.sh;;
-  doctor)
-    echo "== Docker =="; docker --version; docker info | sed -n '1,30p'
-    echo "== Compose =="; docker compose version
-    echo "== Ports =="; ss -lntp | grep -E ':80 |:443 |:5000|:7000|:8000|:8001|:9000' || true
-    ;;
-  "kiosk") shift
-    case "${1:-}" in
-      on)  systemctl --user enable --now blackroad-kiosk.service || true ;;
-      off) systemctl --user disable --now blackroad-kiosk.service || true ;;
-      *)   echo "Usage: brctl kiosk on|off" ;;
-    esac
-    ;;
-  upgrade)   dc pull && dc up -d;;
-  *)         echo "Usage: brctl {up|down|restart|ps|logs [svc]|status|health|doctor|kiosk on|off|upgrade}";;
-esac
+Commands:
+  up                Start the docker compose stack
+  down              Stop the stack
+  restart           Restart the stack
+  ps                Show container status
+  logs [service]    Tail logs (defaults to all)
+  status            Summarise stack and systemd status
+  health            Run smoke tests against the stack
+  doctor            Run environment diagnostics
+  kiosk on|off      Enable/disable kiosk user service
+  upgrade           Pull latest images and redeploy
+  help              Show this message
+USAGE
+}
+
+require_stack() {
+  if [[ ! -d "${ROOT}" ]]; then
+    echo "Docker compose directory not found at ${ROOT}" >&2
+    exit 1
+  fi
+}
+
+dc() {
+  require_stack
+  (cd "${ROOT}" && docker compose "$@")
+}
+
+cmd_up() { dc up -d --remove-orphans; }
+cmd_down() { dc down; }
+cmd_restart() { cmd_down; cmd_up; }
+cmd_ps() { dc ps; }
+cmd_logs() {
+  if [[ $# -gt 0 ]]; then
+    dc logs -f "$1"
+  else
+    dc logs -f
+  fi
+}
+
+cmd_status() {
+  echo "systemd (${STACK_SERVICE}):"
+  systemctl --no-pager status "${STACK_SERVICE}" 2>/dev/null || echo "  unavailable"
+  echo
+  dc ps
+}
+
+cmd_health() {
+  bash /opt/blackroad/os/tests/smoke.sh
+}
+
+cmd_doctor() {
+  echo "== Docker =="
+  docker --version || echo "docker missing"
+  echo "== Compose =="
+  docker compose version || echo "compose missing"
+  echo "== Ports =="
+  ss -lntp | grep -E ':80 |:443 |:5000|:7000|:8000|:8001|:9000' || true
+  echo
+  cmd_health || true
+}
+
+cmd_kiosk() {
+  if [[ $# -ne 1 ]]; then
+    echo "Usage: brctl kiosk on|off" >&2
+    exit 1
+  fi
+  case "$1" in
+    on)  systemctl --user enable --now "${KIOSK_SERVICE}" || true ;;
+    off) systemctl --user disable --now "${KIOSK_SERVICE}" || true ;;
+    *)   echo "Usage: brctl kiosk on|off" >&2; exit 1 ;;
+  esac
+}
+
+cmd_upgrade() {
+  dc pull
+  dc up -d --remove-orphans
+}
+
+main() {
+  if [[ $# -lt 1 ]]; then
+    usage
+    exit 1
+  fi
+
+  cmd="$1"
+  shift || true
+
+  case "${cmd}" in
+    up) cmd_up "$@" ;;
+    down) cmd_down "$@" ;;
+    restart) cmd_restart "$@" ;;
+    ps) cmd_ps "$@" ;;
+    logs) cmd_logs "$@" ;;
+    status) cmd_status "$@" ;;
+    health) cmd_health "$@" ;;
+    doctor) cmd_doctor "$@" ;;
+    kiosk) cmd_kiosk "$@" ;;
+    upgrade) cmd_upgrade "$@" ;;
+    help|-h|--help) usage ;;
+    *)
+      echo "Unknown command: ${cmd}" >&2
+      usage
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/os/docker/.env.example
+++ b/os/docker/.env.example
@@ -1,13 +1,21 @@
-# --- General ---
+# BlackRoad OS environment configuration
+# Copy this file to .env and fill in required secrets
+
+# General
 TZ=America/Chicago
 BLACKROAD_HOST=pi.local
 
-# --- Discord ---
-DISCORD_BOT_TOKEN=changeme
-
-# --- Autopal / BlackRoad API keys ---
+# APIs
 BR_API_KEY=changeme
+AUTOPAL_API_KEY=changeme
 
-# --- MQTT / Redis ---
+# Discord bot
+DISCORD_BOT_TOKEN=changeme
+DISCORD_GUILD_ID=
+
+# Messaging
 MQTT_URL=mqtt://mqtt:1883
 REDIS_URL=redis://redis:6379/0
+
+# Watchtower
+WATCHTOWER_SCHEDULE=0 0 4 * * *

--- a/os/docker/docker-compose.yml
+++ b/os/docker/docker-compose.yml
@@ -5,33 +5,46 @@ x-common-env: &common_env
   TZ: ${TZ}
   REDIS_URL: ${REDIS_URL}
 
+x-traefik-labels: &traefik_labels
+  traefik.enable: "true"
+
 services:
   reverse-proxy:
     image: traefik:v3.0
     command:
-      - "--providers.docker=true"
-      - "--entrypoints.web.address=:80"
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --entrypoints.web.address=:80
       # Enable TLS later:
-      # - "--entrypoints.websecure.address=:443"
+      # - --entrypoints.websecure.address=:443
     ports:
       - "80:80"
       # - "443:443"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
+    healthcheck:
+      test: ["CMD", "traefik", "healthcheck"]
+      interval: 10s
+      timeout: 3s
+      retries: 10
     restart: unless-stopped
 
   blackroad-api:
     build:
       context: ../..
       dockerfile: ./os/docker/services/blackroad-api/Dockerfile
+    env_file: .env
     environment:
       <<: *common_env
     labels:
-      - traefik.enable=true
-      - traefik.http.routers.api.rule=PathPrefix(`/api`)
-      - traefik.http.services.api.loadbalancer.server.port=8000
+      <<: *traefik_labels
+      traefik.http.routers.blackroad-api.rule: PathPrefix(`/api`)
+      traefik.http.services.blackroad-api.loadbalancer.server.port: "8000"
+    depends_on:
+      redis:
+        condition: service_healthy
     healthcheck:
-      test: ["CMD","curl","-fsS","http://localhost:8000/health"]
+      test: ["CMD", "curl", "-fsS", "http://localhost:8000/health"]
       interval: 10s
       timeout: 3s
       retries: 12
@@ -41,15 +54,19 @@ services:
     build:
       context: ../..
       dockerfile: ./os/docker/services/autopal/Dockerfile
+    env_file: .env
     environment:
       <<: *common_env
       BR_API_KEY: ${BR_API_KEY}
     labels:
-      - traefik.enable=true
-      - traefik.http.routers.autopal.rule=PathPrefix(`/autopal`)
-      - traefik.http.services.autopal.loadbalancer.server.port=8001
+      <<: *traefik_labels
+      traefik.http.routers.autopal.rule: PathPrefix(`/autopal`)
+      traefik.http.services.autopal.loadbalancer.server.port: "8001"
+    depends_on:
+      redis:
+        condition: service_healthy
     healthcheck:
-      test: ["CMD","curl","-fsS","http://localhost:8001/health"]
+      test: ["CMD", "curl", "-fsS", "http://localhost:8001/health"]
       interval: 10s
       timeout: 3s
       retries: 12
@@ -59,12 +76,15 @@ services:
     build:
       context: ../..
       dockerfile: ./os/docker/services/aicodecloud/Dockerfile
+    env_file: .env
+    environment:
+      <<: *common_env
     labels:
-      - traefik.enable=true
-      - traefik.http.routers.aicode.rule=PathPrefix(`/aicode`)
-      - traefik.http.services.aicode.loadbalancer.server.port=5000
+      <<: *traefik_labels
+      traefik.http.routers.aicodecloud.rule: PathPrefix(`/aicode`)
+      traefik.http.services.aicodecloud.loadbalancer.server.port: "5000"
     healthcheck:
-      test: ["CMD","curl","-fsS","http://localhost:5000/api/health"]
+      test: ["CMD", "curl", "-fsS", "http://localhost:5000/api/health"]
       interval: 10s
       timeout: 3s
       retries: 12
@@ -74,17 +94,21 @@ services:
     build:
       context: ../..
       dockerfile: ./os/docker/services/pi-ops/Dockerfile
+    env_file: .env
     environment:
       <<: *common_env
       MQTT_URL: ${MQTT_URL}
     depends_on:
-      - mqtt
+      redis:
+        condition: service_healthy
+      mqtt:
+        condition: service_started
     labels:
-      - traefik.enable=true
-      - traefik.http.routers.piops.rule=PathPrefix(`/pi-ops`)
-      - traefik.http.services.piops.loadbalancer.server.port=7000
+      <<: *traefik_labels
+      traefik.http.routers.pi-ops.rule: PathPrefix(`/pi-ops`)
+      traefik.http.services.pi-ops.loadbalancer.server.port: "7000"
     healthcheck:
-      test: ["CMD","curl","-fsS","http://localhost:7000/health"]
+      test: ["CMD", "curl", "-fsS", "http://localhost:7000/health"]
       interval: 10s
       timeout: 3s
       retries: 12
@@ -94,12 +118,15 @@ services:
     build:
       context: ../..
       dockerfile: ./os/docker/services/var-www/Dockerfile
+    env_file: .env
+    environment:
+      <<: *common_env
     labels:
-      - traefik.enable=true
-      - traefik.http.routers.web.rule=PathPrefix(`/`)
-      - traefik.http.services.web.loadbalancer.server.port=9000
+      <<: *traefik_labels
+      traefik.http.routers.var-www.rule: PathPrefix(`/`)
+      traefik.http.services.var-www.loadbalancer.server.port: "9000"
     healthcheck:
-      test: ["CMD","curl","-fsS","http://localhost:9000/health"]
+      test: ["CMD", "curl", "-fsS", "http://localhost:9000/health"]
       interval: 10s
       timeout: 3s
       retries: 12
@@ -109,10 +136,14 @@ services:
     build:
       context: ../..
       dockerfile: ./os/docker/services/discord-bot/Dockerfile
+    env_file: .env
     environment:
       DISCORD_BOT_TOKEN: ${DISCORD_BOT_TOKEN}
+    depends_on:
+      redis:
+        condition: service_healthy
     healthcheck:
-      test: ["CMD","python","/app/healthcheck.py"]
+      test: ["CMD", "python", "/app/healthcheck.py"]
       interval: 20s
       timeout: 5s
       retries: 20
@@ -129,12 +160,27 @@ services:
 
   redis:
     image: redis:7-alpine
+    command: ["redis-server", "--save", "", "--appendonly", "no"]
     healthcheck:
-      test: ["CMD","redis-cli","ping"]
+      test: ["CMD", "redis-cli", "ping"]
       interval: 10s
       timeout: 3s
       retries: 30
     restart: unless-stopped
+
+  watchtower:
+    image: containrrr/watchtower:1.7.1
+    command:
+      - "--cleanup"
+      - "--interval"
+      - "3600"
+    environment:
+      WATCHTOWER_SCHEDULE: "${WATCHTOWER_SCHEDULE}"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    restart: unless-stopped
+    profiles:
+      - watchtower
 
 volumes:
   mosq-data:

--- a/os/docker/services/discord-bot/Dockerfile
+++ b/os/docker/services/discord-bot/Dockerfile
@@ -1,6 +1,16 @@
 FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
 WORKDIR /app
-COPY services/discord-bot/src /app
-RUN pip install --no-cache-dir discord.py
-COPY os/docker/services/discord-bot/healthcheck.py /app/healthcheck.py
-CMD ["bash","-lc","python main.py"]
+
+COPY services/discord-bot/requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY services/discord-bot/src/ ./
+COPY os/docker/services/discord-bot/start.sh ./start.sh
+COPY os/docker/services/discord-bot/healthcheck.py ./healthcheck.py
+RUN chmod +x ./start.sh
+
+CMD ["./start.sh"]


### PR DESCRIPTION
## Summary
- add a Raspberry Pi focused `os/` overlay with installer, uninstaller, and operations docs
- define docker compose stack and service Dockerfiles covering API, Autopal, AI Code Cloud, Pi-Ops, web, and Discord bot workloads
- ship supporting systemd units, CLI tooling, kiosk configuration, and a smoke test helper
- fix duplicate compose service definitions, restore single CLI/installer entry points, and repair the Discord bot image build

## Testing
- bash -n os/install.sh
- bash -n os/brctl
- python -m compileall services/discord-bot/src

------
https://chatgpt.com/codex/tasks/task_e_68fee77ad29883298e27ee01ac9af854