### PR TITLE
feat(qlm_lab): integrate llm tool-calling runtime

### DIFF
--- a/modules/qlm_lab/.github/workflows/ci.yml
+++ b/modules/qlm_lab/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
       - run: pip install -e modules/qlm_lab[qiskit] pytest pytest-cov ruff mypy jupyter nbconvert
       - run: pytest --cov=qlm_lab.tools.quantum_np --cov-report=term --cov-report=json:coverage.json modules/qlm_lab/tests
       - run: python -m qlm_lab.demos.demo_bell
+      - run: make -C modules/qlm_lab demo_toolcaller
       - name: Write coverage summary
         run: |
           python - <<'PY'

--- a/modules/qlm_lab/Makefile
+++ b/modules/qlm_lab/Makefile
@@ -1,15 +1,20 @@
-.PHONY: setup demo test lint notebooks
+.PHONY: setup demo demo_toolcaller test lint notebooks gate
 setup:
-python -m venv .venv && . .venv/bin/activate && pip install -e .[viz] -r requirements-dev.txt || true
+	python -m venv .venv && . .venv/bin/activate && pip install -e .[qiskit] pytest pytest-cov ruff mypy jupyter nbconvert
 
 demo:
-python -m qlm_lab.demos.demo_bell
+	python -m qlm_lab.demos.demo_bell
+
+demo_toolcaller:
+	python -m qlm_lab.demos.demo_toolcaller
 
 test:
-pytest -q
+	pytest --cov=qlm_lab --cov-report=xml
 
 lint:
-ruff check . && mypy qlm_lab
+	ruff check . && mypy qlm_lab
 
 notebooks:
-jupyter nbconvert --to notebook --execute notebooks/01_bell_chsh.ipynb --output out01.ipynb
+	jupyter nbconvert --to notebook --execute notebooks/01_bell_chsh.ipynb --output out01.ipynb
+
+gate: test

--- a/modules/qlm_lab/qlm_lab/agents/qlm.py
+++ b/modules/qlm_lab/qlm_lab/agents/qlm.py
@@ -3,19 +3,54 @@ from __future__ import annotations
 from typing import List
 
 from .base import Agent
+from ..llm.providers import NullLLM
+from ..llm.runtime import ToolContext, execute_tagged_text
+from ..policies import Policy
 from ..proto import Msg, new
 from ..tools import quantum_np as Q, viz
+from ..tools.registry import default_registry
 
 
 class QLM(Agent):
-    """Rule-based quantum agent leveraging NumPy primitives."""
+    """Quantum laboratory agent capable of rule-based and tool-called flows."""
 
     name = "qlm"
 
+    def __init__(self, bus, policy: Policy | None = None):
+        super().__init__(bus)
+        self.policy = policy or Policy()
+        self.llm = NullLLM()
+        self.registry = default_registry()
+        self.ctx = ToolContext()
+
     def can_handle(self, m: Msg) -> bool:
-        return m.recipient == self.name and m.kind == "task" and m.op in {"solve_quantum", "prove_chsh"}
+        supported = {"solve_quantum", "prove_chsh", "solve_quantum_llm", "prove_chsh_llm"}
+        return m.recipient == self.name and m.kind == "task" and m.op in supported
+
+    def _run_llm_plan(self, plan: str, sender: str, op: str) -> List[Msg]:
+        text_with_tags = self.llm.run(plan, self.policy)
+        stitched, trace = execute_tagged_text(text_with_tags, self.registry, self.policy, self.ctx)
+        return [new(self.name, sender, "result", op, text=stitched, trace=trace)]
 
     def handle(self, m: Msg) -> List[Msg]:
+        if m.op == "prove_chsh_llm":
+            plan = '''
+Compute CHSH for |Φ+> and verify violation:
+<tool name="quantum_np.chsh_value_phi_plus" as="S"/>
+Plot an ideal Bell histogram (00/11):
+<tool name="viz.hist" args="{\"00\":0.5,\"11\":0.5}" fname="bell_hist_toolcaller.png" as="hist_path"/>
+'''
+            return self._run_llm_plan(plan, m.sender, m.op)
+
+        if m.op == "solve_quantum_llm":
+            plan = '''
+Prepare Bell and measure 4096 shots with a plot:
+<tool name="quantum_np.bell_phi_plus" as="psi"/>
+<tool name="quantum_np.measure_counts" from="psi" shots="4096" as="counts"/>
+<tool name="viz.hist" from="counts" fname="bell_hist_empirical_toolcaller.png" as="hist_path"/>
+'''
+            return self._run_llm_plan(plan, m.sender, m.op)
+
         if m.op == "prove_chsh":
             s = Q.chsh_value_phi_plus()
             psi = Q.bell_phi_plus()
@@ -42,6 +77,7 @@ class QLM(Agent):
                     path=bloch_path,
                 )
             ]
+
         if m.op == "solve_quantum":
             psi = Q.bell_phi_plus()
             counts = Q.measure_counts(psi, shots=4096)
@@ -56,4 +92,5 @@ class QLM(Agent):
                     path=hist_path,
                 )
             ]
+
         return []

--- a/modules/qlm_lab/qlm_lab/demos/demo_toolcaller.py
+++ b/modules/qlm_lab/qlm_lab/demos/demo_toolcaller.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+"""Demonstration of the QLM agent executing tool-tagged plans."""
+
+from ..bus import Bus
+from ..policies import Policy
+from ..proto import new
+from ..agents.qlm import QLM
+
+
+def main() -> None:
+    bus = Bus()
+    qlm = QLM(bus, policy=Policy(allow_network=False))
+    bus.subscribe(lambda m: None)
+    bus.publish(new("user", "qlm", "task", "prove_chsh_llm"))
+    bus.publish(new("user", "qlm", "task", "solve_quantum_llm"))
+    print("OK: toolcaller demo executed. See artifacts/ for histograms.")
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/qlm_lab/qlm_lab/lineage.py
+++ b/modules/qlm_lab/qlm_lab/lineage.py
@@ -9,6 +9,20 @@ from typing import List
 from .proto import Msg
 
 
+DEFAULT_LINEAGE_PATH = Path(__file__).resolve().parents[1] / "artifacts" / "lineage.jsonl"
+
+
+def append(event: dict[str, object], path: Path | None = None) -> None:
+    """Append a lightweight lineage ``event`` to the JSONL log."""
+
+    target = Path(path) if path is not None else DEFAULT_LINEAGE_PATH
+    target.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(event, default=str)
+    with target.open("a", encoding="utf-8") as handle:
+        handle.write(line + "\n")
+
+
+
 @dataclass
 class LineageRecord:
     """Serializable lineage record for agent activity."""
@@ -56,4 +70,4 @@ class LineageLogger:
         return list(self._records)
 
 
-__all__ = ["LineageLogger", "LineageRecord"]
+__all__ = ["LineageLogger", "LineageRecord", "append"]

--- a/modules/qlm_lab/qlm_lab/llm/__init__.py
+++ b/modules/qlm_lab/qlm_lab/llm/__init__.py
@@ -1,0 +1,12 @@
+"""LLM runtime utilities for QLM Lab."""
+
+from .providers import LLMProvider, NullLLM, OpenAIProvider
+from .runtime import ToolContext, execute_tagged_text
+
+__all__ = [
+    "LLMProvider",
+    "NullLLM",
+    "OpenAIProvider",
+    "ToolContext",
+    "execute_tagged_text",
+]

--- a/modules/qlm_lab/qlm_lab/llm/providers.py
+++ b/modules/qlm_lab/qlm_lab/llm/providers.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+"""LLM provider abstractions used by the QLM agent."""
+
+from dataclasses import dataclass
+
+from ..policies import Policy
+
+
+@dataclass
+class LLMProvider:
+    """Abstract interface returning text that may contain tool tags."""
+
+    def run(self, prompt: str, policy: Policy) -> str:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class NullLLM(LLMProvider):
+    """Offline provider that simply echoes the prompt."""
+
+    def run(self, prompt: str, policy: Policy) -> str:
+        return prompt
+
+
+class OpenAIProvider(LLMProvider):
+    """Placeholder provider raising when network access is disallowed."""
+
+    def __init__(self) -> None:  # pragma: no cover - trivial init
+        pass
+
+    def run(self, prompt: str, policy: Policy) -> str:
+        if not policy.allow_network:
+            raise PermissionError("Remote LLM disabled by policy")
+        raise NotImplementedError("Wire a real client only when policy allows")
+
+
+__all__ = ["LLMProvider", "NullLLM", "OpenAIProvider"]

--- a/modules/qlm_lab/qlm_lab/llm/runtime.py
+++ b/modules/qlm_lab/qlm_lab/llm/runtime.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+"""Runtime utilities for executing <tool .../> tags produced by an LLM."""
+
+import json
+import re
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Match, Tuple
+
+from ..lineage import append as log_event
+from ..policies import Policy
+from ..tools.registry import ToolRegistry
+
+_TAG = re.compile(r"<tool\s+[^>]*?/>")
+
+
+@dataclass
+class ToolContext:
+    """Variable scope shared across tool invocations."""
+
+    vars: Dict[str, Any] = field(default_factory=dict)
+
+
+def _coerce(val: str) -> Any:
+    v = val.strip()
+    if v.lower() in {"true", "false"}:
+        return v.lower() == "true"
+    try:
+        if "." in v:
+            return float(v)
+        return int(v)
+    except ValueError:
+        return v
+
+
+def _parse_attrs(elem: ET.Element) -> Dict[str, Any]:
+    out: Dict[str, Any] = {}
+    for key, value in elem.attrib.items():
+        if key == "args":
+            try:
+                out.update(json.loads(value))
+            except Exception:
+                out["args_raw"] = value
+        else:
+            out[key] = _coerce(value)
+    return out
+
+
+def _resolve_args(attrs: Dict[str, Any], ctx: ToolContext) -> Tuple[str, Dict[str, Any], str | None, str]:
+    name = attrs.pop("name")
+    as_var = attrs.pop("as", None)
+    from_var = attrs.pop("from", None)
+    fname = attrs.pop("fname", None)
+    if from_var:
+        obj = ctx.vars.get(from_var)
+        if obj is None:
+            raise ValueError(f"Unknown var '{from_var}'")
+        attrs["from_obj"] = obj
+    if fname is not None:
+        attrs["fname"] = fname
+    return name, attrs, as_var, from_var or ""
+
+
+def execute_tagged_text(
+    text: str, registry: ToolRegistry, policy: Policy, ctx: ToolContext | None = None
+) -> Tuple[str, List[Dict[str, Any]]]:
+    """Execute tool tags in ``text`` and return the stitched output and trace."""
+
+    ctx = ctx or ToolContext()
+    trace: List[Dict[str, Any]] = []
+
+    def _repl(match: Match[str]) -> str:
+        tag = match.group(0)
+        try:
+            elem = ET.fromstring(tag)
+            attrs = _parse_attrs(elem)
+            name, args, as_var, from_var = _resolve_args(attrs, ctx)
+            if name.startswith("llm.") and not policy.allow_network:
+                raise PermissionError("Network/remote LLM disabled by policy")
+            fn = registry.get(name)
+            call_args = dict(args)
+            if "from_obj" in call_args:
+                from_obj = call_args.pop("from_obj")
+                result = fn(from_obj, **call_args)
+            else:
+                result = fn(**call_args)
+            if as_var:
+                ctx.vars[as_var] = result
+            log_event(
+                {
+                    "kind": "tool",
+                    "name": name,
+                    "args": {k: str(v)[:200] for k, v in call_args.items()},
+                    "as": as_var,
+                    "from": from_var,
+                }
+            )
+            rtype = type(result).__name__
+            trace.append({"name": name, "type": rtype, "as": as_var, "from": from_var})
+            return f'<result name="{as_var or name}" type="{rtype}"/>'
+        except Exception as exc:  # pragma: no cover - exercised indirectly
+            log_event({"kind": "tool_error", "tag": tag, "error": str(exc)})
+            return f'<error tool="{tag}" reason="{str(exc)}"/>'
+
+    new_text = _TAG.sub(_repl, text)
+    return new_text, trace
+
+
+__all__ = ["ToolContext", "execute_tagged_text"]

--- a/modules/qlm_lab/qlm_lab/policies.py
+++ b/modules/qlm_lab/qlm_lab/policies.py
@@ -1,10 +1,33 @@
-"""Policy helpers for QLM Lab demos and agents."""
 from __future__ import annotations
+
+"""Policy helpers for QLM Lab demos and agents."""
 
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable, List, Mapping
+
+
+def _default_artifact_dir() -> Path:
+    """Return the default artifact directory for the lab."""
+
+    return Path(__file__).resolve().parents[1] / "artifacts"
+
+
+@dataclass
+class Policy:
+    """Runtime policy applied to tool-calling flows."""
+
+    allow_network: bool = False
+    artifact_dir: Path = field(default_factory=_default_artifact_dir)
+    lineage_path: Path = field(init=False)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.artifact_dir, Path):
+            self.artifact_dir = Path(self.artifact_dir)
+        self.artifact_dir.mkdir(parents=True, exist_ok=True)
+        self.lineage_path = self.artifact_dir / "lineage.jsonl"
+        self.lineage_path.parent.mkdir(parents=True, exist_ok=True)
 
 
 @dataclass
@@ -17,10 +40,7 @@ class PolicyConfig:
 
 
 def artifact_paths(root: Path, patterns: Iterable[str]) -> List[Path]:
-    """Resolve artifact paths relative to ``root``.
-
-    Missing paths are returned as-is so callers can report the failure.
-    """
+    """Resolve artifact paths relative to ``root``."""
 
     resolved: List[Path] = []
     for pattern in patterns:
@@ -68,6 +88,7 @@ def network_allowed(config: PolicyConfig | None = None) -> bool:
 
 
 __all__ = [
+    "Policy",
     "PolicyConfig",
     "artifact_paths",
     "check_artifact_quota",

--- a/modules/qlm_lab/qlm_lab/tools/registry.py
+++ b/modules/qlm_lab/qlm_lab/tools/registry.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+"""Tool registry for mapping tag names to callables."""
+
+from typing import Any, Callable, Dict
+
+from . import la
+from . import math_cas
+from . import quantum_np as Q
+from . import viz as V
+
+
+class ToolRegistry:
+    """Name→callable registry for LLM tool-calling."""
+
+    def __init__(self) -> None:
+        self._map: Dict[str, Callable[..., Any]] = {}
+
+    def register(self, name: str, fn: Callable[..., Any]) -> None:
+        """Register ``fn`` under ``name``."""
+
+        self._map[name] = fn
+
+    def get(self, name: str) -> Callable[..., Any]:
+        """Return the callable registered for ``name``."""
+
+        if name not in self._map:
+            raise KeyError(f"Unknown tool '{name}'")
+        return self._map[name]
+
+
+def default_registry() -> ToolRegistry:
+    """Populate a registry with the standard QLM tools."""
+
+    reg = ToolRegistry()
+    reg.register("quantum_np.bell_phi_plus", Q.bell_phi_plus)
+    reg.register("quantum_np.measure_counts", Q.measure_counts)
+    reg.register("quantum_np.chsh_value_phi_plus", Q.chsh_value_phi_plus)
+    reg.register("quantum_np.qft_matrix", Q.qft_matrix)
+    reg.register("viz.hist", V.hist)
+    if hasattr(la, "eig"):
+        reg.register("la.eig", getattr(la, "eig"))
+    if hasattr(math_cas, "simplify"):
+        reg.register("math_cas.simplify", getattr(math_cas, "simplify"))
+    return reg
+
+
+__all__ = ["ToolRegistry", "default_registry"]

--- a/modules/qlm_lab/tests/test_toolcalling.py
+++ b/modules/qlm_lab/tests/test_toolcalling.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+"""Tests for the LLM tool-calling runtime."""
+
+import json
+import os
+from pathlib import Path
+
+from qlm_lab.llm.runtime import ToolContext, execute_tagged_text
+from qlm_lab.tools.registry import ToolRegistry, default_registry
+from qlm_lab.policies import Policy
+from qlm_lab.agents.qlm import QLM
+from qlm_lab.bus import Bus
+from qlm_lab.proto import new
+
+
+LINEAGE_PATH = Path("artifacts/lineage.jsonl")
+
+
+def _reset_lineage() -> None:
+    if LINEAGE_PATH.exists():
+        LINEAGE_PATH.unlink()
+
+
+def test_tag_parse_and_dispatch_simple(monkeypatch):
+    _reset_lineage()
+    reg = default_registry()
+    policy = Policy(allow_network=False)
+    ctx = ToolContext()
+    text = '<tool name="quantum_np.chsh_value_phi_plus" as="S"/>'
+    out, trace = execute_tagged_text(text, reg, policy, ctx)
+    assert "<result" in out
+    assert any(t["name"].endswith("chsh_value_phi_plus") for t in trace)
+    assert "S" in ctx.vars
+
+
+def test_variable_flow_and_hist():
+    _reset_lineage()
+    reg = default_registry()
+    policy = Policy()
+    ctx = ToolContext()
+    plan = (
+        '<tool name="quantum_np.bell_phi_plus" as="psi"/>'
+        '<tool name="quantum_np.measure_counts" from="psi" shots="1024" as="counts"/>'
+        '<tool name="viz.hist" from="counts" fname="bell_hist_toolcaller_test.png" as="hist_path"/>'
+    )
+    out, trace = execute_tagged_text(plan, reg, policy, ctx)
+    assert '<result name="counts"' in out
+    assert ctx.vars["hist_path"].endswith("bell_hist_toolcaller_test.png")
+    assert os.path.exists("artifacts/bell_hist_toolcaller_test.png")
+    assert len(trace) == 3
+
+
+def test_policy_blocks_llm_tools():
+    _reset_lineage()
+    reg = ToolRegistry()
+    reg.register("llm.fake", lambda: "nope")
+    policy = Policy(allow_network=False)
+    ctx = ToolContext()
+    text = '<tool name="llm.fake" as="resp"/>'
+    out, trace = execute_tagged_text(text, reg, policy, ctx)
+    assert "<error" in out
+    assert trace == []
+    assert LINEAGE_PATH.exists()
+    lines = [json.loads(line) for line in LINEAGE_PATH.read_text().splitlines() if line.strip()]
+    assert any(entry.get("kind") == "tool_error" for entry in lines)
+
+
+def test_lineage_logs_tool_invocations():
+    _reset_lineage()
+    reg = default_registry()
+    policy = Policy()
+    ctx = ToolContext()
+    execute_tagged_text('<tool name="quantum_np.chsh_value_phi_plus" as="S"/>', reg, policy, ctx)
+    assert LINEAGE_PATH.exists()
+    entries = [json.loads(line) for line in LINEAGE_PATH.read_text().splitlines() if line.strip()]
+    assert any(entry.get("kind") == "tool" for entry in entries)
+
+
+def test_qlm_agent_end_to_end_toolcaller():
+    _reset_lineage()
+    bus = Bus()
+    agent = QLM(bus, policy=Policy(allow_network=False))
+    msg = new("user", "qlm", "task", "solve_quantum_llm")
+    responses = agent.handle(msg)
+    assert responses and responses[0].kind == "result"
+    payload = responses[0].args["text"]
+    assert "<result" in payload
+    assert os.path.exists("artifacts/bell_hist_empirical_toolcaller.png")
+    entries = [json.loads(line) for line in LINEAGE_PATH.read_text().splitlines() if line.strip()]
+    assert any(entry.get("kind") == "tool" for entry in entries)


### PR DESCRIPTION
## Summary
- add a tool registry plus LLM runtime that executes `<tool .../>` tags with policy enforcement and lineage logging
- wire the QLM agent to the offline NullLLM provider, add a demo, and cover the flow with new tests
- update the Makefile and CI workflow to exercise the tool-caller demo and collect coverage

## Testing
- make -C modules/qlm_lab demo_toolcaller
- make -C modules/qlm_lab test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d9c1cb90c8329afe5b72562601656)