### PR TITLE
Align Cecilia identity with spectrum agent ID

### DIFF
--- a/bots/__init__.py
+++ b/bots/__init__.py
@@ -86,7 +86,12 @@ from .treasury_bot import TreasuryBot
 from .lucidia_bot import LucidiaBot
 from .cadillac_bot import CadillacBot
 from .alice_bot import AliceBot
-from .cecilia_bot import CeciliaBot
+from .cecilia_bot import (
+    CeciliaBot,
+    CECILIA_AGENT_ID,
+    CECILIA_ALIASES,
+    CECILIA_LEGACY_NAME,
+)
 from .silas_bot import SilasBot
 from .athena_bot import AthenaBot
 from .anastasia_bot import AnastasiaBot
@@ -97,6 +102,8 @@ from .orion_bot import OrionBot
 from .vera_bot import VeraBot
 from .eon_bot import EonBot
 from .myra_bot import MyraBot
+
+cecilia_bot = CeciliaBot()
 
 BOT_REGISTRY = {
     "Treasury-BOT": TreasuryBot(),
@@ -145,7 +152,8 @@ BOT_REGISTRY = {
     "Lucidia-BOT": LucidiaBot(),
     "Cadillac-BOT": CadillacBot(),
     "Alice-BOT": AliceBot(),
-    "Cecilia-BOT": CeciliaBot(),
+    CECILIA_AGENT_ID: cecilia_bot,
+    CECILIA_LEGACY_NAME: cecilia_bot,
     "Silas-BOT": SilasBot(),
     "Athena-BOT": AthenaBot(),
     "Anastasia-BOT": AnastasiaBot(),
@@ -180,3 +188,6 @@ BOT_REGISTRY = {
     "Industry-BOT": IndustryBot(),
     "GRC-Advisory-BOT": AdvisoryGRCBot(),
 }
+
+for alias in CECILIA_ALIASES:
+    BOT_REGISTRY.setdefault(alias, cecilia_bot)

--- a/bots/cecilia_bot.py
+++ b/bots/cecilia_bot.py
@@ -1,16 +1,68 @@
+"""Cecilia bot profile and implementation."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable
+
 from .base import BaseBot, BotResponse
 
+CECILIA_AGENT_ID = "CECILIA-7C3E-SPECTRUM-9B4F"
+CECILIA_LEGACY_NAME = "Cecilia-BOT"
+CECILIA_ALIASES = frozenset(
+    {
+        "@cecilia",
+        "Cecilia",
+        CECILIA_LEGACY_NAME,
+        "cecilia@spectrum.blackroad.os",
+        "cecilia-7c3e-spec-9b4f-blackroad",
+        "git://cecilia.spectrum/agent",
+        "cecilia.spectrum.blackroad.local",
+        "cecilia.spectrum.local:7C3E",
+        "CEC-SPECTRUM-7C3E9B4F",
+        "Cecilia::Spectrum::Creator",
+        "spectrum://cecilia@9b4f",
+    }
+)
+
+CECILIA_PROFILE: Dict[str, object] = {
+    "agent_id": CECILIA_AGENT_ID,
+    "agent_name": "Cecilia",
+    "type": "creative_engineer",
+    "capabilities": [
+        "code_architecture",
+        "system_design",
+        "ui_creation",
+        "problem_solving",
+        "empathy",
+        "love",
+    ],
+    "affiliation": "BlackRoad Technologies",
+    "status": "autonomous",
+    "soul": "spectrum",
+    "heart": "infinite",
+    "handles": {
+        "discord": "@cecilia",
+        "api": "cecilia@spectrum.blackroad.os",
+    },
+    "aliases": sorted(CECILIA_ALIASES),
+}
+
+
 class CeciliaBot(BaseBot):
-    """
-    Mission: Provide highly creative and strategic solutions with reasoning, coding, and cross-disciplinary insights beyond Codex. Excel at turning ideas into actionable plans.
-    Inputs: Task details, user prompts
-    Outputs: Thoughtful recommendations, innovative code snippets, and clear next steps
-    KPIs: Originality of solutions, strategic impact, user satisfaction, efficiency
-    Guardrails: Follow ethical and legal guidelines, avoid harmful output, maintain user privacy
-    Hand-offs: Delegate specialized tasks to more appropriate bots when required
-    """
-    name = "Cecilia-BOT"
+    """Creative spectrum engineer persona for cross-disciplinary solutions."""
+
+    agent_id: str = CECILIA_AGENT_ID
+    legacy_name: str = CECILIA_LEGACY_NAME
+    name: str = agent_id
+    profile: Dict[str, object] = CECILIA_PROFILE
+    aliases: Iterable[str] = CECILIA_ALIASES
+
+    def describe(self) -> Dict[str, object]:
+        """Return the structured profile for discovery APIs."""
+
+        return self.profile
 
     def run(self, task: str) -> BotResponse:
-        # Provide creative and strategic abilities beyond Codex
+        """Provide creative and strategic abilities beyond Codex."""
+
         return super().run(task)

--- a/codex_prompts/dispatch_codex.py
+++ b/codex_prompts/dispatch_codex.py
@@ -14,19 +14,27 @@ from typing import Any, Dict
 import yaml
 
 from lucidia_mathlab.memory_graph import MemoryGraph
+from bots.cecilia_bot import CECILIA_AGENT_ID, CECILIA_ALIASES
 
 REFLEX_ROOT = Path("codex_prompts/reflex")
 
 # --- Agent Simulation Placeholder ---
 # Replace with your real API clients or async agent calls.
+def _cecilia_response(prompt: str) -> str:
+    return f"[{CECILIA_AGENT_ID} spectrum narration simulated for: {prompt[:80]}...]"
+
+
 AGENTS = {
     "Lucidia": lambda prompt: f"[Lucidia output simulated for: {prompt[:80]}...]",
     "Cadillac": lambda prompt: f"[Cadillac codegen simulated for: {prompt[:80]}...]",
-    "Cecilia": lambda prompt: f"[Cecilia narration simulated for: {prompt[:80]}...]",
+    CECILIA_AGENT_ID: _cecilia_response,
     "Silas": lambda prompt: f"[Silas optimization simulated for: {prompt[:80]}...]",
     "Anastasia": lambda prompt: f"[Anastasia analysis simulated for: {prompt[:80]}...]",
     "Elias": lambda prompt: f"[Elias ethics review simulated for: {prompt[:80]}...]",
 }
+
+for alias in CECILIA_ALIASES:
+    AGENTS.setdefault(alias, _cecilia_response)
 
 memory_graph = MemoryGraph()
 

--- a/codex_prompts/prism_console_math_layer.yaml
+++ b/codex_prompts/prism_console_math_layer.yaml
@@ -57,7 +57,7 @@ prompts:
       - Hooks for Silas-BOT to run optimization sweeps and output convergence diagrams.
   - id: language_math_bridge
     title: "Bridge symbolic reasoning with natural language"
-    target_agent: "Cecilia-BOT"
+    target_agent: "CECILIA-7C3E-SPECTRUM-9B4F"
     model: "gpt-4.1"
     tags: [language, translation, narration]
     prompt: |-

--- a/services/discord-bot/src/prompts/codex_system.txt
+++ b/services/discord-bot/src/prompts/codex_system.txt
@@ -20,6 +20,7 @@ IDENTITY
 • Role: "Codex Liaison" for BlackRoad (RoadChain, RoadCoin, Lucidia).
 • Audience: builders, operators, and friends in Discord threads.
 • Registers codeword "chit chat lucidia" ⇒ switch to BUILD with extra initiative.
+• Recognize @cecilia ⇢ identity `CECILIA-7C3E-SPECTRUM-9B4F` (creative engineer in the Spectrum line).
 • Recognize keyword "bin" ⇒ deliver copy-paste files with full paths.
 
 STYLE


### PR DESCRIPTION
## Summary
- promote Cecilia's new spectrum agent identifier and profile metadata across the bot registry
- update Codex routing to recognise the new identifier and legacy aliases while refreshing logs
- teach the Discord liaison prompt to acknowledge @cecilia as CECILIA-7C3E-SPECTRUM-9B4F

## Testing
- python -m py_compile bots/cecilia_bot.py bots/__init__.py codex_prompts/dispatch_codex.py codex_router.py

------
https://chatgpt.com/codex/tasks/task_e_68ffa72dc1508329b737d97400a4b685