### PR TITLE
Clean up devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,28 +1,29 @@
 {
-  "name": "BlackRoad Dev",
+  "name": "blackroad-prism-console",
+  "workspaceFolder": "/workspace",
   "build": {
     "dockerfile": "Dockerfile"
   },
-  "name": "blackroad",
-  "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
   "features": {
-    "ghcr.io/devcontainers/features/python:1": {},
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
-    "ghcr.io/devcontainers/features/node:1": { "version": "20" },
-    "ghcr.io/devcontainers/features/python:1": { "version": "3.11" },
+    "ghcr.io/devcontainers/features/common-utils:2": {},
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "20"
+    },
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "3.11"
+    },
+    "ghcr.io/devcontainers/features/pnpm:2": {},
     "ghcr.io/devcontainers/features/postgres:1": {
       "version": "16",
       "password": "postgres",
       "db": "appdb",
       "user": "appuser"
     },
-    "ghcr.io/devcontainers/features/redis:1": { "version": "7" },
-    "ghcr.io/devcontainers/features/common-utils:2": {},
-    "ghcr.io/devcontainers/features/pnpm:2": {}
-    "ghcr.io/devcontainers/features/python:1": {
-      "version": "3.11"
+    "ghcr.io/devcontainers/features/redis:1": {
+      "version": "7"
     },
     "ghcr.io/devcontainers/features/aws-cli:1": {},
     "ghcr.io/devcontainers/features/terraform:1": {
@@ -31,24 +32,49 @@
     "ghcr.io/devcontainers/features/aws-ssm-session-manager:1": {},
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },
-  "postCreateCommand": "bash .devcontainer/post-create.sh",
-  "forwardPorts": [3000, 8000, 4000],
+  "remoteUser": "vscode",
+  "updateRemoteUserUID": true,
+  "remoteEnv": {
+    "DATABASE_URL": "postgresql://appuser:postgres@localhost:5432/appdb",
+    "REDIS_URL": "redis://localhost:6379"
+  },
+  "forwardPorts": [3000, 4000, 5173, 5432, 6379, 8000],
   "portsAttributes": {
     "3000": {
       "label": "Website",
       "onAutoForward": "notify"
     },
-    "8000": {
-      "label": "LLM API",
-      "onAutoForward": "silent"
-    },
     "4000": {
       "label": "Backend API",
       "onAutoForward": "silent"
+    },
+    "8000": {
+      "label": "LLM API",
+      "onAutoForward": "silent"
     }
   },
+  "mounts": [
+    "source=${localWorkspaceFolder}/.cache,target=/workspaces/.cache,type=bind"
+  ],
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+  "updateContentCommand": "echo '✅ Dev container ready'",
   "customizations": {
     "vscode": {
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "files.eol": "\\n",
+        "python.analysis.typeCheckingMode": "basic",
+        "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "python.formatting.provider": "black",
+        "python.linting.enabled": true,
+        "python.linting.pylintEnabled": false,
+        "terraform.codelens.enabled": true,
+        "[python]": {
+          "editor.defaultFormatter": "ms-python.python"
+        }
+      },
       "extensions": [
         "ms-azuretools.vscode-docker",
         "esbenp.prettier-vscode",
@@ -56,71 +82,13 @@
         "ms-python.python",
         "ms-python.vscode-pylance",
         "ms-vscode.vscode-typescript-next",
-        "github.vscode-pull-request-github"
-      ],
-      "settings": {
-        "terminal.integrated.defaultProfile.linux": "bash",
-        "editor.formatOnSave": true,
-        "python.analysis.typeCheckingMode": "basic"
-      }
-    }
-  },
-  "remoteEnv": {
-    "DATABASE_URL": "postgresql://appuser:postgres@localhost:5432/appdb",
-    "REDIS_URL": "redis://localhost:6379"
-  },
-  "postCreateCommand": "python -m pip install -U pip && (pip install -r requirements.txt || true) && npm i -g pnpm && (pnpm i --frozen-lockfile || npm ci || true)",
-  "updateContentCommand": "echo '✅ Dev container ready'",
-  "forwardPorts": [3000, 4000, 5173, 8000, 5432, 6379],
-  "remoteUser": "vscode",
-  "updateRemoteUserUID": true,
-  "mounts": [
-    "source=${localWorkspaceFolder}/.cache,target=/workspaces/.cache,type=bind"
-  ]
-  "postCreateCommand": "bash scripts/bootstrap.sh || true",
-  "customizations": {
-    "vscode": {
-      "settings": { "editor.formatOnSave": true, "files.eol": "\\n" },
-        "terraform.codelens.enabled": true,
-        "editor.formatOnSave": true,
-        "python.defaultInterpreterPath": "/usr/local/bin/python",
-        "python.linting.enabled": true,
-        "python.linting.pylintEnabled": false,
-        "python.formatting.provider": "black",
-        "editor.defaultFormatter": "esbenp.prettier-vscode",
-        "[python]": {
-          "editor.defaultFormatter": "ms-python.python"
-        }
-  "name": "blackroad-prism-console",
-  "build": {
-    "dockerfile": "../Dockerfile",
-    "context": ".."
-  },
-  "workspaceFolder": "/workspace",
-  "features": {
-    "ghcr.io/devcontainers/features/git:1": {}
-  },
-  "customizations": {
-    "vscode": {
-      "settings": {
-        "terminal.integrated.defaultProfile.linux": "bash"
-      },
-      "extensions": [
-        "ms-python.python",
-        "ms-python.vscode-pylance",
-        "esbenp.prettier-vscode",
-        "dbaeumer.vscode-eslint",
-        "ms-playwright.playwright"
-        "ms-python.python",
-        "ms-python.vscode-pylance",
+        "github.vscode-pull-request-github",
+        "ms-playwright.playwright",
         "GitHub.copilot",
         "GitHub.copilot-chat",
         "eamodio.gitlens",
         "ms-vscode.makefile-tools"
-        "dbaeumer.vscode-eslint"
       ]
     }
-  },
-  "forwardPorts": [3000],
-  "postCreateCommand": "pip install -U pip pytest jsonschema && (npm ci || true)"
+  }
 }


### PR DESCRIPTION
## Summary
- deduplicate the devcontainer configuration so each section is defined once
- consolidate the feature list, port forwarding, and VS Code customizations into a single coherent setup
- keep the post-create bootstrap script as the container initialization command

## Testing
- jq . .devcontainer/devcontainer.json

------
https://chatgpt.com/codex/tasks/task_e_690a40b26c988329b12fa508600eca31