### PR TITLE
Add Everything Cipher reference utilities

### DIFF
--- a/tools/everything_cipher.py
+++ b/tools/everything_cipher.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Reference implementation of the Everything Cipher (v1).
+
+This script provides both library-style helpers and a simple CLI for
+encrypting/decrypting byte streams using the "Everything Cipher" recipe. It
+implements Argon2id for passphrase stretching, HKDF for domain-separated key
+material, and AES-256-GCM for authenticated encryption.  The context label is
+bound as AEAD associated data to enforce the "Peter Panda" lock described in
+internal security notes.
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import getpass
+import os
+import sys
+from dataclasses import dataclass
+from typing import Dict
+
+from argon2.low_level import Type as Argon2Type
+from argon2.low_level import hash_secret_raw
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+# ---- Tunable parameters ----------------------------------------------------
+
+ARGON2_MEMORY_MB = 64
+ARGON2_TIME = 3
+ARGON2_PARALLELISM = 1
+AAD = b"Peter Panda Dance v1"
+HKDF_INFO_CONTENT = b"EV1/aes-gcm/content"
+HEADER_VERSION = "EV1"
+KDF_NAME = "argon2id"
+
+
+def _b64e(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode("utf-8").rstrip("=")
+
+
+def _b64d(data: str) -> bytes:
+    padding = "=" * (-len(data) % 4)
+    return base64.urlsafe_b64decode(data + padding)
+
+
+@dataclass
+class CipherParams:
+    argon2_memory_mb: int
+    argon2_time: int
+    argon2_parallelism: int
+    salt: bytes
+    hkdf_salt: bytes
+    nonce: bytes
+    ciphertext: bytes
+
+    def header_tokens(self) -> Dict[str, str]:
+        return {
+            "kdf": KDF_NAME,
+            "argon2_params": f"m={self.argon2_memory_mb}MB,t={self.argon2_time},p={self.argon2_parallelism}",
+            "salt": _b64e(self.salt),
+            "hkdf_salt": _b64e(self.hkdf_salt),
+            "nonce": _b64e(self.nonce),
+            "ct": _b64e(self.ciphertext),
+        }
+
+
+def _derive_root_key(passphrase: str, salt: bytes) -> bytes:
+    return hash_secret_raw(
+        secret=passphrase.encode("utf-8"),
+        salt=salt,
+        time_cost=ARGON2_TIME,
+        memory_cost=ARGON2_MEMORY_MB * 1024,
+        parallelism=ARGON2_PARALLELISM,
+        hash_len=32,
+        type=Argon2Type.ID,
+        version=19,
+    )
+
+
+def _derive_encryption_key(root_key: bytes, hkdf_salt: bytes) -> bytes:
+    hkdf = HKDF(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=hkdf_salt,
+        info=HKDF_INFO_CONTENT,
+    )
+    return hkdf.derive(root_key)
+
+
+def encrypt(plaintext: bytes, passphrase: str) -> str:
+    salt = os.urandom(16)
+    hkdf_salt = os.urandom(16)
+    nonce = os.urandom(12)
+
+    root_key = _derive_root_key(passphrase, salt)
+    enc_key = _derive_encryption_key(root_key, hkdf_salt)
+
+    aes = AESGCM(enc_key)
+    ciphertext = aes.encrypt(nonce, plaintext, AAD)
+
+    params = CipherParams(
+        argon2_memory_mb=ARGON2_MEMORY_MB,
+        argon2_time=ARGON2_TIME,
+        argon2_parallelism=ARGON2_PARALLELISM,
+        salt=salt,
+        hkdf_salt=hkdf_salt,
+        nonce=nonce,
+        ciphertext=ciphertext,
+    )
+
+    header = params.header_tokens()
+    tokens = [HEADER_VERSION, f"kdf={KDF_NAME}", header["argon2_params"]]
+    for key in ("salt", "hkdf_salt", "nonce", "ct"):
+        tokens.append(f"{key}={header[key]}")
+    return "|".join(tokens)
+
+
+def _parse_header(blob: str) -> Dict[str, str]:
+    tokens = blob.split("|")
+    if len(tokens) < 7 or tokens[0] != HEADER_VERSION:
+        raise ValueError("Unsupported or corrupted Everything Cipher header")
+
+    params: Dict[str, str] = {}
+    for token in tokens[1:]:
+        if token.startswith("m="):
+            params["argon2_params"] = token
+            continue
+        if "=" not in token:
+            raise ValueError("Malformed header token")
+        key, value = token.split("=", 1)
+        params[key] = value
+    return params
+
+
+def decrypt(blob: str, passphrase: str) -> bytes:
+    params = _parse_header(blob)
+    if params.get("kdf") != KDF_NAME:
+        raise ValueError("Unsupported KDF declared in header")
+
+    salt = _b64d(params["salt"])
+    hkdf_salt = _b64d(params["hkdf_salt"])
+    nonce = _b64d(params["nonce"])
+    ciphertext = _b64d(params["ct"])
+
+    root_key = _derive_root_key(passphrase, salt)
+    enc_key = _derive_encryption_key(root_key, hkdf_salt)
+
+    aes = AESGCM(enc_key)
+    return aes.decrypt(nonce, ciphertext, AAD)
+
+
+def _cli(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Everything Cipher (EV1)")
+    parser.add_argument("mode", choices=["enc", "dec"], help="encrypt or decrypt")
+    args = parser.parse_args(argv)
+
+    data = sys.stdin.buffer.read()
+    passphrase = getpass.getpass("Passphrase: ")
+
+    if args.mode == "enc":
+        blob = encrypt(data, passphrase)
+        sys.stdout.write(blob)
+    else:
+        plaintext = decrypt(data.decode("utf-8"), passphrase)
+        sys.stdout.buffer.write(plaintext)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_cli(sys.argv[1:]))

--- a/tools/everything_cipher_webcrypto.js
+++ b/tools/everything_cipher_webcrypto.js
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+/**
+ * Minimal Node/WebCrypto implementation of the Everything Cipher (v1).
+ *
+ * Dependencies:
+ *   npm install argon2
+ *
+ * Usage:
+ *   node tools/everything_cipher_webcrypto.js enc < secret.txt > secret.ev1
+ *   node tools/everything_cipher_webcrypto.js dec < secret.ev1 > plain.txt
+ */
+const { hkdfSync, randomBytes, webcrypto } = require('node:crypto');
+const { stdin: input, stdout: output, argv, exit } = require('node:process');
+const { Buffer } = require('node:buffer');
+const { createInterface } = require('node:readline/promises');
+const argon2 = require('argon2');
+
+const ARGON2_MEMORY_MB = 64;
+const ARGON2_TIME = 3;
+const ARGON2_PARALLELISM = 1;
+const AAD = new TextEncoder().encode('Peter Panda Dance v1');
+const HKDF_INFO_CONTENT = new TextEncoder().encode('EV1/aes-gcm/content');
+const HEADER_VERSION = 'EV1';
+const KDF_NAME = 'argon2id';
+
+function b64e(buf) {
+  return Buffer.from(buf).toString('base64url');
+}
+
+function b64d(str) {
+  return Buffer.from(str, 'base64url');
+}
+
+async function readStdin() {
+  const chunks = [];
+  for await (const chunk of input) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+  }
+  return Buffer.concat(chunks);
+}
+
+async function promptPassphrase() {
+  const rl = createInterface({ input: process.stdin, output: process.stderr, terminal: true });
+  rl.stdoutMuted = true;
+  rl._writeToOutput = function writeToOutput(stringToWrite) {
+    if (rl.stdoutMuted) {
+      if (stringToWrite.includes('\n')) {
+        rl.output.write('\n');
+      } else {
+        rl.output.write('*');
+      }
+    } else {
+      rl.output.write(stringToWrite);
+    }
+  };
+  try {
+    const answer = await rl.question('Passphrase: ');
+    rl.output.write('\n');
+    return answer;
+  } finally {
+    rl.stdoutMuted = false;
+    rl.close();
+  }
+}
+
+async function deriveRootKey(passphrase, salt) {
+  return argon2.hash(passphrase, {
+    type: argon2.argon2id,
+    salt,
+    raw: true,
+    hashLength: 32,
+    memoryCost: ARGON2_MEMORY_MB * 1024,
+    timeCost: ARGON2_TIME,
+    parallelism: ARGON2_PARALLELISM,
+    version: 0x13,
+  });
+}
+
+function hkdfSubkey(rootKey, hkdfSalt, info) {
+  return hkdfSync('sha256', rootKey, hkdfSalt, info, 32);
+}
+
+async function encryptBlob(plaintext, passphrase) {
+  const salt = randomBytes(16);
+  const hkdfSalt = randomBytes(16);
+  const nonce = randomBytes(12);
+
+  const rootKey = await deriveRootKey(passphrase, salt);
+  const encKey = hkdfSubkey(rootKey, hkdfSalt, HKDF_INFO_CONTENT);
+
+  const cipher = await webcrypto.subtle.importKey('raw', encKey, 'AES-GCM', false, ['encrypt']);
+  const ciphertext = new Uint8Array(
+    await webcrypto.subtle.encrypt({ name: 'AES-GCM', iv: nonce, additionalData: AAD }, cipher, plaintext)
+  );
+
+  const tokens = [
+    HEADER_VERSION,
+    `kdf=${KDF_NAME}`,
+    `m=${ARGON2_MEMORY_MB}MB,t=${ARGON2_TIME},p=${ARGON2_PARALLELISM}`,
+    `salt=${b64e(salt)}`,
+    `hkdf_salt=${b64e(hkdfSalt)}`,
+    `nonce=${b64e(nonce)}`,
+    `ct=${b64e(ciphertext)}`,
+  ];
+  return tokens.join('|');
+}
+
+async function decryptBlob(blob, passphrase) {
+  const tokens = blob.trim().split('|');
+  if (tokens.length < 7 || tokens[0] !== HEADER_VERSION) {
+    throw new Error('Unsupported or corrupted Everything Cipher header');
+  }
+  const params = {};
+  for (const token of tokens.slice(1)) {
+    if (token.startsWith('m=')) {
+      params.argon2_params = token;
+      continue;
+    }
+    const [key, value] = token.split('=');
+    params[key] = value;
+  }
+  if (params.kdf !== KDF_NAME) {
+    throw new Error('Unsupported KDF declared in header');
+  }
+
+  const salt = b64d(params.salt);
+  const hkdfSalt = b64d(params.hkdf_salt);
+  const nonce = b64d(params.nonce);
+  const ciphertext = b64d(params.ct);
+
+  const rootKey = await deriveRootKey(passphrase, salt);
+  const encKey = hkdfSubkey(rootKey, hkdfSalt, HKDF_INFO_CONTENT);
+  const key = await webcrypto.subtle.importKey('raw', encKey, 'AES-GCM', false, ['decrypt']);
+  const plaintext = await webcrypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: nonce, additionalData: AAD },
+    key,
+    ciphertext
+  );
+  return new Uint8Array(plaintext);
+}
+
+async function main() {
+  const [, , mode] = argv;
+  if (!['enc', 'dec'].includes(mode)) {
+    console.error('Usage: node tools/everything_cipher_webcrypto.js <enc|dec>');
+    exit(1);
+  }
+
+  const stdinData = await readStdin();
+  const passphrase = await promptPassphrase();
+
+  if (mode === 'enc') {
+    const blob = await encryptBlob(stdinData, passphrase);
+    output.write(blob);
+  } else {
+    const plaintext = await decryptBlob(stdinData.toString('utf8'), passphrase);
+    output.write(Buffer.from(plaintext));
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  exit(1);
+});


### PR DESCRIPTION
## Summary
- add a Python reference implementation of the Everything Cipher EV1 with CLI helpers
- add a Node/WebCrypto script that produces and consumes the same EV1 envelope

## Testing
- python -m compileall tools/everything_cipher.py
- node --check tools/everything_cipher_webcrypto.js

------
https://chatgpt.com/codex/tasks/task_e_690a8a1e6c308329af3656ff7e5ba8f3