### PR TITLE
Add AI provider health service and fallback routing

### DIFF
--- a/apps/web/app/api/ai/stream/route.ts
+++ b/apps/web/app/api/ai/stream/route.ts
@@ -6,6 +6,63 @@ const buckets = new Map<string, { count: number; reset: number }>();
 const LIMIT = 60;
 const WINDOW_MS = 60_000;
 
+const HEALTH_ENDPOINT = process.env.LLM_HEALTH_URL ?? '';
+const PRIMARY_PROVIDER_ID = process.env.PRIMARY_LLM_ID ?? 'openai-primary';
+const FALLBACK_PROVIDER_ID = process.env.FALLBACK_LLM_ID ?? 'azure-fallback';
+
+interface ProviderConfig {
+  id: string;
+  name: string;
+  baseUrl: string;
+  model: string;
+  apiKey: string;
+  authHeader: string;
+}
+
+interface ProviderHealthPayload {
+  state?: string;
+  fallback_ratio?: number;
+}
+
+interface ProviderSelection {
+  config: ProviderConfig;
+  usedFallback: boolean;
+  canAttemptFallback: boolean;
+  reason: string;
+  health: ProviderHealthPayload | null;
+}
+
+const providerStateCache = new Map<string, { expires: number; payload: ProviderHealthPayload | null }>();
+
+const primaryProvider: ProviderConfig = {
+  id: PRIMARY_PROVIDER_ID,
+  name: process.env.PRIMARY_LLM_PROVIDER ?? 'openai',
+  baseUrl: process.env.PRIMARY_LLM_BASE_URL ?? 'https://api.openai.com/v1/responses',
+  model: process.env.PRIMARY_LLM_MODEL ?? 'gpt-4o-mini',
+  apiKey: process.env.PRIMARY_LLM_API_KEY ?? process.env.OPENAI_API_KEY ?? '',
+  authHeader: process.env.PRIMARY_LLM_AUTH_HEADER ?? 'Authorization',
+};
+
+const fallbackProvider: ProviderConfig = {
+  id: FALLBACK_PROVIDER_ID,
+  name: process.env.FALLBACK_LLM_PROVIDER ?? 'azure-openai',
+  baseUrl:
+    process.env.FALLBACK_LLM_BASE_URL ??
+    process.env.FALLBACK_CANARY_URL ??
+    process.env.PRIMARY_LLM_BASE_URL ??
+    'https://api.openai.com/v1/responses',
+  model:
+    process.env.FALLBACK_LLM_MODEL ??
+    process.env.FALLBACK_MODEL ??
+    process.env.PRIMARY_LLM_MODEL ??
+    'gpt-4o-mini',
+  apiKey: process.env.FALLBACK_LLM_API_KEY ?? process.env.FALLBACK_API_KEY ?? '',
+  authHeader:
+    process.env.FALLBACK_LLM_AUTH_HEADER ??
+    process.env.PRIMARY_LLM_AUTH_HEADER ??
+    'Authorization',
+};
+
 export function rateLimit(key: string, limit: number = LIMIT) {
   const now = Date.now();
   const bucket = buckets.get(key);
@@ -27,6 +84,115 @@ interface RequestBody {
   messages: ChatMessage[];
   tools?: unknown[];
   system?: string;
+}
+
+async function fetchProviderHealth(providerId: string): Promise<ProviderHealthPayload | null> {
+  if (!HEALTH_ENDPOINT) return null;
+  const cached = providerStateCache.get(providerId);
+  const now = Date.now();
+  if (cached && cached.expires > now) {
+    return cached.payload;
+  }
+  try {
+    const response = await fetch(`${HEALTH_ENDPOINT.replace(/\/$/, '')}/providers/${providerId}`, {
+      cache: 'no-store',
+    });
+    const payload = (await response.json().catch(() => null)) as ProviderHealthPayload | null;
+    providerStateCache.set(providerId, { expires: now + 30_000, payload });
+    return payload;
+  } catch (error) {
+    providerStateCache.set(providerId, { expires: now + 30_000, payload: null });
+    return null;
+  }
+}
+
+function buildAuthHeader(headerName: string, token: string): string {
+  if (!token) return '';
+  if (headerName.toLowerCase() === 'authorization' && !token.toLowerCase().startsWith('bearer ')) {
+    return `Bearer ${token}`;
+  }
+  return token;
+}
+
+async function callProvider(
+  provider: ProviderConfig,
+  body: Record<string, unknown>,
+  signal: AbortSignal,
+): Promise<Response> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  if (provider.apiKey) {
+    const value = buildAuthHeader(provider.authHeader, provider.apiKey);
+    if (value) {
+      headers[provider.authHeader] = value;
+    }
+  }
+  headers['X-Prism-Upstream'] = provider.id;
+  const payload = { ...body, model: provider.model, stream: true };
+  return fetch(provider.baseUrl, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(payload),
+    signal,
+    cache: 'no-store',
+  });
+}
+
+function fallbackAvailable(): boolean {
+  return Boolean(fallbackProvider.apiKey && fallbackProvider.baseUrl);
+}
+
+async function chooseProvider(): Promise<ProviderSelection> {
+  const availableFallback = fallbackAvailable();
+  const health = await fetchProviderHealth(primaryProvider.id);
+  if (!health) {
+    return {
+      config: primaryProvider,
+      usedFallback: false,
+      canAttemptFallback: availableFallback,
+      reason: 'health_unavailable',
+      health: null,
+    };
+  }
+  const state = health.state ?? 'unknown';
+  if (state === 'red') {
+    if (availableFallback) {
+      return {
+        config: fallbackProvider,
+        usedFallback: true,
+        canAttemptFallback: false,
+        reason: 'health_red',
+        health,
+      };
+    }
+    return {
+      config: primaryProvider,
+      usedFallback: false,
+      canAttemptFallback: false,
+      reason: 'health_red_no_fallback',
+      health,
+    };
+  }
+  const ratio = typeof health.fallback_ratio === 'number' ? Math.min(Math.max(health.fallback_ratio, 0), 1) : 0;
+  if (ratio > 0 && availableFallback) {
+    if (Math.random() < ratio) {
+      return {
+        config: fallbackProvider,
+        usedFallback: true,
+        canAttemptFallback: false,
+        reason: 'half_open',
+        health,
+      };
+    }
+  }
+  return {
+    config: primaryProvider,
+    usedFallback: false,
+    canAttemptFallback: availableFallback,
+    reason: state,
+    health,
+  };
 }
 
 export async function POST(req: Request) {
@@ -56,28 +222,43 @@ export async function POST(req: Request) {
     );
   }
 
+  const payload = {
+    messages,
+    tools,
+    system,
+  };
+
+  const selection = await chooseProvider();
   const controller = new AbortController();
+  let activeProvider = selection.config;
+  let activeController = controller;
+  let upstream = await callProvider(activeProvider, payload, controller.signal);
 
-  const upstream = await fetch('https://api.openai.com/v1/responses', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${process.env.OPENAI_API_KEY ?? ''}`,
-    },
-    body: JSON.stringify({
-      model: 'gpt-4o-mini',
-      stream: true,
-      messages,
-      tools,
-      system,
-    }),
-    signal: controller.signal,
-  });
-
-  if (!upstream.ok || !upstream.body) {
+  if ((!upstream.ok || !upstream.body) && selection.canAttemptFallback) {
+    const fallbackController = new AbortController();
+    const fallbackResponse = await callProvider(fallbackProvider, payload, fallbackController.signal);
+    if (fallbackResponse.ok && fallbackResponse.body) {
+      activeProvider = fallbackProvider;
+      activeController = fallbackController;
+      upstream = fallbackResponse;
+    } else {
+      const errText = await fallbackResponse.text();
+      return new Response(errText || fallbackResponse.statusText, {
+        status: fallbackResponse.status,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+  } else if ((!upstream.ok || !upstream.body) && selection.usedFallback) {
     const err = await upstream.text();
     return new Response(err || upstream.statusText, {
       status: upstream.status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  if (!upstream.body) {
+    return new Response(JSON.stringify({ error: 'upstream_stream_missing' }), {
+      status: 502,
       headers: { 'Content-Type': 'application/json' },
     });
   }
@@ -98,17 +279,21 @@ export async function POST(req: Request) {
       push();
     },
     cancel() {
-      controller.abort();
+      activeController.abort();
     },
   });
 
-  return new Response(stream, {
-    headers: {
-      'Content-Type': 'text/event-stream',
-      'Cache-Control': 'no-cache, no-transform',
-      Connection: 'keep-alive',
-    },
+  const responseHeaders = new Headers({
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache, no-transform',
+    Connection: 'keep-alive',
   });
+  responseHeaders.set('X-Upstream-Provider', activeProvider.id);
+  responseHeaders.set('X-Upstream-Reason', selection.reason);
+  if (selection.health?.state) {
+    responseHeaders.set('X-Upstream-State', selection.health.state);
+  }
+  return new Response(stream, { headers: responseHeaders });
 }
 
 /* Example client usage:

--- a/configs/aiops/providers.yaml
+++ b/configs/aiops/providers.yaml
@@ -1,0 +1,56 @@
+# Provider definitions for AI canary probes and health classification.
+#
+# Each provider includes the HTTP request template used by the minute canary,
+# SLO expectations for the rolling 5 minute window, and the fallback mapping
+# consumed by the gateway circuit breaker.
+providers:
+  - name: openai-primary
+    description: "Primary OpenAI GPT-4o-mini deployment"
+    canary:
+      url: "https://api.openai.com/v1/chat/completions"
+      method: POST
+      timeout_seconds: 10
+      headers:
+        Authorization: "Bearer ${OPENAI_API_KEY}"
+        Content-Type: "application/json"
+      body:
+        model: "gpt-4o-mini"
+        max_tokens: 8
+        messages:
+          - role: "user"
+            content: "BlackRoad Prism sentinel ping"
+    expectations:
+      max_tokens: 32
+      max_latency_ms: 1200
+    slo:
+      p95_ms: 1200
+      error_rate: 0.02
+      amber_error_rate: 0.05
+      minimum_samples: 20
+      half_open_ratio: 0.2
+    fallback: azure-fallback
+  - name: azure-fallback
+    description: "Fallback Azure-hosted GPT-4o-mini deployment"
+    canary:
+      url: "${FALLBACK_CANARY_URL}"
+      method: POST
+      timeout_seconds: 10
+      headers:
+        Authorization: "Bearer ${FALLBACK_API_KEY}"
+        Content-Type: "application/json"
+      body:
+        model: "${FALLBACK_MODEL}"
+        max_tokens: 8
+        messages:
+          - role: "user"
+            content: "BlackRoad Prism sentinel ping"
+    expectations:
+      max_tokens: 32
+      max_latency_ms: 1500
+    slo:
+      p95_ms: 1500
+      error_rate: 0.03
+      amber_error_rate: 0.06
+      minimum_samples: 10
+      half_open_ratio: 0.5
+    fallback: null

--- a/k8s/model-health/cronjob.yaml
+++ b/k8s/model-health/cronjob.yaml
@@ -1,0 +1,38 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: model-provider-canary
+spec:
+  schedule: "*/1 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            job: model-provider-canary
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: canary
+              image: ghcr.io/blackroad/model-health:latest
+              imagePullPolicy: IfNotPresent
+              command: ["python", "/app/canary.py"]
+              env:
+                - name: PROVIDER_CONFIG_PATH
+                  value: /config/providers.yaml
+                - name: HEALTH_SINK_URL
+                  value: http://model-health:8080
+              volumeMounts:
+                - name: provider-config
+                  mountPath: /config
+                  readOnly: true
+          volumes:
+            - name: provider-config
+              configMap:
+                name: model-health-config
+                items:
+                  - key: providers.yaml
+                    path: providers.yaml

--- a/k8s/model-health/deployment.yaml
+++ b/k8s/model-health/deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: model-health
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: model-health
+  template:
+    metadata:
+      labels:
+        app: model-health
+    spec:
+      containers:
+        - name: api
+          image: ghcr.io/blackroad/model-health:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: PROVIDER_CONFIG_PATH
+              value: /config/providers.yaml
+            - name: INCIDENT_LOG_PATH
+              value: /var/log/model-incidents.jsonl
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          volumeMounts:
+            - name: provider-config
+              mountPath: /config
+              readOnly: true
+            - name: incident-log
+              mountPath: /var/log
+      volumes:
+        - name: provider-config
+          configMap:
+            name: model-health-config
+            items:
+              - key: providers.yaml
+                path: providers.yaml
+        - name: incident-log
+          emptyDir: {}

--- a/k8s/model-health/kustomization.yaml
+++ b/k8s/model-health/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: prism-ops
+resources:
+  - deployment.yaml
+  - service.yaml
+  - cronjob.yaml
+configMapGenerator:
+  - name: model-health-config
+    files:
+      - providers.yaml=../../configs/aiops/providers.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/k8s/model-health/service.yaml
+++ b/k8s/model-health/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: model-health
+spec:
+  selector:
+    app: model-health
+  ports:
+    - port: 8080
+      targetPort: 8080
+      name: http

--- a/services/model-health/Dockerfile
+++ b/services/model-health/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
+WORKDIR /app
+
+COPY requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+COPY canary.py ./canary.py
+
+EXPOSE 8080
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/services/model-health/README.md
+++ b/services/model-health/README.md
@@ -1,0 +1,48 @@
+# Model Health Service
+
+This service provides a centralized `/healthz` endpoint and incident log for the
+LLM providers that power Prism. It ingests minute-level canary samples, computes
+rolling five minute SLOs (error rate, p95 latency, timeout rate), and recommends
+fallback ratios for the API gateway when the primary provider degrades.
+
+## Features
+
+- **/samples** — ingest canary results (`provider`, `latency_ms`, `code`,
+  `ok`, `tokens`). Samples older than five minutes are discarded automatically.
+- **/healthz** — aggregate red/amber/green classification with JSON details for
+  dashboards and Kubernetes probes. Returns HTTP 503 while red.
+- **/providers/{name}** — provider-level health snapshot including recommended
+  fallback ratio.
+- **/config** — exposes currently loaded SLO and expectation metadata.
+- **Incident logging** — transitions to `red` append an incident record to
+  `${INCIDENT_LOG_PATH:-/var/log/model-incidents.jsonl}`; resolutions append a
+  matching `resolve` entry with duration.
+
+## Configuration
+
+The service expects `PROVIDER_CONFIG_PATH` (default `/config/providers.yaml`) to
+point at a configuration file that matches `configs/aiops/providers.yaml` in this
+repository. Mount the same file into the canary CronJob so both components stay
+in sync.
+
+Environment variables:
+
+| Variable | Purpose |
+| --- | --- |
+| `PROVIDER_CONFIG_PATH` | Location of the provider config file (YAML). |
+| `INCIDENT_LOG_PATH` | Optional path for JSONL incident log output. |
+
+## Development
+
+```bash
+pip install -r services/model-health/requirements.txt
+uvicorn services.model-health.app.main:app --reload --port 8080
+```
+
+Run the bundled canary locally (requires provider credentials):
+
+```bash
+PROVIDER_CONFIG_PATH=configs/aiops/providers.yaml \
+HEALTH_SINK_URL=http://127.0.0.1:8080 \
+python services/model-health/canary.py
+```

--- a/services/model-health/app/__init__.py
+++ b/services/model-health/app/__init__.py
@@ -1,0 +1,1 @@
+"""Model health service."""

--- a/services/model-health/app/main.py
+++ b/services/model-health/app/main.py
@@ -1,0 +1,357 @@
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import yaml
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field, ValidationError
+
+WINDOW_SECONDS = 5 * 60
+
+
+def _determine_config_path() -> Path:
+    env_path = os.getenv("PROVIDER_CONFIG_PATH")
+    if env_path:
+        path = Path(env_path)
+        if path.exists():
+            return path
+    default = Path("/config/providers.yaml")
+    if default.exists():
+        return default
+    fallback = Path(__file__).resolve().parents[3] / "configs" / "aiops" / "providers.yaml"
+    return fallback
+
+
+CONFIG_PATH = _determine_config_path()
+INCIDENT_LOG_PATH = Path(os.getenv("INCIDENT_LOG_PATH", "/var/log/model-incidents.jsonl"))
+
+
+class SamplePayload(BaseModel):
+    provider: str
+    latency_ms: int = Field(..., ge=0)
+    code: int
+    ok: bool
+    tokens: Optional[int] = Field(default=None, ge=0)
+    timestamp: Optional[float] = None
+
+
+class CanaryConfig(BaseModel):
+    url: Optional[str]
+    method: str = "POST"
+    timeout_seconds: int = 10
+    headers: Dict[str, str] = Field(default_factory=dict)
+    body: Dict[str, Any] = Field(default_factory=dict)
+
+
+class ExpectationConfig(BaseModel):
+    max_tokens: int = 32
+    max_latency_ms: int = 1200
+
+
+class SLOConfig(BaseModel):
+    p95_ms: int = 1200
+    error_rate: float = 0.02
+    amber_error_rate: float = 0.05
+    minimum_samples: int = 20
+    half_open_ratio: float = 0.2
+
+    def normalized_half_open_ratio(self) -> float:
+        if self.half_open_ratio < 0:
+            return 0.0
+        if self.half_open_ratio > 1:
+            return 1.0
+        return self.half_open_ratio
+
+
+class ProviderSpec(BaseModel):
+    name: str
+    description: Optional[str] = None
+    canary: CanaryConfig
+    expectations: ExpectationConfig = ExpectationConfig()
+    slo: SLOConfig = SLOConfig()
+    fallback: Optional[str] = None
+
+
+@dataclass
+class ProviderHealth:
+    provider: str
+    state: str
+    p95_ms: float
+    error_rate: float
+    timeout_rate: float
+    sample_count: int
+    reason: str
+    fallback: Optional[str]
+    fallback_ratio: float
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "provider": self.provider,
+            "state": self.state,
+            "p95_ms": self.p95_ms,
+            "error_rate": self.error_rate,
+            "timeout_rate": self.timeout_rate,
+            "samples": self.sample_count,
+            "reason": self.reason,
+            "fallback": self.fallback,
+            "fallback_ratio": self.fallback_ratio,
+        }
+
+
+class _ConfigState:
+    def __init__(self) -> None:
+        self._providers: Dict[str, ProviderSpec] = {}
+        self._lock = threading.Lock()
+        self.reload()
+
+    def reload(self) -> None:
+        if not CONFIG_PATH.exists():
+            raise FileNotFoundError(f"provider config not found at {CONFIG_PATH}")
+        with open(CONFIG_PATH, "r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+        providers: Dict[str, ProviderSpec] = {}
+        for raw in data.get("providers", []):
+            try:
+                spec = ProviderSpec(**raw)
+            except ValidationError as exc:  # pragma: no cover - config errors should surface loudly
+                raise ValueError(f"invalid provider config: {exc}") from exc
+            providers[spec.name] = spec
+        if not providers:
+            raise ValueError("no providers configured")
+        with self._lock:
+            self._providers = providers
+
+    def providers(self) -> Dict[str, ProviderSpec]:
+        with self._lock:
+            return dict(self._providers)
+
+    def get(self, name: str) -> ProviderSpec:
+        with self._lock:
+            spec = self._providers.get(name)
+        if not spec:
+            raise KeyError(name)
+        return spec
+
+
+class _HealthState:
+    def __init__(self) -> None:
+        self._samples: Dict[str, List[Dict[str, Any]]] = {}
+        self._health: Dict[str, ProviderHealth] = {}
+        self._lock = threading.Lock()
+        self._open_incidents: Dict[str, Dict[str, Any]] = {}
+
+    def add_sample(self, spec: ProviderSpec, payload: SamplePayload) -> ProviderHealth:
+        now = payload.timestamp or time.time()
+        record = {
+            "ts": now,
+            "latency_ms": payload.latency_ms,
+            "ok": bool(payload.ok),
+            "code": payload.code,
+            "tokens": payload.tokens,
+        }
+        with self._lock:
+            bucket = self._samples.setdefault(spec.name, [])
+            bucket.append(record)
+            health = self._classify(spec, now)
+            self._health[spec.name] = health
+            self._manage_incidents(spec, health, now)
+            return health
+
+    def _purge(self, provider: str, now: float) -> List[Dict[str, Any]]:
+        bucket = self._samples.get(provider, [])
+        if not bucket:
+            return []
+        cutoff = now - WINDOW_SECONDS
+        filtered = [row for row in bucket if row["ts"] >= cutoff]
+        self._samples[provider] = filtered
+        return filtered
+
+    def _classify(self, spec: ProviderSpec, now: float) -> ProviderHealth:
+        samples = self._purge(spec.name, now)
+        sample_count = len(samples)
+        if sample_count == 0:
+            return ProviderHealth(
+                provider=spec.name,
+                state="amber",
+                p95_ms=0.0,
+                error_rate=0.0,
+                timeout_rate=0.0,
+                sample_count=0,
+                reason="no_data",
+                fallback=spec.fallback,
+                fallback_ratio=spec.slo.normalized_half_open_ratio(),
+            )
+        latencies = sorted(row["latency_ms"] for row in samples)
+        percentile_index = max(int(0.95 * len(latencies)) - 1, 0)
+        p95 = float(latencies[percentile_index])
+        errors = sum(1 for row in samples if not row["ok"])
+        error_rate = errors / sample_count
+        timeouts = sum(1 for row in samples if row["latency_ms"] >= spec.expectations.max_latency_ms)
+        timeout_rate = timeouts / sample_count
+        state = "green"
+        reason = "healthy"
+        if sample_count < spec.slo.minimum_samples:
+            state = "amber"
+            reason = "insufficient_data"
+        elif error_rate > spec.slo.amber_error_rate or p95 > spec.slo.p95_ms * 1.5:
+            state = "red"
+            reason = "slo_exceeded"
+        elif error_rate > spec.slo.error_rate or p95 > spec.slo.p95_ms:
+            state = "amber"
+            reason = "approaching_limit"
+        fallback_ratio = 0.0
+        if state == "red":
+            fallback_ratio = 1.0
+        elif state == "amber":
+            fallback_ratio = spec.slo.normalized_half_open_ratio()
+        return ProviderHealth(
+            provider=spec.name,
+            state=state,
+            p95_ms=p95,
+            error_rate=round(error_rate, 4),
+            timeout_rate=round(timeout_rate, 4),
+            sample_count=sample_count,
+            reason=reason,
+            fallback=spec.fallback,
+            fallback_ratio=fallback_ratio,
+        )
+
+    def current(self, spec: ProviderSpec) -> ProviderHealth:
+        now = time.time()
+        with self._lock:
+            health = self._classify(spec, now)
+            self._health[spec.name] = health
+            return health
+
+    def snapshot(self) -> Dict[str, ProviderHealth]:
+        with self._lock:
+            return dict(self._health)
+
+    def _manage_incidents(self, spec: ProviderSpec, health: ProviderHealth, now: float) -> None:
+        previous = self._open_incidents.get(spec.name)
+        if health.state == "red":
+            if not previous:
+                incident = {
+                    "provider": spec.name,
+                    "opened_at": now,
+                    "fallback": spec.fallback,
+                    "reason": health.reason,
+                }
+                self._open_incidents[spec.name] = incident
+                _append_incident({
+                    "provider": spec.name,
+                    "event": "open",
+                    "state": "red",
+                    "opened_at": _iso(now),
+                    "fallback": spec.fallback,
+                    "reason": health.reason,
+                })
+        else:
+            if previous:
+                duration = max(now - previous["opened_at"], 0.0)
+                _append_incident({
+                    "provider": spec.name,
+                    "event": "resolve",
+                    "state": health.state,
+                    "opened_at": _iso(previous["opened_at"]),
+                    "resolved_at": _iso(now),
+                    "duration_seconds": round(duration, 2),
+                    "fallback": spec.fallback,
+                    "reason": health.reason,
+                })
+                self._open_incidents.pop(spec.name, None)
+
+
+def _iso(ts: float) -> str:
+    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+
+
+def _append_incident(payload: Dict[str, Any]) -> None:
+    try:
+        INCIDENT_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with open(INCIDENT_LOG_PATH, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(payload) + "\n")
+    except OSError:
+        # Logging should never break health evaluation.
+        pass
+
+
+_config = _ConfigState()
+_health = _HealthState()
+app = FastAPI(title="Model Health Service", version="1.0.0")
+
+
+@app.post("/samples")
+async def ingest_sample(payload: SamplePayload) -> JSONResponse:
+    try:
+        spec = _config.get(payload.provider)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="unknown_provider") from exc
+    health = _health.add_sample(spec, payload)
+    return JSONResponse({"provider": payload.provider, "health": health.to_dict()})
+
+
+@app.get("/providers")
+async def list_providers() -> Dict[str, Any]:
+    providers = _config.providers()
+    snapshot: Dict[str, Any] = {}
+    for name, spec in providers.items():
+        snapshot[name] = _health.current(spec).to_dict()
+    return {"providers": snapshot}
+
+
+@app.get("/providers/{provider}")
+async def provider_health(provider: str) -> JSONResponse:
+    try:
+        spec = _config.get(provider)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="unknown_provider") from exc
+    health = _health.current(spec)
+    status_code = 200 if health.state != "red" else 503
+    return JSONResponse(health.to_dict(), status_code=status_code)
+
+
+@app.get("/healthz")
+async def healthz() -> JSONResponse:
+    providers = _config.providers()
+    summary: Dict[str, Any] = {}
+    overall_state = "green"
+    for name, spec in providers.items():
+        health = _health.current(spec)
+        summary[name] = health.to_dict()
+        if health.state == "red":
+            overall_state = "red"
+        elif health.state == "amber" and overall_state == "green":
+            overall_state = "amber"
+    status_code = 200 if overall_state != "red" else 503
+    return JSONResponse({"state": overall_state, "providers": summary}, status_code=status_code)
+
+
+@app.post("/config/reload")
+async def reload_config() -> Dict[str, str]:
+    _config.reload()
+    return {"status": "ok"}
+
+
+@app.get("/config")
+async def config_snapshot() -> Dict[str, Any]:
+    providers = _config.providers()
+    return {
+        "providers": {
+            name: {
+                "description": spec.description,
+                "fallback": spec.fallback,
+                "slo": spec.slo.model_dump(),
+                "expectations": spec.expectations.model_dump(),
+            }
+            for name, spec in providers.items()
+        }
+    }

--- a/services/model-health/canary.py
+++ b/services/model-health/canary.py
@@ -1,0 +1,176 @@
+"""Minute interval provider canary."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import requests
+import yaml
+
+CONFIG_PATH = Path(os.getenv("PROVIDER_CONFIG_PATH", "/config/providers.yaml"))
+HEALTH_SINK_URL = os.getenv("HEALTH_SINK_URL")
+DEFAULT_MODEL = os.getenv("OPENAI_CANARY_MODEL", "gpt-4o-mini")
+
+_ENV_PATTERN = re.compile(r"\$\{([^}]+)\}")
+
+
+@dataclass
+class Provider:
+    name: str
+    request: Dict[str, Any]
+    expectations: Dict[str, Any]
+
+
+class ConfigurationError(RuntimeError):
+    """Raised when provider configuration is invalid."""
+
+
+def _resolve_env(value: Any) -> Any:
+    if isinstance(value, str):
+        def repl(match: re.Match[str]) -> str:
+            key = match.group(1)
+            return os.getenv(key, "")
+
+        return _ENV_PATTERN.sub(repl, value)
+    if isinstance(value, dict):
+        return {k: _resolve_env(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_resolve_env(item) for item in value]
+    return value
+
+
+def load_providers() -> List[Provider]:
+    if not CONFIG_PATH.exists():
+        raise ConfigurationError(f"Provider config not found at {CONFIG_PATH}")
+    with open(CONFIG_PATH, "r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+    providers: List[Provider] = []
+    for raw in data.get("providers", []):
+        name = raw.get("name")
+        canary = raw.get("canary", {})
+        expectations = raw.get("expectations", {})
+        if not name:
+            raise ConfigurationError("Provider entry missing name")
+        if "url" not in canary:
+            raise ConfigurationError(f"Provider '{name}' missing canary.url")
+        request = {
+            "url": canary.get("url"),
+            "method": (canary.get("method") or "POST").upper(),
+            "timeout": canary.get("timeout_seconds", 10),
+            "headers": canary.get("headers", {}),
+            "body": canary.get("body", {}),
+        }
+        providers.append(Provider(name=name, request=request, expectations=expectations))
+    if not providers:
+        raise ConfigurationError("No providers configured")
+    return providers
+
+
+def _tokens_from_response(payload: Dict[str, Any]) -> int:
+    usage = payload.get("usage", {})
+    total = usage.get("total_tokens")
+    if isinstance(total, int):
+        return total
+    if isinstance(total, str) and total.isdigit():
+        return int(total)
+    return 0
+
+
+def _call_provider(provider: Provider) -> Dict[str, Any]:
+    req = _resolve_env(provider.request)
+    url = req.get("url")
+    if not url:
+        raise ConfigurationError(f"Provider '{provider.name}' url resolved to empty string")
+    method = req.get("method", "POST")
+    timeout = req.get("timeout", 10)
+    headers = req.get("headers", {})
+    body = req.get("body", {})
+    if not body.get("model"):
+        body["model"] = DEFAULT_MODEL
+    if "messages" not in body:
+        body["messages"] = [{"role": "user", "content": "BlackRoad Prism canary"}]
+    start = time.time()
+    response = requests.request(method, url, headers=headers, json=body, timeout=timeout)
+    elapsed_ms = int((time.time() - start) * 1000)
+    ok = response.status_code == 200
+    tokens = 0
+    details: Dict[str, Any] = {}
+    try:
+        payload = response.json()
+    except ValueError:
+        payload = {}
+    tokens = _tokens_from_response(payload)
+    expectations = provider.expectations
+    max_latency = expectations.get("max_latency_ms")
+    max_tokens = expectations.get("max_tokens")
+    if max_latency is not None:
+        ok = ok and elapsed_ms <= int(max_latency)
+    if max_tokens is not None:
+        ok = ok and tokens <= int(max_tokens)
+    details.update(payload if isinstance(payload, dict) else {})
+    return {
+        "provider": provider.name,
+        "status_code": response.status_code,
+        "latency_ms": elapsed_ms,
+        "ok": bool(ok),
+        "tokens": tokens,
+        "response": details,
+    }
+
+
+def _emit_sample(sample: Dict[str, Any]) -> None:
+    if not HEALTH_SINK_URL:
+        return
+    try:
+        requests.post(
+            HEALTH_SINK_URL.rstrip("/") + "/samples",
+            json={
+                "provider": sample["provider"],
+                "latency_ms": sample["latency_ms"],
+                "code": sample["status_code"],
+                "ok": sample["ok"],
+                "tokens": sample["tokens"],
+                "timestamp": time.time(),
+            },
+            timeout=5,
+        )
+    except requests.RequestException:
+        pass
+
+
+def main() -> int:
+    providers = load_providers()
+    results: List[Dict[str, Any]] = []
+    for provider in providers:
+        try:
+            outcome = _call_provider(provider)
+        except Exception as exc:  # pragma: no cover - surfaced in job logs
+            outcome = {
+                "provider": provider.name,
+                "status_code": 0,
+                "latency_ms": 0,
+                "ok": False,
+                "tokens": 0,
+                "error": str(exc),
+            }
+        results.append(outcome)
+        _emit_sample(outcome)
+    ts = int(time.time())
+    print(json.dumps({"ts": ts, "results": results}))
+    return 0 if all(item.get("ok") for item in results) else 2
+
+
+if __name__ == "__main__":
+    try:
+        exit_code = main()
+    except ConfigurationError as exc:
+        print(json.dumps({"ts": int(time.time()), "error": str(exc)}))
+        exit_code = 2
+    sys.exit(exit_code)

--- a/services/model-health/requirements.txt
+++ b/services/model-health/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.110.0
+uvicorn[standard]==0.27.1
+requests==2.32.3
+PyYAML==6.0.2


### PR DESCRIPTION
## Summary
- add a provider configuration and model-health FastAPI service that exposes /healthz classifications, incident logging, and provider snapshots
- add a minute-level canary CronJob plus kustomize manifests that share the provider config between the job and service
- update the edge stream route to consult the health service, apply a circuit breaker, and surface the active provider in response headers

## Testing
- python -m compileall services/model-health
- npm --prefix apps/web install *(fails: registry lacks @lucidia/core package)*

------
https://chatgpt.com/codex/tasks/task_e_690b8b7b3fe88329ac1dabb19394e2c8