### PR TITLE
Enhance lang_master agent with polyglot code generation

### DIFF
--- a/agents/lang_master/index.js
+++ b/agents/lang_master/index.js
@@ -6,6 +6,424 @@ const base = path.join(__dirname, '..', '..', 'prism');
 const logDir = path.join(base, 'logs');
 const contrDir = path.join(base, 'contradictions');
 
+const LANGUAGE_PROFILES = [
+  {
+    key: 'python',
+    aliases: ['py'],
+    label: 'Python',
+    template: (summary) => [
+      `"""${summary}"""`,
+      '',
+      'from typing import Any',
+      '',
+      'def main() -> None:',
+      '    """Entry point for the routine."""',
+      '    raise NotImplementedError("TODO: implement main routine")',
+      '',
+      'if __name__ == "__main__":',
+      '    main()',
+    ].join('\n'),
+    review: [
+      {
+        test: (snippet) => /print\(/.test(snippet),
+        suggestion: 'Prefer the logging module over bare print statements in production code.',
+      },
+      {
+        test: (snippet) => /except\s*:\s*pass/.test(snippet),
+        suggestion: 'Catch specific exceptions or log the failure instead of silently passing.',
+      },
+    ],
+  },
+  {
+    key: 'javascript',
+    aliases: ['js', 'node', 'nodejs'],
+    label: 'JavaScript',
+    template: (summary) => [
+      `'use strict';`,
+      '',
+      `/** ${summary}. */`,
+      'function main() {',
+      '  throw new Error("TODO: implement main routine");',
+      '}',
+      '',
+      'if (require.main === module) {',
+      '  main();',
+      '}',
+    ].join('\n'),
+    review: [
+      {
+        test: (snippet) => /\bvar\s+/.test(snippet),
+        suggestion: 'Use const or let instead of var for better scoping.',
+      },
+      {
+        test: (snippet) => /console\.log/.test(snippet),
+        suggestion: 'Remove debug logging or guard it behind environment checks.',
+      },
+    ],
+  },
+  {
+    key: 'typescript',
+    aliases: ['ts'],
+    label: 'TypeScript',
+    template: (summary) => [
+      `/** ${summary}. */`,
+      'export function main(): void {',
+      '  throw new Error("TODO: implement main routine");',
+      '}',
+      '',
+      'if (require.main === module) {',
+      '  main();',
+      '}',
+    ].join('\n'),
+    review: [
+      {
+        test: (snippet) => !/:\s*[A-Za-z_][\w<>?]*/.test(snippet),
+        suggestion: 'Add explicit type annotations for public functions.',
+      },
+    ],
+  },
+  {
+    key: 'go',
+    aliases: ['golang'],
+    label: 'Go',
+    template: (summary) => [
+      'package main',
+      '',
+      'import "fmt"',
+      '',
+      `// ${summary}.`,
+      'func main() {',
+      '    panic("TODO: implement main routine")',
+      '}',
+    ].join('\n'),
+    review: [
+      {
+        test: (snippet) => /fmt\.Println/.test(snippet),
+        suggestion: 'Consider using a structured logger instead of fmt.Println for production services.',
+      },
+    ],
+  },
+  {
+    key: 'rust',
+    aliases: [],
+    label: 'Rust',
+    template: (summary) => [
+      'fn main() -> anyhow::Result<()> {',
+      `    // ${summary}.`,
+      '    anyhow::bail!("TODO: implement main routine");',
+      '}',
+    ].join('\n'),
+    review: [
+      {
+        test: (snippet) => /unwrap\(\)/.test(snippet),
+        suggestion: 'Handle Result values with ? or match instead of unwrap() in production.',
+      },
+    ],
+  },
+  {
+    key: 'java',
+    aliases: [],
+    label: 'Java',
+    template: (summary) => [
+      'public final class Main {',
+      `    // ${summary}.`,
+      '    public static void main(String[] args) {',
+      '        throw new UnsupportedOperationException("TODO: implement main routine");',
+      '    }',
+      '}',
+    ].join('\n'),
+    review: [
+      {
+        test: (snippet) => /System\.out\.println/.test(snippet),
+        suggestion: 'Route logs through a logging framework instead of System.out.',
+      },
+    ],
+  },
+  {
+    key: 'csharp',
+    aliases: ['c#', 'dotnet'],
+    label: 'C#',
+    template: (summary) => [
+      'using System;',
+      '',
+      'public static class Program',
+      '{',
+      `    // ${summary}.`,
+      '    public static void Main(string[] args)',
+      '    {',
+      '        throw new NotImplementedException("TODO: implement main routine");',
+      '    }',
+      '}',
+    ].join('\n'),
+    review: [
+      {
+        test: (snippet) => /Console\.Write(Line)?/.test(snippet),
+        suggestion: 'Prefer ILogger abstractions over Console.WriteLine for services.',
+      },
+    ],
+  },
+  {
+    key: 'cpp',
+    aliases: ['c++'],
+    label: 'C++',
+    template: (summary) => [
+      '#include <stdexcept>',
+      '',
+      `// ${summary}.`,
+      'int main() {',
+      '    throw std::logic_error("TODO: implement main routine");',
+      '}',
+    ].join('\n'),
+    review: [
+      {
+        test: (snippet) => /using namespace std;/.test(snippet),
+        suggestion: 'Avoid using namespace std in headers or global scope to prevent symbol collisions.',
+      },
+    ],
+  },
+  {
+    key: 'ruby',
+    aliases: [],
+    label: 'Ruby',
+    template: (summary) => [
+      `# ${summary}.`,
+      '',
+      'def main',
+      '  raise NotImplementedError, "TODO: implement main routine"',
+      'end',
+      '',
+      'main if $PROGRAM_NAME == __FILE__',
+    ].join('\n'),
+    review: [
+      {
+        test: (snippet) => /puts\s+/.test(snippet),
+        suggestion: 'Use a logger (e.g., Logger class) instead of puts for structured output.',
+      },
+    ],
+  },
+  {
+    key: 'php',
+    aliases: [],
+    label: 'PHP',
+    template: (summary) => [
+      '<?php',
+      `// ${summary}.`,
+      '',
+      'function main(): void {',
+      '    throw new RuntimeException("TODO: implement main routine");',
+      '}',
+      '',
+      'main();',
+    ].join('\n'),
+    review: [
+      {
+        test: (snippet) => /echo\s+/.test(snippet),
+        suggestion: 'Prefer dependency-injected loggers over echo statements for observability.',
+      },
+    ],
+  },
+  {
+    key: 'swift',
+    aliases: [],
+    label: 'Swift',
+    template: (summary) => [
+      `// ${summary}.`,
+      '',
+      'import Foundation',
+      '',
+      'func main() throws {',
+      '    throw NSError(domain: "TODO", code: 1, userInfo: nil)',
+      '}',
+      '',
+      'try main()',
+    ].join('\n'),
+    review: [],
+  },
+  {
+    key: 'kotlin',
+    aliases: [],
+    label: 'Kotlin',
+    template: (summary) => [
+      `// ${summary}.`,
+      '',
+      'fun main() {',
+      '    TODO("Implement main routine")',
+      '}',
+    ].join('\n'),
+    review: [],
+  },
+  {
+    key: 'scala',
+    aliases: [],
+    label: 'Scala',
+    template: (summary) => [
+      `// ${summary}.`,
+      '',
+      'object Main extends App {',
+      '  throw new NotImplementedError("Implement main routine")',
+      '}',
+    ].join('\n'),
+    review: [],
+  },
+  {
+    key: 'haskell',
+    aliases: [],
+    label: 'Haskell',
+    template: (summary) => [
+      `-- ${summary}.`,
+      '',
+      'main :: IO ()',
+      'main = error "TODO: implement main routine"',
+    ].join('\n'),
+    review: [],
+  },
+  {
+    key: 'elixir',
+    aliases: [],
+    label: 'Elixir',
+    template: (summary) => [
+      `# ${summary}.`,
+      '',
+      'defmodule Main do',
+      '  def run do',
+      '    raise "TODO: implement main routine"',
+      '  end',
+      'end',
+      '',
+      'Main.run()',
+    ].join('\n'),
+    review: [],
+  },
+  {
+    key: 'bash',
+    aliases: ['shell', 'sh'],
+    label: 'Bash',
+    template: (summary) => [
+      '#!/usr/bin/env bash',
+      `# ${summary}.`,
+      '',
+      'set -euo pipefail',
+      '',
+      'main() {',
+      '  echo "TODO: implement main routine" >&2',
+      '  return 1',
+      '}',
+      '',
+      'main "$@"',
+    ].join('\n'),
+    review: [
+      {
+        test: (snippet) => !/set -e/.test(snippet),
+        suggestion: 'Enable strict mode (set -euo pipefail) for safer shell scripts.',
+      },
+    ],
+  },
+  {
+    key: 'r',
+    aliases: [],
+    label: 'R',
+    template: (summary) => [
+      `# ${summary}.`,
+      '',
+      'main <- function() {',
+      '  stop("TODO: implement main routine")',
+      '}',
+      '',
+      'main()',
+    ].join('\n'),
+    review: [],
+  },
+  {
+    key: 'dart',
+    aliases: [],
+    label: 'Dart',
+    template: (summary) => [
+      `// ${summary}.`,
+      '',
+      'void main(List<String> args) {',
+      '  throw UnimplementedError("TODO: implement main routine");',
+      '}',
+    ].join('\n'),
+    review: [],
+  },
+  {
+    key: 'sql',
+    aliases: ['postgres', 'mysql'],
+    label: 'SQL',
+    template: (summary) => [
+      `-- ${summary}.`,
+      'BEGIN;',
+      '',
+      '-- TODO: add statements',
+      '',
+      'COMMIT;',
+    ].join('\n'),
+    review: [
+      {
+        test: (snippet) => !/transaction|begin/i.test(snippet),
+        suggestion: 'Wrap data mutations in explicit transactions to ensure consistency.',
+      },
+    ],
+  },
+  {
+    key: 'matlab',
+    aliases: ['octave'],
+    label: 'MATLAB',
+    template: (summary) => [
+      `% ${summary}.`,
+      '',
+      'function main()',
+      '    error("TODO: implement main routine");',
+      'end',
+      '',
+      'main;',
+    ].join('\n'),
+    review: [],
+  },
+  {
+    key: 'perl',
+    aliases: [],
+    label: 'Perl',
+    template: (summary) => [
+      '#!/usr/bin/env perl',
+      'use strict;',
+      'use warnings;',
+      '',
+      `# ${summary}.`,
+      '',
+      'sub main {',
+      '    die "TODO: implement main routine";',
+      '}',
+      '',
+      'main();',
+    ].join('\n'),
+    review: [],
+  },
+  {
+    key: 'lua',
+    aliases: [],
+    label: 'Lua',
+    template: (summary) => [
+      `-- ${summary}.`,
+      '',
+      'local function main()',
+      '  error("TODO: implement main routine")',
+      'end',
+      '',
+      'main()',
+    ].join('\n'),
+    review: [],
+  },
+];
+
+const LANGUAGE_LOOKUP = new Map();
+for (const profile of LANGUAGE_PROFILES) {
+  LANGUAGE_LOOKUP.set(profile.key, profile);
+  for (const alias of profile.aliases) {
+    LANGUAGE_LOOKUP.set(alias, profile);
+  }
+}
+
 function ensure() {
   fs.mkdirSync(logDir, { recursive: true });
   fs.mkdirSync(contrDir, { recursive: true });
@@ -59,6 +477,52 @@ function enhanceEnglish(text) {
   return `${cleaned} This version emphasises clarity and a confident tone.`;
 }
 
+function summarizeSpec(spec) {
+  if (!spec) {
+    return 'Implement the requested functionality';
+  }
+  const trimmed = spec.toString().trim();
+  if (!trimmed) {
+    return 'Implement the requested functionality';
+  }
+  return trimmed.replace(/\s+/g, ' ');
+}
+
+function resolveLanguage(language) {
+  if (!language) {
+    return null;
+  }
+  const key = language.toString().trim().toLowerCase();
+  return LANGUAGE_LOOKUP.get(key) || null;
+}
+
+function supportedLanguages() {
+  return LANGUAGE_PROFILES.map((profile) => ({
+    key: profile.key,
+    label: profile.label,
+    aliases: profile.aliases,
+  }));
+}
+
+function generateStub(spec, language) {
+  const summary = summarizeSpec(spec);
+  if (language) {
+    const profile = resolveLanguage(language);
+    if (profile) {
+      return profile.template(summary);
+    }
+  }
+  return [
+    `// ${summary}.`,
+    '',
+    'function main() {',
+    '  throw new Error("TODO: implement main routine");',
+    '}',
+    '',
+    'main();',
+  ].join('\n');
+}
+
 function buildCodingPlan(goal) {
   const header = goal && goal.trim() ? goal.trim() : 'Implement the requested feature';
   return [
@@ -78,11 +542,18 @@ function reviewCode(snippet, language = 'unknown') {
   if (!snippet.includes('test')) {
     suggestions.push('Consider adding automated tests to cover critical paths.');
   }
-  if (/console\.log|print\(/.test(snippet)) {
-    suggestions.push('Remove debug logging before final commit.');
-  }
   if (/TODO/.test(snippet)) {
     suggestions.push('Address remaining TODO items before shipping.');
+  }
+  const profile = resolveLanguage(language);
+  if (profile && profile.review.length > 0) {
+    for (const rule of profile.review) {
+      if (rule.test(snippet)) {
+        suggestions.push(rule.suggestion);
+      }
+    }
+  } else if (/console\.log|print\(/.test(snippet)) {
+    suggestions.push('Remove debug logging before final commit.');
   }
   return {
     summary: `Preliminary review for ${language} code complete.`,
@@ -101,14 +572,17 @@ module.exports = {
         log(`analyze:${msg.path}`);
         return 'analysis complete';
       case 'codegen':
-        log(`codegen:${msg.spec}`);
-        return `code stub for ${msg.spec}`;
+        log(`codegen:${msg.spec || 'unspecified'}:${msg.language || 'unspecified'}`);
+        return generateStub(msg.spec, msg.language);
       case 'coding_plan':
         log(`coding_plan:${msg.goal || 'unspecified'}`);
         return buildCodingPlan(msg.goal);
       case 'code_review':
         log(`code_review:${msg.language || 'unknown'}`);
         return reviewCode(msg.snippet, msg.language);
+      case 'languages':
+        log('languages');
+        return supportedLanguages();
       case 'grammar_check':
         log('grammar_check');
         return grammarCheck(msg.text);
@@ -121,5 +595,10 @@ module.exports = {
       default:
         return 'unknown';
     }
+  },
+  _internal: {
+    supportedLanguages,
+    generateStub,
+    resolveLanguage,
   }
 };

--- a/agents/lang_master/manifest.json
+++ b/agents/lang_master/manifest.json
@@ -1,13 +1,14 @@
 {
   "name": "lang_master",
   "version": "1.0.0",
-  "description": "lang_master elite coding and language agent",
+  "description": "lang_master elite coding and language agent with polyglot generation",
   "capabilities": [
     "ping",
     "analyze",
     "codegen",
     "coding_plan",
     "code_review",
+    "languages",
     "grammar_check",
     "english_refine"
   ]


### PR DESCRIPTION
## Summary
- add comprehensive language profiles so lang_master can generate idiomatic stubs and targeted review feedback across many ecosystems
- provide helpers to resolve aliases, surface supported languages, and export them for other modules to consume
- update the agent manifest to advertise the new polyglot capability

## Testing
- node -e "const agent=require('./agents/lang_master');console.log(agent.handle({type:'codegen',language:'python',spec:'Compute factorial'}));console.log(agent.handle({type:'code_review',language:'python',snippet:'def f():\n    print(\'hi\')'}));console.log(agent.handle({type:'languages'}));"

------
https://chatgpt.com/codex/tasks/task_e_690bb1eb5ab883298128b1813bf2dd04