### PR TITLE
Add WebDAV and Jetson/Pi connectivity health check

### DIFF
--- a/docs/ops/infrastructure-inventory.md
+++ b/docs/ops/infrastructure-inventory.md
@@ -22,6 +22,7 @@ This quick-reference note collects the assets that keep the BlackRoad stack onli
 
 - Working Copy automation is stubbed throughout the sync scripts (`docs/github-droplet-sync.md`, `scripts/blackroad_sync.sh`). Use these to refresh iOS mirrors after confirming the WebDAV endpoint.
 - WebDAV endpoint for manual sync: `http://192.168.4.55:8080/` (Working Copy server). Record the credential location alongside your password manager entry; this repo intentionally stores only the endpoint.
+- Combined WebDAV + device check: run `./scripts/webdav_device_check.sh` to confirm the Working Copy server responds **and** that the Jetson/Pi hosts still accept SSH.
 - If the iOS mirror falls behind, update `WORKING_COPY_PATH`/`WORKING_COPY_DEVICES` per the sync guide and rerun the refresh step to pull from GitHub and redeploy to the droplet.
 
 ## Raspberry Pi network

--- a/docs/ops/webdav-jetson-pi-check.md
+++ b/docs/ops/webdav-jetson-pi-check.md
@@ -1,0 +1,58 @@
+# WebDAV + Jetson/Pi connectivity check
+
+Use this checklist when you need to confirm that the Working Copy WebDAV mirror
+is reachable without breaking SSH connectivity to the Jetson and Raspberry Pi
+devices on the lab network.
+
+## 1. Verify the WebDAV endpoint
+
+1. Confirm the expected endpoint from the infrastructure inventory: the default
+   Working Copy server listens on `http://192.168.4.55:8080/`.
+2. Run the combined health check script (see below). It pings the host and sends
+   a `PROPFIND` request to make sure the WebDAV service is responding.
+3. If the check fails, restart or reseat the Working Copy host, then re-run the
+   script until you receive `[OK]` for both the ping and the WebDAV request.
+
+## 2. Validate Jetson and Pi connectivity
+
+1. Keep the Jetson on a wired link where possible so `jetson.local` resolves
+   predictably. If you have a static override from `docs/jetson-connectivity.md`
+   follow it before continuing.
+2. Ensure the Raspberry Pi hosts listed in `scripts/pi_network_check.sh` still
+   respond to ping and passwordless SSH.
+3. The combined health check script runs these validations for you; if a device
+   fails ping or SSH, fix the underlying network or key exchange before moving
+   on (restart services, re-add `~/.ssh/known_hosts`, etc.).
+
+## 3. Run the combined health check script
+
+```sh
+./scripts/webdav_device_check.sh
+```
+
+- Default WebDAV endpoint: `http://192.168.4.55:8080/`
+- Default Jetson target: `jetson@jetson.local`
+- Default Pi targets: `lucidia@pi`, `alice@raspberrypi`
+
+Override any of these on the fly:
+
+```sh
+WEBDAV_URL=http://192.168.4.23:3000/ \
+JETSON_HOST=jetson@192.168.4.23 \
+./scripts/webdav_device_check.sh --pi-host lucidia@192.168.4.42 piops@192.168.4.44
+```
+
+The script exits non-zero when any check fails, making it easy to drop into
+monitoring or CI jobs.
+
+## 4. Follow-up when checks fail
+
+- **WebDAV down**: cross-reference the Working Copy runbooks (`docs/github-
+  droplet-sync.md`, `scripts/blackroad_sync.sh`) and restart the sync host.
+- **Jetson unreachable**: fall back to the manual overrides from
+  `docs/jetson-connectivity.md` and verify SSH keys.
+- **Pi unreachable**: refresh the Raspberry Pi playbook (`docs/pi-network-setup.md`)
+  to redo host discovery and key exchange.
+
+Document any permanent IP or hostname changes back in
+`docs/ops/infrastructure-inventory.md` so future responders have the current map.

--- a/scripts/webdav_device_check.sh
+++ b/scripts/webdav_device_check.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WEBDAV_URL=${WEBDAV_URL:-"http://192.168.4.55:8080/"}
+JETSON_HOST=${JETSON_HOST:-"jetson@jetson.local"}
+PI_HOSTS_DEFAULT=("lucidia@pi" "alice@raspberrypi")
+EXTRA_HOSTS=()
+
+usage() {
+  cat <<'USAGE'
+Usage: webdav_device_check.sh [options] [additional_host ...]
+
+Checks the Working Copy WebDAV endpoint and verifies SSH connectivity to the
+Jetson companion plus Raspberry Pi hosts.
+
+Options:
+  --webdav-url <url>   Override the WebDAV endpoint URL (env: WEBDAV_URL)
+  --jetson <host>      Override the Jetson SSH target (env: JETSON_HOST)
+  --pi-host <host>     Add/override a Raspberry Pi SSH target (repeatable)
+  -h, --help           Show this help text
+
+Additional positional arguments are treated as extra SSH targets.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --webdav-url)
+      if [[ $# -lt 2 ]]; then
+        echo "[ERROR] --webdav-url requires a value" >&2
+        exit 1
+      fi
+      WEBDAV_URL=$2
+      shift 2
+      ;;
+    --jetson)
+      if [[ $# -lt 2 ]]; then
+        echo "[ERROR] --jetson requires a value" >&2
+        exit 1
+      fi
+      JETSON_HOST=$2
+      shift 2
+      ;;
+    --pi-host)
+      if [[ $# -lt 2 ]]; then
+        echo "[ERROR] --pi-host requires a value" >&2
+        exit 1
+      fi
+      EXTRA_HOSTS+=("$2")
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      EXTRA_HOSTS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+commands=(curl ping ssh)
+missing=0
+for cmd in "${commands[@]}"; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "[ERROR] Required dependency '$cmd' is not installed" >&2
+    missing=1
+  fi
+done
+
+if [[ $missing -ne 0 ]]; then
+  exit 1
+fi
+
+status=0
+
+printf '\n== WebDAV endpoint check ==\n'
+WEBDAV_HOST=${WEBDAV_URL#*://}
+WEBDAV_HOST=${WEBDAV_HOST%%/*}
+if [[ -z "$WEBDAV_HOST" ]]; then
+  echo "[WARN] Could not determine host from WEBDAV_URL ($WEBDAV_URL)"
+  status=1
+else
+  if ping -c 1 -W 2 "$WEBDAV_HOST" >/dev/null 2>&1; then
+    echo "[OK] WebDAV host $WEBDAV_HOST responded to ping"
+  else
+    echo "[WARN] WebDAV host $WEBDAV_HOST did not respond to ping"
+    status=1
+  fi
+fi
+
+if curl -fsS -o /dev/null -X PROPFIND "$WEBDAV_URL"; then
+  echo "[OK] WebDAV endpoint $WEBDAV_URL responded to PROPFIND"
+else
+  echo "[WARN] WebDAV endpoint $WEBDAV_URL did not respond successfully"
+  status=1
+fi
+
+ALL_HOSTS=("$JETSON_HOST")
+if [[ ${#EXTRA_HOSTS[@]} -gt 0 ]]; then
+  ALL_HOSTS+=("${EXTRA_HOSTS[@]}")
+else
+  ALL_HOSTS+=("${PI_HOSTS_DEFAULT[@]}")
+fi
+
+printf '\n== Device connectivity checks ==\n'
+for host in "${ALL_HOSTS[@]}"; do
+  echo "\n--- $host ---"
+  target=${host#*@}
+  if ping -c 1 -W 2 "$target" >/dev/null 2>&1; then
+    echo "[OK] Host $target responded to ping"
+  else
+    echo "[WARN] Host $target did not respond to ping"
+    status=1
+  fi
+
+  if ssh -o BatchMode=yes -o ConnectTimeout=5 "$host" exit >/dev/null 2>&1; then
+    echo "[OK] SSH connectivity to $host confirmed"
+  else
+    echo "[WARN] Could not establish passwordless SSH session to $host"
+    status=1
+  fi
+
+done
+
+printf '\nSummary: '
+if [[ $status -eq 0 ]]; then
+  echo "all checks passed"
+else
+  echo "review warnings above"
+fi
+
+exit $status


### PR DESCRIPTION
## Summary
- add a combined WebDAV + device connectivity check script for the Working Copy mirror, Jetson, and Raspberry Pis
- document the checklist for keeping WebDAV online while maintaining Jetson/Pi access and link it from the infrastructure inventory

## Testing
- ./scripts/webdav_device_check.sh --help

------
https://chatgpt.com/codex/tasks/task_e_68fef350a8c483299c50b55b36befc26