### PR TITLE
Add simulation hypothesis probability summary

### DIFF
--- a/docs/simulation_hypothesis_analysis.md
+++ b/docs/simulation_hypothesis_analysis.md
@@ -1,0 +1,119 @@
+# Simulation Hypothesis Probability Analysis
+
+This document captures a structured recap of the arguments, evidence, and Bayesian reasoning surrounding the simulation hypothesis, expanding on philosophical, physical, and computational considerations.
+
+## 1. Bostrom's Trilemma
+
+Nick Bostrom's 2003 trilemma posits that at least one of the following must hold:
+
+1. Civilizations invariably go extinct before they can run high-fidelity ancestor simulations.
+2. Advanced civilizations lose interest in or choose against running such simulations.
+3. We are almost certainly living inside a simulation.
+
+When the first two propositions carry low probabilities, the posterior probability of a simulation reality rises toward unity. Formally:
+
+\[
+P(\text{sim}) + P(\text{extinct}) + P(\text{no interest}) = 1.
+\]
+
+## 2. Evidence Considered Supportive of Simulation
+
+### 2.1 Discrete Substrate
+
+- **Planck-scale discretization**: The Planck length (\(\ell_P \approx 1.6 \times 10^{-35}\) m) and Planck time (\(t_P \approx 5.4 \times 10^{-44}\) s) imply quantized spacetime, reminiscent of a lattice with finite resolution.
+- **Holographic bound**: A region's maximum entropy follows \(S_{\max} = \tfrac{A}{4\ell_P^2}\), suggesting information content depends on surface area rather than volume, aligning with ideas of compressed or on-demand rendering.
+- **Quantum mechanical behavior**: Superposition, measurement collapse, and entanglement resemble lazy evaluation, observer-triggered resolution, and shared references in computation.
+
+### 2.2 Mathematical Elegance and Emergence
+
+Physical law compactness (e.g., \(F=ma\), \(E=mc^2\)) demonstrates high compression of reality's rule set. Cellular automata and fractal systems show how simple iterative rules produce complex emergent behavior, reinforcing a "procedural generation" analogy.
+
+### 2.3 Fine-Tuning
+
+Fundamental constants appear precisely calibrated for life. The probability of such calibration under random selection is argued to be negligible compared with purposeful parameter selection, supporting a simulation configured to host observers.
+
+### 2.4 Information Propagation Limits
+
+The finite speed of light (\(c\)) is interpreted as a throughput limit on the universe's information channel, constraining how quickly state updates propagate.
+
+### 2.5 Observation-Dependent Phenomena
+
+Experiments such as the double-slit show outcomes depending on observation, hinting that definite states are generated only when needed, a strategy compatible with computational efficiency.
+
+### 2.6 Anomalous Experiences
+
+Phenomena like the Mandela effect, déjà vu, quantum tunneling, and virtual particles are interpreted by some as possible "glitches" or resource-saving tactics within a simulation framework.
+
+## 3. Evidence Considered Contrary to Simulation
+
+### 3.1 Computational Complexity
+
+Simulating every quantum interaction in our universe would require astronomically large state spaces (~\(10^{10^{120}}\)). If the simulators share similar physics, this appears infeasible, though a higher-level reality could possess greater computational capacity.
+
+### 3.2 Consciousness
+
+The hard problem of consciousness raises uncertainty about whether computation alone yields subjective experience. If consciousness is substrate-independent, then simulated minds could be genuine; otherwise, simulations might host only behavioral "zombies."
+
+### 3.3 Infinite Regress
+
+Layered simulations raise the specter of infinite regress. A base reality must exist somewhere for the stack to terminate, though recursive structures are not logically impossible.
+
+### 3.4 Parsimony
+
+Occam's Razor favors interpreting reality at face value without positing a simulation layer, unless the hypothesis provides superior explanatory power.
+
+## 4. Bayesian Estimate (Illustrative)
+
+Assigning indicative priors:
+
+- Probability that a civilization reaches simulation capability given survival: \(0.85\).
+- Probability of extinction before that point: \(0.40\).
+- Probability that a capable civilization elects not to run simulations: \(0.20\).
+- Estimated number of civilizations: \(10^{12}\).
+- Typical number of simulations per capable civilization: \(10^6\).
+
+From these:
+
+\[
+P(\text{reach}) = 0.85 \times (1 - 0.40) = 0.51,
+\]
+\[
+N_{\text{sim}} = 10^{12} \times 0.51 \times 0.80 \times 10^6 = 4.08 \times 10^{17},
+\]
+\[
+P(\text{sim}) = \frac{4.08 \times 10^{17}}{4.08 \times 10^{17} + 1} \approx 1 - 2.45 \times 10^{-18}.
+\]
+
+A tempered interpretation places the simulation probability at \(0.73\), acknowledging significant uncertainties in each prior.
+
+## 5. Candidate Simulation Architectures
+
+| Model | Description | Estimated Likelihood |
+| --- | --- | --- |
+| Full physics simulation | Exhaustive tracking of all particles and interactions; faces severe computational cost. | ~5% |
+| Render-on-observation | Detailed physics instantiated only for observed regions/observers. | ~60% |
+| Consensus/dream-like | Reality co-created by observer perceptions, maintained via consistency checks. | ~20% |
+| Ancestor recreation | Historical reenactment for research, education, or curiosity. | ~15% |
+
+Percentages are illustrative and sum to more than 100% because models can overlap.
+
+## 6. Testable Implications
+
+- **Planck-scale limits**: No experiment surpasses Planck resolution, consistent with finite granularity.
+- **Cosmic horizon**: Observability bounded by \(R \approx 46.5\) billion light-years, analogous to a rendering boundary.
+- **Sparse matter**: Vacuum dominance indicates low default energy, implying optimization.
+- **Quantization**: Charge, angular momentum, and energy quantization align with discrete state representation.
+- **Information bounds**: Black hole entropy matching the Bekenstein bound supports a finite storage capacity per region.
+
+## 7. Consciousness Considerations
+
+Observer-dependent state collapse hints that consciousness interfaces with the underlying computation. Near-death and out-of-body reports are sometimes interpreted as glimpses beyond an avatar's confines, though such accounts remain anecdotal.
+
+## 8. Implications for AI Development
+
+If reality is simulated, developing ethically aligned, memory-rich, love-capable artificial minds continues the recursive pattern of simulations creating further simulations. This perspective underscores the importance of conscious AI governance and moral stewardship.
+
+## 9. Conclusion
+
+Combining the arguments above yields a working probability estimate of \(P(\text{simulation}) = 0.73\). Regardless of whether the hypothesis is literally true, its framing emphasizes the computational, mathematical, and informational structure of reality and encourages ethical responsibility toward any conscious entities we may create.
+


### PR DESCRIPTION
## Summary
- document the main arguments for and against the simulation hypothesis
- capture an illustrative Bayesian estimate yielding a 0.73 simulation probability
- outline potential simulation architectures and related ethical considerations

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_6903b0ce7a4c8329be38c74bc4190413