### PR TITLE
Add compliance engine API slice

### DIFF
--- a/bots/__init__.py
+++ b/bots/__init__.py
@@ -1,47 +1,47 @@
-"""Bot registry for Prism Console."""
-
-from __future__ import annotations
-
-from typing import Sequence
-
-from orchestrator import BotRegistry
-
-from .close_bot import CloseBot
-from .sop_bot import SopBot
-from .treasury_bot import TreasuryBot
-
-
-def build_registry() -> BotRegistry:
-    """Instantiate all bots and register them."""
-
-    registry = BotRegistry()
-    for bot_cls in (TreasuryBot, CloseBot, SopBot):
-        registry.register(bot_cls())
-    return registry
-
-
-def list_bots() -> Sequence[str]:
-    """Return the names of all registered bots."""
-
-    registry = build_registry()
-    return [bot.metadata.name for bot in registry.list()]
-"""Bot registry and auto-discovery."""
+"""Bot registry helpers for the Prism Console orchestrator."""
 
 from __future__ import annotations
 
 from importlib import import_module
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Sequence
 
+from orchestrator import BotRegistry
 from orchestrator.protocols import BaseBot
+
+from .close_bot import CloseBot
+from .sop_bot import SopBot
+from .treasury_bot import TreasuryBot
+
+__all__ = ["build_registry", "list_bots", "BOT_REGISTRY"]
 
 BOT_REGISTRY: Dict[str, BaseBot] = {}
 
 
+def build_registry() -> BotRegistry:
+    """Instantiate all known bots and register them with the orchestrator."""
+
+    registry = BotRegistry()
+    for bot_cls in (TreasuryBot, CloseBot, SopBot):
+        registry.register(bot_cls())
+    for bot in BOT_REGISTRY.values():
+        registry.register(bot)
+    return registry
+
+
+def list_bots() -> Sequence[str]:
+    """Return the names of every registered bot."""
+
+    registry = build_registry()
+    return [bot.metadata.name for bot in registry.list()]
+
+
 def _discover() -> None:
+    """Auto-discover any additional bots defined in this package."""
+
     pkg_path = Path(__file__).parent
-    for mod in pkg_path.glob("*_bot.py"):
-        module = import_module(f"bots.{mod.stem}")
+    for module_path in pkg_path.glob("*_bot.py"):
+        module = import_module(f"bots.{module_path.stem}")
         bot_cls = getattr(module, "Bot", None)
         if bot_cls is None:
             continue
@@ -50,6 +50,3 @@ def _discover() -> None:
 
 
 _discover()
-
-__all__ = ["BOT_REGISTRY"]
-

--- a/docs/compliance-engine.md
+++ b/docs/compliance-engine.md
@@ -1,0 +1,50 @@
+# Prism Console Compliance Engine
+
+The compliance engine exposes a FastAPI application that evaluates onboarding
+requests against concrete policy rules and persists decisions to SQLite. It is
+an end-to-end slice of functionality that turns marketing copy into a running
+service.
+
+## Running the API
+
+```bash
+uvicorn services.compliance_engine.app:create_app --factory --reload
+```
+
+By default the service stores decisions in `data/compliance/events.sqlite`. Set
+`PRISM_COMPLIANCE_DB` to point at a different location when starting the app:
+
+```bash
+PRISM_COMPLIANCE_DB=/tmp/events.sqlite \
+uvicorn services.compliance_engine.app:create_app --factory --reload
+```
+
+## Endpoints
+
+### `POST /v1/compliance/account-opening`
+
+Evaluates an account opening request. On success it returns the persisted
+record, including the status and any violations. When the payload fails a
+policy check the response contains `status="rejected"` with descriptive
+violations.
+
+### `GET /v1/compliance/events/{client_id}`
+
+Returns the stored compliance history for a client. Responds with HTTP 404 if
+no events exist.
+
+### `GET /v1/compliance/disclosures`
+
+Lists the disclosures enforced by the policy module so that UIs can surface the
+requirements alongside onboarding forms.
+
+## Tests
+
+Execute the targeted unit tests with:
+
+```bash
+pytest tests/unit/test_compliance_engine.py
+```
+
+The suite uses FastAPI's `TestClient` to exercise the API and confirms that
+results are persisted.

--- a/services/compliance_engine/__init__.py
+++ b/services/compliance_engine/__init__.py
@@ -1,0 +1,13 @@
+"""Compliance engine service package."""
+
+from .app import create_app
+from .policy import AccountOpeningPolicy, AccountOpeningRequest
+from .storage import ComplianceRecord, ComplianceStore
+
+__all__ = [
+    "create_app",
+    "AccountOpeningPolicy",
+    "AccountOpeningRequest",
+    "ComplianceRecord",
+    "ComplianceStore",
+]

--- a/services/compliance_engine/app.py
+++ b/services/compliance_engine/app.py
@@ -1,0 +1,75 @@
+"""FastAPI application that exposes compliance evaluation endpoints."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterable, List
+
+from fastapi import Depends, FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+from .policy import AccountOpeningPolicy, AccountOpeningRequest
+from .storage import ComplianceStore
+
+DEFAULT_DB_PATH = Path("data/compliance/events.sqlite")
+
+
+def create_app(db_path: Path | None = None) -> FastAPI:
+    """Create the FastAPI app with a SQLite-backed compliance store."""
+
+    if db_path:
+        database_path = Path(db_path)
+    else:
+        env_path = os.environ.get("PRISM_COMPLIANCE_DB")
+        database_path = Path(env_path) if env_path else DEFAULT_DB_PATH
+    store = ComplianceStore(database_path)
+    policy = AccountOpeningPolicy()
+
+    app = FastAPI(
+        title="Prism Console Compliance API",
+        version="0.1.0",
+        description="Operational compliance checks for onboarding workflows.",
+    )
+
+    class AccountOpeningResponse(BaseModel):
+        status: str = Field(..., description="Outcome of the compliance evaluation")
+        violations: List[str] = Field(default_factory=list, description="Any policy failures encountered")
+        record_id: int = Field(..., description="Primary key of the persisted compliance record")
+        created_at: str = Field(..., description="UTC ISO-8601 timestamp of when the decision was recorded")
+
+    class ComplianceHistoryResponse(BaseModel):
+        client_id: str
+        events: List[AccountOpeningResponse]
+
+    def get_store() -> ComplianceStore:
+        return store
+
+    def get_policy() -> AccountOpeningPolicy:
+        return policy
+
+    @app.post("/v1/compliance/account-opening", response_model=AccountOpeningResponse)
+    def evaluate_account_opening(
+        payload: AccountOpeningRequest,
+        store: ComplianceStore = Depends(get_store),
+        policy: AccountOpeningPolicy = Depends(get_policy),
+    ) -> AccountOpeningResponse:
+        status, violations = policy.evaluate(payload)
+        record = store.record_event(payload=payload, status=status, violations=violations)
+        return AccountOpeningResponse(**record.as_dict())
+
+    @app.get("/v1/compliance/events/{client_id}", response_model=ComplianceHistoryResponse)
+    def get_client_events(
+        client_id: str,
+        store: ComplianceStore = Depends(get_store),
+    ) -> ComplianceHistoryResponse:
+        events = [AccountOpeningResponse(**record.as_dict()) for record in store.list_events(client_id)]
+        if not events:
+            raise HTTPException(status_code=404, detail=f"No compliance history for client '{client_id}'.")
+        return ComplianceHistoryResponse(client_id=client_id, events=events)
+
+    @app.get("/v1/compliance/disclosures", response_model=List[str])
+    def list_required_disclosures(policy: AccountOpeningPolicy = Depends(get_policy)) -> Iterable[str]:
+        return list(policy.required_disclosures())
+
+    return app

--- a/services/compliance_engine/policy.py
+++ b/services/compliance_engine/policy.py
@@ -1,0 +1,73 @@
+"""Compliance policy definitions for the Prism Console backend."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterable, List
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class AccountOpeningRequest(BaseModel):
+    """Input payload for an account opening compliance review."""
+
+    client_id: str = Field(..., min_length=1, description="Unique identifier for the client")
+    representative_id: str = Field(..., min_length=1, description="Registered rep handling the request")
+    product_type: str = Field(..., min_length=1, description="Financial product category")
+    submitted_at: datetime = Field(..., description="UTC timestamp for the request submission")
+    risk_acknowledged: bool = Field(..., description="Client confirmed they reviewed the risk disclosure")
+    forward_looking_acknowledged: bool = Field(
+        ..., description="Client confirmed awareness of forward looking statement limitations"
+    )
+    liability_acknowledged: bool = Field(..., description="Client acknowledged liability language")
+    disclosures: List[str] = Field(default_factory=list, description="List of disclosure codes provided")
+
+    @field_validator("product_type")
+    @classmethod
+    def _normalise_product_type(cls, value: str) -> str:
+        return value.lower()
+
+    @field_validator("disclosures", mode="before")
+    @classmethod
+    def _normalise_disclosures(cls, value: Iterable[str] | None) -> List[str]:
+        if value is None:
+            return []
+        return [str(item).strip().lower() for item in value]
+
+
+class AccountOpeningPolicy:
+    """Evaluate requests against a handful of concrete regulatory checks."""
+
+    REQUIRED_ACKS = {
+        "risk_acknowledged": "FINRA Rule 2210 requires explicit customer risk acknowledgement.",
+        "forward_looking_acknowledged": "SEC Rule 175 disclosures must be reviewed before account approval.",
+        "liability_acknowledged": "Regulation Best Interest requires liability acknowledgement prior to onboarding.",
+    }
+
+    DERIVATIVE_DISCLOSURE = "options agreement"
+
+    def evaluate(self, payload: AccountOpeningRequest) -> tuple[str, List[str]]:
+        """Return a tuple of (status, violations)."""
+
+        violations: List[str] = []
+
+        for field_name, message in self.REQUIRED_ACKS.items():
+            if not getattr(payload, field_name):
+                violations.append(message)
+
+        if payload.product_type == "derivative" and self.DERIVATIVE_DISCLOSURE not in payload.disclosures:
+            violations.append(
+                "Derivative accounts require an executed options agreement under FINRA Rule 2360."
+            )
+
+        status = "approved" if not violations else "rejected"
+        return status, violations
+
+    def required_disclosures(self) -> Iterable[str]:
+        """Expose the compliance disclosures this policy enforces."""
+
+        disclosures = list(self.REQUIRED_ACKS.values())
+        disclosures.append(
+            "Derivative accounts must include an options agreement disclosure when applicable."
+        )
+        return disclosures

--- a/services/compliance_engine/storage.py
+++ b/services/compliance_engine/storage.py
@@ -1,0 +1,158 @@
+"""Persistence helpers for compliance events."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, List
+
+from .policy import AccountOpeningRequest
+
+
+@dataclass
+class ComplianceRecord:
+    """Structured view of a compliance decision stored in SQLite."""
+
+    record_id: int
+    client_id: str
+    representative_id: str
+    product_type: str
+    status: str
+    violations: List[str]
+    payload: AccountOpeningRequest
+    created_at: datetime
+
+    def as_dict(self) -> dict:
+        """Convert the record into a JSON-serialisable dictionary."""
+
+        return {
+            "record_id": self.record_id,
+            "client_id": self.client_id,
+            "representative_id": self.representative_id,
+            "product_type": self.product_type,
+            "status": self.status,
+            "violations": self.violations,
+            "created_at": self.created_at.isoformat(),
+        }
+
+
+class ComplianceStore:
+    """Very small SQLite-backed persistence layer."""
+
+    def __init__(self, db_path: Path) -> None:
+        self._db_path = Path(db_path)
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._initialise()
+
+    def _connect(self) -> sqlite3.Connection:
+        return sqlite3.connect(self._db_path)
+
+    def _initialise(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS compliance_events (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    client_id TEXT NOT NULL,
+                    representative_id TEXT NOT NULL,
+                    product_type TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    violations TEXT NOT NULL,
+                    payload TEXT NOT NULL,
+                    created_at TEXT NOT NULL
+                )
+                """
+            )
+            conn.commit()
+
+    def record_event(
+        self,
+        payload: AccountOpeningRequest,
+        status: str,
+        violations: List[str],
+    ) -> ComplianceRecord:
+        """Persist the compliance decision and return the stored record."""
+
+        created_at = datetime.now(tz=timezone.utc)
+        serialised_payload = payload.model_dump_json()
+        violations_json = json.dumps(violations)
+
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                INSERT INTO compliance_events (
+                    client_id,
+                    representative_id,
+                    product_type,
+                    status,
+                    violations,
+                    payload,
+                    created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    payload.client_id,
+                    payload.representative_id,
+                    payload.product_type,
+                    status,
+                    violations_json,
+                    serialised_payload,
+                    created_at.isoformat(),
+                ),
+            )
+            conn.commit()
+            record_id = cursor.lastrowid
+
+        return ComplianceRecord(
+            record_id=record_id,
+            client_id=payload.client_id,
+            representative_id=payload.representative_id,
+            product_type=payload.product_type,
+            status=status,
+            violations=violations,
+            payload=payload,
+            created_at=created_at,
+        )
+
+    def list_events(self, client_id: str) -> Iterable[ComplianceRecord]:
+        """Return all compliance events for a given client."""
+
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                SELECT
+                    id,
+                    client_id,
+                    representative_id,
+                    product_type,
+                    status,
+                    violations,
+                    payload,
+                    created_at
+                FROM compliance_events
+                WHERE client_id = ?
+                ORDER BY created_at ASC
+                """,
+                (client_id,),
+            )
+            rows = cursor.fetchall()
+
+        records: List[ComplianceRecord] = []
+        for row in rows:
+            (record_id, c_id, rep_id, product_type, status, violations_json, payload_json, created_at) = row
+            payload = AccountOpeningRequest.model_validate_json(payload_json)
+            record = ComplianceRecord(
+                record_id=record_id,
+                client_id=c_id,
+                representative_id=rep_id,
+                product_type=product_type,
+                status=status,
+                violations=json.loads(violations_json),
+                payload=payload,
+                created_at=datetime.fromisoformat(created_at),
+            )
+            records.append(record)
+        return records

--- a/tests/unit/test_compliance_engine.py
+++ b/tests/unit/test_compliance_engine.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+
+from services.compliance_engine import create_app
+
+
+def _build_payload(**overrides: object) -> dict:
+    payload = {
+        "client_id": "CL-123",
+        "representative_id": "RR-9",
+        "product_type": "derivative",
+        "submitted_at": datetime(2025, 1, 15, tzinfo=timezone.utc).isoformat(),
+        "risk_acknowledged": True,
+        "forward_looking_acknowledged": True,
+        "liability_acknowledged": True,
+        "disclosures": ["Options Agreement", "SEC-175"],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_compliance_endpoint_persists_and_returns_approval(tmp_path):
+    app = create_app(db_path=tmp_path / "compliance.sqlite")
+    client = TestClient(app)
+
+    response = client.post("/v1/compliance/account-opening", json=_build_payload())
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "approved"
+    assert body["violations"] == []
+
+    history = client.get("/v1/compliance/events/CL-123")
+    assert history.status_code == 200
+    events = history.json()["events"]
+    assert len(events) == 1
+    assert events[0]["record_id"] == body["record_id"]
+
+
+def test_compliance_endpoint_flags_missing_disclosures(tmp_path):
+    app = create_app(db_path=tmp_path / "compliance.sqlite")
+    client = TestClient(app)
+
+    payload = _build_payload(liability_acknowledged=False, disclosures=["sec-175"])
+    response = client.post("/v1/compliance/account-opening", json=payload)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "rejected"
+    assert any("liability" in message for message in body["violations"])
+    assert any("options agreement" in message.lower() for message in body["violations"])
+
+    history = client.get("/v1/compliance/events/CL-123")
+    assert history.status_code == 200
+    events = history.json()["events"]
+    assert len(events) == 1
+    assert events[0]["status"] == "rejected"


### PR DESCRIPTION
## Summary
- add a FastAPI-based compliance engine with policy evaluation and persisted decisions
- normalize orchestrator protocols/router utilities and clean bot registry discovery
- document the API usage and add pytest coverage for compliance decision flows

## Testing
- pytest tests/unit/test_compliance_engine.py

------
https://chatgpt.com/codex/tasks/task_e_690c14d78cd883298524330b7175fb95