### PR TITLE
Add Lucidia licensing safe haven checklist

### DIFF
--- a/docs/regulatory/lucidia-licensing-safe-haven.md
+++ b/docs/regulatory/lucidia-licensing-safe-haven.md
@@ -1,0 +1,78 @@
+# Lucidia Licensing "Safe Haven" Structure
+
+This note documents how to house BlackRoad's advisory and brokerage registrations inside the Lucidia subsidiary while keeping BlackRoad Inc. insulated from day-to-day regulatory liability. Use it as an operations checklist and confirm details with securities counsel before filing.
+
+## Entity map
+
+| Layer | Role | Key actions |
+| --- | --- | --- |
+| **BlackRoad Inc.** | Ultimate parent. Holds Lucidia equity, brand, and non-regulated lines of business. | Maintain board oversight, consolidated financials, and inter-company agreements for shared services. Keep regulated activity at arm's length. |
+| **Lucidia (C-Corp or LLC)** | Operating entity for the Registered Investment Adviser (RIA) and broker-dealer (BD). | File formation documents in Minnesota with BlackRoad as sole owner, obtain an EIN, open dedicated bank accounts, adopt bylaws/operating agreement, and execute a services agreement with BlackRoad. |
+| **Lucidia RIA Division** | Houses investment advisory services. | Register with Minnesota (sub-$100M AUM) via IARD, maintain Form ADV Parts 1 & 2, and designate you as the Investment Adviser Representative (IAR). |
+| **Lucidia BD Division** | Manages securities brokerage activity. | Maintain FINRA membership, Form BD registration, SIPC coverage, and written supervisory procedures (WSPs). Operate as an introducing broker to reduce custody obligations. |
+
+## Corporate shell maintenance checklist
+
+- File Minnesota annual renewals for Lucidia and update the registered agent.
+- Submit Beneficial Ownership Information (BOI) report to FinCEN within 30 days of formation and refresh within 30 days of any ownership or control change.
+- Track minutes, equity ledger, inter-company loans, and expense allocations so Lucidia stays adequately capitalized.
+- Keep dedicated insurance (E&O, cyber) in Lucidia's name to shield BlackRoad Inc.
+
+## RIA compliance stream
+
+1. **Registration scope**
+   - Minnesota requires state-level registration for advisers under $100M AUM. Keep your Series 65 active; no additional exam is needed.
+   - Maintain the FINRA WebCRD/IARD account to submit Form ADV updates and pay annual renewal fees.
+2. **Filings & renewals**
+   - File an annual Form ADV amendment within 90 days of fiscal year end; submit material updates promptly.
+   - File Form U-4 for yourself (and any other IARs) and update within 30 days for address, disciplinary, or employment changes.
+3. **Policies & records**
+   - Maintain a written code of ethics, privacy notice, client advisory contract templates, and trade monitoring logs.
+   - Retain required books/records for five years (two years easily accessible) per Minn. R. 2876.4130.
+   - Document that the RIA can remain active with zero clients, provided filings, recordkeeping, and fee payments continue.
+4. **Operational cadence**
+   - Calendar compliance reviews (annually), privacy notice delivery (initial + annual), and client consent for any cross-entity referrals.
+   - Capture expense sharing with BlackRoad via a management services agreement to avoid implied custody.
+
+## Broker-dealer compliance stream
+
+1. **Membership requirements**
+   - Keep FINRA membership current: pay Gross Income Assessment, membership fees, and state registration fees through WebCRD.
+   - Ensure Form BD is accurate; file amendments within 30 days of material changes.
+   - Maintain SIPC membership, annual assessments, and surety bond coverage if required.
+2. **Supervision & personnel**
+   - Designate at least two registered principals (e.g., Series 24) or obtain a FINRA waiver for a single principal structure.
+   - Keep your Series 7/63 active via WebCRD registration and complete FINRA Regulatory Element CE within 120 days of each anniversary plus Firm Element CE annually.
+   - Document segregation between RIA and BD staff to manage dual-hat conflicts.
+3. **Financial & reporting obligations**
+   - Maintain net capital consistent with Rule 15c3-1 (introducing brokers often fall under the $5,000 minimum).
+   - File FOCUS reports (Part II or IIA) quarterly, with annual audited financials by a PCAOB-registered firm.
+   - Implement anti-money laundering (AML) program, business continuity plan, and cybersecurity controls aligned to FINRA Rule 4370.
+4. **Operational simplifications**
+   - Operate as an introducing broker clearing through a carrying firm to avoid custody of client assets.
+   - Limit product shelf to agency trades and fee-based accounts to reduce supervisory complexity.
+
+## Control separation between BlackRoad & Lucidia
+
+- Draft an inter-company agreement outlining services (technology, HR, finance) provided by BlackRoad Inc. and fees charged to Lucidia.
+- Maintain independent branding for client-facing advisory/brokerage materials; disclose the parent relationship in ADV Part 1/2 and Form BD.
+- Route all client cash flows through Lucidia accounts; prohibit commingling with BlackRoad Inc.
+- Centralize conflicts-of-interest disclosures to note any affiliation with BlackRock or other third parties.
+
+## Minimal activity playbook
+
+| Cadence | RIA obligations | Broker-dealer obligations |
+| --- | --- | --- |
+| **Quarterly** | Review books/records, test code of ethics logs, refresh compliance calendar. | File FOCUS report, reconcile net capital, test AML surveillance. |
+| **Annually** | File Form ADV amendment, pay IARD renewals, deliver privacy notice, conduct annual compliance review. | Pay FINRA and state renewals, run Firm Element CE, refresh AML/BSA training, update WSPs, and complete annual AML independent test. |
+| **Event-driven** | Update Form U-4 within 30 days for personal changes; document zero-client status if applicable. | Amend Form BD for organizational changes; notify FINRA/SIPC of any ownership or control changes. |
+
+## Counsel & advisory support
+
+Engage a securities attorney or compliance consultant familiar with dual RIA/BD structures to:
+
+- Validate Lucidia's supervisory procedures, escalation map, and CE tracking.
+- Review financials before each FOCUS filing to pre-empt net capital breaches.
+- Coordinate with BlackRoad's governance team so corporate disclosures (e.g., 10-K/8-K if applicable) align with Lucidia's filings.
+
+Keeping Lucidia fully compliant allows you to preserve your Series 65 and Series 7/63 registrations without exposing BlackRoad Inc. to daily regulatory risk.


### PR DESCRIPTION
## Summary
- add a regulatory playbook for housing BlackRoad's RIA and broker-dealer registrations inside Lucidia
- outline corporate maintenance steps, RIA obligations, and broker-dealer requirements to keep licenses active with minimal activity
- document separation controls between BlackRoad Inc. and Lucidia plus an annual/quarterly compliance cadence

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6906579d58d88329ab4b0857c058c9b1