### PR TITLE
Add immersive desktop OS experience page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -82,6 +82,7 @@ import PeriodicTableOfEquations from './pages/PeriodicTableOfEquations.jsx'
 import Resilience from './pages/Resilience.jsx'
 import AgentLineage from './pages/AgentLineage.jsx'
 import WebEngine from './pages/WebEngine.jsx'
+import DesktopOS from './pages/DesktopOS.jsx'
 import MusicApp from './pages/MusicApp.jsx'
 
 export default function App(){
@@ -289,6 +290,7 @@ export default function App(){
     { key: 'you', to: '/you', text: 'You', icon: <User size={18} /> },
     { key: 'roadview', to: '/roadview', text: 'RoadView', icon: <LayoutGrid size={18} /> },
     { key: 'web-engine', to: '/web-engine', text: 'Web Engine', icon: <span className="text-lg" aria-hidden="true">🌐</span> },
+    { key: 'desktop-os', to: '/desktop-os', text: 'Desktop OS', icon: <span className="text-lg" aria-hidden="true">🖥️</span> },
     { key: 'autoheal', to: '/autoheal', text: 'Auto-Heal', icon: <HeartPulse size={18} /> },
     { key: 'security', to: '/security', text: 'Security Spotlights', icon: <Shield size={18} /> },
     { key: 'guardian', to: '/guardian', text: 'Guardian', icon: <ShieldCheck size={18} /> },
@@ -343,6 +345,7 @@ export default function App(){
               <Route path="/you" element={<Section><You /></Section>} />
               <Route path="/roadview" element={<Section><RoadView agents={agents} /></Section>} />
               <Route path="/web-engine" element={<WebEngine />} />
+              <Route path="/desktop-os" element={<DesktopOS />} />
               <Route path="/autoheal" element={<Section><AutoHeal /></Section>} />
               <Route path="/security" element={<Section><SecuritySpotlights /></Section>} />
               <Route path="/guardian" element={<Guardian />} />

--- a/frontend/src/pages/DesktopOS.css
+++ b/frontend/src/pages/DesktopOS.css
@@ -1,0 +1,660 @@
+.desktop-os {
+  --spectrum-gold: #fdba2d;
+  --spectrum-orange: #ff6b35;
+  --spectrum-pink: #ff4fd8;
+  --spectrum-purple: #c753ff;
+  --spectrum-indigo: #6366f1;
+  --spectrum-blue: #3b82f6;
+  --spectrum-cyan: #06b6d4;
+  --spectrum-green: #10b981;
+  --void: #000000;
+  --void-10: #0a0a0f;
+  --void-20: #13131a;
+  --void-30: #1a1a24;
+  --void-40: #202030;
+  --text: #ffffff;
+  --text-secondary: rgba(255, 255, 255, 0.7);
+  --text-tertiary: rgba(255, 255, 255, 0.5);
+  --border: rgba(255, 255, 255, 0.08);
+  --gradient-spectrum: linear-gradient(
+    135deg,
+    var(--spectrum-gold) 0%,
+    var(--spectrum-orange) 20%,
+    var(--spectrum-pink) 40%,
+    var(--spectrum-purple) 60%,
+    var(--spectrum-indigo) 80%,
+    var(--spectrum-blue) 100%
+  );
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Inter', sans-serif;
+  background: var(--void);
+  color: var(--text);
+  overflow: hidden;
+  position: relative;
+  min-height: 100vh;
+}
+
+.desktop-os .desktop {
+  position: fixed;
+  inset: 0;
+  background:
+    radial-gradient(circle at 30% 40%, rgba(253, 186, 45, 0.2) 0%, transparent 50%),
+    radial-gradient(circle at 70% 60%, rgba(255, 79, 216, 0.2) 0%, transparent 50%),
+    radial-gradient(circle at 50% 80%, rgba(6, 182, 212, 0.15) 0%, transparent 50%),
+    linear-gradient(180deg, #1a1a2e 0%, #0f0f18 50%, #000000 100%);
+  background-size: cover;
+  background-position: center;
+}
+
+.desktop-os .stars {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+}
+
+.desktop-os .star {
+  position: absolute;
+  width: 2px;
+  height: 2px;
+  background: white;
+  border-radius: 50%;
+  opacity: 0.6;
+  animation: desktop-os-twinkle 3s ease-in-out infinite;
+}
+
+@keyframes desktop-os-twinkle {
+  0%,
+  100% {
+    opacity: 0.3;
+  }
+  50% {
+    opacity: 0.8;
+  }
+}
+
+.desktop-os .desktop-icons {
+  position: absolute;
+  top: 20px;
+  left: 20px;
+  display: grid;
+  grid-template-columns: repeat(1, 100px);
+  gap: 20px;
+  z-index: 10;
+}
+
+.desktop-os .desktop-icon {
+  width: 100px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  padding: 12px 8px;
+  border-radius: 8px;
+  transition: background 0.2s;
+  background: transparent;
+  border: none;
+  color: inherit;
+}
+
+.desktop-os .desktop-icon:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.desktop-os .desktop-icon.selected {
+  background: rgba(6, 182, 212, 0.3);
+  outline: 1px solid var(--spectrum-cyan);
+}
+
+.desktop-os .desktop-icon-image {
+  width: 56px;
+  height: 56px;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.desktop-os .desktop-icon-label {
+  font-size: 0.8rem;
+  text-align: center;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.8);
+  max-width: 100%;
+  word-wrap: break-word;
+}
+
+.desktop-os .taskbar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 48px;
+  background: rgba(10, 10, 15, 0.95);
+  backdrop-filter: blur(30px);
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  display: flex;
+  align-items: center;
+  padding: 0 8px;
+  z-index: 9999;
+  box-shadow: 0 -2px 20px rgba(0, 0, 0, 0.3);
+  gap: 8px;
+}
+
+.desktop-os .start-button {
+  width: 48px;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-size: 1.5rem;
+  position: relative;
+  border: none;
+  background: transparent;
+  color: inherit;
+}
+
+.desktop-os .start-button::before {
+  content: '';
+  position: absolute;
+  inset: 8px;
+  background: var(--gradient-spectrum);
+  border-radius: 8px;
+  opacity: 0.8;
+  transition: all 0.2s;
+}
+
+.desktop-os .start-button:hover::before {
+  opacity: 1;
+  inset: 4px;
+}
+
+.desktop-os .start-logo {
+  position: relative;
+  z-index: 1;
+  font-weight: 900;
+  font-size: 1.2rem;
+  color: var(--void);
+}
+
+.desktop-os .search-bar {
+  flex: 0 0 300px;
+  height: 32px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  padding: 0 12px;
+  gap: 8px;
+  cursor: text;
+  transition: all 0.2s;
+}
+
+.desktop-os .search-bar:hover {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: var(--spectrum-cyan);
+}
+
+.desktop-os .search-bar input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--text);
+  font-size: 0.9rem;
+}
+
+.desktop-os .search-bar input::placeholder {
+  color: var(--text-tertiary);
+}
+
+.desktop-os .taskbar-apps {
+  flex: 1;
+  display: flex;
+  gap: 4px;
+  margin-left: 8px;
+  overflow-x: auto;
+}
+
+.desktop-os .taskbar-apps::-webkit-scrollbar {
+  display: none;
+}
+
+.desktop-os .taskbar-app {
+  min-width: 48px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s;
+  position: relative;
+  font-size: 1.3rem;
+  border: none;
+  color: inherit;
+}
+
+.desktop-os .taskbar-app:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.desktop-os .taskbar-app.active {
+  background: rgba(6, 182, 212, 0.2);
+  border-bottom: 2px solid var(--spectrum-cyan);
+}
+
+.desktop-os .taskbar-app.active::after {
+  content: '';
+  position: absolute;
+  bottom: -1px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 4px;
+  height: 4px;
+  background: var(--spectrum-cyan);
+  border-radius: 50%;
+}
+
+.desktop-os .system-tray {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 12px;
+  height: 100%;
+  border-left: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.desktop-os .tray-icon {
+  font-size: 1rem;
+  cursor: pointer;
+  transition: all 0.2s;
+  padding: 6px;
+  border-radius: 4px;
+  border: none;
+  background: transparent;
+  color: inherit;
+}
+
+.desktop-os .tray-icon:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--spectrum-cyan);
+}
+
+.desktop-os .clock {
+  font-size: 0.85rem;
+  font-variant-numeric: tabular-nums;
+  cursor: pointer;
+  padding: 8px 12px;
+  border-radius: 4px;
+  transition: all 0.2s;
+  text-align: right;
+  min-width: 90px;
+  border: none;
+  background: transparent;
+  color: inherit;
+}
+
+.desktop-os .clock:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.desktop-os .clock-time {
+  font-weight: 600;
+}
+
+.desktop-os .clock-date {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.desktop-os .start-menu {
+  position: fixed;
+  bottom: 60px;
+  left: 8px;
+  width: 600px;
+  height: 650px;
+  background: rgba(10, 10, 15, 0.98);
+  backdrop-filter: blur(40px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  box-shadow: 0 10px 60px rgba(0, 0, 0, 0.5);
+  display: none;
+  flex-direction: column;
+  z-index: 10000;
+  animation: desktop-os-start-menu-open 0.2s ease-out;
+}
+
+.desktop-os .start-menu.show {
+  display: flex;
+}
+
+@keyframes desktop-os-start-menu-open {
+  from {
+    opacity: 0;
+    transform: translateY(20px) scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.desktop-os .start-menu-header {
+  padding: 24px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.desktop-os .start-menu-user {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.desktop-os .user-avatar {
+  width: 50px;
+  height: 50px;
+  background: var(--gradient-spectrum);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  font-weight: 900;
+}
+
+.desktop-os .user-info h3 {
+  font-size: 1.1rem;
+  margin-bottom: 4px;
+}
+
+.desktop-os .user-info p {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.desktop-os .start-menu-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 24px;
+}
+
+.desktop-os .start-menu-section {
+  margin-bottom: 32px;
+}
+
+.desktop-os .start-menu-section h4 {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--text-tertiary);
+  margin-bottom: 16px;
+}
+
+.desktop-os .app-grid-start {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+}
+
+.desktop-os .app-tile {
+  aspect-ratio: 1;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  cursor: pointer;
+  transition: all 0.2s;
+  padding: 12px;
+  color: inherit;
+  border: none;
+  background-clip: padding-box;
+}
+
+.desktop-os .app-tile:hover {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: var(--spectrum-pink);
+  transform: scale(1.05);
+}
+
+.desktop-os .app-tile-icon {
+  font-size: 2rem;
+}
+
+.desktop-os .app-tile-name {
+  font-size: 0.75rem;
+  text-align: center;
+}
+
+.desktop-os .recent-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.desktop-os .recent-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s;
+  color: inherit;
+  border: none;
+  text-align: left;
+}
+
+.desktop-os .recent-item:hover {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: var(--spectrum-cyan);
+}
+
+.desktop-os .recent-icon {
+  font-size: 1.5rem;
+}
+
+.desktop-os .recent-name {
+  font-size: 0.9rem;
+  margin-bottom: 2px;
+}
+
+.desktop-os .recent-time {
+  font-size: 0.75rem;
+  color: var(--text-tertiary);
+}
+
+.desktop-os .start-menu-footer {
+  padding: 16px 24px;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  display: flex;
+  gap: 8px;
+}
+
+.desktop-os .footer-button {
+  flex: 1;
+  padding: 12px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  font-size: 0.9rem;
+  color: inherit;
+}
+
+.desktop-os .footer-button:hover {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: var(--spectrum-purple);
+}
+
+.desktop-os .windows-container {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: calc(100vh - 48px);
+  pointer-events: none;
+  z-index: 5000;
+}
+
+.desktop-os .window {
+  position: fixed;
+  background: rgba(15, 15, 20, 0.98);
+  backdrop-filter: blur(40px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  box-shadow: 0 20px 80px rgba(0, 0, 0, 0.5);
+  display: none;
+  flex-direction: column;
+  pointer-events: auto;
+}
+
+.desktop-os .window.show {
+  display: flex;
+  animation: desktop-os-window-open 0.2s ease-out;
+}
+
+@keyframes desktop-os-window-open {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.desktop-os .window-titlebar {
+  height: 40px;
+  background: rgba(255, 255, 255, 0.03);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 16px;
+  cursor: move;
+  border-radius: 12px 12px 0 0;
+}
+
+.desktop-os .window-title {
+  font-size: 0.9rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.desktop-os .window-controls {
+  display: flex;
+  gap: 8px;
+}
+
+.desktop-os .window-control-btn {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-size: 0.9rem;
+  border: none;
+  background: transparent;
+  color: inherit;
+}
+
+.desktop-os .window-control-btn:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.desktop-os .window-control-btn.close:hover {
+  background: #e81123;
+}
+
+.desktop-os .window-control-btn.minimize:hover,
+.desktop-os .window-control-btn.maximize:hover {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.desktop-os .window-content {
+  flex: 1;
+  padding: 24px;
+  overflow-y: auto;
+  color: var(--text);
+}
+
+.desktop-os .window-content h2 {
+  margin-bottom: 16px;
+  background: var(--gradient-spectrum);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.desktop-os .window-content ul {
+  margin-left: 20px;
+  line-height: 1.8;
+}
+
+.desktop-os .terminal-output {
+  background: #000;
+  padding: 20px;
+  border-radius: 8px;
+  color: #0f0;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  white-space: pre-wrap;
+  font-size: 0.85rem;
+}
+
+.desktop-os ::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+.desktop-os ::-webkit-scrollbar-track {
+  background: rgba(0, 0, 0, 0.2);
+}
+
+.desktop-os ::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 4px;
+}
+
+.desktop-os ::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.3);
+}
+
+@media (max-width: 768px) {
+  .desktop-os .start-menu {
+    width: calc(100% - 16px);
+    height: 80vh;
+  }
+
+  .desktop-os .app-grid-start {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .desktop-os .search-bar {
+    flex: 1;
+    max-width: none;
+  }
+}
+

--- a/frontend/src/pages/DesktopOS.jsx
+++ b/frontend/src/pages/DesktopOS.jsx
@@ -1,0 +1,702 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import './DesktopOS.css'
+
+const DESKTOP_ICONS = [
+  { app: 'raptor', label: 'Raptor', emoji: '🦅' },
+  { app: 'connections', label: 'Connections', emoji: '🔗' },
+  { app: 'diaries', label: 'Diaries', emoji: '📔' },
+  { app: 'flights', label: 'Flights', emoji: '✈️' },
+  { app: 'files', label: 'My Files', emoji: '📁' },
+  { app: 'recycle', label: 'Recycle Bin', emoji: '🗑️' },
+]
+
+const PINNED_APPS = [
+  'raptor',
+  'connections',
+  'diaries',
+  'flights',
+  'cascading',
+  'debugging',
+  'meditation',
+  'health',
+  'calendar',
+  'history',
+  'notes',
+  'explorer',
+]
+
+const TASKBAR_APPS = [
+  { app: 'raptor', title: 'Raptor', emoji: '🦅' },
+  { app: 'connections', title: 'Connections', emoji: '🔗' },
+  { app: 'files', title: 'Files', emoji: '📁' },
+  { app: 'terminal', title: 'Terminal', emoji: '⌨️' },
+]
+
+const RECENT_ITEMS = [
+  { icon: '📝', name: 'Meeting Notes.txt', time: 'Opened 5 minutes ago' },
+  { icon: '🎨', name: 'Design Mockup.fig', time: 'Edited 1 hour ago' },
+  { icon: '💻', name: 'BlackRoad Project', time: 'Accessed 2 hours ago' },
+]
+
+const APP_CONTENT = {
+  raptor: {
+    title: '🦅 Raptor',
+    body: (
+      <>
+        <h2>Raptor - AI Assistant</h2>
+        <p>Your intelligent companion for productivity and creativity.</p>
+        <ul>
+          <li>Natural language processing</li>
+          <li>Task automation</li>
+          <li>Smart suggestions</li>
+          <li>Context-aware responses</li>
+        </ul>
+      </>
+    ),
+  },
+  connections: {
+    title: '🔗 Connections',
+    body: (
+      <>
+        <h2>Connections Network</h2>
+        <p>Manage relationships and collaborations.</p>
+        <p>
+          <strong>Active Connections:</strong> 847
+        </p>
+        <ul>
+          <li>Agent Phoenix online</li>
+          <li>3 new messages</li>
+          <li>2 pending requests</li>
+        </ul>
+      </>
+    ),
+  },
+  diaries: {
+    title: '📔 Diaries',
+    body: (
+      <>
+        <h2>Personal Diaries</h2>
+        <p>Capture thoughts and track your journey.</p>
+        <ul>
+          <li>Today: Morning reflections</li>
+          <li>Yesterday: Project insights</li>
+          <li>This week: 5 entries</li>
+        </ul>
+      </>
+    ),
+  },
+  flights: {
+    title: '✈️ Flights',
+    body: (
+      <>
+        <h2>Flight Manager</h2>
+        <p>Track and manage your travels.</p>
+        <ul>
+          <li>Next flight: SF → NYC (Nov 5)</li>
+          <li>Upcoming: NYC → London (Nov 12)</li>
+          <li>Miles earned: 47,842</li>
+        </ul>
+      </>
+    ),
+  },
+  cascading: {
+    title: '💧 Cascading',
+    body: (
+      <>
+        <h2>Cascading Workflows</h2>
+        <p>Design and automate your processes.</p>
+        <ul>
+          <li>12 active workflows</li>
+          <li>Last run: Data pipeline (success)</li>
+          <li>Average execution time: 2.3s</li>
+        </ul>
+      </>
+    ),
+  },
+  debugging: {
+    title: '🐛 Debugging',
+    body: (
+      <>
+        <h2>Debug Console</h2>
+        <p>Development and debugging tools.</p>
+        <ul>
+          <li>Memory leak fixed in Module A</li>
+          <li>Performance: 23% improvement</li>
+          <li>Active breakpoints: 3</li>
+        </ul>
+      </>
+    ),
+  },
+  meditation: {
+    title: '🧘 Meditation',
+    body: (
+      <>
+        <h2>Meditation &amp; Mindfulness</h2>
+        <p>Find peace and balance.</p>
+        <ul>
+          <li>Today's session: 15 minutes</li>
+          <li>Current streak: 7 days</li>
+          <li>Total time: 142 hours</li>
+        </ul>
+      </>
+    ),
+  },
+  health: {
+    title: '💪 Health',
+    body: (
+      <>
+        <h2>Health &amp; Fitness</h2>
+        <p>Track your wellness journey.</p>
+        <ul>
+          <li>Steps: 8,429 / 10,000</li>
+          <li>Calories: 1,847 / 2,200</li>
+          <li>Water: 6 / 8 glasses</li>
+          <li>Sleep: 7.5 hours</li>
+        </ul>
+      </>
+    ),
+  },
+  calendar: {
+    title: '📅 Calendar',
+    body: (
+      <>
+        <h2>Calendar &amp; Events</h2>
+        <p>Manage your schedule.</p>
+        <ul>
+          <li>10:00 AM - Team standup</li>
+          <li>2:00 PM - Design review</li>
+          <li>4:30 PM - Yoga class</li>
+        </ul>
+      </>
+    ),
+  },
+  history: {
+    title: '⏳ History',
+    body: (
+      <>
+        <h2>Activity History</h2>
+        <p>Your complete timeline.</p>
+        <ul>
+          <li>Opened Raptor - 5 min ago</li>
+          <li>Edited document - 1 hour ago</li>
+          <li>Video call - 2 hours ago</li>
+        </ul>
+      </>
+    ),
+  },
+  notes: {
+    title: '📝 Notes',
+    body: (
+      <>
+        <h2>Quick Notes</h2>
+        <p>Capture ideas instantly.</p>
+        <ul>
+          <li>Project ideas for Q4</li>
+          <li>Shopping list</li>
+          <li>Book recommendations</li>
+          <li>Code snippets</li>
+        </ul>
+      </>
+    ),
+  },
+  explorer: {
+    title: '📊 Data Explorer',
+    body: (
+      <>
+        <h2>Data Explorer</h2>
+        <p>Analyze and visualize data.</p>
+        <ul>
+          <li>23 active datasets</li>
+          <li>User engagement metrics</li>
+          <li>Performance benchmarks</li>
+        </ul>
+      </>
+    ),
+  },
+  files: {
+    title: '📁 File Explorer',
+    body: (
+      <>
+        <h2>File Explorer</h2>
+        <p>Browse and manage your files.</p>
+        <ul>
+          <li>Documents: 142 files</li>
+          <li>Downloads: 23 files</li>
+          <li>Pictures: 1,847 files</li>
+          <li>Videos: 47 files</li>
+        </ul>
+      </>
+    ),
+  },
+  terminal: {
+    title: '⌨️ Terminal',
+    body: (
+      <>
+        <h2>Terminal</h2>
+        <pre className="terminal-output">
+blackroad@pi5:~$ neofetch
+Black Road OS 1.0.0
+Kernel: 6.6.31-blackroad
+Uptime: 2 hours, 14 mins
+CPU: BCM2712 (4) @ 2.4GHz
+Memory: 5234MB / 8192MB
+
+blackroad@pi5:~$ █
+        </pre>
+      </>
+    ),
+  },
+  settings: {
+    title: '⚙️ Settings',
+    body: (
+      <>
+        <h2>System Settings</h2>
+        <p>Configure your system.</p>
+        <ul>
+          <li>Appearance &amp; Personalization</li>
+          <li>Network &amp; Internet</li>
+          <li>Privacy &amp; Security</li>
+          <li>System &amp; Updates</li>
+          <li>Apps &amp; Features</li>
+        </ul>
+      </>
+    ),
+  },
+}
+
+const APP_LABELS = {
+  raptor: 'Raptor',
+  connections: 'Connections',
+  diaries: 'Diaries',
+  flights: 'Flights',
+  cascading: 'Cascading',
+  debugging: 'Debugging',
+  meditation: 'Meditation',
+  health: 'Health',
+  calendar: 'Calendar',
+  history: 'History',
+  notes: 'Notes',
+  explorer: 'Data Explorer',
+  files: 'File Explorer',
+  terminal: 'Terminal',
+  settings: 'Settings',
+  recycle: 'Recycle Bin',
+}
+
+export default function DesktopOS(){
+  const [startMenuOpen, setStartMenuOpen] = useState(false)
+  const [selectedIcon, setSelectedIcon] = useState(null)
+  const [windows, setWindows] = useState([])
+  const [activeWindowId, setActiveWindowId] = useState(null)
+  const [clock, setClock] = useState({ time: '', date: '' })
+
+  const startMenuRef = useRef(null)
+  const startButtonRef = useRef(null)
+  const desktopRef = useRef(null)
+  const stars = useMemo(
+    () =>
+      Array.from({ length: 100 }).map(() => ({
+        left: `${Math.random() * 100}%`,
+        top: `${Math.random() * 100}%`,
+        delay: `${Math.random() * 3}s`,
+      })),
+    []
+  )
+
+  const windowIdRef = useRef(0)
+  const topZIndexRef = useRef(6000)
+
+  useEffect(() => {
+    function updateClock(){
+      const now = new Date()
+      const time = now.toLocaleTimeString('en-US', {
+        hour: 'numeric',
+        minute: '2-digit',
+        hour12: true,
+      })
+      const date = now.toLocaleDateString('en-US', {
+        month: 'numeric',
+        day: 'numeric',
+        year: 'numeric',
+      })
+      setClock({ time, date })
+    }
+
+    updateClock()
+    const interval = window.setInterval(updateClock, 1000)
+    return () => window.clearInterval(interval)
+  }, [])
+
+  useEffect(() => {
+    function handleClickOutside(event){
+      if(startMenuOpen){
+        const target = event.target
+        if(
+          startMenuRef.current &&
+          startButtonRef.current &&
+          !startMenuRef.current.contains(target) &&
+          !startButtonRef.current.contains(target)
+        ){
+          setStartMenuOpen(false)
+        }
+      }
+    }
+
+    document.addEventListener('click', handleClickOutside)
+    return () => document.removeEventListener('click', handleClickOutside)
+  }, [startMenuOpen])
+
+  const makeWindowActive = useCallback((id) => {
+    setWindows((prev) =>
+      prev.map((window) =>
+        window.id === id
+          ? { ...window, zIndex: ++topZIndexRef.current, minimized: false }
+          : window
+      )
+    )
+    setActiveWindowId(id)
+  }, [])
+
+  const openWindow = useCallback((appName) => {
+    const data = APP_CONTENT[appName]
+    if(!data){
+      return
+    }
+
+    setStartMenuOpen(false)
+
+    setWindows((prev) => {
+      const existing = prev.find((window) => window.app === appName)
+      if(existing){
+        const nextWindows = prev.map((window) =>
+          window.id === existing.id
+            ? {
+                ...window,
+                minimized: false,
+                zIndex: ++topZIndexRef.current,
+              }
+            : window
+        )
+        setActiveWindowId(existing.id)
+        return nextWindows
+      }
+
+      const id = `window-${++windowIdRef.current}`
+      const offset = prev.length
+      const nextWindow = {
+        id,
+        app: appName,
+        title: data.title,
+        minimized: false,
+        maximized: false,
+        zIndex: ++topZIndexRef.current,
+        top: 100 + offset * 30,
+        left: 200 + offset * 30,
+      }
+      setActiveWindowId(id)
+      return [...prev, nextWindow]
+    })
+  }, [])
+
+  const closeWindow = useCallback((id) => {
+    setWindows((prev) => prev.filter((window) => window.id !== id))
+    setActiveWindowId((current) => (current === id ? null : current))
+  }, [])
+
+  const minimizeWindow = useCallback((id) => {
+    setWindows((prev) =>
+      prev.map((window) =>
+        window.id === id ? { ...window, minimized: true } : window
+      )
+    )
+    setActiveWindowId((current) => (current === id ? null : current))
+  }, [])
+
+  const toggleMaximizeWindow = useCallback((id) => {
+    setWindows((prev) =>
+      prev.map((window) =>
+        window.id === id
+          ? {
+              ...window,
+              maximized: !window.maximized,
+              zIndex: ++topZIndexRef.current,
+            }
+          : window
+      )
+    )
+    setActiveWindowId(id)
+  }, [])
+
+  const handleTaskbarClick = useCallback(
+    (appName) => {
+      const targetWindow = windows.find((window) => window.app === appName)
+      if(!targetWindow){
+        openWindow(appName)
+        return
+      }
+
+      if(targetWindow.minimized){
+        makeWindowActive(targetWindow.id)
+        setWindows((prev) =>
+          prev.map((window) =>
+            window.id === targetWindow.id
+              ? { ...window, minimized: false }
+              : window
+          )
+        )
+        return
+      }
+
+      if(activeWindowId === targetWindow.id){
+        minimizeWindow(targetWindow.id)
+        return
+      }
+
+      makeWindowActive(targetWindow.id)
+    },
+    [activeWindowId, makeWindowActive, minimizeWindow, openWindow, windows]
+  )
+
+  const handleDesktopClick = useCallback((event) => {
+    if(event.target === desktopRef.current){
+      setSelectedIcon(null)
+    }
+  }, [])
+
+  return (
+    <div className="desktop-os">
+      <div className="desktop" ref={desktopRef} onClick={handleDesktopClick}>
+        <div className="stars" aria-hidden="true">
+          {stars.map((star, index) => (
+            <div
+              key={index}
+              className="star"
+              style={{ left: star.left, top: star.top, animationDelay: star.delay }}
+            />
+          ))}
+        </div>
+
+        <div className="desktop-icons">
+          {DESKTOP_ICONS.map((icon) => (
+            <button
+              key={icon.app}
+              type="button"
+              className={`desktop-icon${selectedIcon === icon.app ? ' selected' : ''}`}
+              onClick={() => setSelectedIcon(icon.app)}
+              onDoubleClick={() => openWindow(icon.app)}
+            >
+              <div className="desktop-icon-image" aria-hidden="true">
+                {icon.emoji}
+              </div>
+              <div className="desktop-icon-label">{icon.label}</div>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="taskbar">
+        <button
+          type="button"
+          className="start-button"
+          ref={startButtonRef}
+          onClick={(event) => {
+            event.stopPropagation()
+            setStartMenuOpen((open) => !open)
+          }}
+        >
+          <span className="start-logo">RB</span>
+        </button>
+
+        <label className="search-bar">
+          <span role="img" aria-label="Search">
+            🔍
+          </span>
+          <input type="text" placeholder="Search apps, files, settings..." />
+        </label>
+
+        <div className="taskbar-apps">
+          {TASKBAR_APPS.map((app) => {
+            const windowForApp = windows.find((window) => window.app === app.app && !window.minimized)
+            return (
+              <button
+                key={app.app}
+                type="button"
+                className={`taskbar-app${windowForApp ? ' active' : ''}`}
+                data-app={app.app}
+                title={app.title}
+                onClick={() => handleTaskbarClick(app.app)}
+              >
+                {app.emoji}
+              </button>
+            )
+          })}
+        </div>
+
+        <div className="system-tray">
+          <button type="button" className="tray-icon" title="Network">
+            📡
+          </button>
+          <button type="button" className="tray-icon" title="Volume">
+            🔊
+          </button>
+          <button type="button" className="tray-icon" title="Battery">
+            🔋
+          </button>
+          <button type="button" className="clock" title="Open clock">
+            <div className="clock-time">{clock.time}</div>
+            <div className="clock-date">{clock.date}</div>
+          </button>
+        </div>
+      </div>
+
+      <div
+        className={`start-menu${startMenuOpen ? ' show' : ''}`}
+        ref={startMenuRef}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="start-menu-header">
+          <div className="start-menu-user">
+            <div className="user-avatar">C</div>
+            <div className="user-info">
+              <h3>Cecilia</h3>
+              <p>cecilia@blackroad.os</p>
+            </div>
+          </div>
+        </div>
+
+        <div className="start-menu-content">
+          <div className="start-menu-section">
+            <h4>📌 Pinned Apps</h4>
+            <div className="app-grid-start">
+              {PINNED_APPS.map((appName) => (
+                <button
+                  key={appName}
+                  type="button"
+                  className="app-tile"
+                  onClick={() => openWindow(appName)}
+                >
+                  <div className="app-tile-icon" aria-hidden="true">
+                    {APP_CONTENT[appName]?.title?.split(' ')[0] || '📁'}
+                  </div>
+                  <div className="app-tile-name">{APP_LABELS[appName] || appName}</div>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="start-menu-section">
+            <h4>🕐 Recent</h4>
+            <div className="recent-list">
+              {RECENT_ITEMS.map((item) => (
+                <button
+                  key={item.name}
+                  type="button"
+                  className="recent-item"
+                  onClick={() => window.alert(`Opening: ${item.name}`)}
+                >
+                  <div className="recent-icon" aria-hidden="true">
+                    {item.icon}
+                  </div>
+                  <div className="recent-info">
+                    <div className="recent-name">{item.name}</div>
+                    <div className="recent-time">{item.time}</div>
+                  </div>
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="start-menu-footer">
+          <button type="button" className="footer-button">
+            <span role="img" aria-label="Profile">
+              👤
+            </span>
+            <span>Profile</span>
+          </button>
+          <button type="button" className="footer-button" onClick={() => openWindow('settings')}>
+            <span role="img" aria-label="Settings">
+              ⚙️
+            </span>
+            <span>Settings</span>
+          </button>
+          <button
+            type="button"
+            className="footer-button"
+            onClick={() => window.alert('💤 Sleep Mode\n\nSystem will enter sleep mode.')}
+          >
+            <span role="img" aria-label="Power">
+              ⏻
+            </span>
+            <span>Power</span>
+          </button>
+        </div>
+      </div>
+
+      <div className="windows-container">
+        {windows.map((window) => {
+          const data = APP_CONTENT[window.app]
+          const style = window.maximized
+            ? {
+                width: '100vw',
+                height: 'calc(100vh - 48px)',
+                top: 0,
+                left: 0,
+                borderRadius: '0',
+              }
+            : {
+                width: '700px',
+                height: '500px',
+                top: `${window.top}px`,
+                left: `${window.left}px`,
+                borderRadius: '12px',
+              }
+
+          return (
+            <div
+              key={window.id}
+              className="window show"
+              style={{
+                ...style,
+                zIndex: window.zIndex,
+                display: window.minimized ? 'none' : 'flex',
+              }}
+              onMouseDown={() => makeWindowActive(window.id)}
+            >
+              <div className="window-titlebar">
+                <div className="window-title">
+                  <span>{data?.title}</span>
+                </div>
+                <div className="window-controls">
+                  <button
+                    type="button"
+                    className="window-control-btn minimize"
+                    onClick={() => minimizeWindow(window.id)}
+                  >
+                    ─
+                  </button>
+                  <button
+                    type="button"
+                    className="window-control-btn maximize"
+                    onClick={() => toggleMaximizeWindow(window.id)}
+                  >
+                    □
+                  </button>
+                  <button
+                    type="button"
+                    className="window-control-btn close"
+                    onClick={() => closeWindow(window.id)}
+                  >
+                    ✕
+                  </button>
+                </div>
+              </div>
+              <div className="window-content">{data?.body}</div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add a dedicated Desktop OS page with interactive window management and start menu experience
- implement scoped styling for the desktop simulation and animations
- register the new page in the app navigation and routing

## Testing
- npm install *(fails: frontend/package.json contains invalid JSON)*

------
https://chatgpt.com/codex/tasks/task_e_68ffa408b50883298279b181da353508