### PR TITLE
Add filesystem fallback for Cecilia memory service

### DIFF
--- a/srv/blackroad-api/.env.sample
+++ b/srv/blackroad-api/.env.sample
@@ -6,6 +6,7 @@ ALLOW_ORIGINS=https://example.com  # comma-separated list
 DB_PATH=/srv/blackroad-api/blackroad.db
 LLM_URL=http://127.0.0.1:8000/chat
 ALLOW_SHELL=false
+MEMORY_FALLBACK_FILE=/home/agents/cecilia/logs/memory.txt
 <!-- FILE: srv/blackroad-api/.env.sample -->
 # Sample environment for BlackRoad API
 PORT=4000
@@ -16,3 +17,4 @@ ALLOW_SHELL=false                  # enable /api/exec
 ALLOW_ORIGINS=                     # comma-separated list
 INTERNAL_TOKEN=change_me           # internal auth token
 BILLING_DISABLE=false
+MEMORY_FALLBACK_FILE=/home/agents/cecilia/logs/memory.txt


### PR DESCRIPTION
## Summary
- add a filesystem-backed fallback for the memory module when SQLite cannot be loaded or opened
- persist indexed entries to a configurable text file and expose a simple search path in fallback mode
- log whether the service is in database or fallback mode for easier diagnostics

## Testing
- node -e "const attach=require('./srv/blackroad-api/modules/memory.js'); attach({app:{post:()=>{}}});"


------
https://chatgpt.com/codex/tasks/task_e_69018d31c064832986abe501857253bb