### PR TITLE
feat: enrich offline plm and mfg tooling

### DIFF
--- a/cli/console.py
+++ b/cli/console.py
@@ -1039,27 +1039,24 @@ def plm_bom_explode(
     level: int = typer.Option(1, "--level"),
 ):
 def plm_bom_explode(item: str = typer.Option(..., "--item"), rev: str = typer.Option(..., "--rev"), level: int = typer.Option(1, "--level")):
-    lines = plm_bom.explode(item, rev, level)
-    for lvl, comp, qty in lines:
-        typer.echo(f"{lvl}\t{comp}\t{qty}")
+    rows = plm_bom.explode(item, rev, level)
+    for row in rows:
+        typer.echo(
+            "\t".join(
+                [
+                    str(row.get("level")),
+                    row.get("component_id", ""),
+                    f"{row.get('qty', 0):.6f}",
+                ]
+            )
+        )
 
 
 @app.command("plm:bom:where-used")
 def plm_bom_where_used(component: str = typer.Option(..., "--component")):
     rows = plm_bom.where_used(component)
-    for item_id, rev in rows:
-        typer.echo(f"{item_id}\t{rev}")
-
-
-@app.command("plm:bom:explode")
-def plm_bom_explode(
-    item: str = typer.Option(..., "--item"),
-    rev: str = typer.Option(..., "--rev"),
-    level: int = typer.Option(1, "--level"),
-):
-    lines = plm_bom.explode(item, rev, level)
-    for lvl, comp, qty in lines:
-        typer.echo(f"{lvl}\t{comp}\t{qty}")
+    for row in rows:
+        typer.echo(f"{row['item_id']}\t{row['rev']}")
 
 
 @app.command("plm:eco:new")

--- a/docs/mfg-routing.md
+++ b/docs/mfg-routing.md
@@ -1,3 +1,20 @@
 # Manufacturing Routing
 
-Placeholder doc for routing and work centers.
+The manufacturing toolkit models deterministic routings and capacity
+checks without external systems.
+
+## Work centre catalog
+
+* `python -m cli.console mfg:wc:load --file fixtures/mfg/work_centers.csv`
+  normalises CSV data into `artifacts/mfg/routing/work_centers.json` with
+  consistent skill lists and rate metadata.
+
+## Routing definitions
+
+* `python -m cli.console mfg:routing:load --dir fixtures/mfg/routings`
+  parses YAML routings into an in-memory registry and persists
+  `routings.json` for contract validation.
+* `python -m cli.console mfg:routing:capcheck --item PROD-100 --rev B
+  --qty 1000` emits capacity and labour-cost calculations per work
+  centre and writes the result to
+  `artifacts/mfg/routing/capcheck_<item>_<rev>.json`.

--- a/docs/mrp-lite.md
+++ b/docs/mrp-lite.md
@@ -1,3 +1,12 @@
 # MRP Lite
 
-Placeholder doc for minimal MRP planning.
+The lightweight MRP planner consumes deterministic CSV inputs and writes
+artifacts under `artifacts/mfg/mrp/`.
+
+* Demand: `python -m cli.console mfg:mrp --demand demand.csv --inventory inventory.csv --pos open_pos.csv`
+  nets demand against inventory and open purchase orders.
+* Plan output includes the planned quantity, release lead-time offsets
+  (derived from the item catalog), and a kitting list generated via the
+  BOM explosion helpers.
+* For every planned item a `kitting_<item>.csv` is emitted so warehouse
+  teams can pick component quantities without additional systems.

--- a/docs/plm.md
+++ b/docs/plm.md
@@ -1,3 +1,32 @@
 # PLM Operations
 
-Placeholder documentation for PLM features.
+The offline Product Lifecycle Management tooling ships deterministic
+catalog and change-control workflows that run without external
+dependencies.  Key entry points live in `plm/bom.py` and `plm/eco.py` and
+are surfaced through the Typer console (`python -m cli.console`).
+
+## Item and BOM catalog
+
+* `python -m cli.console plm:items:load --dir fixtures/plm/items` loads
+  CSV records into `artifacts/plm/items.json`.  Supplier strings may be
+  delimited with `|` or `;`; they are normalised into arrays.
+* `python -m cli.console plm:bom:load --dir fixtures/plm/boms` persists
+  structured BOMs to `artifacts/plm/boms.json` and materialises a
+  `where_used` lookup for downstream analytics.
+* `python -m cli.console plm:bom:explode --item PROD-100 --rev A
+  --level 2` emits a deterministic multi-level explosion that honours
+  scrap percentages and writes the results to disk for contract
+  validation.
+
+## Engineering change control
+
+* `python -m cli.console plm:eco:new --item PROD-100 --from A --to B
+  --reason "Connector change"` creates a JSON + Markdown record under
+  `artifacts/plm/changes`.
+* `python -m cli.console plm:eco:impact --id ECO-00001` summarises cost
+  deltas, newly introduced components, supplier risk and the downstream
+  work centres that must absorb the change.  The analysis is persisted to
+  `<change>_impact.json` for reporting pipelines.
+* Releases (`plm:eco:release`) enforce dual approval for high-risk
+  changes and honour SPC duty-of-care flags.  The Markdown summary is
+  updated with the release timestamp for audit trails.

--- a/docs/spc-yield.md
+++ b/docs/spc-yield.md
@@ -1,3 +1,22 @@
 # SPC and Yield
 
-Placeholder doc for SPC analysis and yield reporting.
+## Statistical process control
+
+`python -m cli.console mfg:spc:analyze --op OP-200 --window 50` consumes
+fixture CSV samples, calculates classical X-bar/R style thresholds and
+persists artefacts under `artifacts/mfg/spc/`:
+
+* `report.json` with the deterministic summary (mean, sigma, rule hits).
+* `charts.csv` and `charts.md` for ASCII-friendly visualisation.
+* `findings.json` for contract validation and automation gates.
+* `blocking.flag` whenever a 3σ violation is detected; ECO releases read
+  this flag to enforce duty-of-care.
+
+## Yield and cost of quality
+
+`python -m cli.console mfg:yield --period 2025-09` materialises a yield
+summary with FPY/RTY metrics, Markdown output, and a Pareto of defects.
+
+`python -m cli.console mfg:coq --period 2025-Q3` aggregates ledger-like
+fixtures into prevention/appraisal/failure buckets for operations
+reporting.

--- a/mfg/mrp.py
+++ b/mfg/mrp.py
@@ -6,9 +6,12 @@ import argparse
 import csv
 import json
 from pathlib import Path
-from typing import Dict
+from typing import Dict, List
 
 ART_DIR: Path = Path("artifacts/mfg/mrp")
+PLM_DIR: Path = Path("artifacts/plm")
+ITEMS_PATH: Path = PLM_DIR / "items.json"
+BOMS_PATH: Path = PLM_DIR / "boms.json"
 
 
 def _ensure_art_dir() -> Path:
@@ -36,6 +39,98 @@ def _read_table(path: str, key_field: str, value_field: str) -> Dict[str, float]
     return table
 
 
+def _load_items_catalog() -> Dict[str, Dict[str, float]]:
+    catalog: Dict[str, Dict[str, float]] = {}
+    if not ITEMS_PATH.exists():
+        return catalog
+    with ITEMS_PATH.open(encoding="utf-8") as handle:
+        data = json.load(handle)
+    if isinstance(data, list):
+        for row in data:
+            item_id = str(row.get("id", ""))
+            if not item_id:
+                continue
+            rev = str(row.get("rev", "A")) or "A"
+            entry = catalog.setdefault(item_id, {})
+            entry[rev] = float(row.get("lead_time_days", 0) or 0.0)
+    return catalog
+
+
+def _load_boms_catalog() -> Dict[tuple[str, str], Dict[str, object]]:
+    mapping: Dict[tuple[str, str], Dict[str, object]] = {}
+    if not BOMS_PATH.exists():
+        return mapping
+    with BOMS_PATH.open(encoding="utf-8") as handle:
+        data = json.load(handle)
+    if isinstance(data, list):
+        for row in data:
+            item_id = str(row.get("item_id", ""))
+            rev = str(row.get("rev", "A")) or "A"
+            if item_id:
+                mapping[(item_id, rev)] = row
+    return mapping
+
+
+def _latest_lead_time(item_id: str, catalog: Dict[str, Dict[str, float]]) -> float:
+    revs = catalog.get(item_id, {})
+    if not revs:
+        return 0.0
+    latest_rev = sorted(revs)[-1]
+    return float(revs.get(latest_rev, 0.0))
+
+
+def _explode_components(
+    item_id: str,
+    planned_qty: float,
+    boms_catalog: Dict[tuple[str, str], Dict[str, object]],
+) -> List[Dict[str, float]]:
+    try:
+        from plm import bom as plm_bom  # type: ignore
+
+        if getattr(plm_bom, "_BOMS", []):
+            rev = plm_bom.latest_revision(item_id)
+            rows = plm_bom.explode(item_id, rev, level=1)
+            return [
+                {
+                    "component_id": row["component_id"],
+                    "qty": round(row["qty"] * planned_qty, 6),
+                }
+                for row in rows
+            ]
+    except Exception:
+        pass
+
+    revs = sorted(rev for (itm, rev) in boms_catalog if itm == item_id)
+    if not revs:
+        return []
+    bom_row = boms_catalog[(item_id, revs[-1])]
+    components: List[Dict[str, float]] = []
+    for line in bom_row.get("lines", []) or []:
+        if not isinstance(line, dict):
+            continue
+        comp_id = str(line.get("component_id", ""))
+        if not comp_id:
+            continue
+        qty = float(line.get("qty", 0) or 0.0)
+        scrap = float(line.get("scrap_pct", 0) or 0.0)
+        components.append(
+            {
+                "component_id": comp_id,
+                "qty": round(planned_qty * qty * (1 + scrap / 100.0), 6),
+            }
+        )
+    return components
+
+
+def _write_kitting_csv(art_dir: Path, item_id: str, components: List[Dict[str, float]]) -> None:
+    path = art_dir / f"kitting_{item_id}.csv"
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["component_id", "qty"])
+        for row in components:
+            writer.writerow([row["component_id"], f"{row['qty']:.6f}"])
+
+
 def plan(demand_csv: str, inventory_csv: str, pos_csv: str) -> Dict[str, Dict[str, float]]:
     """Compute a minimal MRP plan.
 
@@ -48,21 +143,30 @@ def plan(demand_csv: str, inventory_csv: str, pos_csv: str) -> Dict[str, Dict[st
     demand = _read_table(demand_csv, "item_id", "qty")
     inventory = _read_table(inventory_csv, "item_id", "qty")
     pos = _read_table(pos_csv, "item_id", "qty_open")
+    items_catalog = _load_items_catalog()
+    boms_catalog = _load_boms_catalog()
 
     plan_output: Dict[str, Dict[str, float]] = {}
+    kitting_components: Dict[str, List[Dict[str, float]]] = {}
     for item_id, demand_qty in sorted(demand.items()):
         net = demand_qty - inventory.get(item_id, 0.0) - pos.get(item_id, 0.0)
         if net <= 0:
             continue
+        planned_qty = round(net, 6)
+        components = _explode_components(item_id, planned_qty, boms_catalog)
+        release_offset = _latest_lead_time(item_id, items_catalog)
         plan_output[item_id] = {
-            "planned_qty": round(net, 6),
-            "release_day_offset": 0.0,
-            "kitting_list": [item_id],
+            "planned_qty": planned_qty,
+            "release_day_offset": release_offset,
+            "kitting_list": [row["component_id"] for row in components] or [item_id],
         }
+        kitting_components[item_id] = components
 
     art_dir = _ensure_art_dir()
     plan_path = art_dir / "plan.json"
     plan_path.write_text(json.dumps(plan_output, indent=2, sort_keys=True), encoding="utf-8")
+    for item_id, components in kitting_components.items():
+        _write_kitting_csv(art_dir, item_id, components)
     return plan_output
 
 

--- a/mfg/routing.py
+++ b/mfg/routing.py
@@ -2,10 +2,91 @@
 
 from __future__ import annotations
 
+import csv
+import json
+from pathlib import Path
 from typing import Dict, Iterable, List
+
+import yaml
+
+ART_DIR: Path = Path("artifacts/mfg/routing")
+WC_PATH: Path = ART_DIR / "work_centers.json"
+ROUTINGS_PATH: Path = ART_DIR / "routings.json"
 
 WC_DB: Dict[str, Dict[str, float]] = {}
 ROUT_DB: Dict[str, Dict[str, object]] = {}
+
+
+def _ensure_art_dir() -> Path:
+    path = Path(ART_DIR)
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def load_work_centers(csv_path: str) -> Dict[str, Dict[str, float]]:
+    table: Dict[str, Dict[str, float]] = {}
+    with Path(csv_path).open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            wc_id = (row.get("id") or row.get("work_center_id") or "").strip()
+            if not wc_id:
+                continue
+            skills_raw = row.get("skills", "")
+            if isinstance(skills_raw, str):
+                skills = [token.strip() for token in skills_raw.replace(";", "|").split("|") if token.strip()]
+            else:
+                skills = []
+            table[wc_id] = {
+                "name": (row.get("name") or wc_id).strip(),
+                "capacity_per_shift": float(row.get("capacity_per_shift", 0) or 0.0),
+                "skills": skills,
+                "cost_rate": float(row.get("cost_rate", 0) or 0.0),
+            }
+
+    WC_DB.clear()
+    WC_DB.update(table)
+    _ensure_art_dir()
+    WC_PATH.write_text(json.dumps(table, indent=2, sort_keys=True), encoding="utf-8")
+    return table
+
+
+def load_routings(directory: str, strict: bool = False) -> Dict[str, Dict[str, object]]:
+    routings: Dict[str, Dict[str, object]] = {}
+    for path in sorted(Path(directory).glob("*.y*ml")):
+        with path.open(encoding="utf-8") as handle:
+            data = yaml.safe_load(handle) or {}
+        if not isinstance(data, dict):
+            if strict:
+                raise ValueError(f"invalid routing payload in {path}")
+            continue
+        item = str(data.get("item") or data.get("item_id") or "").strip()
+        rev = str(data.get("rev", "A")).strip() or "A"
+        if not item:
+            if strict:
+                raise ValueError(f"routing missing item id in {path}")
+            continue
+        key = f"{item}_{rev}"
+        steps = data.get("steps") or []
+        normalised_steps: List[dict] = []
+        if isinstance(steps, list):
+            for step in steps:
+                if isinstance(step, dict):
+                    normalised_steps.append(
+                        {
+                            "wc": step.get("wc"),
+                            "op": step.get("op"),
+                            "std_time_min": float(step.get("std_time_min", 0) or 0.0),
+                            "yield_pct": float(step.get("yield_pct", 100) or 100.0),
+                            "instructions_path": step.get("instructions_path"),
+                        }
+                    )
+        routings[key] = {"item": item, "rev": rev, "steps": normalised_steps}
+
+    ROUT_DB.clear()
+    ROUT_DB.update(routings)
+    _ensure_art_dir()
+    ROUTINGS_PATH.write_text(json.dumps(routings, indent=2, sort_keys=True), encoding="utf-8")
+    return routings
 
 
 def _iter_steps(item: str, rev: str) -> Iterable[dict]:
@@ -53,13 +134,24 @@ def capcheck(item: str, rev: str, qty: float) -> Dict[str, object]:
         }
         labour_cost += (required_min / 60.0) * cost_rate
 
-    return {
+    result = {
         "item": item,
         "rev": rev,
         "qty": qty,
         "work_centers": work_centers,
         "theoretical_labor_cost": labour_cost,
     }
+    _ensure_art_dir()
+    out_path = ART_DIR / f"capcheck_{item}_{rev}.json"
+    out_path.write_text(json.dumps(result, indent=2, sort_keys=True), encoding="utf-8")
+    return result
 
 
-__all__ = ["WC_DB", "ROUT_DB", "capcheck"]
+__all__ = [
+    "ART_DIR",
+    "WC_DB",
+    "ROUT_DB",
+    "load_work_centers",
+    "load_routings",
+    "capcheck",
+]

--- a/mfg/spc.py
+++ b/mfg/spc.py
@@ -94,6 +94,11 @@ def analyze(op: str, window: int, csv_dir: str | Path = Path("fixtures/mfg/spc")
 
     chart_lines = ["index,value"] + [f"{idx + 1},{value}" for idx, value in enumerate(series)]
     (art_dir / "charts.csv").write_text("\n".join(chart_lines), encoding="utf-8")
+    _write_charts_md(art_dir / "charts.md", series, mu)
+    (art_dir / "findings.json").write_text(
+        json.dumps({"op": op, "findings": findings}, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
 
     flag_path = art_dir / "blocking.flag"
     if RULE_POINT_BEYOND_3SIG in findings:
@@ -102,6 +107,13 @@ def analyze(op: str, window: int, csv_dir: str | Path = Path("fixtures/mfg/spc")
         flag_path.unlink()
 
     return report
+
+
+def _write_charts_md(path: Path, series: List[float], mean: float) -> None:
+    lines = ["# SPC Series", "", "| Sample | Value | Deviation |", "| --- | --- | --- |"]
+    for idx, value in enumerate(series, 1):
+        lines.append(f"| {idx} | {value:.4f} | {value - mean:.4f} |")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
 def cli_spc_analyze(argv: List[str] | None = None) -> Dict[str, object]:
@@ -118,6 +130,7 @@ __all__ = [
     "cli_spc_analyze",
     "_mean",
     "_stdev",
+    "_write_charts_md",
     "ART_DIR",
     "RULE_POINT_BEYOND_3SIG",
     "RULE_TREND_7",

--- a/mfg/work_instructions.py
+++ b/mfg/work_instructions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, Iterable, Optional
@@ -23,11 +24,50 @@ def _format_steps(steps: Iterable[str]) -> str:
     return "\n".join(lines) if lines else "1. Assemble per routing"
 
 
+def _resolve_routing(
+    item: str, rev: str, routing: Optional[Dict[str, object]]
+) -> Dict[str, object]:
+    if routing is None:
+        try:
+            from mfg import routing as routing_mod  # type: ignore
+
+            routing = routing_mod.ROUT_DB.get(f"{item}_{rev}")
+        except Exception:  # pragma: no cover - routing module optional in tests
+            routing = None
+    if routing is None:
+        raise FileNotFoundError(f"routing not found for {item} rev {rev}")
+
+    if isinstance(routing, dict):
+        item_hint = str(routing.get("item")) if routing.get("item") else item
+        rev_hint = str(routing.get("rev")) if routing.get("rev") else rev
+        if item_hint and item_hint != item:
+            raise SystemExit("DUTY_REV_MISMATCH: routing item mismatch")
+        if rev_hint and rev_hint != rev:
+            raise SystemExit("DUTY_REV_MISMATCH: routing revision mismatch")
+    else:
+        raise ValueError("routing must be a dictionary")
+
+    try:
+        from plm import bom as plm_bom  # type: ignore
+
+        if plm_bom._BOMS:  # type: ignore[attr-defined]
+            bom = plm_bom.get_bom(item, rev)
+            if bom is None:
+                raise SystemExit("DUTY_REV_MISMATCH: BOM revision missing")
+    except Exception:
+        # BOM catalog not loaded – skip duty gate
+        pass
+
+    return routing
+
+
 def render(item: str, rev: str, routing: Optional[Dict[str, object]] = None) -> Path:
     """Render Markdown and HTML work instructions for ``item``/``rev``."""
 
     art_dir = _ensure_art_dir()
     key = f"{item}_{rev}"
+
+    routing = _resolve_routing(item, rev, routing)
 
     routing_steps = []
     if routing and isinstance(routing.get("steps"), list):
@@ -54,8 +94,22 @@ def render(item: str, rev: str, routing: Optional[Dict[str, object]] = None) -> 
 
     md_path = art_dir / f"{key}.md"
     html_path = art_dir / f"{key}.html"
+    meta_path = art_dir / f"{key}.json"
     md_path.write_text(markdown, encoding="utf-8")
     html_path.write_text(f"<html><body><pre>{markdown}</pre></body></html>", encoding="utf-8")
+    meta_path.write_text(
+        json.dumps(
+            {
+                "item": item,
+                "rev": rev,
+                "generated_at": timestamp,
+                "step_count": len(routing_steps),
+            },
+            indent=2,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
     return md_path
 
 

--- a/plm/eco.py
+++ b/plm/eco.py
@@ -11,11 +11,14 @@ from __future__ import annotations
 import argparse
 import json
 from dataclasses import asdict, dataclass, field
+from datetime import datetime
 from pathlib import Path
-from typing import List
+from typing import Dict, List
 
 ART_DIR: Path = Path("artifacts/plm/changes")
 COUNTER_FILE: Path = ART_DIR / "_counter"
+PLM_CATALOG_DIR: Path = Path("artifacts/plm")
+ROUTING_DIR: Path = Path("artifacts/mfg/routing")
 
 
 @dataclass
@@ -62,7 +65,121 @@ def _load(change_id: str) -> Change:
 
 
 def _write(change: Change) -> None:
-    _path(change.id).write_text(json.dumps(asdict(change), indent=2, sort_keys=True), encoding="utf-8")
+    payload = json.dumps(asdict(change), indent=2, sort_keys=True)
+    _path(change.id).write_text(payload, encoding="utf-8")
+    _write_markdown(change)
+
+
+def _markdown_path(change_id: str) -> Path:
+    return _ensure_art_dir() / f"eco_{change_id}.md"
+
+
+def _write_markdown(change: Change) -> None:
+    lines = [
+        f"# Engineering Change {change.id}",
+        "",
+        f"Item: {change.item_id}",
+        f"From rev: {change.from_rev}",
+        f"To rev: {change.to_rev}",
+        f"Status: {change.status}",
+        f"Risk: {change.risk}",
+        "",
+        f"Reason: {change.reason}",
+        "",
+        f"Updated: {datetime.utcnow().isoformat(timespec='seconds')}Z",
+    ]
+    _markdown_path(change.id).write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _catalog_path(name: str) -> Path:
+    return PLM_CATALOG_DIR / name
+
+
+def _load_catalog(name: str) -> List[Dict[str, object]]:
+    path = _catalog_path(name)
+    if not path.exists():
+        return []
+    with path.open(encoding="utf-8") as handle:
+        data = json.load(handle)
+    if isinstance(data, list):
+        return data
+    # support legacy dict payloads
+    return list(data.values())
+
+
+def _items_index() -> Dict[str, Dict[str, object]]:
+    index: Dict[str, Dict[str, object]] = {}
+    for row in _load_catalog("items.json"):
+        item_id = str(row.get("id", "")).strip()
+        if not item_id:
+            continue
+        index.setdefault(item_id, {})[str(row.get("rev", "A"))] = row
+    return index
+
+
+def _boms_index() -> Dict[tuple[str, str], Dict[str, object]]:
+    index: Dict[tuple[str, str], Dict[str, object]] = {}
+    for row in _load_catalog("boms.json"):
+        item_id = str(row.get("item_id", "")).strip()
+        rev = str(row.get("rev", "A")).strip() or "A"
+        if not item_id:
+            continue
+        index[(item_id, rev)] = row
+    return index
+
+
+def _routing_index() -> Dict[str, Dict[str, object]]:
+    try:
+        from mfg import routing as routing_mod  # type: ignore
+
+        if getattr(routing_mod, "ROUT_DB", {}):
+            return routing_mod.ROUT_DB
+    except Exception:  # pragma: no cover - routing module optional during tests
+        pass
+
+    path = ROUTING_DIR / "routings.json"
+    if not path.exists():
+        return {}
+    with path.open(encoding="utf-8") as handle:
+        data = json.load(handle)
+    if isinstance(data, dict):
+        return data
+    index: Dict[str, Dict[str, object]] = {}
+    if isinstance(data, list):
+        for entry in data:
+            if not isinstance(entry, dict):
+                continue
+            key = f"{entry.get('item')}" + "_" + f"{entry.get('rev')}"
+            index[key] = entry
+    return index
+
+
+def _bom_cost(bom_row: Dict[str, object], item_costs: Dict[str, float]) -> float:
+    total = 0.0
+    for line in bom_row.get("lines", []) or []:
+        if not isinstance(line, dict):
+            continue
+        component = str(line.get("component_id", ""))
+        qty = float(line.get("qty", 0) or 0.0)
+        scrap = float(line.get("scrap_pct", 0) or 0.0)
+        total += qty * (1 + scrap / 100.0) * item_costs.get(component, 0.0)
+    return total
+
+
+def _supplier_risk(components: List[str], items: Dict[str, Dict[str, object]]) -> str:
+    for component in components:
+        options = items.get(component, {})
+        if not options:
+            continue
+        latest = options.get(sorted(options)[-1])
+        suppliers = (latest or {}).get("suppliers", []) if latest else []
+        if isinstance(suppliers, list) and len(suppliers) < 2:
+            return "single_source"
+    return "ok"
+
+
+def _impact_path(change_id: str) -> Path:
+    return _ensure_art_dir() / f"{change_id}_impact.json"
 
 
 def create_change(item_id: str, from_rev: str, to_rev: str, reason: str) -> Change:
@@ -78,6 +195,9 @@ def create_change(item_id: str, from_rev: str, to_rev: str, reason: str) -> Chan
     return change
 
 
+new_change = create_change
+
+
 def approve(change_id: str, user: str) -> Change:
     change = _load(change_id)
     if user not in change.approvals:
@@ -90,6 +210,66 @@ def approve(change_id: str, user: str) -> Change:
 
 def _spc_blocking_flag() -> Path:
     return Path("artifacts/mfg/spc/blocking.flag")
+
+
+def impact(change_id: str) -> Dict[str, object]:
+    change = _load(change_id)
+
+    items = _items_index()
+    item_costs = {
+        item_id: float((options.get(sorted(options)[-1]) or {}).get("cost", 0) or 0.0)
+        for item_id, options in items.items()
+        if options
+    }
+
+    boms = _boms_index()
+    from_bom = boms.get((change.item_id, change.from_rev)) or {"lines": []}
+    to_bom = boms.get((change.item_id, change.to_rev)) or {"lines": []}
+
+    def _components(bom_row: Dict[str, object]) -> List[str]:
+        comps: List[str] = []
+        for line in bom_row.get("lines", []) or []:
+            if isinstance(line, dict):
+                comp = str(line.get("component_id", ""))
+                if comp:
+                    comps.append(comp)
+        return comps
+
+    from_components = set(_components(from_bom))
+    to_components = set(_components(to_bom))
+    components_added = sorted(to_components - from_components)
+    components_removed = sorted(from_components - to_components)
+
+    cost_from = _bom_cost(from_bom, item_costs)
+    cost_to = _bom_cost(to_bom, item_costs)
+    cost_delta = cost_to - cost_from
+
+    routing_key = f"{change.item_id}_{change.to_rev}"
+    routing = _routing_index().get(routing_key, {})
+    work_centers = sorted(
+        {
+            str(step.get("wc"))
+            for step in routing.get("steps", []) or []
+            if isinstance(step, dict) and step.get("wc")
+        }
+    )
+
+    impact_payload = {
+        "id": change.id,
+        "item_id": change.item_id,
+        "from_rev": change.from_rev,
+        "to_rev": change.to_rev,
+        "cost_delta": round(cost_delta, 4),
+        "components_added": components_added,
+        "components_removed": components_removed,
+        "supplier_risk": _supplier_risk(list(to_components), items),
+        "impacted_work_centers": work_centers,
+    }
+
+    _impact_path(change.id).write_text(
+        json.dumps(impact_payload, indent=2, sort_keys=True), encoding="utf-8"
+    )
+    return impact_payload
 
 
 def release(change_id: str) -> Change:
@@ -117,6 +297,13 @@ def cli_eco_new(argv: List[str] | None = None) -> Change:
     return create_change(args.item, args.from_rev, args.to_rev, args.reason)
 
 
+def cli_eco_impact(argv: List[str] | None = None) -> Dict[str, object]:
+    parser = argparse.ArgumentParser(prog="plm:eco:impact", description="Summarise ECO impact")
+    parser.add_argument("--id", required=True)
+    args = parser.parse_args(argv)
+    return impact(args.id)
+
+
 def cli_eco_release(argv: List[str] | None = None) -> Change:
     parser = argparse.ArgumentParser(prog="plm:eco:release", description="Release an ECO")
     parser.add_argument("--id", required=True)
@@ -127,9 +314,12 @@ def cli_eco_release(argv: List[str] | None = None) -> Change:
 __all__ = [
     "Change",
     "create_change",
+    "new_change",
     "approve",
     "release",
+    "impact",
     "cli_eco_new",
+    "cli_eco_impact",
     "cli_eco_release",
     "ART_DIR",
     "_path",

--- a/tests/plm_mfg/test_bom.py
+++ b/tests/plm_mfg/test_bom.py
@@ -1,7 +1,37 @@
+from pathlib import Path
+
 from plm import bom
 
-def test_explode():
-    bom._ITEMS = [bom.Item('PROD-100','A','assembly','ea',0,0.0,[]), bom.Item('COMP-001','A','component','ea',0,0.0,[])]
-    bom._BOMS = [bom.BOM('PROD-100','A',[{'component_id':'COMP-001','qty':2}])]
-    rows = bom.explode('PROD-100','A', level=2)
-    assert any(r['component_id']=='COMP-001' for r in rows)
+
+def test_load_and_explode(tmp_path, monkeypatch):
+    art_dir = tmp_path / "plm"
+    monkeypatch.setattr(bom, "ART_DIR", art_dir)
+    monkeypatch.setattr(bom, "ITEMS_PATH", art_dir / "items.json")
+    monkeypatch.setattr(bom, "BOMS_PATH", art_dir / "boms.json")
+    monkeypatch.setattr(bom, "WHERE_USED_PATH", art_dir / "where_used.json")
+
+    items_dir = tmp_path / "items"
+    boms_dir = tmp_path / "boms"
+    items_dir.mkdir()
+    boms_dir.mkdir()
+
+    (items_dir / "items.csv").write_text(
+        "id,rev,type,uom,lead_time_days,cost,suppliers\n"
+        "PROD-100,A,assembly,ea,5,100,SUP-A;SUP-B\n"
+        "COMP-001,A,component,ea,2,5,SUP-C\n"
+    )
+    (boms_dir / "prod.csv").write_text(
+        "item_id,rev,component_id,qty,scrap_pct\n"
+        "PROD-100,A,COMP-001,2,5\n"
+    )
+
+    bom.load_items(str(items_dir))
+    bom.load_boms(str(boms_dir))
+
+    results = bom.explode("PROD-100", "A", level=1)
+    assert results and results[0]["component_id"] == "COMP-001"
+    assert results[0]["qty"] == 2 * (1 + 0.05)
+
+    where_used = Path(bom.WHERE_USED_PATH).read_text(encoding="utf-8")
+    assert "PROD-100" in where_used
+    assert bom.latest_revision("PROD-100") == "A"

--- a/tests/plm_mfg/test_eco.py
+++ b/tests/plm_mfg/test_eco.py
@@ -1,8 +1,11 @@
 import json, os
-from plm import eco
+from pathlib import Path
+
+from plm import bom, eco
 
 def test_policy_dual_approval(monkeypatch, tmp_path):
-    monkeypatch.setattr(eco, 'ART_DIR', str(tmp_path))
+    art_dir = tmp_path / "changes"
+    monkeypatch.setattr(eco, 'ART_DIR', art_dir)
     ch = eco.create_change('X', 'A', 'B', 'update')
     path = eco._path(ch.id)
     with open(path) as f:
@@ -27,3 +30,33 @@ def test_policy_dual_approval(monkeypatch, tmp_path):
     with open(path) as f:
         out = json.load(f)
     assert out['status'] == 'released'
+
+    # prepare catalogs for impact analysis
+    plm_art = tmp_path / "plm"
+    monkeypatch.setattr(bom, 'ART_DIR', plm_art)
+    monkeypatch.setattr(bom, 'ITEMS_PATH', plm_art / 'items.json')
+    monkeypatch.setattr(bom, 'BOMS_PATH', plm_art / 'boms.json')
+    monkeypatch.setattr(bom, 'WHERE_USED_PATH', plm_art / 'where_used.json')
+    monkeypatch.setattr(eco, 'PLM_CATALOG_DIR', plm_art)
+    items_dir = tmp_path / "items"
+    boms_dir = tmp_path / "boms"
+    items_dir.mkdir()
+    boms_dir.mkdir()
+    (items_dir / 'items.csv').write_text(
+        "id,rev,type,uom,lead_time_days,cost,suppliers\n"
+        "X,A,assembly,ea,5,20,SUP-1|SUP-2\n"
+        "C1,A,component,ea,2,3,SUP-3\n"
+        "C2,A,component,ea,2,1,SUP-4\n"
+    )
+    (boms_dir / 'bom.csv').write_text(
+        "item_id,rev,component_id,qty\n"
+        "X,B,C1,2\n"
+        "X,B,C2,1\n"
+    )
+    bom.load_items(str(items_dir))
+    bom.load_boms(str(boms_dir))
+
+    impact = eco.impact(ch.id)
+    assert impact['components_added']
+    impact_path = Path(eco.ART_DIR) / f"{ch.id}_impact.json"
+    assert impact_path.exists()

--- a/tests/plm_mfg/test_mrp.py
+++ b/tests/plm_mfg/test_mrp.py
@@ -1,14 +1,40 @@
+import json
+import os
+
+from plm import bom
 from mfg import mrp
-import os, json
+
 
 def test_mrp_plan(tmp_path, monkeypatch):
     d = tmp_path
-    dem = d/'demand.csv'; dem.write_text('item_id,qty\nA,10\nB,2\n')
-    inv = d/'inv.csv'; inv.write_text('item_id,qty\nA,8\n')
-    pos = d/'pos.csv'; pos.write_text('item_id,qty_open\nB,2\n')
-    monkeypatch.setattr(mrp, 'ART_DIR', str(d/'mrp'))
-    os.makedirs(mrp.ART_DIR, exist_ok=True)
+    dem = d / 'demand.csv'; dem.write_text('item_id,qty\nA,10\nB,2\n')
+    inv = d / 'inv.csv'; inv.write_text('item_id,qty\nA,8\n')
+    pos = d / 'pos.csv'; pos.write_text('item_id,qty_open\nB,2\n')
+
+    art_dir = d / 'mrp'
+    monkeypatch.setattr(mrp, 'ART_DIR', art_dir)
+    monkeypatch.setattr(mrp, 'ITEMS_PATH', d / 'items.json')
+    monkeypatch.setattr(mrp, 'BOMS_PATH', d / 'boms.json')
+    os.makedirs(art_dir, exist_ok=True)
+
+    items = [
+        {'id': 'A', 'rev': 'A', 'type': 'assembly', 'uom': 'ea', 'lead_time_days': 4, 'cost': 0, 'suppliers': []},
+        {'id': 'C1', 'rev': 'A', 'type': 'component', 'uom': 'ea', 'lead_time_days': 2, 'cost': 0, 'suppliers': []},
+    ]
+    boms = [
+        {'item_id': 'A', 'rev': 'A', 'lines': [{'component_id': 'C1', 'qty': 2}]}
+    ]
+    (mrp.ITEMS_PATH).write_text(json.dumps(items), encoding='utf-8')
+    (mrp.BOMS_PATH).write_text(json.dumps(boms), encoding='utf-8')
+
+    # ensure PLM cache does not interfere with catalog fallback
+    bom._BOMS = []
+
     out = mrp.plan(str(dem), str(inv), str(pos))
     assert 'A' in out and out['A']['planned_qty'] == 2
     assert 'B' not in out
-    assert os.path.exists(os.path.join(mrp.ART_DIR, 'plan.json'))
+    assert out['A']['release_day_offset'] == 4
+    assert os.path.exists(art_dir / 'plan.json')
+    kitting_path = art_dir / 'kitting_A.csv'
+    assert kitting_path.exists()
+    assert 'C1' in kitting_path.read_text()

--- a/tests/plm_mfg/test_routing_cap.py
+++ b/tests/plm_mfg/test_routing_cap.py
@@ -1,7 +1,21 @@
 from mfg import routing
 
-def test_cap_math():
-    routing.WC_DB={'W':{'capacity_per_shift':60,'cost_rate':30,'name':'W','skills':[]}}
-    routing.ROUT_DB={'X_A':{'steps':[{'wc':'W','op':'OP','std_time_min':3.0}]}}
-    out = routing.capcheck('X','A', qty=10)
-    assert 'theoretical_labor_cost' in out
+
+def test_cap_math(tmp_path, monkeypatch):
+    art_dir = tmp_path / "routing"
+    monkeypatch.setattr(routing, 'ART_DIR', art_dir)
+    monkeypatch.setattr(routing, 'WC_PATH', art_dir / 'work_centers.json')
+    monkeypatch.setattr(routing, 'ROUTINGS_PATH', art_dir / 'routings.json')
+
+    wc_csv = tmp_path / 'work_centers.csv'
+    wc_csv.write_text('id,name,capacity_per_shift,cost_rate\nW,Assembly,60,30\n')
+    routing.load_work_centers(str(wc_csv))
+
+    rout_dir = tmp_path / 'routings'
+    rout_dir.mkdir()
+    (rout_dir / 'X_A.yaml').write_text('item: X\nrev: A\nsteps:\n  - wc: W\n    op: OP\n    std_time_min: 3\n')
+    routing.load_routings(str(rout_dir))
+
+    out = routing.capcheck('X', 'A', qty=10)
+    assert out['work_centers']['W']['required_minutes'] == 30.0
+    assert (art_dir / 'capcheck_X_A.json').exists()

--- a/tests/plm_mfg/test_spc.py
+++ b/tests/plm_mfg/test_spc.py
@@ -1,7 +1,13 @@
 from mfg import spc
 
-def test_stdev_and_rules():
-    xs = [1.0]*7 + [5.0]
+
+def test_stdev_and_rules(tmp_path, monkeypatch):
+    xs = [1.0] * 7 + [5.0]
     m = spc._mean(xs)
     s = spc._stdev(xs)
-    assert s > 0 and (xs[-1] > m + 3*s) is False
+    assert s > 0 and (xs[-1] > m + 3 * s) is False
+
+    monkeypatch.setattr(spc, 'ART_DIR', tmp_path)
+    report = spc.analyze('OP-200', 10, csv_dir='fixtures/mfg/spc')
+    assert 'findings' in report
+    assert (tmp_path / 'findings.json').exists()

--- a/tests/plm_mfg/test_wi.py
+++ b/tests/plm_mfg/test_wi.py
@@ -1,8 +1,20 @@
-from mfg import work_instructions as wi
 import os
+from pathlib import Path
+
+import pytest
+
+from mfg import routing, work_instructions as wi
+
 
 def test_wi_paths(tmp_path, monkeypatch):
-    monkeypatch.setattr(wi, 'ART_DIR', str(tmp_path))
-    wi.render('ITEM','A', None)
-    assert os.path.exists(os.path.join(tmp_path,'ITEM_A.md'))
-    assert os.path.exists(os.path.join(tmp_path,'ITEM_A.html'))
+    monkeypatch.setattr(wi, 'ART_DIR', tmp_path)
+    routing.ROUT_DB = {'ITEM_A': {'item': 'ITEM', 'rev': 'A', 'steps': [{'wc': 'WC', 'op': 'OP'}]}}
+    wi.render('ITEM', 'A')
+    assert os.path.exists(tmp_path / 'ITEM_A.md')
+    assert os.path.exists(tmp_path / 'ITEM_A.html')
+
+
+def test_wi_revision_gate(monkeypatch):
+    monkeypatch.setattr(wi, 'ART_DIR', Path('.'))
+    with pytest.raises(SystemExit):
+        wi.render('ITEM', 'B', {'item': 'ITEM', 'rev': 'C', 'steps': []})


### PR DESCRIPTION
## Summary
- expand the PLM item/BOM loaders with CLI entrypoints and deterministic artifacts
- add ECO impact analysis plus duty-of-care gating for releases
- extend manufacturing routing, work instructions, SPC, and MRP flows with docs and tests

## Testing
- pytest tests/plm_mfg -q

------
https://chatgpt.com/codex/tasks/task_e_690a85a34df483299f2cb1f2f8eed018