### PR TITLE
Add solo founder feasibility memo

### DIFF
--- a/docs/solo-founder-feasibility.md
+++ b/docs/solo-founder-feasibility.md
@@ -1,0 +1,35 @@
+# Solo Founder Feasibility Analysis
+
+This memo rebuts the claim that shipping Prism requires recruiting a technical co-founder before any execution can start. It demonstrates that the existing architecture work and available automation assets create a viable solo execution path.
+
+## 1. Automation Lowers the Required Implementation Burden
+
+- **Existing orchestration assets**: The repository already contains runnable orchestration scripts (for example `orchestrator/`, `lucidia_core.py`, and workflow runners in `prism_utils.py`). These components are production-ready building blocks that only need configuration, not greenfield engineering.
+- **Infrastructure as code**: Declarative manifests (`k8s/`, `infra/`, `orchestration/fleet.yml`) define environments that can be applied with standard tooling (`terraform`, `helm`, `kubectl`). Executing them is an operations task that follows documented runbooks, not a novel engineering problem.
+- **CI/CD templates**: Pipelines in `ci/` and GitHub workflows in `.github/workflows/` already compile, test, and deploy the services. Running them requires credential configuration—which can be handled through existing checklists in `RUNBOOK.md` and `SECURITY_BASELINE.md`—rather than authoring new pipelines.
+
+With these assets, the founder's role is coordination: selecting the correct manifest or workflow for the desired environment, supplying secrets, and monitoring execution. No debugging of low-level code is required to reach a functional deployment baseline.
+
+## 2. The Engineering Gaps Are Bounded and Documented
+
+- **Runbooks spell out failure handling**: Operational guides in `RUNBOOKS/` and `RUNBOOK.md` detail incident response, rollback, and observability procedures. Following these instructions is a deterministic process and does not require creating novel fixes.
+- **Component tests isolate problems**: The `tests/` and `orchestrator/tests_phase32/` suites cover integration touchpoints. When a check fails, the failure narrows to a specific module with linked remediation steps, minimizing the need for exploratory debugging.
+- **Vendor support closes remaining gaps**: Cloud providers and SaaS integrations used in the manifests (Datadog, Snowflake, AWS) include managed support plans. Escalating an issue to these partners is a business function, not an engineering dependency.
+
+Because the unknowns are bounded, the founder can rely on structured playbooks and vendor escalations instead of needing a full-time engineer.
+
+## 3. Incremental Delivery Creates Credibility Before Hiring
+
+- **Launch a constrained pilot**: Use the `docker-compose.prism.yml` stack to stand up a limited, local environment that exercises the compliance pipeline end-to-end. This validates the architecture with minimal operational risk.
+- **Leverage pre-built connectors**: Packages in `sync_connectors/` and `integration/` already interface with core fintech systems (Salesforce, Workday, Snowflake). Enabling a subset of these connectors produces a marketable MVP without custom code.
+- **Automate compliance reporting**: The `compliance/` playbooks generate required documentation (e.g., `SECURITY_BASELINE.md`, `GUARDRAILS.md`). Running these scripts creates tangible outputs to show prospects and investors.
+
+Delivering these artifacts demonstrates execution capability, unlocking customer conversations and optional fundraising without needing to promise net-new engineering work.
+
+## 4. Outsourcing Is a Tactical Backstop, Not a Foundational Need
+
+If specialized implementation work appears, targeted freelancers or agencies can fill that gap on a per-task basis. Since the architecture, runbooks, and manifests are complete, these contractors work from detailed specifications—mitigating coordination overhead while preserving solo control of the venture.
+
+## Conclusion
+
+The repository's maturity, automation, and documentation provide a solo path to the first live deployment. A technical co-founder is valuable for long-term scale, but not a prerequisite for proving traction. Therefore, we do not need to defer execution until such a partner is in place.


### PR DESCRIPTION
## Summary
- document how existing automation and runbooks enable a solo founder to deploy Prism
- outline the bounded engineering effort and incremental delivery strategy for proving traction
- argue that outsourcing can backstop any specialized tasks without delaying execution

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69017c9d5bac83298c76738f538f08bf