### PR TITLE
Add fallback file storage for memory service when SQLite is unavailable

### DIFF
--- a/srv/blackroad-api/.env.sample
+++ b/srv/blackroad-api/.env.sample
@@ -6,6 +6,7 @@ ALLOW_ORIGINS=https://example.com  # comma-separated list
 DB_PATH=/srv/blackroad-api/blackroad.db
 LLM_URL=http://127.0.0.1:8000/chat
 ALLOW_SHELL=false
+MEMORY_FALLBACK_FILE=/home/agents/cecilia/logs/memory.txt
 <!-- FILE: srv/blackroad-api/.env.sample -->
 # Sample environment for BlackRoad API
 PORT=4000
@@ -16,3 +17,4 @@ ALLOW_SHELL=false                  # enable /api/exec
 ALLOW_ORIGINS=                     # comma-separated list
 INTERNAL_TOKEN=change_me           # internal auth token
 BILLING_DISABLE=false
+MEMORY_FALLBACK_FILE=/home/agents/cecilia/logs/memory.txt


### PR DESCRIPTION
## Summary
- wrap better-sqlite3 loading so the memory module can fall back when the dependency or database is unavailable
- add JSONL-based persistence and search when running in fallback mode to keep write and query APIs working
- report the active mode at startup and create any required directories for the fallback file

## Testing
- node -e "require('./srv/blackroad-api/modules/memory.js')({app:{post:()=>{}}})"


------
https://chatgpt.com/codex/tasks/task_e_69018e5e5384832986c74d6adc4cae57