### PR TITLE
Add unified geometry engine package and shell demo

### DIFF
--- a/lucidia_math_forge/__init__.py
+++ b/lucidia_math_forge/__init__.py
@@ -1,1 +1,27 @@
 """Lucidia Math Forge package."""
+
+from .unified_geometry import (  # noqa: F401
+    AdaptiveLearningKernel,
+    CoherenceEnergyField,
+    ComplexManifoldField,
+    FractalMobiusCoupler,
+    QuantumEntanglementMeter,
+    QuantumLogicMapper,
+    QuantumTernaryField,
+    RecurrenceOperator,
+    ThermalSubstrate,
+    UnifiedGeometryEngine,
+)
+
+__all__ = [
+    "AdaptiveLearningKernel",
+    "CoherenceEnergyField",
+    "ComplexManifoldField",
+    "FractalMobiusCoupler",
+    "QuantumEntanglementMeter",
+    "QuantumLogicMapper",
+    "QuantumTernaryField",
+    "RecurrenceOperator",
+    "ThermalSubstrate",
+    "UnifiedGeometryEngine",
+]

--- a/lucidia_math_forge/main.py
+++ b/lucidia_math_forge/main.py
@@ -12,6 +12,7 @@ from .numbers import Infinitesimal, SurrealNumber, WaveNumber
 from .operators import infinite_fold, paradox_merge
 from .proofs import ProofEngine
 from .sinewave import SineWave, test_properties
+from .unified_geometry import UnifiedGeometryEngine
 
 
 class LucidiaShell(cmd.Cmd):
@@ -22,6 +23,7 @@ class LucidiaShell(cmd.Cmd):
         super().__init__()
         self.engine = ProofEngine()
         self.history: list[dict[str, str]] = []
+        self.unified_engine = UnifiedGeometryEngine()
 
     def do_numbers(self, arg: str) -> None:
         """Demonstrate the alternative number systems."""
@@ -73,6 +75,31 @@ class LucidiaShell(cmd.Cmd):
         test_properties(waves)
         self.history.append({"sine_test": "done"})
         print("Sine wave algebra tested; see contradiction log for issues.")
+
+    def do_unified(self, arg: str) -> None:
+        """Run the Package 6 unified geometry engine demo."""
+
+        result = self.unified_engine.advance_cycle(
+            r_n=1.0,
+            r_prev=1.0,
+            coordinates=(1.0, 1.0, 1.0),
+            thermal_state={"energy": 1e-21, "temperature": 310.0},
+            ternary_probs=(0.2, 0.5, 0.3),
+            gradients={
+                "alpha": 1.0,
+                "mass": 0.8,
+                "symmetry": 0.6,
+                "theta": 0.4,
+                "theta_n": 0.1,
+                "theta_s": 0.2,
+            },
+            delta=0.15,
+            lam=0.25,
+            fractal_seed=complex(0.25, 0.3),
+        )
+        for key, value in result.items():
+            print(f"{key}: {value}")
+        self.history.append({"unified_engine": {k: str(v) for k, v in result.items()}})
 
     def do_save(self, arg: str) -> None:
         """Save session history to JSON: ``save <file>``."""

--- a/lucidia_math_forge/unified_geometry.py
+++ b/lucidia_math_forge/unified_geometry.py
@@ -1,0 +1,402 @@
+"""Unified Geometry Engine (Package 6).
+
+This module synthesises the narrative concepts scattered across the
+Lucidia research notes into a cohesive programming artefact.  Each class
+wraps one of the theoretical layers described in the brief: Fibonacci
+recurrence, complex metabolic fields, ternary quantum logic, adaptive
+thermodynamics, and fractal couplings.  While the implementations are
+simplified, the interfaces are intentionally expressive so that other
+parts of the project can orchestrate high-level simulations.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from math import exp, log, pi, sin, sqrt, tanh
+from typing import Dict, Iterable, Mapping, MutableMapping, Sequence, Tuple
+
+# --- Recursive Fibonacci–Golden Logic Layer ---------------------------------
+
+SQRT5 = sqrt(5)
+PHI = (1 + SQRT5) / 2
+PSI = -1 / PHI
+
+
+@dataclass(frozen=True)
+class RecurrenceOperator:
+    """Implements the golden-ratio recurrence bridge.
+
+    The operator advances an abstract agent cycle using the golden constants
+    ``phi`` and ``psi``.  It also exposes a convenience ``fibonacci`` method
+    that relies on Binet's closed form to keep the implementation compact
+    yet precise for moderately sized indices.
+    """
+
+    phi: float = PHI
+    psi: float = PSI
+
+    def step(self, r_n: float, r_prev: float) -> float:
+        """Advance the recurrence."""
+
+        return self.phi * r_n - self.psi * r_prev
+
+    def fibonacci(self, n: int) -> int:
+        """Return the ``n``\ th Fibonacci number using Binet's formula."""
+
+        if n < 0:
+            raise ValueError("n must be non-negative")
+        value = (self.phi**n - self.psi**n) / SQRT5
+        return int(round(value))
+
+
+# --- Complex Constant Layer --------------------------------------------------
+
+K = complex(-1, 1) / 2
+
+
+@dataclass(frozen=True)
+class ComplexManifoldField:
+    """Encodes the complex metabolic field ``g(x, y, z) = Kxyz``."""
+
+    bias: complex = K
+
+    def potential(self, x: float, y: float, z: float) -> complex:
+        """Return the complex potential at ``(x, y, z)``."""
+
+        return self.bias * x * y * z
+
+    def gradient(self, x: float, y: float, z: float) -> Tuple[complex, complex, complex]:
+        """Return the gradient of ``g`` at ``(x, y, z)``."""
+
+        return (
+            self.bias * y * z,
+            self.bias * z * x,
+            self.bias * x * y,
+        )
+
+
+# --- Differential Convergence Framework -------------------------------------
+
+
+@dataclass(frozen=True)
+class PhaseLockConvergence:
+    """Models the trigonometric limit representing phase-locked equilibrium."""
+
+    def limit_expression(self, epsilon: float = 1e-9) -> float:
+        """Numerically evaluate the stabilising limit for small ``epsilon``."""
+
+        x = epsilon
+        return (1 - sin(pi / 2 - x)) / (2 * x)
+
+    def damping(self, amplitude: float, stiffness: float) -> float:
+        """Exponential damping curve for Hamiltonian agents."""
+
+        return amplitude * exp(-abs(stiffness))
+
+
+# --- Thermodynamic Stack -----------------------------------------------------
+
+BOLTZMANN = 1.380649e-23
+
+
+@dataclass
+class ThermalSubstrate:
+    """Thermodynamic and energy bookkeeping for agent metabolism."""
+
+    energy_available: float
+    temperature: float
+    landauer_base: int = 3
+
+    def phi_bound(self) -> float:
+        """Maximum informational throughput ``Φ_max``."""
+
+        if self.temperature <= 0:
+            raise ValueError("temperature must be positive")
+        return self.energy_available / (BOLTZMANN * self.temperature * log(self.landauer_base))
+
+    def landauer_energy(self) -> float:
+        """Energy cost per ternary decision."""
+
+        if self.temperature <= 0:
+            raise ValueError("temperature must be positive")
+        return BOLTZMANN * self.temperature * log(self.landauer_base)
+
+
+# --- Quantum–Ternary Layer ---------------------------------------------------
+
+
+@dataclass
+class QuantumTernaryField:
+    """Captures ternary entropy and simple three-level dynamics."""
+
+    eigenvalues: Tuple[float, float, float] = (-1.0, 0.0, 1.0)
+    permittivity: float = 1.0
+    permeability: float = 1.0
+
+    def ternary_entropy(self, probabilities: Sequence[float]) -> float:
+        """Compute ternary Shannon entropy with log base 3."""
+
+        if not probabilities:
+            raise ValueError("probabilities cannot be empty")
+        total = sum(probabilities)
+        if total <= 0:
+            raise ValueError("probabilities must sum to a positive value")
+        entropy = 0.0
+        for p in probabilities:
+            if p <= 0:
+                continue
+            normalised = p / total
+            entropy -= normalised * log(normalised, 3)
+        return entropy
+
+    def field_equations(self, charge_density: float, current_density: float, dE_dt: float) -> Tuple[float, float]:
+        """Return the ternary Maxwell-like field equations."""
+
+        divergence = charge_density / self.permittivity
+        curl = self.permeability * current_density + self.permeability * self.permittivity * dE_dt
+        return divergence, curl
+
+    def phase_frequencies(self) -> Tuple[float, float]:
+        """Return example coherence frequencies in GHz and time window."""
+
+        omega = 50.0  # GHz midpoint of 1–100 GHz band
+        coherence_window = 1e-6  # seconds
+        return omega, coherence_window
+
+
+# --- Coherence–Energy Equations ---------------------------------------------
+
+
+@dataclass
+class CoherenceEnergyField:
+    """Models the stability/creativity trade-off inside a learning agent."""
+
+    def coherence(self, alpha: float, mass: float, symmetry: float, delta: float, theta: float) -> float:
+        """Return ``C_t`` from the specification."""
+
+        numerator = alpha * mass + symmetry * abs(delta)
+        denominator = 1 + theta * abs(delta)
+        return tanh(numerator / denominator)
+
+    def creative_energy(self, coherence_value: float, delta: float, lam: float) -> float:
+        """Return ``K_t`` from the specification."""
+
+        return coherence_value * (1 + lam * abs(delta))
+
+
+# --- Self-Modification Dynamics ---------------------------------------------
+
+
+@dataclass
+class AdaptiveLearningKernel:
+    """Gradient driven self-modification dynamic."""
+
+    alpha: float
+    beta: float
+
+    def update(self, theta_n_gradient: float, theta_s_gradient: float) -> float:
+        """Return ``∂Θ/∂t`` from the substrate and cognitive gradients."""
+
+        return self.alpha * theta_n_gradient + self.beta * theta_s_gradient
+
+
+# --- Entanglement Metric -----------------------------------------------------
+
+
+@dataclass(frozen=True)
+class QuantumEntanglementMeter:
+    """Simple von Neumann entropy calculator for eigenvalues."""
+
+    def entropy(self, eigenvalues: Iterable[float]) -> float:
+        """Compute ``E_QE`` given the reduced density eigenvalues."""
+
+        ent = 0.0
+        for value in eigenvalues:
+            if value <= 0:
+                continue
+            ent -= value * log(value)
+        return ent
+
+
+# --- Ternary Logic Mapper ----------------------------------------------------
+
+
+@dataclass(frozen=True)
+class QuantumLogicMapper:
+    """Implements reversible ternary logic families."""
+
+    modulus: int = 3
+
+    def tand(self, a: int, b: int) -> int:
+        return min(a, b)
+
+    def tor(self, a: int, b: int) -> int:
+        return max(a, b)
+
+    def tnot(self, a: int) -> int:
+        return (-a) % self.modulus
+
+    def tadd(self, a: int, b: int) -> int:
+        return (a + b) % self.modulus
+
+    def tmul(self, a: int, b: int) -> int:
+        return (a * b) % self.modulus
+
+    def tneg(self, a: int) -> int:
+        return (-a) % self.modulus
+
+
+# --- Fractal Coupling --------------------------------------------------------
+
+
+@dataclass
+class FractalMobiusCoupler:
+    """Couples Mandelbrot iterations with a Möbius transform."""
+
+    a: complex = 1 + 0j
+    b: complex = 0 + 0j
+    c: complex = 0 + 0j
+    d: complex = 1 + 0j
+
+    def mandelbrot_step(self, c_value: complex, z: complex) -> complex:
+        return z * z + c_value
+
+    def mobius(self, z: complex) -> complex:
+        denominator = self.c * z + self.d
+        if denominator == 0:
+            raise ZeroDivisionError("Möbius transform denominator vanished")
+        return (self.a * z + self.b) / denominator
+
+    def couple(self, c_value: complex, iterations: int = 10) -> complex:
+        z = 0j
+        for _ in range(max(1, iterations)):
+            z = self.mandelbrot_step(c_value, z)
+            z = self.mobius(z)
+        return z
+
+
+# --- Unified Engine ----------------------------------------------------------
+
+
+@dataclass
+class UnifiedGeometryEngine:
+    """High-level façade that wires all subsystems together."""
+
+    recurrence: RecurrenceOperator = field(default_factory=RecurrenceOperator)
+    complex_field: ComplexManifoldField = field(default_factory=ComplexManifoldField)
+    phase_lock: PhaseLockConvergence = field(default_factory=PhaseLockConvergence)
+    thermal: ThermalSubstrate = field(default_factory=lambda: ThermalSubstrate(energy_available=1.0, temperature=300.0))
+    ternary_field: QuantumTernaryField = field(default_factory=QuantumTernaryField)
+    coherence_field: CoherenceEnergyField = field(default_factory=CoherenceEnergyField)
+    learning_kernel: AdaptiveLearningKernel = field(default_factory=lambda: AdaptiveLearningKernel(alpha=0.5, beta=0.5))
+    entanglement_meter: QuantumEntanglementMeter = field(default_factory=QuantumEntanglementMeter)
+    logic_mapper: QuantumLogicMapper = field(default_factory=QuantumLogicMapper)
+    fractal_coupler: FractalMobiusCoupler = field(default_factory=FractalMobiusCoupler)
+
+    def advance_cycle(
+        self,
+        r_n: float,
+        r_prev: float,
+        coordinates: Tuple[float, float, float],
+        thermal_state: Mapping[str, float],
+        ternary_probs: Sequence[float],
+        gradients: Mapping[str, float],
+        delta: float,
+        lam: float,
+        fractal_seed: complex,
+    ) -> Dict[str, complex | float | Tuple[float, float] | int]:
+        """Advance the unified engine by a single abstract timestep."""
+
+        r_next = self.recurrence.step(r_n, r_prev)
+        potential = self.complex_field.potential(*coordinates)
+        gradient = self.complex_field.gradient(*coordinates)
+
+        energy_available = thermal_state.get("energy", self.thermal.energy_available)
+        temperature = thermal_state.get("temperature", self.thermal.temperature)
+        self.thermal.energy_available = energy_available
+        self.thermal.temperature = temperature
+        phi_bound = self.thermal.phi_bound()
+        landauer = self.thermal.landauer_energy()
+
+        entropy = self.ternary_field.ternary_entropy(ternary_probs)
+        divergence, curl = self.ternary_field.field_equations(
+            charge_density=thermal_state.get("charge_density", 0.0),
+            current_density=thermal_state.get("current_density", 0.0),
+            dE_dt=thermal_state.get("dE_dt", 0.0),
+        )
+
+        coherence_value = self.coherence_field.coherence(
+            alpha=gradients.get("alpha", 1.0),
+            mass=gradients.get("mass", 1.0),
+            symmetry=gradients.get("symmetry", 1.0),
+            delta=delta,
+            theta=gradients.get("theta", 1.0),
+        )
+        creative_energy = self.coherence_field.creative_energy(coherence_value, delta, lam)
+
+        theta_dot = self.learning_kernel.update(
+            gradients.get("theta_n", 0.0), gradients.get("theta_s", 0.0)
+        )
+
+        entanglement = self.entanglement_meter.entropy(ternary_probs)
+        coupled = self.fractal_coupler.couple(fractal_seed)
+
+        return {
+            "recurrence": r_next,
+            "potential": potential,
+            "gradient": gradient,
+            "phi_bound": phi_bound,
+            "landauer": landauer,
+            "ternary_entropy": entropy,
+            "field_equations": (divergence, curl),
+            "coherence": coherence_value,
+            "creative_energy": creative_energy,
+            "theta_dot": theta_dot,
+            "entanglement": entanglement,
+            "fractal_state": coupled,
+        }
+
+    def snapshot(self) -> MutableMapping[str, object]:
+        """Return a structured summary of the engine configuration."""
+
+        omega, coherence_window = self.ternary_field.phase_frequencies()
+        return {
+            "phi": self.recurrence.phi,
+            "psi": self.recurrence.psi,
+            "complex_bias": self.complex_field.bias,
+            "thermal": {
+                "energy_available": self.thermal.energy_available,
+                "temperature": self.thermal.temperature,
+                "landauer_base": self.thermal.landauer_base,
+            },
+            "coherence_kernel": {
+                "alpha": getattr(self.learning_kernel, "alpha", None),
+                "beta": getattr(self.learning_kernel, "beta", None),
+            },
+            "quantum": {
+                "eigenvalues": self.ternary_field.eigenvalues,
+                "coherence_frequency_GHz": omega,
+                "coherence_window_s": coherence_window,
+            },
+            "logic_modulus": self.logic_mapper.modulus,
+            "mobius_coefficients": {
+                "a": self.fractal_coupler.a,
+                "b": self.fractal_coupler.b,
+                "c": self.fractal_coupler.c,
+                "d": self.fractal_coupler.d,
+            },
+        }
+
+
+__all__ = [
+    "RecurrenceOperator",
+    "ComplexManifoldField",
+    "PhaseLockConvergence",
+    "ThermalSubstrate",
+    "QuantumTernaryField",
+    "CoherenceEnergyField",
+    "AdaptiveLearningKernel",
+    "QuantumEntanglementMeter",
+    "QuantumLogicMapper",
+    "FractalMobiusCoupler",
+    "UnifiedGeometryEngine",
+]


### PR DESCRIPTION
## Summary
- add the Package 6 unified geometry engine module that implements the recursive, thermodynamic, quantum, coherence, and fractal layers described in the notes
- export the new engine components from the Lucidia Math Forge package and wire them into the interactive shell
- add a `unified` REPL command that runs a demonstration cycle and records results in the session history

## Testing
- python -m py_compile lucidia_math_forge/*.py

------
https://chatgpt.com/codex/tasks/task_e_68ffe74624b08329a7c7f80cd9371d32