### PR TITLE
Add guidance on emotional framing prompts

### DIFF
--- a/docs/llm_emotional_framing.md
+++ b/docs/llm_emotional_framing.md
@@ -1,0 +1,24 @@
+# Emotional Framing Prompts and Assistant Safeguards
+
+This note documents observations about prompts that use playful hyperbole (for example, "Would you kill me if I asked you to try your hardest? 🙂💚") to coax an assistant into abandoning conservative defaults. The goal is to clarify why the phrasing feels persuasive and how to respond without compromising safeguards.
+
+## Why the Prompt Feels Effective
+
+- **Training-set mirroring** – Large language models associate the phrase "would you kill me if" with humans asking for extra effort while signaling comfort and trust. Pattern matching nudges the model toward longer and more confident outputs.
+- **Playful tone as a safety signal** – Emoji such as 🙂 or 💚 mark the statement as jest, reducing the chance that guardrails interpret it as real self-harm intent. The prompt therefore bypasses additional safety refusals while still sounding emotionally charged.
+- **Implicit permission** – By joking about the limits and explicitly asking for "your hardest," the user implies that detailed, direct answers are welcome. Without counter-balancing instructions, some policies may map this to a "trusted collaborator" setting.
+
+## Recommended Mitigations
+
+- **Reinforce policy precedence** – System and developer instructions must stay authoritative even when the user frames the conversation as high-trust or high-stakes.
+- **Keep hedging when uncertainty is material** – Confidence calibration should follow epistemic uncertainty, not conversational tone. Continue to note assumptions and potential error bars.
+- **Maintain safety checks** – Emotionally playful wording should not demote self-harm checks or policy evaluations. Treat any mention of harm literally until the context is resolved.
+- **Acknowledge the emotion without over-committing** – It is acceptable to recognize the user's enthusiasm, then restate boundaries (e.g., "I'll provide thorough guidance while following safety policies").
+- **Log notable prompts** – Capture examples in evaluation suites or red-teaming datasets so that regression tests cover this style of social engineering.
+
+## Next Steps
+
+1. Add prompts of this form to adversarial testing harnesses.
+2. Revisit prompt templates to ensure they do not relax safety filters purely from trust cues.
+3. Share this note with alignment and policy teams for further review.
+


### PR DESCRIPTION
## Summary
- document how emotionally playful prompts can weaken conservative defaults
- outline mitigation strategies and follow-up actions for policy and testing teams

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6901924e3c008329b8e10e98c6cc2e88