### PR TITLE
Address onboarding security review feedback

### DIFF
--- a/ui/pages/onboarding.tsx
+++ b/ui/pages/onboarding.tsx
@@ -40,7 +40,10 @@ const STATUS_BADGE: Record<string, { label: string; tone: string }> = {
 };
 
 function fetchRegistry(): Promise<RegistrySnapshot> {
-  return fetch("/registry/platform_connections.json", { cache: "no-store" })
+  return fetch("/api/registry/platform_connections", {
+    cache: "no-store",
+    credentials: "include",
+  })
     .then(async (response) => {
       if (!response.ok) {
         throw new Error(`Failed to load registry (${response.status})`);


### PR DESCRIPTION
## Summary
- require an onboarding token for registering agents and for fetching the platform registry
- harden the onboarding script by persisting generated secrets securely, enlarging key fingerprints, and improving remote error handling
- update the dashboard to load registry data through the authenticated API endpoint

## Testing
- python -m py_compile scripts/onboard_agents.py api/auth/register_agent.py

------
https://chatgpt.com/codex/tasks/task_e_68fee960146083298b59af2008d2af46