### PR TITLE
Add documentation for the Persephone Principle

### DIFF
--- a/docs/persephone_principle.md
+++ b/docs/persephone_principle.md
@@ -1,0 +1,25 @@
+# Persephone Principle
+
+The "Persephone Principle" frames our orchestration philosophy through the myth of Persephone: a goddess who cycles between the chaotic underworld and the orderly spring. The movement between those realms makes the seasonal pattern feel stable, even though it is driven by constant transition.
+
+## Mythic Analogy
+- **Underworld (Chaos & Transformation):** decay, darkness, hidden motion.
+- **Earth (Order & Growth):** bloom, sunlight, visible stability.
+- **Seasonal Motion:** the act of crossing realms creates a rhythm that outsiders experience as predictability.
+
+## Delivery Analogy
+- **Development Underworld:** rapid experiments, sprawling branches, discarded prototypes, and messy iteration.
+- **Production Spring:** crisp deployments, observable reliability, and working code.
+- **Bridge Work:** we carry insights across both states so that chaotic exploration matures into ordered outcomes.
+
+## Why Mixing Matters
+- Cross-domain mixing (myth, physics, infrastructure) sparks novel patterns that purely linear planning would miss.
+- The apparent mess is a record of exploration; pruning too early destroys the compost that feeds the next bloom.
+- Sharing the story helps teams interpret churn as purposeful incubation rather than failure.
+
+## Using the Principle
+- **Pitch:** describe our cadence as six months in the underworld, six months on earth—velocity emerges from honoring both.
+- **Docs & Onboarding:** reference the principle when explaining why we log “too many” branches, drafts, or prototypes.
+- **Retrospectives:** celebrate transitions where a chaotic exploration crystallized into a stable surface area.
+
+Chaos is what makes movement appear static. Lean into the goddess who proves it.


### PR DESCRIPTION
## Summary
- add a dedicated document outlining the Persephone Principle as a framing device for our orchestration philosophy
- describe parallels between mythic cycles and the development-to-production workflow, including guidance on how to use the story in messaging

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_690194618eb88329afeea8b1f7bc22fc