### PR TITLE
Add CI status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # BlackRoad.io — Dependency & Ops Bundle
 
+[![prism-ci](https://github.com/blackboxprogramming/blackroad-prism-console/actions/workflows/prism-ci.yml/badge.svg)](https://github.com/blackboxprogramming/blackroad-prism-console/actions/workflows/prism-ci.yml)
+
 Date: 2025-08-22
 
 Requires Node.js 20 or later.


### PR DESCRIPTION
## Summary
- add a status badge for the prism-ci workflow to the README so build health is visible at a glance

## Testing
- not run (docs only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d7d786f58832981eeb31fac54669f)