### PR TITLE
Add OpenAI cover letter and resume assets to job applier

### DIFF
--- a/opt/blackroad/services/job_applier/app/assets/__init__.py
+++ b/opt/blackroad/services/job_applier/app/assets/__init__.py
@@ -43,6 +43,18 @@ _ASSETS: Dict[str, Asset] = {
         filename="cover_note_micro_template.txt",
         media_type="text/plain",
     ),
+    "openai_cover_letter": Asset(
+        key="openai_cover_letter",
+        description="Revised OpenAI cover letter grounded in repository evidence.",
+        filename="openai_cover_letter.md",
+        media_type="text/markdown",
+    ),
+    "openai_resume": Asset(
+        key="openai_resume",
+        description="Revised OpenAI-facing resume highlighting compliance architecture and orchestration.",
+        filename="openai_resume.md",
+        media_type="text/markdown",
+    ),
     "application_qa_schema": Asset(
         key="application_qa_schema",
         description="Structured JSON of common application questions and placeholders.",

--- a/opt/blackroad/services/job_applier/app/assets/openai_cover_letter.md
+++ b/opt/blackroad/services/job_applier/app/assets/openai_cover_letter.md
@@ -1,0 +1,19 @@
+ALEXA LOUISE AMUNDSON  
+Lakeville, MN • amundsonalexa@gmail.com • (507) 828-0842  
+blackroad.io • github.com/blackboxprogramming • linkedin.com/in/alexaamundson
+
+Dear Hiring Team at OpenAI,
+
+I’m Alexa Amundson — a solo founder and architect who built a self-orchestrating network of autonomous AI agents, replacing traditional engineering teams. The system self-builds, tests, and deploys financial pipelines with 99.9% SEC/FINRA compliance via zero-trust policy enforcement.
+
+Three years out of an advertising degree, I’ve built zero-trust, air-gapped architectures that merge multi-model orchestration (MoE, RAG-Fusion) with policy-as-code enforcement (OPA/Rego). My work proves that safe, verifiable multi-agent ecosystems are operational—not theoretical. For evidence, see the HARDENING.md in my blackroad-prism-console repo for Rego policy examples, and the Merge Queue Primer for compliance protection in high-velocity PR flows.
+
+OpenAI’s work on o1 and multi-agent alignment mirrors the foundation of my patent-pending Agent Orchestration and Cryptographic Verification Ledger. I understand both the creative and regulatory “pitstops” of scaling intelligence—where compliance, ethics, and reproducibility converge. I’d bring immediate value to OpenAI’s applied teams driving agent orchestration, compliance frameworks, and trust-layer design, including microservices with dedicated Rego-based policy enforcement (detailed in my Blackroad Microservices Architecture paper).
+
+I’m seeking a senior or applied role in AI orchestration or compliance architecture with a target of $300K base + equity. I’d welcome the chance to discuss how my systems-first approach could accelerate OpenAI’s mission of safe, scalable intelligence.
+
+Thank you for your time and consideration.
+
+Sincerely,  
+Alexa Louise Amundson  
+amundsonalexa@gmail.com | (507) 828-0842

--- a/opt/blackroad/services/job_applier/app/assets/openai_resume.md
+++ b/opt/blackroad/services/job_applier/app/assets/openai_resume.md
@@ -1,0 +1,60 @@
+# Alexa Louise Amundson
+AI Orchestration Architect | RegTech Founder | FinTech Sales Leader  
+Lakeville, MN • amundsonalexa@gmail.com • (507) 828-0842  
+LinkedIn: linkedin.com/in/alexaamundson • GitHub: github.com/blackboxprogramming • Portfolio: blackroad.io  
+Patent Pending
+
+## Executive Summary
+Solo founder and architect who built a self-orchestrating network of autonomous AI agents—delivering compliant financial pipelines while maintaining 99.9% compliance. Blends cold-calling tenacity with AI orchestration to fuse product, compliance, and revenue streams.
+
+## Core Competencies
+- AI Orchestration & Architecture: Multi-agent swarm; multi-model MoE + RAG-Fusion; zero-trust policy-as-code (OPA/Rego).
+- FinTech & RegTech: 99.9% audit pass; lead lift via predictive models.
+- Leadership & Strategy: Cross-functional execution; public speaking; negotiation; deal structuring.
+- Compliance & Security: SEC Rule 204-2 & FINRA 2210 enforcement.
+- Capital-Efficient Engineering: High-velocity CI/CD; offline-first air-gapped runtime; 85%+ test coverage.
+
+## Professional Experience
+### Founder & Chief Architect — BlackRoad Inc. / Prism Console (Remote) | May 2025 – Present
+- Conceived 5-layer Prism architecture (Interface → Orchestration → Data → Compliance → Compute) enabling autonomous agents to self-build/test/deploy financial pipelines.
+- Orchestrated agents (GPT-4, Claude, Llama 3, Mistral, Qwen, Grok) to produce high-volume pull requests at low cost; agents wrote majority of production code.
+- Implemented zero-trust compliance layer with OPA/Rego enforcing SEC 204-2 & FINRA 2210, achieving 99.9% audit pass rate (see HARDENING.md in github.com/blackboxprogramming/blackroad-prism-console for Rego snippets).
+- Built <100 ms RAG retrieval layer (FastAPI + Qdrant) with mandatory contextual citations.
+- Protected compliance artifacts via merge queue for 60–100 weekly PRs, preventing regressions (detailed in Merge Queue Primer doc).
+- Deployed air-gapped runtime for field kits; integrated Prometheus/Grafana/Jaeger; enforced CI/CD guardrails (85%+ coverage, ≤10 min CI, auto-rollback on P95 latency > 2× baseline).
+- Led core refactor (ddbf8269): stabilized CLI, orchestrator, audit trails, HITL, compliance loops across finance, legal, supply chain, security, and AI ops.
+- Architected 12 microservices: zkVM (SNARK/PLONK), in-toto DAGs, SBOM closure, TPM validation; with dedicated Rego-based policy enforcement service (see Blackroad Microservices Architecture paper).
+
+### Internal Annuity Wholesaler / Senior Sales Analyst — Securian Financial Services (St. Paul, MN – Remote) | Jul 2024 – Jun 2025
+- Generated high-volume fixed index annuity sales, ranking #3 nationally.
+- Developed Excel/VBA predictive lead model across five annuity structures, boosting qualified lead attribution by 75%.
+- Audited 6,000+ Salesforce records for FINRA 2210 compliance, correcting 139 entries.
+- Managed 2,300 targeted emails and 160+ client calls monthly, driving 33% month-over-month case growth.
+- Selected presenter for LPL Financial Due Diligence Conference (24K advisors, 2024); transitioned before event.
+- Simplified actuarial structures for advisors, mitigating cap-lock, renewal, and reinsurance risks.
+- Partnered with product owners on hedging strategies and capital constraints.
+
+### Financial Advisor / Advisor-in-Training — Ameriprise Financial (Minneapolis, MN) | Aug 2023 – May 2024
+- Identified new assets under management; retained at-risk assets with 97% client satisfaction.
+- Closed pipeline via options-based hedging (collars, spreads, straddles).
+- Ranked #1 in qualified appointment setting; onboarded 40+ clients with 70% product acceptance.
+
+### Licensed Real Estate Agent — eXp Realty / Pemberton Homes Team (Twin Cities) | Aug 2022 – Aug 2023
+- Supported buyer transactions (avg $450K) with 100% inspection/appraisal protection.
+- Generated 1,000+ cold calls (10% pickup, 80% conversion); managed 100+ follow-ups.
+
+### Earlier Roles
+Customer Service Rep — Enterprise Holdings (3× MSP Select Award, 2019)  
+Sales & Marketing Intern — CDW Inc. (CRM analytics, 2019)  
+Aquatic Center Attendant — City of Marshall (2016–2017)
+
+## Education & Licenses
+B.A., Strategic Communication (Advertising & Public Relations) — University of Minnesota Twin Cities, Dec 2022  
+Series 7 (Nov 2023) • SIE (Sep 2023) • Series 65 (Feb 2024) • Series 63 (Feb 2024) • Life & Health (MN) • Real Estate (Inactive)
+
+## Leadership & Recognition
+Selected Presenter: LPL Due Diligence (2024) & Securian Winter Sales (2024). National Speech & Debate Finalist • Speech Captain • Class President • Marching Band Leader. Awards: Ameriprise Sales Training • MSP Select (x3).
+
+## Patents, Publications & Trademarks
+U.S. Provisional Patent (Pending): “Agent Orchestration and Cryptographic Verification Ledger” (2024). Prism Repository Grammar: Open-source framework for auditable AI agent orchestration. Trademarks (Pending): BlackRoad® (2025) • Lucidia® (2025) • Alice® (2025)  
+“I don’t manage teams. I build systems that manage themselves.”


### PR DESCRIPTION
## Summary
- add markdown assets containing the revised OpenAI cover letter and resume for Alexa Louise Amundson
- register the new documents in the job applier asset catalog so they can be downloaded like other templates

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_690c5191586483298c7e4ee9ebf04e9e