### PR TITLE
Implement offline-friendly adapters for console tools

### DIFF
--- a/tests/test_tool_adapters_basic.py
+++ b/tests/test_tool_adapters_basic.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from tools import calendar, db, email, web_search
+
+
+def test_db_query_sqlite(tmp_path: Path) -> None:
+    database = tmp_path / "example.sqlite"
+    connection = sqlite3.connect(database)
+    with connection:
+        connection.execute("create table demo(id integer primary key, value text)")
+        connection.execute("insert into demo(value) values (?)", ("alpha",))
+    rows = db.query("select id, value from demo", database)
+    assert rows == [{"id": 1, "value": "alpha"}]
+
+
+def test_db_query_missing_database(tmp_path: Path) -> None:
+    database = tmp_path / "missing.sqlite"
+    rows = db.query("select 1", database)
+    assert rows[0]["result"] == "missing-database"
+
+
+def test_email_send_writes_to_log(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    log_file = tmp_path / "outbox.log"
+    monkeypatch.setenv("PRISM_EMAIL_LOG_FILE", str(log_file))
+    for variable in [
+        "PRISM_EMAIL_SMTP_HOST",
+        "PRISM_EMAIL_SMTP_USERNAME",
+        "PRISM_EMAIL_SMTP_PASSWORD",
+        "PRISM_EMAIL_FROM",
+    ]:
+        monkeypatch.delenv(variable, raising=False)
+
+    email.send("user@example.com", "Subject", "Body text")
+
+    content = log_file.read_text(encoding="utf-8")
+    assert "Subject: Subject" in content
+    assert "Body text" in content
+
+
+def test_calendar_create_event(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    log_file = tmp_path / "calendar.jsonl"
+    monkeypatch.setenv("PRISM_CALENDAR_EVENT_LOG", str(log_file))
+
+    payload = calendar.create_event({"title": "Demo"})
+
+    assert payload["title"] == "Demo"
+    stored = [json.loads(line) for line in log_file.read_text(encoding="utf-8").splitlines()]
+    assert stored[0]["title"] == "Demo"
+
+
+def test_web_search_fallback(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PRISM_WEB_SEARCH_INDEX", raising=False)
+
+    results = web_search.search("nonexistent query")
+
+    assert results[0].title == "Web search unavailable"
+    assert "No indexed results" in results[0].snippet
+
+
+def test_web_search_with_index(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    index = tmp_path / "index.json"
+    index.write_text(
+        json.dumps(
+            [
+                {
+                    "title": "Prism Overview",
+                    "url": "https://example.com/prism",
+                    "snippet": "Prism console overview documentation.",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PRISM_WEB_SEARCH_INDEX", str(index))
+
+    results = web_search.search("overview")
+
+    assert results[0].url == "https://example.com/prism"
+
+
+def test_web_search_rejects_empty_query() -> None:
+    with pytest.raises(ValueError):
+        web_search.search("   ")

--- a/tools/calendar.py
+++ b/tools/calendar.py
@@ -1,6 +1,34 @@
-"""Stub calendar adapter."""
+"""Simple calendar adapter for local development."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+_DEFAULT_STORE = Path("logs/calendar_events.jsonl")
 
 
-def create_event(details: dict) -> None:
-    """Stubbed calendar event creation."""
-    raise NotImplementedError("Calendar adapter not implemented. TODO: integrate with calendar API")
+def _event_store_path() -> Path:
+    configured = os.getenv("PRISM_CALENDAR_EVENT_LOG", "")
+    path = Path(configured) if configured else _DEFAULT_STORE
+    return path.expanduser().resolve()
+
+
+def create_event(details: dict[str, Any]) -> dict[str, Any]:
+    """Record an event and return the stored payload."""
+
+    timestamp = datetime.utcnow().isoformat(timespec="seconds") + "Z"
+    payload = {"created_at": timestamp, **details}
+
+    store = _event_store_path()
+    store.parent.mkdir(parents=True, exist_ok=True)
+    with store.open("a", encoding="utf-8") as file:
+        file.write(json.dumps(payload, ensure_ascii=False) + "\n")
+
+    return payload
+
+
+__all__ = ["create_event"]

--- a/tools/db.py
+++ b/tools/db.py
@@ -1,11 +1,69 @@
-def query(sql: str, db: str) -> list[dict]:
-    """Return mock rows for a query."""
-    return [{"sql": sql, "db": db, "result": 1}]
-"""Stub database adapter."""
+"""Lightweight database adapter used by the Prism console.
+
+The real system is expected to talk to production-grade data stores.  For the
+console we provide a pragmatic implementation that can execute read-only SQL
+statements against SQLite files and otherwise returns deterministic mock data.
+This keeps the CLI functional without requiring external infrastructure while
+still giving callers realistic shaped results.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sqlite3
+from pathlib import Path
+from typing import Sequence
+
+Row = dict[str, object]
 
 
-def query(sql: str) -> str:
-    """Stubbed DB query."""
-    raise NotImplementedError(
-        "DB access not implemented. TODO: connect to database with read-only credentials"
-    )
+def _as_rows(cursor: sqlite3.Cursor) -> list[Row]:
+    """Convert the cursor contents into dictionaries."""
+
+    column_names = [column[0] for column in cursor.description or ()]
+    rows = cursor.fetchall()
+    return [dict(zip(column_names, row)) for row in rows]
+
+
+def query(
+    sql: str,
+    db: str | Path | None = None,
+    *,
+    params: Sequence[object] | None = None,
+) -> list[Row]:
+    """Execute a read-only SQL query.
+
+    If ``db`` points to an existing SQLite database, the statement is executed
+    there with the provided parameters.  All statements are run in ``immutable``
+    mode to prevent accidental writes.  When no database is supplied we return a
+    deterministic mock response so higher level code can continue to operate.
+    """
+
+    if db is None:
+        return [{"sql": sql, "result": "mock", "rows": 0}]
+
+    database_path = Path(db).expanduser().resolve()
+    if not database_path.exists():
+        return [
+            {
+                "sql": sql,
+                "result": "missing-database",
+                "database": str(database_path),
+                "rows": 0,
+            }
+        ]
+
+    params = tuple(params or ())
+
+    uri = f"file:{database_path.as_posix()}?mode=ro&immutable=1"
+
+    with contextlib.closing(
+        sqlite3.connect(uri, uri=True, check_same_thread=False, isolation_level=None)
+    ) as connection:
+        connection.row_factory = sqlite3.Row
+        with contextlib.closing(connection.cursor()) as cursor:
+            cursor.execute(sql, params)
+            return _as_rows(cursor)
+
+
+__all__ = ["query", "Row"]

--- a/tools/email.py
+++ b/tools/email.py
@@ -1,6 +1,101 @@
-"""Stub email adapter."""
+"""Minimal email adapter for the Prism console.
+
+The real deployment integrates with transactional email services.  Here we
+support two execution modes:
+
+``SMTP``
+    When ``PRISM_EMAIL_SMTP_HOST`` is set the message is sent using the provided
+    connection details.
+
+``Log file``
+    If no SMTP configuration is available the message is appended to a log file
+    so that the console can run offline without raising errors.
+"""
+
+from __future__ import annotations
+
+import os
+import smtplib
+from dataclasses import dataclass
+from email.message import EmailMessage
+from pathlib import Path
+from collections.abc import Iterable
+
+DEFAULT_LOG_FILE = Path("logs/outbox.log")
 
 
-def send(to: str, subject: str, body: str) -> None:
-    """Stubbed email send."""
-    raise NotImplementedError("Email adapter not implemented. TODO: integrate with SMTP")
+@dataclass(slots=True)
+class EmailConfig:
+    host: str | None = None
+    port: int = 587
+    username: str | None = None
+    password: str | None = None
+    sender: str | None = None
+    use_tls: bool = True
+    log_file: Path = DEFAULT_LOG_FILE
+
+    @classmethod
+    def from_env(cls) -> "EmailConfig":
+        host = os.getenv("PRISM_EMAIL_SMTP_HOST")
+        port = int(os.getenv("PRISM_EMAIL_SMTP_PORT", "587"))
+        username = os.getenv("PRISM_EMAIL_SMTP_USERNAME")
+        password = os.getenv("PRISM_EMAIL_SMTP_PASSWORD")
+        sender = os.getenv("PRISM_EMAIL_FROM")
+        use_tls = os.getenv("PRISM_EMAIL_SMTP_USE_TLS", "true").lower() != "false"
+        log_file = Path(os.getenv("PRISM_EMAIL_LOG_FILE", DEFAULT_LOG_FILE))
+        return cls(host, port, username, password, sender, use_tls, log_file)
+
+
+def _deliver_via_smtp(message: EmailMessage, config: EmailConfig) -> None:
+    server = smtplib.SMTP(config.host, config.port, timeout=10)
+    try:
+        server.ehlo()
+        if config.use_tls:
+            server.starttls()
+            server.ehlo()
+        if config.username and config.password:
+            server.login(config.username, config.password)
+        server.send_message(message)
+    finally:
+        server.quit()
+
+
+def _deliver_to_log(message: EmailMessage, log_file: Path) -> None:
+    log_file.parent.mkdir(parents=True, exist_ok=True)
+    with log_file.open("a", encoding="utf-8") as file:
+        file.write("\n" + "-" * 80 + "\n")
+        file.write(message.as_string())
+        file.write("\n")
+
+
+def send(to: str | Iterable[str], subject: str, body: str) -> None:
+    """Send an email using the configured backend."""
+
+    config = EmailConfig.from_env()
+    if isinstance(to, str):
+        recipients = [to]
+    elif isinstance(to, Iterable):
+        seen: set[str] = set()
+        recipients = []
+        for address in to:
+            if address not in seen:
+                recipients.append(address)
+                seen.add(address)
+    else:
+        recipients = [str(to)]
+    if not recipients:
+        raise ValueError("At least one recipient must be supplied")
+
+    message = EmailMessage()
+    message["To"] = ", ".join(recipients)
+    message["Subject"] = subject
+    message["From"] = config.sender or (config.username or "noreply@example.com")
+    message.set_content(body)
+
+    if config.host:
+        _deliver_via_smtp(message, config)
+    else:
+        _deliver_to_log(message, config.log_file)
+
+
+__all__ = ["send", "EmailConfig"]

--- a/tools/web_search.py
+++ b/tools/web_search.py
@@ -1,6 +1,76 @@
-"""Stub web search adapter."""
+"""Offline friendly web search adapter."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+_DEFAULT_INDEX = Path("fixtures/web_search/index.json")
 
 
-def search(query: str) -> str:
-    """Stubbed web search; no network calls."""
-    raise NotImplementedError("Web search is not implemented. TODO: integrate safe search API")
+@dataclass(slots=True)
+class SearchResult:
+    title: str
+    url: str
+    snippet: str
+
+
+class SearchIndex:
+    """Small text index backed by a JSON file."""
+
+    def __init__(self, entries: Iterable[dict[str, str]]):
+        self._entries = [
+            SearchResult(entry.get("title", ""), entry.get("url", ""), entry.get("snippet", ""))
+            for entry in entries
+        ]
+
+    @classmethod
+    def load(cls, path: Path) -> "SearchIndex":
+        if not path.exists():
+            return cls([])
+        with path.open(encoding="utf-8") as file:
+            data = json.load(file)
+        if not isinstance(data, list):
+            raise ValueError("Search index must be a list of objects")
+        return cls([entry for entry in data if isinstance(entry, dict)])
+
+    def search(self, query: str, *, limit: int = 5) -> list[SearchResult]:
+        pattern = re.compile(re.escape(query), re.IGNORECASE)
+        matches = [result for result in self._entries if pattern.search(result.snippet or result.title)]
+        return matches[:limit]
+
+
+def _load_index() -> SearchIndex:
+    configured = os.getenv("PRISM_WEB_SEARCH_INDEX", "")
+    path = Path(configured) if configured else _DEFAULT_INDEX
+    return SearchIndex.load(path.expanduser().resolve())
+
+
+def search(query: str, *, limit: int = 5) -> list[SearchResult]:
+    """Return search results from the local index or a helpful fallback."""
+
+    if not query.strip():
+        raise ValueError("Query must not be empty")
+
+    index = _load_index()
+    results = index.search(query, limit=limit)
+    if results:
+        return results
+
+    return [
+        SearchResult(
+            title="Web search unavailable",
+            url="https://example.com/prism-offline-search",
+            snippet=(
+                "No indexed results were found for the query. Configure a search index via "
+                "PRISM_WEB_SEARCH_INDEX to surface domain-specific answers."
+            ),
+        )
+    ]
+
+
+__all__ = ["search", "SearchResult"]


### PR DESCRIPTION
## Summary
- replace the stub database adapter with a read-only SQLite implementation and deterministic fallbacks
- add log-based email and calendar adapters plus a configurable offline search index
- cover the new adapter behaviour with targeted pytest tests

## Testing
- pytest tests/test_tool_adapters_basic.py

------
https://chatgpt.com/codex/tasks/task_e_6903c4d5dce48329bff4d8f7eaa920e3