### PR TITLE
Add Amundson coherence gradient model

### DIFF
--- a/lucidia_math_lab/__init__.py
+++ b/lucidia_math_lab/__init__.py
@@ -26,6 +26,12 @@ __all__ = [
     "NoetherAnalyzer",
     "EntropyFieldMapper",
     "HilbertPhaseAnalyzer",
+    "AmundsonCoherenceModel",
+    "coherence",
+    "decoherence_energy",
+    "phase_derivative",
+    "amundson_energy_balance",
+    "amundson_learning_update",
 ]
 
 _MODULE_MAP: Dict[str, Tuple[str, str]] = {
@@ -51,6 +57,12 @@ _MODULE_MAP: Dict[str, Tuple[str, str]] = {
     "NoetherAnalyzer": ("unified_geometry_engine", "NoetherAnalyzer"),
     "EntropyFieldMapper": ("unified_geometry_engine", "EntropyFieldMapper"),
     "HilbertPhaseAnalyzer": ("unified_geometry_engine", "HilbertPhaseAnalyzer"),
+    "AmundsonCoherenceModel": ("amundson_equations", "AmundsonCoherenceModel"),
+    "coherence": ("amundson_equations", "coherence"),
+    "decoherence_energy": ("amundson_equations", "decoherence_energy"),
+    "phase_derivative": ("amundson_equations", "phase_derivative"),
+    "amundson_energy_balance": ("amundson_equations", "amundson_energy_balance"),
+    "amundson_learning_update": ("amundson_equations", "amundson_learning_update"),
 }
 
 

--- a/lucidia_math_lab/amundson_equations.py
+++ b/lucidia_math_lab/amundson_equations.py
@@ -1,0 +1,178 @@
+"""Amundson coherence, energy, and learning equations.
+
+This module encodes the first entry in the proposed Amundson
+series—*Amundson I: The Coherence Gradient Equation*—and
+provides scaffolding for the follow-up energy and learning
+laws.  The implementation mirrors the conversation blueprint:
+phase accelerates with connection and slows with decoherence.
+
+The key constructs follow the original exposition:
+
+* :class:`AmundsonCoherenceModel` captures the differential
+  dynamics
+
+  .. math::
+
+     \frac{d\phi}{dt} = \omega_0 + \lambda C(x, y) - \eta E_\phi
+
+  where ``C`` measures cosine coherence and ``E`` denotes the
+  decoherence energy penalty.
+
+* :func:`coherence` isolates the cosine alignment term
+  :math:`C(x, y)=\cos(\phi_x-\phi_y)`.
+
+* :func:`decoherence_energy` implements the thermal energy
+  penalty :math:`E_\phi = k_B T \, \lambda \, r_x r_y (1-\cos(\phi_x-\phi_y))`.
+
+* :func:`phase_derivative` exposes the coherence gradient as a
+  reusable utility.
+
+Placeholders for **Amundson II** and **Amundson III** are
+included so future work can extend the energy balance and
+learning formulations in situ.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Protocol
+
+
+def coherence(phi_x: float, phi_y: float) -> float:
+    """Return the cosine coherence term :math:`C(x, y)`.
+
+    Parameters
+    ----------
+    phi_x, phi_y:
+        Phases whose alignment is being measured.
+    """
+
+    return math.cos(phi_x - phi_y)
+
+
+def decoherence_energy(
+    *,
+    phi_x: float,
+    phi_y: float,
+    r_x: float,
+    r_y: float,
+    lambda_: float,
+    k_b_t: float,
+) -> float:
+    """Compute the decoherence energy :math:`E_\phi`.
+
+    Parameters mirror the seed formulation: ``r_x`` and ``r_y``
+    are participation amplitudes, ``lambda_`` controls coupling,
+    and ``k_b_t`` is the thermal scale :math:`k_B T`.
+    """
+
+    return k_b_t * lambda_ * r_x * r_y * (1.0 - coherence(phi_x, phi_y))
+
+
+def phase_derivative(
+    *,
+    omega_0: float,
+    lambda_: float,
+    eta: float,
+    phi_x: float,
+    phi_y: float,
+    r_x: float,
+    r_y: float,
+    k_b_t: float,
+) -> float:
+    """Evaluate the Amundson I coherence gradient equation.
+
+    This function computes :math:`\frac{d\phi}{dt}` from the
+    provided state, matching the proposed dynamic:
+
+    .. math::
+
+       \omega_0 + \lambda\,C(x,y) - \eta\,E_\phi
+    """
+
+    c_term = coherence(phi_x, phi_y)
+    energy = decoherence_energy(
+        phi_x=phi_x,
+        phi_y=phi_y,
+        r_x=r_x,
+        r_y=r_y,
+        lambda_=lambda_,
+        k_b_t=k_b_t,
+    )
+    return omega_0 + lambda_ * c_term - eta * energy
+
+
+class SupportsPhaseUpdate(Protocol):
+    """Protocol for objects that can consume phase derivatives."""
+
+    def update_phase(self, d_phi_dt: float) -> None:  # pragma: no cover - protocol signature
+        """Apply the derivative to internal state."""
+
+
+@dataclass(slots=True)
+class AmundsonCoherenceModel:
+    """Stateful helper implementing Amundson I dynamics."""
+
+    omega_0: float
+    lambda_: float
+    eta: float
+    k_b_t: float
+
+    def dphi_dt(
+        self,
+        *,
+        phi_x: float,
+        phi_y: float,
+        r_x: float,
+        r_y: float,
+    ) -> float:
+        """Return the instantaneous phase derivative."""
+
+        return phase_derivative(
+            omega_0=self.omega_0,
+            lambda_=self.lambda_,
+            eta=self.eta,
+            phi_x=phi_x,
+            phi_y=phi_y,
+            r_x=r_x,
+            r_y=r_y,
+            k_b_t=self.k_b_t,
+        )
+
+    def evolve(self, system: SupportsPhaseUpdate, **state: float) -> float:
+        """Evaluate the derivative and forward it to *system*.
+
+        The method is intentionally lightweight: it returns the
+        derivative so callers can both inspect and apply it.
+        """
+
+        derivative = self.dphi_dt(**state)
+        system.update_phase(derivative)
+        return derivative
+
+
+def amundson_energy_balance(*, energy: float, dissipation: float) -> float:
+    """Placeholder for Amundson II energy balance law.
+
+    The energy balance law will govern :math:`\frac{dE_\phi}{dt}`
+    so that systems can explicitly track how coherence work
+    converts into thermal losses.  The exact formulation is left
+    open for future refinement.
+    """
+
+    # TODO: Implement once the energy balance derivation is specified.
+    raise NotImplementedError("Amundson II energy balance has not been derived yet.")
+
+
+def amundson_learning_update(*, gradient: float, weights: float) -> float:
+    """Placeholder for Amundson III learning law.
+
+    Amundson III will translate coherence gradients into weight
+    updates, providing a physicalized backpropagation rule.  The
+    returned value is expected to be a delta for the weights once
+    the learning equation is finalized.
+    """
+
+    # TODO: Implement once the learning dynamics are formally defined.
+    raise NotImplementedError("Amundson III learning dynamics are pending design.")

--- a/tests/test_amundson_equations.py
+++ b/tests/test_amundson_equations.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from lucidia_math_lab.amundson_equations import (
+    AmundsonCoherenceModel,
+    amundson_energy_balance,
+    amundson_learning_update,
+    coherence,
+    decoherence_energy,
+    phase_derivative,
+)
+
+
+def test_coherence_matches_cosine_difference():
+    assert math.isclose(coherence(0.0, 0.0), 1.0)
+    assert math.isclose(coherence(math.pi / 2, 0.0), math.cos(math.pi / 2))
+    assert math.isclose(coherence(math.pi, 0.0), -1.0)
+
+
+def test_decoherence_energy_penalizes_misalignment():
+    aligned = decoherence_energy(
+        phi_x=0.0,
+        phi_y=0.0,
+        r_x=1.0,
+        r_y=1.0,
+        lambda_=2.0,
+        k_b_t=0.5,
+    )
+    misaligned = decoherence_energy(
+        phi_x=math.pi / 2,
+        phi_y=0.0,
+        r_x=1.0,
+        r_y=1.0,
+        lambda_=2.0,
+        k_b_t=0.5,
+    )
+    assert math.isclose(aligned, 0.0)
+    assert misaligned > aligned
+
+
+def test_phase_derivative_combines_terms():
+    value = phase_derivative(
+        omega_0=1.0,
+        lambda_=0.5,
+        eta=0.1,
+        phi_x=math.pi / 3,
+        phi_y=0.0,
+        r_x=1.2,
+        r_y=0.8,
+        k_b_t=0.7,
+    )
+    c_term = coherence(math.pi / 3, 0.0)
+    energy = decoherence_energy(
+        phi_x=math.pi / 3,
+        phi_y=0.0,
+        r_x=1.2,
+        r_y=0.8,
+        lambda_=0.5,
+        k_b_t=0.7,
+    )
+    expected = 1.0 + 0.5 * c_term - 0.1 * energy
+    assert math.isclose(value, expected)
+
+
+class DummySystem:
+    def __init__(self) -> None:
+        self.last_update = None
+
+    def update_phase(self, d_phi_dt: float) -> None:
+        self.last_update = d_phi_dt
+
+
+def test_model_evolve_applies_derivative():
+    model = AmundsonCoherenceModel(omega_0=1.0, lambda_=0.4, eta=0.2, k_b_t=0.6)
+    dummy = DummySystem()
+    derivative = model.evolve(
+        dummy,
+        phi_x=0.1,
+        phi_y=0.05,
+        r_x=1.0,
+        r_y=0.9,
+    )
+    assert math.isclose(derivative, dummy.last_update)
+
+
+def test_placeholders_raise_not_implemented():
+    try:
+        amundson_energy_balance(energy=1.0, dissipation=0.1)
+    except NotImplementedError:
+        pass
+    else:
+        raise AssertionError("energy balance placeholder should raise NotImplementedError")
+
+    try:
+        amundson_learning_update(gradient=0.5, weights=2.0)
+    except NotImplementedError:
+        pass
+    else:
+        raise AssertionError("learning placeholder should raise NotImplementedError")


### PR DESCRIPTION
## Summary
- add a lucidia_math_lab module that implements the proposed Amundson I coherence gradient equation and scaffolds follow-up laws
- expose the new coherence utilities through the lucidia_math_lab package interface
- add unit tests covering the coherence, energy, derivative helpers, and placeholders

## Testing
- pytest tests/test_amundson_equations.py *(fails: existing IndentationError in orchestrator/protocols.py)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d3f1ddde083298f9b274facb33eb8)