### PR TITLE
fix(os): avoid pruning unrelated volumes during uninstall

### DIFF
--- a/os/uninstall.sh
+++ b/os/uninstall.sh
@@ -51,8 +51,19 @@ sudo systemctl daemon-reload
 sudo rm -f /usr/local/bin/brctl
 
 if [[ "${PURGE}" == true ]]; then
-  echo "Purging named Docker volumes"
-  docker volume prune -f
+  echo "Purging BlackRoad Docker volumes"
+  if command -v docker >/dev/null 2>&1; then
+    mapfile -t blackroad_volumes < <(docker volume ls --format '{{.Name}}' | awk '/^blackroad_/')
+    if [[ ${#blackroad_volumes[@]} -eq 0 ]]; then
+      echo "No BlackRoad Docker volumes found to purge."
+    else
+      for volume in "${blackroad_volumes[@]}"; do
+        docker volume rm -f "${volume}" || true
+      done
+    fi
+  else
+    echo "Docker not available; unable to purge volumes" >&2
+  fi
 fi
 
 echo "BlackRoad OS components removed. Application data in ${TARGET_DIR} retained."


### PR DESCRIPTION
## Summary
- replace the global `docker volume prune` call in the uninstall script
- explicitly delete only Docker volumes owned by the BlackRoad stack when `--purge` is used

## Testing
- not run (not supported in container)

------
https://chatgpt.com/codex/tasks/task_e_68feed9aef9c832997be26a13bbc206a