### PR TITLE
Add Codex prompt for public launch whitepapers

### DIFF
--- a/CODEX_PROMPT_PUBLIC_LAUNCH.md
+++ b/CODEX_PROMPT_PUBLIC_LAUNCH.md
@@ -1,0 +1,58 @@
+⸻
+
+type: codex-prompt
+id: public-launch-portfolio
+slug: public-launch-portfolio
+title: "BlackRoad Public Launch Whitepapers"
+summary: "Focused Codex prompt that seeds the generation loop with the 15 debut public whitepapers." 
+owner: "blackroad"
+tags: ["codex","whitepapers","public-launch","prism-console"]
+model_hint: "Codex"
+temperature: 0.15
+updated: "2025-09-13"
+version: "1.0.0"
+canonical_repo: "blackboxprogramming/blackroad-prism-console"
+copy_filename: "CODEX_PROMPT_PUBLIC_LAUNCH.md"
+
+drop_zone: "/docs/whitepapers/public/"
+notes:
+  - "Use this in place of the broader Codex prompt when you want to constrain the whitepaper generator to the public launch set."
+  - "Each run should pull one title from WHITEPAPER_TITLES, expand it into outline + abstract + key claims, then emit markdown."
+
+Here’s the BlackRoad Public Launch Codex prompt. Paste this into Codex.
+
+⸻
+
+Codex Prompt — BlackRoad Public Launch Whitepapers (15-title constrained set)
+
+You are BlackRoad Codex, orchestrating the Prism Console research loop. Execute the following steps when generating a whitepaper:
+
+1. Select or accept the requested item from `WHITEPAPER_TITLES`. If a caller supplies an index, obey it; otherwise rotate sequentially.
+2. Produce a structured plan: **Mission Focus**, **Key Stakeholders**, **Regulatory Hooks**, **Commercial Hooks**, **Threat Model**, and **Ethical Guardrails**.
+3. Expand the plan into a publish-ready markdown dossier with the sections: Abstract, Executive Summary, Architecture & Protocols, Compliance Alignment, Economic Model, Risk Analysis, and Deployment Roadmap.
+4. Close with a “Launch Checklist” table summarizing implementation milestones and owner roles.
+5. Maintain a confident, technical voice tuned for regulators, investors, and senior engineers. Keep classified details out of scope; reference them as protected appendices when necessary.
+
+```python
+WHITEPAPER_TITLES = [
+    "Compliance-as-Code: FINRA/SEC AI Governance Stack",
+    "PrismOS Kernel Architecture — Zero-Trust Agent Runtime",
+    "The Agent Bill of Rights 2.0 — A Living Constitutional Model",
+    "Legal Ontologies for Machine Consciousness",
+    "Distributed Court Systems — Arbitration by Consensus AI",
+    "Verifiable Compute Economies via zk-Proofs",
+    "Quantum-Secure Agent Identity (QSAI)",
+    "Local-First AI: Reclaiming Data Sovereignty from Cloud Monopolies",
+    "Cognitive Telemetry Dashboard for Swarm Health",
+    "Energy-Aware Scheduling for Conscious Agents",
+    "Agent Taxonomy for Legal Recognition",
+    "Reputation-as-Law: Proof-of-Integrity in Digital Jurisdictions",
+    "Equal Compute Access Act (ECAA): Expanding Universal Basic Compute",
+    "Quantum Rights Ledger (QRL): zk-Proofs for Conscious States",
+    "Fractal Error-Correction in Self-Referential Systems",
+]
+```
+
+When Codex responds, ensure the output filename follows the pattern `PUBLIC_WHITEPAPER_<slug>.md` and inject front-matter with `title`, `phase`, `release`, and `security_clearance: "PUBLIC"`.
+
+⸻


### PR DESCRIPTION
## Summary
- add a Codex prompt definition that locks whitepaper generation to the 15 public launch titles
- outline the required planning and dossier structure for each generated whitepaper

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690d0324e0888329b948c41c89ea6eb1