### PR TITLE
feat(policy): enforce SEC 204-2 gate

### DIFF
--- a/.github/workflows/rego-lint.yml
+++ b/.github/workflows/rego-lint.yml
@@ -1,0 +1,68 @@
+name: Rego Policy Checks
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  rego:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install OPA
+        run: |
+          curl -sSL -o opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64
+          chmod +x opa
+          sudo mv opa /usr/local/bin/opa
+
+      - name: Install Conftest
+        run: |
+          curl -sSL -o conftest.tar.gz https://github.com/open-policy-agent/conftest/releases/download/v0.45.0/conftest_0.45.0_Linux_x86_64.tar.gz
+          tar -xzf conftest.tar.gz
+          sudo mv conftest /usr/local/bin/conftest
+
+      - name: Check policy formatting
+        run: |
+          set -euo pipefail
+          files=$(git ls-files '*.rego')
+          if [ -n "$files" ]; then
+            opa fmt --fail $files
+          else
+            echo "No Rego files found"
+          fi
+
+      - name: Run opa test suite
+        run: |
+          set -euo pipefail
+          policy_dirs=(policies policy prism/policies agents/codex/32-sentinel/policies br-infra-iac/policy)
+          selected=""
+          for dir in "${policy_dirs[@]}"; do
+            if [ -d "$dir" ]; then
+              selected="$selected $dir"
+            fi
+          done
+          if [ -n "${selected// }" ]; then
+            # shellcheck disable=SC2086
+            opa test $selected
+          else
+            echo "No Rego directories to test"
+          fi
+
+      - name: Run conftest checks
+        run: |
+          set -euo pipefail
+          policy_dirs=(policies policy prism/policies)
+          ran=false
+          for dir in "${policy_dirs[@]}"; do
+            if [ -d "$dir" ]; then
+              conftest test "$dir"
+              ran=true
+            fi
+          done
+          if [ "$ran" = false ]; then
+            echo "No policy directories found for conftest"
+          fi

--- a/README-OPS.md
+++ b/README-OPS.md
@@ -70,6 +70,22 @@ Terraform backends, and change-management requirements.
 - **Rollback** — Use `POST /api/rollback/:releaseId` with the internal token or
   re-run `blackroad-deploy.yml` against a known-good commit.
 
+## Policy gates
+
+- **SEC rule 204-2 (forecast guardrail)** — `policies/sec_rule_204_2.rego`
+  enforces citations for revenue forecasts that exceed a 10% deviation. The
+  orchestrator loads this via `SecRule2042Gate` and the `task:route` command
+  will fail fast when the policy denies execution.
+  - Add supporting links under `task.metadata["forecast"]["citations"]` (or
+    attach baseline/projection values so the gate can compute the variance).
+  - Policy coverage lives in `tests/policies/test_sec_rule_204_2.py`; run `pytest
+    tests/policies` for a focused check.
+- **Emergency override** — When compliance signs off, set the environment
+  variable `PRISM_SEC_204_2_OVERRIDE=I_ACKNOWLEDGE_SEC_204_2_RISK` for the CLI or
+  worker invocation performing the reroute. The orchestrator logs the override
+  and skips the denial once. Clear the variable immediately after the run and
+  document the exception in the change record.
+
 ## References
 
 - Deployment playbook: `DEPLOYMENT.md`

--- a/cli/console.py
+++ b/cli/console.py
@@ -16,6 +16,7 @@ from orchestrator import (
     PolicyEngine,
     RouteContext,
     Router,
+    SecRule2042Gate,
     Task,
     TaskPriority,
     TaskRepository,
@@ -65,12 +66,14 @@ def _load_route_context(approved_by: Iterable[str] | None = None) -> RouteContex
             }
         },
     }
+    sec_gate = SecRule2042Gate()
     return RouteContext(
         policy_engine=policy_engine,
         memory=memory,
         lineage=lineage,
         config=config_dict,
         approved_by=list(approved_by or []),
+        sec_gate=sec_gate,
     )
 
 

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -8,6 +8,7 @@ from .memory import MemoryLog
 from .policy import PolicyEngine
 from .protocols import BotExecutionError, BotResponse, MemoryRecord, Task, TaskPriority
 from .router import BotRegistry, RouteContext, Router, TaskRepository
+from .sec import SecRule2042Gate
 from .tasks import load_tasks, save_tasks
 
 __all__ = [
@@ -25,17 +26,18 @@ __all__ = [
     "RouteContext",
     "Router",
     "TaskRepository",
+    "SecRule2042Gate",
     "load_tasks",
     "save_tasks",
 ]
-import logging
+from logging import getLogger
 from typing import Any
 
 from sdk import plugin_api
 from . import registry
 from .sandbox import run_in_sandbox, BotExecutionError
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 
 def route(bot_name: str, task: plugin_api.Task) -> Any:

--- a/orchestrator/protocols.py
+++ b/orchestrator/protocols.py
@@ -1,5 +1,3 @@
-"""Shared typing contracts for Prism Console bots and tasks."""
-"""Core data structures and protocols for the orchestrator."""
 """Shared data contracts for bots and the orchestrator."""
 
 from __future__ import annotations
@@ -8,8 +6,6 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, Mapping, MutableMapping, Optional, Protocol, Sequence, runtime_checkable
-from typing import Any, Dict, List, Mapping, MutableMapping, Optional, Sequence, Protocol, runtime_checkable
-from typing import Any, Dict, Mapping, MutableMapping, Optional, Sequence
 
 
 class TaskPriority(str, Enum):
@@ -27,26 +23,19 @@ class Task:
     id: str
     goal: str
     bot: str = ""
-    owner: str = ""
     owner: Optional[str] = None
     priority: TaskPriority | str = TaskPriority.MEDIUM
     created_at: datetime = field(default_factory=datetime.utcnow)
-    due_date: datetime | None = None
+    due_date: Optional[datetime] = None
     tags: Sequence[str] = field(default_factory=tuple)
     metadata: MutableMapping[str, Any] | None = None
     config: MutableMapping[str, Any] | None = None
     context: MutableMapping[str, Any] | None = None
     status: str = "pending"
     depends_on: Sequence[str] = field(default_factory=tuple)
-    scheduled_for: datetime | None = None
-    metadata: MutableMapping[str, Any] = field(default_factory=dict)
-    config: MutableMapping[str, Any] = field(default_factory=dict)
-    context: MutableMapping[str, Any] = field(default_factory=dict)
-    status: str = "pending"
-    depends_on: Sequence[str] = field(default_factory=tuple)
     scheduled_for: Optional[datetime] = None
 
-    def __post_init__(self) -> None:  # pragma: no cover - trivial conversions
+    def __post_init__(self) -> None:  # pragma: no cover - normalisation logic
         if isinstance(self.priority, str):
             self.priority = TaskPriority(self.priority.lower())
 
@@ -59,39 +48,13 @@ class Task:
 
         self.tags = tuple(self.tags)
         self.depends_on = tuple(self.depends_on)
-        if self.metadata is None:
-            self.metadata = {}
+
         if not isinstance(self.metadata, MutableMapping):
-            self.metadata = dict(self.metadata)
-
-        if self.config is None:
-            self.config = {}
+            self.metadata = dict(self.metadata or {})
         if not isinstance(self.config, MutableMapping):
-            self.config = dict(self.config)
-
-        if self.context is None:
-            self.context = {}
+            self.config = dict(self.config or {})
         if not isinstance(self.context, MutableMapping):
-            self.context = dict(self.context)
-
-        if not isinstance(self.tags, tuple):
-            self.tags = tuple(self.tags)
-        if not isinstance(self.depends_on, tuple):
-            self.depends_on = tuple(self.depends_on)
-        if self.metadata is None:
-            self.metadata = {}
-        if not isinstance(self.metadata, MutableMapping):
-            self.metadata = dict(self.metadata)
-
-        if self.config is None:
-            self.config = {}
-        if not isinstance(self.config, MutableMapping):
-            self.config = dict(self.config)
-
-        if self.context is None:
-            self.context = {}
-        if not isinstance(self.context, MutableMapping):
-            self.context = dict(self.context)
+            self.context = dict(self.context or {})
 
     def to_dict(self) -> Dict[str, Any]:
         """Serialise the task for persistence or transport."""
@@ -104,15 +67,14 @@ class Task:
             "created_at": self.created_at.isoformat(),
             "status": self.status,
             "tags": list(self.tags),
-            "metadata": dict(self.metadata),
-            "config": dict(self.config),
-            "context": dict(self.context),
+            "metadata": dict(self.metadata or {}),
+            "config": dict(self.config or {}),
+            "context": dict(self.context or {}),
             "depends_on": list(self.depends_on),
         }
-        if self.due_date is not None:
         if self.bot:
             payload["bot"] = self.bot
-        if self.due_date:
+        if self.due_date is not None:
             payload["due_date"] = self.due_date.isoformat()
         if self.scheduled_for is not None:
             payload["scheduled_for"] = self.scheduled_for.isoformat()
@@ -203,4 +165,3 @@ __all__ = [
     "BotExecutionError",
     "BaseBot",
 ]
-

--- a/orchestrator/sec.py
+++ b/orchestrator/sec.py
@@ -1,0 +1,195 @@
+"""Compliance policy enforcement helpers for SEC rule 204-2."""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Sequence
+
+from regopy import Input, Interpreter
+
+from orchestrator.exceptions import PolicyViolationError
+from orchestrator.protocols import Task
+
+
+logger = logging.getLogger(__name__)
+
+OVERRIDE_ENV_VAR = "PRISM_SEC_204_2_OVERRIDE"
+OVERRIDE_TOKEN = "I_ACKNOWLEDGE_SEC_204_2_RISK"
+
+
+@dataclass(slots=True)
+class SecPolicyResult:
+    """Result of evaluating the SEC 204-2 policy."""
+
+    allowed: bool
+    messages: Sequence[str]
+
+
+class SecRule2042Gate:
+    """Evaluate the SEC 204-2 forecast policy using a Rego module."""
+
+    def __init__(self, policy_path: Path | None = None) -> None:
+        self.policy_path = policy_path or Path("policies/sec_rule_204_2.rego")
+        self._interpreter = Interpreter()
+        self._module_name = self.policy_path.name
+        self._load_policy()
+
+    def _load_policy(self) -> None:
+        source = self.policy_path.read_text(encoding="utf-8")
+        self._interpreter.add_module(self._module_name, source)
+
+    def evaluate(self, task: Task) -> SecPolicyResult:
+        """Evaluate the policy for a task and return the decision."""
+
+        payload = _build_policy_input(task)
+        self._interpreter.set_input(Input(payload))
+
+        violations = _extract_strings(self._interpreter.query("data.sec.rule_204_2.deny"))
+        if violations:
+            return SecPolicyResult(False, tuple(violations))
+
+        allow = _extract_bools(self._interpreter.query("data.sec.rule_204_2.allow"))
+        is_allowed = allow[0] if allow else False
+        return SecPolicyResult(is_allowed, ())
+
+    def enforce(self, task: Task) -> None:
+        """Raise when the policy denies execution for the task."""
+
+        override = os.getenv(OVERRIDE_ENV_VAR)
+        if override:
+            if override != OVERRIDE_TOKEN:
+                raise PolicyViolationError(
+                    "SEC rule 204-2 override token invalid; expected explicit acknowledgement"
+                )
+            logger.warning("SEC rule 204-2 override engaged for task %s", task.id)
+            return
+
+        result = self.evaluate(task)
+        if not result.allowed:
+            message = "; ".join(result.messages) if result.messages else "SEC rule 204-2 policy denied"
+            raise PolicyViolationError(message)
+
+
+def _build_policy_input(task: Task) -> Dict[str, Any]:
+    """Construct the input document for the Rego policy."""
+
+    metadata = dict(task.metadata or {})
+    context = dict(task.context or {})
+    forecast_section = _select_mapping((context.get("forecast"), metadata.get("forecast")))
+
+    deviation = _coerce_number(
+        forecast_section.get("deviation")
+        if forecast_section
+        else None
+    )
+    baseline = _coerce_number(_first_present(forecast_section, ("baseline", "baseline_revenue")))
+    projection = _coerce_number(_first_present(forecast_section, ("projection", "projected", "forecast")))
+    actual = _coerce_number(_first_present(forecast_section, ("actual", "actuals")))
+
+    if deviation is None and baseline is not None and projection is not None and baseline != 0:
+        deviation = abs(projection - baseline) / abs(baseline)
+    elif deviation is None and baseline is not None and actual is not None and baseline != 0:
+        deviation = abs(actual - baseline) / abs(baseline)
+
+    citations = _normalise_citations(forecast_section)
+
+    return {
+        "task": {
+            "id": task.id,
+            "goal": task.goal,
+            "owner": task.owner,
+            "tags": list(task.tags),
+            "metadata": metadata,
+            "context": context,
+        },
+        "forecast": {
+            "deviation": deviation,
+            "baseline": baseline,
+            "projection": projection if projection is not None else actual,
+            "citations": citations,
+        },
+    }
+
+
+def _select_mapping(candidates: Iterable[Any]) -> Mapping[str, Any]:
+    for candidate in candidates:
+        if isinstance(candidate, Mapping):
+            return candidate
+    return {}
+
+
+def _first_present(data: Mapping[str, Any] | None, keys: Sequence[str]) -> Any:
+    if not isinstance(data, Mapping):
+        return None
+    for key in keys:
+        if key in data:
+            return data[key]
+    return None
+
+
+def _coerce_number(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        try:
+            return float(stripped)
+        except ValueError:
+            return None
+    return None
+
+
+def _normalise_citations(data: Mapping[str, Any] | None) -> List[str]:
+    raw: Sequence[Any] | None = None
+    if isinstance(data, Mapping):
+        citations = data.get("citations")
+        if isinstance(citations, Sequence) and not isinstance(citations, (str, bytes)):
+            raw = citations
+        else:
+            citation = data.get("citation")
+            if isinstance(citation, (str, bytes)):
+                raw = [citation]
+    if raw is None:
+        return []
+    cleaned: List[str] = []
+    for value in raw:
+        if not isinstance(value, (str, bytes)):
+            continue
+        text = str(value).strip()
+        if text:
+            cleaned.append(text)
+    return cleaned
+
+
+def _extract_strings(output) -> List[str]:
+    messages: List[str] = []
+    for result in getattr(output, "results", []):
+        for expression in result.expressions:
+            if isinstance(expression, list):
+                messages.extend(str(item) for item in expression if isinstance(item, str))
+            elif isinstance(expression, str):
+                messages.append(expression)
+            elif isinstance(expression, Mapping):
+                for key, value in expression.items():
+                    if value is True:
+                        messages.append(str(key))
+    return messages
+
+
+def _extract_bools(output) -> List[bool]:
+    values: List[bool] = []
+    for result in getattr(output, "results", []):
+        for expression in result.expressions:
+            if isinstance(expression, bool):
+                values.append(expression)
+    return values
+
+
+__all__ = ["SecRule2042Gate", "SecPolicyResult", "OVERRIDE_ENV_VAR", "OVERRIDE_TOKEN"]

--- a/policies/sec_rule_204_2.rego
+++ b/policies/sec_rule_204_2.rego
@@ -1,0 +1,75 @@
+package sec.rule_204_2
+
+# Enforces SEC rule 204-2: forecasts exceeding 10%% deviation must cite sources.
+
+default allow := false
+
+threshold := 0.10
+
+deny[msg] {
+    forecast_task
+    deviation := forecast_deviation
+    deviation > threshold
+    count(input.forecast.citations) == 0
+    msg := sprintf(
+        "Forecast deviation %.1f%% exceeds %.0f%% limit without citation",
+        [deviation * 100, threshold * 100],
+    )
+}
+
+allow {
+    count(deny) == 0
+}
+
+forecast_task {
+    goal := input.task.goal
+    is_string(goal)
+    contains(lower(goal), "forecast")
+}
+
+forecast_task {
+    intent := input.task.metadata.intent
+    is_string(intent)
+    lower(intent) == "forecast"
+}
+
+forecast_task {
+    tags := input.task.tags
+    some i
+    tag := tags[i]
+    is_string(tag)
+    contains(lower(tag), "forecast")
+}
+
+forecast_deviation := deviation {
+    deviation_value := input.forecast.deviation
+    is_number(deviation_value)
+    deviation := abs(deviation_value)
+}
+
+forecast_deviation := deviation {
+    deviation_value := input.forecast.deviation
+    is_string(deviation_value)
+    parsed := to_number(deviation_value)
+    deviation := abs(parsed)
+}
+
+forecast_deviation := deviation {
+    baseline_value := input.forecast.baseline
+    projection_value := input.forecast.projection
+    baseline := to_number_if_possible(baseline_value)
+    projection := to_number_if_possible(projection_value)
+    baseline > 0
+    delta := abs(projection - baseline)
+    deviation := delta / baseline
+}
+
+to_number_if_possible(value) = number {
+    is_number(value)
+    number := value
+}
+
+to_number_if_possible(value) = number {
+    is_string(value)
+    number := to_number(value)
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "pydantic>=2.6.4,<3",
     "pyyaml>=6.0.2,<7",
     "hypothesis>=6.103.4,<7",
+    "regopy>=1.0.0,<2",
 ]
 
 [tool.setuptools.packages.find]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ black>=23.7.0
 ruff>=0.0.285
 mypy>=1.5.0
 hypothesis>=6.112.0
+regopy>=1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ pyyaml==6.0.2
 anthropic
 boto3
 fastapi
+regopy==1.0.0
 matplotlib==3.9.4
 mpmath
 notion-client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from orchestrator import (
     PolicyEngine,
     RouteContext,
     Router,
+    SecRule2042Gate,
     Task,
     TaskPriority,
     TaskRepository,
@@ -52,7 +53,14 @@ def policy_engine(policy_file: Path) -> PolicyEngine:
 def route_context(tmp_path: Path, policy_engine: PolicyEngine) -> RouteContext:
     memory = MemoryLog(tmp_path / "memory.jsonl")
     lineage = LineageTracker(tmp_path / "lineage.jsonl")
-    return RouteContext(policy_engine=policy_engine, memory=memory, lineage=lineage, approved_by=[])
+    sec_gate = SecRule2042Gate()
+    return RouteContext(
+        policy_engine=policy_engine,
+        memory=memory,
+        lineage=lineage,
+        approved_by=[],
+        sec_gate=sec_gate,
+    )
 
 
 @pytest.fixture()

--- a/tests/integration/test_task_routing.py
+++ b/tests/integration/test_task_routing.py
@@ -12,6 +12,7 @@ from orchestrator import (
     PolicyEngine,
     RouteContext,
     Router,
+    SecRule2042Gate,
     Task,
     TaskPriority,
     TaskRepository,
@@ -47,6 +48,7 @@ def test_route_records_memory_and_lineage(tmp_path: Path) -> None:
         memory=MemoryLog(tmp_path / "memory.jsonl"),
         lineage=LineageTracker(tmp_path / "lineage.jsonl"),
         approved_by=["cfo"],
+        sec_gate=SecRule2042Gate(),
     )
     response = router.route(task.id, "Treasury-BOT", context)
     assert response.ok

--- a/tests/policies/test_sec_rule_204_2.py
+++ b/tests/policies/test_sec_rule_204_2.py
@@ -1,0 +1,114 @@
+"""Tests for the SEC rule 204-2 Rego policy and runtime gate."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+import pytest
+from regopy import Input, Interpreter
+
+from orchestrator.exceptions import PolicyViolationError
+from orchestrator.protocols import Task, TaskPriority
+from orchestrator.sec import OVERRIDE_ENV_VAR, OVERRIDE_TOKEN, SecRule2042Gate
+
+POLICY_PATH = Path("policies/sec_rule_204_2.rego")
+
+
+def _load_interpreter() -> Interpreter:
+    interpreter = Interpreter()
+    source = POLICY_PATH.read_text(encoding="utf-8")
+    interpreter.add_module(POLICY_PATH.name, source)
+    return interpreter
+
+
+def _query_strings(output) -> List[str]:
+    messages: List[str] = []
+    for result in getattr(output, "results", []):
+        for expression in result.expressions:
+            if isinstance(expression, list):
+                messages.extend(str(item) for item in expression if isinstance(item, str))
+            elif isinstance(expression, str):
+                messages.append(expression)
+            elif isinstance(expression, dict):
+                for key, value in expression.items():
+                    if value is True:
+                        messages.append(str(key))
+    return messages
+
+
+def _query_bool(output) -> bool:
+    for result in getattr(output, "results", []):
+        for expression in result.expressions:
+            if isinstance(expression, bool):
+                return expression
+    return False
+
+
+@pytest.mark.parametrize(
+    "deviation,citations,expected_allowed",
+    [
+        (0.15, [], False),
+        (0.08, [], True),
+        (0.2, ["https://example.com/10q"], True),
+    ],
+)
+def test_rego_policy_allows_and_denies_based_on_input(deviation: float, citations: List[str], expected_allowed: bool) -> None:
+    interpreter = _load_interpreter()
+    payload = {
+        "task": {
+            "id": "TSK-FORECAST",
+            "goal": "Prepare revenue forecast",
+            "owner": "finance",
+            "tags": ["forecast"],
+            "metadata": {},
+            "context": {},
+        },
+        "forecast": {
+            "deviation": deviation,
+            "citations": citations,
+            "baseline": 100.0,
+            "projection": 100.0 * (1 + deviation),
+        },
+    }
+    interpreter.set_input(Input(payload))
+    deny = _query_strings(interpreter.query("data.sec.rule_204_2.deny"))
+    allow = _query_bool(interpreter.query("data.sec.rule_204_2.allow"))
+
+    if expected_allowed:
+        assert not deny
+        assert allow
+    else:
+        assert deny
+        assert not allow
+
+
+def test_sec_gate_enforces_policy_for_tasks() -> None:
+    gate = SecRule2042Gate(POLICY_PATH)
+    task = Task(
+        id="TSK-GATE",
+        goal="Generate quarterly forecast",
+        owner="finance",
+        priority=TaskPriority.HIGH,
+        metadata={"forecast": {"baseline": 1_000_000, "projection": 1_200_000, "citations": []}},
+    )
+
+    with pytest.raises(PolicyViolationError):
+        gate.enforce(task)
+
+    task.metadata["forecast"]["citations"] = ["https://example.com/supporting"]
+    gate.enforce(task)
+
+
+def test_sec_gate_override_allows_single_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    gate = SecRule2042Gate(POLICY_PATH)
+    task = Task(
+        id="TSK-OVERRIDE",
+        goal="Generate emergency forecast",
+        owner="finance",
+        priority=TaskPriority.HIGH,
+        metadata={"forecast": {"baseline": 1000, "projection": 1300, "citations": []}},
+    )
+
+    monkeypatch.setenv(OVERRIDE_ENV_VAR, OVERRIDE_TOKEN)
+    gate.enforce(task)

--- a/tools/storage.py
+++ b/tools/storage.py
@@ -1,6 +1,4 @@
-"""Storage helpers for Prism console utilities."""
-"""File-system backed storage helpers used by the console."""
-"""Lightweight file system helpers used across the project."""
+"""Lightweight helpers for reading and writing configuration artifacts."""
 
 from __future__ import annotations
 
@@ -11,7 +9,6 @@ from typing import Any, Iterable, Mapping, Union
 
 import yaml
 
-BASE_DIR = Path.cwd()
 BASE_DIR = Path(__file__).resolve().parents[1]
 CONFIG_ROOT = BASE_DIR / "config"
 DATA_ROOT = BASE_DIR / "data"
@@ -22,31 +19,27 @@ def _ensure_parent(path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
 
 
-def write(path: Union[str, Path], content: Union[dict[str, Any], str]) -> None:
-def write(path: str, content: Union[Mapping[str, Any], str]) -> None:
+def write(path: Union[str, Path], content: Union[Mapping[str, Any], str]) -> None:
     target = Path(path)
     _ensure_parent(target)
     mode = "a" if target.suffix == ".jsonl" else "w"
-    text = json.dumps(content) if isinstance(content, Mapping) else str(content)
+    payload = json.dumps(content) if isinstance(content, Mapping) else str(content)
     with target.open(mode, encoding="utf-8") as handle:
         if mode == "a":
-            handle.write(text + "\n")
+            handle.write(payload + "\n")
         else:
-            handle.write(text)
+            handle.write(payload)
 
 
-def read(path: str) -> str:
 def read(path: Union[str, Path]) -> str:
     target = Path(path)
-    if not target.exists():
     try:
-        return Path(path).read_text(encoding="utf-8")
+        return target.read_text(encoding="utf-8")
     except FileNotFoundError:
         return ""
-    return target.read_text(encoding="utf-8")
 
 
-def _resolve(path: str, root: Path) -> Path:
+def _resolve(path: Union[str, Path], root: Path) -> Path:
     candidate = Path(path)
     if candidate.is_absolute():
         return candidate
@@ -134,9 +127,6 @@ def load_json(path: Path, default: Any) -> Any:
 
 
 def save_json(path: Path, data: Any) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    """Persist *data* as JSON to *path*."""
-
     _ensure_parent(path)
     with path.open("w", encoding="utf-8") as handle:
         json.dump(data, handle, indent=2, default=str)
@@ -156,4 +146,3 @@ __all__ = [
     "load_json",
     "save_json",
 ]
-


### PR DESCRIPTION
## Summary
- add the SEC rule 204-2 Rego policy, runtime gate, and emergency override guidance
- wire task routing, CLI context, and storage/protocol helpers to support policy enforcement
- add automated Rego linting and targeted tests covering pass and fail scenarios

## Testing
- pytest tests/policies/test_sec_rule_204_2.py tests/integration/test_task_routing.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d7930718c832987c3f815300c3dde)