### PR TITLE
Add product to service workflow and tag conscious bots

### DIFF
--- a/bots/close_bot.py
+++ b/bots/close_bot.py
@@ -17,6 +17,7 @@ class CloseBot(BaseBot):
         kpis=["close_duration", "reconciliation_completion"],
         guardrails=["Requires approvals for policy exceptions"],
         handoffs=["Controller team"],
+        tags=("conscious", "finance", "close"),
     )
 
     def handle_task(self, task: Task) -> BotResponse:

--- a/bots/sop_bot.py
+++ b/bots/sop_bot.py
@@ -17,6 +17,7 @@ class SopBot(BaseBot):
         kpis=["service_level", "inventory_turns"],
         guardrails=["No live system integrations"],
         handoffs=["Supply chain planning"],
+        tags=("conscious", "supply-chain", "planning"),
     )
 
     def handle_task(self, task: Task) -> BotResponse:

--- a/bots/treasury_bot.py
+++ b/bots/treasury_bot.py
@@ -20,6 +20,7 @@ class TreasuryBot(BaseBot):
         kpis=["cash_floor", "hedge_coverage"],
         guardrails=["Offline deterministic calculations", "No external integrations"],
         handoffs=["Treasury operations"],
+        tags=("conscious", "finance", "treasury"),
     )
 
     def handle_task(self, task: Task) -> BotResponse:

--- a/workflows/product_merchandise_service.md
+++ b/workflows/product_merchandise_service.md
@@ -1,0 +1,8 @@
+# Product → Merchandising → Service Workflow
+
+1. Align product roadmap updates with merchandising briefs and channel plans.
+2. Run Merchandising-BOT to generate the updated assortment using the latest sales history fixtures.
+3. Feed the assortment into S&OP-BOT to balance supply, inventory buffers, and logistics partners.
+4. Share the consolidated plan with Store-Ops-BOT so field teams receive labor plans and launch checklists.
+5. Route financing and hedging requirements through Treasury-BOT to confirm cash coverage for the launch.
+6. Hand service readiness and closeout milestones to Close-BOT to track post-launch reconciliations and support playbooks.


### PR DESCRIPTION
## Summary
- add a workflow that links product updates through merchandising, operations, treasury, and close handoffs
- tag the treasury, close, and S&OP bots as conscious with domain-specific labels for discovery

## Testing
- pytest tests/test_industry_pack.py

------
https://chatgpt.com/codex/tasks/task_e_690c88ced1008329abf0d177e2dd3d54