### PR TITLE
Ignore Python egg-info directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 *.pyc
 *.pyo
 *.pyd
+*.egg-info/
 .env
 .venv/
 .mypy_cache/


### PR DESCRIPTION
## Summary
- ignore Python egg-info metadata directories so they do not appear as untracked files

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690c1f6803608329846eaf9a9e0a6f55