### PR TITLE
Fix bot registry and storage utilities

### DIFF
--- a/orchestrator/protocols.py
+++ b/orchestrator/protocols.py
@@ -1,13 +1,11 @@
-"""Shared typing contracts for Prism Console bots and tasks."""
-"""Core data structures shared across orchestrator components."""
+"""Shared data contracts for bots and the orchestrator."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, List, Mapping, MutableMapping, Optional, Protocol, Sequence, runtime_checkable
-from typing import Any, Dict, List, Mapping, MutableMapping, Optional, Sequence
+from typing import Any, Dict, Mapping, MutableMapping, Optional, Sequence
 
 
 class TaskPriority(str, Enum):
@@ -25,12 +23,6 @@ class Task:
     id: str
     goal: str
     owner: Optional[str] = None
-    """Normalised task representation used by bots and the router."""
-
-    id: str
-    goal: str
-    bot: str = ""
-    owner: str = ""
     priority: TaskPriority | str = TaskPriority.MEDIUM
     created_at: datetime = field(default_factory=datetime.utcnow)
     due_date: Optional[datetime] = None
@@ -41,34 +33,31 @@ class Task:
     context: MutableMapping[str, Any] | None = None
     status: str = "pending"
     depends_on: Sequence[str] = field(default_factory=tuple)
-    metadata: MutableMapping[str, Any] = field(default_factory=dict)
-    config: Mapping[str, Any] = field(default_factory=dict)
-    context: Dict[str, Any] = field(default_factory=dict)
-    status: str = "pending"
-    depends_on: List[str] = field(default_factory=list)
     scheduled_for: Optional[datetime] = None
 
     def __post_init__(self) -> None:
         if isinstance(self.priority, str):
             self.priority = TaskPriority(self.priority.lower())
+
         if self.metadata is None:
             self.metadata = {}
-        if self.config is None:
-            self.config = {}
-        if self.context is None:
-            self.context = {}
-        self.tags = tuple(self.tags)
-        self.depends_on = tuple(self.depends_on)
-        if not isinstance(self.tags, tuple):
-            self.tags = tuple(self.tags)
         if not isinstance(self.metadata, MutableMapping):
             self.metadata = dict(self.metadata)
-        if not isinstance(self.config, Mapping):
+
+        if self.config is None:
+            self.config = {}
+        if not isinstance(self.config, MutableMapping):
             self.config = dict(self.config)
-        if not isinstance(self.context, dict):
+
+        if self.context is None:
+            self.context = {}
+        if not isinstance(self.context, MutableMapping):
             self.context = dict(self.context)
-        if not isinstance(self.depends_on, list):
-            self.depends_on = list(self.depends_on)
+
+        if not isinstance(self.tags, tuple):
+            self.tags = tuple(self.tags)
+        if not isinstance(self.depends_on, tuple):
+            self.depends_on = tuple(self.depends_on)
 
     def to_dict(self) -> Dict[str, Any]:
         """Serialise the task for persistence or transport."""
@@ -76,7 +65,6 @@ class Task:
         payload: Dict[str, Any] = {
             "id": self.id,
             "goal": self.goal,
-            "bot": self.bot,
             "owner": self.owner,
             "priority": self.priority.value,
             "created_at": self.created_at.isoformat(),
@@ -85,17 +73,14 @@ class Task:
             "metadata": dict(self.metadata),
             "config": dict(self.config),
             "context": dict(self.context),
-            "status": self.status,
             "depends_on": list(self.depends_on),
         }
+        if self.bot:
+            payload["bot"] = self.bot
         if self.due_date:
             payload["due_date"] = self.due_date.isoformat()
         if self.scheduled_for:
             payload["scheduled_for"] = self.scheduled_for.isoformat()
-        if self.bot:
-            payload["bot"] = self.bot
-        if self.context:
-            payload["context"] = dict(self.context)
         return payload
 
 
@@ -164,15 +149,6 @@ class BotExecutionError(Exception):
         self.details = details
 
 
-@runtime_checkable
-class BaseBot(Protocol):
-    """Protocol describing the runtime contract for bots."""
-
-    NAME: str
-    SUPPORTED_TASKS: List[str]
-
-    def run(self, task: Task) -> Any:  # pragma: no cover - implementation specific
-        ...
 __all__ = [
     "TaskPriority",
     "Task",
@@ -180,3 +156,4 @@ __all__ = [
     "MemoryRecord",
     "BotExecutionError",
 ]
+

--- a/prism_utils.py
+++ b/prism_utils.py
@@ -1,4 +1,4 @@
-"""Utility functions for the BlackRoad Prism console."""
+"""Utility helpers for Prism console scripts."""
 
 from __future__ import annotations
 
@@ -7,47 +7,28 @@ import re
 # Match an optional sign and decimal number at the start of the string.
 #
 # The pattern also accepts numbers like ``.5`` or ``-.25`` that omit the
-# leading ``0`` before the decimal point.
-_NUMERIC_PREFIX = re.compile(r"^\s*([+-]?(?:\d+(?:\.\d+)?|\.\d+))")
+# leading ``0`` before the decimal point. The negative lookahead ensures the
+# match is not immediately followed by an alphanumeric character so that
+# strings such as ``"1a"`` are treated as invalid.
+_NUMERIC_PREFIX = re.compile(r"^\s*([+-]?(?:\d+(?:\.\d*)?|\.\d+))(?![0-9A-Za-z_])")
 
 
 def parse_numeric_prefix(text: str) -> float:
     """Extract a leading decimal value from ``text``.
 
-    The regex ignores leading whitespace and accepts an optional ``+`` or ``-``
-    sign and an optional fractional part. Numbers lacking a leading zero, such
-    as ``".5 kg"`` or ``"-.25"``, are also recognized. If no valid number is
-    found, ``1.0`` is returned. Inputs such as ``"-3.5 apples"`` or ``"2, rest"``
-    are recognized; malformed values default to ``1.0``.
-# Matches a decimal number with optional leading whitespace, sign, and fractional part.
-_NUMERIC_PREFIX = re.compile(r"^\s*([+-]?\d+(?:\.\d+)?)")
-
-
-def parse_numeric_prefix(text: str) -> float:
-    """Return the leading decimal value in ``text``.
-
-    Allows leading whitespace, an optional sign, and fractional part while
-    ignoring trailing characters. Returns ``1.0`` when no valid number is
-    found.
+    Numbers lacking a leading zero (``".5"``) or containing a sign are
+    accepted, while invalid prefixes (``"1a"``) fall back to ``1.0``.
+    Trailing characters after the numeric component are ignored.
     """
+
     match = _NUMERIC_PREFIX.match(text)
-    if match:
-        try:
-            return float(match.group(1))
-        except ValueError:
-            pass
-    This uses :func:`ast.literal_eval` for safety instead of ``eval`` and
-    accepts inputs like ``"2, something"``. Literal boolean values such as
-    ``"True"`` or ``"False"`` are treated as non-numeric, and only
-    ``ValueError`` or ``SyntaxError`` are suppressed—these yield a default
-    return of ``1.0``.
-    """
+    if not match:
+        return 1.0
     try:
-        value = ast.literal_eval(text.split(",", maxsplit=1)[0].strip())
-        if isinstance(value, bool):
-            return 1.0
-        if isinstance(value, (int, float)):
-            return float(value)
-    except (ValueError, SyntaxError):
-        pass
-    return 1.0
+        return float(match.group(1))
+    except ValueError:  # pragma: no cover - defensive guard
+        return 1.0
+
+
+__all__ = ["parse_numeric_prefix"]
+

--- a/tools/storage.py
+++ b/tools/storage.py
@@ -1,18 +1,17 @@
-"""Persistent storage helpers for Prism Console modules."""
-"""Storage helpers for Prism console utilities."""
+"""Lightweight file system helpers used across the project."""
 
 from __future__ import annotations
 
 import json
 import os
 from pathlib import Path
-from typing import Any, Iterable, Union
+from typing import Any, Iterable, Mapping, Union
 
 import yaml
 
 BASE_DIR = Path(__file__).resolve().parents[1]
-DATA_ROOT = Path(os.environ.get("PRISM_DATA_ROOT", BASE_DIR / "data"))
 CONFIG_ROOT = BASE_DIR / "config"
+DATA_ROOT = BASE_DIR / "data"
 READ_ONLY = os.environ.get("PRISM_READ_ONLY", "0") == "1"
 
 
@@ -20,13 +19,12 @@ def _ensure_parent(path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
 
 
-def write(path: str, content: Union[dict, str]) -> None:
+def write(path: str, content: Union[Mapping[str, Any], str]) -> None:
     target = Path(path)
     _ensure_parent(target)
     mode = "a" if target.suffix == ".jsonl" else "w"
-    text = json.dumps(content) if isinstance(content, dict) else str(content)
+    text = json.dumps(content) if isinstance(content, Mapping) else str(content)
     with target.open(mode, encoding="utf-8") as handle:
-    with target.open(mode, encoding="utf-8") as fh:
         if mode == "a":
             handle.write(text + "\n")
         else:
@@ -36,14 +34,15 @@ def write(path: str, content: Union[dict, str]) -> None:
 def read(path: str) -> str:
     try:
         return Path(path).read_text(encoding="utf-8")
-        with Path(path).open("r", encoding="utf-8") as fh:
-            return fh.read()
     except FileNotFoundError:
         return ""
 
 
 def _resolve(path: str, root: Path) -> Path:
-    return root / path
+    candidate = Path(path)
+    if candidate.is_absolute():
+        return candidate
+    return root / candidate
 
 
 def read_json(path: str, *, from_data: bool = False) -> Any:
@@ -98,7 +97,6 @@ def read_text(path: str, *, from_data: bool = False) -> str:
     target = _resolve(path, root)
     if not from_data and not target.exists():
         target = BASE_DIR / path
-    return target.read_text(encoding="utf-8")
     with target.open("r", encoding="utf-8") as handle:
         return handle.read()
 
@@ -113,25 +111,14 @@ def write_text(path: str, text: str, *, from_data: bool = False) -> None:
 
 
 def save(path: str, content: bytes) -> None:
-    raise NotImplementedError("Storage adapter not implemented. TODO: connect to object store")
+    if READ_ONLY:
+        raise RuntimeError("read-only mode")
+    target = Path(path)
+    _ensure_parent(target)
+    target.write_bytes(content)
 
 
 def load_json(path: Path, default: Any) -> Any:
-    with target.open("w", encoding="utf-8") as handle:
-        handle.write(text)
-
-
-def save(path: str, content: bytes) -> None:
-    """Stubbed storage write used by legacy callers."""
-
-    raise NotImplementedError(
-        "Storage adapter not implemented. TODO: connect to object store"
-    )
-
-
-def load_json(path: Path, default: Any) -> Any:
-    """Load JSON data from *path* if it exists, otherwise return *default*."""
-
     if path.exists():
         with path.open("r", encoding="utf-8") as handle:
             return json.load(handle)
@@ -139,12 +126,7 @@ def load_json(path: Path, default: Any) -> Any:
 
 
 def save_json(path: Path, data: Any) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w", encoding="utf-8") as handle:
-        json.dump(data, handle, indent=2, default=str)
-    """Persist *data* as JSON to *path*."""
-
-    path.parent.mkdir(parents=True, exist_ok=True)
+    _ensure_parent(path)
     with path.open("w", encoding="utf-8") as handle:
         json.dump(data, handle, indent=2, default=str)
 
@@ -163,3 +145,4 @@ __all__ = [
     "load_json",
     "save_json",
 ]
+


### PR DESCRIPTION
## Summary
- rebuild the bots package registry to autodiscover both BaseBot subclasses and lightweight bots
- restore the orchestrator protocols, router, and shared utilities that had been duplicated and malformed
- repair the numeric prefix helper used in tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690c20b8edc083299d73816079886d99