### PR TITLE
Add sustainable income playbook

### DIFF
--- a/docs/sustainable_income_playbook.md
+++ b/docs/sustainable_income_playbook.md
@@ -1,0 +1,30 @@
+# Sustainable Income Playbook
+
+## Immediate Priorities (Week 0-1)
+- **Quantify baseline throughput**: Schedule a 5-day sprint with four focused hours per day. Capture total branches merged, QA outcomes, and API spend.
+- **Productize the story**: Turn the data into a one-pager and slide summary showing delivery pace, quality rate, and economics.
+- **Cash runway check**: List personal expenses for the next 60 days and current reserves to size the funding gap.
+- **Offer structure**: Prepare two pre-priced service packages (e.g., $12.5K for 4-week prototype, $25K for 6-week MVP) with clear deliverables and acceptance criteria.
+
+## Near-Term Cash Generation (Week 1-4)
+- **Client acquisition sprint**:
+  - Reach out to the warmest 20 founder leads (accelerators, past contacts, indie hacker forums).
+  - Share the throughput proof, service menu, and offer a 30-minute diagnostic call.
+  - Target signing one client for at least $12.5K with 50% upfront.
+- **Protect delivery capacity**: Cap intake to one active project at a time while maintaining the 3-5 branches/hour cadence.
+- **Document everything**: Record daily QA notes, blockers, and delivered features to convert into future case studies.
+
+## Mid-Term Leverage (Month 2-3)
+- **Parallel Prism build**: Dedicate one day per week to shipping the Prism runtime and deployment milestones (200-300 quality branches in Month 1 scope).
+- **Upsell path**: For the initial client, outline a follow-on security or scaling sprint ($10K-$15K) scheduled immediately after MVP handoff.
+- **Partnership channels**: Line up at least two fractional CTOs or product studios willing to refer overflow work for a 10-15% fee.
+
+## Financial Targets & Metrics
+- **Weekly**: 60-100 quality branches, <$15 API spend per mergeable branch, zero regressions post-QA.
+- **Monthly**: $25K collected revenue, 70%+ gross margin after API costs, one case study draft.
+- **Quarterly**: Two paying clients delivered, Prism Month 1 roadmap complete, investor-ready metrics pack.
+
+## Personal Sustainability
+- **Energy management**: Block two no-meeting mornings per week for deep work, with enforced shutdown rituals to avoid burnout.
+- **Support system**: Schedule weekly check-ins with a mentor or peer founder for accountability and emotional grounding.
+- **Financial buffer**: After each client payment, reserve one month of living expenses before reinvesting into growth or infrastructure.


### PR DESCRIPTION
## Summary
- add a focused playbook that translates the sustainable engineering cadence into cash-generating actions
- outline immediate, near-term, and mid-term monetization steps with concrete targets
- include sustainability practices to support consistent delivery

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_69017ffaedd88329b0e5cb4d14123dfa