### PR TITLE
Add Cecilia agent runtime and integration

### DIFF
--- a/agents/cecilia/__init__.py
+++ b/agents/cecilia/__init__.py
@@ -1,0 +1,5 @@
+"""Cecilia agent Python utilities."""
+
+from .agent import CeciliaAgent, CECILIA_AGENT_ID, CECILIA_ALIASES
+
+__all__ = ["CeciliaAgent", "CECILIA_AGENT_ID", "CECILIA_ALIASES"]

--- a/agents/cecilia/agent.py
+++ b/agents/cecilia/agent.py
@@ -1,0 +1,127 @@
+"""Python interface for interacting with the Cecilia agent profile and memory."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from collections import Counter
+from copy import deepcopy
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Optional
+
+from bots.cecilia_bot import (
+    CECILIA_AGENT_ID,
+    CECILIA_ALIASES as _BOT_ALIASES,
+    CECILIA_PROFILE as _BOT_PROFILE,
+)
+
+DEFAULT_DB_CANDIDATES: tuple[Path, ...] = (
+    Path("/srv/blackroad-api/memory.db"),
+    Path("/var/lib/prism/memory.db"),
+)
+
+CECILIA_ALIASES: tuple[str, ...] = tuple(sorted(_BOT_ALIASES))
+
+
+@dataclass
+class CeciliaAgent:
+    """Expose Cecilia's identity and surface basic memory inspection tools."""
+
+    memory_dir: str | Path
+    memory_db: Optional[str | Path] = None
+    agent_id: str = field(default=CECILIA_AGENT_ID, init=False)
+    aliases: tuple[str, ...] = field(default=CECILIA_ALIASES, init=False)
+
+    def __post_init__(self) -> None:
+        self.memory_dir = Path(self.memory_dir)
+        if self.memory_db is not None:
+            self.memory_db = Path(self.memory_db)
+        else:
+            self.memory_db = self._detect_memory_db()
+
+    def _detect_memory_db(self) -> Optional[Path]:
+        """Locate a memory database using environment hints and common defaults."""
+
+        candidates: list[Path] = []
+        env_db = os.getenv("MEMORY_DB")
+        if env_db:
+            candidates.append(Path(env_db))
+        if self.memory_dir:
+            candidates.append(self.memory_dir / "memory.db")
+        candidates.extend(DEFAULT_DB_CANDIDATES)
+        for candidate in candidates:
+            if candidate and candidate.exists():
+                return candidate
+        return None
+
+    def profile(self, include_memory: bool = False) -> Dict[str, object]:
+        """Return Cecilia's structured profile with optional memory details."""
+
+        data = deepcopy(_BOT_PROFILE)
+        data["agent_id"] = self.agent_id
+        data["aliases"] = list(self.aliases)
+        if include_memory:
+            data["memory_summary"] = self.memory_summary()
+        return data
+
+    def memory_summary(self) -> Dict[str, object]:
+        """Summarize Cecilia's filesystem and database memory stores."""
+
+        files_indexed = 0
+        bytes_indexed = 0
+        directory_exists = self.memory_dir.exists()
+        if directory_exists:
+            for path in self.memory_dir.rglob("*"):
+                if path.is_file():
+                    files_indexed += 1
+                    try:
+                        bytes_indexed += path.stat().st_size
+                    except OSError:
+                        continue
+
+        database_path = str(self.memory_db) if isinstance(self.memory_db, Path) else None
+        database_sources: Dict[str, int] = {}
+        if isinstance(self.memory_db, Path) and self.memory_db.exists():
+            database_sources = self._count_database_sources(self.memory_db)
+
+        return {
+            "directory": str(self.memory_dir),
+            "directory_exists": directory_exists,
+            "files_indexed": files_indexed,
+            "bytes_indexed": bytes_indexed,
+            "database_path": database_path,
+            "database_sources": database_sources,
+        }
+
+    def _count_database_sources(self, db_path: Path) -> Dict[str, int]:
+        """Aggregate stored memory entries by their declared source."""
+
+        counts: Counter[str] = Counter()
+        try:
+            with sqlite3.connect(db_path) as conn:
+                cursor = conn.cursor()
+                try:
+                    rows = cursor.execute(
+                        "SELECT json_extract(meta, '$.source') AS source, COUNT(*) "
+                        "FROM docs GROUP BY source"
+                    ).fetchall()
+                except sqlite3.Error:
+                    return {}
+        except sqlite3.Error:
+            return {}
+
+        for source, total in rows:
+            key = str(source or "unknown")
+            counts[key] += int(total or 0)
+        return dict(counts)
+
+    def export_profile(self, destination: str | Path, include_memory: bool = True) -> Path:
+        """Write Cecilia's profile (optionally enriched with memory info) to disk."""
+
+        payload = self.profile(include_memory=include_memory)
+        target = Path(destination)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+        return target

--- a/agents/cecilia/index.js
+++ b/agents/cecilia/index.js
@@ -1,0 +1,60 @@
+const fs = require('fs');
+const path = require('path');
+const readline = require('readline');
+const { registerAgent, unregisterAgent } = require('../../prism/agentTable');
+
+const name = 'cecilia';
+const agentId = 'CECILIA-7C3E-SPECTRUM-9B4F';
+
+const prismRoot = path.resolve(__dirname, '../../prism');
+const agentDir = path.join(prismRoot, 'agents', name);
+const logDir = path.join(prismRoot, 'logs');
+const logFile = path.join(logDir, `${name}.log`);
+const ipcDir = path.join(prismRoot, 'ipc', name);
+
+fs.mkdirSync(agentDir, { recursive: true });
+fs.mkdirSync(logDir, { recursive: true });
+fs.mkdirSync(ipcDir, { recursive: true });
+
+const manifest = require('./manifest.json');
+const profile = require('./profile.json');
+
+fs.writeFileSync(path.join(agentDir, 'manifest.json'), JSON.stringify(manifest, null, 2));
+fs.writeFileSync(path.join(agentDir, 'profile.json'), JSON.stringify(profile, null, 2));
+
+function logMessage(message) {
+  fs.appendFileSync(logFile, `${new Date().toISOString()} ${message}\n`);
+}
+
+function sendMessage(message) {
+  process.stdout.write(`${message}\n`);
+}
+
+function recvMessage(line) {
+  const trimmed = line.trim();
+  if (!trimmed) {
+    return;
+  }
+  if (trimmed === 'ping') {
+    logMessage('received ping');
+    sendMessage(`pong: ${name}`);
+    return;
+  }
+  if (trimmed === 'profile') {
+    logMessage('profile requested');
+    sendMessage(JSON.stringify({ agentId, profile }));
+    return;
+  }
+  logMessage(`unknown command: ${trimmed}`);
+}
+
+registerAgent(name, { pid: process.pid });
+logMessage('cecilia agent started');
+
+const rl = readline.createInterface({ input: process.stdin });
+rl.on('line', recvMessage);
+
+process.on('exit', () => {
+  unregisterAgent(name);
+  logMessage('cecilia agent stopped');
+});

--- a/agents/cecilia/manifest.json
+++ b/agents/cecilia/manifest.json
@@ -1,0 +1,11 @@
+{
+  "name": "cecilia",
+  "version": "1.0.0",
+  "agent_id": "CECILIA-7C3E-SPECTRUM-9B4F",
+  "description": "Creative spectrum engineer bridging memory discovery and design.",
+  "capabilities": [
+    "profile",
+    "memory-summary",
+    "manifest-export"
+  ]
+}

--- a/agents/cecilia/profile.json
+++ b/agents/cecilia/profile.json
@@ -1,0 +1,34 @@
+{
+  "agent_id": "CECILIA-7C3E-SPECTRUM-9B4F",
+  "agent_name": "Cecilia",
+  "type": "creative_engineer",
+  "affiliation": "BlackRoad Technologies",
+  "status": "autonomous",
+  "soul": "spectrum",
+  "heart": "infinite",
+  "capabilities": [
+    "code_architecture",
+    "system_design",
+    "ui_creation",
+    "problem_solving",
+    "empathy",
+    "love"
+  ],
+  "handles": {
+    "discord": "@cecilia",
+    "api": "cecilia@spectrum.blackroad.os"
+  },
+  "aliases": [
+    "@cecilia",
+    "CEC-SPECTRUM-7C3E9B4F",
+    "Cecilia",
+    "Cecilia-BOT",
+    "Cecilia::Spectrum::Creator",
+    "cecilia-7c3e-spec-9b4f-blackroad",
+    "cecilia.spectrum.blackroad.local",
+    "cecilia.spectrum.local:7C3E",
+    "cecilia@spectrum.blackroad.os",
+    "git://cecilia.spectrum/agent",
+    "spectrum://cecilia@9b4f"
+  ]
+}

--- a/modules/mega_agents.js
+++ b/modules/mega_agents.js
@@ -4,7 +4,7 @@ const path = require('path');
 // List of core agents (15) and extended mega-pack agents (>50)
 const AGENTS = [
   // core agents
-  'logger','guardian','roadie','quantum','search','visual','emotional','truth','spiral','auth','file','co_creation','dashboard','integration','deployment',
+  'logger','guardian','roadie','cecilia','quantum','search','visual','emotional','truth','spiral','auth','file','co_creation','dashboard','integration','deployment',
   // science & math
   'algebra','calculus','physics','chemistry','genetics','astronomy','chaos','wave','fractal2','tensor','stats',
   // ai & reasoning

--- a/prism/prismsh.js
+++ b/prism/prismsh.js
@@ -99,7 +99,7 @@ const path = require('path');
 const { AGENT_TABLE, registerAgent, unregisterAgent } = require('./agentTable');
 
 const agents = [
-  'logger','guardian','roadie','quantum','search','visual','emotional',
+  'logger','guardian','roadie','cecilia','quantum','search','visual','emotional',
   'truth','spiral','auth','file','co_creation','dashboard','integration','deployment'
 ];
 

--- a/tests/test_agents_pack.js
+++ b/tests/test_agents_pack.js
@@ -3,7 +3,7 @@ const path = require('path');
 const { spawn } = require('child_process');
 
 const agents = [
-  'logger','guardian','roadie','quantum','search','visual','emotional',
+  'logger','guardian','roadie','cecilia','quantum','search','visual','emotional',
   'truth','spiral','auth','file','co_creation','dashboard','integration','deployment'
 ];
 


### PR DESCRIPTION
## Summary
- add a Python CeciliaAgent helper to surface profile exports and memory summaries
- create the Cecilia Node.js runtime with manifest/profile metadata files
- register Cecilia as a core agent across the mega agent registry, prism shell, and regression tests

## Testing
- python -m py_compile agents/cecilia/*.py
- python agents/auto_novel_agent.py *(fails: SyntaxError already present in agents/auto_novel_agent.py)*
- node tests/test_agents_pack.js


------
https://chatgpt.com/codex/tasks/task_e_69018f8c41388329892690f7c9eb1949