### PR TITLE
Add team alignment playbook for collaborator decisions

### DIFF
--- a/docs/team_alignment_playbook.md
+++ b/docs/team_alignment_playbook.md
@@ -1,0 +1,87 @@
+# Team Alignment Playbook
+
+This playbook helps founders evaluate whether their current collaborators are
+co-founders ready to build a company or casual contributors who prefer lighter
+engagement. Use it as a working document when discussing commitment levels with
+"besties" (friends, contractors, or collaborators) who contribute to the
+product.
+
+## 1. Team Inventory
+
+| Question | Notes |
+| --- | --- |
+| How many active collaborators are involved today? | |
+| What are their core skills (frontend, backend, DevOps, security, product)? | |
+| How are they compensated (equity split, cash, favors)? | |
+| How long has each person worked with you on this product? | |
+| Are collaborators willing to commit full time if funding is secured? | |
+| What motivates each person to stay involved long term? | |
+
+## 2. Execution Velocity
+
+Track how fast the team can deliver production-ready changes.
+
+- Maintain a changelog of recent pull requests (ex: PR #2710) and note the
+  author, scope, and security relevance.
+- Measure throughput (PRs per week) and lead time (idea → merged code).
+- Capture who reviewed and approved each change to map code ownership.
+- Identify blockers (availability, unclear specs, lack of tooling) that limit
+  the pace of delivery.
+
+## 3. Founder Roles & Responsibilities
+
+Clarify your leadership lane so everyone understands how decisions happen.
+
+- Product leadership: set the vision, write specs, prioritize the roadmap.
+- Security and compliance: maintain the security framework and review sensitive
+  updates.
+- Program orchestration: run rituals (standups, async updates) and coordinate
+  humans + AI agents.
+- Business development: handle customer discovery, partnerships, and future
+  fundraising conversations.
+
+Use this section to decide which responsibilities remain yours and which can be
+delegated as the team scales.
+
+## 4. Commitment Spectrum
+
+Rank each collaborator on the following spectrum and document evidence:
+
+1. **Co-founder** — ready for equity, long-term commitment, and fundraising.
+2. **Core contractor** — ongoing paid engagement, flexible equity, steady
+   output.
+3. **Specialist** — short bursts of focused work (security review, UX polish).
+4. **Supporter** — occasional help, no ongoing obligations.
+
+Document each person's status quarterly so expectations stay aligned.
+
+## 5. Decision Outcomes
+
+Depending on how the assessment lands, choose a primary path forward:
+
+### Path A — Raise a Seed Round
+
+- Formalize entity and equity splits using a founders' agreement.
+- Sprint toward a polished demo within 30 days, highlighting security wins and
+  recent PRs.
+- Prepare a pitch deck covering problem, solution, team, traction, and use of
+  funds (e.g., 18-month runway, infra, legal, buffer).
+- Target $750K–$1.5M to bring collaborators full time and accelerate delivery.
+
+### Path B — Secure a Leadership Role
+
+- Package the architecture, security framework, and shipping history into a
+  portfolio for interviews.
+- Pursue Director/VP-level roles in AI, fintech, or security-focused startups
+  with $170K–$220K cash compensation plus equity.
+- Continue building the product nights/weekends while recruiting committed
+  co-founders.
+
+## 6. Weekly Ritual
+
+1. Run a 30-minute retrospective with collaborators.
+2. Update this document with new learnings (commitment shifts, PR metrics).
+3. Publish a short async note summarizing wins, blockers, and next steps.
+
+This rhythm keeps expectations aligned and shows investors or hiring teams that
+you operate with clarity and discipline.


### PR DESCRIPTION
## Summary
- add a team alignment playbook that helps founders assess collaborator commitment
- outline execution metrics, role clarity, and decision paths for fundraising versus leadership roles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69017d1ecde08329a79096d1732584f0