### PR TITLE
feat: expand quantum math lab capabilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,3 +261,19 @@ jobs:
         with:
           name: api-dist
           path: apps/api/dist
+
+  quantum-math-lab:
+    name: Quantum Math Lab tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          python -m pip install -e .
+      - name: Run pytest
+        run: pytest tests/test_simulator.py -k "quantum"

--- a/README.md
+++ b/README.md
@@ -109,6 +109,66 @@ See `src/modmath/__init__.py` for docstrings, parameter validation details, and 
   prime factors due to naive factorisation.
 - The toolkit is educational and **not** suitable for production cryptography.
 
+## Quantum Math Lab
+
+[![Quantum Math Lab CI](https://img.shields.io/github/actions/workflow/status/blackboxprogramming/blackroad-prism-console/ci.yml?label=Quantum%20Math%20Lab%20CI)](https://github.com/blackboxprogramming/blackroad-prism-console/actions/workflows/ci.yml)
+[![Unsolved Problems](https://img.shields.io/badge/docs-unsolved%20problems-blue)](quantum_math_lab/docs/unsolved_problems.md)
+
+The `quantum_math_lab` package upgrades our NumPy-based simulator with Qiskit execution, Torch-driven variational solvers, Matplotlib visuals, and curated quantum-friendly research prompts. It targets Python 3.11+ and integrates with IBM Quantum backends via `qiskit`/`qiskit-aer`.
+
+### Feature highlights
+
+- Local `QuantumCircuit` simulator with Hadamard/Pauli/CNOT and parameterised rotations.
+- Seamless conversion to `qiskit.QuantumCircuit`, transpilation, and Aer execution helpers.
+- Torch-powered `TorchVQESolver` for hybrid VQE workflows (see `examples/vqe_example.py`).
+- Grover search walkthrough with Aer sampling (`examples/grover_demo.py`).
+- `visuals/plot_states.py` for Bloch spheres and state probability plots.
+- Bit-flip error-correction helpers in `quantum_math_lab/error_correction.py`.
+- Research prompts in [`quantum_math_lab/docs/unsolved_problems.md`](quantum_math_lab/docs/unsolved_problems.md).
+
+### Quickstart (Python 3.11+)
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+pip install -r requirements.txt
+python -m pip install -e .
+pytest tests/test_simulator.py -k "quantum"
+```
+
+### Run the demos
+
+```bash
+python -m quantum_math_lab.examples.vqe_example
+python -m quantum_math_lab.examples.grover_demo
+```
+
+### Visualise states
+
+```python
+from quantum_math_lab import QuantumCircuit
+from quantum_math_lab.visuals import plot_states
+
+circuit = QuantumCircuit(1)
+circuit.hadamard(0)
+state = circuit.simulate()
+fig = plot_states.plot_bloch_sphere(state)
+fig.savefig("bloch.png")
+```
+
+### Execute on Qiskit backends
+
+```python
+from quantum_math_lab import QuantumCircuit, get_aer_simulator
+
+circuit = QuantumCircuit(2)
+circuit.hadamard(0)
+circuit.cnot(0, 1)
+result = circuit.execute_on_backend(get_aer_simulator(), shots=1024, measure=True)
+print(result.get_counts())
+```
+
 > Nothing here overwrites your existing code. The scripts are defensive: they detect paths,
 > **merge** deps, and only generate files if missing.
 

--- a/quantum_math_lab/__init__.py
+++ b/quantum_math_lab/__init__.py
@@ -1,0 +1,17 @@
+"""Quantum Math Lab package with simulation, visualization, and ML utilities."""
+
+from .quantum_simulator import QuantumCircuit, QISKIT_AVAILABLE, get_aer_simulator
+from .ml_integration import HamiltonianTerm, TorchVQESolver, VariationalResult
+from .error_correction import BitFlipCode, BitFlipResult, infer_bit_flip
+
+__all__ = [
+    "QuantumCircuit",
+    "QISKIT_AVAILABLE",
+    "get_aer_simulator",
+    "HamiltonianTerm",
+    "TorchVQESolver",
+    "VariationalResult",
+    "BitFlipCode",
+    "BitFlipResult",
+    "infer_bit_flip",
+]

--- a/quantum_math_lab/docs/unsolved_problems.md
+++ b/quantum_math_lab/docs/unsolved_problems.md
@@ -1,0 +1,25 @@
+# Unsolved Problems Worth Quantum Exploration
+
+## Riemann Hypothesis
+- **Status:** Open
+- **Quantum Angle:** Explore quantum algorithms for zero-distribution sampling and amplitude amplification around critical strip statistics.
+
+## Birch and Swinnerton-Dyer Conjecture
+- **Status:** Open
+- **Quantum Angle:** Variational quantum eigensolvers for L-function approximations and lattice-based regulator estimation.
+
+## Navier–Stokes Existence and Smoothness
+- **Status:** Open
+- **Quantum Angle:** Hybrid quantum-classical solvers for turbulence energy spectra and error-corrected PDE discretizations.
+
+## Quantum PCP Conjecture
+- **Status:** Open
+- **Quantum Angle:** Test harness for approximate constraint satisfaction on noisy intermediate-scale quantum devices via Qiskit backends.
+
+## P vs NP
+- **Status:** Open
+- **Quantum Angle:** Grover-based heuristics for SAT with tensor-network visualizations from `visuals/plot_states.py` to debug amplitude landscapes.
+
+---
+
+Contributions are welcome—open an issue describing how your experiment or notebook advances these explorations.

--- a/quantum_math_lab/error_correction.py
+++ b/quantum_math_lab/error_correction.py
@@ -1,0 +1,78 @@
+"""Elementary quantum error-correction helpers (bit-flip code)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Mapping, Sequence
+
+import numpy as np
+
+from .quantum_simulator import QuantumCircuit
+
+BIT_FLIP_SYNDROMES: Mapping[int | None, Sequence[str]] = {
+    None: ("000", "111"),
+    0: ("100", "011"),
+    1: ("010", "101"),
+    2: ("001", "110"),
+}
+
+
+def _bitstring_probabilities(probabilities: np.ndarray) -> Dict[str, float]:
+    width = int(np.log2(probabilities.size))
+    return {format(index, f"0{width}b"): float(prob) for index, prob in enumerate(probabilities)}
+
+
+def infer_bit_flip(probabilities: np.ndarray) -> int | None:
+    distribution = _bitstring_probabilities(probabilities)
+    best_label = None
+    best_value = -1.0
+    for qubit, patterns in BIT_FLIP_SYNDROMES.items():
+        value = sum(distribution.get(pattern, 0.0) for pattern in patterns)
+        if value > best_value:
+            best_value = value
+            best_label = qubit
+    return best_label
+
+
+@dataclass
+class BitFlipResult:
+    """Summary of bit-flip error diagnosis."""
+
+    inferred_error: int | None
+    distribution: Dict[str, float]
+
+
+class BitFlipCode:
+    """Utility class that wires a three-qubit bit-flip encoding."""
+
+    def prepare(self, theta: float = 0.0, phi: float = 0.0) -> QuantumCircuit:
+        circuit = QuantumCircuit(3)
+        if theta:
+            circuit.ry(0, theta)
+        if phi:
+            circuit.rz(0, phi)
+        circuit.cnot(0, 1)
+        circuit.cnot(0, 2)
+        return circuit
+
+    def introduce_error(self, circuit: QuantumCircuit, qubit: int) -> None:
+        circuit.pauli_x(qubit)
+
+    def diagnose(self, circuit: QuantumCircuit) -> BitFlipResult:
+        probabilities = circuit.probabilities()
+        inferred = infer_bit_flip(probabilities)
+        return BitFlipResult(inferred_error=inferred, distribution=_bitstring_probabilities(probabilities))
+
+    def correct(self, circuit: QuantumCircuit) -> int | None:
+        result = self.diagnose(circuit)
+        if result.inferred_error is not None:
+            circuit.pauli_x(result.inferred_error)
+            circuit.simulate()
+        return result.inferred_error
+
+    def decode(self, circuit: QuantumCircuit) -> None:
+        circuit.cnot(0, 2)
+        circuit.cnot(0, 1)
+
+
+__all__ = ["BitFlipCode", "BitFlipResult", "infer_bit_flip", "BIT_FLIP_SYNDROMES"]

--- a/quantum_math_lab/examples/__init__.py
+++ b/quantum_math_lab/examples/__init__.py
@@ -1,0 +1,10 @@
+"""Executable demonstrations for the quantum math lab."""
+
+from .grover_demo import grover_circuit, run_local as run_grover_local
+from .vqe_example import hardware_efficient_ansatz
+
+__all__ = [
+    "grover_circuit",
+    "run_grover_local",
+    "hardware_efficient_ansatz",
+]

--- a/quantum_math_lab/examples/grover_demo.py
+++ b/quantum_math_lab/examples/grover_demo.py
@@ -1,0 +1,74 @@
+"""Grover's search algorithm demo using the local simulator and Qiskit."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+import numpy as np
+
+from ..quantum_simulator import QISKIT_AVAILABLE, QuantumCircuit, get_aer_simulator
+
+TARGET_STATE = "11"
+
+
+def apply_oracle(circuit: QuantumCircuit) -> None:
+    circuit.cnot(0, 1)
+    circuit.rz(1, np.pi)
+    circuit.cnot(0, 1)
+
+
+def apply_diffusion(circuit: QuantumCircuit) -> None:
+    for qubit in range(circuit.num_qubits):
+        circuit.hadamard(qubit)
+        circuit.pauli_x(qubit)
+    circuit.cnot(0, 1)
+    circuit.rz(1, np.pi)
+    circuit.cnot(0, 1)
+    for qubit in range(circuit.num_qubits):
+        circuit.pauli_x(qubit)
+        circuit.hadamard(qubit)
+
+
+def grover_circuit(iterations: int = 1) -> QuantumCircuit:
+    circuit = QuantumCircuit(2)
+    for qubit in range(2):
+        circuit.hadamard(qubit)
+    for _ in range(iterations):
+        apply_oracle(circuit)
+        apply_diffusion(circuit)
+    circuit.measure_all()
+    return circuit
+
+
+def run_local(iterations: int = 1) -> Dict[str, float]:
+    circuit = grover_circuit(iterations)
+    state = circuit.simulate()
+    probabilities = np.abs(state) ** 2
+    labels = [format(i, "02b") for i in range(probabilities.size)]
+    return dict(zip(labels, probabilities))
+
+
+def run_qiskit(iterations: int = 1, shots: int = 1024) -> Dict[str, int]:  # pragma: no cover - optional dep
+    if not QISKIT_AVAILABLE:
+        raise RuntimeError("Qiskit is required for backend execution")
+    circuit = grover_circuit(iterations)
+    backend = get_aer_simulator()
+    result = circuit.execute_on_backend(backend=backend, shots=shots, measure=True)
+    return result.get_counts()
+
+
+def main() -> None:
+    print(f"Target state: {TARGET_STATE}")
+    local = run_local(iterations=1)
+    print("Local simulator distribution:")
+    for bitstring, probability in sorted(local.items()):
+        print(f"  {bitstring}: {probability:.3f}")
+    if QISKIT_AVAILABLE:
+        counts = run_qiskit(iterations=1)
+        print("\nAer simulator sample counts:")
+        for bitstring, count in sorted(counts.items()):
+            print(f"  {bitstring}: {count}")
+
+
+if __name__ == "__main__":
+    main()

--- a/quantum_math_lab/examples/vqe_example.py
+++ b/quantum_math_lab/examples/vqe_example.py
@@ -1,0 +1,55 @@
+"""Variational Quantum Eigensolver demo for a minimal H2 molecule."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+
+from ..ml_integration import TorchVQESolver, pauli_terms_from_coefficients
+from ..quantum_simulator import QISKIT_AVAILABLE, QuantumCircuit
+
+H2_COEFFICIENTS = [
+    ("II", -1.052373245772859),
+    ("IZ", 0.39793742484318045),
+    ("ZI", -0.39793742484318045),
+    ("ZZ", -0.01128010425623538),
+    ("XX", 0.18093119978423156),
+]
+
+
+def hardware_efficient_ansatz(parameters: Sequence[float]) -> QuantumCircuit:
+    circuit = QuantumCircuit(2)
+    circuit.hadamard(0)
+    circuit.hadamard(1)
+    circuit.ry(0, parameters[0])
+    circuit.ry(1, parameters[1])
+    circuit.cnot(0, 1)
+    circuit.ry(0, parameters[2])
+    circuit.ry(1, parameters[3])
+    circuit.cnot(0, 1)
+    return circuit
+
+
+def main() -> None:
+    hamiltonian = pauli_terms_from_coefficients(H2_COEFFICIENTS)
+    solver = TorchVQESolver(
+        hardware_efficient_ansatz,
+        hamiltonian,
+        learning_rate=0.15,
+        max_iterations=150,
+    )
+    result = solver.solve([0.0, 0.0, 0.0, 0.0])
+    print("Optimal H2 energy:", result.optimal_value)
+    print("Parameters:", result.optimal_parameters)
+    output = Path("outputs")
+    output.mkdir(exist_ok=True)
+    np.savetxt(output / "vqe_history.csv", np.array(result.history), delimiter=",")
+    if QISKIT_AVAILABLE:
+        qc = hardware_efficient_ansatz(result.optimal_parameters)
+        print(qc.to_qiskit().draw(output="text"))
+
+
+if __name__ == "__main__":
+    main()

--- a/quantum_math_lab/ml_integration.py
+++ b/quantum_math_lab/ml_integration.py
@@ -1,0 +1,112 @@
+"""Hybrid quantum-classical tooling built on top of :mod:`torch`."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Iterable, List, Sequence
+
+import numpy as np
+
+from .quantum_simulator import QISKIT_AVAILABLE, QuantumCircuit
+
+try:  # pragma: no cover - optional dependency import
+    import torch
+except Exception:  # pragma: no cover - degrade gracefully when torch is missing
+    torch = None  # type: ignore[assignment]
+
+
+@dataclass(frozen=True)
+class HamiltonianTerm:
+    """Simple Pauli-term Hamiltonian representation."""
+
+    coefficient: float
+    pauli_string: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "pauli_string", self.pauli_string.upper())
+
+    def expectation(self, circuit: QuantumCircuit) -> float:
+        return self.coefficient * circuit.expectation_value(self.pauli_string)
+
+    def to_qiskit(self):  # pragma: no cover - optional dependency
+        if not QISKIT_AVAILABLE:
+            raise RuntimeError("Qiskit is required to convert Hamiltonians")
+        from qiskit.quantum_info import SparsePauliOp
+
+        return self.coefficient * SparsePauliOp.from_list([(self.pauli_string, 1.0)])
+
+
+@dataclass(frozen=True)
+class VariationalResult:
+    """Result container for variational hybrid workflows."""
+
+    optimal_value: float
+    optimal_parameters: np.ndarray
+    history: List[float]
+
+
+class TorchVQESolver:
+    """Parameter-shift based VQE optimizer orchestrated with PyTorch."""
+
+    def __init__(
+        self,
+        circuit_builder: Callable[[Sequence[float]], QuantumCircuit],
+        hamiltonian: Iterable[HamiltonianTerm],
+        learning_rate: float = 0.1,
+        max_iterations: int = 200,
+        shift: float = np.pi / 2,
+    ) -> None:
+        if torch is None:  # pragma: no cover - optional dependency
+            raise RuntimeError("PyTorch is required for TorchVQESolver")
+        self.circuit_builder = circuit_builder
+        self.hamiltonian = list(hamiltonian)
+        self.learning_rate = learning_rate
+        self.max_iterations = max_iterations
+        self.shift = shift
+
+    # ------------------------------------------------------------------
+    def energy(self, parameters: Sequence[float]) -> float:
+        circuit = self.circuit_builder(parameters)
+        circuit.simulate()
+        return sum(term.expectation(circuit) for term in self.hamiltonian)
+
+    def _parameter_shift_gradient(self, parameters: torch.Tensor) -> torch.Tensor:
+        grads: List[float] = []
+        base = parameters.detach().clone()
+        for idx in range(base.numel()):
+            plus = base.clone()
+            minus = base.clone()
+            plus.view(-1)[idx] += self.shift
+            minus.view(-1)[idx] -= self.shift
+            grad = 0.5 * (self.energy(plus.numpy()) - self.energy(minus.numpy()))
+            grads.append(grad)
+        return torch.tensor(grads, dtype=parameters.dtype).reshape_as(parameters)
+
+    def solve(self, initial_parameters: Sequence[float]) -> VariationalResult:
+        params = torch.nn.Parameter(torch.tensor(initial_parameters, dtype=torch.float64))
+        optimizer = torch.optim.Adam([params], lr=self.learning_rate)
+        history: List[float] = []
+        best_value = float("inf")
+        best_params = params.detach().numpy().copy()
+        for _ in range(self.max_iterations):
+            optimizer.zero_grad()
+            energy_value = self.energy(params.detach().numpy())
+            history.append(energy_value)
+            grads = self._parameter_shift_gradient(params)
+            params.grad = grads
+            optimizer.step()
+            if energy_value < best_value:
+                best_value = energy_value
+                best_params = params.detach().numpy().copy()
+        if not history:
+            best_value = self.energy(params.detach().numpy())
+            best_params = params.detach().numpy().copy()
+        return VariationalResult(
+            optimal_value=best_value,
+            optimal_parameters=best_params,
+            history=history,
+        )
+
+
+def pauli_terms_from_coefficients(coefficients: Sequence[tuple[str, float]]) -> List[HamiltonianTerm]:
+    return [HamiltonianTerm(coefficient=value, pauli_string=pauli) for pauli, value in coefficients]

--- a/quantum_math_lab/quantum_simulator.py
+++ b/quantum_math_lab/quantum_simulator.py
@@ -1,0 +1,299 @@
+"""Lightweight quantum circuit simulator with optional Qiskit integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Mapping, Optional, Tuple
+
+import numpy as np
+
+try:  # pragma: no cover - import guard
+    from qiskit import QuantumCircuit as QiskitCircuit
+    from qiskit import transpile
+    from qiskit.providers.backend import Backend
+    from qiskit_aer import Aer
+
+    QISKIT_AVAILABLE = True
+except Exception:  # pragma: no cover - graceful fallback
+    QiskitCircuit = None  # type: ignore[assignment]
+    Backend = object  # type: ignore[misc,assignment]
+    Aer = None  # type: ignore[assignment]
+    transpile = None  # type: ignore[assignment]
+    QISKIT_AVAILABLE = False
+
+
+_I2 = np.eye(2, dtype=np.complex128)
+_SIGMA_X = np.array([[0.0, 1.0], [1.0, 0.0]], dtype=np.complex128)
+_SIGMA_Y = np.array([[0.0, -1.0j], [1.0j, 0.0]], dtype=np.complex128)
+_SIGMA_Z = np.array([[1.0, 0.0], [0.0, -1.0]], dtype=np.complex128)
+_HADAMARD = (1 / np.sqrt(2.0)) * np.array([[1.0, 1.0], [1.0, -1.0]], dtype=np.complex128)
+_CNOT = np.array(
+    [
+        [1.0, 0.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 1.0],
+        [0.0, 0.0, 1.0, 0.0],
+    ],
+    dtype=np.complex128,
+)
+
+
+@dataclass(frozen=True)
+class GateOperation:
+    """Representation of a gate application for simulation and export."""
+
+    name: str
+    targets: Tuple[int, ...]
+    parameters: Tuple[float, ...] = ()
+
+
+class QuantumCircuit:
+    """Small educational circuit simulator with NumPy and Qiskit backends."""
+
+    def __init__(self, num_qubits: int):
+        if num_qubits <= 0:
+            raise ValueError("QuantumCircuit requires at least one qubit")
+        self.num_qubits = num_qubits
+        self._operations: List[GateOperation] = []
+        self._measure_all = False
+        self._dirty = False
+        self.reset()
+
+    # ------------------------------------------------------------------
+    # gate creation helpers
+    def reset(self) -> None:
+        """Reset recorded operations and the state vector to |0..0>."""
+
+        self._state = np.zeros(2**self.num_qubits, dtype=np.complex128)
+        self._state[0] = 1.0
+        self._operations.clear()
+        self._measure_all = False
+        self._dirty = False
+
+    def copy(self) -> "QuantumCircuit":
+        clone = QuantumCircuit(self.num_qubits)
+        clone._operations = list(self._operations)
+        clone._measure_all = self._measure_all
+        clone._state = self._state.copy()
+        clone._dirty = self._dirty
+        return clone
+
+    # ------------------------------------------------------------------
+    # public gate API
+    def hadamard(self, qubit: int) -> None:
+        self._append_gate("h", (qubit,))
+
+    def pauli_x(self, qubit: int) -> None:
+        self._append_gate("x", (qubit,))
+
+    def pauli_y(self, qubit: int) -> None:
+        self._append_gate("y", (qubit,))
+
+    def pauli_z(self, qubit: int) -> None:
+        self._append_gate("z", (qubit,))
+
+    def phase(self, qubit: int, theta: float) -> None:
+        self._append_gate("phase", (qubit,), (theta,))
+
+    def rx(self, qubit: int, theta: float) -> None:
+        self._append_gate("rx", (qubit,), (theta,))
+
+    def ry(self, qubit: int, theta: float) -> None:
+        self._append_gate("ry", (qubit,), (theta,))
+
+    def rz(self, qubit: int, theta: float) -> None:
+        self._append_gate("rz", (qubit,), (theta,))
+
+    def cnot(self, control: int, target: int) -> None:
+        self._append_gate("cnot", (control, target))
+
+    def measure_all(self) -> None:
+        """Record a full measurement for Qiskit export."""
+
+        self._measure_all = True
+
+    # ------------------------------------------------------------------
+    # simulation utilities
+    def simulate(self) -> np.ndarray:
+        """Simulate the recorded circuit locally with NumPy."""
+
+        state = np.zeros_like(self._state)
+        state[0] = 1.0
+        for gate in self._operations:
+            state = self._apply_gate_to_state(state, gate)
+        self._state = state
+        self._dirty = False
+        return self._state.copy()
+
+    def state(self) -> np.ndarray:
+        """Return the most recent simulated state (calling :meth:`simulate` if needed)."""
+
+        if self._dirty:
+            return self.simulate()
+        return self._state.copy()
+
+    def probabilities(self) -> np.ndarray:
+        state = self.state()
+        return np.abs(state) ** 2
+
+    def sample_counts(self, shots: int = 1024, seed: Optional[int] = None) -> Dict[str, int]:
+        if shots <= 0:
+            raise ValueError("shots must be positive")
+        rng = np.random.default_rng(seed)
+        probs = self.probabilities()
+        outcomes = rng.choice(len(probs), size=shots, p=probs)
+        counts: Dict[str, int] = {}
+        for outcome in outcomes:
+            bitstring = format(outcome, f"0{self.num_qubits}b")
+            counts[bitstring] = counts.get(bitstring, 0) + 1
+        return counts
+
+    def expectation_value(self, pauli_string: str) -> float:
+        if len(pauli_string) != self.num_qubits:
+            raise ValueError("Pauli string must match qubit count")
+        state = self.state()
+        operator = _tensor_pauli(pauli_string)
+        return float(np.real(np.vdot(state, operator @ state)))
+
+    # ------------------------------------------------------------------
+    # Qiskit integration
+    def to_qiskit(self, measure: Optional[bool] = None) -> "QiskitCircuit":
+        if not QISKIT_AVAILABLE:  # pragma: no cover - depends on optional dep
+            raise RuntimeError("Qiskit is not installed. Install qiskit to export circuits.")
+        qc = QiskitCircuit(self.num_qubits, self.num_qubits if (measure or self._measure_all) else 0)
+        for gate in self._operations:
+            if gate.name == "h":
+                qc.h(gate.targets[0])
+            elif gate.name == "x":
+                qc.x(gate.targets[0])
+            elif gate.name == "y":
+                qc.y(gate.targets[0])
+            elif gate.name == "z":
+                qc.z(gate.targets[0])
+            elif gate.name == "phase":
+                qc.p(gate.parameters[0], gate.targets[0])
+            elif gate.name == "rx":
+                qc.rx(gate.parameters[0], gate.targets[0])
+            elif gate.name == "ry":
+                qc.ry(gate.parameters[0], gate.targets[0])
+            elif gate.name == "rz":
+                qc.rz(gate.parameters[0], gate.targets[0])
+            elif gate.name == "cnot":
+                qc.cx(gate.targets[0], gate.targets[1])
+            else:  # pragma: no cover - defensive
+                raise ValueError(f"Unsupported gate for Qiskit export: {gate.name}")
+        if measure or self._measure_all:
+            qc.measure_all()
+        return qc
+
+    def transpile_for_backend(
+        self,
+        backend: "Backend",
+        measure: Optional[bool] = None,
+        **transpile_options: object,
+    ):
+        if not QISKIT_AVAILABLE or transpile is None:  # pragma: no cover - optional dep
+            raise RuntimeError("Qiskit transpiler not available")
+        circuit = self.to_qiskit(measure=measure)
+        return transpile(circuit, backend=backend, **transpile_options)
+
+    def execute_on_backend(
+        self,
+        backend: "Backend" | None = None,
+        shots: int = 1024,
+        measure: Optional[bool] = None,
+        **run_options: object,
+    ):
+        if not QISKIT_AVAILABLE:  # pragma: no cover - optional dep
+            raise RuntimeError("Qiskit is not installed. Install qiskit to run on backends.")
+        resolved_backend = backend or get_aer_simulator()
+        compiled = self.transpile_for_backend(resolved_backend, measure=measure)
+        job = resolved_backend.run(compiled, shots=shots, **run_options)
+        return job.result()
+
+    # ------------------------------------------------------------------
+    # internal helpers
+    def _append_gate(self, name: str, targets: Tuple[int, ...], parameters: Tuple[float, ...] = ()) -> None:
+        self._validate_targets(targets)
+        self._operations.append(GateOperation(name=name, targets=targets, parameters=parameters))
+        self._dirty = True
+
+    def _validate_targets(self, targets: Tuple[int, ...]) -> None:
+        for target in targets:
+            if not 0 <= target < self.num_qubits:
+                raise ValueError(f"Qubit index {target} is out of range for {self.num_qubits} qubits")
+        if len(set(targets)) != len(targets):
+            raise ValueError("Repeated qubit targets are not supported")
+
+    def _apply_gate_to_state(self, state: np.ndarray, gate: GateOperation) -> np.ndarray:
+        matrix = _matrix_for_gate(gate)
+        return _apply_unitary(state, matrix, gate.targets, self.num_qubits)
+
+
+def get_aer_simulator():
+    """Return the default Aer simulator backend if available."""
+
+    if not QISKIT_AVAILABLE:  # pragma: no cover - optional dep
+        raise RuntimeError("Qiskit is not installed. Install qiskit-aer to access simulators.")
+    if Aer is None:  # pragma: no cover - optional dep
+        from qiskit import Aer as legacy_aer  # type: ignore
+
+        return legacy_aer.get_backend("aer_simulator")
+    return Aer.get_backend("aer_simulator")
+
+
+def _matrix_for_gate(gate: GateOperation) -> np.ndarray:
+    if gate.name == "h":
+        return _HADAMARD
+    if gate.name == "x":
+        return _SIGMA_X
+    if gate.name == "y":
+        return _SIGMA_Y
+    if gate.name == "z":
+        return _SIGMA_Z
+    if gate.name == "phase":
+        theta = gate.parameters[0]
+        return np.array([[1.0, 0.0], [0.0, np.exp(1j * theta)]], dtype=np.complex128)
+    if gate.name == "rx":
+        theta = gate.parameters[0]
+        return np.cos(theta / 2.0) * _I2 - 1j * np.sin(theta / 2.0) * _SIGMA_X
+    if gate.name == "ry":
+        theta = gate.parameters[0]
+        return np.cos(theta / 2.0) * _I2 - 1j * np.sin(theta / 2.0) * _SIGMA_Y
+    if gate.name == "rz":
+        theta = gate.parameters[0]
+        return np.cos(theta / 2.0) * _I2 - 1j * np.sin(theta / 2.0) * _SIGMA_Z
+    if gate.name == "cnot":
+        return _CNOT
+    raise ValueError(f"Unknown gate: {gate.name}")
+
+
+def _apply_unitary(state: np.ndarray, matrix: np.ndarray, targets: Tuple[int, ...], num_qubits: int) -> np.ndarray:
+    targets = tuple(targets)
+    num_targets = len(targets)
+    if num_targets == 0:
+        return state
+    reshaped = state.reshape([2] * num_qubits)
+    perm = [idx for idx in range(num_qubits) if idx not in targets] + list(targets)
+    transposed = np.transpose(reshaped, perm)
+    leading = 2 ** (num_qubits - num_targets)
+    trailing = transposed.reshape(leading, 2**num_targets)
+    updated = trailing @ matrix.T
+    updated = updated.reshape([2] * num_qubits)
+    inverse = np.argsort(perm)
+    final_state = np.transpose(updated, inverse)
+    return final_state.reshape(-1)
+
+
+def _tensor_pauli(pauli_string: str) -> np.ndarray:
+    pauli_map: Mapping[str, np.ndarray] = {
+        "I": _I2,
+        "X": _SIGMA_X,
+        "Y": _SIGMA_Y,
+        "Z": _SIGMA_Z,
+    }
+    operators = [pauli_map[char] for char in pauli_string.upper()]
+    result = operators[0]
+    for op in operators[1:]:
+        result = np.kron(result, op)
+    return result

--- a/quantum_math_lab/visuals/__init__.py
+++ b/quantum_math_lab/visuals/__init__.py
@@ -1,0 +1,10 @@
+"""Visualization helpers for quantum math lab."""
+
+from .plot_states import bloch_vector, plot_bloch_sphere, plot_circuit_state, plot_state_probabilities
+
+__all__ = [
+    "bloch_vector",
+    "plot_bloch_sphere",
+    "plot_circuit_state",
+    "plot_state_probabilities",
+]

--- a/quantum_math_lab/visuals/plot_states.py
+++ b/quantum_math_lab/visuals/plot_states.py
@@ -1,0 +1,81 @@
+"""Visualization utilities for quantum states and circuits."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from ..quantum_simulator import QuantumCircuit
+
+
+def bloch_vector(state: Sequence[complex]) -> np.ndarray:
+    """Compute the Bloch vector for a single-qubit state."""
+
+    amplitudes = np.asarray(state, dtype=np.complex128)
+    if amplitudes.size != 2:
+        raise ValueError("Bloch vectors are defined for single-qubit states")
+    norm = np.linalg.norm(amplitudes)
+    if not np.isclose(norm, 1.0):
+        amplitudes = amplitudes / norm
+    alpha, beta = amplitudes
+    x = 2 * np.real(np.conj(alpha) * beta)
+    y = 2 * np.imag(np.conj(alpha) * beta)
+    z = np.abs(alpha) ** 2 - np.abs(beta) ** 2
+    return np.array([x, y, z], dtype=float)
+
+
+def plot_bloch_sphere(state: Sequence[complex], ax: plt.Axes | None = None) -> plt.Figure:
+    """Plot a Bloch vector for the given single-qubit state."""
+
+    if ax is None:
+        fig = plt.figure(figsize=(4, 4))
+        ax = fig.add_subplot(111, projection="3d")
+    else:
+        fig = ax.figure
+    vector = bloch_vector(state)
+    u = np.linspace(0, 2 * np.pi, 100)
+    v = np.linspace(0, np.pi, 100)
+    x = np.outer(np.cos(u), np.sin(v))
+    y = np.outer(np.sin(u), np.sin(v))
+    z = np.outer(np.ones_like(u), np.cos(v))
+    ax.plot_surface(x, y, z, color="lightgray", alpha=0.2, linewidth=0)
+    ax.quiver(0, 0, 0, *vector, color="crimson", linewidth=2)
+    ax.set_xlim([-1, 1])
+    ax.set_ylim([-1, 1])
+    ax.set_zlim([-1, 1])
+    ax.set_xlabel("X")
+    ax.set_ylabel("Y")
+    ax.set_zlabel("Z")
+    ax.set_title("Bloch Sphere")
+    return fig
+
+
+def plot_state_probabilities(state: Sequence[complex], ax: plt.Axes | None = None) -> plt.Figure:
+    """Plot measurement probabilities of a computational basis state vector."""
+
+    amplitudes = np.asarray(state, dtype=np.complex128)
+    probabilities = np.abs(amplitudes) ** 2
+    labels = [format(i, f"0{int(np.log2(probabilities.size))}b") for i in range(probabilities.size)]
+    if ax is None:
+        fig, ax = plt.subplots(figsize=(6, 3))
+    else:
+        fig = ax.figure
+    ax.bar(labels, probabilities, color="navy", alpha=0.7)
+    ax.set_ylim(0, 1)
+    ax.set_ylabel("Probability")
+    ax.set_xlabel("Computational basis state")
+    ax.set_title("Measurement distribution")
+    ax.grid(axis="y", linestyle="--", linewidth=0.5, alpha=0.5)
+    return fig
+
+
+def plot_circuit_state(circuit: QuantumCircuit, ax: plt.Axes | None = None) -> plt.Figure:
+    """Simulate ``circuit`` and plot the resulting probability distribution."""
+
+    state = circuit.simulate()
+    return plot_state_probabilities(state, ax=ax)
+
+
+__all__ = ["plot_bloch_sphere", "plot_state_probabilities", "plot_circuit_state", "bloch_vector"]

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -1,7 +1,13 @@
 from __future__ import annotations
 
+import numpy as np
+import pytest
+
 from bots.simple import get_default_bots
 from simulator.engine import Scenario, run_scenario
+from quantum_math_lab import BitFlipCode, QuantumCircuit, get_aer_simulator
+from quantum_math_lab.ml_integration import HamiltonianTerm, TorchVQESolver
+from quantum_math_lab.visuals import bloch_vector
 from tests.golden import assert_matches_golden
 
 
@@ -25,3 +31,76 @@ def test_scenarios_run_with_trace_id():
     result = run_scenario(scenario)
     assert "trace_id" in result
     assert result["steps"][0]["output"] == {"forecast": 1}
+
+
+def test_quantum_circuit_hadamard_superposition():
+    circuit = QuantumCircuit(1)
+    circuit.hadamard(0)
+    state = circuit.simulate()
+    probabilities = np.abs(state) ** 2
+    assert pytest.approx(probabilities[0], abs=1e-9) == 0.5
+    assert pytest.approx(probabilities[1], abs=1e-9) == 0.5
+
+
+def test_quantum_circuit_cnot_creates_bell_state():
+    circuit = QuantumCircuit(2)
+    circuit.hadamard(0)
+    circuit.cnot(0, 1)
+    state = circuit.simulate()
+    expected = np.zeros(4, dtype=np.complex128)
+    expected[0] = 1 / np.sqrt(2)
+    expected[3] = 1 / np.sqrt(2)
+    assert np.allclose(state, expected)
+
+
+def test_quantum_circuit_qiskit_execution_roundtrip():
+    pytest.importorskip("qiskit")
+    circuit = QuantumCircuit(2)
+    circuit.hadamard(0)
+    circuit.cnot(0, 1)
+    result = circuit.execute_on_backend(get_aer_simulator(), shots=128, measure=True)
+    raw_counts = result.get_counts()
+    counts: dict[str, int] = {}
+    for key, value in raw_counts.items():
+        trimmed = key.replace(" ", "")[-circuit.num_qubits :]
+        counts[trimmed] = counts.get(trimmed, 0) + value
+    assert sum(counts.values()) == 128
+    assert set(counts).issubset({"00", "11"})
+
+
+def test_quantum_bit_flip_code_corrects_single_error():
+    code = BitFlipCode()
+    circuit = code.prepare(theta=np.pi / 3)
+    circuit.simulate()
+    code.introduce_error(circuit, 1)
+    inferred = code.correct(circuit)
+    assert inferred == 1
+    probabilities = circuit.probabilities()
+    no_error_prob = sum(probabilities[int(bitstring, 2)] for bitstring in ("000", "111"))
+    assert no_error_prob > 0.95
+
+
+def test_quantum_bloch_vector_normalised_state():
+    circuit = QuantumCircuit(1)
+    circuit.hadamard(0)
+    state = circuit.simulate()
+    vector = bloch_vector(state)
+    assert np.isclose(np.linalg.norm(vector), 1.0)
+
+
+def test_quantum_torch_vqe_minimises_simple_hamiltonian():
+    pytest.importorskip("torch")
+
+    def ansatz(parameters):
+        circuit = QuantumCircuit(1)
+        circuit.ry(0, float(parameters[0]))
+        return circuit
+
+    solver = TorchVQESolver(
+        ansatz,
+        [HamiltonianTerm(coefficient=1.0, pauli_string="Z")],
+        learning_rate=0.2,
+        max_iterations=30,
+    )
+    result = solver.solve([0.3])
+    assert result.optimal_value <= -0.5


### PR DESCRIPTION
## Summary
- add a `quantum_math_lab` package with a NumPy circuit simulator, Qiskit/Aer execution helpers, error-correction utilities, Torch-based VQE tooling, and state-visualization helpers
- provide VQE and Grover demos plus unsolved-problem documentation and README quickstart guidance for the new toolkit
- extend pytest coverage and CI to exercise the quantum math lab functionality

## Testing
- pytest tests/test_simulator.py -k "quantum"


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d912c49748329b249bc195e12ef17)