### PR TITLE
Add Amundson-BlackRoad kernels and validation pipeline

### DIFF
--- a/.github/workflows/amundson-blackroad.yml
+++ b/.github/workflows/amundson-blackroad.yml
@@ -1,0 +1,21 @@
+name: Amundson-BlackRoad Validation
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install .
+          pip install pytest
+      - name: Run validation suite
+        run: pytest --noconftest tests/test_amundson_blackroad.py

--- a/docs/amundson_blackroad_tree.md
+++ b/docs/amundson_blackroad_tree.md
@@ -1,0 +1,22 @@
+# Amundson–BlackRoad Buildout Tree
+
+```
+packages/
+└── amundson_blackroad/
+    ├── __init__.py
+    ├── spiral.py        # AM-1/2/3 spiral kernels
+    ├── autonomy.py      # BR-1/2 transport + BR-7 trust step
+    ├── coupling.py      # BR-6 curvature ↔ a-field helpers
+    └── thermo.py        # Landauer helpers and provenance
+
+srv/
+└── lucidia-math/
+    └── ui.py            # Flask service exposing AMBR endpoints
+
+tests/
+└── test_amundson_blackroad.py  # V1–V4 validation suite
+
+.github/
+└── workflows/
+    └── amundson-blackroad.yml  # Continuous validation (added in this sprint)
+```

--- a/packages/amundson_blackroad/__init__.py
+++ b/packages/amundson_blackroad/__init__.py
@@ -1,0 +1,34 @@
+"""Core kernels for the Amundson-BlackRoad simulations."""
+
+from .spiral import (
+    simulate_am2,
+    am2_step,
+    field_lift,
+    jacobian_am2,
+)
+from .autonomy import (
+    step_transport,
+    simulate_transport,
+    conserved_mass,
+    compute_flux,
+    trust_field_step,
+)
+from .coupling import curvature_source, couple_curvature_response
+from .thermo import landauer_floor, irreversible_energy, annotate_run_with_thermo
+
+__all__ = [
+    "simulate_am2",
+    "am2_step",
+    "field_lift",
+    "jacobian_am2",
+    "step_transport",
+    "simulate_transport",
+    "conserved_mass",
+    "compute_flux",
+    "trust_field_step",
+    "curvature_source",
+    "couple_curvature_response",
+    "landauer_floor",
+    "irreversible_energy",
+    "annotate_run_with_thermo",
+]

--- a/packages/amundson_blackroad/autonomy.py
+++ b/packages/amundson_blackroad/autonomy.py
@@ -1,0 +1,103 @@
+"""BlackRoad autonomy transport equations (BR-1/2/7)."""
+
+from __future__ import annotations
+
+from typing import Dict, Optional, Tuple
+
+import numpy as np
+
+Array = np.ndarray
+
+
+def compute_flux(
+    A: Array,
+    rho_trust: Array,
+    dx: float,
+    *,
+    mu_A: float = 1.0,
+    chi_A: float = 0.0,
+    Uc: Optional[Array] = None,
+) -> Array:
+    """Compute BR-2 flux J_A."""
+
+    if dx <= 0:
+        raise ValueError("dx must be positive")
+    if Uc is None:
+        Uc = np.zeros_like(A)
+
+    grad_rho = np.gradient(rho_trust, dx, edge_order=2)
+    grad_Uc = np.gradient(Uc, dx, edge_order=2)
+    return mu_A * grad_rho - chi_A * grad_Uc
+
+
+def conserved_mass(x: Array, A: Array) -> float:
+    """Integrate the A field over x."""
+
+    return float(np.trapz(A, x))
+
+
+def step_transport(
+    A: Array,
+    rho_trust: Array,
+    dx: float,
+    dt: float,
+    *,
+    mu_A: float = 1.0,
+    chi_A: float = 0.0,
+    Uc: Optional[Array] = None,
+) -> Tuple[Array, Array]:
+    """Advance the BR-1 transport equation by one step."""
+
+    flux = compute_flux(A, rho_trust, dx, mu_A=mu_A, chi_A=chi_A, Uc=Uc)
+    divergence = np.gradient(flux, dx, edge_order=2)
+    next_A = A - dt * divergence
+    return next_A, flux
+
+
+def simulate_transport(
+    x: Array,
+    A0: Array,
+    rho_trust: Array,
+    steps: int,
+    dt: float,
+    *,
+    mu_A: float = 1.0,
+    chi_A: float = 0.0,
+    Uc: Optional[Array] = None,
+) -> Dict[str, Array]:
+    """Iteratively integrate the transport equation."""
+
+    if steps <= 0:
+        raise ValueError("steps must be positive")
+    if dt <= 0:
+        raise ValueError("dt must be positive")
+    dx = float(x[1] - x[0])
+    A = A0.copy()
+    last_flux = np.zeros_like(A)
+    for _ in range(steps):
+        A, last_flux = step_transport(A, rho_trust, dx, dt, mu_A=mu_A, chi_A=chi_A, Uc=Uc)
+    return {
+        "x": x,
+        "A": A,
+        "flux": last_flux,
+        "mass": float(conserved_mass(x, A)),
+    }
+
+
+def trust_field_step(
+    rho_trust: Array,
+    dx: float,
+    dt: float,
+    *,
+    diffusion: float = 0.1,
+    relaxation: float = 0.0,
+    source: Optional[Array] = None,
+) -> Array:
+    """Evolve the trust field following BR-7."""
+
+    if diffusion < 0:
+        raise ValueError("diffusion must be non-negative")
+    if source is None:
+        source = np.zeros_like(rho_trust)
+    laplacian = np.gradient(np.gradient(rho_trust, dx, edge_order=2), dx, edge_order=2)
+    return rho_trust + dt * (diffusion * laplacian - relaxation * rho_trust + source)

--- a/packages/amundson_blackroad/coupling.py
+++ b/packages/amundson_blackroad/coupling.py
@@ -1,0 +1,30 @@
+"""Curvature coupling helpers (BR-6)."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import numpy as np
+
+Array = np.ndarray
+
+
+def curvature_source(curvature: Array, *, gain: float = 1.0) -> Array:
+    """Map curvature input into a source term for the autonomy field."""
+
+    return gain * curvature
+
+
+def couple_curvature_response(
+    curvature: Array,
+    a_field: Array,
+    *,
+    gain: float = 1.0,
+    response_fn: Callable[[Array], Array] | None = None,
+) -> Array:
+    """Apply curvature sourced signals onto the a-field."""
+
+    if response_fn is None:
+        response_fn = np.tanh
+    source = curvature_source(curvature, gain=gain)
+    return a_field + response_fn(source)

--- a/packages/amundson_blackroad/spiral.py
+++ b/packages/amundson_blackroad/spiral.py
@@ -1,0 +1,138 @@
+"""Amundson spiral dynamics kernels (AM-1/2/3)."""
+
+from __future__ import annotations
+
+from typing import Callable, Tuple
+
+import numpy as np
+
+FieldLift = Callable[[float, float], float]
+PhiTransform = Callable[[float], float]
+
+
+def field_lift(a: float, theta: float, mode: str = "exponential") -> float:
+    """Lift the (a, theta) state into an amplitude field.
+
+    Parameters
+    ----------
+    a:
+        Spiral amplitude parameter.
+    theta:
+        Spiral angle parameter.
+    mode:
+        Strategy for the lift. ``"exponential"`` realises AM-3 directly, while
+        ``"linear"`` is a numerically gentle option used in tests.
+    """
+
+    if mode == "exponential":
+        return float(np.exp(a * theta))
+    if mode == "linear":
+        return float(a)
+    if mode == "theta":
+        return float(theta)
+    raise ValueError(f"unsupported lift mode: {mode}")
+
+
+def am2_step(
+    a: float,
+    theta: float,
+    gamma: float,
+    kappa: float,
+    eta: float,
+    omega0: float = 1.0,
+    *,
+    phi: PhiTransform | None = None,
+    lift_fn: FieldLift | None = None,
+) -> Tuple[float, float, float]:
+    """Compute the instantaneous AM-2 derivatives and lifted field."""
+
+    if phi is None:
+        phi = lambda amp: amp
+    if lift_fn is None:
+        lift_fn = lambda x, y: field_lift(x, y, mode="exponential")
+
+    lifted = lift_fn(a, theta)
+    response = phi(lifted)
+    a_dot = -gamma * a + eta * response
+    theta_dot = omega0 + kappa * a
+    return a_dot, theta_dot, response
+
+
+def simulate_am2(
+    T: float = 10.0,
+    dt: float = 1e-3,
+    a0: float = 0.1,
+    theta0: float = 0.0,
+    gamma: float = 0.3,
+    kappa: float = 0.7,
+    eta: float = 0.5,
+    omega0: float = 1.0,
+    *,
+    phi: PhiTransform | None = None,
+    lift_fn: FieldLift | None = None,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Simulate the coupled AM-2 spiral equations."""
+
+    if dt <= 0:
+        raise ValueError("time step must be positive")
+    if T <= 0:
+        raise ValueError("horizon must be positive")
+
+    n_steps = int(np.ceil(T / dt)) + 1
+    t = np.linspace(0.0, dt * (n_steps - 1), n_steps)
+    a = np.empty(n_steps, dtype=float)
+    theta = np.empty(n_steps, dtype=float)
+    amp = np.empty(n_steps, dtype=float)
+    a[0] = a0
+    theta[0] = theta0
+
+    a_dot, theta_dot, response = am2_step(
+        a0, theta0, gamma, kappa, eta, omega0, phi=phi, lift_fn=lift_fn
+    )
+    amp[0] = response
+
+    for i in range(1, n_steps):
+        a_dot, theta_dot, response = am2_step(
+            a[i - 1], theta[i - 1], gamma, kappa, eta, omega0, phi=phi, lift_fn=lift_fn
+        )
+        a[i] = a[i - 1] + dt * a_dot
+        theta[i] = theta[i - 1] + dt * theta_dot
+        amp[i] = response
+
+    return t, a, theta, amp
+
+
+def jacobian_am2(
+    a: float,
+    theta: float,
+    gamma: float,
+    kappa: float,
+    eta: float,
+    omega0: float,
+    *,
+    phi: PhiTransform | None = None,
+    lift_fn: FieldLift | None = None,
+    eps: float = 1e-6,
+) -> np.ndarray:
+    """Numerically estimate the Jacobian of the AM-2 system at a point."""
+
+    base = np.array(am2_step(a, theta, gamma, kappa, eta, omega0, phi=phi, lift_fn=lift_fn)[0:2])
+    jac = np.zeros((2, 2), dtype=float)
+    perturb = np.array([eps, 0.0])
+    for idx in range(2):
+        if idx == 1:
+            perturb = np.array([0.0, eps])
+        shifted = np.array(
+            am2_step(
+                a + perturb[0],
+                theta + perturb[1],
+                gamma,
+                kappa,
+                eta,
+                omega0,
+                phi=phi,
+                lift_fn=lift_fn,
+            )[0:2]
+        )
+        jac[:, idx] = (shifted - base) / eps
+    return jac

--- a/packages/amundson_blackroad/thermo.py
+++ b/packages/amundson_blackroad/thermo.py
@@ -1,0 +1,57 @@
+"""Thermodynamic helpers anchored to the Codex Landauer floor."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+import numpy as np
+
+K_BOLTZMANN = 1.380649e-23  # J/K
+
+
+@dataclass
+class ThermoRecord:
+    bits: float
+    temperature: float
+    delta_e_min: float
+    seed: Optional[int] = None
+
+
+def landauer_floor(bits: float, temperature: float, *, k_b: float = K_BOLTZMANN) -> float:
+    """Return the minimal energy dissipation for irreversible computation."""
+
+    if bits < 0:
+        raise ValueError("bits must be non-negative")
+    if temperature <= 0:
+        raise ValueError("temperature must be positive")
+    return k_b * temperature * np.log(2.0) * bits
+
+
+def irreversible_energy(transitions: int, temperature: float) -> float:
+    """Compute the floor given a count of irreversible transitions."""
+
+    if transitions < 0:
+        raise ValueError("transitions must be non-negative")
+    return landauer_floor(float(transitions), temperature)
+
+
+def annotate_run_with_thermo(
+    payload: Dict[str, object],
+    *,
+    bits: float,
+    temperature: float,
+    seed: Optional[int] = None,
+) -> Dict[str, object]:
+    """Attach thermo provenance metadata to a run payload."""
+
+    delta_e = landauer_floor(bits, temperature)
+    record = ThermoRecord(bits=bits, temperature=temperature, delta_e_min=delta_e, seed=seed)
+    enriched = dict(payload)
+    enriched["thermo"] = {
+        "bits": record.bits,
+        "temperature": record.temperature,
+        "delta_e_min": record.delta_e_min,
+        "seed": record.seed,
+    }
+    return enriched

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,13 +14,15 @@ dependencies = [
     "pydantic>=2.6.4,<3",
     "pyyaml>=6.0.2,<7",
     "hypothesis>=6.103.4,<7",
+    "numpy>=1.26,<3",
 ]
 
 [tool.setuptools.packages.find]
-where = ["src"]
+where = ["src", "packages"]
 
 [tool.setuptools.package-dir]
 "" = "src"
+"amundson_blackroad" = "packages/amundson_blackroad"
 
 [tool.black]
 line-length = 100

--- a/srv/lucidia-math/ui.py
+++ b/srv/lucidia-math/ui.py
@@ -75,28 +75,87 @@ def demo() -> None:
 
     repl()
 
-app = create_app()
+interactive_app = create_app()
 
-"""Flask API for the Infinity Math system."""
-from flask import Flask, send_from_directory, jsonify
+# Flask API for the Infinity Math system.
 from pathlib import Path
+
+import numpy as np
+from flask import Flask, jsonify, request, send_from_directory
+
+from amundson_blackroad.autonomy import conserved_mass, simulate_transport
+from amundson_blackroad.spiral import simulate_am2
+from amundson_blackroad.thermo import annotate_run_with_thermo
 
 BASE_DIR = Path(__file__).resolve().parent
 OUTPUT_DIR = BASE_DIR / "output"
 
-app = Flask(__name__)
+api_app = Flask(__name__)
+app = api_app
 
 
-@app.get("/health")
+@api_app.get("/health")
 def health() -> tuple:
     return jsonify({"status": "ok"})
 
 
-@app.get("/api/math/<path:subpath>")
+@api_app.get("/api/math/<path:subpath>")
 def get_output(subpath: str):
     """Serve generated artifacts from the output tree."""
     return send_from_directory(OUTPUT_DIR, subpath)
 
 
+@api_app.get("/api/ambr/sim/am2")
+def simulate_am2_endpoint():
+    """Run the AM-2 spiral simulation."""
+
+    args = request.args
+    t, a, theta, amp = simulate_am2(
+        float(args.get("T", 10.0)),
+        float(args.get("dt", 1e-3)),
+        float(args.get("a0", 0.1)),
+        float(args.get("theta0", 0.0)),
+        float(args.get("gamma", 0.3)),
+        float(args.get("kappa", 0.7)),
+        float(args.get("eta", 0.5)),
+        float(args.get("omega0", 1.0)),
+    )
+    payload = {
+        "t": t.tolist(),
+        "a": a.tolist(),
+        "theta": theta.tolist(),
+        "amp": amp.tolist(),
+    }
+    annotated = annotate_run_with_thermo(payload, bits=float(args.get("bits", 0.0)), temperature=float(args.get("temperature", 300.0)))
+    return jsonify(annotated)
+
+
+@api_app.post("/api/ambr/sim/transport")
+def simulate_transport_endpoint():
+    """Run BR-1/2 transport and report conservation metrics."""
+
+    body = request.get_json(force=True)
+    x = np.asarray(body["x"], dtype=float)
+    A0 = np.asarray(body["A"], dtype=float)
+    rho = np.asarray(body["rho"], dtype=float)
+    dt = float(body.get("dt", 1e-3))
+    steps = int(body.get("steps", 100))
+    mu_A = float(body.get("mu", 1.0))
+    chi_A = float(body.get("chi", 0.0))
+    Uc = np.asarray(body["Uc"], dtype=float) if "Uc" in body else None
+    result = simulate_transport(x, A0, rho, steps, dt, mu_A=mu_A, chi_A=chi_A, Uc=Uc)
+    initial_mass = conserved_mass(x, A0)
+    payload = {
+        "x": result["x"].tolist(),
+        "A": result["A"].tolist(),
+        "flux": result["flux"].tolist(),
+        "mass": float(result["mass"]),
+        "mass_initial": initial_mass,
+        "mass_error": float(result["mass"] - initial_mass),
+    }
+    annotated = annotate_run_with_thermo(payload, bits=float(body.get("bits", 0.0)), temperature=float(body.get("temperature", 300.0)), seed=body.get("seed"))
+    return jsonify(annotated)
+
+
 if __name__ == "__main__":
-    app.run(host="127.0.0.1", port=8500)
+    api_app.run(host="127.0.0.1", port=8500)

--- a/tests/test_amundson_blackroad.py
+++ b/tests/test_amundson_blackroad.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'packages'))
+
+from amundson_blackroad.autonomy import conserved_mass, simulate_transport
+from amundson_blackroad.spiral import jacobian_am2, simulate_am2
+from amundson_blackroad.thermo import landauer_floor
+
+
+@pytest.mark.parametrize('steps', [250, 500])
+def test_v1_mass_conservation(steps):
+    x = np.linspace(-5.0, 5.0, 512)
+    A0 = np.exp(-x**2)
+    rho = np.tanh(x)
+    dt = 1e-3
+    result = simulate_transport(x, A0, rho, steps, dt, mu_A=0.8)
+    m0 = conserved_mass(x, A0)
+    m1 = float(result['mass'])
+    assert pytest.approx(m0, rel=1e-3) == m1
+
+
+
+def test_v2_linear_lift_matches_analytic():
+    gamma = 0.8
+    eta = 0.2
+    kappa = 0.1
+    omega0 = 1.5
+    a0 = 0.3
+    t, a, theta, _ = simulate_am2(
+        1.0,
+        1e-3,
+        a0,
+        0.0,
+        gamma,
+        kappa,
+        eta,
+        omega0,
+        phi=lambda amp: amp,
+        lift_fn=lambda a_val, _theta: a_val,
+    )
+    expected = a0 * np.exp((eta - gamma) * t)
+    assert np.allclose(a, expected, atol=1e-3)
+    numerical_frequency = np.gradient(theta, t)
+    assert np.allclose(numerical_frequency, omega0 + kappa * a, atol=1e-3)
+
+
+
+def test_v3_landauer_floor_positive():
+    bits = 128
+    temperature = 310.0
+    energy = landauer_floor(bits, temperature)
+    assert energy > 0
+    manual = 1.380649e-23 * temperature * np.log(2.0) * bits
+    assert pytest.approx(manual, rel=1e-12) == energy
+
+
+
+def test_v4_jacobian_stability():
+    gamma = 1.0
+    eta = 0.2
+    kappa = 0.4
+    omega0 = 1.2
+    J = jacobian_am2(
+        0.0,
+        0.0,
+        gamma,
+        kappa,
+        eta,
+        omega0,
+        phi=lambda amp: amp,
+        lift_fn=lambda a_val, _theta: a_val,
+        eps=1e-6,
+    )
+    eigenvalues = np.linalg.eigvals(J)
+    assert np.all(eigenvalues.real <= 1e-8)
+    assert np.isclose(eigenvalues.max().real, 0.0, atol=1e-8)
+    assert eigenvalues.min().real <= 0.0


### PR DESCRIPTION
## Summary
- add the amundson_blackroad math package with spiral, autonomy, coupling, and thermo kernels wired through a clean interface
- expose AM-2 and BR-1/2 simulations via lucidia-math API endpoints and document the new layout
- stand up a pytest-based validation suite with CI coverage for the new kernels

## Testing
- pytest --noconftest tests/test_amundson_blackroad.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d775540688329baf089d67b64b188)