### PR TITLE
chore(ops): automate merge queue guardrails

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -25,3 +25,7 @@
 - name: no-rerun
   color: "b60205"
   description: Opt out of automatic reruns
+- name: queue:ready
+  color: "0e8a16"
+  description: Eligible for merge queue automation
+

--- a/.github/workflows/auto-queue-ready.yml
+++ b/.github/workflows/auto-queue-ready.yml
@@ -1,0 +1,126 @@
+name: auto-queue-ready
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+  check_suite:
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+  checks: read
+
+jobs:
+  label-when-green:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync queue:ready label with required checks
+        uses: actions/github-script@v7
+        env:
+          REQUIRED_CHECKS: build,test,lint,security,sbom,policy,eval
+        with:
+          script: |
+            const required = (process.env.REQUIRED_CHECKS || '')
+              .split(',')
+              .map((name) => name.trim())
+              .filter(Boolean);
+            if (!required.length) {
+              core.setFailed('REQUIRED_CHECKS cannot be empty.');
+              return;
+            }
+
+            let prNumber = null;
+            let headSha = null;
+
+            if (context.eventName === 'pull_request') {
+              prNumber = context.payload.pull_request?.number ?? null;
+              headSha = context.payload.pull_request?.head?.sha ?? null;
+            } else if (context.eventName === 'check_suite') {
+              const suite = context.payload.check_suite;
+              prNumber = suite?.pull_requests?.[0]?.number ?? null;
+              headSha = suite?.head_sha ?? null;
+            }
+
+            if (!prNumber || !headSha) {
+              core.info('No pull request head SHA to evaluate; skipping.');
+              return;
+            }
+
+            const { data: prData } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            if (prData.draft) {
+              core.info('PR is draft; ensure queue:ready label is removed.');
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  name: 'queue:ready',
+                });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+                core.info('queue:ready label not present; nothing to remove.');
+              }
+              return;
+            }
+
+            const checkRuns = await github.rest.checks.listForRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: prData.head.sha,
+              status: 'completed',
+              per_page: 100,
+            });
+
+            const successfulChecks = new Set();
+            for (const check of checkRuns.data.check_runs) {
+              if (check.conclusion === 'success') {
+                successfulChecks.add(check.name);
+              }
+            }
+
+            const combinedStatus = await github.rest.repos.getCombinedStatusForRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: prData.head.sha,
+            });
+
+            for (const status of combinedStatus.data.statuses) {
+              if (status.state === 'success') {
+                successfulChecks.add(status.context);
+              }
+            }
+
+            const missing = required.filter((name) => !successfulChecks.has(name));
+
+            if (!missing.length) {
+              core.info(`All required checks are green: ${required.join(', ')}`);
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                labels: ['queue:ready'],
+              });
+            } else {
+              core.info(`Missing checks: ${missing.join(', ')}`);
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  name: 'queue:ready',
+                });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+                core.info('queue:ready label not present; nothing to remove.');
+              }
+            }

--- a/README-OPS.md
+++ b/README-OPS.md
@@ -49,6 +49,11 @@ Terraform backends, and change-management requirements.
   delete merged branches automatically. Override the base with
   `BASE_BRANCH=origin/staging` when pruning staging-specific branches.
 
+## Merge queue guardrails
+
+- `docs/ops/merge-queue.md` explains how to apply branch protection with the CLI, enable the merge queue, and keep the `queue:ready` label in sync.
+- `docs/ops/required-checks.md` lists the commit status contexts that must stay green before labeling a pull request as queue-ready.
+
 ## Health & verification
 
 - Preview: `curl -fsS https://pr-<n>.dev.blackroad.io/healthz/ui` (already run in

--- a/docs/ops/merge-queue.md
+++ b/docs/ops/merge-queue.md
@@ -1,0 +1,59 @@
+# Merge queue runbook
+
+This document converts the high-level guidance from `docs/MERGE_QUEUE_PRIMER.md`
+into concrete commands and repository automation. Follow the steps below to roll
+out branch protection, enable the merge queue, and keep the `queue:ready` label in
+sync with passing checks.
+
+## 1. Apply branch protection from the CLI
+
+1. Authenticate `gh` with the repository (`gh auth status`).
+2. Adjust the required contexts in `REQ_CHECKS` if needed (see
+   `docs/ops/required-checks.md` for the canonical names).
+3. Run the helper script from the repo root:
+
+   ```bash
+   REQ_CHECKS='["build","test","lint","security","sbom","policy","eval"]' \
+     repo-ops/enforce-branch-protection.sh
+   ```
+
+   The script enforces:
+
+   - Required status checks with strict mode enabled.
+   - Required reviews with code-owner coverage and stale-review dismissal.
+   - Linear history with squash or rebase merges only.
+   - Automatic creation of the `queue:ready` label if it does not already exist.
+
+   Re-run the script whenever check names change so branch protection stays in
+   sync with the documentation.
+
+## 2. Enable merge queue in the GitHub UI
+
+1. Navigate to **Settings → General → Merge queue**.
+2. Enable the merge queue and add a rule for the `main` branch that requires the
+   `queue:ready` label before enqueueing.
+3. Confirm that “Allow auto-merge” is on for squash or rebase merges only.
+
+## 3. Keep the `queue:ready` label synchronized automatically
+
+The workflow `.github/workflows/auto-queue-ready.yml` monitors pull requests and
+check suites. It adds the `queue:ready` label when all required contexts succeed
+and removes it when a check is missing, failing, or the pull request is marked as
+Draft. No manual action is required besides ensuring the required checks list in
+the workflow matches your policy.
+
+## 4. Maintain required check documentation
+
+The table in `docs/ops/required-checks.md` maps each alias (build, test, lint,
+etc.) to the actual commit-status contexts emitted by CI. Update the document
+whenever a workflow or job name changes so future automation stays aligned.
+
+## 5. Operational tips
+
+- **Watch the queue**: keep an eye on the merge queue badge in GitHub after each
+  batch lands to make sure the tip of `main` stays green.
+- **Debugging failures**: removing `queue:ready` ejects a PR from the queue.
+  Re-apply after addressing flakiness or legitimate failures.
+- **Expanding coverage**: when new surfaces require gating (for example, a new
+  service or security scanner), add the check to the table and rerun
+  `enforce-branch-protection.sh` with the updated `REQ_CHECKS`.

--- a/docs/ops/required-checks.md
+++ b/docs/ops/required-checks.md
@@ -1,0 +1,22 @@
+# Required status checks
+
+These are the commit status contexts that must stay green before a pull request can
+enter the merge queue or merge to `main`. The aliases below match the defaults used
+by `repo-ops/enforce-branch-protection.sh`; update the script's `REQ_CHECKS`
+environment variable if you need to add or remove contexts.
+
+| Alias | Commit status context(s) to require | Source workflow | Purpose |
+| --- | --- | --- | --- |
+| `build` | `CI / Web quality checks`<br>`prism-ci / build` | `.github/workflows/ci.yml`<br>`.github/workflows/prism-ci.yml` | Builds the web bundles, runs end-to-end packaging, and ensures the Prism service still compiles and ships images. |
+| `test` | `Tests / test`<br>`Tests / site-playwright` | `.github/workflows/test.yml` | Node unit tests plus Playwright UI coverage. |
+| `lint` | `lint-suite / eslint`<br>`lint-suite / go-vet`<br>`lint-suite / python-static-analysis` | `.github/workflows/lint.yml` | Static analysis across the JavaScript, Go, and Python surfaces that ship from this repo. |
+| `security` | `Security • gitleaks / scan`<br>`Secret Scan / scan`<br>`PR Preview Containers / Vulnerability Scan` | `.github/workflows/gitleaks.yml`<br>`.github/workflows/secret-scan.yml`<br>`.github/workflows/preview-containers.yml` | Detects leaked credentials, enforces quick secret scans, and executes Grype against preview container images. |
+| `sbom` | `PR Preview Containers / Generate SBOM` | `.github/workflows/preview-containers.yml` | Publishes an SPDX bill of materials for the preview container created from the PR. |
+| `policy` | `policy-guard / org-guard` | `.github/workflows/policy-guard.yml` | Runs OPA checks to confirm branch protections and other guardrails have not drifted. |
+| `eval` | `quality-gates / pulse-check` | `.github/workflows/quality-gates.yml` | Verifies the quick-release checklist inside the pull request description stays checked. |
+
+## Updating the branch-protection script
+
+Run `REQ_CHECKS='["CI / Web quality checks", ...]' repo-ops/enforce-branch-protection.sh`
+if you need to pin the exact contexts above. The JSON array should contain the
+**commit status names** (for example `CI / Web quality checks`), not just the alias.

--- a/repo-ops/enforce-branch-protection.sh
+++ b/repo-ops/enforce-branch-protection.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Enforce merge-queue friendly branch protection for the current repository.
+# Requires: gh CLI (authenticated) and jq.
+
+set -euo pipefail
+trap 'rc=$?; echo "[enforce-branch-protection] failed with exit code $rc at line $LINENO: $BASH_COMMAND" >&2' ERR
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "ERROR: gh CLI is required." >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required." >&2
+  exit 1
+fi
+
+DEFAULT_CHECKS=(build test lint security sbom policy eval)
+IFS=',' read -r -a CHECKS <<< "${REQ_CHECKS:-${DEFAULT_CHECKS[*]}}"
+
+for idx in "${!CHECKS[@]}"; do
+  CHECKS[$idx]="$(echo "${CHECKS[$idx]}" | xargs)"
+  if [[ -z "${CHECKS[$idx]}" ]]; then
+    unset 'CHECKS[idx]'
+  fi
+done
+
+if [[ ${#CHECKS[@]} -eq 0 ]]; then
+  echo "ERROR: At least one required status check must be specified via REQ_CHECKS." >&2
+  exit 1
+fi
+
+CONTEXTS_JSON=$(printf '"%s",' "${CHECKS[@]}")
+CONTEXTS_JSON="[${CONTEXTS_JSON%,}]"
+
+cat <<JSON | gh api -X PUT repos/:owner/:repo/branches/main/protection --input - >/dev/null
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ${CONTEXTS_JSON}
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 1,
+    "require_code_owner_reviews": true,
+    "dismiss_stale_reviews": true
+  },
+  "restrictions": null,
+  "required_linear_history": true,
+  "allow_deletions": false,
+  "allow_force_pushes": false
+}
+JSON
+
+cat <<'JSON' | gh api -X PATCH repos/:owner/:repo --input - >/dev/null
+{
+  "allow_merge_commit": false,
+  "allow_squash_merge": true,
+  "allow_rebase_merge": true
+}
+JSON
+
+if ! gh api repos/:owner/:repo/labels/queue:ready >/dev/null 2>&1; then
+  cat <<'JSON' | gh api -X POST repos/:owner/:repo/labels --input - >/dev/null
+  {
+    "name": "queue:ready",
+    "color": "0e8a16",
+    "description": "Eligible for merge queue processing"
+  }
+  JSON
+fi
+
+echo "Branch protection updated. Current settings:"
+gh api repos/:owner/:repo/branches/main/protection   | jq '{
+      linear_history: .required_linear_history.enabled,
+      force_push: .allow_force_pushes.enabled,
+      deletions: .allow_deletions.enabled,
+      admins: .enforce_admins.enabled,
+      reviews: .required_pull_request_reviews,
+      status_checks: .required_status_checks.contexts
+    }'
+
+echo
+if gh api repos/:owner/:repo/labels/queue:ready >/dev/null 2>&1; then
+  echo "Label 'queue:ready' ensured."
+fi


### PR DESCRIPTION
## Summary
- add a gh-cli helper script to enforce branch protection and create the queue:ready label
- document the required status contexts and merge-queue rollout steps
- auto-sync the queue:ready label with passing checks and register the label in labels.yml

## Testing
- not run (docs and workflow updates only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d787c49a4832994bc133b0b5c05f7)