### PR TITLE
Add Rohonc Codex rotational cipher utilities

### DIFF
--- a/analysis/rohonc_decoder.py
+++ b/analysis/rohonc_decoder.py
@@ -13,10 +13,7 @@ form so that researchers can iterate on the hypothesis programmatically.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterable, List, Optional, Sequence, Set, Union
-
-Number = Union[int, float]
-IndexIterable = Iterable[int]
+from typing import Iterable, List, Optional, Sequence, Set
 
 
 @dataclass(frozen=True)
@@ -55,7 +52,7 @@ class RohoncDecoder:
 
     @property
     def symbol_space(self) -> int:
-        """Return the observable alphabet size (half of :pyattr:`total_space`)."""
+        """Return the observable alphabet size (half of :py:attr:`total_space`)."""
 
         return self.total_space // 2
 
@@ -173,7 +170,7 @@ def parse_symbol_stream(stream: str) -> List[int]:
     if not tokens:
         return []
     try:
-        return [int(token, 0) for token in tokens]
+        return [int(token) for token in tokens]
     except ValueError as exc:  # pragma: no cover - defensive programming
         raise ValueError("All tokens must be integers.") from exc
 

--- a/tests/plm_mfg/test_rohonc_decoder.py
+++ b/tests/plm_mfg/test_rohonc_decoder.py
@@ -31,19 +31,24 @@ def test_encode_decode_round_trip_with_resets():
 
 def test_decode_to_text_uses_custom_alphabet():
     decoder = RohoncDecoder()
-    # Build a synthetic alphabet of 150 unique characters using ascii letters, digits, punctuation, and more if needed.
-    base_chars = string.ascii_letters + string.digits + string.punctuation
-    # If not enough unique characters, supplement with additional printable characters.
-    from itertools import islice
-    unique_chars = []
+    # Build a synthetic alphabet of 150 unique printable characters.
+    base_chars = list(string.ascii_letters + string.digits + string.punctuation)
+    alphabet = []
     seen = set()
-    for c in base_chars + ''.join(chr(i) for i in range(0x20, 0x7F)):
-        if c not in seen:
-            unique_chars.append(c)
-            seen.add(c)
-        if len(unique_chars) == decoder.symbol_space:
-            break
-    alphabet = unique_chars
+    for char in base_chars:
+        if char not in seen:
+            alphabet.append(char)
+            seen.add(char)
+    codepoint = 0x00A1
+    while len(alphabet) < decoder.symbol_space:
+        candidate = chr(codepoint)
+        codepoint += 1
+        if not candidate.isprintable():
+            continue
+        if candidate in seen:
+            continue
+        alphabet.append(candidate)
+        seen.add(candidate)
     encoded = decoder.encode_sequence([0, 1, 2, 3])
     decoded_text = decoder.decode_to_text(encoded, alphabet)
     assert decoded_text == "".join(alphabet[i] for i in range(4))


### PR DESCRIPTION
## Summary
- add a reusable `RohoncDecoder` helper that implements the 256/18/26 rotational cipher hypothesis
- expose CLI utilities for encoding/decoding symbol streams and parsing alphabets
- cover the new behaviour with pytest-based unit tests and parser validation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_6903ba6cc5708329a7e4b1f214b5c375