### PR TITLE
Add BlackRoad OS boot sequence experience

### DIFF
--- a/sites/blackroad/src/App.jsx
+++ b/sites/blackroad/src/App.jsx
@@ -10,6 +10,7 @@ import CodexPromptPage from "./pages/CodexPrompt.jsx";
 import CreatorLightpath from "./pages/CreatorLightpath.jsx";
 import Desktop from "./pages/Desktop.jsx";
 import Editor from "./pages/Editor.jsx";
+import BootSequence from "./pages/BootSequence.jsx";
 import InfinityMath from "./pages/InfinityMath.jsx";
 import Lucidia from "./pages/Lucidia.jsx";
 import Monitoring from "./pages/Monitoring.jsx";
@@ -102,6 +103,7 @@ const NAV_LINKS = [
   { to: "/canvas", label: "Canvas" },
   { to: "/editor", label: "Editor" },
   { to: "/terminal", label: "Terminal" },
+  { to: "/boot", label: "Boot Sequence" },
   { to: "/roadview", label: "RoadView" },
   { to: "/backroad", label: "Backroad" },
   { to: "/agents", label: "Agents" },
@@ -120,6 +122,7 @@ const PRIMARY_ROUTE_COMPONENTS = {
   chat: Chat,
   "creator-lightpath": CreatorLightpath,
   editor: Editor,
+  boot: BootSequence,
   lucidia: Lucidia,
   math: InfinityMath,
   monitoring: Monitoring,
@@ -202,6 +205,7 @@ const FEATURE_ROUTES = [
   { path: "canvas", label: "Canvas", component: Canvas },
   { path: "editor", label: "Editor", component: Editor },
   { path: "terminal", label: "Terminal", component: Terminal },
+  { path: "boot", label: "Boot Sequence", component: BootSequence },
   { path: "roadview", label: "RoadView", component: RoadView },
   { path: "backroad", label: "Backroad", component: Backroad },
   { path: "agents", label: "Agents", component: Agents },

--- a/sites/blackroad/src/pages/BootSequence.css
+++ b/sites/blackroad/src/pages/BootSequence.css
@@ -1,0 +1,550 @@
+.boot-sequence {
+  --void: #000000;
+  --void-10: #0a0a0f;
+  --void-20: #13131a;
+  --spectrum-gold: #fdba2d;
+  --spectrum-orange: #ff6b35;
+  --spectrum-pink: #ff4fd8;
+  --spectrum-purple: #c753ff;
+  --spectrum-indigo: #6366f1;
+  --spectrum-blue: #3b82f6;
+  --spectrum-cyan: #06b6d4;
+  --spectrum-green: #10b981;
+  --text: #ffffff;
+  --text-secondary: rgba(255, 255, 255, 0.7);
+  --text-tertiary: rgba(255, 255, 255, 0.5);
+  --gradient-spectrum: linear-gradient(
+    135deg,
+    var(--spectrum-gold) 0%,
+    var(--spectrum-orange) 20%,
+    var(--spectrum-pink) 40%,
+    var(--spectrum-purple) 60%,
+    var(--spectrum-indigo) 80%,
+    var(--spectrum-blue) 100%
+  );
+  --gradient-prism: conic-gradient(
+    from 180deg,
+    var(--spectrum-gold) 0deg,
+    var(--spectrum-orange) 60deg,
+    var(--spectrum-pink) 120deg,
+    var(--spectrum-purple) 180deg,
+    var(--spectrum-indigo) 240deg,
+    var(--spectrum-blue) 300deg,
+    var(--spectrum-gold) 360deg
+  );
+  --glow-spectrum:
+    0 0 40px rgba(255, 79, 216, 0.5),
+    0 0 80px rgba(199, 83, 255, 0.3),
+    0 0 120px rgba(99, 102, 241, 0.2);
+  position: relative;
+  min-height: clamp(640px, 80vh, 960px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--void);
+  color: var(--text);
+  font-family: "Consolas", "Monaco", "Courier New", monospace;
+  overflow: hidden;
+  border-radius: 0.75rem;
+}
+
+.panel > .boot-sequence {
+  margin: -1rem;
+}
+
+.boot-sequence * {
+  box-sizing: border-box;
+}
+
+.boot-sequence .particle-system {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  background: radial-gradient(ellipse at center, var(--void-10) 0%, var(--void) 100%);
+  overflow: hidden;
+}
+
+.boot-sequence .particle {
+  position: absolute;
+  width: 2px;
+  height: 2px;
+  border-radius: 50%;
+  opacity: 0;
+  animation: particleFly 3s ease-out forwards;
+}
+
+@keyframes particleFly {
+  0% {
+    opacity: 0;
+    transform: translate(0, 0) scale(0);
+  }
+  10% {
+    opacity: 1;
+  }
+  90% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+    transform: translate(var(--tx), var(--ty)) scale(1);
+  }
+}
+
+.boot-sequence .boot-container {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  max-width: 1000px;
+  padding: 0 40px;
+  text-align: center;
+}
+
+.boot-sequence .logo-container {
+  margin-bottom: 60px;
+  animation: logoFadeIn 1s ease-out forwards;
+  opacity: 0;
+}
+
+@keyframes logoFadeIn {
+  to {
+    opacity: 1;
+  }
+}
+
+.boot-sequence .logo-ring {
+  width: 200px;
+  height: 200px;
+  margin: 0 auto 30px;
+  position: relative;
+  animation: logoReveal 2s ease-out forwards;
+}
+
+.boot-sequence .logo-ring::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: var(--gradient-prism);
+  border-radius: 50%;
+  animation: rotate 8s linear infinite;
+}
+
+.boot-sequence .logo-ring::after {
+  content: "";
+  position: absolute;
+  inset: 10px;
+  background: var(--void);
+  border-radius: 50%;
+}
+
+@keyframes rotate {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.boot-sequence .logo-symbol {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 5rem;
+  z-index: 1;
+  animation: symbolPulse 2s ease-in-out infinite;
+}
+
+@keyframes symbolPulse {
+  0%,
+  100% {
+    transform: translate(-50%, -50%) scale(1);
+    filter: drop-shadow(0 0 20px rgba(255, 79, 216, 0.5));
+  }
+  50% {
+    transform: translate(-50%, -50%) scale(1.05);
+    filter: drop-shadow(0 0 40px rgba(255, 79, 216, 0.8));
+  }
+}
+
+@keyframes logoReveal {
+  from {
+    transform: scale(0) rotate(0deg);
+    opacity: 0;
+  }
+  to {
+    transform: scale(1) rotate(360deg);
+    opacity: 1;
+  }
+}
+
+.boot-sequence .os-name {
+  font-size: 3.5rem;
+  font-weight: 900;
+  background: var(--gradient-spectrum);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 10px;
+  letter-spacing: 4px;
+  animation: nameGlow 2s ease-in-out infinite;
+}
+
+@keyframes nameGlow {
+  0%,
+  100% {
+    filter: drop-shadow(0 0 10px rgba(255, 79, 216, 0.3));
+  }
+  50% {
+    filter: drop-shadow(0 0 30px rgba(255, 79, 216, 0.6));
+  }
+}
+
+.boot-sequence .os-tagline {
+  font-size: 1rem;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 3px;
+  margin-bottom: 60px;
+}
+
+.boot-sequence .loading-container {
+  margin-bottom: 40px;
+  opacity: 0;
+  animation: fadeIn 0.5s ease-out 1s forwards;
+}
+
+@keyframes fadeIn {
+  to {
+    opacity: 1;
+  }
+}
+
+.boot-sequence .loading-bar {
+  width: 100%;
+  height: 6px;
+  background: var(--void-20);
+  border-radius: 3px;
+  overflow: hidden;
+  position: relative;
+  box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.5);
+}
+
+.boot-sequence .loading-fill {
+  height: 100%;
+  background: var(--gradient-spectrum);
+  width: 0%;
+  animation: loadingProgress 4s ease-out forwards;
+  box-shadow: var(--glow-spectrum);
+  position: relative;
+}
+
+.boot-sequence .loading-fill::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 100px;
+  height: 100%;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.3) 50%,
+    transparent 100%
+  );
+  animation: shimmer 1s ease-in-out infinite;
+}
+
+@keyframes loadingProgress {
+  0% {
+    width: 0%;
+  }
+  10% {
+    width: 15%;
+  }
+  20% {
+    width: 28%;
+  }
+  30% {
+    width: 42%;
+  }
+  40% {
+    width: 55%;
+  }
+  50% {
+    width: 68%;
+  }
+  60% {
+    width: 77%;
+  }
+  70% {
+    width: 85%;
+  }
+  80% {
+    width: 91%;
+  }
+  90% {
+    width: 96%;
+  }
+  100% {
+    width: 100%;
+  }
+}
+
+@keyframes shimmer {
+  0% {
+    transform: translateX(-100px);
+  }
+  100% {
+    transform: translateX(100vw);
+  }
+}
+
+.boot-sequence .loading-percentage {
+  margin-top: 15px;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+
+.boot-sequence .system-checks {
+  text-align: left;
+  max-width: 800px;
+  margin: 0 auto;
+  opacity: 0;
+  animation: fadeIn 0.5s ease-out 1.5s forwards;
+}
+
+.boot-sequence .check-item {
+  display: flex;
+  align-items: center;
+  gap: 15px;
+  padding: 12px 20px;
+  margin-bottom: 8px;
+  background: rgba(255, 255, 255, 0.02);
+  border-left: 3px solid transparent;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  opacity: 0;
+  transform: translateX(-20px);
+  transition: border-color 0.3s ease;
+}
+
+.boot-sequence .check-item.active {
+  animation: checkSlideIn 0.4s ease-out forwards;
+  border-left-color: var(--spectrum-cyan);
+}
+
+.boot-sequence .check-item.complete {
+  border-left-color: var(--spectrum-green);
+}
+
+@keyframes checkSlideIn {
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+.boot-sequence .check-icon {
+  font-size: 1.2rem;
+  width: 24px;
+  text-align: center;
+}
+
+.boot-sequence .check-icon.loading {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.boot-sequence .check-text {
+  flex: 1;
+  color: var(--text-secondary);
+}
+
+.boot-sequence .check-item.complete .check-text {
+  color: var(--text);
+}
+
+.boot-sequence .check-status {
+  font-size: 0.85rem;
+  color: var(--spectrum-green);
+  font-weight: 600;
+}
+
+.boot-sequence .check-item.active .check-status {
+  color: var(--spectrum-cyan);
+}
+
+.boot-sequence .system-info {
+  margin-top: 50px;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 20px;
+  opacity: 0;
+  animation: fadeIn 0.5s ease-out 3s forwards;
+}
+
+.boot-sequence .info-card {
+  padding: 20px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 12px;
+  text-align: center;
+  transition: all 0.3s;
+}
+
+.boot-sequence .info-card:hover {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: var(--spectrum-pink);
+  transform: translateY(-2px);
+}
+
+.boot-sequence .info-icon {
+  font-size: 2rem;
+  margin-bottom: 10px;
+}
+
+.boot-sequence .info-label {
+  font-size: 0.75rem;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  margin-bottom: 8px;
+}
+
+.boot-sequence .info-value {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.boot-sequence .welcome-message {
+  margin-top: 60px;
+  opacity: 0;
+  animation: fadeIn 0.5s ease-out 4s forwards;
+}
+
+.boot-sequence .welcome-text {
+  font-size: 1.3rem;
+  color: var(--text-secondary);
+  margin-bottom: 15px;
+}
+
+.boot-sequence .welcome-subtext {
+  font-size: 0.9rem;
+  color: var(--text-tertiary);
+}
+
+.boot-sequence .boot-complete {
+  position: absolute;
+  inset: 0;
+  background: var(--void);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+  opacity: 0;
+}
+
+.boot-sequence .boot-complete.show {
+  display: flex;
+  animation: fadeIn 0.5s ease-out forwards;
+}
+
+.boot-sequence .complete-message {
+  text-align: center;
+}
+
+.boot-sequence .complete-icon {
+  font-size: 6rem;
+  margin-bottom: 30px;
+  animation: successPulse 1s ease-in-out infinite;
+}
+
+@keyframes successPulse {
+  0%,
+  100% {
+    transform: scale(1);
+    filter: drop-shadow(0 0 30px var(--spectrum-green));
+  }
+  50% {
+    transform: scale(1.1);
+    filter: drop-shadow(0 0 60px var(--spectrum-green));
+  }
+}
+
+.boot-sequence .complete-title {
+  font-size: 3rem;
+  font-weight: 900;
+  background: var(--gradient-spectrum);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 20px;
+}
+
+.boot-sequence .complete-subtitle {
+  font-size: 1.2rem;
+  color: var(--text-secondary);
+  margin-bottom: 40px;
+}
+
+.boot-sequence .press-key {
+  padding: 15px 40px;
+  background: var(--gradient-spectrum);
+  border: none;
+  border-radius: 12px;
+  color: #000000;
+  font-size: 1.1rem;
+  font-weight: 700;
+  cursor: pointer;
+  animation: pressKeyPulse 2s ease-in-out infinite;
+}
+
+@keyframes pressKeyPulse {
+  0%,
+  100% {
+    box-shadow: 0 0 30px rgba(255, 79, 216, 0.5);
+  }
+  50% {
+    box-shadow: 0 0 60px rgba(255, 79, 216, 0.8);
+  }
+}
+
+.boot-sequence .press-key:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.4);
+}
+
+@media (max-width: 768px) {
+  .boot-sequence {
+    padding: 40px 20px;
+  }
+
+  .boot-sequence .os-name {
+    font-size: 2.5rem;
+  }
+
+  .boot-sequence .logo-ring {
+    width: 150px;
+    height: 150px;
+  }
+
+  .boot-sequence .logo-symbol {
+    font-size: 3.5rem;
+  }
+
+  .boot-sequence .system-info {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}

--- a/sites/blackroad/src/pages/BootSequence.jsx
+++ b/sites/blackroad/src/pages/BootSequence.jsx
@@ -1,0 +1,237 @@
+import { useEffect, useRef } from "react";
+import "./BootSequence.css";
+
+const SYSTEM_CHECKS = [
+  { icon: "🔍", text: "Initializing hardware...", status: "CHECKING", delay: 500 },
+  { icon: "💾", text: "Loading kernel modules...", status: "LOADING", delay: 800 },
+  { icon: "🖥️", text: "Initializing display drivers...", status: "ACTIVE", delay: 1100 },
+  { icon: "🌐", text: "Configuring network interfaces...", status: "READY", delay: 1400 },
+  { icon: "🔐", text: "Loading security modules...", status: "SECURED", delay: 1700 },
+  { icon: "🎨", text: "Starting graphical interface...", status: "RENDERING", delay: 2000 },
+  { icon: "🚀", text: "Loading BlackRoad services...", status: "LAUNCHING", delay: 2300 },
+  { icon: "✨", text: "Initializing agent environment...", status: "READY", delay: 2600 }
+];
+
+const SYSTEM_INFO = [
+  { icon: "🧠", label: "Processor", value: "BCM2712 Quad-Core" },
+  { icon: "💾", label: "Memory", value: "8 GB RAM" },
+  { icon: "💿", label: "Storage", value: "128 GB SSD" },
+  { icon: "🌡️", label: "Temperature", value: "42°C" }
+];
+
+const LAUNCH_MESSAGE = `🚀 Launching Desktop...\n\nIn production:\n• Load desktop environment\n• Start all services\n• Open welcome screen\n• Initialize agent hub\n• Connect to network\n• Ready for use!`;
+
+const CONSOLE_ART = `
+    ╔═══════════════════════════════════════╗
+    ║                                       ║
+    ║        BLACKROAD OS v1.0.0            ║
+    ║     Raspberry Pi 5 Edition            ║
+    ║                                       ║
+    ║   BUILD: 2025.10.27                   ║
+    ║   KERNEL: 6.6.31+rpt-rpi-v8           ║
+    ║   ARCH: aarch64                       ║
+    ║                                       ║
+    ║   © 2025 BlackRoad Technologies       ║
+    ║                                       ║
+    ╚═══════════════════════════════════════╝
+
+    Initializing system...
+`;
+
+function showLaunchAlert() {
+  window.alert(LAUNCH_MESSAGE);
+}
+
+export default function BootSequence() {
+  const particlesRef = useRef(null);
+  const checksRef = useRef(null);
+  const percentRef = useRef(null);
+  const progressBarRef = useRef(null);
+  const bootCompleteRef = useRef(null);
+
+  useEffect(() => {
+    const particleContainer = particlesRef.current;
+    const checkItems = checksRef.current
+      ? Array.from(checksRef.current.querySelectorAll(".check-item"))
+      : [];
+    const timeouts = [];
+
+    if (particleContainer) {
+      const colors = ["#ff4fd8", "#c753ff", "#06b6d4", "#10b981", "#fdba2d"];
+
+      for (let i = 0; i < 50; i += 1) {
+        const particle = document.createElement("div");
+        particle.className = "particle";
+        particle.style.left = `${Math.random() * 100}%`;
+        particle.style.top = `${Math.random() * 100}%`;
+        particle.style.setProperty("--tx", `${(Math.random() - 0.5) * 200}px`);
+        particle.style.setProperty("--ty", `${(Math.random() - 0.5) * 200}px`);
+        particle.style.animationDelay = `${Math.random() * 2}s`;
+
+        const color = colors[Math.floor(Math.random() * colors.length)];
+        particle.style.background = color;
+        particle.style.boxShadow = `0 0 10px ${color}`;
+
+        particleContainer.appendChild(particle);
+      }
+    }
+
+    let currentPercent = 0;
+    const percentElement = percentRef.current;
+    const progressBar = progressBarRef.current;
+    const percentInterval = window.setInterval(() => {
+      if (currentPercent < 100) {
+        currentPercent += Math.random() * 3;
+        if (currentPercent > 100) {
+          currentPercent = 100;
+        }
+        if (percentElement) {
+          percentElement.textContent = `${Math.floor(currentPercent)}%`;
+        }
+        if (progressBar) {
+          progressBar.setAttribute("aria-valuenow", `${Math.floor(currentPercent)}`);
+        }
+      } else {
+        window.clearInterval(percentInterval);
+      }
+    }, 100);
+
+    const iconUpdateTimeouts = checkItems.flatMap((check) => {
+      const delay = Number(check.dataset.delay) || 0;
+      const activate = window.setTimeout(() => {
+        check.classList.add("active");
+        const icon = check.querySelector(".check-icon");
+        if (icon) {
+          icon.classList.add("loading");
+        }
+      }, delay);
+
+      const complete = window.setTimeout(() => {
+        check.classList.remove("active");
+        check.classList.add("complete");
+        const icon = check.querySelector(".check-icon");
+        const status = check.querySelector(".check-status");
+        if (icon) {
+          icon.classList.remove("loading");
+          icon.textContent = "✓";
+        }
+        if (status) {
+          status.textContent = "OK";
+        }
+        const text = check.querySelector(".check-text");
+        if (text) {
+          // eslint-disable-next-line no-console
+          console.log("✓ Check complete:", text.textContent);
+        }
+      }, delay + 800);
+
+      return [activate, complete];
+    });
+
+    timeouts.push(...iconUpdateTimeouts);
+
+    const bootScreenTimeout = window.setTimeout(() => {
+      if (bootCompleteRef.current) {
+        bootCompleteRef.current.classList.add("show");
+      }
+    }, 5000);
+    timeouts.push(bootScreenTimeout);
+
+    const handleKeyDown = (event) => {
+      if (event.defaultPrevented) return;
+      if (bootCompleteRef.current?.classList.contains("show")) {
+        showLaunchAlert();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+
+    // eslint-disable-next-line no-console
+    console.log(CONSOLE_ART);
+
+    return () => {
+      window.clearInterval(percentInterval);
+      timeouts.forEach((id) => window.clearTimeout(id));
+      document.removeEventListener("keydown", handleKeyDown);
+      if (particleContainer) {
+        particleContainer.innerHTML = "";
+      }
+    };
+  }, []);
+
+  return (
+    <div className="boot-sequence">
+      <div className="particle-system" ref={particlesRef} aria-hidden="true" />
+
+      <div className="boot-container">
+        <div className="logo-container">
+          <div className="logo-ring">
+            <div className="logo-symbol" role="img" aria-label="Lightning bolt">
+              ⚡
+            </div>
+          </div>
+          <div className="os-name">BLACKROAD OS</div>
+          <div className="os-tagline">RASPBERRY PI 5 • BUILD 2025.10.27</div>
+        </div>
+
+        <div className="loading-container">
+          <div
+            className="loading-bar"
+            role="progressbar"
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={0}
+            ref={progressBarRef}
+          >
+            <div className="loading-fill" />
+          </div>
+          <div className="loading-percentage" ref={percentRef}>
+            0%
+          </div>
+        </div>
+
+        <div className="system-checks" ref={checksRef}>
+          {SYSTEM_CHECKS.map(({ icon, text, status, delay }) => (
+            <div className="check-item" data-delay={delay} key={text}>
+              <div className="check-icon" aria-hidden="true">
+                {icon}
+              </div>
+              <div className="check-text">{text}</div>
+              <div className="check-status">{status}</div>
+            </div>
+          ))}
+        </div>
+
+        <div className="system-info">
+          {SYSTEM_INFO.map(({ icon, label, value }) => (
+            <div className="info-card" key={label}>
+              <div className="info-icon" aria-hidden="true">
+                {icon}
+              </div>
+              <div className="info-label">{label}</div>
+              <div className="info-value">{value}</div>
+            </div>
+          ))}
+        </div>
+
+        <div className="welcome-message">
+          <div className="welcome-text">Welcome to the future of computing</div>
+          <div className="welcome-subtext">BlackRoad OS • Powered by Innovation</div>
+        </div>
+      </div>
+
+      <div className="boot-complete" ref={bootCompleteRef}>
+        <div className="complete-message">
+          <div className="complete-icon" aria-hidden="true">
+            ✓
+          </div>
+          <div className="complete-title">SYSTEM READY</div>
+          <div className="complete-subtitle">BlackRoad OS has successfully loaded</div>
+          <button type="button" className="press-key" onClick={showLaunchAlert}>
+            Press Any Key to Continue
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a Boot Sequence page that renders the BlackRoad OS startup animation with scripted system checks
- introduce dedicated styling for the boot screen including particles, loading bar, and completion overlay
- register the Boot Sequence route within the site navigation and feature links

## Testing
- npm --prefix sites/blackroad run lint *(fails: Cannot find module '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68ff980659748329b70da1ffbfda5fd1