### PR TITLE
Add modular arithmetic utilities and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,67 @@ LLM stub on port **8000** if none is running.
 - `srv/lucidia-llm/` — minimal FastAPI echo stub (only used if you don’t already run an LLM on 8000)
 - `srv/lucia-llm/` — same stub (duplicate dir name for compatibility with earlier scripts)
 
+## Modular Arithmetic Toolkit
+
+This repository now ships a focused toolkit for modular exponentiation and multiplicative order
+analysis, suitable for demonstrating classical number-theoretic routines that underpin
+Shor-style period finding. The implementation is deterministic, relies on Python 3.11 standard
+libraries, and exposes both programmatic and CLI entry points.
+
+### Quickstart
+
+```bash
+python -m pip install -e .
+python cli.py modexp --a 7 --e 560 --modulus 561
+```
+
+### Examples
+
+```bash
+# Fast modular exponentiation
+python cli.py modexp --a 7 --e 560 --modulus 561 --json
+
+# Compute a multiplicative order with verbose diagnostics
+python cli.py order --a 4 --modulus 21 --verbose
+
+# Benchmark the exponentiation routine
+python cli.py bench --a 2 --e 2048 --modulus 8191 --iterations 500
+```
+
+### API Highlights
+
+- `modmath.modexp(base, exponent, modulus)` → `int`
+- `modmath.multiplicative_order(base, modulus, max_iter=None)` → `int`
+- `modmath.benchmark_modexp(base, exponent, modulus, iterations=10)` → `BenchmarkResult`
+
+See `src/modmath/__init__.py` for docstrings, parameter validation details, and error classes.
+
+### I/O Contract
+
+- **Inputs:** integers `base`, `exponent ≥ 0`, `modulus ≥ 1`; optional `max_iter ≥ 1` and
+  `iterations ≥ 1`. All values validated before execution.
+- **Outputs:** integers for modular exponentiation and order; benchmarking returns structured
+  timings via `BenchmarkResult` or JSON payloads when requested from the CLI.
+- **Edge cases:** zero exponents yield `1` modulo `N`; modulus of `1` collapses results to `0` or
+  `1`; non-coprime pairs for order raise `MultiplicativeOrderError`; negative values are
+  accepted after modular reduction.
+- **Performance target:** handles moduli up to ~64-bit comfortably; `modexp` runs in `O(log e)`;
+  order finding relies on trial division factoring and is suitable for toy RSA composites.
+
+### Complexity & Performance
+
+- `modexp` performs `O(log exponent)` modular multiplications via exponentiation by squaring.
+- `multiplicative_order` factors Euler’s totient φ(n) by trial division—fast for 64-bit composites
+  but not intended for cryptographic-scale moduli.
+- The CLI benchmark reports aggregate and per-iteration timings to help profile repeated calls.
+
+### Limitations
+
+- Inputs must be integers; non-integer values raise type errors.
+- Multiplicative order requires `gcd(base, modulus) == 1` and may be slow for moduli with large
+  prime factors due to naive factorisation.
+- The toolkit is educational and **not** suitable for production cryptography.
+
 > Nothing here overwrites your existing code. The scripts are defensive: they detect paths,
 > **merge** deps, and only generate files if missing.
 

--- a/bots/__init__.py
+++ b/bots/__init__.py
@@ -1,6 +1,4 @@
-"""Bot discovery helpers used by the Prism Console orchestrator."""
-"""Bot discovery utilities."""
-"""Bot registry helpers for the Prism Console orchestrator."""
+"""Bot discovery helpers used by integration tests."""
 
 from __future__ import annotations
 
@@ -10,38 +8,21 @@ from typing import Dict, Iterable, Iterator, Sequence, Tuple
 
 from orchestrator import BaseBot, BotRegistry
 
-BOT_REGISTRY: Dict[str, object] = {}
-
-
-def _iter_bot_modules() -> Iterable[str]:
-    """Yield module names for available bot implementations."""
-
-    package_path = Path(__file__).resolve().parent
-    for module_path in package_path.glob("*_bot.py"):
-        if module_path.name == "simple.py":
-            # ``simple.py`` contains fixtures used in tests rather than a bot module.
-__all__ = ["BOT_REGISTRY", "build_registry", "list_bots"]
-
-BOT_REGISTRY: Dict[str, BaseBot | object] = {}
 BotLike = BaseBot | object
-
-# Public mapping used by tests to access lightweight script-style bots.
 BOT_REGISTRY: Dict[str, BotLike] = {}
 
 
 def _iter_bot_modules() -> Iterable[str]:
-    """Yield module names for all bot implementations in this package."""
+    """Yield module names for concrete bot implementations."""
 
     package_path = Path(__file__).resolve().parent
     for module_path in package_path.glob("*_bot.py"):
         if module_path.stem == "simple":
-            # ``simple.py`` hosts fixtures rather than a runnable bot.
+            # ``simple.py`` contains fixtures used only in tests.
             continue
         yield module_path.stem
 
 
-def _instantiate_bots(module_name: str) -> Iterator[Tuple[str, object]]:
-    """Instantiate bot objects exposed by *module_name*."""
 def _instantiate_bots(module_name: str) -> Iterator[Tuple[str, BotLike]]:
     """Instantiate bots exposed by ``module_name``."""
 
@@ -79,7 +60,7 @@ def build_registry() -> BotRegistry:
     """Instantiate a :class:`BotRegistry` populated with discovered bots."""
 
     registry = BotRegistry()
-    for name, bot in BOT_REGISTRY.items():
+    for bot in BOT_REGISTRY.values():
         if isinstance(bot, BaseBot):
             registry.register(bot)
     return registry
@@ -92,4 +73,3 @@ def list_bots() -> Sequence[str]:
 
 
 __all__ = ["BOT_REGISTRY", "build_registry", "list_bots"]
-

--- a/cli.py
+++ b/cli.py
@@ -1,16 +1,142 @@
-"""Command line entry point for the universal simulation starter bundle."""
+"""Command line interface for modular arithmetic utilities."""
 
 from __future__ import annotations
 
-from universal_sim import run_pipeline
+import json
+from typing import Any
+
+import typer
+
+from modmath import (
+    MultiplicativeOrderError,
+    benchmark_modexp,
+    modexp,
+    multiplicative_order,
+)
+
+app = typer.Typer(
+    add_completion=False,
+    help=(
+        "Efficient modular exponentiation and multiplicative order calculations.\n\n"
+        "Examples:\n"
+        "  python cli.py modexp --a 7 --e 560 --modulus 561\n"
+        "  python cli.py order --a 4 --modulus 21\n"
+        "  python cli.py bench --a 2 --e 1024 --modulus 101 --iterations 100"
+    ),
+    no_args_is_help=True,
+)
 
 
-def main() -> None:
-    files = run_pipeline()
-    print("Generated artefacts:")
-    for label, location in files.items():
-        print(f"- {label}: {location}")
+def _echo_verbose(ctx: typer.Context, message: str) -> None:
+    if ctx.obj and ctx.obj.get("verbose"):
+        typer.echo(message, err=True)
+
+
+@app.callback()
+def main(
+    ctx: typer.Context,
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable verbose diagnostics."),
+) -> None:
+    """Initialize shared CLI state."""
+
+    ctx.ensure_object(dict)
+    ctx.obj["verbose"] = verbose
+
+
+@app.command("modexp")
+def modexp_cmd(
+    ctx: typer.Context,
+    a: int = typer.Option(..., "--a", help="Base of the exponentiation."),
+    e: int = typer.Option(..., "--e", help="Exponent (non-negative)."),
+    modulus: int = typer.Option(..., "--modulus", help="Modulus (positive integer)."),
+    json_output: bool = typer.Option(False, "--json", help="Emit JSON instead of plain text."),
+) -> None:
+    """Compute a modular exponent."""
+
+    try:
+        result = modexp(a, e, modulus)
+    except Exception as exc:  # pragma: no cover - defensive branch
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1) from exc
+
+    _echo_verbose(ctx, f"Computed {a}^{e} mod {modulus} -> {result}")
+    if json_output:
+        typer.echo(json.dumps({"result": result}))
+    else:
+        typer.echo(str(result))
+
+
+@app.command("order")
+def order_cmd(
+    ctx: typer.Context,
+    a: int = typer.Option(..., "--a", help="Base value; must be coprime with the modulus."),
+    modulus: int = typer.Option(..., "--modulus", help="Modulus (>= 2)."),
+    max_iter: int | None = typer.Option(
+        None,
+        "--max-iter",
+        help="Optional safety bound for the order search.",
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Emit JSON instead of plain text."),
+) -> None:
+    """Determine the multiplicative order of a base modulo N."""
+
+    try:
+        order = multiplicative_order(a, modulus, max_iter=max_iter)
+    except MultiplicativeOrderError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=2) from exc
+    except Exception as exc:  # pragma: no cover - defensive branch
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1) from exc
+
+    _echo_verbose(ctx, f"Order({a}, mod {modulus}) = {order}")
+    if json_output:
+        typer.echo(json.dumps({"order": order}))
+    else:
+        typer.echo(str(order))
+
+
+@app.command()
+def bench(
+    ctx: typer.Context,
+    a: int = typer.Option(..., "--a", help="Base for repeated exponentiation."),
+    e: int = typer.Option(..., "--e", help="Exponent used during benchmarking."),
+    modulus: int = typer.Option(..., "--modulus", help="Modulus for exponentiation."),
+    iterations: int = typer.Option(100, "--iterations", help="Number of iterations to run."),
+    json_output: bool = typer.Option(False, "--json", help="Emit JSON instead of plain text."),
+) -> None:
+    """Benchmark the modular exponentiation routine."""
+
+    try:
+        result = benchmark_modexp(a, e, modulus, iterations=iterations)
+    except Exception as exc:  # pragma: no cover - defensive branch
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1) from exc
+
+    _echo_verbose(ctx, f"Benchmark completed in {result.elapsed_seconds:.6f}s")
+    payload: dict[str, Any] = {
+        "iterations": result.iterations,
+        "elapsed_seconds": result.elapsed_seconds,
+        "seconds_per_iteration": result.elapsed_seconds / result.iterations,
+    }
+
+    if json_output:
+        typer.echo(json.dumps(payload))
+    else:
+        typer.echo(
+            "Iterations: {iterations}\nElapsed (s): {elapsed:.6f}\nPer iteration (s): {per_iter:.6e}".format(
+                iterations=payload["iterations"],
+                elapsed=payload["elapsed_seconds"],
+                per_iter=payload["seconds_per_iteration"],
+            )
+        )
+
+
+def run() -> None:
+    """Entrypoint for invoking the Typer application."""
+
+    app()
 
 
 if __name__ == "__main__":
-    main()
+    run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,10 +10,17 @@ readme = "README.md"
 requires-python = ">=3.11"
 authors = [{ name = "BlackRoad", email = "eng@blackroadinc.us" }]
 dependencies = [
-    "typer==0.12.3",
-    "pydantic==2.6.4",
-    "pyyaml==6.0.2",
+    "typer>=0.15.1,<0.22",
+    "pydantic>=2.6.4,<3",
+    "pyyaml>=6.0.2,<7",
+    "hypothesis>=6.103.4,<7",
 ]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-dir]
+"" = "src"
 
 [tool.black]
 line-length = 100

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,7 @@
 [pytest]
-testpaths = tests
+testpaths =
+    tests
+    phase9/tests
 python_files = test_*.py
 pythonpath = .
 addopts = --strict-markers
-testpaths = phase9/tests

--- a/src/modmath/__init__.py
+++ b/src/modmath/__init__.py
@@ -1,0 +1,128 @@
+"""Modular arithmetic utilities including modular exponentiation and order finding."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from time import perf_counter
+
+__all__ = [
+    "modexp",
+    "multiplicative_order",
+    "MultiplicativeOrderError",
+    "benchmark_modexp",
+    "BenchmarkResult",
+]
+
+
+class MultiplicativeOrderError(ValueError):
+    """Raised when the multiplicative order cannot be determined under the given constraints."""
+
+
+def _validate_int(name: str, value: int, *, minimum: int | None = None) -> int:
+    if not isinstance(value, int):
+        raise TypeError(f"{name} must be an integer; received {type(value).__name__}.")
+    if minimum is not None and value < minimum:
+        raise ValueError(f"{name} must be >= {minimum}.")
+    return value
+
+
+def modexp(base: int, exponent: int, modulus: int) -> int:
+    """Compute ``base ** exponent mod modulus`` using exponentiation by squaring."""
+
+    base = _validate_int("base", base)
+    exponent = _validate_int("exponent", exponent, minimum=0)
+    modulus = _validate_int("modulus", modulus, minimum=1)
+
+    base %= modulus
+    result = 1
+    power = base
+    exp = exponent
+
+    # Complexity note: O(log exponent) modular multiplications.
+    while exp > 0:
+        if exp & 1:
+            result = (result * power) % modulus
+        power = (power * power) % modulus
+        exp >>= 1
+    return result
+
+
+def multiplicative_order(base: int, modulus: int, *, max_iter: int | None = None) -> int:
+    """Return the smallest positive integer ``k`` with ``base**k ≡ 1 (mod modulus)``.
+
+    The inputs must be coprime. If ``max_iter`` is provided, the computation aborts when the
+    theoretical order exceeds that bound.
+    """
+
+    base = _validate_int("base", base)
+    modulus = _validate_int("modulus", modulus, minimum=2)
+    if max_iter is not None:
+        max_iter = _validate_int("max_iter", max_iter, minimum=1)
+
+    if gcd(base, modulus) != 1:
+        raise MultiplicativeOrderError("base and modulus must be coprime to have an order.")
+
+    phi = euler_totient(modulus)
+    order = phi
+    for prime in set(prime_factors(phi)):
+        while order % prime == 0 and modexp(base, order // prime, modulus) == 1:
+            order //= prime
+
+    if max_iter is not None and order > max_iter:
+        raise MultiplicativeOrderError(
+            "order exceeds max_iter; increase the limit to compute the full order."
+        )
+
+    if modexp(base, order, modulus) != 1:
+        raise MultiplicativeOrderError("failed to determine multiplicative order within limits.")
+    return order
+
+
+def gcd(a: int, b: int) -> int:
+    while b:
+        a, b = b, a % b
+    return abs(a)
+
+
+def prime_factors(n: int) -> list[int]:
+    """Return the prime factors of ``n`` with multiplicity using trial division."""
+
+    n = _validate_int("n", n, minimum=1)
+    factors: list[int] = []
+    candidate = 2
+    value = n
+    while candidate * candidate <= value:
+        while value % candidate == 0:
+            factors.append(candidate)
+            value //= candidate
+        candidate += 1 if candidate == 2 else 2
+    if value > 1:
+        factors.append(value)
+    return factors
+
+
+def euler_totient(n: int) -> int:
+    """Compute Euler's totient function φ(n) via prime factorisation."""
+
+    n = _validate_int("n", n, minimum=1)
+    result = n
+    for p in set(prime_factors(n)):
+        result -= result // p
+    return result
+
+
+@dataclass(frozen=True)
+class BenchmarkResult:
+    iterations: int
+    elapsed_seconds: float
+
+
+def benchmark_modexp(base: int, exponent: int, modulus: int, *, iterations: int = 10) -> BenchmarkResult:
+    """Benchmark ``modexp`` for a number of iterations and report total runtime."""
+
+    iterations = _validate_int("iterations", iterations, minimum=1)
+    start = perf_counter()
+    for _ in range(iterations):
+        modexp(base, exponent, modulus)
+    elapsed = perf_counter() - start
+    return BenchmarkResult(iterations=iterations, elapsed_seconds=elapsed)

--- a/tests/test_modmath.py
+++ b/tests/test_modmath.py
@@ -1,0 +1,130 @@
+"""Tests for modular arithmetic utilities."""
+
+from __future__ import annotations
+
+import json
+import math
+import subprocess
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+CLI_PATH = PROJECT_ROOT / "cli.py"
+
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+
+import pytest
+from hypothesis import given, strategies as st
+
+from modmath import MultiplicativeOrderError, modexp, multiplicative_order
+
+
+def run_cli(args: list[str]) -> subprocess.CompletedProcess[str]:
+    """Execute the CLI with the provided arguments and return the process result."""
+
+    return subprocess.run(
+        [sys.executable, str(CLI_PATH), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_modexp_matches_python_pow():
+    assert modexp(7, 560, 561) == pow(7, 560, 561)
+    assert modexp(2, 1024, 997) == pow(2, 1024, 997)
+
+
+def test_modexp_handles_zero_and_one():
+    assert modexp(0, 5, 13) == 0
+    assert modexp(5, 0, 13) == 1
+    assert modexp(1, 123456, 17) == 1
+
+
+def test_multiplicative_order_basic_cases():
+    assert multiplicative_order(2, 5) == 4
+    assert multiplicative_order(4, 7) == 3
+    assert multiplicative_order(10, 11) == 2
+
+
+def test_multiplicative_order_requires_coprime_inputs():
+    with pytest.raises(MultiplicativeOrderError):
+        multiplicative_order(6, 21)
+
+
+def test_multiplicative_order_respects_iteration_limit():
+    with pytest.raises(MultiplicativeOrderError):
+        multiplicative_order(2, 7, max_iter=2)
+
+
+def test_cli_help_lists_subcommands():
+    result = run_cli(["--help"])
+    assert result.returncode == 0
+    assert "modexp" in result.stdout
+    assert "order" in result.stdout
+    assert "bench" in result.stdout
+
+
+def test_cli_modexp_plain_output():
+    result = run_cli(["modexp", "--a", "7", "--e", "560", "--modulus", "561"])
+    assert result.returncode == 0
+    assert "561" not in result.stderr
+    assert result.stdout.strip() == "1"
+
+
+def test_cli_modexp_json_output():
+    result = run_cli(
+        [
+            "modexp",
+            "--a",
+            "4",
+            "--e",
+            "13",
+            "--modulus",
+            "497",
+            "--json",
+        ]
+    )
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["result"] == modexp(4, 13, 497)
+
+
+def test_cli_order_handles_errors_gracefully():
+    result = run_cli(["order", "--a", "6", "--modulus", "21"])
+    assert result.returncode != 0
+    assert "coprime" in result.stderr.lower()
+
+
+def test_cli_bench_reports_runtime():
+    result = run_cli(["bench", "--a", "7", "--e", "560", "--modulus", "561"])
+    assert result.returncode == 0
+    assert "iterations" in result.stdout.lower()
+
+
+def is_prime(n: int) -> bool:
+    if n < 2:
+        return False
+    for divisor in range(2, int(math.isqrt(n)) + 1):
+        if n % divisor == 0:
+            return False
+    return True
+
+
+@st.composite
+def coprime_bases(draw: st.DrawFn) -> tuple[int, int, int]:
+    prime_candidates = [p for p in range(3, 50) if is_prime(p)]
+    p = draw(st.sampled_from(prime_candidates))
+    q = draw(st.sampled_from([x for x in prime_candidates if x != p]))
+    modulus = p * q
+    base = draw(st.integers(min_value=2, max_value=modulus - 1).filter(lambda x: math.gcd(x, modulus) == 1))
+    return base, p, q
+
+
+@given(coprime_bases())
+def test_modexp_euler_totient_property(data: tuple[int, int, int]):
+    base, p, q = data
+    modulus = p * q
+    totient = (p - 1) * (q - 1)
+    assert modexp(base, totient, modulus) == 1


### PR DESCRIPTION
## Summary
- add a dedicated `modmath` package with modular exponentiation, multiplicative order, and benchmarking helpers
- replace the CLI with a Typer-powered interface offering `modexp`, `order`, and `bench` subcommands plus JSON/verbose output
- document the toolkit, enable package discovery from `src/`, refresh pytest config, and back the features with property-based & CLI tests

## Testing
- pytest --noconftest tests/test_modmath.py

------
https://chatgpt.com/codex/tasks/task_e_690cf830b6a483299ce9aa846067f62a