### PR TITLE
Add Lucidia LLM resilience canary, healthwatch, and gateway

### DIFF
--- a/helm/prism-llm-resilience/Chart.yaml
+++ b/helm/prism-llm-resilience/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: prism-llm-resilience
+version: 0.1.0
+description: Canary, healthwatch, and circuit-breaker gateway for Lucidia LLM
+home: https://blackroad.io
+maintainers:
+  - name: Prism SRE
+    email: sre@blackroad.io
+keywords:
+  - lucidia
+  - prism
+  - resilience
+  - llm

--- a/helm/prism-llm-resilience/README.md
+++ b/helm/prism-llm-resilience/README.md
@@ -1,0 +1,14 @@
+# Prism LLM Resilience Chart
+
+Deploys the Lucidia canary CronJob, `llm-healthwatch` service, and the
+circuit-breaking `llm-gateway`.
+
+```bash
+helm upgrade --install llm-resilience ./helm/prism-llm-resilience \
+  --namespace prism --create-namespace
+```
+
+Values expose knobs for namespaces, replica counts, half-open ratios, and
+storage for the incident log. The CronJob mounts the `lucidia_llm_canary`
+script directly so updates stay in lock-step with the repo copy under
+`resilience/canary/`.

--- a/helm/prism-llm-resilience/files/lucidia_llm_canary.py
+++ b/helm/prism-llm-resilience/files/lucidia_llm_canary.py
@@ -1,0 +1,195 @@
+"""Lucidia LLM canary probe.
+
+This script pings the lightest-weight chat endpoint for each configured
+provider to detect outages or latency regressions before user traffic is
+impacted. It is tailored for the BlackRoad/Prism stack:
+
+* Primary provider – the in-cluster Lucidia LLM service (`llm.prism.svc`).
+* Fallback provider – the pre-approved secondary model (defaults to the
+  Qwen2 bridge exposed via `ollama-bridge.prism.svc`).
+
+The probe emits structured JSON so Loki/Cloud Logging can aggregate the
+results. When invoked inside the Kubernetes CronJob it also forwards the
+samples to the `llm-healthwatch` sidecar which maintains rolling SLOs for
+`/healthz`.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from dataclasses import dataclass
+from typing import Iterable, List, Mapping, MutableMapping
+
+import requests
+
+DEFAULT_EXPECTATIONS = {
+    "max_p95_ms": int(os.getenv("PRISM_LLM_CANARY_MAX_P95_MS", "1200")),
+    "max_tokens": int(os.getenv("PRISM_LLM_CANARY_MAX_TOKENS", "32")),
+}
+
+HEALTHWATCH_ENDPOINT = os.getenv(
+    "PRISM_LLM_HEALTHWATCH_URL", "http://llm-healthwatch.prism.svc.cluster.local:8080"
+)
+HEALTHWATCH_SAMPLES_PATH = os.getenv("PRISM_LLM_HEALTHWATCH_SAMPLES_PATH", "/samples")
+
+
+@dataclass(frozen=True)
+class Provider:
+    name: str
+    url: str
+    api_key: str | None = None
+    model: str = "lucidia"
+
+    @classmethod
+    def from_env(cls, name: str, prefix: str) -> "Provider":
+        base_url = os.getenv(f"{prefix}_URL")
+        if not base_url:
+            raise RuntimeError(f"Missing {prefix}_URL for provider '{name}'")
+        api_key = os.getenv(f"{prefix}_KEY")
+        model = os.getenv(f"{prefix}_MODEL", "lucidia")
+        return cls(name=name, url=base_url.rstrip("/"), api_key=api_key, model=model)
+
+
+def load_providers() -> List[Provider]:
+    providers: List[Provider] = []
+    mapping: MutableMapping[str, str] = {
+        "lucidia-primary": "PRISM_LUCIDIA_PRIMARY",
+        "lucidia-fallback": "PRISM_LUCIDIA_FALLBACK",
+    }
+    for name, prefix in mapping.items():
+        try:
+            providers.append(Provider.from_env(name, prefix))
+        except RuntimeError as exc:
+            raise RuntimeError(
+                f"Provider configuration error for {name}: {exc}.\n"
+                "Ensure the CronJob secret exposes env vars like PRISM_LUCIDIA_PRIMARY_URL."
+            ) from exc
+    extra_prefixes = os.getenv("PRISM_LLM_EXTRA_CANARY_PROVIDERS", "").split(",")
+    for entry in filter(None, (val.strip() for val in extra_prefixes)):
+        safe = entry.upper().replace("-", "_")
+        providers.append(Provider.from_env(entry, safe))
+    return providers
+
+
+def build_request(provider: Provider) -> Mapping[str, object]:
+    return {
+        "model": provider.model,
+        "messages": [
+            {
+                "role": "system",
+                "content": "You are Lucidia. Reply with the exact word 'pong'.",
+            },
+            {"role": "user", "content": "Ping?"},
+        ],
+        "max_tokens": 8,
+        "temperature": 0,
+        "stream": False,
+    }
+
+
+def call_provider(provider: Provider) -> Mapping[str, object]:
+    payload = build_request(provider)
+    headers = {"Content-Type": "application/json"}
+    if provider.api_key:
+        headers["Authorization"] = f"Bearer {provider.api_key}"
+
+    if provider.url.endswith("/v1/chat") or provider.url.endswith("/chat"):
+        request_url = provider.url
+    else:
+        request_url = f"{provider.url}/v1/chat"
+    started = time.perf_counter()
+    timed_out = False
+    try:
+        response = requests.post(request_url, headers=headers, json=payload, timeout=10)
+        latency_ms = int((time.perf_counter() - started) * 1000)
+        ok = response.status_code == 200
+        token_usage = 0
+        if ok:
+            data = response.json()
+            usage = data.get("usage") or {}
+            token_usage = int(usage.get("total_tokens", 0))
+            text = "".join(chunk.get("text", "") for chunk in data.get("choices", []))
+            if text.strip().lower() != "pong":
+                ok = False
+        else:
+            data = None
+    except (requests.Timeout, requests.ConnectionError):
+        latency_ms = int((time.perf_counter() - started) * 1000)
+        ok = False
+        data = None
+        response = None
+        timed_out = True
+        token_usage = 0
+
+    record = {
+        "provider": provider.name,
+        "model": provider.model,
+        "latency_ms": latency_ms,
+        "status_code": getattr(response, "status_code", 0),
+        "ok": ok and latency_ms < DEFAULT_EXPECTATIONS["max_p95_ms"] and token_usage <= DEFAULT_EXPECTATIONS["max_tokens"],
+        "timed_out": timed_out,
+        "token_usage": token_usage,
+    }
+    if data is not None:
+        record["raw"] = data
+    return record
+
+
+def push_samples(samples: Iterable[Mapping[str, object]]) -> None:
+    url = f"{HEALTHWATCH_ENDPOINT.rstrip('/')}{HEALTHWATCH_SAMPLES_PATH}"
+    try:
+        response = requests.post(url, json={"samples": list(samples)}, timeout=3)
+        if response.status_code >= 300:
+            print(
+                json.dumps(
+                    {
+                        "ts": int(time.time()),
+                        "component": "lucidia-canary",
+                        "level": "warn",
+                        "message": "failed to push samples to healthwatch",
+                        "status": response.status_code,
+                        "body": response.text,
+                    }
+                ),
+                file=sys.stderr,
+            )
+    except requests.RequestException as exc:
+        print(
+            json.dumps(
+                {
+                    "ts": int(time.time()),
+                    "component": "lucidia-canary",
+                    "level": "warn",
+                    "message": "exception while pushing samples",
+                    "error": str(exc),
+                }
+            ),
+            file=sys.stderr,
+        )
+
+
+
+def main() -> int:
+    try:
+        providers = load_providers()
+    except RuntimeError as exc:
+        print(json.dumps({"ts": int(time.time()), "component": "lucidia-canary", "error": str(exc)}))
+        return 2
+
+    samples = [call_provider(provider) for provider in providers]
+    push_samples(samples)
+
+    payload = {
+        "ts": int(time.time()),
+        "component": "lucidia-canary",
+        "results": samples,
+    }
+    print(json.dumps(payload))
+    overall_ok = all(sample.get("ok") for sample in samples)
+    return 0 if overall_ok else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/helm/prism-llm-resilience/templates/_helpers.tpl
+++ b/helm/prism-llm-resilience/templates/_helpers.tpl
@@ -1,0 +1,7 @@
+{{- define "prism-llm-resilience.canaryScript" -}}
+{{- $path := "files/lucidia_llm_canary.py" -}}
+{{- $lines := .Files.Get $path | splitList "\n" -}}
+{{- range $lines -}}
+{{ . | replace "\t" "    " }}
+{{ end -}}
+{{- end -}}

--- a/helm/prism-llm-resilience/templates/canary-configmap.yaml
+++ b/helm/prism-llm-resilience/templates/canary-configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lucidia-llm-canary
+  namespace: {{ .Values.namespace }}
+data:
+  canary.py: |
+{{ include "prism-llm-resilience.canaryScript" . | indent 4 }}

--- a/helm/prism-llm-resilience/templates/canary-cronjob.yaml
+++ b/helm/prism-llm-resilience/templates/canary-cronjob.yaml
@@ -1,0 +1,44 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: lucidia-llm-canary
+  namespace: {{ .Values.namespace }}
+spec:
+  schedule: {{ .Values.canary.schedule | quote }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: canary
+              image: {{ .Values.canary.image | quote }}
+              imagePullPolicy: IfNotPresent
+              command: ["python", "/app/canary.py"]
+              env:
+                - name: PRISM_LUCIDIA_PRIMARY_URL
+                  value: "http://llm.{{ .Values.namespace }}.svc.cluster.local:8000"
+                - name: PRISM_LUCIDIA_PRIMARY_MODEL
+                  value: "lucidia"
+                - name: PRISM_LUCIDIA_FALLBACK_URL
+                  value: "http://ollama-bridge.{{ .Values.namespace }}.svc.cluster.local:4010/api/chat"
+                - name: PRISM_LUCIDIA_FALLBACK_MODEL
+                  value: "lucidia"
+                - name: PRISM_LLM_CANARY_MAX_P95_MS
+                  value: {{ .Values.canary.expectations.maxP95Ms | quote }}
+                - name: PRISM_LLM_CANARY_MAX_TOKENS
+                  value: {{ .Values.canary.expectations.maxTokens | quote }}
+                - name: PRISM_LLM_HEALTHWATCH_URL
+                  value: "http://llm-healthwatch.{{ .Values.namespace }}.svc.cluster.local:8080"
+              envFrom: []
+              volumeMounts:
+                - name: canary-code
+                  mountPath: /app
+              resources: {{- toYaml .Values.canary.resources | nindent 16 }}
+          volumes:
+            - name: canary-code
+              configMap:
+                name: lucidia-llm-canary
+                items:
+                  - key: canary.py
+                    path: canary.py

--- a/helm/prism-llm-resilience/templates/gateway-deployment.yaml
+++ b/helm/prism-llm-resilience/templates/gateway-deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llm-gateway
+  namespace: {{ .Values.namespace }}
+spec:
+  replicas: {{ .Values.gateway.replicas }}
+  selector:
+    matchLabels:
+      app: llm-gateway
+  template:
+    metadata:
+      labels:
+        app: llm-gateway
+    spec:
+      containers:
+        - name: gateway
+          image: {{ .Values.image.gateway | quote }}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: HEALTH_ENDPOINT
+              value: "http://llm-healthwatch.{{ .Values.namespace }}.svc.cluster.local:8080/healthz"
+            - name: HALF_OPEN_RATIO
+              value: {{ .Values.gateway.halfOpenRatio | quote }}
+            - name: HALF_OPEN_SUCCESS_THRESHOLD
+              value: {{ .Values.gateway.halfOpenSuccesses | quote }}
+            - name: INCIDENT_LOG_PATH
+              value: /var/log/llm/incidents.jsonl
+          volumeMounts:
+            - name: incident-log
+              mountPath: /var/log/llm
+          ports:
+            - containerPort: 4010
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 4010
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 4010
+            periodSeconds: 30
+          resources: {{- toYaml .Values.gateway.resources | nindent 12 }}
+      volumes:
+        - name: incident-log
+          persistentVolumeClaim:
+            claimName: llm-gateway-incidents
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: llm-gateway
+  namespace: {{ .Values.namespace }}
+spec:
+  selector:
+    app: llm-gateway
+  ports:
+    - name: http
+      port: 4010
+      targetPort: 4010
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: llm-gateway-incidents
+  namespace: {{ .Values.namespace }}
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: {{ .Values.incidentLog.size }}
+{{- if .Values.incidentLog.storageClassName }}
+  storageClassName: {{ .Values.incidentLog.storageClassName }}
+{{- end }}

--- a/helm/prism-llm-resilience/templates/healthwatch-deployment.yaml
+++ b/helm/prism-llm-resilience/templates/healthwatch-deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llm-healthwatch
+  namespace: {{ .Values.namespace }}
+spec:
+  replicas: {{ .Values.healthwatch.replicas }}
+  selector:
+    matchLabels:
+      app: llm-healthwatch
+  template:
+    metadata:
+      labels:
+        app: llm-healthwatch
+    spec:
+      containers:
+        - name: healthwatch
+          image: {{ .Values.image.healthwatch | quote }}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: WINDOW_MS
+              value: "300000"
+            - name: P95_SLO_MS
+              value: "1200"
+            - name: ERROR_RATE_SLO
+              value: "0.02"
+            - name: ERROR_RATE_AMBER
+              value: "0.05"
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            periodSeconds: 30
+          resources: {{- toYaml .Values.healthwatch.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: llm-healthwatch
+  namespace: {{ .Values.namespace }}
+spec:
+  selector:
+    app: llm-healthwatch
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080

--- a/helm/prism-llm-resilience/values.yaml
+++ b/helm/prism-llm-resilience/values.yaml
@@ -1,0 +1,28 @@
+namespace: prism
+
+image:
+  healthwatch: ghcr.io/blackroad-prism/llm-healthwatch:latest
+  gateway: ghcr.io/blackroad-prism/llm-gateway:latest
+
+canary:
+  image: python:3.11-slim
+  schedule: "*/1 * * * *"
+  expectations:
+    maxP95Ms: 1200
+    maxTokens: 32
+  extraEnv: []
+  resources: {}
+
+healthwatch:
+  replicas: 1
+  resources: {}
+
+gateway:
+  replicas: 1
+  resources: {}
+  halfOpenRatio: 0.2
+  halfOpenSuccesses: 5
+
+incidentLog:
+  size: 1Gi
+  storageClassName: null

--- a/resilience/canary/README.md
+++ b/resilience/canary/README.md
@@ -1,0 +1,39 @@
+# Lucidia LLM Canary
+
+This probe exercises the lightest-weight chat path for the Lucidia model
+fleet. It mirrors the production wiring inside the Prism namespace and
+feeds the `/healthz` controller so we can alert or fail over before end
+users notice.
+
+## Providers
+
+By default the canary tests the following endpoints every minute:
+
+| Provider          | Env var prefix           | Default URL                                      | Notes |
+| ----------------- | ------------------------ | ------------------------------------------------ | ----- |
+| `lucidia-primary` | `PRISM_LUCIDIA_PRIMARY`  | `http://llm.prism.svc.cluster.local:8000`        | In-cluster Lucidia LLM |
+| `lucidia-fallback`| `PRISM_LUCIDIA_FALLBACK` | `http://ollama-bridge.prism.svc.cluster.local:4010` | Qwen2/Qwen2.5 bridge |
+
+Additional providers can be appended by setting
+`PRISM_LLM_EXTRA_CANARY_PROVIDERS` to a comma-separated list. For each
+entry `foo-bar` the script expects environment variables:
+`FOO_BAR_URL`, `FOO_BAR_KEY` (optional), and `FOO_BAR_MODEL` (optional).
+
+## Expectations
+
+The probe enforces the Lucidia SLO guardrails:
+
+- p95 latency under **1.2s** (`PRISM_LLM_CANARY_MAX_P95_MS`)
+- Total tokens under **32** (`PRISM_LLM_CANARY_MAX_TOKENS`)
+- HTTP `200` response with the literal payload `pong`
+
+Failures exit with code `2`, allowing Kubernetes Jobs and alerting to
+surface the regression immediately.
+
+## Healthwatch integration
+
+When the `PRISM_LLM_HEALTHWATCH_URL` variable is set (defaulting to the
+cluster service name) each run posts its samples to the
+`llm-healthwatch` sidecar via `POST /samples`. That service keeps a
+five-minute sliding window to drive the `/healthz` state machine and the
+circuit breaker controller.

--- a/resilience/canary/lucidia_llm_canary.py
+++ b/resilience/canary/lucidia_llm_canary.py
@@ -1,0 +1,195 @@
+"""Lucidia LLM canary probe.
+
+This script pings the lightest-weight chat endpoint for each configured
+provider to detect outages or latency regressions before user traffic is
+impacted. It is tailored for the BlackRoad/Prism stack:
+
+* Primary provider – the in-cluster Lucidia LLM service (`llm.prism.svc`).
+* Fallback provider – the pre-approved secondary model (defaults to the
+  Qwen2 bridge exposed via `ollama-bridge.prism.svc`).
+
+The probe emits structured JSON so Loki/Cloud Logging can aggregate the
+results. When invoked inside the Kubernetes CronJob it also forwards the
+samples to the `llm-healthwatch` sidecar which maintains rolling SLOs for
+`/healthz`.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from dataclasses import dataclass
+from typing import Iterable, List, Mapping, MutableMapping
+
+import requests
+
+DEFAULT_EXPECTATIONS = {
+    "max_p95_ms": int(os.getenv("PRISM_LLM_CANARY_MAX_P95_MS", "1200")),
+    "max_tokens": int(os.getenv("PRISM_LLM_CANARY_MAX_TOKENS", "32")),
+}
+
+HEALTHWATCH_ENDPOINT = os.getenv(
+    "PRISM_LLM_HEALTHWATCH_URL", "http://llm-healthwatch.prism.svc.cluster.local:8080"
+)
+HEALTHWATCH_SAMPLES_PATH = os.getenv("PRISM_LLM_HEALTHWATCH_SAMPLES_PATH", "/samples")
+
+
+@dataclass(frozen=True)
+class Provider:
+    name: str
+    url: str
+    api_key: str | None = None
+    model: str = "lucidia"
+
+    @classmethod
+    def from_env(cls, name: str, prefix: str) -> "Provider":
+        base_url = os.getenv(f"{prefix}_URL")
+        if not base_url:
+            raise RuntimeError(f"Missing {prefix}_URL for provider '{name}'")
+        api_key = os.getenv(f"{prefix}_KEY")
+        model = os.getenv(f"{prefix}_MODEL", "lucidia")
+        return cls(name=name, url=base_url.rstrip("/"), api_key=api_key, model=model)
+
+
+def load_providers() -> List[Provider]:
+    providers: List[Provider] = []
+    mapping: MutableMapping[str, str] = {
+        "lucidia-primary": "PRISM_LUCIDIA_PRIMARY",
+        "lucidia-fallback": "PRISM_LUCIDIA_FALLBACK",
+    }
+    for name, prefix in mapping.items():
+        try:
+            providers.append(Provider.from_env(name, prefix))
+        except RuntimeError as exc:
+            raise RuntimeError(
+                f"Provider configuration error for {name}: {exc}.\n"
+                "Ensure the CronJob secret exposes env vars like PRISM_LUCIDIA_PRIMARY_URL."
+            ) from exc
+    extra_prefixes = os.getenv("PRISM_LLM_EXTRA_CANARY_PROVIDERS", "").split(",")
+    for entry in filter(None, (val.strip() for val in extra_prefixes)):
+        safe = entry.upper().replace("-", "_")
+        providers.append(Provider.from_env(entry, safe))
+    return providers
+
+
+def build_request(provider: Provider) -> Mapping[str, object]:
+    return {
+        "model": provider.model,
+        "messages": [
+            {
+                "role": "system",
+                "content": "You are Lucidia. Reply with the exact word 'pong'.",
+            },
+            {"role": "user", "content": "Ping?"},
+        ],
+        "max_tokens": 8,
+        "temperature": 0,
+        "stream": False,
+    }
+
+
+def call_provider(provider: Provider) -> Mapping[str, object]:
+    payload = build_request(provider)
+    headers = {"Content-Type": "application/json"}
+    if provider.api_key:
+        headers["Authorization"] = f"Bearer {provider.api_key}"
+
+    if provider.url.endswith("/v1/chat") or provider.url.endswith("/chat"):
+        request_url = provider.url
+    else:
+        request_url = f"{provider.url}/v1/chat"
+    started = time.perf_counter()
+    timed_out = False
+    try:
+        response = requests.post(request_url, headers=headers, json=payload, timeout=10)
+        latency_ms = int((time.perf_counter() - started) * 1000)
+        ok = response.status_code == 200
+        token_usage = 0
+        if ok:
+            data = response.json()
+            usage = data.get("usage") or {}
+            token_usage = int(usage.get("total_tokens", 0))
+            text = "".join(chunk.get("text", "") for chunk in data.get("choices", []))
+            if text.strip().lower() != "pong":
+                ok = False
+        else:
+            data = None
+    except (requests.Timeout, requests.ConnectionError):
+        latency_ms = int((time.perf_counter() - started) * 1000)
+        ok = False
+        data = None
+        response = None
+        timed_out = True
+        token_usage = 0
+
+    record = {
+        "provider": provider.name,
+        "model": provider.model,
+        "latency_ms": latency_ms,
+        "status_code": getattr(response, "status_code", 0),
+        "ok": ok and latency_ms < DEFAULT_EXPECTATIONS["max_p95_ms"] and token_usage <= DEFAULT_EXPECTATIONS["max_tokens"],
+        "timed_out": timed_out,
+        "token_usage": token_usage,
+    }
+    if data is not None:
+        record["raw"] = data
+    return record
+
+
+def push_samples(samples: Iterable[Mapping[str, object]]) -> None:
+    url = f"{HEALTHWATCH_ENDPOINT.rstrip('/')}{HEALTHWATCH_SAMPLES_PATH}"
+    try:
+        response = requests.post(url, json={"samples": list(samples)}, timeout=3)
+        if response.status_code >= 300:
+            print(
+                json.dumps(
+                    {
+                        "ts": int(time.time()),
+                        "component": "lucidia-canary",
+                        "level": "warn",
+                        "message": "failed to push samples to healthwatch",
+                        "status": response.status_code,
+                        "body": response.text,
+                    }
+                ),
+                file=sys.stderr,
+            )
+    except requests.RequestException as exc:
+        print(
+            json.dumps(
+                {
+                    "ts": int(time.time()),
+                    "component": "lucidia-canary",
+                    "level": "warn",
+                    "message": "exception while pushing samples",
+                    "error": str(exc),
+                }
+            ),
+            file=sys.stderr,
+        )
+
+
+
+def main() -> int:
+    try:
+        providers = load_providers()
+    except RuntimeError as exc:
+        print(json.dumps({"ts": int(time.time()), "component": "lucidia-canary", "error": str(exc)}))
+        return 2
+
+    samples = [call_provider(provider) for provider in providers]
+    push_samples(samples)
+
+    payload = {
+        "ts": int(time.time()),
+        "component": "lucidia-canary",
+        "results": samples,
+    }
+    print(json.dumps(payload))
+    overall_ok = all(sample.get("ok") for sample in samples)
+    return 0 if overall_ok else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/resilience/playbooks/llm_resilience_runbook.md
+++ b/resilience/playbooks/llm_resilience_runbook.md
@@ -1,0 +1,36 @@
+# Lucidia LLM Resilience Controls
+
+This runbook documents the canary, `/healthz` controller, and circuit
+breaker now shipping with Prism.
+
+## Canary probe
+
+- CronJob: `lucidia-llm-canary` (namespace `prism`)
+- Schedule: every minute
+- Script: `resilience/canary/lucidia_llm_canary.py`
+- Alerts: exits with code `2` on latency, token, or HTTP failures. Hook
+  the Job failure metric into Alertmanager to page on consecutive misses.
+
+## Healthwatch service
+
+- Deployment: `llm-healthwatch`
+- Metrics: `prism_llm_canary_requests_total`,
+  `prism_llm_canary_latency_ms`
+- `/healthz` returns `green|amber|red` + JSON metrics for dashboards.
+
+## Circuit breaker gateway
+
+- Deployment: `llm-gateway` (port `4010`)
+- Reads `/healthz` every 15s and flips between `closed → open → half-open`
+- Incident log: `/var/log/llm/incidents.jsonl` (PVC `llm-gateway-incidents`)
+- Update Nginx or API clients to call the gateway instead of the raw
+  Lucidia service for automatic failover.
+
+## Helm deployment
+
+```
+helm upgrade --install llm-resilience ./helm/prism-llm-resilience \
+  --namespace prism --create-namespace
+```
+
+Override `image.*` values with the published container tags from CI.

--- a/services/llm-gateway/Dockerfile
+++ b/services/llm-gateway/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install --production && npm cache clean --force
+COPY server.js ./
+EXPOSE 4010
+CMD ["node", "server.js"]

--- a/services/llm-gateway/README.md
+++ b/services/llm-gateway/README.md
@@ -1,0 +1,34 @@
+# LLM Gateway
+
+`llm-gateway` fronts Lucidia chat traffic with a circuit breaker that can
+shift requests to the approved fallback model when the `/healthz` signal
+turns red. It polls the `llm-healthwatch` service, logs incidents, and
+supports gradual recovery (half-open) before returning to steady state.
+
+## Behaviour
+
+1. `closed` — all traffic to the primary Lucidia deployment.
+2. `open` — all traffic to the fallback bridge when `/healthz` is red or
+   primary requests fail.
+3. `half-open` — while `/healthz` is amber, route a configurable fraction
+   back to the primary and close the incident after consecutive successes.
+
+Incidents append JSON lines to `INCIDENT_LOG_PATH` so ops can review the
+impact window and metrics.
+
+## Environment
+
+| Variable                         | Default                                                      | Description |
+| -------------------------------- | ------------------------------------------------------------ | ----------- |
+| `PORT`                           | `4010`                                                       | Listen port |
+| `PRIMARY_URL`                    | `http://llm.prism.svc.cluster.local:8000/v1/chat`            | Primary chat endpoint |
+| `FALLBACK_URL`                   | `http://ollama-bridge.prism.svc.cluster.local:4010/api/chat` | Fallback chat endpoint |
+| `HEALTH_ENDPOINT`                | `http://llm-healthwatch.prism.svc.cluster.local:8080/healthz`| Health source |
+| `HEALTH_INTERVAL_MS`             | `15000`                                                      | Poll cadence |
+| `HALF_OPEN_RATIO`                | `0.2`                                                        | Fraction of traffic retried on primary |
+| `HALF_OPEN_SUCCESS_THRESHOLD`    | `5`                                                          | Successes required before closing |
+| `REQUEST_TIMEOUT_MS`             | `15000`                                                      | Upstream timeout |
+| `INCIDENT_LOG_PATH`              | `/var/log/llm-incidents.jsonl`                               | Append-only log |
+
+Mount the incident log onto persistent storage (e.g., emptyDir + Fluent
+Bit tail) so postmortems capture every failover.

--- a/services/llm-gateway/package-lock.json
+++ b/services/llm-gateway/package-lock.json
@@ -1,0 +1,832 @@
+{
+  "name": "llm-gateway",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "llm-gateway",
+      "version": "0.1.0",
+      "dependencies": {
+        "express": "^4.19.2"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.13.0",
+        "raw-body": "2.5.2",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.3",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.7.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.3.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.13.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.19.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  }
+}

--- a/services/llm-gateway/package.json
+++ b/services/llm-gateway/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "llm-gateway",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2"
+  }
+}

--- a/services/llm-gateway/server.js
+++ b/services/llm-gateway/server.js
@@ -1,0 +1,199 @@
+import fs from 'fs';
+import { randomUUID } from 'crypto';
+import express from 'express';
+
+const PORT = process.env.PORT || 4010;
+const PRIMARY_URL = process.env.PRIMARY_URL || 'http://llm.prism.svc.cluster.local:8000/v1/chat';
+const FALLBACK_URL = process.env.FALLBACK_URL || 'http://ollama-bridge.prism.svc.cluster.local:4010/api/chat';
+const PRIMARY_TOKEN = process.env.PRIMARY_TOKEN;
+const FALLBACK_TOKEN = process.env.FALLBACK_TOKEN;
+const HEALTH_ENDPOINT = process.env.HEALTH_ENDPOINT || 'http://llm-healthwatch.prism.svc.cluster.local:8080/healthz';
+const HEALTH_INTERVAL_MS = Number(process.env.HEALTH_INTERVAL_MS ?? 15000);
+const HALF_OPEN_RATIO = Number(process.env.HALF_OPEN_RATIO ?? 0.2);
+const HALF_OPEN_SUCCESS_THRESHOLD = Number(process.env.HALF_OPEN_SUCCESS_THRESHOLD ?? 5);
+const REQUEST_TIMEOUT_MS = Number(process.env.REQUEST_TIMEOUT_MS ?? 15000);
+const INCIDENT_LOG_PATH = process.env.INCIDENT_LOG_PATH || '/var/log/llm-incidents.jsonl';
+
+const app = express();
+app.use(express.json({ limit: '1mb' }));
+
+const STATE = {
+  status: 'closed',
+  openedAt: null,
+  incidentId: null,
+  consecutivePrimarySuccesses: 0,
+};
+
+function appendIncident(entry) {
+  const line = `${JSON.stringify({ ts: new Date().toISOString(), ...entry })}\n`;
+  try {
+    fs.appendFileSync(INCIDENT_LOG_PATH, line, { encoding: 'utf8' });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn('[llm-gateway] failed to append incident log', err);
+  }
+}
+
+async function refreshHealth() {
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 3000);
+    const response = await fetch(HEALTH_ENDPOINT, { signal: controller.signal });
+    clearTimeout(timeout);
+    if (!response.ok) {
+      handleHealthState('red', { reason: `http_${response.status}` });
+      return;
+    }
+    const body = await response.json();
+    handleHealthState(body.state, body);
+  } catch (error) {
+    handleHealthState('red', { reason: 'health_fetch_failed', error: String(error?.message || error) });
+  }
+}
+
+function handleHealthState(newState, body = {}) {
+  const previous = STATE.status;
+  if (newState === 'red') {
+    if (previous !== 'open') {
+      STATE.status = 'open';
+      STATE.openedAt = Date.now();
+      STATE.consecutivePrimarySuccesses = 0;
+      STATE.incidentId = randomUUID();
+      appendIncident({
+        incident_id: STATE.incidentId,
+        event: 'opened',
+        reason: body.reason ?? 'red',
+        metrics: body.metrics ?? null,
+      });
+    }
+    return;
+  }
+  if (newState === 'amber') {
+    if (previous === 'open') {
+      STATE.status = 'half-open';
+      STATE.consecutivePrimarySuccesses = 0;
+      appendIncident({
+        incident_id: STATE.incidentId,
+        event: 'half_open',
+        reason: body.reason ?? 'amber',
+        metrics: body.metrics ?? null,
+      });
+    }
+    return;
+  }
+  if (newState === 'green' && previous !== 'closed') {
+    appendIncident({
+      incident_id: STATE.incidentId,
+      event: 'closed',
+      duration_ms: STATE.openedAt ? Date.now() - STATE.openedAt : null,
+      metrics: body.metrics ?? null,
+    });
+    STATE.status = 'closed';
+    STATE.openedAt = null;
+    STATE.incidentId = null;
+    STATE.consecutivePrimarySuccesses = 0;
+  }
+}
+
+async function forwardRequest(targetUrl, token, body) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetch(targetUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+    return response;
+  } catch (error) {
+    clearTimeout(timeout);
+    throw error;
+  }
+}
+
+function chooseTarget() {
+  if (STATE.status === 'open') return { url: FALLBACK_URL, token: FALLBACK_TOKEN, label: 'fallback' };
+  if (STATE.status === 'half-open') {
+    if (Math.random() < HALF_OPEN_RATIO) {
+      return { url: PRIMARY_URL, token: PRIMARY_TOKEN, label: 'primary' };
+    }
+    return { url: FALLBACK_URL, token: FALLBACK_TOKEN, label: 'fallback' };
+  }
+  return { url: PRIMARY_URL, token: PRIMARY_TOKEN, label: 'primary' };
+}
+
+async function handlePrimaryResult(ok) {
+  if (STATE.status === 'half-open' || STATE.status === 'open') {
+    if (ok) {
+      STATE.consecutivePrimarySuccesses += 1;
+      if (STATE.consecutivePrimarySuccesses >= HALF_OPEN_SUCCESS_THRESHOLD) {
+        handleHealthState('green', { reason: 'half_open_recovery' });
+      }
+    } else {
+      STATE.consecutivePrimarySuccesses = 0;
+      STATE.status = 'open';
+      if (!STATE.incidentId) {
+        STATE.incidentId = randomUUID();
+      }
+      appendIncident({
+        incident_id: STATE.incidentId,
+        event: 'reopened',
+        reason: 'half_open_failure',
+      });
+    }
+  } else if (!ok) {
+    handleHealthState('red', { reason: 'primary_request_failed' });
+  }
+}
+
+app.post('/v1/chat', async (req, res) => {
+  const target = chooseTarget();
+  try {
+    const response = await forwardRequest(target.url, target.token, req.body ?? {});
+    const text = await response.text();
+    const ok = response.ok;
+    if (target.label === 'primary') {
+      await handlePrimaryResult(ok);
+    }
+    const headers = Object.fromEntries(response.headers.entries());
+    if (headers['content-type']) {
+      res.set('Content-Type', headers['content-type']);
+    }
+    res.status(response.status).send(text);
+  } catch (error) {
+    if (target.label === 'primary') {
+      await handlePrimaryResult(false);
+      try {
+        const fallbackResponse = await forwardRequest(FALLBACK_URL, FALLBACK_TOKEN, req.body ?? {});
+        res.status(fallbackResponse.status).send(await fallbackResponse.text());
+        return;
+      } catch (fallbackError) {
+        res.status(503).json({ error: 'llm_unavailable', detail: String(fallbackError?.message || fallbackError) });
+        return;
+      }
+    }
+    res.status(503).json({ error: 'llm_unavailable', detail: String(error?.message || error) });
+  }
+});
+
+app.get('/healthz', (_req, res) => {
+  res.json({
+    status: STATE.status,
+    opened_at: STATE.openedAt ? new Date(STATE.openedAt).toISOString() : null,
+    half_open_ratio: STATE.status === 'half-open' ? HALF_OPEN_RATIO : 0,
+    incident_id: STATE.incidentId,
+  });
+});
+
+refreshHealth();
+setInterval(refreshHealth, HEALTH_INTERVAL_MS).unref();
+
+app.listen(PORT, () => {
+  // eslint-disable-next-line no-console
+  console.log(`[llm-gateway] listening on :${PORT}`);
+});

--- a/services/llm-healthwatch/Dockerfile
+++ b/services/llm-healthwatch/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install --production && npm cache clean --force
+COPY server.js ./
+EXPOSE 8080
+CMD ["node", "server.js"]

--- a/services/llm-healthwatch/README.md
+++ b/services/llm-healthwatch/README.md
@@ -1,0 +1,30 @@
+# LLM Healthwatch
+
+`llm-healthwatch` ingests Lucidia canary samples and exposes a unified
+`/healthz` endpoint for Kubernetes probes, dashboards, and automation.
+It computes rolling five-minute SLOs and exports Prometheus metrics for
+p95 latency, error rate, and timeouts.
+
+## Endpoints
+
+- `POST /samples` — accepts `{ "samples": [...] }` payloads from the
+  CronJob. Each sample should contain `provider`, `latency_ms`, `ok`, and
+  optional `status_code` / `timed_out` fields.
+- `GET /healthz` — returns `green|amber|red` and the computed window
+  metrics. Responds with HTTP `503` when **red** so K8s readiness probes
+  will hold traffic.
+- `GET /metrics` — Prometheus exposition with `prism_llm_canary_*`
+  series.
+
+## Configuration
+
+| Variable              | Default | Description |
+| --------------------- | ------- | ----------- |
+| `PORT`                | `8080`  | Listen port |
+| `WINDOW_MS`           | `300000`| Sliding window size |
+| `P95_SLO_MS`          | `1200`  | Target p95 latency |
+| `ERROR_RATE_SLO`      | `0.02`  | Error rate before amber |
+| `ERROR_RATE_AMBER`    | `0.05`  | Error rate triggering red |
+| `MIN_SAMPLE_COUNT`    | `20`    | Minimum samples required for green |
+
+Deploy via the Helm chart at `helm/prism-llm-resilience`.

--- a/services/llm-healthwatch/package-lock.json
+++ b/services/llm-healthwatch/package-lock.json
@@ -1,0 +1,870 @@
+{
+  "name": "llm-healthwatch",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "llm-healthwatch",
+      "version": "0.1.0",
+      "dependencies": {
+        "express": "^4.19.2",
+        "prom-client": "^15.1.3"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.13.0",
+        "raw-body": "2.5.2",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.3",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.7.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.3.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.13.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.19.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  }
+}

--- a/services/llm-healthwatch/package.json
+++ b/services/llm-healthwatch/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "llm-healthwatch",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "prom-client": "^15.1.3"
+  }
+}

--- a/services/llm-healthwatch/server.js
+++ b/services/llm-healthwatch/server.js
@@ -1,0 +1,112 @@
+import express from 'express';
+import promClient from 'prom-client';
+
+const PORT = process.env.PORT || 8080;
+const WINDOW_MS = Number(process.env.WINDOW_MS ?? 5 * 60 * 1000);
+const P95_SLO_MS = Number(process.env.P95_SLO_MS ?? 1200);
+const ERROR_RATE_SLO = Number(process.env.ERROR_RATE_SLO ?? 0.02);
+const ERROR_RATE_AMBER = Number(process.env.ERROR_RATE_AMBER ?? 0.05);
+const MIN_SAMPLE_COUNT = Number(process.env.MIN_SAMPLE_COUNT ?? 20);
+
+const app = express();
+app.use(express.json({ limit: '256kb' }));
+
+const metricsRegistry = new promClient.Registry();
+const requestCounter = new promClient.Counter({
+  name: 'prism_llm_canary_requests_total',
+  help: 'Total canary requests ingested by provider',
+  labelNames: ['provider', 'status'],
+});
+const latencyHistogram = new promClient.Histogram({
+  name: 'prism_llm_canary_latency_ms',
+  help: 'Latency histogram for canary calls (milliseconds)',
+  labelNames: ['provider'],
+  buckets: [100, 250, 500, 750, 1000, 1250, 1500, 2000, 5000],
+});
+metricsRegistry.registerMetric(requestCounter);
+metricsRegistry.registerMetric(latencyHistogram);
+promClient.collectDefaultMetrics({ register: metricsRegistry });
+
+let samples = [];
+
+function pruneSamples(now = Date.now()) {
+  samples = samples.filter((sample) => sample.ts >= now - WINDOW_MS);
+}
+
+function percentile(sortedNumbers, ratio) {
+  if (!sortedNumbers.length) return 0;
+  const index = Math.max(Math.ceil(sortedNumbers.length * ratio) - 1, 0);
+  return sortedNumbers[index];
+}
+
+function classifyWindow(now = Date.now()) {
+  pruneSamples(now);
+  if (samples.length < MIN_SAMPLE_COUNT) {
+    return { state: 'amber', reason: 'insufficient_data', sampleCount: samples.length };
+  }
+  const latencies = samples.map((sample) => sample.latency_ms).sort((a, b) => a - b);
+  const p95 = percentile(latencies, 0.95);
+  const errors = samples.filter((sample) => !sample.ok).length;
+  const errRate = errors / samples.length;
+  const timedOut = samples.filter((sample) => sample.timed_out).length / samples.length;
+
+  if (errRate > ERROR_RATE_AMBER || p95 > P95_SLO_MS * 1.5) {
+    return { state: 'red', p95, errRate, timeoutRate: timedOut, sampleCount: samples.length };
+  }
+  if (errRate > ERROR_RATE_SLO || p95 > P95_SLO_MS) {
+    return { state: 'amber', p95, errRate, timeoutRate: timedOut, sampleCount: samples.length };
+  }
+  return { state: 'green', p95, errRate, timeoutRate: timedOut, sampleCount: samples.length };
+}
+
+app.post('/samples', (req, res) => {
+  const { samples: payload } = req.body ?? {};
+  if (!Array.isArray(payload)) {
+    return res.status(400).json({ error: 'invalid_payload' });
+  }
+  const now = Date.now();
+  const normalized = payload
+    .map((sample) => ({
+      ts: typeof sample.ts === 'number' ? sample.ts * 1000 : now,
+      provider: String(sample.provider ?? 'unknown'),
+      ok: Boolean(sample.ok),
+      latency_ms: Number(sample.latency_ms ?? 0),
+      timed_out: Boolean(sample.timed_out),
+      status_code: Number(sample.status_code ?? 0),
+    }))
+    .filter((sample) => Number.isFinite(sample.latency_ms));
+  normalized.forEach((sample) => {
+    requestCounter.inc({ provider: sample.provider, status: sample.ok ? 'ok' : 'error' });
+    latencyHistogram.observe({ provider: sample.provider }, sample.latency_ms);
+  });
+  samples.push(...normalized.map((sample) => ({ ...sample, ts: sample.ts || now })));
+  pruneSamples(now);
+  return res.json({ accepted: normalized.length, windowSize: samples.length });
+});
+
+app.get('/healthz', (_req, res) => {
+  const classification = classifyWindow();
+  const statusCode = classification.state === 'red' ? 503 : 200;
+  res.status(statusCode).json({
+    state: classification.state,
+    metrics: {
+      p95_ms: classification.p95 ?? null,
+      error_rate: classification.errRate ?? null,
+      timeout_rate: classification.timeoutRate ?? null,
+      sample_count: classification.sampleCount,
+      window_ms: WINDOW_MS,
+    },
+    reason: classification.reason ?? null,
+    ts: new Date().toISOString(),
+  });
+});
+
+app.get('/metrics', async (_req, res) => {
+  res.set('Content-Type', metricsRegistry.contentType);
+  res.send(await metricsRegistry.metrics());
+});
+
+app.listen(PORT, () => {
+  // eslint-disable-next-line no-console
+  console.log(`[llm-healthwatch] listening on :${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add a Lucidia-specific canary probe script plus helm CronJob wiring
- introduce llm-healthwatch service that maintains rolling /healthz SLOs and Prometheus metrics
- add circuit-breaking llm-gateway deployment with incident logging and persistent volume

## Testing
- python -m compileall resilience/canary/lucidia_llm_canary.py

------
https://chatgpt.com/codex/tasks/task_e_690b8e30227c83298f33aa24975bc08e