### PR TITLE
Add zeta functor toolkit for scripture graph analysis

### DIFF
--- a/zetafunctor/README.md
+++ b/zetafunctor/README.md
@@ -1,0 +1,34 @@
+# Zeta Functor Scaffold
+
+This package stitches together text hashing, Mandelbrot escape analysis, and
+weighted adjacency construction for scripture cross-reference studies.
+
+## Features
+
+- Rolling SHA-256 hashing with projections to the complex plane.
+- Mandelbrot escape-time histograms for hashed points.
+- Log-damped, row-normalised adjacency builders for bigram or edge-list inputs.
+- CSV parser for Bible cross references with optional prime-index filtering.
+- Rohonc glyph mapper that fits glyphs into a 256-symbol alphabet.
+- Matrix zeta scans with spectral radius-derived convergence bounds.
+- Command line interface and demo pipeline that produce ready-to-inspect plots.
+
+## Quickstart
+
+```bash
+python -m zetafunctor.demo
+```
+
+This generates `histogram_mandelbrot_escape.png`, `zeta_mag_plot.png`, and a
+sample cross-reference CSV illustrating the new tooling.
+
+To explore individual pieces:
+
+```bash
+python -m zetafunctor.cli hash --text "In the beginning..."
+python -m zetafunctor.cli crossref demo_crossrefs.csv
+python -m zetafunctor.cli scan demo_crossrefs.csv --start 0.0 --stop 0.9 --steps 20
+```
+
+Add `--prime-only` to `crossref` or `scan` commands to restrict attention to
+prime-indexed entries (1-based indexing).

--- a/zetafunctor/__init__.py
+++ b/zetafunctor/__init__.py
@@ -1,0 +1,12 @@
+"""Utility package for exploring weighted scripture graphs and dynamical zeta scans."""
+
+from . import hashing, mandelbrot, graphing, zeta, primes, rohonc
+
+__all__ = [
+    "hashing",
+    "mandelbrot",
+    "graphing",
+    "zeta",
+    "primes",
+    "rohonc",
+]

--- a/zetafunctor/cli.py
+++ b/zetafunctor/cli.py
@@ -1,0 +1,99 @@
+"""Command line interface for the zeta functor toolkit."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+
+from . import graphing, hashing, mandelbrot, zeta
+
+
+def _load_text(args: argparse.Namespace) -> str:
+    if args.file:
+        return Path(args.file).read_text(encoding="utf-8")
+    if args.text:
+        return args.text
+    raise SystemExit("Either --text or --file must be provided")
+
+
+def command_hash(args: argparse.Namespace) -> None:
+    text = _load_text(args)
+    points = hashing.rolling_hash_to_complex(text, window=args.window, step=args.step)
+    histogram = mandelbrot.escape_histogram(points, max_iter=args.max_iter, bailout=args.bailout)
+    normalised = mandelbrot.normalise_histogram(histogram)
+    for iteration, probability in normalised:
+        print(f"iter={iteration:3d} probability={probability:.4f}")
+
+
+def command_crossref(args: argparse.Namespace) -> None:
+    edges = graphing.parse_cross_reference_csv(
+        Path(args.csv),
+        delimiter=args.delimiter,
+        prime_only=args.prime_only,
+    )
+    adjacency = graphing.build_weighted_adjacency(edges)
+    radius = zeta.radius_of_convergence(adjacency.matrix)
+    print(f"parsed_edges={len(edges)} nodes={len(adjacency.index_to_node)} radius_bound={radius:.4f}")
+
+
+def command_scan(args: argparse.Namespace) -> None:
+    adjacency = graphing.build_cross_reference_adjacency(
+        Path(args.csv),
+        delimiter=args.delimiter,
+        prime_only=args.prime_only,
+    )
+    radius = zeta.radius_of_convergence(adjacency.matrix)
+    if np.isfinite(radius):
+        stop = min(args.stop, 0.99 * radius)
+    else:
+        stop = args.stop
+    if stop <= args.start:
+        raise SystemExit("Scan stop must be greater than start after applying radius bound")
+    z_values = np.linspace(args.start, stop, args.steps)
+    samples = zeta.scan_zeta_magnitude(adjacency.matrix, (complex(z, 0.0) for z in z_values))
+    for z_value, magnitude in samples:
+        print(f"z={z_value.real:.4f} |zeta|={magnitude}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Zeta functor sandbox")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    hash_parser = subparsers.add_parser("hash", help="Hash text and collect Mandelbrot escape stats")
+    hash_parser.add_argument("--text", help="Text to analyse")
+    hash_parser.add_argument("--file", help="Path to text file")
+    hash_parser.add_argument("--window", type=int, default=128, help="Sliding window size")
+    hash_parser.add_argument("--step", type=int, default=1, help="Stride between windows")
+    hash_parser.add_argument("--max-iter", type=int, default=256, help="Maximum Mandelbrot iterations")
+    hash_parser.add_argument("--bailout", type=float, default=2.0, help="Escape radius")
+    hash_parser.set_defaults(func=command_hash)
+
+    cross_parser = subparsers.add_parser("crossref", help="Summarise cross-reference CSV into adjacency stats")
+    cross_parser.add_argument("csv", help="Path to cross-reference CSV")
+    cross_parser.add_argument("--delimiter", default=",", help="CSV delimiter")
+    cross_parser.add_argument("--prime-only", action="store_true", help="Keep only prime-indexed rows")
+    cross_parser.set_defaults(func=command_crossref)
+
+    scan_parser = subparsers.add_parser("scan", help="Scan |zeta_A(z)| along the real axis")
+    scan_parser.add_argument("csv", help="Path to cross-reference CSV")
+    scan_parser.add_argument("--delimiter", default=",", help="CSV delimiter")
+    scan_parser.add_argument("--prime-only", action="store_true", help="Keep only prime-indexed rows")
+    scan_parser.add_argument("--start", type=float, default=0.0, help="Start of scan range")
+    scan_parser.add_argument("--stop", type=float, default=1.0, help="End of scan range")
+    scan_parser.add_argument("--steps", type=int, default=25, help="Number of evaluation points")
+    scan_parser.set_defaults(func=command_scan)
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    args.func(args)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/zetafunctor/demo.py
+++ b/zetafunctor/demo.py
@@ -1,0 +1,91 @@
+"""Run the complete zeta functor showcase pipeline."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from . import graphing, hashing, mandelbrot, zeta
+
+
+OUTPUT_DIR = Path(".")
+HISTOGRAM_PATH = OUTPUT_DIR / "histogram_mandelbrot_escape.png"
+ZETA_PATH = OUTPUT_DIR / "zeta_mag_plot.png"
+CROSSREF_CSV = OUTPUT_DIR / "demo_crossrefs.csv"
+
+
+SAMPLE_TEXT = """In the beginning God created the heaven and the earth. The earth was without form."""
+
+
+SAMPLE_CROSSREFS = [
+    {"source": "Genesis 1:1", "target": "John 1:1", "count": 12, "semantic": 0.92},
+    {"source": "Genesis 1:1", "target": "Psalm 104:30", "count": 5, "semantic": 0.71},
+    {"source": "Exodus 3:14", "target": "John 8:58", "count": 7, "semantic": 0.88},
+    {"source": "Isaiah 40:3", "target": "Matthew 3:3", "count": 10, "semantic": 0.94},
+    {"source": "Jeremiah 31:31", "target": "Hebrews 8:8", "count": 4, "semantic": 0.67},
+]
+
+
+def write_demo_crossrefs(path: Path) -> None:
+    with path.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=["source", "target", "count", "semantic"])
+        writer.writeheader()
+        writer.writerows(SAMPLE_CROSSREFS)
+
+
+def run_hashing_demo(text: str) -> None:
+    points = hashing.hash_blocks_to_complex(text, block_size=64)
+    histogram = mandelbrot.escape_histogram(points, max_iter=128)
+    normalised = mandelbrot.normalise_histogram(histogram)
+
+    plt.figure(figsize=(6, 4))
+    xs = [iteration for iteration, _ in normalised]
+    ys = [probability for _, probability in normalised]
+    plt.bar(xs, ys, width=0.8)
+    plt.xlabel("Iterations")
+    plt.ylabel("Probability")
+    plt.title("Mandelbrot Escape Histogram")
+    plt.tight_layout()
+    plt.savefig(HISTOGRAM_PATH)
+    plt.close()
+
+
+def run_crossref_demo(csv_path: Path) -> graphing.AdjacencyResult:
+    edges = graphing.parse_cross_reference_csv(csv_path)
+    adjacency = graphing.build_weighted_adjacency(edges)
+    prime_edges = graphing.parse_cross_reference_csv(csv_path, prime_only=True)
+    print(f"parsed {len(edges)} edges ({len(prime_edges)} with prime index toggle)")
+    return adjacency
+
+
+def run_zeta_scan(adjacency: graphing.AdjacencyResult) -> None:
+    radius = zeta.radius_of_convergence(adjacency.matrix)
+    if not np.isfinite(radius):
+        radius = 1.0
+    z_values = np.linspace(0.0, 0.99 * radius, 50)
+    samples = zeta.scan_zeta_magnitude(adjacency.matrix, (complex(z, 0.0) for z in z_values))
+
+    plt.figure(figsize=(6, 4))
+    plt.plot([z.real for z, _ in samples], [mag for _, mag in samples])
+    plt.xlabel("z (real axis)")
+    plt.ylabel("|zeta_A(z)|")
+    plt.title("Zeta Magnitude Scan")
+    plt.tight_layout()
+    plt.savefig(ZETA_PATH)
+    plt.close()
+
+
+def main() -> None:
+    write_demo_crossrefs(CROSSREF_CSV)
+    run_hashing_demo(SAMPLE_TEXT)
+    adjacency = run_crossref_demo(CROSSREF_CSV)
+    run_zeta_scan(adjacency)
+    print(f"Histogram written to {HISTOGRAM_PATH}")
+    print(f"Zeta scan written to {ZETA_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/zetafunctor/graphing.py
+++ b/zetafunctor/graphing.py
@@ -1,0 +1,182 @@
+"""Utilities for constructing weighted adjacency matrices from textual data."""
+
+from __future__ import annotations
+
+import csv
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple
+
+import numpy as np
+
+from . import primes
+
+
+@dataclass
+class Edge:
+    source: str
+    target: str
+    count: float = 1.0
+    semantic: Optional[float] = None
+
+
+@dataclass
+class AdjacencyResult:
+    matrix: np.ndarray
+    index_to_node: List[str]
+    node_to_index: Dict[str, int]
+
+
+def _ensure_node(node: str, mapping: MutableMapping[str, int], order: List[str]) -> int:
+    if node not in mapping:
+        mapping[node] = len(order)
+        order.append(node)
+    return mapping[node]
+
+
+def _combine_weights(count: float, semantic: Optional[float]) -> float:
+    damped = math.log1p(max(count, 0.0))
+    if semantic is None or semantic <= 0:
+        return damped
+    if damped <= 0:
+        return semantic
+    return math.sqrt(damped * semantic)
+
+
+def build_bigram_adjacency(tokens: Sequence[str], row_normalise: bool = True) -> AdjacencyResult:
+    """Create a weighted adjacency matrix from token bigrams."""
+
+    node_to_index: Dict[str, int] = {}
+    index_to_node: List[str] = []
+    weights: Dict[Tuple[int, int], float] = {}
+
+    for current, nxt in zip(tokens, tokens[1:]):
+        i = _ensure_node(current, node_to_index, index_to_node)
+        j = _ensure_node(nxt, node_to_index, index_to_node)
+        weights[(i, j)] = weights.get((i, j), 0.0) + 1.0
+
+    size = len(index_to_node)
+    matrix = np.zeros((size, size), dtype=float)
+    for (i, j), value in weights.items():
+        matrix[i, j] = value
+
+    if row_normalise and size:
+        row_sums = matrix.sum(axis=1, keepdims=True)
+        row_sums[row_sums == 0] = 1.0
+        matrix = matrix / row_sums
+
+    return AdjacencyResult(matrix=matrix, index_to_node=index_to_node, node_to_index=node_to_index)
+
+
+def build_weighted_adjacency(edges: Iterable[Edge], row_normalise: bool = True) -> AdjacencyResult:
+    """Create a row-stochastic adjacency matrix using damped counts and optional semantics."""
+
+    node_to_index: Dict[str, int] = {}
+    index_to_node: List[str] = []
+    matrix_map: Dict[Tuple[int, int], float] = {}
+
+    for edge in edges:
+        i = _ensure_node(edge.source, node_to_index, index_to_node)
+        j = _ensure_node(edge.target, node_to_index, index_to_node)
+        weight = _combine_weights(edge.count, edge.semantic)
+        if weight <= 0:
+            continue
+        matrix_map[(i, j)] = matrix_map.get((i, j), 0.0) + weight
+
+    size = len(index_to_node)
+    matrix = np.zeros((size, size), dtype=float)
+    for (i, j), value in matrix_map.items():
+        matrix[i, j] = value
+
+    if row_normalise and size:
+        row_sums = matrix.sum(axis=1, keepdims=True)
+        row_sums[row_sums == 0] = 1.0
+        matrix = matrix / row_sums
+
+    return AdjacencyResult(matrix=matrix, index_to_node=index_to_node, node_to_index=node_to_index)
+
+
+def _canonical_reference(row: Mapping[str, str], prefix: str) -> Optional[str]:
+    direct_fields = [prefix, prefix.lower(), prefix.upper()]
+    for field in direct_fields:
+        if field in row and row[field].strip():
+            return row[field].strip()
+
+    book = row.get(f"{prefix}_book") or row.get(f"{prefix}_Book")
+    chapter = row.get(f"{prefix}_chapter") or row.get(f"{prefix}_Chapter")
+    verse = row.get(f"{prefix}_verse") or row.get(f"{prefix}_Verse")
+
+    if book and chapter and verse:
+        return f"{book.strip()} {chapter.strip()}:{verse.strip()}"
+    if book and chapter:
+        return f"{book.strip()} {chapter.strip()}"
+    return None
+
+
+def _extract_float(row: Mapping[str, str], candidates: Sequence[str], default: float = 0.0) -> float:
+    for field in candidates:
+        if field in row and row[field].strip():
+            try:
+                return float(row[field])
+            except ValueError:
+                continue
+    return default
+
+
+def parse_cross_reference_csv(
+    path: Path,
+    *,
+    count_fields: Sequence[str] = ("count", "weight", "xref_count"),
+    semantic_fields: Sequence[str] = ("semantic", "similarity", "cosine_similarity"),
+    delimiter: str = ",",
+    prime_only: bool = False,
+) -> List[Edge]:
+    """Parse a cross-reference CSV into ``Edge`` objects.
+
+    The parser is tolerant of different column naming conventions. It looks for
+    either canonical ``source``/``target`` fields or ``*_book/chapter/verse``
+    triplets. When ``prime_only`` is enabled, only rows whose 1-based position is
+    prime are retained, offering a quick way to focus on prime-indexed verses.
+    """
+
+    edges: List[Edge] = []
+    with Path(path).open("r", encoding="utf-8", newline="") as fh:
+        reader = csv.DictReader(fh, delimiter=delimiter)
+        if not reader.fieldnames:
+            return edges
+        source_field = next((f for f in reader.fieldnames if f.lower() in {"source", "from", "src"}), "source")
+        target_field = next((f for f in reader.fieldnames if f.lower() in {"target", "to", "dst"}), "target")
+
+        for idx, row in enumerate(reader, start=1):
+            if prime_only and not primes.is_prime(idx):
+                continue
+            source = _canonical_reference(row, source_field)
+            target = _canonical_reference(row, target_field)
+            if not source or not target:
+                continue
+            count = _extract_float(row, count_fields, default=1.0)
+            semantic = _extract_float(row, semantic_fields, default=0.0)
+            semantic_value = semantic if semantic > 0 else None
+            edges.append(Edge(source=source, target=target, count=count, semantic=semantic_value))
+    return edges
+
+
+def build_cross_reference_adjacency(
+    path: Path,
+    *,
+    count_fields: Sequence[str] = ("count", "weight", "xref_count"),
+    semantic_fields: Sequence[str] = ("semantic", "similarity", "cosine_similarity"),
+    delimiter: str = ",",
+    prime_only: bool = False,
+) -> AdjacencyResult:
+    """Parse a CSV file and immediately convert it into an adjacency matrix."""
+
+    edges = parse_cross_reference_csv(
+        path,
+        count_fields=count_fields,
+        semantic_fields=semantic_fields,
+        delimiter=delimiter,
+        prime_only=prime_only,
+    )
+    return build_weighted_adjacency(edges)

--- a/zetafunctor/hashing.py
+++ b/zetafunctor/hashing.py
@@ -1,0 +1,90 @@
+"""Hash-based utilities for projecting text streams into the complex plane."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Iterator, List
+
+
+def rolling_sha256(text: str, window: int = 128, step: int = 1) -> List[str]:
+    """Compute SHA-256 digests over a sliding window of the input text.
+
+    Parameters
+    ----------
+    text:
+        Source text to hash.
+    window:
+        Number of characters per sliding window. Defaults to 128 which captures
+        a few sentences without being overly expensive.
+    step:
+        Advance the window by this many characters for each digest. A ``step`` of
+        1 maximises resolution but can be more expensive for large corpora.
+
+    Returns
+    -------
+    list[str]
+        Hex digests ordered by their starting offset.
+    """
+
+    if window <= 0:
+        raise ValueError("window must be positive")
+    if step <= 0:
+        raise ValueError("step must be positive")
+
+    digests: List[str] = []
+    for start in range(0, max(len(text) - window + 1, 1), step):
+        chunk = text[start : start + window]
+        digest = hashlib.sha256(chunk.encode("utf-8")).hexdigest()
+        digests.append(digest)
+    return digests
+
+
+def _scale_to_interval(value: int, bits: int, lower: float, upper: float) -> float:
+    span = upper - lower
+    if span == 0:
+        return lower
+    max_value = (1 << bits) - 1
+    return lower + (value / max_value) * span
+
+
+def hash_to_complex(digest: str, lower: float = -2.0, upper: float = 2.0) -> complex:
+    """Project a SHA-256 hex digest onto the complex plane.
+
+    The digest is split into two 128-bit halves that are independently scaled to
+    ``[lower, upper]`` and combined into a complex number.
+    """
+
+    if len(digest) != 64:
+        raise ValueError("SHA-256 digest must be 64 hex characters long")
+    real_bits = int(digest[:32], 16)
+    imag_bits = int(digest[32:], 16)
+    real = _scale_to_interval(real_bits, 128, lower, upper)
+    imag = _scale_to_interval(imag_bits, 128, lower, upper)
+    return complex(real, imag)
+
+
+def rolling_hash_to_complex(
+    text: str,
+    window: int = 128,
+    step: int = 1,
+    lower: float = -2.0,
+    upper: float = 2.0,
+) -> List[complex]:
+    """Convenience wrapper that hashes and immediately maps to the complex plane."""
+
+    return [hash_to_complex(d, lower=lower, upper=upper) for d in rolling_sha256(text, window, step)]
+
+
+def chunk_text(text: str, chunk_size: int) -> Iterator[str]:
+    """Yield successive ``chunk_size``-sized pieces from ``text``."""
+
+    if chunk_size <= 0:
+        raise ValueError("chunk_size must be positive")
+    for start in range(0, len(text), chunk_size):
+        yield text[start : start + chunk_size]
+
+
+def hash_blocks_to_complex(text: str, block_size: int = 256) -> List[complex]:
+    """Map non-overlapping blocks of text to complex points using SHA-256."""
+
+    return [hash_to_complex(hashlib.sha256(block.encode("utf-8")).hexdigest()) for block in chunk_text(text, block_size)]

--- a/zetafunctor/mandelbrot.py
+++ b/zetafunctor/mandelbrot.py
@@ -1,0 +1,35 @@
+"""Mandelbrot escape-time helpers."""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Iterable, List, Tuple
+
+
+def escape_time(c: complex, max_iter: int = 256, bailout: float = 2.0) -> int:
+    """Return the iteration count needed for ``c`` to escape the Mandelbrot set."""
+
+    z = 0j
+    for i in range(max_iter):
+        z = z * z + c
+        if abs(z) > bailout:
+            return i
+    return max_iter
+
+
+def escape_histogram(points: Iterable[complex], max_iter: int = 256, bailout: float = 2.0) -> Counter:
+    """Compute a histogram of escape iterations for a collection of points."""
+
+    histogram: Counter = Counter()
+    for point in points:
+        histogram[escape_time(point, max_iter=max_iter, bailout=bailout)] += 1
+    return histogram
+
+
+def normalise_histogram(histogram: Counter) -> List[Tuple[int, float]]:
+    """Normalise a histogram so that the values sum to 1."""
+
+    total = sum(histogram.values())
+    if total == 0:
+        return [(key, 0.0) for key in sorted(histogram.keys())]
+    return [(key, count / total) for key, count in sorted(histogram.items())]

--- a/zetafunctor/primes.py
+++ b/zetafunctor/primes.py
@@ -1,0 +1,55 @@
+"""Prime utilities used throughout the zeta functor toolkit."""
+
+from __future__ import annotations
+
+from math import isqrt
+from typing import Iterable, Iterator, List, Sequence
+
+
+def sieve(limit: int) -> List[int]:
+    """Return all primes ``<= limit`` using a standard sieve of Eratosthenes."""
+
+    if limit < 2:
+        return []
+    is_prime = [True] * (limit + 1)
+    is_prime[0:2] = [False, False]
+    for number in range(2, isqrt(limit) + 1):
+        if is_prime[number]:
+            step = number
+            start = number * number
+            is_prime[start : limit + 1 : step] = [False] * ((limit - start) // step + 1)
+    return [i for i, prime in enumerate(is_prime) if prime]
+
+
+def is_prime(value: int) -> bool:
+    """Simple primality check suitable for moderate values."""
+
+    if value < 2:
+        return False
+    if value in (2, 3):
+        return True
+    if value % 2 == 0 or value % 3 == 0:
+        return False
+    limit = isqrt(value)
+    factor = 5
+    step = 2
+    while factor <= limit:
+        if value % factor == 0:
+            return False
+        factor += step
+        step = 6 - step
+    return True
+
+
+def prime_index_subsequence(sequence: Sequence) -> List:
+    """Return elements whose 1-based index is prime."""
+
+    return [value for idx, value in enumerate(sequence, start=1) if is_prime(idx)]
+
+
+def prime_index_iterable(iterable: Iterable) -> Iterator:
+    """Yield elements from ``iterable`` whose 1-based index is prime."""
+
+    for idx, value in enumerate(iterable, start=1):
+        if is_prime(idx):
+            yield value

--- a/zetafunctor/rohonc.py
+++ b/zetafunctor/rohonc.py
@@ -1,0 +1,79 @@
+"""Utilities for mapping Rohonc glyphs into a byte-friendly alphabet."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Optional
+
+
+@dataclass
+class RohoncGlyphMapper:
+    """Assign unique byte values to Rohonc glyphs up to a 256-symbol alphabet."""
+
+    alphabet_size: int = 256
+    unknown_token: int = 0
+    _mapping: Dict[str, int] = field(default_factory=dict)
+    _reverse: Dict[int, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not (1 <= self.alphabet_size <= 256):
+            raise ValueError("alphabet_size must be between 1 and 256")
+        if not (0 <= self.unknown_token < self.alphabet_size):
+            raise ValueError("unknown_token must be a valid symbol index")
+
+    @property
+    def mapping(self) -> Dict[str, int]:
+        return dict(self._mapping)
+
+    def _next_symbol(self) -> int:
+        used = set(self._reverse.keys()) | {self.unknown_token}
+        for symbol in range(self.alphabet_size):
+            if symbol in used:
+                continue
+            return symbol
+        raise RuntimeError("alphabet exhausted; consider increasing alphabet_size")
+
+    def fit(self, glyphs: Iterable[str]) -> None:
+        """Register glyphs so they receive stable byte assignments."""
+
+        for glyph in glyphs:
+            if glyph in self._mapping:
+                continue
+            symbol = self._next_symbol()
+            self._mapping[glyph] = symbol
+            self._reverse[symbol] = glyph
+
+    def transform(self, glyphs: Iterable[str]) -> List[int]:
+        """Convert a glyph sequence into a list of byte values."""
+
+        encoded: List[int] = []
+        for glyph in glyphs:
+            if glyph not in self._mapping:
+                symbol = self.unknown_token
+            else:
+                symbol = self._mapping[glyph]
+            encoded.append(symbol)
+        return encoded
+
+    def fit_transform(self, glyphs: Iterable[str]) -> List[int]:
+        glyph_list = list(glyphs)
+        self.fit(glyph_list)
+        return self.transform(glyph_list)
+
+    def inverse_transform(self, codes: Iterable[int]) -> List[str]:
+        """Convert byte values back to glyphs when possible."""
+
+        decoded: List[str] = []
+        for code in codes:
+            glyph = self._reverse.get(code)
+            if glyph is None:
+                raise KeyError(f"code {code} not present in mapper")
+            decoded.append(glyph)
+        return decoded
+
+
+def encode_text_blocks(text: str, mapper: Optional[RohoncGlyphMapper] = None) -> List[int]:
+    """Encode the characters from ``text`` using a ``RohoncGlyphMapper``."""
+
+    mapper = mapper or RohoncGlyphMapper()
+    return mapper.fit_transform(list(text))

--- a/zetafunctor/zeta.py
+++ b/zetafunctor/zeta.py
@@ -1,0 +1,52 @@
+"""Matrix zeta utilities."""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Tuple
+
+import numpy as np
+
+
+def spectral_radius(matrix: np.ndarray) -> float:
+    """Return the spectral radius of ``matrix``."""
+
+    eigenvalues = np.linalg.eigvals(matrix)
+    return float(max(abs(ev) for ev in eigenvalues)) if eigenvalues.size else 0.0
+
+
+def radius_of_convergence(matrix: np.ndarray) -> float:
+    """Return the ``|z|`` radius where ``det(I - zA)`` is guaranteed to converge."""
+
+    rho = spectral_radius(matrix)
+    if rho == 0:
+        return float("inf")
+    return 1.0 / rho
+
+
+def matrix_zeta(z: complex, matrix: np.ndarray) -> complex:
+    """Compute ``1 / det(I - zA)`` for the provided matrix ``A``."""
+
+    identity = np.eye(matrix.shape[0], dtype=complex)
+    shifted = identity - z * matrix.astype(complex)
+    determinant = np.linalg.det(shifted)
+    if determinant == 0:
+        raise ZeroDivisionError("det(I - zA) is zero; zeta function has a pole")
+    return 1.0 / determinant
+
+
+def scan_zeta_magnitude(
+    matrix: np.ndarray,
+    z_values: Iterable[complex],
+) -> List[Tuple[complex, float]]:
+    """Return ``(z, |zeta(z)|)`` pairs for an iterable of sample points."""
+
+    magnitudes: List[Tuple[complex, float]] = []
+    for z in z_values:
+        try:
+            value = matrix_zeta(z, matrix)
+        except ZeroDivisionError:
+            magnitude = float("inf")
+        else:
+            magnitude = abs(value)
+        magnitudes.append((z, magnitude))
+    return magnitudes


### PR DESCRIPTION
## Summary
- introduce a `zetafunctor` package with hashing, graph construction, zeta, and prime utilities for scripture network exploration
- add a Rohonc glyph mapper plus cross-reference CSV parser with log-damped and semantic edge weighting and optional prime-index filtering
- provide a CLI and runnable demo that generate Mandelbrot escape histograms and zeta magnitude plots

## Testing
- python -m zetafunctor.demo
- python -m zetafunctor.cli hash --text "In the beginning"


------
https://chatgpt.com/codex/tasks/task_e_690cfc322e8083298386b33256dde25b