### PR TITLE
Add tailored executive resume PDFs for FinTech leadership roles

### DIFF
--- a/docs/resumes/Executive Resume (CTO FinTech Focus).pdf
+++ b/docs/resumes/Executive Resume (CTO FinTech Focus).pdf
@@ -1,0 +1,99 @@
+%PDF-1.4
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/Contents 10 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/Contents 11 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/PageMode /UseNone /Pages 9 0 R /Type /Catalog
+>>
+endobj
+8 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20251101203119+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20251101203119+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+9 0 obj
+<<
+/Count 2 /Kids [ 5 0 R 6 0 R ] /Type /Pages
+>>
+endobj
+10 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2810
+>>
+stream
+GauHM?$"a[&q&$/R"s`pfp-7@6_[\*%qdEdSo:0ZfCnX_<VZfm+:9hln3GEZmakeV5Y?4ZaA/k[Q*RNR+:%+Eo^kC4%IqcR^XEqFaUK8]q;_d&ZQML',.b=Xe!i;rIH(e8A3?BD2[oX=%e4`u%cS(glqLn1+60%S$-5Y@r:J##rHK=$jS@hE4Gh,eggfa@3"5-Uj'b%KGD,J?a[BVW-TiI\S&E,k9#sXP_[pb,hanC5YaDK+SN\C3_UJYpL-5.E::tf;rQCt">blR5Mtq_2q+N_3nToZa-K$k'!?]!4oLAabJ&H9c\,/?r=caHjl?r0lHT9_RcXbOp/sT\gND,[mc?6Rh:Q'p!V4lZ#o]FWiHTIlc0Bojb<$A)877OaP&C[$sp_ioI?-/$im@EYnD"3>q#+3%p3!p;VS2e0r`[C7&%O%GWcXf&>&7(3GcAX/L<Md9&dpou^j-[dJJ'9t/4JCQL>SVI'XpQi4X!:UaM9jp2DEt)aAM^[%m@B[E;Au)DZ!(S,8))FDd\pn<89Ieo>jbm2)"U)/\iNG1:LktH]\')3FQqe]L,N6La&Oc1,#8VF`:UFi3\To4;/8OF61n.(<0XBuq;@L$VJtj@VL$_?;l"A`--<PQGI5/\<@W%'H[J"R74jEih90Y!b?WO6[&RdKFN?<317)!0WNPN(jh3\$=!_/s4h>0?B^2gq\]jS%;\?Mq!0VD[*Kr!.;n8neIJbI.&4)fZVOgf9gi%+h@ZDlq`E[QgW`$u"l!bV/n+K]KXoI_78f*k(Rd4S2j,1CV0/oZJpo3&-K8uC1L7Pue6TkbR;>^k\_f"f:^/H&qbO\^_d[L07Z=T&g]%T60d)neX?893,ZILQ\BU()k=mmWtlZr73:S]pbnm'b,U?uDUYM*)\hfi5reU,>sQ4F8c(tuT$\g%u(7C*H/$+cp[Tgl=eN<(6$&+]]u=]$b>a!0k"C`uphZN9A_A0@mEWS1=Z`0bj"C8tgY(t;8'W@;VjP0AVsdU/)A5Q9u9NaE!i$h\O2_s\b;,[N6Pf.GWA-(8!RHDR*g'NAtq>8dRN!ZHIe#/X#f%b+S47=a63RS%,pp;n9\d@1k8,jJQ6[G[QSqiSe??OJk1l2\n"mABoO/hT=SUC&MI[$:BVXE`)e*nEsf?)j@!e>?iX#/d($ORjf1Cl%`horbSS"s_o6;2"_s]:`H/EFD(b;<#>+KPdXi5kr09"f/\DWqtqGkp8SO/IVS+NMb358#',3I?PJq30@7#<,+6^64aSG`(&puTO<u+\cn,9k:jUK1o5`b7cjG%.)s@B!Zd7iLCi[u0.!De(?s]P*JO#^Q+HWg60G;3elI4Nm8<>r<AF7nB<[Cj\l?(*NNi-@ERhF_XRWo3F)iF9Hg=09N*Ah65DS,%rE[#QY_Q[a6L]#);=Q4f_(Z-+I!fX="jtsAFSL/NX,V7PU,<d6=CQq-J$XmGmZIS$$X1?F%!&U=QF_sL5n[U+_UU!]GQLQV0-^*WJOWX3'tb5:]equseF9`[>[D9R3OI7s!_-rWjdk.B>Qs!C]dTP@'>LL&m+j'uHiV-7@4Ku5L[Yg^3tPlf;:+5BiSn8_NQ>4A2%oI<q?Y%g)G!ULmK$lfMgVj;8t!$?=Qk.Xpg0RfO3Z%#]/lfek:5;ta5n,*2RSo\4(XC*Gd#9!\G'*]3--TYF2+c8qgjbSY6T1A<0P\&q*Rlnob&:nh*Y[G!9bB^gf6fdTaD"tYoNl)S0qV4/Zo\6qF*KTEOi'8%ne96UOI$qG/a9W.Je/>b`8iqR="9rcMeV>_#9o2_<ZXn"G^I\%5=uqF5i(W!Dc>OOd6OpelDell"L'Hr?X8IYg)+'%=DJD#n]uNO`-mBXB(uC]H83Q:NAX,Xf=<AF.=-tMld`$6=T\?OeU8mCX:NeeMm,mC6-6WZ2Nd9pd#cK7@QI]QWQFJ677<K\-(dDm8'$A>7dtP#0LSZ@??-IX+l)?eW?ikhMC1ooGTAnBH-7K%)&lF0,b9rjM2.,DIuA3[l/V1+Etj1kgEIRfC+S?4Nd&<(6E:18ilrrEV/RHVQOB+WCk:Q!,W5O!@Eq=Q\0VY9!68C8N_C0jf6e"P.-*QL#3mV0Lq&$'F#UqJ,'JH"1[`b_B8`Lh;/7KBF:+5<'PQPK:+Xa%iK,^;VT>S&9G8;)H@-ra43hXRqu4/g<baq6Ym1fj\:m'oFBp<qHe+BC"^W9pPT64"f1lRDiat,4$E*]AAs&5(;O"d*l@p?:^E[0'nii#oXKGiT]]G,=>)3?AK'F#YW?8g=1&``]me<^=+*]-@TA$K8,.U+(E)e]7Uan[01!p>p19.tTkc[;qQ@+OD"<Kd@98h/:`_gNn+b"u>*',K?K0E/cs?\!LTZ5LO-J8(,e6`u&"W[@iS"ckm"Eqcp-p%:?I.$=3e[OemW8gc?)rpF`L%KX.<7W5!LLSTlXli82,g?d4dUlP-JeK8X\1k(s5P#g6%SY[gCq!GbRH`1[=u[P3FJU_o1:PkHcO=<<VO2j`,0mhMTX4W5<&Q1oid;4efbacO$YGN>.!*eT,s7T#CD21n>ZCZn0'(d=dmL'/"Q$I!C&ZpBH]>QE5<,?[\1go9[;i!HImB%C1`,rno:.]22]G]'l]<$oeTDT?a%Rb@iYX9hdiU"A_X1i%0qHj_Atj%idI7jqqSD9n>Boc-Qk/de$2;AN,C)m4-<\&o64%)^e&WWe[,QZ>C]ZE+aShV.<j^16t<.=AU=(jaMANnqkINQ[4;)>J(q0'*e-Q.V[k9;Y@X6R>'7do52iC*[eF^<!?X`2&&hZ,^>Cm@3'!MmL99["^C!MMrXW^dY0d~>endstream
+endobj
+11 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2121
+>>
+stream
+GauI7?$"^h'Sc)T/'^T<E=rhG!""%..If+^#I-gt1N>%5eNn!rC";#S%fQ&`/'3g81l=*>0UW4i900]2q0LA5i6jinqO_C#kA(pIp;$9.]`i?8N*q&?MtP3L-][Le"*Xg,47n9dO?P%C+-&W5-[GB05S&QI*u)Tcjb`#C@5&&)nH(Y>N54uLa-tc#TjKqo\BXtjab87sAe[KaRF$7TRcT3G23Z)"3.A2uE+H)$1Ca<QBPQF!%sX.>ntrY:i,hnp.@M'WrX7:1mIO+jd/k4j[)GVM-"lL<-SDNH>/1*,pBFB+he\W;FbUX2Tj?F;Q&JT%iZF+FQYMR*9j,aRZsikWg^CH`Y6nDZncZ*JTb%C),"LIA<8OCUQ_W4cD!:Rl-4ose!m>(%o2P:Ap94*J'?SPlbtcA9ffa0;Zqup\f(P];<03BE&Ugs#&6QR]>,hZAZE0TM8:8ZFn;kW'[abQUAZh"HV'58aJ?k/*KfMCrMDWo"\<:$Jn%,\&o7V@`,2rd.cf/,R+EB)DbRGuDCP1[VE1PB!P8/O5?@gAK!--;[5m<]MKc7VGB,=+$Rih,?#BnF#?QD$M^=_l#ma\Ar%po.kH$7)#(g'o4q7pb1HfL2i_.e#<"u?_'_;\CEap=!/CE[s&gXj:5>[<hF^8m%HoCP`HSM8,ZWUL>YX:U,_rP`q1\?HHJ2#aWJ5d:adV>AhsgJT!3KFJ&`HbjR=>tEm/2bKrD:mti(<X5sp3O$H9aZ`78ddBl^4W;2k<!N\1.5OpIZ89"XY@*sE1+#1F!I;!o#3BG.Q(&hbMr\`3lHj<a3Od-&n7/=NWHp8A$(-IXbdW0Rf-0=Z\AmLkB[rraeO=VkrEN7G?re26;[Fj07$fi3@[N#Vb:0#Bb8D&J=0P7h*$bkG#>*m3[UpJ:CQ$EV/Sn@O!-uCW+SJ'<CeR%BXM&#&"m)VsI#TReBW;kU.(1EHm>M/9=<Z@bl6%>sjJAmGdPlk,V+q4hVF$#`f7P)`^1RfM[Pq*Ts+gna_dt=mU!IhQ;sUPH?Z\(/TAk+0m*YPlgL6(&O;ZAt2>Tn0nQf62'bjG1k.6SmN7kqSOT^KO?QlE<k=H1jMu9I!TZ[2(*?ZRhBm!^&Uc9*Pe:9FfEe2hrZmpa?mWk1aW=<).[MO2G?3nUNW/D./M2VS%hMHiQfW:2eX`iOjd2Z8XlG.tS($!kp`-]54JNKK;7+AM59q2aVeo>Kd4.?4PBtg;jfMrDhDD,-'bngbDYt3t"UOLbYT$anI=nb$PNN"O6II7''c\7TTMG<hZ6@1=XdV\4dn/][Z!_R0'p$R9$hltK2quB]"8sZnUn0jeJ%8guBMn3%6,EYkKH:r+b#?QT;i4B*KIFPhd@&O7V"@D*[[d7pd+uLVfb=F^]n[OM$?Gn.nXANHQ'j@joa<dsSLV_A#;OdN/P;W'&ob7,XG8j8,:?55ZAjpEHKW#5CCf9&mSC0BOGIc@)Q*]<GmYPVL/am#Qo'h^;f,IX/7-M2CYt.Hj/&A4C4k8^1Pp\9H(9U&#e$([1'ngcfe_QVXU?F86DeBSl4rBLHD%kR^h$^aa_@YjQ@+u#<>U6=<^Ii"GA7Zf@`rZEbar!F4HZqNC>t+.s17\8T7/q)WcKlGknogiT\L=ar)6Kcgn6#*m9Qf9bGL;:O1$t'K:=YfZk_INQSSba0c;P7-TCoic;?cRej`Rr?>sn4<gRCEndIQFGFpYM*l>enWXm$X,^UlO6gjWog[DQthj3][!NIPt0qYi<CP+71tCl;UHN0PT_9-]?#'>[8>,a`<b?LUnn<YU7)il&s=pr=<BIM&]K=0qQ$Idp_<%J8VG&UjY/Q@HOl_T#Um_^*4MhPU.(5`h"7UgWO,'^9KSEEKFpgNb8+ed$r"<0"u*+gnnO?!f7g0Au4'I+KHiTP@l\#/Nk**B@^NC-2,"eEcqjn]rYn'=u=?^3e6;eN94kDG50cK!M&TC@(T+>^`0Qogrhf^76)tc18:hhaBjb+i*3ZU!&'_8eJUrT*ckX`A2d,>@1<l`VmZfP%Mr'Ps8aA*_gH0VRg2<[9n8I-4HK^TWhKS>g'.sg!_W\0ES.c7QXR:,KVq1@?gW5aN_k0(eA4)KDAil-ttfcj>ZWB:AtF(0e;V~>endstream
+endobj
+xref
+0 12
+0000000000 65535 f 
+0000000073 00000 n 
+0000000124 00000 n 
+0000000231 00000 n 
+0000000343 00000 n 
+0000000458 00000 n 
+0000000652 00000 n 
+0000000846 00000 n 
+0000000914 00000 n 
+0000001197 00000 n 
+0000001262 00000 n 
+0000004164 00000 n 
+trailer
+<<
+/ID 
+[<9ae1645de735e340e3f2832defeb6b6c><9ae1645de735e340e3f2832defeb6b6c>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 8 0 R
+/Root 7 0 R
+/Size 12
+>>
+startxref
+6377
+%%EOF

--- a/docs/resumes/Executive Resume (Head of AI Focus - Final Draft).pdf
+++ b/docs/resumes/Executive Resume (Head of AI Focus - Final Draft).pdf
@@ -1,0 +1,99 @@
+%PDF-1.4
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/Contents 10 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/Contents 11 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/PageMode /UseNone /Pages 9 0 R /Type /Catalog
+>>
+endobj
+8 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20251101203119+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20251101203119+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+9 0 obj
+<<
+/Count 2 /Kids [ 5 0 R 6 0 R ] /Type /Pages
+>>
+endobj
+10 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2802
+>>
+stream
+GauHMgN)%<&q0LUoRjh'-R=?Q8J%kL=G`.\,uUg8MRU#d010+QNWifu>XUAT^Sb]E;R0lfWN]JW9,''Fc^aDeICe[*Mgq>o)<XDc[rhPf,L<:B"aM>*7(3tSG5L:Z$chq7M*!$(%D3eln9[4d__G0UMo%S?_*_Yl;^H/J_[FNV_T=2Oa.'TtF@;.-+7#5JJSuTs\D@!G@)D4f1RcZ9ir-+7..kQTLn&/D#'`4Y:]8(r`Ep7&p9E!b>PH6`H0`2tpsFriX$`eQM!liGP1OgQJSotqoDJ-4_+E,o%!^YN3V_j![t[++(c^R4V!%8\i&*D^cT]I\D:F36$Rl]kd@K`]FE1,(<P2:jN178="1kLSd`)aP1mM`b\fT4F=n&PagDgIS2T(?%-"e-Tr<W0f(?a#QkrVhU9ogL=HIXsd]Fb=\WC.?!3n=D%S^<oDL*St\BAV\1#\>Z$WjnCP.\'W(a/V*7+#[p$JlFVNG&D2e4*1A"XE7X&4BFst]NIBK.okcM=;SBjFrrOHq4O?c*CnTHper,[:?98VI/FQ]gm?'BS8`iS^mmVCkPo*VY>dj"P^m+B_hDt9G1LE-.Fs?WWEDh+.=@k!>[`uXW_*YGVsN2?L^Gec[g+19"FiV6'`P0Gf4g`EWs:K5U.WZ.rl@U0G`Xe#;PeMBdg?)<r7Hmc(0N/GGjQV=J/-<[<hqWc*rmad(%:lE.UfAkL(tmA&Hi?'R=\B!&E"oK7Uo;q7V"ls=K#>1m9m7*hXB4Rb@/*(",XA-*TQDF3Hn0p4rPg8%s#PD*KffM__73cRkg:;N%<3F;?4gG<4^<C^SuGFA7RHg,H?i41YpEBj*)a`g2Q9/j7@[mGTTHI2ToY&`7WWTR&Mn7rQuC./_I:RBL7R4h&qS1KM09jSDCocNhQcHku]h4iU!SZ-5'TB8f'CkAnV)8cDB%&1gZ@q8/EU639bUu12ma.@*l1RF!t1)*b"_aPj.DnkRo!Pa:Is19W/_s"SI<ED2]RMoR8mIFb(OD\@A=V.F*$n<M_6_g//PEd45iHU)FYagf=KLYnIl[Y7koPl^Di7hp]j'N8u@Kf=O>err+X.?M&Xo>$Kl+L>M!,ES/k_A3FL-QSfT^6rZ%)QijTmRk2L57T1#8!o/d8(W]GVUOi$5+'aEU*b<[hH:qDHa,qBR6M^KUj=/iJ@\"_OC4)tK6<:]a*ei'qJ_\r4#KWgFar1DL.HZqa3AL2Yl3;D#-TX/8+l3pn"[t,<^)V54T$+!/EG]4;<"DSh]el@kZ7IJ.0+k\t4"=I`I(b6%C$$AE:7`^%d:b1DIeF'_Pt>\&GoujWB:-NER`[)oIWK%Re^m54*PL_&p:k:L<-#5Y=]T]//Y_Bjd=^&P>qX'CB<<%sI0&QN+F_3"=&l3F&rT$^&?/T\MJ#cU?/LG-aV>d#s6MKZ9Z)KOI:m=+;*T.C*,u*IE4^_im[_/S8dglq@4'Rp;Qm""m,AX[YNn[?V""RCTXtKa+R;K53nJ5n6lmjTIgtOb<'<CrrNXs_bY2*i)fN<")cFUI>"O!Xp!r(HYYb7lB"]utJr+\2='/](+J>.aFC>-)eWWV$QI,kQX(bp4TfUf+V3DjrKGHUA(giNEj#?/9?_:/o1M'Mi*g`b;&TaaHg4GA8TsFM$bHpAP@=6rt#rdILZQ!T=d_UIB[QZm9k20&_2bPu(pQ*i/!MD)&a_IdT<o!f`<A:WsLuVRd6J^ad&SF>%'&_=u<Xn8p[a]f7DO(Rp>#l.`7SeT]DeE,jY\1uFFUNnJe]s4og:;Xu4a[2B>0brs]@#S&GGBRTpFS)&(V7a$?e64cTK?*6''-pb._m9WQp6K-Os@4]8/A16SZGnY63J,pTR\APfue!q)@u<bR1,LaRVcc@j%;peTLINFM9,kLpf\W_2C9BW!IO<0p%9PJ:Bg9$<T,@]G+OpX5#=:#kN]P\j2C(-;l2""f*VoI2liW:Fn\oG]ni^4=2g^Ga+mUHSZR<.k_6!^U[\ma%WOeXDU\[Tg`>&R1sn6)Lm.^%?OWW*mTq]#e4WfialUM3DuZ<[MFjWo;6C6^Pn6dX/_ZSNFZW"$Ot/:U'"Y8)Z"c:sjHQUe^gJsYi#"%\#]MS2fEo<B3;q[dg'dhQ/Rhc$VAgDuFiF3=Tr'm%-LD7uR9FQhl?X(JX)sg`90aFUUUpM__-,V1B[#qMm\T+AVqbt[[),O9"ig\m#G&7_G=!8H]dXiihou<qJAWPsqYNVS]Vn,T/Yi',XRn24+5PkfOAqHZBTL%"N"K@g;C$PlJh8cqS%f!C99GQspLATdVMc/f@A0p!<]j>EOY7YY$f/n7f(Vul^muEep!#Z50L!CahK3*V#`j6ij4oXd7Jk7OpOmg/99KUhEu+.sqeJ:+M'Z=Yg1bPK\=TJ%[1E5Da`IV6h5I^=!@e.\,t3RHj&eWq))^00*)PU(oFf@LRNb(&c?%N*QTW%_o*1aO!V\1XR;=85>R,Rl+gP8]=f@bQ5*,*?]%;s+4D/bN'-EsC2Z*;>D#/p&0fiP9@":HL4#uW<Y5pd8CDQUX^>P]70$9Wf(3(l]Y&puD"n\l6Bs9CdJk*W/%`7hJ9G2ffm5m'\Y=,5Jdl&Ff'sHjOi$-XNh,$UslS5.(^4?2gVRfX%RG(\\KPt%]U=FtR]@h#9m92FtIWKXh0U>jN-^fp1.H5]:R]&_q(CDTVimIKt#5AY?0tIpe_a2G*k3_pnOn&BfLo8WV6lYhUL@>$icej2XeranFQ.>a^3dViY5HE;X_%"^/C.7ujE^t:soNt5kQ_K"\@]8^$n,E0%IuG=gN'$jZ+MIP7qRNqc~>endstream
+endobj
+11 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1991
+>>
+stream
+GauI7?$"^Z'Sc)J/'c+O-Y^E%%G6b(6:lr<+;EVEBmLq=!SYVX/'0('YMUSZ8SHh@FP"E@#-_V58C.*X,nF8Yo8:jR"h9NLr5o,fLM-itgM'#3L1,2pou(j`?Jp"CEEca"CuKRsnA>a7onb)O#<4-uq4K.;hOZ]u(C'7<*%u9KDAsS1**,3D[esT"i)\0R6k`laR<AQr[u9i<WMU?_flS;`j7q/(_R?iR:+u6$m@J_b%e(O+jRjWfiH1K/:<aYEIm`kZNo.="'<#a+'"d7gS=\L$\iAkZq>Tj>)`XO>Z^k:GBbdRMG&F2kR8>3^5;WD3X"@nQ'+n0iL;^Q?a34a;.S<Sceh@t/`\P])TXk//hGIj&0D]`lio=:H+n0sd+qhs#Qgq3V0+K@G]eN6f;)2Ks*gUr;.2c'dm5$8l+O.H*9se[aOCZPA<')dI=ZbN&Gg8JAO2nr@<<r8\d"[tD+ErN)ac^XUG-K70:Ge/88ZfgQh02-')L588`&!pU`AR7;M3oSg(f6OMP+jbJFkZ#X/FXnT!j&%!OE2l\<M3j$W!9I&j9!GVH%Bl]Y\S]:[oJRcB"9M*<j.%'IcZ4Ff`aHG?t&$g"08$^F[BUBVi.*(1tD("LA)QcL1tsQ/dUoqq`8tmX%QC;(Ke8To\lB?Ii],>g/mg!)&etalc'n-O"Oh;Qqh'4KpE^2I>r\d0j*m$?m:AVH%Q$1?t?>u]k:Q,^PlWD96^QQk!YS!`EScDHoEA[ameg:guu=>6W]_V!SpGk,``C4qk3#@fj)<7dH,`%4(1$H1X([.p]IApQC'd'Lr:tr)E-O8WjsD/(,^_U`6]]H/C5s`3CVHfD8sdc@\%C]/7OmDf@Q;=ccXBfAl1i[?bh3M&d`Id=">%B>:YG..4JA(0l`auX>iTo==uS],^I68IN"VT-oZED7$@p.hR(D$bTNd?VG]*o38Q])qe5Uo;`2o@;hEh%DchbdC^"^ZEY2LgKS.3JUUHTDl\>gApPHmFc*3FBqeX''B[VDG'BPK2a\.J`@4et@DscAupc:X`TjOq*:CFInVeW4:mC'[&\ZI\gKA.0m.<LOqZs"[/p]tEM#tl0jB3E7%#LS8E1+,0A:JfE#rR%4o+Ka^$iT.ltnnQNuY9`6.U>5VpWQQIik>J/g.3^Srk(+<,Cb8J%`>]staR*fK>j''.]/"mYMPhT>-G^Io"KD\5<bPk[98MF=1&aLJE'$SM<gp%>gH_WM0!%=MZiZ4fbiX!f+Y].a\Ze#&VIFG>0a:XWjS"K5,hTGbECQ0)AH3c@ea@a+'S.G$d'@>u_5]u,C1N"`K9kg7eZX$l48>M4r"!ONi[c&`<G?'a'.dtC6g06!(5<+M@jLP8@,*5K4aFB355V+EZ\(AZH,noAR]7Uc/WV&Fjf)@@%;`6FQW3Zda;%C9^hoW!j<07ZE&8-&W>\$,NMc;2/9']QZ@WR4T#A'dh42<@(PXWJ4-(+D[FiOLBMP@r3uF/*Vi1Lj7UsXZV@="UoI#P5K#Od%Dq)7;I)t'1Q*`H.j4cqu>J6eKO=F0d\ED=M(1#Z0@dbqFedj]1ch(9N^n4-G`GckaonN;8?_bU(HJ0H.Il87,#5nh2@/=SX3LkRZ=DD'rUMZ&A;`0)p.GE8c_q)7DB'^!5AcIr4,%=9WL3GoOS#$ID!HPJ9230WQo5G;$-N.T`^\P&0-T'ek2L`D+X&FY\J*!(kAZLhI(Q>8o:%]fa\14;"EL=V"YRsC10AGf[923TnY8I/JVS"*1)u$8ZdI[NgCkM3QSM+(Slld1<#'s'TRP(l4fRKQqN$$A#:1G_R9VjSV3BIYWI5L1oRAqP9AVOdH&@I/<m!7TV7s\bCmcgD1"d3(7i-aeImIMXELg8)LgpaI%8aTAbGu%"p1c,$OAmE(@-&2EH7!W@D*em,\[6$umkQRIm#8eAVZ7'j>;VgVs`:an$,eN'?'P/9X0MMGao`4oFSNH+[<1I0Y:l/X;Q/B\V3;FAPRcB#~>endstream
+endobj
+xref
+0 12
+0000000000 65535 f 
+0000000073 00000 n 
+0000000124 00000 n 
+0000000231 00000 n 
+0000000343 00000 n 
+0000000458 00000 n 
+0000000652 00000 n 
+0000000846 00000 n 
+0000000914 00000 n 
+0000001197 00000 n 
+0000001262 00000 n 
+0000004156 00000 n 
+trailer
+<<
+/ID 
+[<b52ef835be03f3244035228a766163f3><b52ef835be03f3244035228a766163f3>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 8 0 R
+/Root 7 0 R
+/Size 12
+>>
+startxref
+6239
+%%EOF

--- a/docs/resumes/Executive Resume (Head of AI Focus).pdf
+++ b/docs/resumes/Executive Resume (Head of AI Focus).pdf
@@ -1,0 +1,99 @@
+%PDF-1.4
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/Contents 10 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/Contents 11 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/PageMode /UseNone /Pages 9 0 R /Type /Catalog
+>>
+endobj
+8 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20251101203119+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20251101203119+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+9 0 obj
+<<
+/Count 2 /Kids [ 5 0 R 6 0 R ] /Type /Pages
+>>
+endobj
+10 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2751
+>>
+stream
+GauHM?$"a[&q&$/R"sbFfop)uk_iI8E4-EmI@KSLD=:e:Q!YXHOq<fW(Ei,/If8qi'P0@dP,_H[;R'eie,VWp4[!1@+oXq0B3#Y9hU(e<6r?W:$]7EiLi,E)qjUZ:]aDV)SV/d+_B_aN$%C2InT7HJq+CP=-b*lZ`agAIIX2_sd<%.4;@lR>l"iaRgtpUf5##L9_^+TOruE8WDD@mm9i>:.LJ=]:Ga)*fcGB_ANo.0&nR8]RW*__(>%6_N`??ltp'X)G$2t[dBd'cDCIJ/fDEcOo:V<=W^Buql]7:3k4/)^>_soYSo70CdhLph3ILWs053UZlaT\5?d#$"JWg6d^a)q:C-,%o'V5:Ok0BkBTVmp>`Y,n\g>j32qX`c=9S9,./V@4mWZXb&R5W3HkI_NTWR'd<\-k4mX`dW?f6IWI[3`@Xe"$/N;gLrVonbJgK%8qaRm@/gXG;<5\a@pl\oWe2H?di>c<;!8ZqiC\'F7Z66Ana\:@[kF:e\fNZ<t7$]SLNXFN@%T\kjs"nW8%<Qj^!t&a:*!:`)QVKqp?[VDYKdur?j0GqQuUn@Gt4[!/;J.;6,%8@OZH%13./3bL4eNO?2Qhj\f-4qc6m3U*,6cRR1+VYNZ'9JB7Y4D=!]`JU?c&ghTkddj=I2Zfe*i('CQG/K-")"UiWXK7ulu>HGa+!Jr.)2.b4e6KrfU2ft'&pJNr5mU]f^%_XQ^XtEJ>s"mfu#M(dLqT]8V:`cP!$Rh&:Ce(c;_b@mgK5ql#j6>/qYcWIW0g*;hAL.?FcYC!?n@s-.=#-@dbYEG\r&(feGCm>'SS=STN>t&fa+W&a1iJ7<ek^m76U>Iu:d7^LjBEV8[,t]W<3J\a_G^IA'g8fWPaH0"TR_508]+/(B/J6cb-ppSY%=%H[o*r0@JG&X]Q2%';Vng/qQI8\k)InYI+@Xq-K4t8@?ga.L.SnY6@:rm"P2iBKXHd\K(kFu\-JB2`E&WK/MNd"*u>.HE.J`6>n(4f<4rB[-guPc>[&KrDEcIB0FnX2ZDLd-?7s(MTOL\%"1=,r%oC_38DeOC+]*Tu"Na2bR?AF<12EDTlh>&4k81m>SPX$NU\l=/FImWLWJrg4BcP6APtPKm3`gHV52?O,Oq5tNXVCTB7hc9")tP)t)51mf$IUQX4s7Ong]KTZoNlZ+b"=)>aZl3f!(EQnn^i<jC4raZ&oTePJj>#E)d6RCpIg9B::Vesl4!C/p^R@Z2e9:+8sd&r#M(bU!?'RMlX]R<R#a`,5/dBtQ\q+=*pd,ugbJSl#Os.?2'2\?C$V"tmHWp!gb_'YQMs@EOm5rs$`>Xgg@S5AQ8a%iCe6gJq9E;&MDcerj6lCMTtb:l@s1TU8ckm84=ZI`,nArP_'bS>B3js5R`qW6@so//&$-k-!OatV@/gau4;1?n/Ki<U6EH<GNE\.\8Lr,hDgJ;6^>3Xk`DnZl:a]?=9(/tC-4'L92]5gBmY@:6L41!Q3_%j6q,lquMSH)rmjs]6&fiS>PJ&tWYT4!(p=k<l\J<:g2?Z2.UmhS".+SnZ.1;HAKdjZeh5Yp8$C,b6,JV=$W<IZ%/K8-g]rL:95@WI.ba$'.^93StDbtW[SW"'aF>A;2H8]HF&3du'gZa7:Y:pd/<YVFQRAAIs!;_J3IIoSsjg[,c]R*a0JE7]icCBGs,*(PW;q7n4N&^"BYUuY$>W&/bVX4AMCC%X$-geUicjK:=_qF/&Qh\?t%G^tp1I&Tkk3[#8Eq[8@"76:U9FhASR-omg2o+3WN%)TH.g(#Ob#Gd#\F_qkU\Q/.=3O(58c"hnI"#`T6pP0KZ%f9_>5:2$i<F`Wo-%mL]eqAoZVn5K];7N@`7I<4c`-Wgn/^/F(V4OT7XJm+n!(dlN#g8:L$c?E"Pn&*`^sC,/=F3q?7B,-^Y94X=h(qY(o?!s\L[*,3'Nk1mUGR9Tc\^7)iZddghK!].S#D$dd<1PT'?^ik2^EaBnl+*[r5D7r.K:bl/V:es#FjV-<7'4]@,-81F*)?DB2a6q.oOf1(E.5>\u?rif^OInCut-k,<HgYjc><gKtpBc@:&Cp&`!B1s?*6+3uRW\ZtK3)/=2[nR_/T/C]8u<$g+Ek35@M$IC-9kVb_8E0W@#*rZZ$]oI^>'[kFQ$IW<5&dq8!:!k'a9)&*N1\0P?>747-LI4%[pP&*jFqDZJdGn/\@;Z)lp'XM^9*=XV^!:lOj]3Qa%hRBn0HOm92q^ff(&36:(Ke%N,!TlXH>1>mp5+4^ERgqPIWG'.=ZhM7.dV&;!TOQF)pS(6JpbLMMa>8Xd-^`cJ?FKE:R&=/8ID/7*\Kt3rJ_iFU_VT3h&13S\='+M[1E;f=1X0OY16FfdP<NuUaZ"[!aOHLa$T<2V@#@H#'@$ML/L4bX]Kn]>4I1A+4lkg1nWKFk8Tt[$Np13Kd`H2Z;L3@^O-$hotB`Y8JI+YgVS`FE.0t-iF[JI&Yk8l%gD_qWs)^cDYb9uPIB&Z^>so-N7k&+*+LS+9GZ%ugNC&WT:Hp[&=a0=i"7[:TZ_@.o:3S0SN@09[t;pmSr=Q17e&?A#P@2'4/#C[2e/ZDI0';I>aejl@;=Q5+!9!XgAQ2<2W/SWL&UH:ne<pH7GaTbq;\C>:+SQoqaV:t!AknL1%7?=)5[sD,!i4lRR`fD-b7I8F(.(TkpaGjF2m^%cfX6SUU!XB]-gHOT8=$@?2+-2l`?FRPj^%sA@G)/D?\s^cnJ9)ea;,Ich$k.\4NU.P@jp\ec,V,IA7J~>endstream
+endobj
+11 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2234
+>>
+stream
+GauI7?$#!`'Sc)J/'^T<8Qp);0fJ*Q:m.Lk!fPagP[4W"(cAb_Q0iDOYO=!r8[IY68Yuo[R?.]t7s`J4/(rFgO'V\o;khG]SR:&\41*e)m92+oDeQdGq0ZXom"*dQPL\pO?,)<D^?>8Sdd`0qVL+]k%ij#f2F!g9[dAFE:R:Bjr4Ygi;bq0MpUa0X_<Wr(ItS-?=cD[/fC*34-d?[ZZ^UmB@P"E[MXMH6A.<pak75_J0u8=mP!,IL8uLu18U,5EbJ.`dZ^LjK()G9L_A<%AQE3Abd-kAeKDPQHH*:lVk07LP"05Y"lC,,O:0#6?'S#_1nl"@dOX*VTSFV8cGP"<<>PtH\98/==H:++AGTnEZ>El'>>as\[\=b]#:K1#Zo-5t-;(3.nhO/::SV_Sq[#;%eA\<HHenM!]aRe1LZVd1>1+>U1Fph%r\ehp*4"=Vu\%X'VP.TlsO*ba0&DSWg018YQi3!*FX[OFk*Q=jGU7>>a<M#E'l23kQ`o,*!LhBh^_)8\naA>90(8MDC22<udA%Cd%Wpg+9"]k2G^c>Buf9D%_o:51H^Fi>L(9d5pH"PAU8%T4eYI<1CHaPC!k>r/H[b7nHHNk6L+'B$m]B=e]SHc^=i+YqNdJ+mF\e$mZ],&3ZhnJg@k3C[MgKiY6Su7>uga#2n9L`=7>`1_@Ocm7IG`/G69X/3_QB3)*;@DHf8bdqJkHl(4[fFf'<Ye<EM.KFBfCo>\Ze&j'^43M[BP\\5-UnA;>4QWZ6&RKO>'-lM1uB$P-!Rb3ANU7+a=t?h=u4Ze'T\48ZoT3RWf/V<cWu#;@oBj$&'FS1X@9lKXS;l,-S66/;h?e"@[+)PiiT+@Qt9M4-ZhLY[U%)5cdm<$'n_LFQUt6<X-l,'pjN-`qC='5P&-rB%(-<4rIP*M^2+F*LD[Z<n]-gY?&PF7k[&65:+a&nQWqBJVbAB\gekoq">V;(Sg`:ugPD&-"t\p6R<eMRR+8&D^b"DPWD-)Fggm*YP(VJ)6r"JT1mq1mN#QBV@Q9pfd4(h2RUQ3J,]aPje9I)8VR6^VT3>odIRB@/-aLE".69'l21MG>pU\&u-$F.ko=)(#>pun0X@1$'1s5l=`%k2oUcmRN6mt_B)`Kq*Zn,bZGe?)4NFjX>U@]Ji$AjTRZ$a/a9Ln$`9N>r1[Aer>qdDZCYX:%2(@'fV"u.>E"ifb@INFG<`#i=7'Ku>_61j%%G(X0fhqj5!4!-ADAtNA\*urP=NNGRtm:L.@EWBRb@oL8/8sRik*m'%gKS=,RX&GqVFRb`b6&<=-X0W1+nVPAQdNbOmC\hW;<33,!Qe'8g`(^sK:Hm>l;c!rZhWn(KG6$ms<j]PaC5;8Q]eiri=WQW6iK#:K7@@&(d_ZW=24!S//?eTT0CV;*U.RcT7V,]/;l9"+#reTW;M%27?oCHd0J5,./*6R0G>i(UJ/P`N']SY*612=T@hnm\e,_tkZjss1Y6eRcC4n5)NqoSA1J,?%S;3O6PktT8gQWl9qjU'kbQr&aX7ha^]gJ$L0g&Sd"$2Y.jqIe#jngTQ#6tfnDt?P1l2V9<C'@Wa=c=u1^iTq5K$$O/dLu'hd3jd^U3"e\=3jVT_o_1[09?+[6sO6e!&8e6G`5?KeKRCNIap7aQ"Mf#L8I:(JZ+1f"lUOtR5LiO!9.a6],4FrSYI<Q4a<Pur<8p(Ac"ZNbXlh"+:Fk;7=2$[ha,LfrM[<2aLE[5+tno-(f#]bK#R\#7)(ZtLLuO,GrsUb/ujqbHVHR,\5[dLH^o<:.=Kf2T7ZlZAp+G[JDINl`M'd/n>(09jlUT^6;e!V+-YGe]NA)'L;iNR8MHRg%W?#?TAN=3_^5;WgJ?;An`%m.V7(.]5UaAZSD?7<\@LbhS0MiIoMSO'@:YB<"qcoiLmX-HP1)'\YjI.c18#V<PIZ!dWW@U.KB6W)>`S%RVpkH,D>M)fkC-T0s*2,]Z#uH2!dS]^I16b\&YloWKB>*)a"pb-H^H3$@B5mA&=O:\Z\I!-ApAYa\\4l$/jVJir^8UtQ^1T!e*VFl7b]Y)5a@("pJRnKoPK7VH*fWe&(UE7'nVFEK7oo?:fa9=Fu5W%9\fK%[SG^mnpD4'>R\F0g;<@T3^H0:eH83PN'j,G3j-N1@So3CYAB!e.plfM*UU_I0m+=f<VnXG=qpmdc8.8>e#fWBS^E:>`W30U/MKL21(HGUWF&pb1cHtMW#-HE*WfY6U8R9@_OF="!H(Y4MZ~>endstream
+endobj
+xref
+0 12
+0000000000 65535 f 
+0000000073 00000 n 
+0000000124 00000 n 
+0000000231 00000 n 
+0000000343 00000 n 
+0000000458 00000 n 
+0000000652 00000 n 
+0000000846 00000 n 
+0000000914 00000 n 
+0000001197 00000 n 
+0000001262 00000 n 
+0000004105 00000 n 
+trailer
+<<
+/ID 
+[<1822c97c58da8e9f95b4b57dd0ba4592><1822c97c58da8e9f95b4b57dd0ba4592>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 8 0 R
+/Root 7 0 R
+/Size 12
+>>
+startxref
+6431
+%%EOF

--- a/docs/resumes/Executive Resume (Head of Product RegTech Focus).pdf
+++ b/docs/resumes/Executive Resume (Head of Product RegTech Focus).pdf
@@ -1,0 +1,99 @@
+%PDF-1.4
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/Contents 10 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/Contents 11 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/PageMode /UseNone /Pages 9 0 R /Type /Catalog
+>>
+endobj
+8 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20251101203119+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20251101203119+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+9 0 obj
+<<
+/Count 2 /Kids [ 5 0 R 6 0 R ] /Type /Pages
+>>
+endobj
+10 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2775
+>>
+stream
+GauHM>uTM!&q/*0k_Dfgh.mDa_ie#B+"jch2S3KY$gbc3nM6EMncVOZ*D$h2YJ6u*+,0cMe9+Wf,1oHOR5:a:T5M1r_`ucP9F@MX90.CfP3^NWMVPuRkjj\h?,$.3NAGY9E4-m%k.?*'j8VR37<:6;S'p.7ihe-ta@KM5pr7=0-k%;?gi+#\!cksA[f5j=pZr@JXM=`FKQ-h-"<iIRYD:$8OZ*e[EoP'^a4'SY_XhVHXOS>XO+e?O\jtV9QgWO\+!*MY3-:=AjP":0r]lfWkjh7#cQ<Z!L2e%!hG\i8cHgXrr%rl6lgctbEdZ`79+HErk1f!cN"1?'+sjpscUOgLda/SsY*IdkrdD1PM)9>9GnHUjlr#0GH:u:#ksC2aSVs$84Xs=QY`c?^k?\R=ist0h;=U/FLPng1e"*INJ[l=<]f2ZZ<1W4ZSK?7F)au$dr-(/ojTsCbRB,m^VQ+_N>o]j78:2;Ykq:%VZYl-'ch9"brO"CA1SQ9sR2q8g:Fi4*@[cMdf"'SH;*X'"If$85p=iqrgiMHmE9HTn9Xb8]G=*b3mbbMNp[.s8ZcI,e3/ZIuV?V"h.rC04Y`gP<5R5dq.VY,"8X58>=)VX&8eO]>F(kdW`PKB">BJS9M^n'oAFf.eVT[4@Q*ncWaft*KcY"=jQV/n=TZnf/8s#q0B50f5bZ2)h\tHq2Jn1:K;Gtu01*s"8Moj[X2#Kq1I$>g&RHSrq2mTBQ?22_*p^qo:J@)4Ua8hD;%J[r74-(H@lOQRBK<]`2Z2Ic)Jqe`o%dYh5SL^+`*4+7fL``r?<QFWUc&'%'*Q6mjFbIDf_e#>#ZFLcf)[\p\LO(t/r281gU%95=hQ/"L7PuXrnu>C<\hP-*op<3?=90K'Oj3`uD=/B-jW^I-IUG/9MCEgDaX5-GTf>6gI?9$[C@DE+T&>O%K.YVh,Z25f*B55t\ur#Go0uFn$!&uaWE_A>h*PXC(/('mJ3M@)=kgTO?`RF^s1fTeg>u1AE"nOoH>OgS-5ZU5X$Psqp&s?h4T?'C7jY)Xb-D0W_%p%RnlC?[.4mKL/5:25pi-%c$I&k.+KYX@65b.]We.($@anC&H]Tgk;ZgUd:a$bhpDEtekg]\"6L=fh1XVN1g+mBd;3p9Jl`(0rFm;F7J>I=PCoFI6d9)L(af:kgWZ(1hTaP"TUeEu"2S-,ugfCi,F0JMQR5E6?31E.,aMGaLLEaM1MJQ3bN*T'^6N7W*jRj;0)_=h@4.ms\fg?#:Q9H.6$Yii7]3d2X=4X+:Z_9>lbFS;MR!Ut?KCcrU7"3Q$HL,tq'-F;\=AW61MDt,h":m^9=l]!p#5.[dUtk`6'^oQ!_rU_@@1;R$Htu-+%9Xi(Jo6m_#f3i4D7)Z1TT3/j1SJqq^aXFaWRKE^)itppY2C7GP>^H8XfJf-7ZP.9ao,VU#6fQ*]X.'ki2>Ns7a8NLM9btOgG>n'\[moFAC\*Eb3K1tk;WN?j-EX[]'^-;HAcQs6#F6(#[n!V+n7N!a\k@W]b+_DQSe'.AT&B.U?kCdX.e=hg'>b:0NZ'U7\aUblI@^WBntC\l<=\.3^!Fe$n,&.4p4>k.EZFR>T/#B%G6]q9mu[:JY^(RZX<S7IS>Wr7HSelhj1fJd,^:jX'J$IN&Xn=JfcXiPLpB^NsN6[Gg?=n;h%-Q:10G9FBfuYYuW]?D]tlcq)[pNcY,)['eY`s.]OT7pSOm,b_jQc\hg'"^E+'EG[F-,"6KXgBF7V;!V1QC1^\@8VfR"5V*EIi4Xj;"HI?#&2I.@#lF!YUps[pDYCE,:C-++bE#`O!R'+]\"Z36@'[7+W.c.<C\!UF+bRKJKY6lu3[XYE4J_Y-d1=_<Wcni<Gr]\n>i#`sYpB]6E2Vbi!e5RfaJaYkJeVZ5p&f^OTps/(]>??@+GCh=eM8>puc$7k1:0:kY.`o]Vi*ZTMNR$:1`HT8X?,5ckc$HkKHJonbnOjH(^XEf[NUXuoDH,(?HN-O2Vl9]]fP`6\attSsBm%F]\9]`)I>]j]jk9bFa\C?\W5/-Pr.7A(0YIV0gl1h6ggojKOV-2C2fbnjF_rKFnuF1#(!fuo06A:5>V?p,re6QR?B"?oE'GS"B5O]s_gW4EEYe6CIN5ed)GX)/[ARg.61[gQG&"/B04%ds4`C='bul-'+7g3qAHeh+qU[%*9/KKq@i*6lD"BqE<LKLOAM^10W.AP`=8_Js]]UicN/&CZ)89'h"g2tScj8)Sbn0:\Wk$ueU$-fL6LgjOH,DP^nlIM.)g7SJ*^'?mb&iK[b;R$I/"E]8^R_!<\T3,eJB%pX/*LeuD5VYbrei[79g9mOL#G@Bo8E_CB&P!1lGgZ3*7>^KSO9t0UQ9uh:7;K:&5'l(Vpr,J\PP@p$+L@mJ&rUPam-l-,L0Z"DY145I_7X^'Y;2]VqH<m10[<6!pq;`ObN]Km[M=MoGcN.+m12Ng*4"+>>rbp!Zn6t]&L1NIpVV<)ooGUl1Q42Oi*T>VJ%:H>#$U9WOU:6rb/AXr;b5fJs3?6k8UGgH?OAYp"e4ehV[('N'BtC;V`IV=[/U,2RJ*"_ccWVIa(uUmk3[?(3`9r8GKtYSp.*7]jBc7Ba";.H4)YUA?Fj,HH3V>p$FP3ch:1t?4-Al4%n#N;#_juh'h%GD`p#bS<_Z;p;Hk,oQ3D9mnPt6:Z$Xc!Kgrb>"_e<EltS@/FPmnd_7dSK34fl[Ess7O56u(?E/)\gJfNO]0Uo<rQanYkMa@`RhK]&L/3jL;4P8m92JSL<btb6m8T5)r"$#giro~>endstream
+endobj
+11 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1695
+>>
+stream
+GauI7?#SFf'Sc)J/'^R`OY/W%!?6&L.&kk\X4URW<-g:O".<a`j3EUIZG1k7fPZpc[j9L-W)<^#cT10VpO'p^(]SdBs%*E6'uS"u#G)Ir%_SC^K6RTaq!@=7j*JVY*J!0n]l)KAT7aoiqk3XqU3o)=LVf_qMSef;RH&R$cjR\[!]M+k_""JGlE>tK^O./ClgK<k'41'"07_FBd%@YuS^;[=G]^sqCKJBE[0"W-o_Z=q4W>L4*^^8WcChQs32bmYi\(kXZ]@=.L%]:\(u_-Fa;MS,JVu,kX5ffogN>i0Y]XdGFA#G9lWJ#"A6L5_U4Y?\e!KQNI.\Q@e!-fl[LGil1a>$I'M/_l\d`@>GfSas4%Pc7j?6LuMj/6o?aLu?Jf=>A0h_qIhf>`!7YT78&(*L,(LROK)kAp8't`2Nle-R"ceqO?n>Jl+bfG@893>-2FKqLrN:TKU8hlmQ"5P.YWnC^//hr!@G>o^.6tSGl`#eD:(.upU&4-*-YQTG;Rc5,E3TKZbS/)dlW590!#p6&`pnna8D5mV&ISfUOgd5OJ@$e*dI/lVpc)@o,M?o&Hb;a-D&'n(Z&cV_af0BZfZhbnaYD&j8.k,\(Ys_1.%"1F$LuD=g.T6dq)]'F1V@'1%Q$-rM($!$d`(5S;.R_-ip-r)e)M10.$2MAN\u2bYR^QX3YS9[2QW(\`e,cgYb\]Vdg-A:&m8ajb^;/$tZg1,bXj:=1nD`.,ca/Wn@:3TbTAN!WqHcD)OJ+P,,c+,jZ5h`<.(s734Z[?0%8M(ZQ)OtGmi43D\$Y[f7SK"MD2?X6qWs\0>VfeqT__*gQ/@*;$)WB]2gb0LqSVa#R+.uO?kVRcgsI$0N<#[sbF!!2%BM?QToOA'3O-mmWM;D%*G7-H:WB1ceGtdo!G[2@;FB$r?u&rF*_]h1=pin8Yi0W>"Ml"u$oX;KjtF0"IQqKiALH\8eb.h:(i(a=Rc2&$e8dK1fk"-[Sd/C1Y:r3"rpq(]f%c*%(o-!rK//FLWrJDeK2##*Ue9T8fP*n2/(h5odE361l/qml&&3<D*gN]/`-Gp>9K5b*@L;!I&UPiQ[M`o/-']i3YQrLB&6):iNe6aq2G2Su)?=b??*$Ol)XO>TZQP":3JWS1L+oLIYT:'H$WEfVQZh/RO[>iY/?F4*AdlRh]4m6poB<\dH@u5soWP.ZaSPZpDcc%f<6ef?9a?;L>u,=;Ja9k'<q4U-Lp[ql-2b'?cc8psaXN<7Q7S--p.u_[.jUsA5>;sAA0"$c_Ku%@1n$$5UD]"kX4_SWMX_]<DWY#ap#i*H[b#G*cZphHr\(E78#@!Sd1g/M71["L\]nES8.ZBhZNN4Q4lmT2_rfENZTLaBA)t!c&O"]q:Qm2uc:@C-hY=8N#B\lu%tD;YbAUbuJ)s^5gM11J6p9A\<8Sl**8PQ`Yo$N3#cfqRP;:l+/iA=fL:`J:c8F]@WRYgl=A0MQi+!:FfC+4/C;;-5gIB&,Ra>l/D9)VW>CJm\(W/Xu*E*hM2s85TH7'YrCK&IdauPbf*/b=]>s2!=XPd2VX7Ufq#qdGJ[n"6Qf"mD#[N$$=o/"ZdHUUcR@UFOqs2NI.m?*s83q=SOm`>\!g/Kj:bP#/D^mB";0#\_EZ7L,/;VgT-+?5(uf)]iP_,i)Z0MMFY3<m6XX*)PnE4O"`nfHCO#q=-[^G\D<qZi'AkRd~>endstream
+endobj
+xref
+0 12
+0000000000 65535 f 
+0000000073 00000 n 
+0000000124 00000 n 
+0000000231 00000 n 
+0000000343 00000 n 
+0000000458 00000 n 
+0000000652 00000 n 
+0000000846 00000 n 
+0000000914 00000 n 
+0000001197 00000 n 
+0000001262 00000 n 
+0000004129 00000 n 
+trailer
+<<
+/ID 
+[<b2e0030e1c1eef69f6e13006ee64f005><b2e0030e1c1eef69f6e13006ee64f005>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 8 0 R
+/Root 7 0 R
+/Size 12
+>>
+startxref
+5916
+%%EOF

--- a/docs/resumes/Founder Focus.pdf
+++ b/docs/resumes/Founder Focus.pdf
@@ -1,0 +1,99 @@
+%PDF-1.4
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/Contents 10 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/Contents 11 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/PageMode /UseNone /Pages 9 0 R /Type /Catalog
+>>
+endobj
+8 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20251101203119+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20251101203119+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+9 0 obj
+<<
+/Count 2 /Kids [ 5 0 R 6 0 R ] /Type /Pages
+>>
+endobj
+10 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2716
+>>
+stream
+GauHM?$"c3&UjDWfS:a4HRmM'LIa/Kku;in>;o=E/*V5S;tg;:+UTq10H_f7rUntM+j*Pr-F_N=16HF2iW<c=SimIl0Z&=BGteWro*(Xi\_qe<=FhDN!A&-HEcL[G`#6+*31>@Rnm+KNn`M1iU+tlu7%00lpn9,05]^'+I,_YR'F#./DE*M#!B=E_0me9.HfbFhaPQqIL2cNhJe5edejEm+a;Y@=3:UP?j4!P]`:H]*>cZU2*uA,=dQR(hZujVFr,h6%c%5JV,nF1aoI!agK#Q'CT3o>>(rgF.B2A2k0g4,/e'mOFY"Mhsi:sZ@(E@fCNVCWF)4Y$47]'G.)-gG'ip1I'262GTi/[&*i]Hn+(VuAu$_FHY*R&b?IesA:Fea64]?[["JVdi&(7^4Gp0n.aDLqd*(seVWd'sWKD-B)Tc(%A8dS)!^9%3hnVJtun&[5&\?L@f7QtS/869am<81.9RR?2(J;g2#a6RM)@ZSZTiGF%MeWE#fu;;fI?]"<`o(0*(_PcRj0HT14[[*c(\\uslgUns[sNt?WkIR&khB)?K07/Qr[B)fTu^I9*-NQ<PS\>B_e-;R:ZfgEI(Wl`ggY^-aPVKbI*joPSDaOuG,N@>OH<flkeQ^(\8]M!"-Z[/Hi;)rSc4,/[V4$H)T2S=Y-]AZBGWlA%<6Lq.nLK,O^n"F8L/oXp5RF77#L4>$_DW_*m==J!N&,Brd&qSY#[1pLq"1(tOZNaL(oWZn@<V$o,;lddjiq/p.NoLpP+!]-uF<SI1::*AOp=sZ[%I3qq)DPMe8.=M07EL]2r[P3rNrSEOU5oCDF=Tlo4_E-aOlKS!MV>0#<8sD6a0^rWAWu;iIMQcB$RNm63WuK!=A]fESs&f#0e9@5@!DirSRBU%E/$Gr#t\5DBr&mO-5)UH9/fPqQu]ti_<cK*BjGKH_"BDC/Eb`aH$\;PVdn8?abQl\_>`ZuLGeua<;k4&P%p(oiHg+5ld3Q6S)>OZ=#L?/Nq:@.)O[W/AI0F0!_]^`U,*r!pHP*8S[r`J_fUgOOB;R`^f"l]9FI.-!GHEDK(ZigW45L%,YX(DGX%S*cD,BdNHGMecBtP$&eG&mL.A+>r9I^Vo>UCCl/E?4Gb`Xk(rDaBJ,Yq!X(kTMNniD]%m6TC_gf0sYi[K2YiCk!C"We=ofu2>a%X`:>W*ReWh5ma[^9O1C1A7cdW94K2&&bkMmgTuZ9t<fr>oQcXX#)<au'qtQPo)dT[e*[fL*/7(PNa2^*V+[df/$p!]7m1e!-TffS6C"Y]NOTcs`E%K_gbRqN26)(Sj2"]L,6ejVR8K<0k3\4n+%>'Z%+&bM/GdfQsW#Xl%uF]e^_QpaK_EB&lL#fWquo"R]%QGO>oIn_(+7995#FmFk&c:<^.PZYaXAGo/ZVUGU*(0;q*lN^dh(lO_"K@?![8VU')fYj,qDgRAT'=BB'3nu@I2Q]hf!>BCSr1osN,MPo;ZD3A(=7(quaZl^;RIt+Pffh_oeAok=i$"9'AC7=]K=5*f()%_<I2Bg0u<K!cHm[")8_7W4L!jiFJS<olfq8g#6Vd1N7d?4+5g@[jU'85mt2X:T'31fEh=GJ$^h^qA)V(n3MeR7-,cj4$7f*8Y2Na+-aS.ib>gUhX[ah"P(9+Y&OX3$P7'@^1&BPjiN[FHe1T8ME<Y.iN7r)R4?^A=Q_qHoKV01,75D9DpV-.X:g=%KX,YKlCH3_`W""Q%57X-119+&"!:QrK6uZ7hpg+4'N4=9jsZnkp$X;<N%T+Kr7I/Q1s&);LjmrSAsY!3&p\%%[lCpHMLq=)1[Mo]+3LLOWW4?a+>>=QaIS"%,uhg&;m-\.SYd3)bW&D`]#Kj^(h(dMnqNhTj\/O^K&gBC9?2(ETbIfiSLH:l/4Q2-_V*`dj^Oq,=00(_Cbn,,$EQ&R)F!I>Q>I:2oZ3@8Mf)6cC"rn]o8SmeU0_P8Yb`+l0*0.;5UBn966\Gl&'_guBOt*:0K^>#r&0)a]T:s"Mt/-12S=3+NBN\266VFL>;Y<'<G0BIL%*RM@.>r="1l7EZ,2;kr_;2.<AD2)FX(e#X$\WG9.HlCfts0`T"/Y/VsW8(f!!TX^TV+%UBid"%l31*-Urkfj9+n(>0`7(HsQCZP1AB;5.ad<!"=$#S<%XW."'F=6%pG\CT8I[P#eb;nt'-p\2]O\%B*7#XX]EdLEF>I/#_5LOI_Jl$2l:b/Vp*:6`tVn0Xf@3m0>^0"TI%g5AIparRL?L_I'.Y1V7k:ZBE*A<fm)fVA+]Ij&/$^Fjj5<%Ef!66`WML7BEPQLb0`JUaNFlidNf%+$W1X$"CnJ82_p66j0c`,C`c@dXW<(reR/@X7dhmT3L@`_P0K.%IpZ<L;nV.M\]<dV>26IlFRa*,6uXrb=[[=>j,)&qnWSp'#/OhdAAD9ER\p>TN]o?3%-r/7VfF!NNe;^7D>Tj-M5bVI(_3a6FH'mF+U',j0o!Shs4d@S`pU9RToSp]]\dIeh>BWX@BEEFt"+7-a71%kP2Yld`ngT'DGRs/8#(MZh?Sh<^V`u5.0j562?s0ZD+^Dcr>h=U[FqgdKBh0p@uJF8AOjD;5%GtO(H31^kb,2#O]nEkuKR#qLl+qb0^nB$nY^U``-B&js?^rSSKJ/<B\T!p)3><6ZFNS;^V=-q7Zf*:m7bUm9Kd*Lp1b/mtn&6fhg7:4e?F+R([`Fp"a!H.>0&kcfM)Yt@:3;G3X>+t!~>endstream
+endobj
+11 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1539
+>>
+stream
+GauI6;,c4/&BE]('`68A5arVFEU8@fO9R&\,c%^09Bh'Q.n5:G)+fSF55hU"_f-S)f9o<eR2AVnh>Qa/?RlXlr:0&J=ob'?E-gJok<lNU05pt`AhZf:mZ/@>)i!b\*4P,(U)lK'Tc`qnAOiJ$*o`o-k_!?Kq/k\B?5*SU3*tf<K)cn+=k8$blM:+)cu$Pt%8D)L1I2;/l_-O5XZM[<B(5/Gj0u0ZJ[GR)0_5+Wd-cl$]]YAC8.%=_=*`*8#pb!do#WM6BaX7:VD,kQ'9P(mLBA>u*]DcfhR;T8G%9jjd-9)RHIfF_9A)2.4"'<RR57qp.5t(BWhed3kmg1O<B2d3D*coP_t'=UX92-5VFnfbK2P9E.9>@W+I/&m0jKSGE:La1,"RP6J6Nh_\>`$%SUZ@eMISU_*/\6AlMaL[%A=TZILdBXO^)'e"!8[po[]2d\q%%">365aL28h<KS83)i4^DP<!B@<c]14JO"UbIR;N:A*MB\dF%ukW`Id/T>cj]udo>K)NSO`Ti2s6KTRnL=+$?`e.10ogpj@s5k^39,NbQL(b*9X%-&+9L+1T;lfP*;.+"VJmWBG@=<QPpjXN4d@PS$U*c1+78C293t2^`S),G4F7\DY6d(.tRM7cmrj+?@c$>rnFkk8-/5SK64B6W%Slm=E]>X99;+Q](9hBq@(aR<,HED!r8Rn\W$aAh<>b3R\ns5f!V]KmZ9'RITXpkS!n'QcU6%U(W^R].&$CK2HAWm=E\e[M@5pL.I42ii4E:!@`P^OrKR.fk/,N[rQ1E*X+F%ESC74K!X;(fH9h]dG,D"X'2F+\&XB&<hN9WG?RHM#>.R'C(J0DG@CdbXsbf1F()?&2F4Sk@O"k[f7H5[cuHD2hN,/"YX2R9S)0\%j:V(q`hP8rLCubZ4=3(`7WD%@R#$\/`fsK.R`Z!T3"*s@&55_aG(Sqi#6WA@g4uCs(TS,tQGSB/Y`G3]RfC1)id4N*A#9[lE0RF9[RPHn"l$nQe3.YW`?h;30jGZ&3ZcQ+GDa@hZ_IK,D+E0tVnR#f[Fbs(4&*?7_:$f"g-^1hj(37B,K-j^5)J0eWB_qZMaO@VOOOI3A%IIDWs%,s<`e1VnapQNR_`[JS5%&!"TO(mp&'3CqRKO>K4/^IE36*&J6OMSeb5e-dDL%G:?D<\MZaWs$tiB\16u\q=4j_EMO,W`*$_@=(=BGmr0YFEF?W;DnA0>)YL%t6!C#D7(%,LJa.rEZi<fg>L<BsS`s_4t_7'1Y6/[QSj'+YSk![jZ@jS+dS`UQ'3fi(Oi\=^Fc171ME].)PVMe+B(4blMrL^"m\YOFW,^a$b'l,pTlp#FhT^4,%@k,HPX+I0,-bH)G%lR=pVY3o>&oWNK&A0kqQ`h@;W,gD:VL;fVF08stQQb:%mGR<Z2-t@lf('X6/i,r#PXX09;j*q^Hh/f"[+Y"5L;C\1mafm:(tQ`GHPJbte'btXY`Q9B4\Bjp9=tSj'qM.)^d/0S9CWG.erR#Si-4ZGT&S[rb7$o1#FsHnUo][X))'t4+3!tM7f~>endstream
+endobj
+xref
+0 12
+0000000000 65535 f 
+0000000073 00000 n 
+0000000124 00000 n 
+0000000231 00000 n 
+0000000343 00000 n 
+0000000458 00000 n 
+0000000652 00000 n 
+0000000846 00000 n 
+0000000914 00000 n 
+0000001197 00000 n 
+0000001262 00000 n 
+0000004070 00000 n 
+trailer
+<<
+/ID 
+[<77413804cc854507394f1e1850045cbd><77413804cc854507394f1e1850045cbd>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 8 0 R
+/Root 7 0 R
+/Size 12
+>>
+startxref
+5701
+%%EOF

--- a/docs/resumes/README.md
+++ b/docs/resumes/README.md
@@ -1,0 +1,23 @@
+# Executive Resume Arsenal
+
+This directory contains five tailored executive resumes exported as PDFs for distinct FinTech, RegTech, and AI leadership tracks. Each variant shares a consistent design language (dark-mode, ATS-safe typography) and includes activation placeholders for patent filings, funding confirmations, CFP timing, and proof microsite links.
+
+| File | Primary Target Roles | Narrative Angle | Signature Line |
+| --- | --- | --- | --- |
+| `Executive Resume (Head of AI Focus).pdf` | VP/Head of AI Architecture, Chief Architect, SVP Engineering (AI-first FinTech) | Tech singularity fused with compliance automation; leads with the Prism Console agentic OS saving $4M annually and 99.9% audit fidelity. | “Proved that a single architect can outpace a 20-person team.” |
+| `Executive Resume (CTO FinTech Focus).pdf` | CTO, VP Engineering (FinTech/RegTech scale-ups) | Capital-Efficient Engineering (CEE) framework detailing Rust/GCP reliability, <$1K cloud spend, and zero-drift operations. | “Pioneering CEE by replacing traditional DevOps teams with proprietary AI agentic systems.” |
+| `Executive Resume (Head of Product RegTech Focus).pdf` | Head of Product, CPO (RegTech & AI SaaS) | Compliance-by-design product leadership turning Prism into a PLG GTM engine with 97% operator satisfaction. | “Solved the critical industry problem of compliance friction.” |
+| `Founder Focus.pdf` | CEO, Founder-in-Residence, Operating Partner (VC-backed FinTech) | IP-first venture thesis emphasizing capital allocation, $4M savings, and defensible compliance technology. | “Transforming compliance from a cost center into a core technological advantage.” |
+| `Executive Resume (Head of AI Focus - Final Draft).pdf` | Universal hybrid for AI/Product/Venture leadership | Densest merge of architecture, product, and venture narratives—positioned as the master template for fast tailoring. | Highlights the 117-agent OS delivering CTO velocity, CPO adoption, and CEO capital efficiency. |
+
+## Activation Checklist
+
+Every PDF includes an activation sidebar so the resume can be finalized in minutes:
+
+1. **Patent Reference** — Replace `[INSERT USPTO PROVISIONAL APPLICATION NUMBER]` with the actual filing number to surface the IP moat.
+2. **Funding Exact** — Swap `[ESTIMATE $200K - $400K]` with the confirmed raise (e.g., `$275K from ex-Ripple CTO`) for instant investor credibility.
+3. **CFP Date** — Update `[PLANNING Q4 2025]` to `December 2025` (or the precise timeline) to signal execution readiness.
+4. **/proofs Microsite** — Upload redacted audit decks and demos to the shared Notion workspace, then link directly from outreach emails.
+5. **GitHub Boost** — Add the live stars badge to the Prism Console repository README to broadcast community traction.
+
+Use each PDF individually when applying to targeted roles, or send the entire set with filenames prefixed by “Tailored for [Role]” when engaging executive recruiters.


### PR DESCRIPTION
## Summary
- add five dark-mode executive resume PDFs aligned to AI, CTO, product, founder, and hybrid leadership roles
- document targets, narrative angles, and activation checklist for each resume in docs/resumes/README.md

## Testing
- not run (non-code content)

------
https://chatgpt.com/codex/tasks/task_e_69066d6434588329a05d9a2448b3123a