### PR TITLE
Document final close-out baseline

### DIFF
--- a/docs/final_close_out.md
+++ b/docs/final_close_out.md
@@ -1,0 +1,18 @@
+# Final Close-Out Baseline
+
+This note captures the outcomes of the Silas lock-in close-out and the new guardrails for future engagements.
+
+## Completed Actions
+- Repository archived and all remaining automation halted.
+- Promotional hype cycle ended to prevent further distraction.
+- Access filter hardened to block low-signal noise.
+- Time commitments reclaimed for high-leverage projects only.
+
+## New Operating Baseline
+- Require a **live URL built from `main@HEAD`** before engaging in any further reviews.
+- Decline speculative workstreams that hinge on YAML-only artifacts or indefinite future milestones.
+- Focus energy on initiatives with demonstrable velocity and production proof.
+- Accept that closing threads without shippable links is a win and frees resources for the next mission.
+
+## Next Step
+Drop the next live link when it exists—or close the laptop and breathe knowing the mission is complete.


### PR DESCRIPTION
## Summary
- capture the completed actions from the Silas lock-in close-out
- document the new operating baseline that requires shipping main@HEAD to a live URL
- encourage either shipping the next live link or closing out confidently

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690c1b3f92b48329bf02701ad936acf5