### PR TITLE
Add demo bot orchestrator and skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,3 +599,18 @@ JSON schemas live in `/schemas` and are enforced via `io.validate.validate_json`
 
 ## i18n & Themes
 Translate messages with `i18n.translate.t` and run the TUI with `--theme light|dark`.
+
+### Bot family demo
+
+The repository now ships with a tiny in-memory bus and a handful of cooperating bots that
+demonstrate planning, execution, and artifact logging. Activate a virtual environment, install
+the project in editable mode, and run the orchestrator entrypoint:
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -e .
+python orchestrator/run_demo.py
+```
+
+You should see a Bell pair histogram saved to `artifacts/bell_hist.png` alongside a
+`lineage.jsonl` log describing the exchanged messages.

--- a/bots/archivist.py
+++ b/bots/archivist.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import List
+
+from .base import Bot, Message
+
+LOG_PATH = "artifacts/lineage.jsonl"
+
+
+class Archivist(Bot):
+    name = "archivist"
+
+    def can_handle(self, msg: Message) -> bool:
+        return msg.kind in {"log", "result"}
+
+    def handle(self, msg: Message) -> List[Message]:
+        os.makedirs(os.path.dirname(LOG_PATH), exist_ok=True)
+        with open(LOG_PATH, "a", encoding="utf-8") as fh:
+            fh.write(
+                json.dumps(
+                    {
+                        "ts": msg.ts,
+                        "sender": msg.sender,
+                        "kind": msg.kind,
+                        "content": msg.content,
+                    }
+                )
+                + "\n"
+            )
+        return []

--- a/bots/base.py
+++ b/bots/base.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+
+@dataclass
+class Message:
+    """Lightweight payload exchanged between bots on the in-memory bus."""
+
+    id: str
+    sender: str
+    recipient: str
+    kind: str
+    content: Dict[str, Any]
+    ts: float = field(default_factory=time.time)
+
+
+def new_msg(sender: str, recipient: str, kind: str, **content: Any) -> Message:
+    """Helper to create a :class:`Message` with a unique identifier."""
+
+    return Message(
+        id=str(uuid.uuid4()),
+        sender=sender,
+        recipient=recipient,
+        kind=kind,
+        content=content,
+    )
+
+
+class Bot:
+    """Base interface used by simple orchestrated bots."""
+
+    name: str = "bot"
+
+    def __init__(self, bus: "Bus") -> None:  # type: ignore[name-defined]
+        self.bus = bus
+
+    def can_handle(self, msg: Message) -> bool:
+        """Return ``True`` if this bot is interested in ``msg``."""
+
+        return False
+
+    def handle(self, msg: Message) -> List[Message]:
+        """Process ``msg`` and return follow-up messages to emit on the bus."""
+
+        return []

--- a/bots/bus.py
+++ b/bots/bus.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import Callable, List
+
+from .base import Message
+
+
+class Bus:
+    """Minimal in-memory message bus used by the demo orchestrator."""
+
+    def __init__(self) -> None:
+        self.subscribers: List[Callable[[Message], None]] = []
+        self.log: List[Message] = []
+
+    def publish(self, msg: Message) -> None:
+        """Record ``msg`` and notify all subscribed handlers."""
+
+        self.log.append(msg)
+        for sub in list(self.subscribers):
+            sub(msg)
+
+    def subscribe(self, fn: Callable[[Message], None]) -> None:
+        """Register ``fn`` to receive every bus message."""
+
+        self.subscribers.append(fn)
+
+    def history(self) -> List[Message]:
+        """Return a shallow copy of the message log."""
+
+        return list(self.log)

--- a/bots/critic.py
+++ b/bots/critic.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import List
+
+from .base import Bot, Message, new_msg
+
+
+class Critic(Bot):
+    name = "critic"
+
+    def can_handle(self, msg: Message) -> bool:
+        return msg.kind == "result"
+
+    def handle(self, msg: Message) -> List[Message]:
+        verdict = "pass"
+        reason = "ok"
+        if msg.content.get("op") == "bell":
+            probs = msg.content.get("probs", {})
+            if abs((probs.get("00", 0.0) + probs.get("11", 0.0)) - 1.0) > 1e-6:
+                verdict, reason = "fail", "probabilities not normalized"
+        return [
+            new_msg(
+                self.name,
+                "archivist",
+                "log",
+                verdict=verdict,
+                reason=reason,
+                payload=msg.content,
+            )
+        ]

--- a/bots/executor.py
+++ b/bots/executor.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import numpy as np
+
+from .base import Bot, Message, new_msg
+from .skills import math_skill as math_ops
+from .skills import quantum_skill as quantum_ops
+from .skills import viz_skill as viz_ops
+
+
+class Executor(Bot):
+    name = "executor"
+
+    def can_handle(self, msg: Message) -> bool:
+        return msg.kind == "task" and msg.content.get("op") in {"execute", "execute_many"}
+
+    def handle(self, msg: Message) -> List[Message]:
+        if msg.content.get("op") == "execute_many":
+            step_messages: List[Message] = []
+            for step in msg.content.get("steps", []):
+                step_messages.extend(self._run_step(step))
+            batch = new_msg(
+                self.name,
+                "critic",
+                "result",
+                op="batch",
+                results=[m.content for m in step_messages],
+                parent=msg.content.get("parent"),
+            )
+            return [*step_messages, batch]
+        return self._run_step(msg.content)
+
+    def _run_step(self, step: Dict[str, Any]) -> List[Message]:
+        op = step.get("skill", "")
+        if op == "quantum.bell":
+            psi = quantum_ops.bell_pair()
+            probs = {"00": float(abs(psi[0]) ** 2), "11": float(abs(psi[3]) ** 2)}
+            return [new_msg(self.name, "critic", "result", op="bell", probs=probs)]
+        if op == "viz.hist_bell":
+            path = viz_ops.save_hist({"00": 0.5, "11": 0.5}, "bell_hist.png")
+            return [new_msg(self.name, "critic", "result", op="plot", path=path)]
+        if op == "math.primes":
+            n = int(step.get("n", 200))
+            primes = math_ops.primes_upto(n)
+            return [
+                new_msg(
+                    self.name,
+                    "critic",
+                    "result",
+                    op="primes",
+                    n=n,
+                    count=len(primes),
+                )
+            ]
+        if op == "math.l2_norm":
+            vec = np.asarray(step.get("vec", []), dtype=float)
+            norm = math_ops.l2_norm(vec)
+            return [new_msg(self.name, "critic", "result", op="l2_norm", value=norm)]
+        return [new_msg(self.name, "critic", "result", op="noop")]

--- a/bots/librarian.py
+++ b/bots/librarian.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import List
+
+from .base import Bot, Message, new_msg
+
+DOCS = {
+    "riemann": "Short note on zeta zeros and phase plots (see pedagogy/riemann.md).",
+    "bell": "Bell pair construction: (H ⊗ I)|00> → CNOT → (|00>+|11>)/√2.",
+}
+
+
+class Librarian(Bot):
+    name = "librarian"
+
+    def can_handle(self, msg: Message) -> bool:
+        return msg.kind == "task" and msg.content.get("op") == "lookup"
+
+    def handle(self, msg: Message) -> List[Message]:
+        key = msg.content.get("key", "").lower()
+        note = DOCS.get(key, "No doc found.")
+        return [new_msg(self.name, msg.sender, "result", op="lookup", key=key, note=note)]

--- a/bots/planner.py
+++ b/bots/planner.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import List
+
+from .base import Bot, Message, new_msg
+
+
+class Planner(Bot):
+    name = "planner"
+
+    def can_handle(self, msg: Message) -> bool:
+        return msg.kind == "task" and msg.content.get("op") == "plan"
+
+    def handle(self, msg: Message) -> List[Message]:
+        goal = msg.content.get("goal")
+        steps = []
+        if goal == "make_bell_hist":
+            steps = [
+                {"op": "execute", "skill": "quantum.bell"},
+                {"op": "execute", "skill": "viz.hist_bell"},
+            ]
+        elif goal == "prime_demo":
+            steps = [{"op": "execute", "skill": "math.primes", "n": 200}]
+        return [
+            new_msg(
+                self.name,
+                "executor",
+                "task",
+                op="execute_many",
+                steps=steps,
+                parent=msg.id,
+            )
+        ]

--- a/bots/skills/__init__.py
+++ b/bots/skills/__init__.py
@@ -1,0 +1,3 @@
+"""Utility skills used by the demo executor bot."""
+
+__all__ = ["math_skill", "quantum_skill", "viz_skill"]

--- a/bots/skills/math_skill.py
+++ b/bots/skills/math_skill.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import numpy as np
+
+
+def primes_upto(n: int) -> list[int]:
+    """Return primes up to ``n`` using a vectorised sieve."""
+
+    if n < 2:
+        return []
+    sieve = np.ones(n + 1, dtype=bool)
+    sieve[:2] = False
+    for p in range(2, int(np.sqrt(n)) + 1):
+        if sieve[p]:
+            sieve[p * p : n + 1 : p] = False
+    return [i for i, v in enumerate(sieve) if v]
+
+
+def l2_norm(x: np.ndarray) -> float:
+    """Return the Euclidean norm of ``x``."""
+
+    return float(np.sqrt((x * x).sum()))
+
+
+def fft_mag(x: np.ndarray) -> np.ndarray:
+    """Return the magnitude of the real FFT of ``x``."""
+
+    fx = np.fft.rfft(x)
+    return np.abs(fx)

--- a/bots/skills/quantum_skill.py
+++ b/bots/skills/quantum_skill.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import numpy as np
+
+H = (1 / np.sqrt(2)) * np.array([[1, 1], [1, -1]], dtype=complex)
+CNOT = np.array(
+    [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]],
+    dtype=complex,
+)
+
+
+def bell_pair() -> np.ndarray:
+    """Return a Bell pair state vector."""
+
+    psi = np.zeros(4, dtype=complex)
+    psi[0] = 1.0
+    hi = np.kron(H, np.eye(2, dtype=complex))
+    psi = hi @ psi
+    psi = CNOT @ psi
+    return psi
+
+
+def qft_matrix(n: int) -> np.ndarray:
+    """Return the Quantum Fourier Transform matrix for ``n`` qubits."""
+
+    if n <= 0:
+        raise ValueError("number of qubits must be positive")
+    N = 2**n
+    omega = np.exp(2j * np.pi / N)
+    F = np.fromfunction(lambda j, k: omega ** (j * k) / np.sqrt(N), (N, N), dtype=int)
+    return F

--- a/bots/skills/viz_skill.py
+++ b/bots/skills/viz_skill.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import os
+from typing import Dict
+
+import matplotlib.pyplot as plt
+
+ART_DIR = "artifacts"
+
+
+def save_hist(probs: Dict[str, float], fname: str = "hist.png") -> str:
+    """Persist a bar chart for ``probs`` and return the artifact path."""
+
+    os.makedirs(ART_DIR, exist_ok=True)
+    keys = list(probs.keys())
+    vals = list(probs.values())
+    fig = plt.figure()
+    plt.bar(range(len(keys)), vals)
+    plt.xticks(range(len(keys)), keys)
+    plt.ylabel("Probability")
+    path = os.path.join(ART_DIR, fname)
+    fig.savefig(path, dpi=160, bbox_inches="tight")
+    plt.close(fig)
+    return path

--- a/orchestrator/policies.py
+++ b/orchestrator/policies.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class Policy:
+    """Simple allow/deny policy used by the demo orchestrator."""
+
+    allow_external_network: bool = False
+    max_artifacts_mb: int = 10
+
+
+DEFAULT_POLICY = Policy()

--- a/orchestrator/run_demo.py
+++ b/orchestrator/run_demo.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+if __package__ is None or __package__ == "":  # pragma: no cover - script execution path
+    script_dir = Path(__file__).resolve().parent
+    project_root = script_dir.parent
+    script_dir_str = str(script_dir)
+    while script_dir_str in sys.path:
+        sys.path.remove(script_dir_str)
+    sys.path.insert(0, str(project_root))
+
+from bots.archivist import Archivist
+from bots.base import new_msg
+from bots.bus import Bus
+from bots.critic import Critic
+from bots.executor import Executor
+from bots.librarian import Librarian
+from bots.planner import Planner
+
+
+def wire(bus: Bus):
+    """Register the demo bots on ``bus`` and return the instances."""
+
+    bots = [Librarian(bus), Planner(bus), Executor(bus), Critic(bus), Archivist(bus)]
+
+    def _subscribe(bot):
+        def _handler(message):
+            if bot.can_handle(message):
+                for reply in bot.handle(message):
+                    bus.publish(reply)
+
+        bus.subscribe(_handler)
+
+    for bot in bots:
+        _subscribe(bot)
+    return bots
+
+
+if __name__ == "__main__":
+    bus = Bus()
+    wire(bus)
+    bus.publish(new_msg("user", "planner", "task", op="plan", goal="make_bell_hist"))
+    bus.publish(new_msg("user", "planner", "task", op="plan", goal="prime_demo"))
+    print("Events:", len(bus.history()))
+    print("Artifacts in ./artifacts (hist + lineage) expected.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "pyyaml>=6.0.2,<7",
     "hypothesis>=6.103.4,<7",
     "numpy>=1.26,<3",
+    "matplotlib>=3.8,<4",
     "regopy>=1.0.0,<2",
 ]
 

--- a/tests/test_bots.py
+++ b/tests/test_bots.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from bots.base import new_msg
+from bots.bus import Bus
+from orchestrator.run_demo import wire
+
+
+def test_pipeline_runs() -> None:
+    bus = Bus()
+    wire(bus)
+    bus.publish(new_msg("user", "planner", "task", op="plan", goal="make_bell_hist"))
+    assert len(bus.history()) > 0


### PR DESCRIPTION
## Summary
- add a lightweight message bus, shared message schema, and utility skills for demo bots
- implement librarian, planner, executor, critic, and archivist bots plus a demo orchestrator and policies stub
- document the quickstart workflow, add matplotlib as a dependency, and cover the new pipeline with a regression test

## Testing
- pytest tests/test_bots.py
- python orchestrator/run_demo.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d8e82b4f883298936dadc69707189)