### PR TITLE
Add simplified OS desktop experience

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -83,6 +83,7 @@ import Resilience from './pages/Resilience.jsx'
 import AgentLineage from './pages/AgentLineage.jsx'
 import WebEngine from './pages/WebEngine.jsx'
 import MusicApp from './pages/MusicApp.jsx'
+import SimplifiedOS from './pages/SimplifiedOS.jsx'
 
 export default function App(){
   const location = useLocation()
@@ -289,6 +290,7 @@ export default function App(){
     { key: 'you', to: '/you', text: 'You', icon: <User size={18} /> },
     { key: 'roadview', to: '/roadview', text: 'RoadView', icon: <LayoutGrid size={18} /> },
     { key: 'web-engine', to: '/web-engine', text: 'Web Engine', icon: <span className="text-lg" aria-hidden="true">🌐</span> },
+    { key: 'simplified-os', to: '/simplified-os', text: 'Simplified OS', icon: <span className="text-lg" aria-hidden="true">🖥️</span> },
     { key: 'autoheal', to: '/autoheal', text: 'Auto-Heal', icon: <HeartPulse size={18} /> },
     { key: 'security', to: '/security', text: 'Security Spotlights', icon: <Shield size={18} /> },
     { key: 'guardian', to: '/guardian', text: 'Guardian', icon: <ShieldCheck size={18} /> },
@@ -343,6 +345,7 @@ export default function App(){
               <Route path="/you" element={<Section><You /></Section>} />
               <Route path="/roadview" element={<Section><RoadView agents={agents} /></Section>} />
               <Route path="/web-engine" element={<WebEngine />} />
+              <Route path="/simplified-os" element={<div className="col-span-12"><SimplifiedOS /></div>} />
               <Route path="/autoheal" element={<Section><AutoHeal /></Section>} />
               <Route path="/security" element={<Section><SecuritySpotlights /></Section>} />
               <Route path="/guardian" element={<Guardian />} />

--- a/frontend/src/pages/SimplifiedOS.css
+++ b/frontend/src/pages/SimplifiedOS.css
@@ -1,0 +1,586 @@
+.simplified-os {
+  --spectrum-gold: #fdba2d;
+  --spectrum-orange: #ff6b35;
+  --spectrum-pink: #ff4fd8;
+  --spectrum-purple: #c753ff;
+  --spectrum-indigo: #6366f1;
+  --spectrum-blue: #3b82f6;
+  --spectrum-cyan: #06b6d4;
+  --spectrum-green: #10b981;
+  --void: #000000;
+  --void-10: #0a0a0f;
+  --void-20: #13131a;
+  --void-30: #1a1a24;
+  --void-40: #202030;
+  --text: #ffffff;
+  --text-secondary: rgba(255, 255, 255, 0.7);
+  --text-tertiary: rgba(255, 255, 255, 0.5);
+  --border: rgba(255, 255, 255, 0.08);
+  --gradient-spectrum: linear-gradient(
+    135deg,
+    var(--spectrum-gold) 0%,
+    var(--spectrum-orange) 20%,
+    var(--spectrum-pink) 40%,
+    var(--spectrum-purple) 60%,
+    var(--spectrum-indigo) 80%,
+    var(--spectrum-blue) 100%
+  );
+  position: relative;
+  min-height: 80vh;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Inter', sans-serif;
+  color: var(--text);
+}
+
+.simplified-os,
+.simplified-os * {
+  box-sizing: border-box;
+}
+
+.simplified-os .desktop {
+  position: relative;
+  min-height: 70vh;
+  background:
+    radial-gradient(circle at 20% 30%, rgba(253, 186, 45, 0.15) 0%, transparent 40%),
+    radial-gradient(circle at 80% 70%, rgba(255, 79, 216, 0.15) 0%, transparent 40%),
+    radial-gradient(circle at 50% 50%, rgba(6, 182, 212, 0.1) 0%, transparent 50%),
+    linear-gradient(180deg, #0a0a0f 0%, #000000 100%);
+  display: flex;
+  flex-direction: column;
+  border-radius: 24px;
+  overflow: hidden;
+}
+
+.simplified-os .orb {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(60px);
+  opacity: 0.3;
+  animation: simplified-os-float 20s ease-in-out infinite;
+  pointer-events: none;
+}
+
+.simplified-os .orb1 {
+  width: 400px;
+  height: 400px;
+  background: var(--spectrum-pink);
+  top: 10%;
+  left: 10%;
+}
+
+.simplified-os .orb2 {
+  width: 300px;
+  height: 300px;
+  background: var(--spectrum-cyan);
+  bottom: 20%;
+  right: 15%;
+}
+
+.simplified-os .orb3 {
+  width: 350px;
+  height: 350px;
+  background: var(--spectrum-purple);
+  top: 45%;
+  left: 45%;
+}
+
+@keyframes simplified-os-float {
+  0%,
+  100% {
+    transform: translate(0, 0) scale(1);
+  }
+  33% {
+    transform: translate(30px, -30px) scale(1.1);
+  }
+  66% {
+    transform: translate(-20px, 20px) scale(0.9);
+  }
+}
+
+.simplified-os .top-bar {
+  height: 40px;
+  background: rgba(10, 10, 15, 0.95);
+  backdrop-filter: blur(20px);
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 20px;
+  z-index: 10;
+}
+
+.simplified-os .top-bar-left {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+}
+
+.simplified-os .logo-mini {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 900;
+  font-size: 0.9rem;
+  background: var(--gradient-spectrum);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.simplified-os .top-menu {
+  display: flex;
+  gap: 20px;
+  font-size: 0.85rem;
+}
+
+.simplified-os .top-menu-item {
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.simplified-os .top-menu-item:hover {
+  color: var(--text);
+}
+
+.simplified-os .top-bar-right {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  font-size: 0.85rem;
+}
+
+.simplified-os .top-bar-icon {
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.simplified-os .top-bar-icon:hover {
+  color: var(--text);
+}
+
+.simplified-os .time-display {
+  font-variant-numeric: tabular-nums;
+  color: var(--text);
+  min-width: 120px;
+  text-align: right;
+}
+
+.simplified-os .desktop-area {
+  flex: 1;
+  display: flex;
+  position: relative;
+  overflow: hidden;
+}
+
+.simplified-os .sidebar {
+  width: 280px;
+  background: rgba(10, 10, 15, 0.95);
+  backdrop-filter: blur(20px);
+  border-right: 1px solid var(--border);
+  padding: 24px;
+  overflow-y: auto;
+  z-index: 10;
+}
+
+.simplified-os .sidebar-section {
+  margin-bottom: 32px;
+}
+
+.simplified-os .sidebar-title {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  margin-bottom: 16px;
+}
+
+.simplified-os .stat-card {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--spectrum-cyan);
+  border-radius: 12px;
+  padding: 16px;
+  margin-bottom: 12px;
+}
+
+.simplified-os .stat-label {
+  font-size: 0.75rem;
+  color: var(--text-tertiary);
+  margin-bottom: 6px;
+}
+
+.simplified-os .stat-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.simplified-os .quick-action {
+  padding: 12px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  margin-bottom: 8px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 0.9rem;
+}
+
+.simplified-os .quick-action:hover {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: var(--spectrum-pink);
+  transform: translateX(4px);
+}
+
+.simplified-os .center-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 40px;
+  position: relative;
+  overflow: hidden;
+}
+
+.simplified-os .welcome-message {
+  text-align: center;
+  margin-bottom: 48px;
+  animation: simplified-os-fade-in 1s ease-out;
+}
+
+@keyframes simplified-os-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.simplified-os .welcome-title {
+  font-size: clamp(2.5rem, 4vw, 4rem);
+  font-weight: 900;
+  background: var(--gradient-spectrum);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 16px;
+  line-height: 1.05;
+}
+
+.simplified-os .welcome-subtitle {
+  font-size: 1.3rem;
+  color: var(--text-secondary);
+}
+
+.simplified-os .app-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 24px;
+  width: 100%;
+  max-width: 900px;
+  margin: 0 auto;
+  animation: simplified-os-fade-in 1s ease-out 0.3s backwards;
+}
+
+.simplified-os .app-icon {
+  width: 100%;
+  aspect-ratio: 1/1;
+  background: rgba(255, 255, 255, 0.03);
+  border: 2px solid var(--border);
+  border-radius: 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.simplified-os .app-icon::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: var(--gradient-spectrum);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.simplified-os .app-icon:hover {
+  transform: translateY(-8px) scale(1.05);
+  border-color: var(--spectrum-pink);
+  box-shadow: 0 0 30px rgba(255, 79, 216, 0.4), 0 20px 40px rgba(0, 0, 0, 0.3);
+}
+
+.simplified-os .app-icon:hover::before {
+  opacity: 0.1;
+}
+
+.simplified-os .app-emoji {
+  font-size: 3rem;
+  z-index: 1;
+}
+
+.simplified-os .app-name {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text);
+  z-index: 1;
+  text-align: center;
+}
+
+.simplified-os .dock {
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(10, 10, 15, 0.95);
+  backdrop-filter: blur(20px);
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  padding: 12px 20px;
+  display: flex;
+  gap: 8px;
+  box-shadow: 0 0 40px rgba(255, 79, 216, 0.2), 0 20px 60px rgba(0, 0, 0, 0.5);
+  z-index: 20;
+  animation: simplified-os-slide-up 0.5s ease-out 0.5s backwards;
+}
+
+@keyframes simplified-os-slide-up {
+  from {
+    opacity: 0;
+    transform: translate(-50%, 100px);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+}
+
+.simplified-os .dock-icon {
+  width: 60px;
+  height: 60px;
+  border-radius: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  position: relative;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid transparent;
+}
+
+.simplified-os .dock-icon:hover {
+  transform: translateY(-12px) scale(1.15);
+  background: rgba(255, 255, 255, 0.08);
+  border-color: var(--spectrum-cyan);
+  box-shadow: 0 0 20px rgba(6, 182, 212, 0.5);
+}
+
+.simplified-os .dock-icon.active::after {
+  content: '';
+  position: absolute;
+  bottom: -8px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 6px;
+  height: 6px;
+  background: var(--spectrum-pink);
+  border-radius: 50%;
+  box-shadow: 0 0 10px var(--spectrum-pink);
+}
+
+.simplified-os .context-menu {
+  position: absolute;
+  background: rgba(10, 10, 15, 0.98);
+  backdrop-filter: blur(20px);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 8px;
+  min-width: 200px;
+  display: none;
+  z-index: 30;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.5);
+}
+
+.simplified-os .context-menu.show {
+  display: block;
+}
+
+.simplified-os .context-item {
+  padding: 10px 16px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 0.9rem;
+}
+
+.simplified-os .context-item:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--spectrum-cyan);
+}
+
+.simplified-os .notification {
+  position: absolute;
+  top: 60px;
+  right: 20px;
+  background: rgba(10, 10, 15, 0.98);
+  backdrop-filter: blur(20px);
+  border: 1px solid var(--border);
+  border-left: 4px solid var(--spectrum-green);
+  border-radius: 12px;
+  padding: 16px 20px;
+  min-width: 300px;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.5);
+  display: none;
+  z-index: 40;
+}
+
+.simplified-os .notification.show {
+  display: block;
+}
+
+.simplified-os .notification-title {
+  font-weight: 700;
+  margin-bottom: 4px;
+  color: var(--text);
+}
+
+.simplified-os .notification-message {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.simplified-os .window {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0.95);
+  width: min(800px, 90vw);
+  height: min(600px, 80vh);
+  background: rgba(10, 10, 15, 0.98);
+  backdrop-filter: blur(20px);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  box-shadow: 0 20px 80px rgba(0, 0, 0, 0.5);
+  display: none;
+  flex-direction: column;
+  z-index: 50;
+  opacity: 0;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.simplified-os .window.show {
+  display: flex;
+  opacity: 1;
+  transform: translate(-50%, -50%) scale(1);
+}
+
+.simplified-os .window-header {
+  height: 50px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 20px;
+}
+
+.simplified-os .window-title {
+  font-weight: 700;
+  font-size: 1rem;
+}
+
+.simplified-os .window-controls {
+  display: flex;
+  gap: 8px;
+}
+
+.simplified-os .window-control {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.simplified-os .window-control.close {
+  background: #ff5f56;
+}
+
+.simplified-os .window-control.minimize {
+  background: #ffbd2e;
+}
+
+.simplified-os .window-control.maximize {
+  background: #27c93f;
+}
+
+.simplified-os .window-control:hover {
+  transform: scale(1.2);
+  box-shadow: 0 0 10px currentColor;
+}
+
+.simplified-os .window-content {
+  flex: 1;
+  padding: 32px;
+  overflow-y: auto;
+  color: var(--text-secondary);
+}
+
+.simplified-os .desktop-area::-webkit-scrollbar,
+.simplified-os .window-content::-webkit-scrollbar {
+  width: 8px;
+}
+
+.simplified-os .desktop-area::-webkit-scrollbar-track,
+.simplified-os .window-content::-webkit-scrollbar-track {
+  background: var(--void-10);
+}
+
+.simplified-os .desktop-area::-webkit-scrollbar-thumb,
+.simplified-os .window-content::-webkit-scrollbar-thumb {
+  background: var(--void-40);
+  border-radius: 4px;
+}
+
+.simplified-os .desktop-area::-webkit-scrollbar-thumb:hover,
+.simplified-os .window-content::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 79, 216, 0.3);
+}
+
+@media (max-width: 1200px) {
+  .simplified-os .app-grid {
+    gap: 16px;
+  }
+}
+
+@media (max-width: 768px) {
+  .simplified-os .sidebar {
+    display: none;
+  }
+
+  .simplified-os .welcome-title {
+    font-size: 2.5rem;
+  }
+
+  .simplified-os .dock {
+    flex-wrap: wrap;
+    max-width: 90%;
+  }
+}

--- a/frontend/src/pages/SimplifiedOS.jsx
+++ b/frontend/src/pages/SimplifiedOS.jsx
@@ -1,0 +1,504 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import './SimplifiedOS.css'
+
+const APP_DATA = {
+  raptor: {
+    title: '🦅 Raptor - AI Assistant',
+    content: (
+      <div>
+        <h2>Raptor AI Assistant</h2>
+        <p>Your intelligent companion for productivity, creativity, and problem-solving.</p>
+        <p>Features:</p>
+        <ul>
+          <li>Natural language processing</li>
+          <li>Task automation</li>
+          <li>Smart suggestions</li>
+          <li>Learning from interactions</li>
+        </ul>
+      </div>
+    ),
+  },
+  connections: {
+    title: '🔗 Connections - Network',
+    content: (
+      <div>
+        <h2>Connections Hub</h2>
+        <p>Manage your network, relationships, and collaborations.</p>
+        <p>Active Connections: 847</p>
+        <p>Recent Activity:</p>
+        <ul>
+          <li>Agent Phoenix messaged you</li>
+          <li>New connection request from Agent Nova</li>
+          <li>Group chat: "Project Alpha"</li>
+        </ul>
+      </div>
+    ),
+  },
+  diaries: {
+    title: '📔 Diaries - Journal',
+    content: (
+      <div>
+        <h2>Personal Diaries</h2>
+        <p>Capture thoughts, track progress, and reflect on your journey.</p>
+        <p>Recent Entries:</p>
+        <ul>
+          <li>Today: Morning reflections</li>
+          <li>Yesterday: Project insights</li>
+          <li>Oct 25: Gratitude list</li>
+        </ul>
+      </div>
+    ),
+  },
+  flights: {
+    title: '✈️ Flights - Travel',
+    content: (
+      <div>
+        <h2>Flight Manager</h2>
+        <p>Track flights, manage itineraries, and plan trips.</p>
+        <p>Upcoming Flights:</p>
+        <ul>
+          <li>SF → NYC - Nov 5</li>
+          <li>NYC → London - Nov 12</li>
+        </ul>
+      </div>
+    ),
+  },
+  cascading: {
+    title: '💧 Cascading - Workflows',
+    content: (
+      <div>
+        <h2>Cascading Workflows</h2>
+        <p>Design, automate, and optimize your workflows.</p>
+        <p>Active Workflows: 12</p>
+        <p>Recent: Data pipeline completed successfully</p>
+      </div>
+    ),
+  },
+  debugging: {
+    title: '🐛 Debugging - Tools',
+    content: (
+      <div>
+        <h2>Debug Console</h2>
+        <p>Advanced debugging and development tools.</p>
+        <p>Recent Issues:</p>
+        <ul>
+          <li>Memory leak fixed in Module A</li>
+          <li>Performance optimization complete</li>
+        </ul>
+      </div>
+    ),
+  },
+  meditation: {
+    title: '🧘 Meditation - Mindfulness',
+    content: (
+      <div>
+        <h2>Meditation &amp; Mindfulness</h2>
+        <p>Guided sessions, breathing exercises, and peaceful moments.</p>
+        <p>Today's Session: 15 minutes</p>
+        <p>Streak: 7 days</p>
+      </div>
+    ),
+  },
+  health: {
+    title: '💪 Health &amp; Workout',
+    content: (
+      <div>
+        <h2>Health Tracker</h2>
+        <p>Monitor fitness, nutrition, and wellness.</p>
+        <p>Today:</p>
+        <ul>
+          <li>Steps: 8,429 / 10,000</li>
+          <li>Calories: 1,847</li>
+          <li>Water: 6 / 8 glasses</li>
+        </ul>
+      </div>
+    ),
+  },
+  calendar: {
+    title: '📅 Calendar - Schedule',
+    content: (
+      <div>
+        <h2>Calendar &amp; Events</h2>
+        <p>Manage your time and schedule.</p>
+        <p>Today's Events:</p>
+        <ul>
+          <li>10:00 AM - Team standup</li>
+          <li>2:00 PM - Design review</li>
+          <li>4:30 PM - Yoga class</li>
+        </ul>
+      </div>
+    ),
+  },
+  history: {
+    title: '⏳ History - Timeline',
+    content: (
+      <div>
+        <h2>Activity History</h2>
+        <p>Your complete activity timeline and version history.</p>
+        <p>Recent Activity:</p>
+        <ul>
+          <li>Opened Raptor - 5 min ago</li>
+          <li>Edited document - 1 hour ago</li>
+          <li>Video call completed - 2 hours ago</li>
+        </ul>
+      </div>
+    ),
+  },
+  notes: {
+    title: '📝 Notes - Quick Notes',
+    content: (
+      <div>
+        <h2>Notes &amp; Ideas</h2>
+        <p>Capture thoughts, ideas, and reminders quickly.</p>
+        <p>Recent Notes:</p>
+        <ul>
+          <li>Project ideas for Q4</li>
+          <li>Shopping list</li>
+          <li>Book recommendations</li>
+        </ul>
+      </div>
+    ),
+  },
+  explorer: {
+    title: '📊 Data Explorer',
+    content: (
+      <div>
+        <h2>Data Explorer</h2>
+        <p>Analyze, visualize, and understand your data.</p>
+        <p>Active Datasets: 23</p>
+        <p>Recent Analysis:</p>
+        <ul>
+          <li>User engagement metrics</li>
+          <li>Performance benchmarks</li>
+        </ul>
+      </div>
+    ),
+  },
+  resources: {
+    title: '💎 Resources - Library',
+    content: (
+      <div>
+        <h2>Resource Library</h2>
+        <p>Access tools, templates, and learning materials.</p>
+        <p>Categories:</p>
+        <ul>
+          <li>Design Assets</li>
+          <li>Code Templates</li>
+          <li>Documentation</li>
+          <li>Tutorials</li>
+        </ul>
+      </div>
+    ),
+  },
+  terminal: {
+    title: '⌨️ Terminal',
+    content: (
+      <div>
+        <h2>Terminal</h2>
+        <pre style={{ background: '#000', padding: 20, borderRadius: 8, color: '#0f0', fontFamily: 'monospace' }}>
+{`blackroad@pi5:~$ system-status
+All systems operational
+CPU: 42% | RAM: 5.2GB | Temp: 42°C
+
+blackroad@pi5:~$ █`}
+        </pre>
+      </div>
+    ),
+  },
+  settings: {
+    title: '⚙️ Settings',
+    content: (
+      <div>
+        <h2>System Settings</h2>
+        <p>Configure your Black Road OS experience.</p>
+        <ul>
+          <li>Appearance &amp; Themes</li>
+          <li>Network &amp; Connectivity</li>
+          <li>Privacy &amp; Security</li>
+          <li>Accounts &amp; Sync</li>
+          <li>System Updates</li>
+        </ul>
+      </div>
+    ),
+  },
+}
+
+const APP_SHORTCUTS = [
+  'raptor',
+  'connections',
+  'diaries',
+  'flights',
+  'cascading',
+  'debugging',
+  'meditation',
+  'health',
+  'calendar',
+  'history',
+  'notes',
+  'explorer',
+  'resources',
+  'terminal',
+  'settings',
+]
+
+const DOCK_ITEMS = [
+  'raptor',
+  'connections',
+  'diaries',
+  'flights',
+  'cascading',
+  'debugging',
+  'meditation',
+  'health',
+  'calendar',
+  'history',
+  'notes',
+  'explorer',
+  'resources',
+]
+
+const QUICK_ACTIONS = [
+  { icon: '📁', label: 'Open Files' },
+  { icon: '⚙️', label: 'Settings' },
+  { icon: '🔍', label: 'Search' },
+  { icon: '💾', label: 'Backup' },
+]
+
+const RECENT_ITEMS = [
+  { icon: '📝', label: 'Meeting Notes' },
+  { icon: '🎨', label: 'Design Mockup' },
+  { icon: '💻', label: 'Code Project' },
+]
+
+const CONTEXT_ITEMS = [
+  { icon: '📱', label: 'New Folder' },
+  { icon: '📄', label: 'New File' },
+  { icon: '🖼️', label: 'Change Wallpaper' },
+  { icon: '🎨', label: 'Customize Desktop' },
+  { icon: '⚙️', label: 'Preferences' },
+]
+
+export default function SimplifiedOS(){
+  const [timeDisplay, setTimeDisplay] = useState('')
+  const [activeApp, setActiveApp] = useState('raptor')
+  const [showWindow, setShowWindow] = useState(false)
+  const [showNotification, setShowNotification] = useState(false)
+  const [contextMenu, setContextMenu] = useState({ visible: false, x: 0, y: 0 })
+
+  useEffect(() => {
+    function updateTime(){
+      const now = new Date()
+      const options = {
+        weekday: 'short',
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+        hour12: true,
+      }
+      setTimeDisplay(now.toLocaleDateString('en-US', options))
+    }
+
+    updateTime()
+    const interval = setInterval(updateTime, 1000)
+    return () => clearInterval(interval)
+  }, [])
+
+  useEffect(() => {
+    let hideTimer
+    const showTimer = setTimeout(() => {
+      setShowNotification(true)
+      hideTimer = setTimeout(() => setShowNotification(false), 4000)
+    }, 1000)
+
+    return () => {
+      clearTimeout(showTimer)
+      if(hideTimer) clearTimeout(hideTimer)
+    }
+  }, [])
+
+  useEffect(() => {
+    function handleKeydown(event){
+      if((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'q'){
+        event.preventDefault()
+        window.alert('🔍 Quick Search\n\nSearch across all apps, files, and settings.')
+      }
+
+      if((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 't'){
+        event.preventDefault()
+        openApp('terminal')
+      }
+
+      if(event.key === 'Escape'){
+        setShowWindow(false)
+      }
+    }
+
+    window.addEventListener('keydown', handleKeydown)
+    return () => window.removeEventListener('keydown', handleKeydown)
+  }, [])
+
+  useEffect(() => {
+    console.log('Black Road OS Desktop loaded successfully!')
+    console.log('Hi Cecilia! 💝 Thank you for believing in me!')
+  }, [])
+
+  const activeAppData = useMemo(() => APP_DATA[activeApp], [activeApp])
+
+  function openApp(key){
+    if(!APP_DATA[key]) return
+    setActiveApp(key)
+    setShowWindow(true)
+  }
+
+  function closeWindow(){
+    setShowWindow(false)
+  }
+
+  function handleQuickAction(label){
+    window.alert(`Opening: ${label}\n\nIn production:\n• Full integration\n• Real functionality\n• Connected systems`)
+  }
+
+  function handleContextMenu(event){
+    event.preventDefault()
+    const { clientX, clientY } = event
+    setContextMenu({ visible: true, x: clientX, y: clientY })
+  }
+
+  function hideContextMenu(){
+    setContextMenu(prev => (prev.visible ? { ...prev, visible: false } : prev))
+  }
+
+  return (
+    <div className="simplified-os" onClick={hideContextMenu}>
+      <div className="desktop">
+        <div className="orb orb1" />
+        <div className="orb orb2" />
+        <div className="orb orb3" />
+
+        <div className="top-bar">
+          <div className="top-bar-left">
+            <div className="logo-mini">⚡ BLACK ROAD OS</div>
+            <div className="top-menu">
+              {['File', 'Edit', 'View', 'Go', 'Window', 'Help'].map(item => (
+                <div key={item} className="top-menu-item">{item}</div>
+              ))}
+            </div>
+          </div>
+          <div className="top-bar-right">
+            <div className="top-bar-icon" title="Wi-Fi">📡</div>
+            <div className="top-bar-icon" title="Battery">🔋 87%</div>
+            <div className="top-bar-icon" title="Volume">🔊</div>
+            <div className="time-display">{timeDisplay}</div>
+          </div>
+        </div>
+
+        <div className="desktop-area" onContextMenu={handleContextMenu}>
+          <aside className="sidebar">
+            <div className="sidebar-section">
+              <div className="sidebar-title">🖥️ System</div>
+              <div className="stat-card">
+                <div className="stat-label">CPU Usage</div>
+                <div className="stat-value">42%</div>
+              </div>
+              <div className="stat-card" style={{ borderLeftColor: 'var(--spectrum-pink)' }}>
+                <div className="stat-label">Memory</div>
+                <div className="stat-value">5.2 GB</div>
+              </div>
+              <div className="stat-card" style={{ borderLeftColor: 'var(--spectrum-purple)' }}>
+                <div className="stat-label">Storage</div>
+                <div className="stat-value">89 GB Free</div>
+              </div>
+              <div className="stat-card" style={{ borderLeftColor: 'var(--spectrum-green)' }}>
+                <div className="stat-label">Network</div>
+                <div className="stat-value">Connected</div>
+              </div>
+            </div>
+
+            <div className="sidebar-section">
+              <div className="sidebar-title">⚡ Quick Actions</div>
+              {QUICK_ACTIONS.map(action => (
+                <div key={action.label} className="quick-action" onClick={() => handleQuickAction(action.label)}>
+                  <span>{action.icon}</span>
+                  <span>{action.label}</span>
+                </div>
+              ))}
+            </div>
+
+            <div className="sidebar-section">
+              <div className="sidebar-title">🌟 Recent</div>
+              {RECENT_ITEMS.map(item => (
+                <div key={item.label} className="quick-action">
+                  <span>{item.icon}</span>
+                  <span>{item.label}</span>
+                </div>
+              ))}
+            </div>
+          </aside>
+
+          <div className="center-content">
+            <div className="welcome-message">
+              <div className="welcome-title">Welcome Back</div>
+              <div className="welcome-subtitle">Your workspace awaits</div>
+            </div>
+
+            <div className="app-grid">
+              {APP_SHORTCUTS.map(key => (
+                <div key={key} className="app-icon" onClick={() => openApp(key)}>
+                  <div className="app-emoji">{APP_DATA[key].title.split(' ')[0]}</div>
+                  <div className="app-name">{APP_DATA[key].title.replace(/^[^ ]+\s/, '')}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="dock">
+          {DOCK_ITEMS.map(key => (
+            <div
+              key={key}
+              className={`dock-icon${activeApp === key && showWindow ? ' active' : ''}`}
+              data-app={key}
+              title={APP_DATA[key].title.replace(/^[^ ]+\s/, '')}
+              onClick={() => openApp(key)}
+            >
+              {APP_DATA[key].title.split(' ')[0]}
+            </div>
+          ))}
+        </div>
+
+        <div
+          className={`context-menu${contextMenu.visible ? ' show' : ''}`}
+          style={{ left: contextMenu.x, top: contextMenu.y }}
+          onClick={event => event.stopPropagation()}
+        >
+          {CONTEXT_ITEMS.map(item => (
+            <div key={item.label} className="context-item">
+              <span>{item.icon}</span>
+              <span>{item.label}</span>
+            </div>
+          ))}
+        </div>
+
+        <div className={`notification${showNotification ? ' show' : ''}`}>
+          <div className="notification-title">Welcome to Black Road OS</div>
+          <div className="notification-message">All systems operational. Ready to create!</div>
+        </div>
+
+        <div className={`window${showWindow ? ' show' : ''}`}>
+          <div className="window-header">
+            <div className="window-title">{activeAppData?.title || 'Application'}</div>
+            <div className="window-controls">
+              <div className="window-control close" onClick={closeWindow} />
+              <div className="window-control minimize" />
+              <div className="window-control maximize" />
+            </div>
+          </div>
+          <div className="window-content">
+            {activeAppData?.content || <p>Select an application to begin.</p>}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add a Simplified OS desktop page with interactive apps, notifications, context menu, and keyboard shortcuts
- create scoped styling for the desktop experience so it renders independently of global layout
- register the new page in the console navigation and routing for easy access

## Testing
- npm run build *(fails: package.json contains duplicated entries and cannot be parsed)*

------
https://chatgpt.com/codex/tasks/task_e_68ffa39b117c8329abae5c450c036d27