### PR TITLE
feat: auto-run ci tasks from codex comments

### DIFF
--- a/agents/pr_autopilot.py
+++ b/agents/pr_autopilot.py
@@ -1,23 +1,31 @@
-"""Automates pull request management tasks for BlackRoad repositories."""
-"""Automated pull request manager for BlackRoad repositories."""
+"""Tools for automating pull request workflows."""
 
 from __future__ import annotations
 
 import logging
 import os
 import subprocess
+import sys
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional, Sequence
+from typing import Callable, Iterable, Optional, Sequence
 
 import requests
+
+Command = Sequence[str] | str
 
 
 @dataclass
 class AutomatedPullRequestManager:
-    """Monitor Git events and orchestrate draft pull requests."""
-    """Monitor git events and orchestrate draft pull requests."""
+    """Automate common PR maintenance and collaboration tasks.
+
+    The manager is intentionally lightweight – it shells out to Git and other
+    command-line tools so it can run inside the existing automations without
+    requiring additional services.  The public helpers are structured so that
+    higher level orchestrators (GitHub webhooks, chat-ops bots, etc.) can call
+    into them directly during tests without touching the network.
+    """
 
     repo: str
     branch_prefix: str = "codex/"
@@ -25,38 +33,41 @@ class AutomatedPullRequestManager:
     codex_trigger: str = "@codex"
     log_file: str = "pr_autopilot.log"
     token: Optional[str] = None
-    auto_fix_commands: tuple[Sequence[str] | str, ...] = (("bash", "fix-everything.sh"),)
+    auto_fix_commands: tuple[Command, ...] = (("bash", "fix-everything.sh"),)
     max_fix_iterations: int = 3
+    _logger: logging.Logger = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
         if self.token is None:
             self.token = os.getenv("GITHUB_TOKEN")
-        logging.basicConfig(filename=self.log_file, level=logging.INFO)
+        self._logger = logging.getLogger(self.__class__.__name__)
+        if not logging.getLogger().handlers:
+            logging.basicConfig(filename=self.log_file, level=logging.INFO)
 
+    # ------------------------------------------------------------------
+    # Git helpers
+    # ------------------------------------------------------------------
     def monitor_repo(self) -> bool:
-        """Return ``True`` when the working tree has uncommitted changes."""
+        """Return ``True`` if the current working tree has uncommitted changes."""
+
         return self._has_uncommitted_changes(Path.cwd())
 
     def prepare_draft_pr(self, base_branch: str = "main") -> Optional[dict]:
-        """Create a draft pull request from the latest commit.
+        """Create a draft pull request for the current HEAD.
 
-        Returns the pull request payload when successful, otherwise ``None``.
+        The method checks that the working tree is clean, creates a timestamped
+        branch, pushes it, and finally opens a draft pull request targeting the
+        provided ``base_branch``.  A short diff excerpt is attached so reviewers
+        can quickly gauge the change.
         """
 
         repo_root = Path.cwd()
-
         if self._has_uncommitted_changes(repo_root):
             self.log(
                 "Working tree has uncommitted changes; commit or stash them before "
                 "preparing a draft PR."
             )
             return None
-        """Check whether the repository has uncommitted changes."""
-
-        return self._has_uncommitted_changes(Path.cwd())
-
-    def prepare_draft_pr(self) -> None:
-        """Create a draft pull request from the latest commit."""
 
         commit_msg = subprocess.run(
             ["git", "log", "-1", "--pretty=%s"],
@@ -65,13 +76,10 @@ class AutomatedPullRequestManager:
             check=False,
             cwd=repo_root,
         ).stdout.strip()
-
         if not commit_msg:
-            self.log("Unable to determine latest commit message; aborting draft PR creation.")
-            return None
+            commit_msg = "Automated draft"
 
         branch_name = f"{self.branch_prefix}{int(time.time())}"
-
         try:
             subprocess.run(["git", "checkout", "-b", branch_name], cwd=repo_root, check=True)
             subprocess.run(
@@ -87,13 +95,6 @@ class AutomatedPullRequestManager:
             text=True,
             check=False,
             cwd=repo_root,
-        subprocess.run(["git", "checkout", "-b", branch_name], check=False)
-        subprocess.run(["git", "push", "-u", "origin", branch_name], check=False)
-        diff = subprocess.run(
-            ["git", "diff", "origin/main..."],
-            capture_output=True,
-            text=True,
-            check=False,
         ).stdout
         body = f"### Diff Summary\n```\n{diff[:1000]}\n```\n"
 
@@ -108,41 +109,169 @@ class AutomatedPullRequestManager:
         logging.info("Opened draft PR #%s", pr["number"])
         return pr
 
-    def _create_pr(self, title: str, head: str, base: str, body: str) -> dict:
-        """Create a pull request via the GitHub API and return its response."""
+    # ------------------------------------------------------------------
+    # Comment orchestration
+    # ------------------------------------------------------------------
+    def process_comment(
+        self,
+        comment: str,
+        *,
+        pr_number: Optional[int] = None,
+        branch_name: Optional[str] = None,
+    ) -> None:
+        """Execute the tasks requested in ``comment``.
 
-        url = f"https://api.github.com/repos/{self.repo}/pulls"
-        headers = {"Accept": "application/vnd.github+json"}
-        if self.token:
-            headers["Authorization"] = f"token {self.token}"
-        payload = {
-            "title": title,
-            "head": head,
-            "base": base,
-            "body": body,
-            "draft": True,
+        The method supports natural language requests ("run security scans") and
+        explicit directives (``@codex run tests``).  Each action is executed at
+        most once per invocation even if it is requested multiple times in the
+        same comment.
+        """
+
+        commands = self._extract_commands(comment)
+        actions_run: set[str] = set()
+
+        def run_once(key: str, func: Callable[[], None]) -> None:
+            if key in actions_run:
+                return
+            try:
+                func()
+            except Exception as exc:  # pragma: no cover - defensive logging
+                self.log(f"Action {key!r} failed: {exc}")
+            else:
+                actions_run.add(key)
+
+        def apply_comment_fixes_once() -> None:
+            run_once(
+                "apply_comment_fixes",
+                lambda: self.apply_comment_fixes(pr_number=pr_number, branch_name=branch_name),
+            )
+
+        # Natural-language hints that should trigger tasks even before parsing
+        lowered = comment.lower()
+        if "review and test" in lowered or "run tests" in lowered:
+            run_once("run_tests", self.run_tests)
+        if "set up ci" in lowered or "preview deploy" in lowered:
+            run_once("setup_ci", self.setup_ci_and_preview_deploy)
+        if "security" in lowered or "dependency" in lowered:
+            run_once("security_scans", self.run_security_and_dependency_scans)
+        if "apply comment fixes" in lowered:
+            apply_comment_fixes_once()
+
+        for command in commands:
+            if "review" in command and "test" in command:
+                run_once("run_tests", self.run_tests)
+            if command.startswith("run tests"):
+                run_once("run_tests", self.run_tests)
+            if "set up ci" in command or "preview" in command:
+                run_once("setup_ci", self.setup_ci_and_preview_deploy)
+            if "security" in command or "dependency" in command:
+                run_once("security_scans", self.run_security_and_dependency_scans)
+            if command.startswith("fix comments"):
+                apply_comment_fixes_once()
+            if command.startswith("apply "):
+                path = command[6:].strip()
+                if path == ".github/prompts/codex-fix-comments.md":
+                    apply_comment_fixes_once()
+                else:
+                    self.log(f"Unhandled apply directive for {path!r}")
+            if command.startswith("patch"):
+                self.log("Patch directive received but no patch context provided; skipping.")
+            if command.startswith("ship when green"):
+                if pr_number is not None:
+                    run_once("auto_merge", lambda: self.enable_auto_merge(pr_number))
+                else:
+                    self.log("Ship when green requested but PR number missing; skipping auto-merge.")
+
+    def _extract_commands(self, comment: str) -> list[str]:
+        """Return normalized commands embedded in ``comment``."""
+
+        commands: list[str] = []
+        for line in comment.splitlines():
+            stripped = line.strip()
+            if not stripped or "@codex" not in stripped.lower():
+                continue
+            tokens = stripped.split()
+            while tokens and tokens[0].startswith("@"):
+                tokens.pop(0)
+            if not tokens:
+                continue
+            command = " ".join(tokens)
+            command = command.split("#", 1)[0].strip().lower()
+            if command:
+                commands.append(command)
+        return commands
+
+    # ------------------------------------------------------------------
+    # High-level actions
+    # ------------------------------------------------------------------
+    def run_tests(self) -> None:
+        """Run the fast local test suites if available."""
+
+        repo_root = Path(__file__).resolve().parents[1]
+        commands: list[Command] = []
+        if (repo_root / "pytest.ini").exists() or (repo_root / "tests").exists():
+            commands.append([sys.executable, "-m", "pytest", "-q"])
+        package_json = repo_root / "package.json"
+        node_modules = repo_root / "node_modules"
+        if package_json.exists() and node_modules.exists():
+            commands.append(["npm", "test", "--", "--watch=false"])
+        if not commands:
+            self.log("No local test suites detected; skipping run.")
+            return
+        self._run_commands(commands, repo_root, "tests")
+
+    def setup_ci_and_preview_deploy(self) -> None:
+        """Ensure CI and preview workflows exist, creating stubs if necessary."""
+
+        repo_root = Path(__file__).resolve().parents[1]
+        workflows = {
+            repo_root / ".github/workflows/ci.yml": self._ci_stub_content(),
+            repo_root / ".github/workflows/preview.yml": self._preview_stub_content(),
         }
-        response = requests.post(url, json=payload, headers=headers, timeout=10)
-        response.raise_for_status()
-        return response.json()
+        created: list[Path] = []
+        for path, template in workflows.items():
+            if path.exists():
+                continue
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(template, encoding="utf-8")
+            created.append(path)
+        if created:
+            names = ", ".join(str(p.relative_to(repo_root)) for p in created)
+            self.log(f"Created placeholder workflows: {names}")
+        else:
+            self.log("CI and preview workflows already present; nothing to do.")
 
-    def _assign_reviewer(self, pr_number: int) -> None:
-        """Request a review from the default reviewer."""
+    def run_security_and_dependency_scans(self) -> None:
+        """Execute lightweight dependency checks available locally."""
 
-        url = f"https://api.github.com/repos/{self.repo}/pulls/{pr_number}/requested_reviewers"
-        headers = {"Accept": "application/vnd.github+json"}
-        if self.token:
-            headers["Authorization"] = f"token {self.token}"
-        payload = {"reviewers": [self.default_reviewer]}
-        requests.post(url, json=payload, headers=headers, timeout=10)
+        repo_root = Path(__file__).resolve().parents[1]
+        commands: list[Command] = []
+        requirements = [
+            repo_root / "requirements.txt",
+            repo_root / "requirements-dev.txt",
+            repo_root / "pyproject.toml",
+        ]
+        if any(path.exists() for path in requirements):
+            commands.append([sys.executable, "-m", "pip", "check"])
+        package_json = repo_root / "package.json"
+        package_lock = repo_root / "package-lock.json"
+        if package_json.exists() and package_lock.exists():
+            commands.append(["npm", "audit", "--omit=dev"])
+        if not commands:
+            self.log("No dependency manifests found; skipping security scans.")
+            return
+        self._run_commands(commands, repo_root, "security scans")
 
+    # ------------------------------------------------------------------
+    # Existing automation entry points
+    # ------------------------------------------------------------------
     def handle_trigger(
         self,
         phrase: str,
         pr_number: Optional[int] = None,
         branch_name: Optional[str] = None,
     ) -> None:
-        """Respond to CODEx trigger phrases and run the matching action."""
+        """Backward compatible trigger handler used by legacy scripts."""
 
         phrase_lower = phrase.lower()
 
@@ -152,6 +281,8 @@ class AutomatedPullRequestManager:
             self.log("Summarizing PR (placeholder)")
         elif "merge" in phrase_lower and pr_number is not None:
             self.enable_auto_merge(pr_number)
+        elif "ship when green" in phrase_lower and pr_number is not None:
+            self.enable_auto_merge(pr_number)
         elif "merge" in phrase_lower:
             self.log("Merge trigger received but no PR number supplied; skipping.")
 
@@ -160,7 +291,7 @@ class AutomatedPullRequestManager:
         pr_number: Optional[int] = None,
         branch_name: Optional[str] = None,
     ) -> None:
-        """Execute the CODEx comment fixer script to update code comments."""
+        """Execute the Codex fixer script to address review comments."""
 
         repo_root = Path(__file__).resolve().parents[1]
 
@@ -208,7 +339,7 @@ class AutomatedPullRequestManager:
     def log(self, message: str) -> None:
         """Write a message to the log file."""
 
-        logging.info(message)
+        self._logger.info(message)
 
     def auto_enhance_pull_request(self, pr_number: int, branch_name: str) -> None:
         """Apply configured fixers to iteratively improve an open pull request."""
@@ -244,6 +375,32 @@ class AutomatedPullRequestManager:
                 f"Auto-fix pass {iteration} applied :sparkles:",
             )
 
+    # ------------------------------------------------------------------
+    # Low-level helpers
+    # ------------------------------------------------------------------
+    def _ci_stub_content(self) -> str:
+        return (
+            "name: CI\n"
+            "on:\n  push:\n  pull_request:\n"
+            "jobs:\n  lint:\n    runs-on: ubuntu-latest\n    steps:\n"
+            "      - uses: actions/checkout@v4\n"
+            "      - name: Placeholder\n        run: echo 'CI stub'\n"
+        )
+
+    def _preview_stub_content(self) -> str:
+        return (
+            "name: Preview Deploy\n"
+            "on:\n  pull_request:\n    types: [opened, synchronize]\n"
+            "jobs:\n  preview:\n    runs-on: ubuntu-latest\n    steps:\n"
+            "      - uses: actions/checkout@v4\n"
+            "      - name: Placeholder\n        run: echo 'Preview deploy stub'\n"
+        )
+
+    def _run_commands(self, commands: Iterable[Command], repo_root: Path, label: str) -> None:
+        for command in commands:
+            self._run_auto_fix_command(command, repo_root)
+        self.log(f"Completed {label} commands")
+
     def _has_uncommitted_changes(self, cwd: Path) -> bool:
         result = subprocess.run(
             ["git", "status", "--porcelain"],
@@ -254,9 +411,7 @@ class AutomatedPullRequestManager:
         )
         return bool(result.stdout.strip())
 
-    def _run_auto_fix_command(
-        self, command: Sequence[str] | str, repo_root: Path
-    ) -> bool:
+    def _run_auto_fix_command(self, command: Command, repo_root: Path) -> bool:
         shell = isinstance(command, str)
         cmd = command if shell else list(command)
         try:
@@ -333,6 +488,34 @@ class AutomatedPullRequestManager:
             response.raise_for_status()
         except requests.RequestException as exc:
             self.log(f"Failed to post auto-fix comment to PR #{pr_number}: {exc}")
+
+    def _create_pr(self, title: str, head: str, base: str, body: str) -> dict:
+        """Create a pull request via the GitHub API and return its response."""
+
+        url = f"https://api.github.com/repos/{self.repo}/pulls"
+        headers = {"Accept": "application/vnd.github+json"}
+        if self.token:
+            headers["Authorization"] = f"token {self.token}"
+        payload = {
+            "title": title,
+            "head": head,
+            "base": base,
+            "body": body,
+            "draft": True,
+        }
+        response = requests.post(url, json=payload, headers=headers, timeout=10)
+        response.raise_for_status()
+        return response.json()
+
+    def _assign_reviewer(self, pr_number: int) -> None:
+        """Request a review from the default reviewer."""
+
+        url = f"https://api.github.com/repos/{self.repo}/pulls/{pr_number}/requested_reviewers"
+        headers = {"Accept": "application/vnd.github+json"}
+        if self.token:
+            headers["Authorization"] = f"token {self.token}"
+        payload = {"reviewers": [self.default_reviewer]}
+        requests.post(url, json=payload, headers=headers, timeout=10)
 
     def enable_auto_merge(self, pr_number: int, merge_method: str = "SQUASH") -> None:
         """Enable GitHub auto-merge for the given pull request."""

--- a/tests/test_pr_autopilot.py
+++ b/tests/test_pr_autopilot.py
@@ -1,0 +1,51 @@
+"""Unit tests for :mod:`agents.pr_autopilot`."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from agents.pr_autopilot import AutomatedPullRequestManager
+
+
+@pytest.fixture()
+def manager(monkeypatch: pytest.MonkeyPatch) -> AutomatedPullRequestManager:
+    mgr = AutomatedPullRequestManager("example/repo")
+    monkeypatch.setattr(mgr, "run_tests", MagicMock())
+    monkeypatch.setattr(mgr, "setup_ci_and_preview_deploy", MagicMock())
+    monkeypatch.setattr(mgr, "run_security_and_dependency_scans", MagicMock())
+    monkeypatch.setattr(mgr, "apply_comment_fixes", MagicMock())
+    monkeypatch.setattr(mgr, "enable_auto_merge", MagicMock())
+    return mgr
+
+
+def test_process_comment_runs_requested_actions(manager: AutomatedPullRequestManager) -> None:
+    comment = """
+    @codex @copilot @blackboxprogramming @dependabot @asana @linear
+    review and test the feature branch, set up CI and preview deploy,
+    run security and dependency scans, and apply comment fixes
+
+    @codex fix comments              # auto-fixes code review comments
+    @codex apply .github/prompts/codex-fix-comments.md
+    @codex patch                     # applies code diffs
+    @codex run tests                 # triggers test suite
+    @codex ship when green           # queues auto-merge
+    """
+
+    manager.process_comment(comment, pr_number=42, branch_name="feature/x")
+
+    assert manager.run_tests.call_count == 1
+    assert manager.setup_ci_and_preview_deploy.call_count == 1
+    assert manager.run_security_and_dependency_scans.call_count == 1
+    manager.apply_comment_fixes.assert_called_once_with(
+        pr_number=42, branch_name="feature/x"
+    )
+    manager.enable_auto_merge.assert_called_once_with(42)
+
+
+def test_process_comment_requires_pr_number_for_auto_merge(
+    manager: AutomatedPullRequestManager,
+) -> None:
+    manager.process_comment("@codex ship when green", branch_name="feature/x")
+    manager.enable_auto_merge.assert_not_called()


### PR DESCRIPTION
## Summary
- rebuild the pull request autopilot so it can parse multi-mention Codex comments and trigger the requested automation steps automatically
- add helpers that run local tests, ensure CI/preview workflows exist, launch dependency checks, and gate redundant executions per comment
- cover the new comment orchestration logic with focused unit tests

## Testing
- pytest tests/test_pr_autopilot.py -q
- python -m py_compile agents/pr_autopilot.py
- python agents/auto_novel_agent.py *(fails: upstream file has an unterminated triple-quoted string)*

------
https://chatgpt.com/codex/tasks/task_e_690a40e6c0248329b82549af2027d019