### PR TITLE
feat: add network heartbeat registry pipeline

### DIFF
--- a/network/registry.json
+++ b/network/registry.json
@@ -1,0 +1,5 @@
+{
+  "network": "blackroad-mesh",
+  "nodes": [],
+  "updated": null
+}

--- a/network/reports/.gitignore
+++ b/network/reports/.gitignore
@@ -1,0 +1,5 @@
+# Ignore node heartbeat reports copied in by remote reporters.
+*.json
+
+# Keep this directory.
+!.gitignore

--- a/systemd/blackroad-agent-report.service
+++ b/systemd/blackroad-agent-report.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=BlackRoad mesh heartbeat reporter
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=-/etc/default/blackroad-agent-report
+ExecStart=/usr/local/bin/blackroad-agent-report.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/blackroad-agent-report.timer
+++ b/systemd/blackroad-agent-report.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run BlackRoad heartbeat reporter every 5 minutes
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+RandomizedDelaySec=30s
+Unit=blackroad-agent-report.service
+
+[Install]
+WantedBy=timers.target

--- a/usr/local/bin/blackroad-agent-report.sh
+++ b/usr/local/bin/blackroad-agent-report.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# BlackRoad Node Reporter — runs on every non-Alice device
+AGENT_ID=${AGENT_ID:-$(hostname)}
+SUPERVISOR=${SUPERVISOR:-alice-pi400.local}
+REPO_DIR=${REPO_DIR:-/home/pi/blackroad-prism-console}
+REPORT_FILE="${REPORT_FILE:-$REPO_DIR/network/status.json}"
+REPORTS_DIR="${REPORTS_DIR:-$REPO_DIR/network/reports}"
+
+mkdir -p "$(dirname "$REPORT_FILE")" "$REPORTS_DIR"
+
+read_cpu_temp() {
+  local thermal_path
+  for thermal_path in /sys/class/thermal/thermal_zone0/temp /sys/class/hwmon/hwmon*/temp1_input; do
+    if [[ -r "$thermal_path" ]]; then
+      awk '{print $1/1000}' "$thermal_path" && return 0
+    fi
+  done
+  echo ""
+}
+
+CPU_TEMP=$(read_cpu_temp || true)
+UPTIME=$(awk '{print int($1/60)}' /proc/uptime 2>/dev/null || echo "")
+LOAD=$(awk '{print $1}' /proc/loadavg 2>/dev/null || echo "")
+AGENT_COUNT=$(pgrep -c blackroad-agent 2>/dev/null || echo "0")
+
+TMP_FILE="$(mktemp)"
+trap 'rm -f "$TMP_FILE"' EXIT
+
+jq -n \
+  --arg id "$AGENT_ID" \
+  --arg time "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+  --arg load "$LOAD" \
+  --arg uptime "$UPTIME" \
+  --arg temp "$CPU_TEMP" \
+  --arg agents "$AGENT_COUNT" \
+  '
+  def num_or_null($v):
+    if ($v | type) == "string" then
+      if ($v | test("^\\s*$")) then null else ($v | tonumber) end
+    else
+      null
+    end;
+  {
+    id: $id,
+    updated: $time,
+    metrics: {
+      load_avg: num_or_null($load),
+      uptime_min: num_or_null($uptime),
+      cpu_temp_c: num_or_null($temp),
+      agents_active: num_or_null($agents)
+    }
+  }
+  ' > "$TMP_FILE"
+
+mv "$TMP_FILE" "$REPORT_FILE"
+
+SUPERVISOR_PATH="pi@${SUPERVISOR}:/home/pi/blackroad-prism-console/network/reports/${AGENT_ID}.json"
+if ! scp -q "$REPORT_FILE" "$SUPERVISOR_PATH"; then
+  echo "[blackroad-agent-report] WARNING: failed to copy report to supervisor ${SUPERVISOR}" >&2
+fi

--- a/usr/local/bin/blackroad-sync.sh
+++ b/usr/local/bin/blackroad-sync.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR=${REPO_DIR:-/home/pi/blackroad-prism-console}
+REGISTRY_FILE=${REGISTRY_FILE:-$REPO_DIR/network/registry.json}
+REPORT_DIR=${REPORT_DIR:-$REPO_DIR/network/reports}
+REMOTE_NAME=${REMOTE_NAME:-origin}
+REMOTE_BRANCH=${REMOTE_BRANCH:-main}
+
+log() {
+  printf '[BlackRoad] %s\n' "$*"
+}
+
+cd "$REPO_DIR"
+
+log "Refreshing repository state from ${REMOTE_NAME}/${REMOTE_BRANCH}..."
+git fetch "$REMOTE_NAME" "$REMOTE_BRANCH"
+git checkout "$REMOTE_BRANCH"
+git pull --ff-only "$REMOTE_NAME" "$REMOTE_BRANCH"
+
+log "Merging incoming node reports..."
+mkdir -p "$REPORT_DIR"
+TMP_REG="$REPO_DIR/network/registry.tmp.json"
+trap 'rm -f "$TMP_REG" "$TMP_REG.tmp"' EXIT
+
+jq -n '{network: "blackroad-mesh", nodes: []}' > "$TMP_REG"
+
+shopt -s nullglob
+for f in "$REPORT_DIR"/*.json; do
+  if jq empty "$f" >/dev/null 2>&1; then
+    jq --slurpfile node "$f" '.nodes += $node' "$TMP_REG" > "$TMP_REG.tmp" && mv "$TMP_REG.tmp" "$TMP_REG"
+  else
+    log "Skipping invalid report: $f"
+  fi
+done
+shopt -u nullglob
+
+jq --arg time "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+   '.updated = $time | .nodes |= sort_by(.id)' \
+   "$TMP_REG" > "$TMP_REG.tmp"
+mv "$TMP_REG.tmp" "$REGISTRY_FILE"
+
+if git diff --quiet -- "$REGISTRY_FILE"; then
+  log "Registry unchanged; nothing to commit."
+else
+  git add "$REGISTRY_FILE"
+  git commit -m "update: merged node reports $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  git push "$REMOTE_NAME" "$REMOTE_BRANCH"
+fi


### PR DESCRIPTION
## Summary
- add a per-node reporter script and timer to publish heartbeat metrics to Alice
- teach the blackroad sync script to assemble incoming node reports into the shared registry
- capture the registry artifact in-repo while ignoring transient report uploads

## Testing
- bash -n usr/local/bin/blackroad-agent-report.sh
- bash -n usr/local/bin/blackroad-sync.sh

------
https://chatgpt.com/codex/tasks/task_e_68ff87933bb083299da24a18281e5c1b