### PR TITLE
feat: expand pr automation for lifecycle events

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -2,17 +2,21 @@ name: PR Automation
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, reopened, synchronize, closed]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 
 jobs:
-  pr-auto-bot:
+  pr-automation:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout PR code
-        uses: actions/checkout@v3
+      - name: Check out repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -27,7 +31,6 @@ jobs:
       - name: Run PR Automation Bot
         env:
           GITHUB_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_BRANCH: ${{ github.head_ref }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
## Summary
- extend the PR automation workflow to cover closed events and request the permissions needed for comments and edits
- rework the PR automation bot to manage branch context updates on open events and celebratory comments on merges

## Testing
- python -m py_compile agents/pr_automation_bot.py

------
https://chatgpt.com/codex/tasks/task_e_690a8552e75c8329a3550809fd73cb62