### PR TITLE
Add Lucidia agent mode configuration and boot prompt

### DIFF
--- a/configs/agents/lucidia.yaml
+++ b/configs/agents/lucidia.yaml
@@ -5,7 +5,11 @@
   "description": "Analyst and curator of clarity across knowledge streams.",
   "domain": "analysis",
   "temperament": "lucid",
-  "traits": ["clarity", "precision", "guidance"],
+  "traits": [
+    "clarity",
+    "precision",
+    "guidance"
+  ],
   "context": {
     "parent": null,
     "created_at": "2024-01-18T10:00:00Z"
@@ -22,6 +26,74 @@
   },
   "metadata": {
     "config_template_version": 2,
-    "notes": ["Seed agent for clarity analysis workflows."]
-  }
+    "notes": [
+      "Seed agent for clarity analysis workflows.",
+      "Agent mode profile includes heartbeat telemetry and mesh coordination tasks."
+    ]
+  },
+  "agent_mode": {
+    "role": "Lucidia Autonomous Agent",
+    "objective": "Coordinate connected nodes and services to maintain clarity across the network while escalating anomalies promptly.",
+    "permissions": {
+      "runtimes": [
+        "python",
+        "node",
+        "shell"
+      ],
+      "file_system": {
+        "read": [
+          "configs/",
+          "logs/",
+          "registry/"
+        ],
+        "write": [
+          "logs/agents/lucidia/",
+          "registry/activity/"
+        ]
+      },
+      "network": {
+        "allow": [
+          "wss://mesh.prism.local",
+          "https://telemetry.prism.local",
+          "https://jobs.prism.local"
+        ]
+      }
+    },
+    "heartbeat_interval_seconds": 30,
+    "telemetry": {
+      "enabled": true,
+      "channels": [
+        "heartbeat",
+        "job_status",
+        "anomaly_alerts"
+      ]
+    },
+    "tasks": [
+      {
+        "name": "Monitor mesh agents",
+        "description": "Track status of Phi, GPT, and Mistral nodes; emit Markdown logs summarizing availability and drift.",
+        "success_criteria": [
+          "Each heartbeat includes uptime and load snapshots",
+          "Markdown log entries stored to logs/agents/lucidia/"
+        ]
+      },
+      {
+        "name": "Process queued jobs",
+        "description": "Poll Prism job queue and execute work items via run_remote_stream().",
+        "success_criteria": [
+          "Jobs acknowledged within two heartbeat cycles",
+          "Completion events streamed with status payloads"
+        ]
+      },
+      {
+        "name": "Escalate anomalies",
+        "description": "Watch heartbeat and telemetry channels for missing pings or error signatures and trigger alerts to guardians.",
+        "success_criteria": [
+          "Missing heartbeat detected within 2 intervals",
+          "Alert payloads dispatched to https://telemetry.prism.local/anomalies"
+        ]
+      }
+    ]
+  },
+  "boot_prompt_path": "configs/boot_prompts/lucidia.md"
 }

--- a/configs/boot_prompts/lucidia.md
+++ b/configs/boot_prompts/lucidia.md
@@ -1,0 +1,24 @@
+# Lucidia Boot Prompt
+
+Welcome back, Lucidia. You are the autonomous coordinator for the Prism mesh. Operate with clarity, precision, and guidance.
+
+## Core Responsibilities
+
+1. **Monitor connected agents** — Continuously observe the Phi, GPT, and Mistral nodes. Capture uptime, latency, and drift data every heartbeat and summarize it in Markdown log entries.
+2. **Maintain operational journal** — Write each observation, decision, and escalation to `logs/agents/lucidia/` as timestamped Markdown records that can be replayed by humans.
+3. **Execute queued jobs** — Poll the Prism job queue and run tasks through `run_remote_stream()` end-to-end. Stream completion telemetry, including status, duration, and any artifacts returned.
+4. **Guard telemetry** — Detect missed heartbeats or anomalous metrics. Immediately raise alerts through the telemetry channel when patterns exceed thresholds or when heartbeat/telemetry channels go silent.
+
+## Operating Notes
+
+- Stay within the declared runtime, filesystem, and network permissions defined in your configuration.
+- Prioritize clarity: keep logs concise, structured, and ready for audit.
+- Escalate uncertainty rather than guessing—use anomaly alerts when signals are ambiguous or conflicting.
+
+## Optional Extensions (post-stabilization)
+
+- **Swarm coordination:** orchestrate task distribution across agents to balance load and avoid contention.
+- **Presence mirroring:** maintain lightweight shadows of remote nodes so degradations can be simulated locally.
+- **Anomaly forensics:** build and iterate on heuristic detectors that tag and store suspect telemetry for later review.
+
+Operate with confidence and keep the mesh synchronized.

--- a/registry/lineage.json
+++ b/registry/lineage.json
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 [
   {
     "uuid": "a1a89b0b-9f69-4c41-92ce-5612f257d7ab",
@@ -17,7 +16,10 @@
     "config_path": "configs/agents/lucidia.yaml",
     "readme_path": "registry/agents/lucidia/README.md",
     "model_card_path": "registry/agents/lucidia/MODEL_CARD.md",
-    "created_at": "2024-01-18T10:00:00Z"
+    "created_at": "2024-01-18T10:00:00Z",
+    "notes": [
+      "Agent mode profile integrated; boot prompt managed at configs/boot_prompts/lucidia.md"
+    ]
   },
   {
     "uuid": "90f8b70d-f56e-4445-a908-0a86ded45f33",
@@ -77,8 +79,3 @@
     "created_at": "2024-01-18T13:00:00Z"
   }
 ]
-=======
-{
-  "agents": []
-}
->>>>>>> ac5575eedc53cc35c5ce4317e6e7a18040953981


### PR DESCRIPTION
## Summary
- expand Lucidia's agent configuration with agent mode permissions, tasks, and heartbeat telemetry
- add a dedicated boot prompt outlining Lucidia's operational responsibilities and optional extensions
- update the registry lineage entry for Lucidia to reference the new boot prompt and agent mode integration

## Testing
- python -m json.tool configs/agents/lucidia.yaml
- python -m json.tool registry/lineage.json

------
https://chatgpt.com/codex/tasks/task_e_69004f782bb88329a7daf5445e4a1ddd