### PR TITLE
Automate PR autopilot comment handling

### DIFF
--- a/.github/workflows/agent-pr.yml
+++ b/.github/workflows/agent-pr.yml
@@ -1,25 +1,40 @@
 name: Agent PR Autopilot
+
 on:
   issue_comment:
     types: [created]
   workflow_dispatch:
     inputs:
-      pr: { description: 'PR number', required: false }
+      pr:
+        description: 'PR number'
+        required: false
+
 jobs:
   autopilot:
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'issue_comment' &&
-       contains(github.event.comment.body, '@codex fix comments'))
+    if: >-
+      github.event_name == 'workflow_dispatch' || (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        github.event.comment.user.login != 'blackboxprogramming' &&
+        github.event.comment.user.login != 'github-actions[bot]'
+      )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with: { fetch-depth: 0 }
+        with:
+          fetch-depth: 0
+
       - uses: actions/setup-node@v4
-        with: { node-version: '20' }
-      - run: npm ci --prefix apps/api
+        with:
+          node-version: '20'
+
       - name: Run PR autopilot
-        run: node scripts/agents/pr_autopilot.ts "${{ github.event.issue.number || inputs.pr || '' }}"
-        run: npx tsx scripts/agents/pr_autopilot.ts "${{ github.event.issue.number || inputs.pr || '' }}"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_PAT != '' && secrets.GITHUB_PAT || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_PAT != '' && secrets.GITHUB_PAT || secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number || inputs.pr || '' }}
+          COMMENT_BODY: ${{ github.event.comment.body || '' }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login || '' }}
+          AUTOPILOT_USER: blackboxprogramming
+          GITHUB_ACTOR: ${{ github.actor }}
+        run: npx tsx scripts/agents/pr_autopilot.ts

--- a/scripts/agents/pr_autopilot.ts
+++ b/scripts/agents/pr_autopilot.ts
@@ -1,24 +1,79 @@
 import { execSync } from 'node:child_process';
 
-const pr = process.argv[2] || '';
-try{
-  const head = pr ? execSync(`gh pr view ${pr} --json headRefName -q .headRefName`, { encoding:'utf-8' }).trim() : '';
-  const ref = head || execSync(`git branch --show-current`, { encoding:'utf-8' }).trim();
-  execSync(`git fetch origin ${ref}`, { stdio:'inherit' });
-  execSync(`git checkout ${ref}`, { stdio:'inherit' });
+const autopilotUser = (process.env.AUTOPILOT_USER || 'blackboxprogramming').trim();
+const prNumber = (process.env.PR_NUMBER || '').trim();
+const commentAuthor = (process.env.COMMENT_AUTHOR || '').trim();
+const actor = (process.env.GITHUB_ACTOR || '').trim();
 
-  // Autofix pass
-  try { execSync(`npx prettier -w .`, { stdio:'inherit' }); } catch {}
-  try { execSync(`npx eslint . --fix`, { stdio:'inherit' }); } catch {}
-
-  execSync(`git add -A && git commit -m "bot: autofix suggestions" || echo "no changes"`, { stdio:'inherit' });
-  execSync(`git push origin ${ref}`, { stdio:'inherit' });
-
-  // Optionally label automerge (best-effort)
-  if (pr) execSync(`gh pr edit ${pr} --add-label automerge`, { stdio:'inherit' });
-
-  console.log('PR autopilot complete');
-} catch (e:any) {
-  console.log('autopilot failed:', e?.message||e);
+if (!prNumber) {
+  console.log('No pull request number supplied; skipping autopilot.');
   process.exit(0);
 }
+
+const triggeredByComment = commentAuthor.length > 0;
+if (triggeredByComment) {
+  if (commentAuthor === autopilotUser || commentAuthor === 'github-actions[bot]') {
+    console.log(
+      `Ignoring comment from automation user (${commentAuthor}); avoiding feedback loop.`,
+    );
+    process.exit(0);
+  }
+
+  console.log(
+    `Autopilot triggered by comment from ${commentAuthor} on PR #${prNumber}.`,
+  );
+} else if (actor) {
+  console.log(`Autopilot manually dispatched by ${actor} for PR #${prNumber}.`);
+} else {
+  console.log(`Autopilot triggered for PR #${prNumber}.`);
+}
+
+const autopilotMessage = [
+  '@codex @copilot @blackboxprogramming @dependabot @asana @linear',
+  'review and test the feature branch, set up CI and preview deploy,',
+  'run security and dependency scans, and apply comment fixes',
+  '',
+  '@codex fix comments              # auto-fixes code review comments',
+  '@codex apply .github/prompts/codex-fix-comments.md',
+  '@codex patch                     # applies code diffs',
+  '@codex run tests                 # triggers test suite',
+  '@codex ship when green           # queues auto-merge',
+  '',
+  'And if it receives more comments it does this again and again and again until the open pull requests turns to merged period',
+  '',
+  'No more user in working copy',
+  '',
+  '@codex @copilot @blackboxprogramming @dependabot @asana @linear',
+  'review and test the feature branch, set up CI and preview deploy,',
+  'run security and dependency scans, and apply comment fixes',
+  '',
+  '@codex fix comments              # auto-fixes code review comments',
+  '@codex apply .github/prompts/codex-fix-comments.md',
+  '@codex patch                     # applies code diffs',
+  '@codex run tests                 # triggers test suite',
+  '@codex ship when green           # queues auto-merge',
+].join('\n');
+
+const runGh = (command: string, allowFailure = false) => {
+  try {
+    execSync(command, { stdio: 'inherit' });
+    return true;
+  } catch (error) {
+    if (!allowFailure) {
+      console.error(`Command failed: ${command}`);
+      console.error(error instanceof Error ? error.message : error);
+      process.exit(1);
+    }
+
+    console.warn(`Command failed (continuing): ${command}`);
+    console.warn(error instanceof Error ? error.message : error);
+    return false;
+  }
+};
+
+runGh(`gh pr comment ${prNumber} --body ${JSON.stringify(autopilotMessage)}`);
+
+// Best-effort: ensure automerge label is present so merge queues once checks pass.
+runGh(`gh pr edit ${prNumber} --add-label automerge`, true);
+
+console.log('Autopilot sequence dispatched successfully.');


### PR DESCRIPTION
## Summary
- update the Agent PR Autopilot workflow to trigger on any non-bot PR comment and forward context to the script
- extend the autopilot script to post the codex automation bundle and avoid feedback loops while keeping automerge queued

## Testing
- not run (depends on GitHub CLI interaction with live pull requests)


------
https://chatgpt.com/codex/tasks/task_e_690a41bf0ef08329a49854dcdacbc16d