### PR TITLE
Add extended complex toolkit primitives to Amundson Kernel doc

### DIFF
--- a/docs/amundson_kernel.md
+++ b/docs/amundson_kernel.md
@@ -121,3 +121,124 @@ This $2 \times 2$ operator combines rotation, scaling, and deformation, forming 
 ## Conceptual Summary
 
 The Amundson Kernel encapsulates how systems rotate, scale, and learn simultaneously. The exponential operator $e^{(\sigma I + \omega J + S)\tau}$ acts as a universal update law for coherent evolution across oscillators, optimizers, and biological systems.
+
+## Extended Complex Toolkit
+
+### Core Complex Primitives (Extended Universal Set)
+
+1. **Exponential transport (phase–gain)**
+
+   $$\mathcal{U}(\theta, a)\, z := e^{(a + i)\theta} z$$
+
+   Scales a state by $e^{a\theta}$ while rotating by $\theta$, fusing growth and oscillation for filters, spirals, and adaptive learning rates.
+
+2. **Complex inner product (signal energy + alignment)**
+
+   $$\langle z, w \rangle := \Re\bigl(z\,\overline{w}\bigr), \qquad |z|^2 = z\overline{z}$$
+
+   Measures energy and phase alignment directly in $\mathbb{C}$ without dropping to real coordinates.
+
+3. **Geodesic blend (shortest-turn interpolation)**
+
+   $$\operatorname{slerp}(z_0, z_1; t) = \frac{\sin[(1-t)\Delta]}{\sin\Delta}\,z_0 + \frac{\sin(t\Delta)}{\sin\Delta}\,\frac{z_1}{|z_1|}\,|z_0|,$$
+
+   $$\Delta = \arg\!\left(\frac{z_1}{z_0}\right)$$
+
+   Produces phase-aware interpolation for graphics, filter design, and policy mixing.
+
+### Differential “Spiral” Dynamics
+
+4. **Spiral ODE (stable focus with tunable swirl)**
+
+   $$\dot{x} = a x - \omega y, \qquad \dot{y} = \omega x + a y$$
+
+   Solves to $z(t) = e^{(a + i\omega)t} z(0)$, giving a minimal oscillator-with-damping block where $a < 0$ attracts and $a > 0$ repels.
+
+5. **Log-spiral distance (scale–rotation metric)**
+
+   $$d_{\log}(z_1, z_2) = \sqrt{\bigl(\ln|z_2| - \ln|z_1|\bigr)^2 + \bigl(\arg z_2 - \arg z_1\bigr)^2}$$
+
+   Treats scale and angle symmetrically, forming a natural loss for complex-state comparisons.
+
+### Learning & Control Kernels
+
+6. **Phase-aligned regression loss**
+
+   $$\mathcal{L}_{\text{phase}}(z, \hat z) = \bigl| z - \hat z\,e^{i\arg(z\overline{\hat z})} \bigr|^2$$
+
+   Ignores global phase while fitting amplitude and relative phase when only the relative orientation matters.
+
+7. **Complex EMA (drift-resistant smoother)**
+
+   $$m_t = \beta m_{t-1} + (1 - \beta)\,\frac{z_t}{|z_t|}\,|m_{t-1}|, \qquad 0 < \beta < 1$$
+
+   Preserves magnitude memory while snapping phase to new observations, denoising rotating signals.
+
+8. **Stability gate (Lyapunov micro-check)**
+
+   For $V(x, y) = x^2 + y^2$ applied to the spiral ODE,
+
+   $$\dot V = 2a(x^2 + y^2) = 2aV$$
+
+   Choosing $a \le 0$ keeps $V$ non-increasing, providing a quick stability certification.
+
+### Discrete Transforms
+
+9. **Phase-difference operator (structure from waves)**
+
+   $$\Delta_\phi[k] = \arg\bigl(x[k]\,\overline{x[k-1]}\bigr)$$
+
+   Extracts instantaneous angular velocity for complex signals, aiding PLLs, pitch tracking, and anomaly detection.
+
+10. **Rotation-invariant hash (tiny descriptor)**
+
+    $$H = \frac{1}{N} \sum_{k=1}^N \frac{x[k]}{|x[k]|}$$
+
+    Aggregates unit phases into a stable, amplitude-invariant fingerprint for periodic behaviors.
+
+### Information & Geometry
+
+11. **Polar KL on log-spiral Gaussians**
+
+    If $r = \ln|z| \sim \mathcal{N}(\mu_r, \sigma_r^2)$ and $\phi = \arg z \sim \mathcal{N}(\mu_\phi, \sigma_\phi^2)$ (wrapped), then
+
+    $$\mathrm{KL}(P\|Q) = \frac{(\mu_r - \mu_r')^2 + \sigma_r^2}{2{\sigma_r'}^2} - \frac{1}{2} + \ln\frac{\sigma_r'}{\sigma_r} + \mathrm{KL}_{\text{wrap}}\bigl(\mu_\phi, \sigma_\phi^2 \mid \mu_\phi', {\sigma_\phi'}^2\bigr)$$
+
+    Separates scale and angle uncertainty for cleaner anomaly scoring.
+
+12. **Conformal Jacobian (how much local distortion?)**
+
+    For holomorphic $f: \mathbb{C} \to \mathbb{C}$,
+
+    $$J_f(z) = |f'(z)|^2$$
+
+    Captures local area scaling to cap distortion in compliance-sensitive transforms.
+
+### BlackRoad / Amundson-Flavored Composites
+
+13. **Policy-filtered update (safe actuator)**
+
+    $$z_{t+1} = \Pi_{\mathcal{P}}\!\left(z_t + \eta\,e^{(a + i\omega)\Delta t} g_t\right)$$
+
+    Projects proposed steps into admissible sets $\mathcal{P}$, enforcing "learn → prove → act" safety loops.
+
+14. **Audit hash-link for complex streams**
+
+    $$h_t = \mathrm{H}\!\left(h_{t-1} \mid \operatorname{round}(\Re z_t, \Im z_t)\right)$$
+
+    Builds a Merkle-by-time ledger for complex telemetry while rounding to avoid leaking high-precision data.
+
+15. **Agent consensus on a circle (fast agreement)**
+
+    Given unit phases $u_k = e^{i\phi_k}$,
+
+    $$\bar u = \frac{1}{K} \sum_{k=1}^K u_k, \qquad u_k \leftarrow \frac{u_k\,\bar u}{|u_k\,\bar u|}$$
+
+    Executes a one-step pull toward the circular mean with $|\bar u|$ acting as a confidence readout.
+
+### Fast Deployment Patterns
+
+- **Simulation block**: instantiate the spiral ODE with $a < 0$ and sweep $\omega$ to generate healthy versus unstable traces for the stability gate.
+- **Losses**: substitute the phase-aligned loss when absolute phase is nuisance and report the log-spiral distance alongside existing metrics.
+- **Compliance loop**: wrap actuator updates in the policy-filtered map and emit audit hash-links to ledgers such as `memory.jsonl`.
+- **Swarm consensus**: normalize agent votes on the unit circle and treat $|\bar u|$ as a collective confidence score.


### PR DESCRIPTION
## Summary
- document an extended set of complex-valued primitives augmenting the Amundson Kernel reference
- capture usage notes spanning dynamics, learning kernels, discrete transforms, and compliance composites
- add deployment patterns that tie the new primitives into simulation, loss design, compliance, and consensus workflows

## Testing
- not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d898a6d1c8329a61bfe52be5a56b7)