### PR TITLE
Add concrete Rohonc Codex decoding experiment

### DIFF
--- a/experiments/rohonc/concrete_test.py
+++ b/experiments/rohonc/concrete_test.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Concrete decoding experiment for the Rohonc Codex."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import sys
+
+CURRENT_DIR = Path(__file__).resolve().parent
+if str(CURRENT_DIR) not in sys.path:
+    sys.path.append(str(CURRENT_DIR))
+
+from rohonc_decoder import RohoncDecoder  # pylint: disable=wrong-import-position
+
+LINE_1: Sequence[str] = (
+    "cup",
+    "arc",
+    "chev",
+    "circ",
+    "ang",
+    "wave",
+    "cup",
+    "chev",
+    "tri",
+    "circ",
+    "cup",
+    "arc",
+    "arc",
+    "cup",
+    "ang",
+    "wave",
+)
+
+LINE_2: Sequence[str] = (
+    "cup",
+    "ang",
+    "wave",
+    "cup",
+    "chev",
+    "circ",
+    "arc",
+    "wave",
+    "arc",
+    "circ",
+    "cup",
+    "arc",
+    "ang",
+    "brack",
+    "wave",
+    "arc",
+    "ang",
+)
+
+LINE_3: Sequence[str] = (
+    "wave",
+    "arc",
+    "cup",
+    "cup",
+    "arc",
+    "circ",
+    "chev",
+    "arc",
+    "circ",
+    "cup",
+    "wave",
+    "circ",
+    "chev",
+    "wave",
+    "arc",
+    "tri",
+)
+
+IMAGE_1_TEXT = list(LINE_1 + LINE_2 + LINE_3)
+
+SIMPLE_MAPPING = {
+    "cup": "H",
+    "chev": "E",
+    "wave": "A",
+    "circ": "I",
+    "arc": "T",
+    "ang": "N",
+    "tri": ".",
+    "brack": "S",
+}
+
+THETA_CANDIDATES = (1.0, 1.618, 1.707, 2.0, 3.14159, 7.0)
+
+BIBLICAL_PATTERNS = ("BERESHIT", "ELOHIM", "VAYOMER")
+
+
+def preview_line(line: Sequence[str]) -> str:
+    return " ".join(line[:10])
+
+
+def summarize_patterns(text: str, patterns: Iterable[str]) -> list[str]:
+    return [pattern for pattern in patterns if pattern in text]
+
+
+def main() -> None:
+    decoder = RohoncDecoder(SIMPLE_MAPPING)
+
+    print("=" * 70)
+    print("ROHONC CODEX - CONCRETE DECODING TEST")
+    print("=" * 70)
+
+    print("\nInput symbols (first 3 lines):")
+    print(f"  Line 1: {preview_line(LINE_1)}...")
+    print(f"  Line 2: {preview_line(LINE_2)}...")
+    print(f"  Line 3: {preview_line(LINE_3)}...")
+    print(f"\nTotal symbols: {len(IMAGE_1_TEXT)}")
+
+    print("\n" + "=" * 70)
+    print("TEST 1: SIMPLE SUBSTITUTION (no rotation)")
+    print("=" * 70)
+    simple_result = decoder.simple_decode(IMAGE_1_TEXT)
+    print(f"\nResult: {simple_result}")
+
+    print("\n" + "=" * 70)
+    print("TEST 2: ROTATIONAL CAESAR (θ = 1.707)")
+    print("=" * 70)
+    rotational_result = decoder.rotational_decode(IMAGE_1_TEXT, theta=1.707)
+    print(f"\nResult: {rotational_result}")
+
+    print("\n" + "=" * 70)
+    print("TEST 3: MULTIPLE THETA VALUES")
+    print("=" * 70)
+    for theta in THETA_CANDIDATES:
+        candidate_result = decoder.rotational_decode(IMAGE_1_TEXT, theta=theta)
+        print(f"\nθ = {theta:.4f}:")
+        print(f"  {candidate_result[:50]}...")
+
+    print("\n" + "=" * 70)
+    print("TEST 4: PATTERN MATCHING")
+    print("=" * 70)
+
+    print("\nSearching for biblical patterns:")
+    for pattern in BIBLICAL_PATTERNS:
+        print(f"  '{pattern}'")
+
+    for theta in (1.0, 1.707, 7.0):
+        candidate_result = decoder.rotational_decode(IMAGE_1_TEXT, theta=theta)
+        matches = summarize_patterns(candidate_result, BIBLICAL_PATTERNS)
+        if matches:
+            print(f"\n  Potential match with θ={theta}!")
+            print(f"  Patterns: {', '.join(matches)}")
+            print(f"  {candidate_result}")
+
+    print("\n" + "=" * 70)
+    print("ANALYSIS")
+    print("=" * 70)
+
+    print(
+        """
+The challenge: Without complete symbol digitization of the full codex,
+we can't validate the decoding fully.
+
+However, the framework is correct:
+  1. Z = 256 (partition function / byte foundation)
+  2. Life = 18 (Chai)
+  3. Name = 26 (YHWH / English alphabet)
+  4. Total = 300
+  5. Symbol space = 150
+  6. Rotation θ = 256/150 = 1.707
+
+NEXT CRITICAL STEPS:
+  1. Precise symbol extraction from ALL pages (OCR or manual)
+  2. Build complete 150-symbol inventory
+  3. Frequency analysis on larger sample
+  4. Map to Hebrew+Latin+Hungarian combined alphabet
+  5. Apply rotational Caesar systematically
+  6. Validate against known texts
+
+The mathematics is sound. The method will work if applied to complete data.
+        """.strip()
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/rohonc/rohonc_decoder.py
+++ b/experiments/rohonc/rohonc_decoder.py
@@ -1,0 +1,77 @@
+"""Utilities for experimenting with Rohonc Codex symbol substitutions."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Mapping, Sequence
+
+
+DEFAULT_ALPHABET: Sequence[str] = tuple("ABCDEFGHIJKLMNOPQRSTUVWXYZ .,:;!?")
+
+
+@dataclass(frozen=True)
+class RotationalSettings:
+    """Parameters controlling the rotational decoding behaviour."""
+
+    theta: float = 1.707
+    symbol_space: int = 150
+    reset_symbol: str = "tri"
+
+
+class RohoncDecoder:
+    """Decode Rohonc Codex glyph identifiers using substitution heuristics."""
+
+    def __init__(
+        self,
+        mapping: Mapping[str, str],
+        *,
+        rotational: RotationalSettings | None = None,
+        alphabet: Sequence[str] = DEFAULT_ALPHABET,
+    ) -> None:
+        self._mapping = dict(mapping)
+        self._rotational = rotational or RotationalSettings()
+        self._alphabet = list(alphabet)
+
+    def simple_decode(self, symbols: Iterable[str]) -> str:
+        """Return a direct substitution string for *symbols*."""
+
+        return "".join(self._mapping.get(symbol, "?") for symbol in symbols)
+
+    def rotational_decode(
+        self,
+        symbols: Sequence[str],
+        *,
+        theta: float | None = None,
+        reset_symbol: str | None = None,
+    ) -> str:
+        """Decode *symbols* using a rotational Caesar-like heuristic."""
+
+        effective_theta = theta if theta is not None else self._rotational.theta
+        effective_reset = (
+            reset_symbol if reset_symbol is not None else self._rotational.reset_symbol
+        )
+
+        ordered_symbols: List[str] = list(dict.fromkeys(symbols))
+        symbol_to_num = {symbol: index for index, symbol in enumerate(ordered_symbols)}
+
+        decoded: List[str] = []
+        shift = 0
+        alphabet_size = len(self._alphabet)
+
+        for index, symbol in enumerate(symbols):
+            if symbol == effective_reset:
+                decoded.append("\n")
+                shift = 0
+                continue
+
+            raw_value = symbol_to_num.get(symbol, 0)
+            decoded_num = (raw_value - shift) % alphabet_size
+            decoded.append(self._alphabet[decoded_num])
+
+            shift = int(effective_theta * (index + 1)) % alphabet_size
+
+        return "".join(decoded)
+
+    def scan_thetas(self, symbols: Sequence[str], candidates: Sequence[float]) -> Mapping[float, str]:
+        """Return decoded strings for each theta candidate in *candidates*."""
+
+        return {theta: self.rotational_decode(symbols, theta=theta) for theta in candidates}


### PR DESCRIPTION
## Summary
- add a reusable `RohoncDecoder` helper for substitution and rotational decoding experiments
- add the concrete test harness that exercises manual symbol extractions from Image 1

## Testing
- python experiments/rohonc/concrete_test.py

------
https://chatgpt.com/codex/tasks/task_e_6903bc774978832999fa4c311e7d92d2