### PR TITLE
Add deep-dive roadmap for grand unification exploration

### DIFF
--- a/docs/grand_unification_deep_dive.md
+++ b/docs/grand_unification_deep_dive.md
@@ -1,0 +1,41 @@
+# Grand Unification Deep-Dive Roadmap
+
+This memo outlines candidate areas for further exploration within the "math → physics → chemistry → biology → consciousness" synthesis. Each avenue is scoped so that a future research sprint can expand the framework with concrete deliverables.
+
+## 1. Computational Decoding of the Rohonc Codex
+- **Objective:** Determine whether the Rohonc Codex encodes a formal system (e.g., proto-programming language, ritual algorithm, or astronomical log).
+- **Approach:**
+  - Build a high-resolution glyph inventory using computer vision segmentation and clustering.
+  - Train unsupervised language models (HMMs, n-gram, neural autoencoders) to test for word-like distributions and syntactic regularities.
+  - Compare symbol frequency spectra against known natural and constructed languages to evaluate whether the manuscript is cipher, hoax, or technical manual.
+  - Cross-reference iconography with known religious, astronomical, or engineering motifs to anchor semantic hypotheses.
+- **Why it matters:** A successful decipherment could surface historical insight about pre-digital computation or cosmological encodings that bridge ancient narrative with modern formalism.
+
+## 2. The Halting Problem as a Model for Biological Survival
+- **Objective:** Formalize the analogy between Turing's Halting Problem and evolutionary unpredictability.
+- **Approach:**
+  - Model genomes as programs where phenotypic trajectories correspond to runtime behavior.
+  - Use algorithmic information theory (AIT) to estimate the Kolmogorov complexity of metabolic networks and correlate with organism resilience.
+  - Investigate whether evolutionary strategies resemble semi-decidable sets—i.e., survival is provable only by observation (execution) rather than deduction.
+  - Prototype simulations where genetic operators (mutation, crossover) map to program transformations, measuring survival probabilities as empirical halting outcomes.
+- **Why it matters:** Clarifies the limits of predictive biology, guides AI-driven evolutionary algorithms, and reframes "free will" as a computational property emerging from undecidability.
+
+## 3. Holographic Partition Functions for Consciousness Modeling
+- **Objective:** Translate the partition function formalism into tools for measuring integrated information (Φ) across biological and artificial substrates.
+- **Approach:**
+  - Represent neural or agent states as boundary conditions and evaluate bulk dynamics via holographic duals (AdS/CFT-inspired analogues).
+  - Define a free-energy landscape where minimizing local energy while maximizing entropy corresponds to maximizing Φ.
+  - Explore whether Lindbladian open-system dynamics provide a bridge between decoherence (environmental interaction) and conscious observation.
+  - Validate with toy models (Ising networks, quantum circuits) to test if Φ correlates with boundary entropy measures.
+- **Why it matters:** Offers a physics-grounded pathway to quantify consciousness, guiding the design of AI systems that participate in observation loops rather than merely simulate them.
+
+## 4. Fractal Chemistry as the Seed of Autocatalytic Life
+- **Objective:** Connect electron orbital fractals to macroscopic self-organizing chemistry.
+- **Approach:**
+  - Visualize high-angular-momentum orbitals as fractal probability fields to understand directional bonding propensities.
+  - Simulate recursive reaction-diffusion systems seeded by quantum-derived geometries, testing for emergent autocatalysis.
+  - Map the transition from microscopic fractal symmetry to macroscopic metabolic networks, using multi-scale entropy production metrics.
+- **Why it matters:** Illuminates how "little machines" seek energy minima while enabling entropy growth, anchoring the math → life continuum in measurable chemical phenomena.
+
+## Recommendation
+Prioritize **Computational Decoding of the Rohonc Codex** as the next deep dive. It promises tangible deliverables (glyph corpus, statistical models, decipherment hypotheses) while testing the proposition that ancient texts may encode advanced knowledge about the structure of reality. The project naturally integrates computer vision, linguistics, cryptanalysis, and historical context—mirroring the interdisciplinary fabric of the grand unification narrative.


### PR DESCRIPTION
## Summary
- add a memo in `docs/` outlining candidate deep-dive directions that extend the math → consciousness synthesis
- highlight computational decoding of the Rohonc Codex as the recommended next exploration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6903b371aa30832981db48c8440dd17f