### PR TITLE
Fix PR automation workflow permissions

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -4,12 +4,16 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   pr-auto-bot:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR code
-        uses: actions/checkout@v3
         uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}


### PR DESCRIPTION
## Summary
- grant the PR automation workflow the explicit issues and pull request permissions required to post comments and update PRs
- remove the stray duplicate checkout declaration so the workflow runs with actions/checkout@v4

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_690a6a711c0c83298441a9530f0d2ec8