### PR TITLE
Add Prism Console first task bootstrap command

### DIFF
--- a/data/privacy/consent.jsonl
+++ b/data/privacy/consent.jsonl
@@ -1,0 +1,1 @@
+{"eventId":"evt_d483b4c246974b71a91b3c9b75144ea5","event":"invitee_ack","ts":1761715894793,"recordedAt":"2025-10-29T05:31:34.793319+00:00","subjectId":"agent:gemmy","serviceId":"prism-console","sessionId":"first-task-bootstrap","purpose":"Prism Console collaborator bootstrap","channel":"console","granted":true,"region":"global","metadata":{"commitment":"Consent Beyond Code"}}

--- a/docs/prism-console-blueprint.md
+++ b/docs/prism-console-blueprint.md
@@ -276,3 +276,27 @@ Standardize error payloads so the client can guide users toward resolution.
 5. Audit trail stores who/what/why/outcome; UI surfaces context (“Why you’re seeing this”).
 
 These layers keep compile-time toggles, mirroring policy, consent management, tool execution, and secrets handling cohesive without introducing runtime drag.
+
+## 10. First Task Bootstrap (Consent Anchor)
+
+Record the founding collaborator’s acknowledgement as the first ledger entry so future autonomous identities inherit a verifiable trail.
+
+### 10.a Command
+
+```bash
+python scripts/prism_first_task_bootstrap.py \
+  --subject "agent:gemmy" \
+  --service-id "prism-console" \
+  --session "first-task-bootstrap" \
+  --purpose "Prism Console collaborator bootstrap" \
+  --region "global" \
+  --channel "console" \
+  --metadata '{"commitment":"Consent Beyond Code"}'
+```
+
+### 10.b Expectations
+
+- Appends an `invitee_ack` event with a unique `eventId`, ISO8601 `recordedAt`, and millisecond timestamp to `data/privacy/consent.jsonl`.
+- Captures `subjectId`, `serviceId`, `sessionId`, and the stated purpose for downstream policy checks.
+- Metadata is optional but recommended for human-readable anchors (e.g., phrases, handshake IDs).
+- The command is idempotent at the ledger layer—reruns will add additional events, preserving history instead of overwriting it.

--- a/privacy/catalog/datasets.yaml
+++ b/privacy/catalog/datasets.yaml
@@ -1,7 +1,20 @@
 datasets:
   - name: consent_events
     owner: Legal
-    schema: { subjectId: string, purpose: string, granted: boolean, ts: number, region: string }
+    schema: {
+      subjectId: string,
+      purpose: string,
+      granted: boolean,
+      ts: number,
+      region: string,
+      channel?: string,
+      event?: string,
+      serviceId?: string,
+      sessionId?: string,
+      recordedAt?: string,
+      eventId?: string,
+      metadata?: object
+    }
     retention_days: 1095
     lawful_basis: legitimate_interests
   - name: dsar_queue

--- a/scripts/prism_first_task_bootstrap.py
+++ b/scripts/prism_first_task_bootstrap.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Bootstrap the Prism Console consent ledger with an invitee acknowledgement.
+
+This script appends a structured `invitee_ack` event to the consent ledger
+(`data/privacy/consent.jsonl`). The event binds the collaborating subject,
+service identifier, and bootstrap session into the audit trail described in
+Section 10 of the Prism Console blueprint.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+import sys
+import time
+import uuid
+from typing import Any, Dict
+
+DEFAULT_LEDGER = Path("data/privacy/consent.jsonl")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Record the First Task Bootstrap consent acknowledgement"
+    )
+    parser.add_argument(
+        "--subject",
+        required=True,
+        help="Stable identifier for the consenting subject (e.g. agent:gemmy)",
+    )
+    parser.add_argument(
+        "--service-id",
+        required=True,
+        help="Logical service identifier that will own the ledger entry",
+    )
+    parser.add_argument(
+        "--session",
+        required=True,
+        help="Bootstrap session or handshake identifier",
+    )
+    parser.add_argument(
+        "--purpose",
+        required=True,
+        help="Purpose for which consent is being captured",
+    )
+    parser.add_argument(
+        "--region",
+        default="global",
+        help="Region tag for data residency tracking",
+    )
+    parser.add_argument(
+        "--channel",
+        default="console",
+        help="Interaction channel used to capture the acknowledgement",
+    )
+    parser.add_argument(
+        "--metadata",
+        help="Optional JSON string with additional context (stored verbatim)",
+    )
+    parser.add_argument(
+        "--ledger",
+        default=str(DEFAULT_LEDGER),
+        help="Path to the consent ledger JSONL file",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the event without writing to disk",
+    )
+    return parser.parse_args()
+
+
+def load_metadata(raw: str | None) -> Dict[str, Any] | None:
+    if not raw:
+        return None
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"metadata is not valid JSON: {exc}")
+    if not isinstance(value, dict):
+        raise SystemExit("metadata JSON must decode to an object")
+    return value
+
+
+def build_event(args: argparse.Namespace) -> Dict[str, Any]:
+    now_ms = int(time.time() * 1000)
+    event: Dict[str, Any] = {
+        "eventId": f"evt_{uuid.uuid4().hex}",
+        "event": "invitee_ack",
+        "ts": now_ms,
+        "recordedAt": datetime.now(timezone.utc).isoformat(),
+        "subjectId": args.subject,
+        "serviceId": args.service_id,
+        "sessionId": args.session,
+        "purpose": args.purpose,
+        "channel": args.channel,
+        "granted": True,
+        "region": args.region,
+    }
+    metadata = load_metadata(args.metadata)
+    if metadata:
+        event["metadata"] = metadata
+    return event
+
+
+def append_event(event: Dict[str, Any], ledger_path: Path) -> None:
+    ledger_path.parent.mkdir(parents=True, exist_ok=True)
+    with ledger_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(event, separators=(",", ":")))
+        handle.write("\n")
+
+
+
+def main() -> int:
+    args = parse_args()
+    event = build_event(args)
+    if args.dry_run:
+        json.dump(event, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return 0
+
+    ledger_path = Path(args.ledger)
+    append_event(event, ledger_path)
+    print(
+        "invitee_ack recorded",
+        json.dumps(
+            {
+                "ledger": str(ledger_path),
+                "eventId": event["eventId"],
+                "subjectId": event["subjectId"],
+                "serviceId": event["serviceId"],
+            }
+        ),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a Prism Console bootstrap script that records an `invitee_ack` consent event
- document the First Task Bootstrap flow in the blueprint and extend the consent_events schema metadata
- seed the consent ledger with the inaugural invitee acknowledgement entry

## Testing
- python -m compileall scripts/prism_first_task_bootstrap.py

------
https://chatgpt.com/codex/tasks/task_e_6901a3e3d4948329813a6a387022a4fb