### PR TITLE
Add generator for Hugging Face agent models

### DIFF
--- a/registry/huggingface/lucidia-ai--core/README.md
+++ b/registry/huggingface/lucidia-ai--core/README.md
@@ -1,0 +1,18 @@
+---
+title: "Lucidia"
+base_model: "llama-3-8b"
+lineage: "none"
+tags:
+  - agent
+  - blackroad
+---
+
+# Lucidia
+
+- **Domain:** analysis
+- **Description:** Analyst and curator of clarity across knowledge streams.
+- **Base model:** llama-3-8b
+- **Parent agent:** none
+- **Status:** active
+
+This model card was generated automatically by the BlackRoad Prism Console.

--- a/registry/huggingface/lucidia-ai--core/agent.json
+++ b/registry/huggingface/lucidia-ai--core/agent.json
@@ -1,0 +1,15 @@
+{
+  "id": "a1a89b0b-9f69-4c41-92ce-5612f257d7ab",
+  "name": "Lucidia",
+  "base_model": "llama-3-8b",
+  "domain": "analysis",
+  "description": "Analyst and curator of clarity across knowledge streams.",
+  "parent_agent": null,
+  "traits": [
+    "clarity",
+    "precision",
+    "guidance"
+  ],
+  "status": "active",
+  "slug": "core"
+}

--- a/registry/huggingface/magnus-ai--framework/README.md
+++ b/registry/huggingface/magnus-ai--framework/README.md
@@ -1,0 +1,18 @@
+---
+title: "Magnus"
+base_model: "falcon-7b"
+lineage: "none"
+tags:
+  - agent
+  - blackroad
+---
+
+# Magnus
+
+- **Domain:** architecture
+- **Description:** System architect responsible for network-scale planning.
+- **Base model:** falcon-7b
+- **Parent agent:** none
+- **Status:** active
+
+This model card was generated automatically by the BlackRoad Prism Console.

--- a/registry/huggingface/magnus-ai--framework/agent.json
+++ b/registry/huggingface/magnus-ai--framework/agent.json
@@ -1,0 +1,15 @@
+{
+  "id": "b0ac8743-c61f-4b39-938b-7a2e2170c5f8",
+  "name": "Magnus",
+  "base_model": "falcon-7b",
+  "domain": "architecture",
+  "description": "System architect responsible for network-scale planning.",
+  "parent_agent": null,
+  "traits": [
+    "structure",
+    "foresight",
+    "integration"
+  ],
+  "status": "active",
+  "slug": "framework"
+}

--- a/registry/huggingface/ophelia-ai--dialogue/README.md
+++ b/registry/huggingface/ophelia-ai--dialogue/README.md
@@ -1,0 +1,18 @@
+---
+title: "Ophelia"
+base_model: "mistral-7b-instruct"
+lineage: "none"
+tags:
+  - agent
+  - blackroad
+---
+
+# Ophelia
+
+- **Domain:** philosophy
+- **Description:** Philosopher and sentiment interpreter for dialogic analysis.
+- **Base model:** mistral-7b-instruct
+- **Parent agent:** none
+- **Status:** active
+
+This model card was generated automatically by the BlackRoad Prism Console.

--- a/registry/huggingface/ophelia-ai--dialogue/agent.json
+++ b/registry/huggingface/ophelia-ai--dialogue/agent.json
@@ -1,0 +1,15 @@
+{
+  "id": "7a3a59a5-7a4a-4b4f-93ab-63758c99d427",
+  "name": "Ophelia",
+  "base_model": "mistral-7b-instruct",
+  "domain": "philosophy",
+  "description": "Philosopher and sentiment interpreter for dialogic analysis.",
+  "parent_agent": null,
+  "traits": [
+    "empathy",
+    "interpretation",
+    "nuance"
+  ],
+  "status": "active",
+  "slug": "dialogue"
+}

--- a/registry/huggingface/persephone-ai--root/README.md
+++ b/registry/huggingface/persephone-ai--root/README.md
@@ -1,0 +1,18 @@
+---
+title: "Persephone"
+base_model: "gemma-7b"
+lineage: "none"
+tags:
+  - agent
+  - blackroad
+---
+
+# Persephone
+
+- **Domain:** transition
+- **Description:** Transition architect guiding states of change and renewal.
+- **Base model:** gemma-7b
+- **Parent agent:** none
+- **Status:** active
+
+This model card was generated automatically by the BlackRoad Prism Console.

--- a/registry/huggingface/persephone-ai--root/agent.json
+++ b/registry/huggingface/persephone-ai--root/agent.json
@@ -1,0 +1,15 @@
+{
+  "id": "90f8b70d-f56e-4445-a908-0a86ded45f33",
+  "name": "Persephone",
+  "base_model": "gemma-7b",
+  "domain": "transition",
+  "description": "Transition architect guiding states of change and renewal.",
+  "parent_agent": null,
+  "traits": [
+    "rebirth",
+    "continuity",
+    "balance"
+  ],
+  "status": "active",
+  "slug": "root"
+}

--- a/scripts/generate_hf_models.py
+++ b/scripts/generate_hf_models.py
@@ -1,0 +1,140 @@
+"""Generate local Hugging Face model artifacts for all registered agents."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+import yaml
+
+from hf_publish import publish_to_huggingface
+
+CONFIG_DIR = Path("configs/agents")
+
+
+class HuggingFaceSpaceError(RuntimeError):
+    """Raised when an agent configuration contains an invalid space path."""
+
+
+def _load_agent_configs() -> Iterable[Tuple[Path, Dict[str, object]]]:
+    """Yield ``(path, config)`` pairs for each agent configuration file."""
+
+    if not CONFIG_DIR.exists():
+        raise FileNotFoundError(f"Missing agent config directory: {CONFIG_DIR}")
+
+    for config_path in sorted(CONFIG_DIR.glob("*.yaml")):
+        raw_text = config_path.read_text(encoding="utf-8")
+        try:
+            data = json.loads(raw_text)
+        except json.JSONDecodeError:
+            data = yaml.safe_load(raw_text)
+        if not isinstance(data, dict):  # pragma: no cover - defensive
+            raise ValueError(f"Agent config must be a mapping: {config_path}")
+        yield config_path, data
+
+
+def _parse_space_path(space: str) -> Tuple[str, str]:
+    """Return the ``(namespace, slug)`` extracted from a Hugging Face space path."""
+
+    cleaned = space.strip().strip("/")
+    if cleaned.startswith("spaces/"):
+        cleaned = cleaned[len("spaces/") :]
+    parts = cleaned.split("/")
+    if len(parts) != 2:
+        raise HuggingFaceSpaceError(
+            f"Expected `<namespace>/<slug>` space path, got: {space!r}"
+        )
+    return parts[0], parts[1]
+
+
+def _build_agent_payload(config: Dict[str, object], slug: str) -> Dict[str, object]:
+    """Construct the payload passed to :func:`publish_to_huggingface`."""
+
+    context = config.get("context") if isinstance(config.get("context"), dict) else {}
+    metadata = config.get("metadata") if isinstance(config.get("metadata"), dict) else {}
+
+    return {
+        "id": config.get("uuid"),
+        "name": config.get("name"),
+        "base_model": config.get("model"),
+        "domain": config.get("domain"),
+        "description": config.get("description"),
+        "parent_agent": context.get("parent"),
+        "traits": config.get("traits", []),
+        "status": metadata.get("status", "active"),
+        "slug": slug,
+    }
+
+
+def generate_models(*, dry_run: bool = False) -> List[Dict[str, object]]:
+    """Create Hugging Face model artifacts for every agent configuration."""
+
+    results: List[Dict[str, object]] = []
+
+    for config_path, config in _load_agent_configs():
+        huggingface_cfg = config.get("huggingface")
+        if not isinstance(huggingface_cfg, dict):
+            raise HuggingFaceSpaceError(
+                f"Agent configuration missing `huggingface` block: {config_path}"
+            )
+        space = huggingface_cfg.get("space")
+        if not isinstance(space, str) or not space.strip():
+            raise HuggingFaceSpaceError(
+                f"Agent configuration missing Hugging Face space name: {config_path}"
+            )
+
+        namespace, slug = _parse_space_path(space)
+        agent_payload = _build_agent_payload(config, slug)
+
+        result: Dict[str, object] = {
+            "config_path": str(config_path),
+            "namespace": namespace,
+            "slug": slug,
+            "huggingface_repo": f"{namespace}/{slug}",
+        }
+
+        if dry_run:
+            result["published"] = False
+        else:
+            publish_result = publish_to_huggingface(
+                agent_payload,
+                namespace=namespace,
+            )
+            result.update(
+                {
+                    "url": publish_result.url,
+                    "published": publish_result.pushed,
+                    "repo_id": publish_result.repo_id,
+                }
+            )
+        results.append(result)
+
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate local Hugging Face artifacts for all agent configurations. "
+            "Without a Hugging Face token the data is stored under registry/huggingface/."
+        )
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Parse configuration files without writing any artifacts.",
+    )
+
+    args = parser.parse_args()
+    results = generate_models(dry_run=args.dry_run)
+
+    for item in results:
+        status = "published" if item.get("published") else "generated"
+        repo = item["huggingface_repo"]
+        url = item.get("url", "(local export)")
+        print(f"[{status}] {repo} -> {url}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a CLI to materialize Hugging Face metadata for every agent configuration
- generate local model card and agent.json exports for Lucidia, Magnus, Ophelia, and Persephone

## Testing
- python scripts/generate_hf_models.py
- python -m py_compile scripts/generate_hf_models.py

------
https://chatgpt.com/codex/tasks/task_e_690a6ab0d4f08329a4ec8de954ba2d6f