### PR TITLE
Refresh proof illustrations and alt text

### DIFF
--- a/sites/blackroad/public/img/proof-agents.svg
+++ b/sites/blackroad/public/img/proof-agents.svg
@@ -1,48 +1,72 @@
 <svg width="640" height="360" viewBox="0 0 640 360" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect width="640" height="360" rx="24" fill="url(#paint0_linear_2_1)"/>
-  <g filter="url(#filter0_d_2_1)">
-    <rect x="60" y="72" width="520" height="216" rx="28" fill="rgba(15,23,42,0.75)"/>
-    <rect x="92" y="104" width="120" height="120" rx="20" fill="rgba(56,189,248,0.25)" stroke="#38bdf8" stroke-width="2"/>
-    <rect x="260" y="104" width="120" height="120" rx="20" fill="rgba(16,185,129,0.25)" stroke="#34d399" stroke-width="2"/>
-    <rect x="428" y="104" width="120" height="120" rx="20" fill="rgba(244,114,182,0.25)" stroke="#f472b6" stroke-width="2"/>
-    <text x="120" y="142" fill="#38bdf8" font-size="14" font-weight="600" font-family="'Inter',sans-serif">Roadie</text>
-    <text x="290" y="142" fill="#34d399" font-size="14" font-weight="600" font-family="'Inter',sans-serif">Guardian</text>
-    <text x="456" y="142" fill="#f472b6" font-size="14" font-weight="600" font-family="'Inter',sans-serif">Lucidia</text>
-    <text x="100" y="194" fill="#e2e8f0" font-size="12" font-family="'Inter',sans-serif">Review · Pair · Ship</text>
-    <text x="274" y="194" fill="#dcfce7" font-size="12" font-family="'Inter',sans-serif">Ops · Alerts · Compliance</text>
-    <text x="444" y="194" fill="#fce7f3" font-size="12" font-family="'Inter',sans-serif">Finance · Splits · Treasury</text>
-    <path d="M212 164H244" stroke="#38bdf8" stroke-width="4" stroke-linecap="round" opacity="0.7"/>
-    <path d="M380 164H412" stroke="#34d399" stroke-width="4" stroke-linecap="round" opacity="0.7"/>
-    <path d="M244 178C244 178 256 210 320 210C384 210 396 178 396 178" stroke="#e2e8f0" stroke-width="2" stroke-dasharray="6 8" opacity="0.4"/>
+  <rect width="640" height="360" rx="28" fill="url(#bg)"/>
+  <g filter="url(#halo)">
+    <circle cx="320" cy="168" r="140" fill="url(#glow)"/>
   </g>
-  <g filter="url(#filter1_d_2_1)">
-    <rect x="96" y="260" width="448" height="44" rx="22" fill="rgba(8,145,178,0.85)"/>
-    <text x="120" y="286" fill="#ecfeff" font-size="16" font-weight="600" font-family="'Inter',sans-serif">Ops graph synced · Release window opens in 12m · Wallet audit clean</text>
+  <g filter="url(#panelShadow)">
+    <rect x="72" y="88" width="192" height="184" rx="20" fill="rgba(15,23,42,0.88)" stroke="rgba(148,163,184,0.35)"/>
+    <text x="104" y="128" fill="#bae6fd" font-family="'Inter',sans-serif" font-size="14" font-weight="600">Roadie</text>
+    <rect x="96" y="144" width="144" height="12" rx="6" fill="#38bdf8"/>
+    <rect x="96" y="168" width="120" height="10" rx="5" fill="#cbd5f5"/>
+    <rect x="96" y="188" width="128" height="10" rx="5" fill="#94a3b8"/>
+    <rect x="96" y="208" width="160" height="40" rx="12" fill="rgba(56,189,248,0.12)" stroke="#38bdf8" stroke-dasharray="10 6"/>
+    <text x="108" y="234" fill="#e2e8f0" font-family="'Inter',sans-serif" font-size="12">Pull request checks · pass</text>
+  </g>
+  <g filter="url(#panelShadow)">
+    <rect x="240" y="64" width="160" height="200" rx="20" fill="rgba(8,47,73,0.92)" stroke="rgba(125,211,252,0.45)"/>
+    <text x="272" y="108" fill="#f8fafc" font-family="'Inter',sans-serif" font-size="14" font-weight="600">Guardian</text>
+    <rect x="264" y="124" width="112" height="12" rx="6" fill="#ecfeff"/>
+    <rect x="264" y="148" width="96" height="12" rx="6" fill="#bae6fd"/>
+    <rect x="264" y="172" width="120" height="36" rx="12" fill="#0ea5e9" opacity="0.32"/>
+    <text x="276" y="194" fill="#ecfeff" font-family="'Inter',sans-serif" font-size="12">Prod drift patched</text>
+    <rect x="264" y="212" width="112" height="32" rx="16" fill="#f0fdfa"/>
+    <text x="282" y="233" fill="#0f172a" font-family="'Inter',sans-serif" font-size="12" font-weight="600">Compliance clean</text>
+  </g>
+  <g filter="url(#panelShadow)">
+    <rect x="416" y="96" width="168" height="192" rx="20" fill="rgba(12,74,110,0.88)" stroke="rgba(165,243,252,0.45)"/>
+    <text x="452" y="132" fill="#f0fdfa" font-family="'Inter',sans-serif" font-size="14" font-weight="600">Lucidia</text>
+    <rect x="440" y="148" width="128" height="12" rx="6" fill="#e0f2fe"/>
+    <rect x="440" y="172" width="120" height="12" rx="6" fill="#bae6fd"/>
+    <rect x="440" y="196" width="96" height="12" rx="6" fill="#38bdf8"/>
+    <rect x="440" y="224" width="128" height="36" rx="12" fill="rgba(14,165,233,0.28)" stroke="#22d3ee" stroke-dasharray="8 6"/>
+    <text x="452" y="246" fill="#ecfeff" font-family="'Inter',sans-serif" font-size="12">Tips + payouts reconciled</text>
+  </g>
+  <g stroke="#38bdf8" stroke-width="2.5" stroke-linecap="round" stroke-dasharray="6 8" opacity="0.8">
+    <path d="M260 132C292 100 348 100 380 132"/>
+    <path d="M212 196C252 220 348 220 404 204"/>
+    <path d="M296 248C332 272 388 276 432 260"/>
+  </g>
+  <g fill="#38bdf8">
+    <circle cx="268" cy="128" r="6"/>
+    <circle cx="376" cy="128" r="6"/>
+    <circle cx="224" cy="196" r="6"/>
+    <circle cx="404" cy="204" r="6"/>
+    <circle cx="304" cy="248" r="6"/>
+    <circle cx="424" cy="260" r="6"/>
   </g>
   <defs>
-    <linearGradient id="paint0_linear_2_1" x1="120" y1="48" x2="520" y2="312" gradientUnits="userSpaceOnUse">
+    <linearGradient id="bg" x1="36" y1="32" x2="604" y2="328" gradientUnits="userSpaceOnUse">
       <stop stop-color="#020617"/>
+      <stop offset="0.45" stop-color="#082f49"/>
       <stop offset="1" stop-color="#0f172a"/>
     </linearGradient>
-    <filter id="filter0_d_2_1" x="36" y="52" width="568" height="264" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+    <radialGradient id="glow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(320 168) rotate(90) scale(160)">
+      <stop stop-color="#0ea5e9" stop-opacity="0.6"/>
+      <stop offset="1" stop-color="#0ea5e9" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="halo" x="128" y="-24" width="384" height="384" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="20" result="blur"/>
+      <feBlend in="SourceGraphic" in2="blur" mode="screen"/>
+    </filter>
+    <filter id="panelShadow" x="56" y="48" width="544" height="264" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
       <feFlood flood-opacity="0" result="BackgroundImageFix"/>
       <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
-      <feOffset dy="10"/>
+      <feOffset dy="8"/>
       <feGaussianBlur stdDeviation="14"/>
       <feComposite in2="hardAlpha" operator="out"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 0.07 0 0 0 0 0.24 0 0 0 0 0.36 0 0 0 0.32 0"/>
-      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
-      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
-    </filter>
-    <filter id="filter1_d_2_1" x="76" y="248" width="488" height="88" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
-      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
-      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
-      <feOffset dy="6"/>
-      <feGaussianBlur stdDeviation="10"/>
-      <feComposite in2="hardAlpha" operator="out"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 0.05 0 0 0 0 0.27 0 0 0 0 0.39 0 0 0 0.34 0"/>
-      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
-      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.04 0 0 0 0 0.34 0 0 0 0 0.45 0 0 0 0.32 0"/>
+      <feBlend in2="BackgroundImageFix" mode="normal" result="effect1_dropShadow"/>
+      <feBlend in="SourceGraphic" in2="effect1_dropShadow" mode="normal" result="shape"/>
     </filter>
   </defs>
 </svg>

--- a/sites/blackroad/public/img/proof-build.svg
+++ b/sites/blackroad/public/img/proof-build.svg
@@ -1,60 +1,80 @@
 <svg width="640" height="360" viewBox="0 0 640 360" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect width="640" height="360" rx="24" fill="url(#paint0_linear_1_1)"/>
-  <g filter="url(#filter0_d_1_1)">
-    <rect x="40" y="56" width="360" height="248" rx="16" fill="rgba(15,23,42,0.88)"/>
-    <rect x="56" y="96" width="200" height="16" rx="8" fill="#38bdf8" opacity="0.8"/>
-    <rect x="56" y="128" width="248" height="12" rx="6" fill="#f8fafc" opacity="0.9"/>
-    <rect x="56" y="152" width="220" height="12" rx="6" fill="#cbd5f5" opacity="0.8"/>
-    <rect x="56" y="176" width="180" height="12" rx="6" fill="#94a3b8" opacity="0.7"/>
-    <rect x="56" y="200" width="260" height="12" rx="6" fill="#f8fafc" opacity="0.85"/>
-    <rect x="56" y="232" width="280" height="28" rx="10" fill="#38bdf8" opacity="0.95"/>
-    <text x="70" y="250" fill="#0f172a" font-size="14" font-weight="600" font-family="'Inter',sans-serif">/ship creator-os build</text>
+  <rect width="640" height="360" rx="28" fill="url(#bg)"/>
+  <rect x="48" y="48" width="368" height="248" rx="20" fill="rgba(15,23,42,0.88)" stroke="rgba(148,163,184,0.25)" stroke-width="1.5"/>
+  <rect x="64" y="76" width="120" height="20" rx="10" fill="rgba(56,189,248,0.2)"/>
+  <circle cx="80" cy="86" r="4" fill="#38bdf8"/>
+  <circle cx="96" cy="86" r="4" fill="#a5f3fc"/>
+  <circle cx="112" cy="86" r="4" fill="#38bdf8"/>
+  <rect x="64" y="112" width="272" height="132" rx="12" fill="rgba(15,23,42,0.92)" stroke="rgba(148,163,184,0.25)"/>
+  <rect x="80" y="132" width="120" height="10" rx="5" fill="#f8fafc"/>
+  <rect x="80" y="152" width="180" height="8" rx="4" fill="#94a3b8"/>
+  <rect x="80" y="168" width="208" height="8" rx="4" fill="#38bdf8" opacity="0.65"/>
+  <rect x="80" y="184" width="150" height="8" rx="4" fill="#cbd5f5"/>
+  <rect x="80" y="200" width="220" height="8" rx="4" fill="#e2e8f0" opacity="0.8"/>
+  <rect x="80" y="216" width="164" height="8" rx="4" fill="#94a3b8" opacity="0.7"/>
+  <rect x="80" y="236" width="120" height="24" rx="12" fill="url(#btn)"/>
+  <text x="92" y="252" fill="#0f172a" font-family="'Inter',sans-serif" font-size="13" font-weight="600">run deploy-story</text>
+  <g filter="url(#chatShadow)">
+    <rect x="280" y="164" width="112" height="104" rx="16" fill="rgba(148,163,184,0.18)" stroke="rgba(226,232,240,0.4)"/>
+    <path d="M300 188h72" stroke="#e2e8f0" stroke-width="3" stroke-linecap="round"/>
+    <path d="M300 210h52" stroke="#38bdf8" stroke-width="3" stroke-linecap="round"/>
+    <path d="M300 232h64" stroke="#cbd5f5" stroke-width="3" stroke-linecap="round"/>
+    <circle cx="312" cy="256" r="8" fill="#38bdf8"/>
+    <circle cx="334" cy="256" r="8" fill="#f8fafc"/>
+    <circle cx="356" cy="256" r="8" fill="#38bdf8"/>
   </g>
-  <g filter="url(#filter1_d_1_1)">
-    <rect x="424" y="92" width="176" height="120" rx="18" fill="rgba(8,145,178,0.92)"/>
-    <rect x="440" y="120" width="144" height="12" rx="6" fill="#ecfeff"/>
-    <rect x="440" y="144" width="96" height="12" rx="6" fill="#cffafe"/>
-    <rect x="440" y="176" width="128" height="28" rx="14" fill="#ecfeff" opacity="0.9"/>
-    <text x="452" y="195" fill="#0f172a" font-size="13" font-weight="600" font-family="'Inter',sans-serif">Storyboard synced</text>
+  <g filter="url(#timelineShadow)">
+    <rect x="440" y="88" width="144" height="216" rx="18" fill="rgba(8,47,73,0.78)" stroke="rgba(125,211,252,0.4)"/>
+    <rect x="456" y="112" width="112" height="12" rx="6" fill="#ecfeff"/>
+    <rect x="456" y="140" width="96" height="12" rx="6" fill="#bae6fd"/>
+    <rect x="456" y="168" width="72" height="12" rx="6" fill="#38bdf8"/>
+    <rect x="456" y="196" width="112" height="48" rx="12" fill="rgba(14,165,233,0.25)" stroke="#38bdf8" stroke-dasharray="8 6"/>
+    <rect x="456" y="252" width="112" height="32" rx="16" fill="rgba(236,254,255,0.9)"/>
+    <text x="468" y="273" fill="#0f172a" font-family="'Inter',sans-serif" font-size="12" font-weight="600">Storyboard sync ✔</text>
   </g>
-  <g filter="url(#filter2_d_1_1)">
-    <rect x="80" y="280" width="480" height="40" rx="20" fill="rgba(15,118,110,0.85)"/>
-    <text x="100" y="305" fill="#ecfdf5" font-size="16" font-weight="600" font-family="'Inter',sans-serif">Chat: "Ship build + render preview"</text>
+  <g filter="url(#footerShadow)">
+    <rect x="120" y="280" width="400" height="44" rx="22" fill="rgba(14,165,233,0.2)" stroke="rgba(125,211,252,0.45)"/>
+    <text x="144" y="307" fill="#ecfeff" font-family="'Inter',sans-serif" font-size="16" font-weight="600">Chat: “Ship build + drop preview to timeline”</text>
   </g>
   <defs>
-    <linearGradient id="paint0_linear_1_1" x1="88" y1="32" x2="552" y2="344" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#0f172a"/>
+    <linearGradient id="bg" x1="60" y1="36" x2="596" y2="324" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#020817"/>
+      <stop offset="0.5" stop-color="#0f172a"/>
       <stop offset="1" stop-color="#1e293b"/>
     </linearGradient>
-    <filter id="filter0_d_1_1" x="24" y="44" width="392" height="280" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+    <linearGradient id="btn" x1="80" y1="236" x2="200" y2="260" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#38bdf8"/>
+      <stop offset="1" stop-color="#22d3ee"/>
+    </linearGradient>
+    <filter id="chatShadow" x="268" y="152" width="136" height="128" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
       <feFlood flood-opacity="0" result="BackgroundImageFix"/>
       <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
       <feOffset dy="4"/>
       <feGaussianBlur stdDeviation="8"/>
       <feComposite in2="hardAlpha" operator="out"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 0.05 0 0 0 0 0.12 0 0 0 0 0.3 0 0 0 0.35 0"/>
-      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
-      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.06 0 0 0 0 0.19 0 0 0 0 0.34 0 0 0 0.35 0"/>
+      <feBlend in2="BackgroundImageFix" mode="normal" result="effect1_dropShadow"/>
+      <feBlend in="SourceGraphic" in2="effect1_dropShadow" mode="normal" result="shape"/>
     </filter>
-    <filter id="filter1_d_1_1" x="404" y="80" width="216" height="176" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+    <filter id="timelineShadow" x="424" y="72" width="176" height="248" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
       <feFlood flood-opacity="0" result="BackgroundImageFix"/>
       <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
       <feOffset dy="6"/>
       <feGaussianBlur stdDeviation="10"/>
       <feComposite in2="hardAlpha" operator="out"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 0.02 0 0 0 0 0.17 0 0 0 0 0.24 0 0 0 0.25 0"/>
-      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
-      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.04 0 0 0 0 0.3 0 0 0 0 0.4 0 0 0 0.35 0"/>
+      <feBlend in2="BackgroundImageFix" mode="normal" result="effect1_dropShadow"/>
+      <feBlend in="SourceGraphic" in2="effect1_dropShadow" mode="normal" result="shape"/>
     </filter>
-    <filter id="filter2_d_1_1" x="60" y="268" width="520" height="80" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+    <filter id="footerShadow" x="100" y="268" width="440" height="84" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
       <feFlood flood-opacity="0" result="BackgroundImageFix"/>
       <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
       <feOffset dy="6"/>
       <feGaussianBlur stdDeviation="10"/>
       <feComposite in2="hardAlpha" operator="out"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 0.02 0 0 0 0 0.28 0 0 0 0 0.25 0 0 0 0.35 0"/>
-      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
-      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.06 0 0 0 0 0.29 0 0 0 0 0.36 0 0 0 0.35 0"/>
+      <feBlend in2="BackgroundImageFix" mode="normal" result="effect1_dropShadow"/>
+      <feBlend in="SourceGraphic" in2="effect1_dropShadow" mode="normal" result="shape"/>
     </filter>
   </defs>
 </svg>

--- a/sites/blackroad/public/img/proof-money.svg
+++ b/sites/blackroad/public/img/proof-money.svg
@@ -1,61 +1,66 @@
 <svg width="640" height="360" viewBox="0 0 640 360" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect width="640" height="360" rx="24" fill="url(#paint0_linear_4_1)"/>
-  <g filter="url(#filter0_d_4_1)">
-    <rect x="80" y="88" width="480" height="216" rx="28" fill="rgba(15,23,42,0.85)"/>
-    <rect x="112" y="120" width="200" height="144" rx="20" fill="rgba(16,185,129,0.2)" stroke="#22c55e" stroke-width="2"/>
-    <rect x="336" y="120" width="192" height="64" rx="16" fill="rgba(20,184,166,0.3)" stroke="#14b8a6" stroke-width="2"/>
-    <rect x="336" y="200" width="192" height="64" rx="16" fill="rgba(56,189,248,0.3)" stroke="#38bdf8" stroke-width="2"/>
-    <text x="140" y="156" fill="#bbf7d0" font-size="14" font-family="'Inter',sans-serif">Creator Wallet</text>
-    <text x="356" y="156" fill="#5eead4" font-size="13" font-family="'Inter',sans-serif">Tips + One-time</text>
-    <text x="356" y="236" fill="#bae6fd" font-size="13" font-family="'Inter',sans-serif">Splits + Payouts</text>
-    <rect x="132" y="176" width="160" height="12" rx="6" fill="#22c55e" opacity="0.8"/>
-    <rect x="132" y="198" width="180" height="12" rx="6" fill="#34d399" opacity="0.7"/>
-    <rect x="132" y="220" width="120" height="12" rx="6" fill="#86efac" opacity="0.6"/>
-    <rect x="132" y="242" width="200" height="32" rx="10" fill="#ecfdf5"/>
-    <text x="150" y="264" fill="#047857" font-size="14" font-weight="600" font-family="'Inter',sans-serif">Next payout · 12:00 UTC</text>
+  <rect width="640" height="360" rx="28" fill="url(#bg)"/>
+  <g filter="url(#panelShadow)">
+    <rect x="80" y="72" width="480" height="224" rx="24" fill="rgba(15,23,42,0.9)" stroke="rgba(148,163,184,0.35)"/>
+    <rect x="112" y="104" width="160" height="120" rx="16" fill="rgba(6,95,70,0.82)" stroke="rgba(45,212,191,0.45)"/>
+    <text x="132" y="136" fill="#d1fae5" font-family="'Inter',sans-serif" font-size="14" font-weight="600">Creator Wallet</text>
+    <rect x="128" y="152" width="128" height="12" rx="6" fill="#d1fae5"/>
+    <rect x="128" y="176" width="112" height="12" rx="6" fill="#99f6e4"/>
+    <rect x="128" y="200" width="144" height="36" rx="12" fill="rgba(45,212,191,0.28)" stroke="#34d399" stroke-dasharray="8 6"/>
+    <text x="140" y="222" fill="#ecfdf5" font-family="'Inter',sans-serif" font-size="12">Instant settlement ✔</text>
+    <rect x="276" y="104" width="132" height="144" rx="18" fill="rgba(15,118,110,0.85)" stroke="rgba(45,212,191,0.45)"/>
+    <text x="296" y="138" fill="#ccfbf1" font-family="'Inter',sans-serif" font-size="14" font-weight="600">Revenue Split</text>
+    <rect x="292" y="154" width="104" height="12" rx="6" fill="#ccfbf1"/>
+    <rect x="292" y="178" width="96" height="12" rx="6" fill="#5eead4"/>
+    <rect x="292" y="202" width="72" height="12" rx="6" fill="#34d399"/>
+    <rect x="292" y="226" width="104" height="28" rx="14" fill="#f0fdfa"/>
+    <text x="306" y="245" fill="#0f172a" font-family="'Inter',sans-serif" font-size="12" font-weight="600">USD · USDC · CRT</text>
+    <rect x="432" y="104" width="112" height="160" rx="18" fill="rgba(4,120,87,0.85)" stroke="rgba(16,185,129,0.45)"/>
+    <text x="452" y="138" fill="#d1fae5" font-family="'Inter',sans-serif" font-size="14" font-weight="600">Payouts</text>
+    <rect x="444" y="154" width="88" height="12" rx="6" fill="#bbf7d0"/>
+    <rect x="444" y="178" width="88" height="12" rx="6" fill="#6ee7b7"/>
+    <rect x="444" y="202" width="88" height="12" rx="6" fill="#34d399"/>
+    <rect x="444" y="226" width="88" height="12" rx="6" fill="#0ea5e9"/>
+    <rect x="444" y="250" width="88" height="28" rx="14" fill="#ecfdf5"/>
+    <text x="452" y="269" fill="#0f172a" font-family="'Inter',sans-serif" font-size="12" font-weight="600">Next run · Fri</text>
   </g>
-  <g filter="url(#filter1_d_4_1)">
-    <rect x="120" y="64" width="220" height="44" rx="22" fill="rgba(16,185,129,0.85)"/>
-    <text x="146" y="90" fill="#ecfdf5" font-size="16" font-weight="600" font-family="'Inter',sans-serif">Live wallet balance: $48,920</text>
+  <path d="M256 184c56-40 124-40 176 0" stroke="#34d399" stroke-width="3" stroke-linecap="round" stroke-dasharray="10 12"/>
+  <path d="M188 236c72 36 168 44 240 8" stroke="#2dd4bf" stroke-width="3" stroke-linecap="round" stroke-dasharray="10 12"/>
+  <g fill="#34d399">
+    <circle cx="256" cy="184" r="7"/>
+    <circle cx="432" cy="184" r="7"/>
+    <circle cx="188" cy="236" r="7"/>
+    <circle cx="428" cy="244" r="7"/>
   </g>
-  <g filter="url(#filter2_d_4_1)">
-    <rect x="160" y="296" width="320" height="40" rx="20" fill="rgba(56,189,248,0.9)"/>
-    <text x="186" y="322" fill="#0f172a" font-size="16" font-weight="600" font-family="'Inter',sans-serif">Automated split sent to 12 creators</text>
+  <g filter="url(#footerShadow)">
+    <rect x="192" y="300" width="256" height="40" rx="20" fill="rgba(16,185,129,0.24)" stroke="rgba(45,212,191,0.4)"/>
+    <text x="210" y="325" fill="#ecfdf5" font-family="'Inter',sans-serif" font-size="15" font-weight="600">Wallet → splits → payouts timeline</text>
   </g>
   <defs>
-    <linearGradient id="paint0_linear_4_1" x1="100" y1="40" x2="520" y2="320" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#0f172a"/>
-      <stop offset="1" stop-color="#064e3b"/>
+    <linearGradient id="bg" x1="80" y1="36" x2="560" y2="328" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#022c22"/>
+      <stop offset="0.45" stop-color="#064e3b"/>
+      <stop offset="1" stop-color="#0f172a"/>
     </linearGradient>
-    <filter id="filter0_d_4_1" x="60" y="72" width="520" height="260" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+    <filter id="panelShadow" x="60" y="52" width="520" height="264" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
       <feFlood flood-opacity="0" result="BackgroundImageFix"/>
       <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
-      <feOffset dy="10"/>
-      <feGaussianBlur stdDeviation="14"/>
+      <feOffset dy="8"/>
+      <feGaussianBlur stdDeviation="12"/>
       <feComposite in2="hardAlpha" operator="out"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 0.08 0 0 0 0 0.33 0 0 0 0 0.24 0 0 0 0.34 0"/>
-      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
-      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.02 0 0 0 0 0.34 0 0 0 0 0.29 0 0 0 0.32 0"/>
+      <feBlend in2="BackgroundImageFix" mode="normal" result="effect1_dropShadow"/>
+      <feBlend in="SourceGraphic" in2="effect1_dropShadow" mode="normal" result="shape"/>
     </filter>
-    <filter id="filter1_d_4_1" x="100" y="52" width="260" height="84" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+    <filter id="footerShadow" x="172" y="284" width="296" height="80" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
       <feFlood flood-opacity="0" result="BackgroundImageFix"/>
       <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
       <feOffset dy="6"/>
       <feGaussianBlur stdDeviation="10"/>
       <feComposite in2="hardAlpha" operator="out"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 0.02 0 0 0 0 0.21 0 0 0 0 0.17 0 0 0 0.28 0"/>
-      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
-      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
-    </filter>
-    <filter id="filter2_d_4_1" x="140" y="284" width="360" height="80" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
-      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
-      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
-      <feOffset dy="6"/>
-      <feGaussianBlur stdDeviation="10"/>
-      <feComposite in2="hardAlpha" operator="out"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 0.05 0 0 0 0 0.31 0 0 0 0 0.44 0 0 0 0.36 0"/>
-      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
-      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.03 0 0 0 0 0.38 0 0 0 0 0.32 0 0 0 0.32 0"/>
+      <feBlend in2="BackgroundImageFix" mode="normal" result="effect1_dropShadow"/>
+      <feBlend in="SourceGraphic" in2="effect1_dropShadow" mode="normal" result="shape"/>
     </filter>
   </defs>
 </svg>

--- a/sites/blackroad/public/img/proof-simulation.svg
+++ b/sites/blackroad/public/img/proof-simulation.svg
@@ -1,60 +1,107 @@
 <svg width="640" height="360" viewBox="0 0 640 360" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect width="640" height="360" rx="24" fill="url(#paint0_linear_3_1)"/>
-  <g filter="url(#filter0_d_3_1)">
-    <rect x="72" y="84" width="496" height="196" rx="24" fill="rgba(15,23,42,0.82)"/>
-    <rect x="108" y="120" width="160" height="112" rx="18" fill="rgba(125,211,252,0.18)" stroke="#38bdf8" stroke-width="2"/>
-    <rect x="250" y="120" width="132" height="112" rx="18" fill="rgba(99,102,241,0.18)" stroke="#6366f1" stroke-width="2"/>
-    <rect x="380" y="120" width="152" height="112" rx="18" fill="rgba(16,185,129,0.2)" stroke="#34d399" stroke-width="2"/>
-    <text x="136" y="210" fill="#bae6fd" font-size="13" font-family="'Inter',sans-serif">Sim Scene</text>
-    <text x="272" y="210" fill="#e0e7ff" font-size="13" font-family="'Inter',sans-serif">Render Queue</text>
-    <text x="412" y="210" fill="#bbf7d0" font-size="13" font-family="'Inter',sans-serif">Publish</text>
-    <path d="M268 176H306" stroke="#38bdf8" stroke-width="4" stroke-linecap="round" opacity="0.8"/>
-    <path d="M402 176H438" stroke="#34d399" stroke-width="4" stroke-linecap="round" opacity="0.8"/>
-    <path d="M188 164C188 164 216 128 260 128C304 128 332 164 332 164" stroke="#38bdf8" stroke-width="2" stroke-dasharray="6 8" opacity="0.4"/>
-    <path d="M332 200C332 200 352 232 396 232C440 232 460 200 460 200" stroke="#a5b4fc" stroke-width="2" stroke-dasharray="6 8" opacity="0.4"/>
+  <rect width="640" height="360" rx="28" fill="url(#bg)"/>
+  <g filter="url(#gridShadow)">
+    <rect x="80" y="72" width="480" height="216" rx="24" fill="rgba(15,23,42,0.88)" stroke="rgba(148,163,184,0.35)"/>
+    <path d="M128 132h384" stroke="rgba(59,130,246,0.25)" stroke-width="1.5" stroke-dasharray="6 8"/>
+    <path d="M128 212h384" stroke="rgba(59,130,246,0.25)" stroke-width="1.5" stroke-dasharray="6 8"/>
+    <path d="M200 104v184" stroke="rgba(59,130,246,0.25)" stroke-width="1.5" stroke-dasharray="6 8"/>
+    <path d="M320 104v184" stroke="rgba(59,130,246,0.25)" stroke-width="1.5" stroke-dasharray="6 8"/>
+    <path d="M440 104v184" stroke="rgba(59,130,246,0.25)" stroke-width="1.5" stroke-dasharray="6 8"/>
   </g>
-  <g filter="url(#filter1_d_3_1)">
-    <rect x="104" y="60" width="224" height="48" rx="20" fill="rgba(56,189,248,0.9)"/>
-    <text x="128" y="90" fill="#0f172a" font-size="16" font-weight="600" font-family="'Inter',sans-serif">GPU burst render ready</text>
+  <g filter="url(#sceneShadow)">
+    <rect x="132" y="120" width="144" height="96" rx="18" fill="url(#scene)"/>
+    <path d="M156 192l28-52 28 40 28-36 20 48" stroke="#e0f2fe" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle cx="228" cy="148" r="10" fill="#f8fafc"/>
   </g>
-  <g filter="url(#filter2_d_3_1)">
-    <rect x="160" y="268" width="320" height="44" rx="22" fill="rgba(59,130,246,0.85)"/>
-    <text x="188" y="294" fill="#dbeafe" font-size="16" font-weight="600" font-family="'Inter',sans-serif">Export video + interactive build</text>
+  <g filter="url(#midShadow)">
+    <rect x="252" y="148" width="152" height="120" rx="20" fill="rgba(8,47,73,0.88)" stroke="rgba(125,211,252,0.4)"/>
+    <rect x="276" y="168" width="104" height="12" rx="6" fill="#ecfeff"/>
+    <rect x="276" y="192" width="88" height="12" rx="6" fill="#bae6fd"/>
+    <rect x="276" y="216" width="120" height="12" rx="6" fill="#38bdf8"/>
+    <rect x="276" y="244" width="120" height="16" rx="8" fill="rgba(14,165,233,0.28)" stroke="#22d3ee" stroke-dasharray="8 6"/>
+    <text x="288" y="258" fill="#f8fafc" font-family="'Inter',sans-serif" font-size="12">GPU burst render · 02:41</text>
+  </g>
+  <g filter="url(#outputShadow)">
+    <rect x="396" y="116" width="148" height="104" rx="20" fill="rgba(12,74,110,0.9)" stroke="rgba(165,243,252,0.4)"/>
+    <rect x="416" y="140" width="108" height="12" rx="6" fill="#e0f2fe"/>
+    <rect x="416" y="164" width="92" height="12" rx="6" fill="#bae6fd"/>
+    <rect x="416" y="188" width="92" height="12" rx="6" fill="#38bdf8"/>
+    <rect x="416" y="216" width="108" height="28" rx="14" fill="#f0fdfa"/>
+    <text x="428" y="235" fill="#0f172a" font-family="'Inter',sans-serif" font-size="12" font-weight="600">Playable export</text>
+  </g>
+  <path d="M264 172c20-32 56-52 88-20" stroke="#38bdf8" stroke-width="3" stroke-linecap="round" stroke-dasharray="8 10"/>
+  <path d="M352 236c28 26 80 30 112-6" stroke="#38bdf8" stroke-width="3" stroke-linecap="round" stroke-dasharray="8 10"/>
+  <path d="M208 176c24 12 48 24 72 48" stroke="#38bdf8" stroke-width="3" stroke-linecap="round" stroke-dasharray="8 10"/>
+  <g fill="#38bdf8">
+    <circle cx="264" cy="172" r="7"/>
+    <circle cx="352" cy="236" r="7"/>
+    <circle cx="280" cy="224" r="7"/>
+    <circle cx="440" cy="208" r="7"/>
+    <circle cx="488" cy="206" r="7"/>
+  </g>
+  <g filter="url(#footerShadow)">
+    <rect x="176" y="292" width="288" height="40" rx="20" fill="rgba(14,165,233,0.24)" stroke="rgba(125,211,252,0.4)"/>
+    <text x="196" y="317" fill="#e0f2fe" font-family="'Inter',sans-serif" font-size="15" font-weight="600">Sim-to-studio: scene → render → build</text>
   </g>
   <defs>
-    <linearGradient id="paint0_linear_3_1" x1="84" y1="36" x2="556" y2="324" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#1e3a8a"/>
-      <stop offset="1" stop-color="#111827"/>
+    <linearGradient id="bg" x1="68" y1="24" x2="568" y2="336" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#020617"/>
+      <stop offset="0.45" stop-color="#0f172a"/>
+      <stop offset="1" stop-color="#1d293b"/>
     </linearGradient>
-    <filter id="filter0_d_3_1" x="52" y="68" width="536" height="240" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+    <linearGradient id="scene" x1="132" y1="120" x2="276" y2="216" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0ea5e9"/>
+      <stop offset="1" stop-color="#38bdf8"/>
+    </linearGradient>
+    <filter id="gridShadow" x="60" y="52" width="520" height="256" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
       <feFlood flood-opacity="0" result="BackgroundImageFix"/>
       <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
-      <feOffset dy="10"/>
-      <feGaussianBlur stdDeviation="14"/>
+      <feOffset dy="8"/>
+      <feGaussianBlur stdDeviation="12"/>
       <feComposite in2="hardAlpha" operator="out"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 0.07 0 0 0 0 0.17 0 0 0 0 0.35 0 0 0 0.3 0"/>
-      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
-      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.04 0 0 0 0 0.31 0 0 0 0 0.46 0 0 0 0.32 0"/>
+      <feBlend in2="BackgroundImageFix" mode="normal" result="effect1_dropShadow"/>
+      <feBlend in="SourceGraphic" in2="effect1_dropShadow" mode="normal" result="shape"/>
     </filter>
-    <filter id="filter1_d_3_1" x="84" y="44" width="264" height="88" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+    <filter id="sceneShadow" x="112" y="100" width="184" height="136" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
       <feFlood flood-opacity="0" result="BackgroundImageFix"/>
       <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
       <feOffset dy="6"/>
       <feGaussianBlur stdDeviation="10"/>
       <feComposite in2="hardAlpha" operator="out"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 0.03 0 0 0 0 0.24 0 0 0 0 0.39 0 0 0 0.35 0"/>
-      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
-      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.06 0 0 0 0 0.32 0 0 0 0 0.4 0 0 0 0.35 0"/>
+      <feBlend in2="BackgroundImageFix" mode="normal" result="effect1_dropShadow"/>
+      <feBlend in="SourceGraphic" in2="effect1_dropShadow" mode="normal" result="shape"/>
     </filter>
-    <filter id="filter2_d_3_1" x="140" y="256" width="360" height="84" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+    <filter id="midShadow" x="232" y="128" width="192" height="160" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
       <feFlood flood-opacity="0" result="BackgroundImageFix"/>
       <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
       <feOffset dy="6"/>
       <feGaussianBlur stdDeviation="10"/>
       <feComposite in2="hardAlpha" operator="out"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 0.07 0 0 0 0 0.34 0 0 0 0 0.52 0 0 0 0.4 0"/>
-      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
-      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.06 0 0 0 0 0.26 0 0 0 0 0.43 0 0 0 0.35 0"/>
+      <feBlend in2="BackgroundImageFix" mode="normal" result="effect1_dropShadow"/>
+      <feBlend in="SourceGraphic" in2="effect1_dropShadow" mode="normal" result="shape"/>
+    </filter>
+    <filter id="outputShadow" x="380" y="100" width="180" height="148" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+      <feOffset dy="6"/>
+      <feGaussianBlur stdDeviation="10"/>
+      <feComposite in2="hardAlpha" operator="out"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.05 0 0 0 0 0.29 0 0 0 0 0.43 0 0 0 0.35 0"/>
+      <feBlend in2="BackgroundImageFix" mode="normal" result="effect1_dropShadow"/>
+      <feBlend in="SourceGraphic" in2="effect1_dropShadow" mode="normal" result="shape"/>
+    </filter>
+    <filter id="footerShadow" x="156" y="276" width="328" height="80" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+      <feOffset dy="6"/>
+      <feGaussianBlur stdDeviation="10"/>
+      <feComposite in2="hardAlpha" operator="out"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.05 0 0 0 0 0.3 0 0 0 0 0.45 0 0 0 0.35 0"/>
+      <feBlend in2="BackgroundImageFix" mode="normal" result="effect1_dropShadow"/>
+      <feBlend in="SourceGraphic" in2="effect1_dropShadow" mode="normal" result="shape"/>
     </filter>
   </defs>
 </svg>

--- a/sites/blackroad/src/pages/Home.jsx
+++ b/sites/blackroad/src/pages/Home.jsx
@@ -10,7 +10,7 @@ const proofBlocks = [
     outcome:
       'Code and media flow in one workspace so teams can script features, frame scenes, and review inline in minutes.',
     image: '/img/proof-build.svg',
-    alt: 'BlackRoad editor with timeline and chat side-by-side',
+    alt: 'Creator-OS workspace showing code panel, storyboard timeline, and chat shipping a preview',
     receipts: [
       'Sub-200ms agent replies inside shared repos',
       'Branch-aware IDE, storyboard, and asset vault',
@@ -23,7 +23,7 @@ const proofBlocks = [
     outcome:
       'Roadie, Guardian, and Lucidia automate review, ops, and finance so you stay focused on shipping.',
     image: '/img/proof-agents.svg',
-    alt: 'Agents coordinating across review, ops, and finance dashboards',
+    alt: 'Roadie, Guardian, and Lucidia dashboards linked by workflow signals',
     receipts: [
       '24/7 code review, release, and compliance runs',
       'Guardian patches drift before it hits prod',
@@ -36,7 +36,7 @@ const proofBlocks = [
     outcome:
       'Spin up physics-grade scenes, iterate in real time, and export footage or interactive builds without leaving chat.',
     image: '/img/proof-simulation.svg',
-    alt: 'Simulation pipeline from 3D scene to rendered experience',
+    alt: 'Sim-to-studio pipeline from 3D scene capture to GPU render and export cards',
     receipts: [
       'Unity & Unreal pipelines pre-integrated',
       'GPU burst renders streamed under 3 seconds',
@@ -49,7 +49,7 @@ const proofBlocks = [
     outcome:
       'Creator Wallet handles tipping, revenue splits, and payouts so every project launches with a business model.',
     image: '/img/proof-money.svg',
-    alt: 'Wallet dashboard showing tips, splits, and payout schedule',
+    alt: 'Creator Wallet panels summarizing instant settlement, splits, and payout schedule',
     receipts: [
       'Self-custodied wallet with instant settlement',
       'Programmable revenue splits per asset bundle',


### PR DESCRIPTION
## Summary
- redesign the proof build, agents, simulation, and money illustrations with higher fidelity multi-panel visuals
- update Home page proof block alt text to describe the refreshed artwork and maintain accessibility

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ffa41325808329990ee34a16d4ccac