### PR TITLE
Add 90-day execution roadmap for orchestrator delivery

### DIFF
--- a/docs/90-day-execution-plan.md
+++ b/docs/90-day-execution-plan.md
@@ -1,0 +1,50 @@
+# 90-Day Orchestration Execution Plan
+
+## Objective
+Deliver a functioning multi-agent orchestration runtime that can execute YAML-defined security sprints, generate corresponding pull requests, and deploy the first set of production-ready microservices.
+
+## Guiding Principles
+- Prioritize shipping end-to-end functionality over expanding architecture diagrams.
+- Automate validation and testing loops for every new capability.
+- Document operational reality (time, cost, blockers) immediately after each milestone.
+- Use small, observable wins to attract collaborators and investors.
+
+## Month 1 — Runtime Foundations
+1. **YAML Execution Engine**
+   - Implement runner that parses sprint YAML, schedules agent tasks, and persists state.
+   - Enable dry-run and live-run modes with audit logging.
+2. **CI/CD Baseline**
+   - Fix existing pipeline permission gaps and validate workflow YAML.
+   - Establish smoke tests for orchestrator services and security primitives.
+3. **First Deployment Target**
+   - Package one security microservice (e.g., WAF policy service) with container image.
+   - Deploy to a low-cost Kubernetes or Nomad cluster with observability hooks.
+
+## Month 2 — Sprint Delivery & Evidence
+1. **Automated Security Sprint**
+   - Execute TLS/WAF/WebAuthn/AIOps sprint end-to-end via orchestrator.
+   - Auto-generate four pull requests with linked task metadata and verification notes.
+2. **Operational Telemetry**
+   - Capture run metrics (duration, cost, failure rate) and push to shared dashboard.
+   - Record demo walkthrough showing orchestrator triggering and completing sprint.
+3. **Documentation & Narrative**
+   - Produce case study describing before/after workflow, highlighting compliance value.
+   - Draft blog post and investor one-pager summarizing outcomes and metrics.
+
+## Month 3 — Scale & Market Signal
+1. **Microservice Expansion**
+   - Deploy three additional compliance microservices with automated rollout scripts.
+   - Integrate secrets management and runtime policy enforcement for each service.
+2. **Beta User Cohort**
+   - Recruit at least ten design partners (friendly auditors, CISOs, or compliance leads).
+   - Run guided sessions collecting feedback, pain points, and feature requests.
+3. **Funding-Ready Assets**
+   - Assemble video demo, metrics dashboard screenshots, and architecture brief.
+   - Finalize financial model and fundraise deck targeting $500K–$1M seed round.
+
+## Success Criteria
+- Orchestrator converts YAML sprint definitions into running automation without manual patches.
+- Continuous delivery pipelines pass reliably for orchestrator and deployed services.
+- At least four security-focused PRs merged via autonomous flow.
+- Observable user interest (beta cohort + testimonials) to validate market readiness.
+- Clear runway decision: pursue funding with evidence or pivot to employment search.


### PR DESCRIPTION
## Summary
- add a focused 90-day execution plan to guide orchestrator delivery work
- outline monthly milestones covering runtime, sprint automation, and go-to-market preparation

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_69017bd24580832990413c5eaee2d800