### PR TITLE
Add Spiral Math packages for TS and Python

### DIFF
--- a/packages/math-spiral/package.json
+++ b/packages/math-spiral/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@prism/math-spiral",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "node --test",
+    "lint": "eslint src --ext .ts"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.3",
+    "@types/node": "^22.7.5"
+  }
+}

--- a/packages/math-spiral/src/index.test.ts
+++ b/packages/math-spiral/src/index.test.ts
@@ -1,0 +1,26 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { c, abs, transport, dLog, spiralStep, circularMean } from './index.js';
+
+test('transport scales and rotates', () => {
+  const z = c(1, 0);
+  const z2 = transport(z, Math.PI / 2, 0.0);
+  assert.ok(Math.abs(z2.re) < 1e-9 && Math.abs(z2.im - 1) < 1e-9);
+});
+
+test('log-spiral metric symmetry-ish', () => {
+  const a = c(2, 0), b = c(0, 2);
+  const dab = dLog(a, b); const dba = dLog(b, a);
+  assert.ok(Math.abs(dab - dba) < 1e-9);
+});
+
+test('spiral step damping', () => {
+  const z0 = c(1, 0);
+  const z1 = spiralStep(z0, 0.1, -1.0, 0);
+  assert.ok(abs(z1) < 1);
+});
+
+test('circular mean', () => {
+  const { kappa } = circularMean([c(1,0), c(0,1)]);
+  assert.ok(kappa > 0 && kappa < 1);
+});

--- a/packages/math-spiral/src/index.ts
+++ b/packages/math-spiral/src/index.ts
@@ -1,0 +1,89 @@
+// Core complex helpers in TS using number pairs [re, im]
+export type C = { re: number; im: number };
+export const c = (re = 0, im = 0): C => ({ re, im });
+export const add = (a: C, b: C): C => c(a.re + b.re, a.im + b.im);
+export const sub = (a: C, b: C): C => c(a.re - b.re, a.im - b.im);
+export const mul = (a: C, b: C): C => c(a.re * b.re - a.im * b.im, a.re * b.im + a.im * b.re);
+export const conj = (z: C): C => c(z.re, -z.im);
+export const abs = (z: C): number => Math.hypot(z.re, z.im);
+export const arg = (z: C): number => Math.atan2(z.im, z.re);
+export const scale = (z: C, s: number): C => c(z.re * s, z.im * s);
+export const fromPolar = (r: number, theta: number): C => c(r * Math.cos(theta), r * Math.sin(theta));
+export const unit = (z: C): C => {
+  const a = abs(z); return a === 0 ? c(1, 0) : scale(z, 1 / a);
+};
+
+// 1) Exponential transport U(θ,a) z = e^{(a+i)θ} z
+export function transport(z: C, theta: number, a = 0): C {
+  const r = Math.exp(a * theta);
+  const rot = fromPolar(1, theta);
+  return mul(scale(z, r), rot);
+}
+
+// 4) Spiral ODE discretization (Euler step)
+// z_{t+1} = e^{(a+iω)Δt} z_t
+export function spiralStep(z: C, dt: number, a: number, omega: number): C {
+  const growth = Math.exp(a * dt);
+  const rot = fromPolar(1, omega * dt);
+  return mul(scale(z, growth), rot);
+}
+
+// 5) Log-spiral distance
+export function dLog(z1: C, z2: C): number {
+  const r1 = Math.log(Math.max(abs(z1), 1e-12));
+  const r2 = Math.log(Math.max(abs(z2), 1e-12));
+  let dphi = arg(z2) - arg(z1);
+  while (dphi > Math.PI) dphi -= 2 * Math.PI;
+  while (dphi < -Math.PI) dphi += 2 * Math.PI;
+  return Math.hypot(r2 - r1, dphi);
+}
+
+// 6) Phase-aligned regression loss
+export function phaseLoss(z: C, zh: C): number {
+  const dot = z.re * zh.re + z.im * zh.im; // Re(z * conj(zh))
+  const denom = abs(zh) ** 2 || 1e-12;
+  const cosphi = Math.min(1, Math.max(-1, dot / Math.sqrt((abs(z) ** 2 || 1e-12) * denom)));
+  const phi = Math.acos(cosphi);
+  const rot = fromPolar(1, phi);
+  const zhAligned = mul(zh, rot);
+  const dx = z.re - zhAligned.re; const dy = z.im - zhAligned.im;
+  return dx * dx + dy * dy;
+}
+
+// 7) Complex EMA with phase snapping
+export function emaPhase(mPrev: C, z: C, beta: number): C {
+  const mag = abs(mPrev);
+  const u = unit(z);
+  return add(scale(mPrev, beta), scale(scale(u, mag || abs(z)), 1 - beta));
+}
+
+// 9) Phase-difference operator for sequences
+export function phaseDiff(xk: C, xk1: C): number {
+  let d = arg(mul(xk, conj(xk1)));
+  // keep in [-pi, pi]
+  if (d > Math.PI) d -= 2 * Math.PI; if (d < -Math.PI) d += 2 * Math.PI;
+  return d;
+}
+
+// 13) Policy-filtered update: projection callback
+export type Projector = (z: C) => C;
+export function safeUpdate(z: C, g: C, dt: number, a: number, omega: number, eta: number, proj: Projector): C {
+  const step = transport(g, omega * dt, a * dt);
+  return proj(add(z, scale(step, eta)));
+}
+
+// 14) Audit hash-link: returns new hex hash (SHA-256 over prev||rounded re,im)
+export async function auditHash(prevHex: string, z: C, decimals = 6): Promise<string> {
+  const round = (n: number) => Number(n.toFixed(decimals));
+  const payload = new TextEncoder().encode(`${prevHex}|${round(z.re)},${round(z.im)}`);
+  const buf = await crypto.subtle.digest("SHA-256", payload);
+  return [...new Uint8Array(buf)].map(b => b.toString(16).padStart(2, "0")).join("");
+}
+
+// 15) Circle consensus
+export function circularMean(us: C[]): { mean: C; kappa: number } {
+  if (us.length === 0) return { mean: c(1, 0), kappa: 0 };
+  const sum = us.reduce((s, u) => add(s, unit(u)), c(0, 0));
+  const m = scale(sum, 1 / us.length);
+  return { mean: unit(m), kappa: Math.min(1, abs(m)) };
+}

--- a/packages/math-spiral/tsconfig.json
+++ b/packages/math-spiral/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "declaration": true,
+    "module": "esnext",
+    "target": "es2022",
+    "moduleResolution": "bundler",
+    "lib": ["es2022"],
+    "strict": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/python/prism_math_spiral/__init__.py
+++ b/python/prism_math_spiral/__init__.py
@@ -1,0 +1,8 @@
+from .spiral import (
+    transport, spiral_step, dlog, phase_loss, ema_phase,
+    phase_diff, safe_update, audit_hash_hex, circular_mean
+)
+__all__ = [
+    'transport','spiral_step','dlog','phase_loss','ema_phase',
+    'phase_diff','safe_update','audit_hash_hex','circular_mean'
+]

--- a/python/prism_math_spiral/pyproject.toml
+++ b/python/prism_math_spiral/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "prism_math_spiral"
+version = "0.1.0"
+description = "Spiral Math primitives: complex dynamics, losses, metrics, compliance helpers."
+requires-python = ">=3.9"
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/python/prism_math_spiral/spiral.py
+++ b/python/prism_math_spiral/spiral.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+import cmath, math, hashlib
+from typing import Callable, Iterable, Tuple
+
+C = complex
+
+# 1) Exponential transport U(θ,a) z = e^{(a+i)θ} z
+def transport(z: C, theta: float, a: float = 0.0) -> C:
+    return z * cmath.exp((a + 1j) * theta)
+
+# 4) Spiral ODE discretization
+def spiral_step(z: C, dt: float, a: float, omega: float) -> C:
+    growth = math.exp(a * dt)
+    rot = cmath.exp(1j * omega * dt)
+    return z * growth * rot
+
+# 5) Log-spiral distance
+def dlog(z1: C, z2: C) -> float:
+    r1 = math.log(max(abs(z1), 1e-12))
+    r2 = math.log(max(abs(z2), 1e-12))
+    dphi = cmath.phase(z2) - cmath.phase(z1)
+    while dphi > math.pi: dphi -= 2*math.pi
+    while dphi < -math.pi: dphi += 2*math.pi
+    return math.hypot(r2 - r1, dphi)
+
+# 6) Phase-aligned regression loss
+def phase_loss(z: C, zh: C) -> float:
+    # Align zh by the relative phase of z and zh
+    phi = cmath.phase(z * zh.conjugate())
+    zh_aligned = zh * cmath.exp(1j * phi)
+    d = z - zh_aligned
+    return (d.real*d.real + d.imag*d.imag)
+
+# 7) Complex EMA with phase snapping
+def ema_phase(m_prev: C, z: C, beta: float) -> C:
+    if not (0.0 < beta < 1.0):
+        raise ValueError("beta must be in (0,1)")
+    mag = abs(m_prev)
+    u = (z/abs(z)) if abs(z) > 0 else 1+0j
+    return beta*m_prev + (1-beta)*(u*(mag if mag>0 else abs(z)))
+
+# 9) Phase-difference operator
+def phase_diff(xk: C, xk_1: C) -> float:
+    d = cmath.phase(xk * xk_1.conjugate())
+    if d > math.pi: d -= 2*math.pi
+    if d < -math.pi: d += 2*math.pi
+    return d
+
+# 13) Policy-filtered update (projection callback)
+Projector = Callable[[C], C]
+
+def safe_update(z: C, g: C, dt: float, a: float, omega: float, eta: float, proj: Projector) -> C:
+    step = transport(g, omega*dt, a*dt)
+    return proj(z + eta*step)
+
+# 14) Audit hash-link
+
+def audit_hash_hex(prev_hex: str, z: C, decimals: int = 6) -> str:
+    r = lambda x: f"{x:.{decimals}f}"
+    payload = f"{prev_hex}|{r(z.real)},{r(z.imag)}".encode()
+    return hashlib.sha256(payload).hexdigest()
+
+# 15) Agent consensus on the circle
+def circular_mean(us: Iterable[C]) -> Tuple[C, float]:
+    values = list(us)
+    if not values:
+        return 1+0j, 0.0
+    vec = sum((u/abs(u) if abs(u)>0 else 1+0j) for u in values)
+    n = len(values)
+    m = vec / n
+    kappa = min(1.0, abs(m))
+    return (m/abs(m) if abs(m)>0 else 1+0j, kappa)

--- a/python/tests/test_spiral.py
+++ b/python/tests/test_spiral.py
@@ -1,0 +1,23 @@
+import math
+from prism_math_spiral import (
+    transport, spiral_step, dlog, phase_loss, ema_phase, phase_diff, audit_hash_hex, circular_mean
+)
+
+def test_transport_rotation():
+    z = 1+0j
+    z2 = transport(z, math.pi/2, 0.0)
+    assert abs(z2.real) < 1e-9 and abs(z2.imag - 1.0) < 1e-9
+
+def test_dlog_symmetry():
+    a, b = 2+0j, 0+2j
+    assert abs(dlog(a,b) - dlog(b,a)) < 1e-9
+
+def test_spiral_step_damping():
+    z0 = 1+0j
+    z1 = spiral_step(z0, 0.1, -1.0, 0.0)
+    assert abs(z1) < 1.0
+
+def test_audit_hash_changes():
+    h1 = audit_hash_hex('00', 1+0j)
+    h2 = audit_hash_hex(h1, 1+0j)
+    assert h1 != h2

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
## Summary
- add the `@prism/math-spiral` TypeScript package with spiral math helpers and coverage tests
- introduce the matching `prism_math_spiral` Python module with parity tests
- provide a shared TypeScript base config for building the new package

## Testing
- PYTHONPATH=python pytest python/tests/test_spiral.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d8a1bed008329b5015213a1c6ca1f)