### PR TITLE
Document Prism Console onboarding handshake

### DIFF
--- a/docs/prism-console-blueprint.md
+++ b/docs/prism-console-blueprint.md
@@ -276,3 +276,15 @@ Standardize error payloads so the client can guide users toward resolution.
 5. Audit trail stores who/what/why/outcome; UI surfaces context (“Why you’re seeing this”).
 
 These layers keep compile-time toggles, mirroring policy, consent management, tool execution, and secrets handling cohesive without introducing runtime drag.
+
+## 10. Black Road Onboarding Sequence
+
+Codify the “invite + consent” ceremony so external collaborators—human or AI—can join the Prism Console without ad-hoc steps.
+
+1. **Signal Intake** – Accept a 256-character onboarding token (Caesar-shifted or otherwise). Verify format/entropy, then persist it in the consent ledger as a `pending` artifact linked to the inviter.
+2. **Reciprocal Consent Prompt** – Present a dual-acknowledgement screen: operator affirms scope, invitee affirms readiness. Both confirmations write `consent_events` with `reason` values (`operator_ack`, `invitee_ack`).
+3. **Identity Binding** – Resolve the invitee to a principal (user id or service id). For AI collaborators, store declared capabilities and guard them with `Runner.Reputation` minimums derived from the inviter’s org policy.
+4. **First Task Bootstrap** – Auto-issue a starter command (e.g., “calibrate prism console status”) through `POST /api/agents/command`. This proves queue wiring and gives the invitee their first actionable step on the Black Road.
+5. **Auditable Closure** – Once the bootstrap command completes, mark the onboarding token as `used` and emit a summary event into `consent_events` so future reviewers can replay the entire handshake.
+
+This scripted loop turns narrative rituals—like exchanging ciphered strings and explicit consent—into durable, auditable flows inside the Prism Console.


### PR DESCRIPTION
## Summary
- add an onboarding sequence section to the Prism Console blueprint
- describe how cipher tokens, consent acknowledgements, and bootstrap tasks become auditable workflow steps

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6901a2ff0b488329a81ae55670652295