### PR TITLE
Restore AutoNovel agent functionality and add regression tests

### DIFF
--- a/agents/auto_novel_agent.py
+++ b/agents/auto_novel_agent.py
@@ -1,8 +1,15 @@
-"""Auto novel agent with creative and coding abilities."""
+"""Runtime implementation of the AutoNovel agent.
+
+The project documentation makes frequent references to an "AutoNovel" agent
+that can ideate small games, produce story snippets, and help with coding
+exercises.  The previous incarnation of this module had an unresolved merge
+conflict which left most behaviours unusable.  This implementation restores the
+agent so that it behaves like a real piece of production code that can be
+imported, instantiated and exercised from tests.
+"""
 
 from __future__ import annotations
 
-<<<<<<< main
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import ClassVar, Iterable
@@ -12,15 +19,11 @@ import sys
 if __package__ is None or __package__ == "":
     sys.path.append(str(Path(__file__).resolve().parent))
     from consent_policy import ConsentRecord, ensure_full_consent  # type: ignore
-else:
+else:  # pragma: no cover - executed when the package is installed
     from .consent_policy import ConsentRecord, ensure_full_consent
 
 
 DEFAULT_SUPPORTED_ENGINES: tuple[str, ...] = ("unity", "unreal")
-=======
-from dataclasses import dataclass
-from typing import ClassVar
->>>>>>> origin/codex/complete-next-step-of-project-582c2w
 
 _OPERATION_SCOPE_MAP: dict[str, str] = {
     "deploy": "agent:deploy",
@@ -35,6 +38,7 @@ _OPERATION_SCOPE_MAP: dict[str, str] = {
     "add_supported_engine": "agent:configure",
     "remove_supported_engine": "agent:configure",
     "set_gamma": "agent:configure",
+    "write_novel": "story:create",
 }
 
 _BASE_CONSENT_SCOPES = {"outline:read", "outline:write"}
@@ -74,6 +78,9 @@ class AutoNovelAgent:
             self._normalize_engine(engine) for engine in self.supported_engines
         }
 
+    # ------------------------------------------------------------------
+    # Consent helpers
+    # ------------------------------------------------------------------
     def _require_scope(self, operation: str) -> None:
         """Ensure the agent has full consent for the requested operation."""
 
@@ -129,11 +136,13 @@ class AutoNovelAgent:
     # ------------------------------------------------------------------
     # Primary abilities
     # ------------------------------------------------------------------
-    def deploy(self) -> None:
-        """Deploy the agent by printing a greeting."""
+    def deploy(self) -> str:
+        """Deploy the agent by returning a greeting."""
 
         self._require_scope("deploy")
-        print(f"{self.name} deployed and ready to generate novels!")
+        message = f"{self.name} deployed and ready to generate novels!"
+        print(message)
+        return message
 
     def _indefinite_article(self, engine_name: str) -> str:
         """Return the appropriate indefinite article for ``engine_name``."""
@@ -170,7 +179,6 @@ class AutoNovelAgent:
         if include_weapons:
             raise ValueError("Weapons are not allowed in generated games.")
 
-<<<<<<< main
         message = self._build_creation_message(normalized)
         print(message)
         return message
@@ -216,6 +224,7 @@ class AutoNovelAgent:
     ) -> list[str]:
         """Generate short stories for each theme in ``themes``."""
 
+        self._require_scope("generate_story_series")
         stories: list[str] = []
         for theme in themes:
             theme_text = str(theme).strip()
@@ -223,6 +232,22 @@ class AutoNovelAgent:
                 raise ValueError("Each theme must be a non-empty string.")
             stories.append(self.generate_story(theme_text, protagonist))
         return stories
+
+    def write_novel(self, title: str, chapters: int = 3) -> list[str]:
+        """Create a simple outline for a novel."""
+
+        self._require_scope("write_novel")
+        title_clean = title.strip()
+        if not title_clean:
+            raise ValueError("Title must be a non-empty string.")
+        if chapters < 1:
+            raise ValueError("Novel must have at least one chapter.")
+
+        outline = [f"Chapter {i}: TBD" for i in range(1, chapters + 1)]
+        print(f"Drafting novel '{title_clean}' with {chapters} chapters...")
+        for heading in outline:
+            print(heading)
+        return outline
 
     # ------------------------------------------------------------------
     # Coding and English assistance
@@ -302,31 +327,6 @@ class AutoNovelAgent:
 
 def main() -> None:
     """Run a tiny demonstration when executed as a script."""
-=======
-    def list_supported_engines(self) -> list[str]:
-        """Return a list of supported game engines."""
-        return sorted(self.SUPPORTED_ENGINES)
-
-    def write_novel(self, title: str, chapters: int = 3) -> list[str]:
-        """Create a simple outline for a novel.
-
-        Args:
-            title: Title of the novel to draft.
-            chapters: Number of chapter headings to generate.
-
-        Returns:
-            A list of generated chapter headings.
-        """
-        if chapters < 1:
-            raise ValueError("Novel must have at least one chapter.")
-
-        outline = [f"Chapter {i}: TBD" for i in range(1, chapters + 1)]
-        print(f"Drafting novel '{title}' with {chapters} chapters...")
-        for heading in outline:
-            print(heading)
-        return outline
-
->>>>>>> origin/codex/complete-next-step-of-project-582c2w
 
     consent = ConsentRecord.full(
         scopes=DEFAULT_CONSENT_SCOPES,
@@ -335,12 +335,12 @@ def main() -> None:
     agent = AutoNovelAgent(consent=consent)
     agent.deploy()
     agent.create_game("unity")
-<<<<<<< main
     print(agent.generate_story("mystery", protagonist="Explorer"))
+    agent.write_novel("The Adventure")
 
 
 if __name__ == "__main__":
     main()
-=======
-    agent.write_novel("The Adventure")
->>>>>>> origin/codex/complete-next-step-of-project-582c2w
+
+
+__all__ = ["AutoNovelAgent", "DEFAULT_SUPPORTED_ENGINES", "DEFAULT_CONSENT_SCOPES"]

--- a/bots/__init__.py
+++ b/bots/__init__.py
@@ -1,55 +1,73 @@
-"""Bot registry for Prism Console."""
-
-from __future__ import annotations
-
-from typing import Sequence
-
-from orchestrator import BotRegistry
-
-from .close_bot import CloseBot
-from .sop_bot import SopBot
-from .treasury_bot import TreasuryBot
-
-
-def build_registry() -> BotRegistry:
-    """Instantiate all bots and register them."""
-
-    registry = BotRegistry()
-    for bot_cls in (TreasuryBot, CloseBot, SopBot):
-        registry.register(bot_cls())
-    return registry
-
-
-def list_bots() -> Sequence[str]:
-    """Return the names of all registered bots."""
-
-    registry = build_registry()
-    return [bot.metadata.name for bot in registry.list()]
-"""Bot registry and auto-discovery."""
+"""Bot registry and auto-discovery utilities."""
 
 from __future__ import annotations
 
 from importlib import import_module
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Iterable, Iterator, Sequence, Tuple
 
-from orchestrator.protocols import BaseBot
+from orchestrator import BaseBot, BotRegistry
 
-BOT_REGISTRY: Dict[str, BaseBot] = {}
+BOT_REGISTRY: Dict[str, BaseBot | object] = {}
+
+
+def _iter_bot_modules() -> Iterable[str]:
+    """Yield module names for all bot implementations."""
+
+    package_path = Path(__file__).resolve().parent
+    for module_path in package_path.glob("*_bot.py"):
+        if module_path.name == "simple.py":
+            # ``simple.py`` hosts helpers used in fixtures rather than a bot.
+            continue
+        yield module_path.stem
+
+
+def _instantiate_bots(module_name: str) -> Iterator[Tuple[str, BaseBot | object]]:
+    """Instantiate bots from the provided module name."""
+
+    module = import_module(f"bots.{module_name}")
+
+    # 1. Explicit ``Bot`` export used by lightweight script-style bots.
+    bot_cls = getattr(module, "Bot", None)
+    if bot_cls is not None:
+        bot = bot_cls()
+        name = getattr(bot, "NAME", bot_cls.__name__)
+        yield name, bot
+
+    # 2. ``BaseBot`` subclasses with metadata for richer orchestration.
+    for attr_name in dir(module):
+        attr = getattr(module, attr_name)
+        if not isinstance(attr, type):
+            continue
+        if not issubclass(attr, BaseBot) or attr is BaseBot:
+            continue
+        bot_instance = attr()
+        yield bot_instance.metadata.name, bot_instance
 
 
 def _discover() -> None:
-    pkg_path = Path(__file__).parent
-    for mod in pkg_path.glob("*_bot.py"):
-        module = import_module(f"bots.{mod.stem}")
-        bot_cls = getattr(module, "Bot", None)
-        if bot_cls is None:
-            continue
-        bot: BaseBot = bot_cls()
-        BOT_REGISTRY[bot.NAME] = bot
+    for module_name in _iter_bot_modules():
+        for name, bot in _instantiate_bots(module_name):
+            BOT_REGISTRY[name] = bot
 
 
 _discover()
 
-__all__ = ["BOT_REGISTRY"]
 
+def build_registry() -> BotRegistry:
+    """Instantiate a :class:`BotRegistry` populated with discovered bots."""
+
+    registry = BotRegistry()
+    for bot in BOT_REGISTRY.values():
+        if isinstance(bot, BaseBot):
+            registry.register(bot)
+    return registry
+
+
+def list_bots() -> Sequence[str]:
+    """Return the sorted list of discovered bot names."""
+
+    return sorted(BOT_REGISTRY)
+
+
+__all__ = ["BOT_REGISTRY", "build_registry", "list_bots"]

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -1,11 +1,14 @@
 """Orchestrator public API."""
 
-from orchestrator.base import BaseBot, BotMetadata
-from orchestrator.lineage import LineageTracker
-from orchestrator.memory import MemoryLog
-from orchestrator.policy import PolicyEngine
-from orchestrator.protocols import BotResponse, MemoryRecord, Task, TaskPriority
-from orchestrator.router import BotRegistry, RouteContext, Router, TaskRepository
+from __future__ import annotations
+
+from .base import BaseBot, BotMetadata
+from .lineage import LineageTracker
+from .memory import MemoryLog
+from .policy import PolicyEngine
+from .protocols import BotExecutionError, BotResponse, MemoryRecord, Task, TaskPriority
+from .router import BotRegistry, RouteContext, Router, TaskRepository
+from .tasks import load_tasks, save_tasks
 
 __all__ = [
     "BaseBot",
@@ -17,23 +20,11 @@ __all__ = [
     "MemoryRecord",
     "Task",
     "TaskPriority",
+    "BotExecutionError",
     "BotRegistry",
     "RouteContext",
     "Router",
     "TaskRepository",
-]
-"""Task orchestrator utilities."""
-
-from .protocols import BaseBot, BotExecutionError, Task
-from .router import route_task
-from .tasks import load_tasks, save_tasks
-
-__all__ = [
-    "Task",
-    "BotExecutionError",
-    "BaseBot",
     "load_tasks",
     "save_tasks",
-    "route_task",
 ]
-

--- a/orchestrator/router.py
+++ b/orchestrator/router.py
@@ -1,4 +1,4 @@
-"""Task routing and bot execution."""
+"""Routing helpers for executing tasks with bots."""
 
 from __future__ import annotations
 
@@ -6,14 +6,15 @@ import json
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Mapping, Sequence
+from typing import Dict, List, Mapping, Sequence
 
-from orchestrator.base import BaseBot
-from orchestrator.exceptions import BotNotRegisteredError, TaskNotFoundError
-from orchestrator.lineage import LineageTracker
-from orchestrator.memory import MemoryLog
-from orchestrator.policy import PolicyEngine
-from orchestrator.protocols import BotResponse, Task, TaskPriority
+from .base import BaseBot
+from .exceptions import BotNotRegisteredError, TaskNotFoundError
+from .lineage import LineageTracker
+from .memory import MemoryLog
+from .metrics import log_metric
+from .policy import PolicyEngine
+from .protocols import BotExecutionError, BotResponse, Task, TaskPriority
 
 
 class BotRegistry:
@@ -42,10 +43,13 @@ class TaskRepository:
         self.path = path
         self.path.parent.mkdir(parents=True, exist_ok=True)
         if not self.path.exists():
-            self.path.write_text(json.dumps({}), encoding="utf-8")
+            self.path.write_text("{}", encoding="utf-8")
 
     def _load(self) -> Dict[str, dict[str, object]]:
-        return json.loads(self.path.read_text(encoding="utf-8"))
+        data = self.path.read_text(encoding="utf-8")
+        if not data.strip():
+            return {}
+        return json.loads(data)
 
     def _save(self, data: Mapping[str, dict[str, object]]) -> None:
         self.path.write_text(json.dumps(data, indent=2), encoding="utf-8")
@@ -61,16 +65,26 @@ class TaskRepository:
         if not payload:
             raise TaskNotFoundError(f"Task '{task_id}' not found")
         due_value = payload.get("due_date")
+        scheduled_value = payload.get("scheduled_for")
         return Task(
             id=payload["id"],
             goal=payload["goal"],
-            owner=payload["owner"],
-            priority=TaskPriority(payload["priority"]),
+            bot=payload.get("bot", ""),
+            owner=payload.get("owner", ""),
+            priority=payload.get("priority", TaskPriority.MEDIUM.value),
             created_at=datetime.fromisoformat(payload["created_at"]),
             due_date=datetime.fromisoformat(due_value) if due_value else None,
             tags=tuple(payload.get("tags", [])),
             metadata=dict(payload.get("metadata", {})),
             config=dict(payload.get("config", {})),
+            context=dict(payload.get("context", {})),
+            status=payload.get("status", "pending"),
+            depends_on=list(payload.get("depends_on", [])),
+            scheduled_for=(
+                datetime.fromisoformat(scheduled_value)
+                if scheduled_value
+                else None
+            ),
         )
 
     def list(self) -> Sequence[Task]:
@@ -78,17 +92,27 @@ class TaskRepository:
         tasks = []
         for payload in data.values():
             due_value = payload.get("due_date")
+            scheduled_value = payload.get("scheduled_for")
             tasks.append(
                 Task(
                     id=payload["id"],
                     goal=payload["goal"],
-                    owner=payload["owner"],
-                    priority=TaskPriority(payload["priority"]),
+                    bot=payload.get("bot", ""),
+                    owner=payload.get("owner", ""),
+                    priority=payload.get("priority", TaskPriority.MEDIUM.value),
                     created_at=datetime.fromisoformat(payload["created_at"]),
                     due_date=datetime.fromisoformat(due_value) if due_value else None,
                     tags=tuple(payload.get("tags", [])),
                     metadata=dict(payload.get("metadata", {})),
                     config=dict(payload.get("config", {})),
+                    context=dict(payload.get("context", {})),
+                    status=payload.get("status", "pending"),
+                    depends_on=list(payload.get("depends_on", [])),
+                    scheduled_for=(
+                        datetime.fromisoformat(scheduled_value)
+                        if scheduled_value
+                        else None
+                    ),
                 )
             )
         return tasks
@@ -101,7 +125,7 @@ class RouteContext:
     policy_engine: PolicyEngine
     memory: MemoryLog
     lineage: LineageTracker
-    config: Mapping[str, object] = None
+    config: Mapping[str, object] | None = None
     approved_by: Sequence[str] | None = None
 
 
@@ -114,7 +138,6 @@ class Router:
 
     def route(self, task_id: str, bot_name: str, context: RouteContext) -> BotResponse:
         task = self.repository.get(task_id)
-        # Merge context config into task config if provided
         if context.config:
             task.config = dict(context.config)
         bot = self.registry.get(bot_name)
@@ -123,14 +146,6 @@ class Router:
         context.memory.append(task, bot.metadata.name, response)
         context.lineage.record(task, bot.metadata.name, response)
         return response
-"""Routing helpers for executing tasks with bots."""
-
-from __future__ import annotations
-
-from typing import List
-
-from .metrics import log_metric
-from .protocols import BotExecutionError, Task
 
 
 def dependencies_met(task: Task, tasks: List[Task]) -> bool:
@@ -153,3 +168,12 @@ def route_task(task: Task, tasks: List[Task]) -> None:
     task.status = "done"
     log_metric("scheduled_run", task.id)
 
+
+__all__ = [
+    "BotRegistry",
+    "TaskRepository",
+    "RouteContext",
+    "Router",
+    "dependencies_met",
+    "route_task",
+]

--- a/tests/unit/test_auto_novel_agent.py
+++ b/tests/unit/test_auto_novel_agent.py
@@ -1,0 +1,72 @@
+"""Unit tests for :mod:`agents.auto_novel_agent`."""
+
+import pytest
+
+from agents.auto_novel_agent import (
+    AutoNovelAgent,
+    DEFAULT_CONSENT_SCOPES,
+    DEFAULT_SUPPORTED_ENGINES,
+)
+from agents.consent_policy import ConsentRecord
+
+
+@pytest.fixture()
+def agent() -> AutoNovelAgent:
+    """Return an agent with deterministic consent scopes for testing."""
+
+    consent = ConsentRecord.full(
+        scopes=DEFAULT_CONSENT_SCOPES,
+        evidence="unit-test",
+    )
+    return AutoNovelAgent(consent=consent)
+
+
+def test_deploy_returns_message(agent: AutoNovelAgent) -> None:
+    message = agent.deploy()
+    assert message.endswith("ready to generate novels!")
+
+
+def test_supported_engines_are_normalised(agent: AutoNovelAgent) -> None:
+    assert agent.supports_engine("Unity")
+    agent.add_supported_engine(" Godot ")
+    assert "godot" in agent.supported_engines
+    agent.remove_supported_engine("godot")
+    assert set(agent.list_supported_engines()) == set(DEFAULT_SUPPORTED_ENGINES)
+
+
+def test_create_game_with_unsupported_engine(agent: AutoNovelAgent) -> None:
+    with pytest.raises(ValueError, match="Unsupported engine"):
+        agent.create_game("cryengine")
+
+
+def test_generate_story_series(agent: AutoNovelAgent) -> None:
+    stories = agent.generate_story_series(["mystery", "sci-fi"], protagonist="Explorer")
+    assert len(stories) == 2
+    assert all("Explorer" in story for story in stories)
+
+
+def test_generate_code_snippet(agent: AutoNovelAgent) -> None:
+    snippet = agent.generate_code_snippet("Implement addition", language="python")
+    assert "TODO: Implement addition" in snippet
+    assert snippet.endswith("pass\n")
+
+
+def test_generate_code_snippet_invalid_language(agent: AutoNovelAgent) -> None:
+    with pytest.raises(ValueError, match="Unsupported language"):
+        agent.generate_code_snippet("demo", language="brainfuck")
+
+
+def test_validate_scopes_rejects_unknown(agent: AutoNovelAgent) -> None:
+    with pytest.raises(ValueError, match="Invalid scopes"):
+        agent.validate_scopes(["agent:configure", "unknown:scope"])
+
+
+def test_set_gamma_updates_value(agent: AutoNovelAgent) -> None:
+    agent.set_gamma(2.5)
+    assert agent.gamma == 2.5
+
+
+def test_write_novel_creates_outline(agent: AutoNovelAgent) -> None:
+    outline = agent.write_novel("Journey", chapters=2)
+    assert outline == ["Chapter 1: TBD", "Chapter 2: TBD"]
+

--- a/tools/storage.py
+++ b/tools/storage.py
@@ -1,3 +1,5 @@
+"""Storage helpers for Prism console utilities."""
+
 from __future__ import annotations
 
 import json
@@ -18,11 +20,11 @@ def _ensure_parent(path: Path) -> None:
 
 
 def write(path: str, content: Union[dict, str]) -> None:
-    p = Path(path)
-    _ensure_parent(p)
-    mode = "a" if p.suffix == ".jsonl" else "w"
+    target = Path(path)
+    _ensure_parent(target)
+    mode = "a" if target.suffix == ".jsonl" else "w"
     text = json.dumps(content) if isinstance(content, dict) else str(content)
-    with open(p, mode, encoding="utf-8") as fh:
+    with target.open(mode, encoding="utf-8") as fh:
         if mode == "a":
             fh.write(text + "\n")
         else:
@@ -30,9 +32,8 @@ def write(path: str, content: Union[dict, str]) -> None:
 
 
 def read(path: str) -> str:
-    p = Path(path)
     try:
-        with open(p, "r", encoding="utf-8") as fh:
+        with Path(path).open("r", encoding="utf-8") as fh:
             return fh.read()
     except FileNotFoundError:
         return ""
@@ -47,8 +48,8 @@ def read_json(path: str, *, from_data: bool = False) -> Any:
     target = _resolve(path, root)
     if not from_data and not target.exists():
         target = BASE_DIR / path
-    with open(target, "r", encoding="utf-8") as f:
-        return json.load(f)
+    with target.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
 
 
 def write_json(path: str, data: Any, *, from_data: bool = True) -> None:
@@ -57,8 +58,8 @@ def write_json(path: str, data: Any, *, from_data: bool = True) -> None:
     root = DATA_ROOT if from_data else CONFIG_ROOT
     target = _resolve(path, root)
     _ensure_parent(target)
-    with open(target, "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2, sort_keys=True)
+    with target.open("w", encoding="utf-8") as handle:
+        json.dump(data, handle, indent=2, sort_keys=True)
 
 
 def append_jsonl(path: str, record: Any, *, from_data: bool = True) -> None:
@@ -67,8 +68,8 @@ def append_jsonl(path: str, record: Any, *, from_data: bool = True) -> None:
     root = DATA_ROOT if from_data else CONFIG_ROOT
     target = _resolve(path, root)
     _ensure_parent(target)
-    with open(target, "a", encoding="utf-8") as f:
-        f.write(json.dumps(record) + "\n")
+    with target.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record) + "\n")
 
 
 def read_jsonl(path: str, *, from_data: bool = True) -> Iterable[Any]:
@@ -76,8 +77,8 @@ def read_jsonl(path: str, *, from_data: bool = True) -> Iterable[Any]:
     target = _resolve(path, root)
     if not target.exists():
         return []
-    with open(target, "r", encoding="utf-8") as f:
-        return [json.loads(line) for line in f if line.strip()]
+    with target.open("r", encoding="utf-8") as handle:
+        return [json.loads(line) for line in handle if line.strip()]
 
 
 def read_yaml(path: str, *, from_data: bool = False) -> Any:
@@ -85,8 +86,8 @@ def read_yaml(path: str, *, from_data: bool = False) -> Any:
     target = _resolve(path, root)
     if not from_data and not target.exists():
         target = BASE_DIR / path
-    with open(target, "r", encoding="utf-8") as f:
-        return yaml.safe_load(f)
+    with target.open("r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
 
 
 def read_text(path: str, *, from_data: bool = False) -> str:
@@ -94,8 +95,8 @@ def read_text(path: str, *, from_data: bool = False) -> str:
     target = _resolve(path, root)
     if not from_data and not target.exists():
         target = BASE_DIR / path
-    with open(target, "r", encoding="utf-8") as f:
-        return f.read()
+    with target.open("r", encoding="utf-8") as handle:
+        return handle.read()
 
 
 def write_text(path: str, text: str, *, from_data: bool = False) -> None:
@@ -104,48 +105,46 @@ def write_text(path: str, text: str, *, from_data: bool = False) -> None:
     root = DATA_ROOT if from_data else CONFIG_ROOT
     target = _resolve(path, root)
     _ensure_parent(target)
-    with open(target, "w", encoding="utf-8") as f:
-        f.write(text)
-"""Stub storage adapter."""
+    with target.open("w", encoding="utf-8") as handle:
+        handle.write(text)
 
 
 def save(path: str, content: bytes) -> None:
-    """Stubbed storage write."""
-    raise NotImplementedError("Storage adapter not implemented. TODO: connect to object store")
-"""Lightweight JSON storage helpers used by CLI modules."""
+    """Stubbed storage write used by legacy callers."""
 
-from __future__ import annotations
-
-import json
-from pathlib import Path
-from typing import Any
+    raise NotImplementedError(
+        "Storage adapter not implemented. TODO: connect to object store"
+    )
 
 
 def load_json(path: Path, default: Any) -> Any:
-    """Load JSON data from *path* if it exists, otherwise return *default*.
-
-    Parameters
-    ----------
-    path:
-        Location of the JSON file.
-    default:
-        Value returned when the file does not yet exist.
-    """
+    """Load JSON data from *path* if it exists, otherwise return *default*."""
 
     if path.exists():
-        with path.open("r", encoding="utf-8") as f:
-            return json.load(f)
+        with path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
     return default
 
 
 def save_json(path: Path, data: Any) -> None:
-    """Persist *data* as JSON to *path*.
-
-    The parent directory is created if necessary.  Datetime and date objects
-    are serialised using their ISO representation via ``default=str``.
-    """
+    """Persist *data* as JSON to *path*."""
 
     path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2, default=str)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(data, handle, indent=2, default=str)
 
+
+__all__ = [
+    "write",
+    "read",
+    "read_json",
+    "write_json",
+    "append_jsonl",
+    "read_jsonl",
+    "read_yaml",
+    "read_text",
+    "write_text",
+    "save",
+    "load_json",
+    "save_json",
+]


### PR DESCRIPTION
## Summary
- rebuild the AutoNovel agent to remove merge conflicts, enforce consent checks, and expose working story/game helpers
- add pytest coverage for the AutoNovel agent behaviours and normalise the bot discovery registry and orchestration protocols
- clean up shared storage and routing utilities so bots and task repositories operate against consistent data structures

## Testing
- pytest tests/unit/test_auto_novel_agent.py

------
https://chatgpt.com/codex/tasks/task_e_690c14621d348329a85b6bf9acfdbdc1