### PR TITLE
feat(qlm-lab): quantum-language agents, numpy backend, demos, tests, ci (v0.1.0)

### DIFF
--- a/modules/qlm_lab/.github/workflows/ci.yml
+++ b/modules/qlm_lab/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
       - run: python -m qlm_lab.demos.demo_bell
       - run: make -C modules/qlm_lab demo_toolcaller
       - run: make -C modules/qlm_lab demo_toolformer
+      - run: make -C modules/qlm_lab demo_rag
       - name: Write coverage summary
         run: |
           python - <<'PY'
@@ -24,6 +25,10 @@ jobs:
           percent = data['files'][file_key]['summary']['percent_covered'] / 100.0
           artifacts_dir = Path('modules/qlm_lab/artifacts')
           artifacts_dir.mkdir(exist_ok=True)
+          rag_path = artifacts_dir / 'rag_topk.json'
+          citations = []
+          if rag_path.exists():
+              citations = json.loads(rag_path.read_text(encoding='utf-8'))
           payload = {
               'coverage': {'qlm_lab/tools/quantum_np.py': round(percent, 4)},
               'metrics': {'chsh': Q.chsh_value_phi_plus()},
@@ -33,6 +38,8 @@ jobs:
           out = Path('prism/ci/qlm_lab.coverage.json')
           out.parent.mkdir(parents=True, exist_ok=True)
           out.write_text(json.dumps(payload, indent=2))
+          rag_out = Path('prism/ci/qlm_lab.rag.json')
+          rag_out.write_text(json.dumps({'citations': {'count': len(citations)}}, indent=2))
           PY
       - run: make -C modules/qlm_lab lint
       - run: make -C modules/qlm_lab test

--- a/modules/qlm_lab/Makefile
+++ b/modules/qlm_lab/Makefile
@@ -1,10 +1,7 @@
-.PHONY: setup demo demo_toolcaller test lint notebooks gate
-.PHONY: setup demo test lint gate
+.PHONY: setup demo demo_toolcaller demo_toolformer demo_rag test lint notebooks ingest index gate
+
 setup:
 	python -m venv .venv && . .venv/bin/activate && pip install -e .[qiskit] pytest pytest-cov ruff mypy jupyter nbconvert
-.PHONY: setup demo demo_toolformer test lint notebooks
-setup:
-	python -m venv .venv && . .venv/bin/activate && pip install -e .[viz] -r requirements-dev.txt || true
 
 demo:
 	python -m qlm_lab.demos.demo_bell
@@ -12,10 +9,11 @@ demo:
 demo_toolcaller:
 	python -m qlm_lab.demos.demo_toolcaller
 
-test:
-	pytest --cov=qlm_lab --cov-report=xml
 demo_toolformer:
 	python -m qlm_lab.demos.demo_toolformer_prompt
+
+demo_rag: ingest index
+	python -m qlm_lab.demos.demo_rag
 
 test:
 	pytest -q
@@ -26,6 +24,11 @@ lint:
 notebooks:
 	jupyter nbconvert --to notebook --execute notebooks/01_bell_chsh.ipynb --output out01.ipynb
 
+ingest:
+	python -c "from qlm_lab.retrieval.ingest import ingest; from pathlib import Path; art=Path('modules/qlm_lab/artifacts'); art.mkdir(parents=True, exist_ok=True); print(ingest('modules/qlm_lab/docs_local', str(art / 'corpus.jsonl')))"
+
+index: ingest
+	python -c "from qlm_lab.retrieval.index import TfidfIndex; from pathlib import Path; art=Path('modules/qlm_lab/artifacts'); idx=TfidfIndex(); idx.build(str(art / 'corpus.jsonl')); idx.save(str(art / 'index.json')); print('ok')"
+
 gate: test
-gate:
 	python modules/qlm_lab/scripts/make_gate_input.py && cat prism/ci/qlm_lab.coverage.json

--- a/modules/qlm_lab/README.md
+++ b/modules/qlm_lab/README.md
@@ -7,6 +7,7 @@ python -m venv .venv && source .venv/bin/activate
 pip install -e .[qiskit]
 make test  # pytest with coverage
 make demo  # generates bell artifacts
+make demo_rag  # builds TF-IDF index and writes artifacts/rag_topk.json
 make gate  # emits prism/ci/qlm_lab.coverage.json
 ```
 
@@ -19,6 +20,7 @@ make gate  # emits prism/ci/qlm_lab.coverage.json
 - `qlm_lab/tools`: numerical, symbolic, visualization, and filesystem helpers.
 - `qlm_lab/agents`: rule-based prototype agents for orchestration and critique.
 - `qlm_lab/demos`: runnable experiments that produce artifacts and metrics.
+- `qlm_lab/retrieval`: TF-IDF chunking/index/search powering local RAG flows.
 - `qlm_lab/notebooks`: reproducible notebooks mirroring the demos.
 - `tests`: pytest suite covering tools, policies, and agent coordination.
 

--- a/modules/qlm_lab/docs_local/bell_chsh.md
+++ b/modules/qlm_lab/docs_local/bell_chsh.md
@@ -1,0 +1,7 @@
+# Bell States and the CHSH Inequality
+
+The maximally entangled Bell state $\lvert \Phi^+ \rangle = (\lvert 00 \rangle + \lvert 11 \rangle)/\sqrt{2}$ violates the classical CHSH bound.
+
+Given measurement settings $A_0 = Z$, $A_1 = X$, $B_0 = (Z+X)/\sqrt{2}$, and $B_1 = (Z-X)/\sqrt{2}$, the quantum expectation reaches $S \approx 2.828$, exceeding the local hidden variable limit of 2.
+
+This experiment provides strong evidence against local realism and is the foundation of many device-independent security proofs.

--- a/modules/qlm_lab/docs_local/grover_intro.md
+++ b/modules/qlm_lab/docs_local/grover_intro.md
@@ -1,0 +1,7 @@
+# Grover Search Overview
+
+Grover's algorithm quadratically accelerates unstructured search. For a marked element $\omega$, the amplitude amplification process rotates the state vector towards $\lvert \omega \rangle$ with each Grover iteration.
+
+The optimal number of iterations is approximately $\frac{\pi}{4}\sqrt{N}$; applying significantly more iterations causes the success probability to oscillate back downward.
+
+Experiments comparing the Grover curve to classical brute force highlight the $O(\sqrt{N})$ complexity advantage.

--- a/modules/qlm_lab/docs_local/qft_notes.md
+++ b/modules/qlm_lab/docs_local/qft_notes.md
@@ -1,0 +1,10 @@
+# Quantum Fourier Transform Notes
+
+The Quantum Fourier Transform (QFT) maps computational basis states to the Fourier basis. For $n$ qubits the transformation acts as
+\[
+\lvert x \rangle \mapsto \frac{1}{2^{n/2}} \sum_{k=0}^{2^n-1} e^{2\pi i xk / 2^n} \lvert k \rangle.
+\]
+
+In period-finding tasks, the QFT enables phase estimation with precision proportional to the number of qubits.
+
+Noise-free simulations show phase errors below $10^{-3}$, while modest depolarising noise rapidly degrades interference fringes.

--- a/modules/qlm_lab/qlm_lab/agents/qlm.py
+++ b/modules/qlm_lab/qlm_lab/agents/qlm.py
@@ -1,16 +1,15 @@
+"""Quantum language model agent orchestrating rule-based and toolformer flows."""
 from __future__ import annotations
 
 from typing import List
 
 from .base import Agent
-from ..llm.providers import NullLLM
-from ..llm.runtime import ToolContext, execute_tagged_text
+from ..cache.prompt_cache import get as cache_get, put as cache_put
+from ..lineage import append as log_lineage
+from ..llm import ToolContext, Toolformer, execute_tagged_text
 from ..policies import Policy
 from ..proto import Msg, new
 from ..tools import quantum_np as Q, viz
-from ..policies import Policy
-from ..llm import ToolContext, Toolformer, execute_tagged_text
-from ..cache.prompt_cache import get as cache_get, put as cache_put
 from ..tools.registry import default_registry
 
 
@@ -19,53 +18,103 @@ class QLM(Agent):
 
     name = "qlm"
 
-    def __init__(self, bus, policy: Policy | None = None):
-        super().__init__(bus)
-        self.policy = policy or Policy()
-        self.llm = NullLLM()
-        self.registry = default_registry()
-        self.ctx = ToolContext()
-
-    def can_handle(self, m: Msg) -> bool:
-        supported = {"solve_quantum", "prove_chsh", "solve_quantum_llm", "prove_chsh_llm"}
-        return m.recipient == self.name and m.kind == "task" and m.op in supported
-
-    def _run_llm_plan(self, plan: str, sender: str, op: str) -> List[Msg]:
-        text_with_tags = self.llm.run(plan, self.policy)
-        stitched, trace = execute_tagged_text(text_with_tags, self.registry, self.policy, self.ctx)
-        return [new(self.name, sender, "result", op, text=stitched, trace=trace)]
-    def __init__(self, bus, policy: Policy | None = None, registry=None):
+    def __init__(self, bus, policy: Policy | None = None, registry=None) -> None:
         super().__init__(bus)
         self.policy = policy or Policy()
         self.registry = registry or default_registry()
         self.toolformer = Toolformer()
         self.ctx = ToolContext()
+        self.last_citations: List[dict[str, object]] = []
 
     def can_handle(self, m: Msg) -> bool:
-        return (
-            m.recipient == self.name
-            and m.kind == "task"
-            and m.op in {"solve_quantum", "prove_chsh", "solve_freeform", "prove_freeform"}
+        if m.recipient != self.name:
+            return False
+        if m.kind == "task" and m.op in {
+            "solve_quantum",
+            "prove_chsh",
+            "solve_freeform",
+            "prove_freeform",
+            "solve_quantum_llm",
+            "prove_chsh_llm",
+        }:
+            return True
+        if m.kind == "result" and m.op == "citations":
+            return True
+        return False
+
+    def _request_citations(self, query: str, k: int = 3) -> List[dict[str, object]]:
+        self.last_citations = []
+        if not query.strip():
+            return []
+        message = new(self.name, "researcher", "task", "retrieve", query=query, k=k)
+        self.bus.publish(message)
+        return self.last_citations
+
+    def _execute_plan(
+        self,
+        plan_text: str,
+        sender: str,
+        op: str,
+        source: str,
+        citations: List[dict[str, object]] | None = None,
+    ) -> tuple[List[Msg], List[str]]:
+        before = set(self.ctx.artifacts)
+        stitched, trace = execute_tagged_text(plan_text, self.registry, self.policy, self.ctx)
+        new_artifacts = [path for path in self.ctx.artifacts if path not in before]
+        message = new(
+            self.name,
+            sender,
+            "result",
+            op,
+            text=stitched,
+            trace=trace,
+            source=source,
+            citations=citations or [],
         )
+        return [message], new_artifacts
+
+    def _run_toolformer_plan(
+        self, prompt: str, sender: str, op: str, citations: List[dict[str, object]]
+    ) -> List[Msg]:
+        cached = cache_get(prompt)
+        if cached:
+            plan_text = cached[0].plan_text
+            source = "cache"
+        else:
+            plan = self.toolformer.generate(prompt)
+            citation_lines = "\n".join(
+                f"# cite: {c['path']} L{c['start']}-{c['end']} (score={c['score']:.3f})" for c in citations
+            )
+            plan_text = f"""{citation_lines}\n{plan.text_with_tags}""" if citation_lines else plan.text_with_tags
+            source = plan.source
+        responses, new_artifacts = self._execute_plan(plan_text, sender, op, source, citations)
+        cache_put(prompt, plan_text, artifacts=new_artifacts, source=source)
+        return responses
 
     def handle(self, m: Msg) -> List[Msg]:
+        if m.kind == "result" and m.op == "citations":
+            self.last_citations = list(m.args.get("citations", []))
+            log_lineage({"agent": self.name, "op": "citations_received", "citations": self.last_citations})
+            return []
+
         if m.op == "prove_chsh_llm":
-            plan = '''
-Compute CHSH for |Φ+> and verify violation:
-<tool name="quantum_np.chsh_value_phi_plus" as="S"/>
-Plot an ideal Bell histogram (00/11):
-<tool name="viz.hist" args="{\"00\":0.5,\"11\":0.5}" fname="bell_hist_toolcaller.png" as="hist_path"/>
-'''
-            return self._run_llm_plan(plan, m.sender, m.op)
+            plan_text = (
+                "Compute CHSH for |Φ+> and render histogram.\n"
+                '<tool name="quantum_np.chsh_value_phi_plus" as="S"/>\n'
+                '<tool name="viz.hist" args="{\\"00\\":0.5,\\"11\\":0.5}" fname="bell_hist_toolcaller.png" as="hist_path"/>'
+            )
+            responses, _ = self._execute_plan(plan_text, m.sender, m.op, "preset", [])
+            return responses
 
         if m.op == "solve_quantum_llm":
-            plan = '''
-Prepare Bell and measure 4096 shots with a plot:
-<tool name="quantum_np.bell_phi_plus" as="psi"/>
-<tool name="quantum_np.measure_counts" from="psi" shots="4096" as="counts"/>
-<tool name="viz.hist" from="counts" fname="bell_hist_empirical_toolcaller.png" as="hist_path"/>
-'''
-            return self._run_llm_plan(plan, m.sender, m.op)
+            plan_text = (
+                "Prepare Bell, measure, and plot histogram.\n"
+                '<tool name="quantum_np.bell_phi_plus" as="psi"/>\n'
+                '<tool name="quantum_np.measure_counts" from="psi" shots="4096" as="counts"/>\n'
+                '<tool name="viz.hist" from="counts" fname="bell_hist_empirical_toolcaller.png" as="hist_path"/>'
+            )
+            responses, _ = self._execute_plan(plan_text, m.sender, m.op, "preset", [])
+            return responses
 
         if m.op == "prove_chsh":
             s = Q.chsh_value_phi_plus()
@@ -121,27 +170,11 @@ Prepare Bell and measure 4096 shots with a plot:
             ]
 
         if m.op in {"solve_freeform", "prove_freeform"}:
-            user_prompt: str = m.args.get("prompt", "")
-            hits = cache_get(user_prompt)
-            if hits:
-                plan_text = hits[0].plan_text
-                source = "cache"
-            else:
-                plan = self.toolformer.generate(user_prompt)
-                plan_text, source = plan.text_with_tags, plan.source
-            before = set(self.ctx.artifacts)
-            stitched, trace = execute_tagged_text(plan_text, self.registry, self.policy, self.ctx)
-            new_artifacts = [path for path in self.ctx.artifacts if path not in before]
-            cache_put(user_prompt, plan_text, artifacts=new_artifacts, source=source)
-            return [
-                new(
-                    self.name,
-                    m.sender,
-                    "result",
-                    m.op,
-                    text=stitched,
-                    trace=trace,
-                    source=source,
-                )
-            ]
+            prompt = str(m.args.get("prompt", ""))
+            citations = self._request_citations(prompt, k=int(m.args.get("k", 3)))
+            return self._run_toolformer_plan(prompt, m.sender, m.op, citations)
+
         return []
+
+
+__all__ = ["QLM"]

--- a/modules/qlm_lab/qlm_lab/agents/researcher.py
+++ b/modules/qlm_lab/qlm_lab/agents/researcher.py
@@ -1,11 +1,43 @@
-"""Research helper agent."""
+"""Research helper agent backed by a local retrieval index."""
 from __future__ import annotations
 
-from typing import List
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, List
 
+from ..lineage import append as log_lineage
 from ..proto import Msg, new
-from ..tools import math_cas
+from ..retrieval.index import TfidfIndex
+from ..retrieval.search import topk
 from .base import Agent
+
+ARTIFACTS_DIR = Path(__file__).resolve().parents[2] / "artifacts"
+CORPUS_PATH = ARTIFACTS_DIR / "corpus.jsonl"
+INDEX_PATH = ARTIFACTS_DIR / "index.json"
+RAG_TOPK_PATH = ARTIFACTS_DIR / "rag_topk.json"
+
+
+@dataclass(slots=True)
+class Citation:
+    """Structured citation returned by the Researcher agent."""
+
+    path: str
+    start: int
+    end: int
+    score: float
+    text: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise the citation into JSON-safe primitives."""
+
+        return {
+            "path": self.path,
+            "start": self.start,
+            "end": self.end,
+            "score": self.score,
+            "text": self.text,
+        }
 
 
 class Researcher(Agent):
@@ -13,21 +45,80 @@ class Researcher(Agent):
 
     name = "researcher"
 
+    def __init__(self, bus, index_path: Path | None = None) -> None:
+        super().__init__(bus)
+        self.index_path = Path(index_path) if index_path is not None else INDEX_PATH
+        self.index: TfidfIndex | None = None
+
     def can_handle(self, m: Msg) -> bool:
-        return m.recipient == self.name and m.kind == "task" and m.op == "gather_context"
+        return m.recipient == self.name and m.kind == "task" and m.op in {"retrieve", "gather_context"}
+
+    def _ensure_index(self) -> TfidfIndex | None:
+        if self.index is not None:
+            return self.index
+        if not self.index_path.exists():
+            return None
+        self.index = TfidfIndex.load(str(self.index_path))
+        return self.index
+
+    def _collect(self, query: str, k: int) -> List[Citation]:
+        index = self._ensure_index()
+        if index is None:
+            return []
+        hits = topk(index, query, k=k)
+        citations: List[Citation] = []
+        for idx, score in hits:
+            if idx >= len(index.meta):
+                continue
+            meta = index.meta[idx]
+            start = int(meta.get("start_line", 0))
+            end = int(meta.get("end_line", start))
+            text = str(meta.get("text", ""))[:400]
+            citations.append(
+                Citation(
+                    path=str(meta.get("path", "")),
+                    start=start,
+                    end=end,
+                    score=float(score),
+                    text=text,
+                )
+            )
+        return citations
 
     def handle(self, m: Msg) -> List[Msg]:
-        goal = m.args.get("goal", "")
-        simpl = math_cas.simplify_expr("sin(x)**2 + cos(x)**2", symbols=["x"])
-        series = str(math_cas.series_expand("exp(I*x)", "x", about=0, order=4))
+        query = str(m.args.get("query", m.args.get("goal", ""))).strip()
+        k = int(m.args.get("k", 5))
+        if k <= 0:
+            k = 1
+        citations = self._collect(query, k)
+        ARTIFACTS_DIR.mkdir(parents=True, exist_ok=True)
+        with RAG_TOPK_PATH.open("w", encoding="utf-8") as handle:
+            json.dump([c.to_dict() for c in citations], handle, ensure_ascii=False, indent=2)
+        log_lineage(
+            {
+                "agent": self.name,
+                "op": "retrieve",
+                "query": query,
+                "citations": [c.to_dict() for c in citations],
+            }
+        )
         return [
             new(
                 self.name,
-                "archivist",
+                m.sender if m.op == "retrieve" else "archivist",
                 "result",
-                "context",
-                goal=goal,
-                simplification=str(simpl),
-                series=series,
+                "citations",
+                citations=[c.to_dict() for c in citations],
+                query=query,
             )
         ]
+
+
+__all__ = [
+    "Researcher",
+    "Citation",
+    "ARTIFACTS_DIR",
+    "CORPUS_PATH",
+    "INDEX_PATH",
+    "RAG_TOPK_PATH",
+]

--- a/modules/qlm_lab/qlm_lab/demos/demo_rag.py
+++ b/modules/qlm_lab/qlm_lab/demos/demo_rag.py
@@ -1,0 +1,38 @@
+"""Demonstrate retrieval-augmented planning between Researcher and QLM."""
+from __future__ import annotations
+
+from ..agents.qlm import QLM
+from ..agents.researcher import INDEX_PATH, RAG_TOPK_PATH, Researcher
+from ..bus import Bus
+from ..policies import Policy
+from ..proto import new
+
+
+def main() -> None:
+    """Run a retrieval query followed by a freeform solve that consumes citations."""
+
+    if not INDEX_PATH.exists():
+        raise FileNotFoundError(
+            f"Missing retrieval index at {INDEX_PATH}. Run `make ingest` and `make index` first."
+        )
+    bus = Bus()
+    researcher = Researcher(bus)
+    qlm = QLM(bus, policy=Policy())
+    for agent in (researcher, qlm):
+        bus.subscribe(agent)
+
+    bus.publish(new("demo", "researcher", "task", "retrieve", query="CHSH Bell inequality", k=3))
+    bus.publish(
+        new(
+            "demo",
+            "qlm",
+            "task",
+            "solve_freeform",
+            prompt="Explain the CHSH violation for Bell states.",
+        )
+    )
+    print(f"RAG demo complete. Citations saved to {RAG_TOPK_PATH.resolve()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/qlm_lab/qlm_lab/lineage.py
+++ b/modules/qlm_lab/qlm_lab/lineage.py
@@ -1,67 +1,55 @@
 """Artifact lineage logging utilities for QLM Lab."""
 from __future__ import annotations
 
-from json import dumps
+import json
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, Iterable, List
 
 ARTIFACTS_DIR = Path(__file__).resolve().parents[1] / "artifacts"
+ROOT_ARTIFACTS_DIR = Path(__file__).resolve().parents[3] / "artifacts"
 LINEAGE_PATH = ARTIFACTS_DIR / "lineage.jsonl"
+ROOT_LINEAGE_PATH = ROOT_ARTIFACTS_DIR / "lineage.jsonl"
 
 
-DEFAULT_LINEAGE_PATH = Path(__file__).resolve().parents[1] / "artifacts" / "lineage.jsonl"
-
-
-def append(event: dict[str, object], path: Path | None = None) -> None:
-    """Append a lightweight lineage ``event`` to the JSONL log."""
-
-    target = Path(path) if path is not None else DEFAULT_LINEAGE_PATH
-    target.parent.mkdir(parents=True, exist_ok=True)
-    line = json.dumps(event, default=str)
-    with target.open("a", encoding="utf-8") as handle:
-        handle.write(line + "\n")
-
-
-
-@dataclass
-class LineageRecord:
-    """Serializable lineage record for agent activity."""
 def _coerce(value: Any) -> Any:
     """Convert values into JSON-serialisable primitives."""
 
     if isinstance(value, Path):
         return str(value)
     if isinstance(value, dict):
-        return {str(k): _coerce(v) for k, v in value.items()}
+        return {str(key): _coerce(val) for key, val in value.items()}
     if isinstance(value, (list, tuple, set)):
         return [_coerce(item) for item in value]
     return value
 
 
-def append(event: Dict[str, Any]) -> Path:
-    """Append ``event`` to the lineage JSONL log."""
+def append(event: Dict[str, Any], path: Path | None = None) -> Path:
+    """Append ``event`` to the lineage JSONL log and return the path used."""
 
-    ARTIFACTS_DIR.mkdir(parents=True, exist_ok=True)
-    payload = _coerce(event)
-    with LINEAGE_PATH.open("a", encoding="utf-8") as handle:
-        handle.write(dumps(payload, sort_keys=True) + "\n")
-    return LINEAGE_PATH
+    target = Path(path) if path is not None else LINEAGE_PATH
+    target.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(_coerce(event), sort_keys=True)
+    with target.open("a", encoding="utf-8") as handle:
+        handle.write(line + "\n")
+    if ROOT_ARTIFACTS_DIR != ARTIFACTS_DIR:
+        ROOT_ARTIFACTS_DIR.mkdir(parents=True, exist_ok=True)
+        with ROOT_LINEAGE_PATH.open("a", encoding="utf-8") as root_handle:
+            root_handle.write(line + "\n")
+    return target
+
+
+def _iter_files(root: Path) -> Iterable[Path]:
+    for entry in root.iterdir():
+        if entry.is_file():
+            yield entry
 
 
 def artifact_index() -> Dict[str, Any]:
     """Return a summary of known artifacts within the lab."""
 
     ARTIFACTS_DIR.mkdir(parents=True, exist_ok=True)
-    files: List[str] = sorted(
-        entry.name for entry in ARTIFACTS_DIR.iterdir() if entry.is_file()
-    )
+    files: List[str] = sorted(entry.name for entry in _iter_files(ARTIFACTS_DIR))
     return {"count": len(files), "files": files}
 
 
-    @property
-    def records(self) -> List[LineageRecord]:
-        return list(self._records)
-
-
-__all__ = ["LineageLogger", "LineageRecord", "append"]
-__all__ = ["append", "artifact_index", "ARTIFACTS_DIR", "LINEAGE_PATH"]
+__all__ = ["append", "artifact_index", "ARTIFACTS_DIR", "LINEAGE_PATH", "ROOT_LINEAGE_PATH"]

--- a/modules/qlm_lab/qlm_lab/llm/runtime.py
+++ b/modules/qlm_lab/qlm_lab/llm/runtime.py
@@ -1,188 +1,76 @@
+"""Runtime for executing <tool .../> tags generated offline."""
 from __future__ import annotations
 
-"""Runtime utilities for executing <tool .../> tags produced by an LLM."""
-
 import json
+import os
 import re
-import xml.etree.ElementTree as ET
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Match, Tuple
+from typing import Any, Dict, List, Tuple
 
 from ..lineage import append as log_event
 from ..policies import Policy
 from ..tools.registry import ToolRegistry
 
-_TAG = re.compile(r"<tool\s+[^>]*?/>")
-"""Runtime for executing <tool .../> tags generated offline."""
-from __future__ import annotations
-
-from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Tuple
-import json
-import os
-import re
-
-from ..policies import Policy
-
-TagRegistry = Dict[str, Callable[..., Any]]
-
-_TAG_RE = re.compile(r"<tool\s+([^>/]+?)/>")
+_TAG = re.compile(r"<tool\s+([^>/]+?)/>")
 _ATTR_RE = re.compile(r"(\w+)\s*=\s*\"((?:\\.|[^\"])*)\"")
-
-
-def _coerce(value: str) -> Any:
-    """Best-effort conversion from attribute strings to Python objects."""
-
-    try:
-        return json.loads(value)
-    except json.JSONDecodeError:
-        try:
-            cleaned = bytes(value, "utf-8").decode("unicode_escape")
-            return json.loads(cleaned)
-        except Exception:
-            pass
-        if value.isdigit():
-            return int(value)
-        try:
-            return float(value)
-        except ValueError:
-            lowered = value.lower()
-            if lowered in {"true", "false"}:
-                return lowered == "true"
-            return value
 
 
 @dataclass
 class ToolContext:
-    """Variable scope shared across tool invocations."""
+    """Execution context tracking variables and artifacts."""
 
     vars: Dict[str, Any] = field(default_factory=dict)
+    artifacts: List[str] = field(default_factory=list)
+
+    def remember(self, value: Any) -> None:
+        """Record ``value`` if it corresponds to a persisted artifact."""
+
+        if isinstance(value, str) and os.path.exists(value) and value not in self.artifacts:
+            self.artifacts.append(value)
 
 
-def _coerce(val: str) -> Any:
-    v = val.strip()
-    if v.lower() in {"true", "false"}:
-        return v.lower() == "true"
+def _decode_value(value: str) -> Any:
     try:
-        if "." in v:
-            return float(v)
-        return int(v)
-    except ValueError:
-        return v
+        return json.loads(value)
+    except json.JSONDecodeError:
+        lowered = value.lower()
+        if lowered in {"true", "false"}:
+            return lowered == "true"
+        try:
+            if "." in value:
+                return float(value)
+            return int(value)
+        except ValueError:
+            return value
 
 
-def _parse_attrs(elem: ET.Element) -> Dict[str, Any]:
+def _parse_attrs(raw: str) -> Dict[str, Any]:
+    attrs = dict(_ATTR_RE.findall(raw))
     out: Dict[str, Any] = {}
-    for key, value in elem.attrib.items():
+    for key, value in attrs.items():
         if key == "args":
             try:
-                out.update(json.loads(value))
-            except Exception:
-                out["args_raw"] = value
+                data = json.loads(value)
+                if isinstance(data, dict):
+                    out.update(data)
+                else:
+                    out[key] = data
+            except json.JSONDecodeError:
+                out[key] = value
         else:
-            out[key] = _coerce(value)
+            out[key] = _decode_value(value)
     return out
 
 
-def _resolve_args(attrs: Dict[str, Any], ctx: ToolContext) -> Tuple[str, Dict[str, Any], str | None, str]:
-    name = attrs.pop("name")
-    as_var = attrs.pop("as", None)
-    from_var = attrs.pop("from", None)
-    fname = attrs.pop("fname", None)
-    if from_var:
-        obj = ctx.vars.get(from_var)
-        if obj is None:
-            raise ValueError(f"Unknown var '{from_var}'")
-        attrs["from_obj"] = obj
-    if fname is not None:
-        attrs["fname"] = fname
-    return name, attrs, as_var, from_var or ""
-
-
-def execute_tagged_text(
-    text: str, registry: ToolRegistry, policy: Policy, ctx: ToolContext | None = None
-) -> Tuple[str, List[Dict[str, Any]]]:
-    """Execute tool tags in ``text`` and return the stitched output and trace."""
-
-    ctx = ctx or ToolContext()
-    trace: List[Dict[str, Any]] = []
-
-    def _repl(match: Match[str]) -> str:
-        tag = match.group(0)
-        try:
-            elem = ET.fromstring(tag)
-            attrs = _parse_attrs(elem)
-            name, args, as_var, from_var = _resolve_args(attrs, ctx)
-            if name.startswith("llm.") and not policy.allow_network:
-                raise PermissionError("Network/remote LLM disabled by policy")
-            fn = registry.get(name)
-            call_args = dict(args)
-            if "from_obj" in call_args:
-                from_obj = call_args.pop("from_obj")
-                result = fn(from_obj, **call_args)
-            else:
-                result = fn(**call_args)
-            if as_var:
-                ctx.vars[as_var] = result
-            log_event(
-                {
-                    "kind": "tool",
-                    "name": name,
-                    "args": {k: str(v)[:200] for k, v in call_args.items()},
-                    "as": as_var,
-                    "from": from_var,
-                }
-            )
-            rtype = type(result).__name__
-            trace.append({"name": name, "type": rtype, "as": as_var, "from": from_var})
-            return f'<result name="{as_var or name}" type="{rtype}"/>'
-        except Exception as exc:  # pragma: no cover - exercised indirectly
-            log_event({"kind": "tool_error", "tag": tag, "error": str(exc)})
-            return f'<error tool="{tag}" reason="{str(exc)}"/>'
-
-    new_text = _TAG.sub(_repl, text)
-    return new_text, trace
-
-
-__all__ = ["ToolContext", "execute_tagged_text"]
-    """Execution context tracking variables and artifacts."""
-
-    variables: Dict[str, Any] = field(default_factory=dict)
-    artifacts: List[str] = field(default_factory=list)
-
-    def remember(self, name: str, value: Any) -> None:
-        self.variables[name] = value
-        if isinstance(value, str) and os.path.exists(value):
-            if value not in self.artifacts:
-                self.artifacts.append(value)
-
-
-@dataclass
-class ToolTrace:
-    name: str
-    alias: str | None
-    result_preview: str
-    artifacts: Tuple[str, ...] = tuple()
-
-    def as_dict(self) -> Dict[str, Any]:
-        payload = {"name": self.name, "result": self.result_preview}
-        if self.alias:
-            payload["as"] = self.alias
-        if self.artifacts:
-            payload["artifacts"] = list(self.artifacts)
-        return payload
-
-
-def _parse_tag(raw: str) -> Dict[str, str]:
-    attrs = dict(_ATTR_RE.findall(raw))
-    if "name" not in attrs:
-        raise ValueError(f"tool tag missing name attribute: {raw}")
-    return attrs
+def _lookup(registry: ToolRegistry | Dict[str, Any], name: str):
+    if hasattr(registry, "get"):
+        return registry.get(name)
+    return registry[name]
 
 
 def execute_tagged_text(
     text: str,
-    registry: TagRegistry,
+    registry: ToolRegistry | Dict[str, Any],
     policy: Policy | None = None,
     ctx: ToolContext | None = None,
 ) -> Tuple[str, List[Dict[str, Any]]]:
@@ -193,36 +81,51 @@ def execute_tagged_text(
     cursor = 0
     rendered: List[str] = []
     trace: List[Dict[str, Any]] = []
-    for match in _TAG_RE.finditer(text):
+
+    for match in _TAG.finditer(text):
         rendered.append(text[cursor : match.start()])
-        attrs = _parse_tag(match.group(1))
-        name = attrs.pop("name")
+        attrs = _parse_attrs(match.group(1))
+        name = attrs.pop("name", None)
+        if not name:
+            raise ValueError(f"tool tag missing name attribute: {match.group(0)}")
+        if name.startswith("llm.") and not policy.allow_network:
+            log_event({"kind": "tool_error", "name": name, "error": "network disabled"})
+            rendered.append(f'<error tool="{name}" reason="network disabled"/>')
+            cursor = match.end()
+            continue
         alias = attrs.pop("as", None)
-        source_name = attrs.pop("from", None)
-        args_payload = attrs.pop("args", None)
-        if not policy.allows(name):
-            raise PermissionError(f"Tool {name} blocked by policy")
-        func = registry.get(name)
-        if func is None:
-            raise KeyError(f"Unknown tool: {name}")
-        positional: List[Any] = []
-        if source_name:
-            if source_name not in ctx.variables:
-                raise KeyError(f"Unknown variable '{source_name}' for tool {name}")
-            positional.append(ctx.variables[source_name])
-        if args_payload is not None:
-            positional.append(_coerce(args_payload))
-        kwargs = {key: _coerce(value) for key, value in attrs.items()}
-        result = func(*positional, **kwargs)
+        source_var = attrs.pop("from", None)
+        call_kwargs = dict(attrs)
+        try:
+            func = _lookup(registry, name)
+            if source_var:
+                if source_var not in ctx.vars:
+                    raise ValueError(f"Unknown var '{source_var}'")
+                result = func(ctx.vars[source_var], **call_kwargs)
+            else:
+                result = func(**call_kwargs)
+        except Exception as exc:
+            log_event({"kind": "tool_error", "name": name, "error": str(exc)})
+            rendered.append(f'<error tool="{name}" reason="{str(exc)}"/>')
+            cursor = match.end()
+            continue
         if alias:
-            ctx.remember(alias, result)
-        artifacts: List[str] = []
-        if isinstance(result, str) and os.path.exists(result):
-            ctx.remember(alias or name, result)
-            artifacts.append(result)
-        preview = repr(result)
-        trace.append(ToolTrace(name, alias, preview, tuple(artifacts)).as_dict())
-        rendered.append(f'<result name="{name}" as="{alias or ""}"/>')
+            ctx.vars[alias] = result
+        ctx.remember(result)
+        trace.append({"name": name, "as": alias, "from": source_var, "type": type(result).__name__})
+        log_event(
+            {
+                "kind": "tool",
+                "name": name,
+                "as": alias,
+                "from": source_var,
+                "args": {k: str(v)[:200] for k, v in call_kwargs.items()},
+            }
+        )
+        rendered.append(f'<result name="{alias or name}" type="{type(result).__name__}"/>')
         cursor = match.end()
     rendered.append(text[cursor:])
-    return ("".join(rendered), trace)
+    return "".join(rendered), trace
+
+
+__all__ = ["ToolContext", "execute_tagged_text"]

--- a/modules/qlm_lab/qlm_lab/policies.py
+++ b/modules/qlm_lab/qlm_lab/policies.py
@@ -1,45 +1,11 @@
-from __future__ import annotations
-
-"""Policy helpers for QLM Lab demos and agents."""
-
-import os
-from dataclasses import dataclass, field
 """Policy primitives for QLM Lab."""
 from __future__ import annotations
 
-from dataclasses import dataclass
+import os
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, List, Mapping
 
-
-def _default_artifact_dir() -> Path:
-    """Return the default artifact directory for the lab."""
-
-    return Path(__file__).resolve().parents[1] / "artifacts"
-
-
-@dataclass
-class Policy:
-    """Runtime policy applied to tool-calling flows."""
-
-    allow_network: bool = False
-    artifact_dir: Path = field(default_factory=_default_artifact_dir)
-    lineage_path: Path = field(init=False)
-
-    def __post_init__(self) -> None:
-        if not isinstance(self.artifact_dir, Path):
-            self.artifact_dir = Path(self.artifact_dir)
-        self.artifact_dir.mkdir(parents=True, exist_ok=True)
-        self.lineage_path = self.artifact_dir / "lineage.jsonl"
-        self.lineage_path.parent.mkdir(parents=True, exist_ok=True)
-
-
-@dataclass
-class Policy:
-    """Runtime policy describing network and artifact constraints."""
-
-    allow_network: bool = False
-    max_artifacts_mb: int = 20
 
 @dataclass
 class Policy:
@@ -49,28 +15,15 @@ class Policy:
     max_artifacts_mb: float = 20.0
     required_artifacts: List[str] = field(default_factory=list)
 
-    def allows(self, tool_name: str) -> bool:
-        if not self.allow_network and tool_name.startswith(('llm.', 'network.')):
-            return False
-        return True
-
-
-def artifact_paths(root: Path, patterns: Iterable[str]) -> List[Path]:
-    """Resolve artifact paths relative to ``root``."""
-def _iter_files(root: Path) -> Iterable[Path]:
-    for path in root.rglob("*"):
-        if path.is_file():
-            yield path
-
 
 def enforce_file_caps(artifacts_dir: str | Path, policy: Policy | None = None) -> None:
-    """Raise ``RuntimeError`` if the total artifact size exceeds the policy cap."""
+    """Raise ``RuntimeError`` if artifacts exceed the configured quota."""
 
     policy = policy or Policy()
     root = Path(artifacts_dir)
     if not root.exists():
         return
-    total_bytes = sum(path.stat().st_size for path in _iter_files(root))
+    total_bytes = sum(path.stat().st_size for path in root.rglob("*") if path.is_file())
     limit_bytes = policy.max_artifacts_mb * 1_048_576
     if total_bytes > limit_bytes:
         raise RuntimeError(
@@ -78,17 +31,10 @@ def enforce_file_caps(artifacts_dir: str | Path, policy: Policy | None = None) -
         )
 
 
-    total_bytes = 0
-    for path in paths:
-        if path.exists():
-            total_bytes += path.stat().st_size
-    return total_bytes <= max_megabytes * 1_048_576
+def ensure_required_artifacts(root: Path, patterns: Iterable[str]) -> List[Path]:
+    """Return missing artifact paths relative to ``root``."""
 
-
-def ensure_required_artifacts(paths: Iterable[Path]) -> List[Path]:
-    """Return the subset of ``paths`` that are missing on disk."""
-
-    return [path for path in paths if not path.exists()]
+    return [root / pattern for pattern in patterns if not (root / pattern).exists()]
 
 
 def chsh_within_bounds(value: float, lower: float = 2.2, upper: float = 2.9) -> bool:
@@ -98,30 +44,26 @@ def chsh_within_bounds(value: float, lower: float = 2.2, upper: float = 2.9) -> 
 
 
 def coverage_thresholds_met(coverage: Mapping[str, float], minimum: float) -> bool:
-    """Ensure all provided coverage values exceed the ``minimum`` threshold."""
+    """Ensure all provided coverage values exceed ``minimum``."""
 
-    return all(value >= minimum for value in coverage.values())
+    return all(score >= minimum for score in coverage.values())
 
 
-def network_allowed(config: PolicyConfig | None = None) -> bool:
-    """Determine whether network access is permitted by policy."""
+def network_allowed(policy: Policy | None = None) -> bool:
+    """Determine whether network access is permitted by policy or env override."""
 
-    config = config or PolicyConfig()
-    env_override = os.environ.get("QLAB_ALLOW_NETWORK")
-    if env_override is not None:
-        return env_override.lower() in {"1", "true", "yes"}
-    return config.allow_network
+    policy = policy or Policy()
+    override = os.environ.get("QLAB_ALLOW_NETWORK")
+    if override is not None:
+        return override.lower() in {"1", "true", "yes"}
+    return policy.allow_network
 
 
 __all__ = [
     "Policy",
-    "PolicyConfig",
-    "Policy",
-    "artifact_paths",
-    "check_artifact_quota",
+    "enforce_file_caps",
     "ensure_required_artifacts",
     "chsh_within_bounds",
     "coverage_thresholds_met",
     "network_allowed",
 ]
-__all__ = ["Policy", "enforce_file_caps"]

--- a/modules/qlm_lab/qlm_lab/retrieval/__init__.py
+++ b/modules/qlm_lab/qlm_lab/retrieval/__init__.py
@@ -1,0 +1,7 @@
+"""Lightweight retrieval stack for local RAG flows."""
+from .chunk import Chunk, by_lines
+from .ingest import ingest
+from .index import TfidfIndex
+from .search import topk
+
+__all__ = ["Chunk", "by_lines", "ingest", "TfidfIndex", "topk"]

--- a/modules/qlm_lab/qlm_lab/retrieval/chunk.py
+++ b/modules/qlm_lab/qlm_lab/retrieval/chunk.py
@@ -1,0 +1,42 @@
+"""Corpus chunking utilities for the local retrieval index."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass(slots=True)
+class Chunk:
+    """Represent a contiguous slice of a source document."""
+
+    doc_id: str
+    path: str
+    start_line: int
+    end_line: int
+    text: str
+
+
+def by_lines(
+    text: str,
+    path: str,
+    doc_id: str,
+    max_lines: int = 80,
+    overlap: int = 10,
+) -> List[Chunk]:
+    """Split ``text`` into ``Chunk`` objects using a sliding window."""
+
+    lines = text.splitlines()
+    out: List[Chunk] = []
+    i = 0
+    n = len(lines)
+    if n == 0:
+        return out
+    step = max(max_lines - overlap, 1)
+    while i < n:
+        j = min(n, i + max_lines)
+        chunk_text = "\n".join(lines[i:j])
+        out.append(Chunk(doc_id=doc_id, path=path, start_line=i + 1, end_line=j, text=chunk_text))
+        if j == n:
+            break
+        i += step
+    return out

--- a/modules/qlm_lab/qlm_lab/retrieval/index.py
+++ b/modules/qlm_lab/qlm_lab/retrieval/index.py
@@ -1,0 +1,97 @@
+"""TF-IDF index construction for the retrieval stack."""
+from __future__ import annotations
+
+import json
+import math
+from collections import Counter, defaultdict
+from typing import Dict, List, Tuple
+
+
+def _tokens(text: str) -> List[str]:
+    """Tokenise ``text`` using a lightweight alphanumeric filter."""
+
+    filtered = [ch.lower() if ch.isalnum() else " " for ch in text]
+    return [token for token in "".join(filtered).split() if token]
+
+
+class TfidfIndex:
+    """Sparse TF-IDF index with cosine similarity search."""
+
+    def __init__(self) -> None:
+        self.vocab: Dict[str, int] = {}
+        self.idf: List[float] = []
+        self.vecs: List[List[Tuple[int, float]]] = []
+        self.meta: List[Dict[str, object]] = []
+
+    def build(self, corpus_jsonl: str) -> None:
+        """Populate the index from a corpus JSONL file."""
+
+        docs: List[Dict[str, object]] = []
+        with open(corpus_jsonl, "r", encoding="utf-8") as handle:
+            for line in handle:
+                docs.append(json.loads(line))
+        if not docs:
+            self.vocab = {}
+            self.idf = []
+            self.vecs = []
+            self.meta = []
+            return
+        doc_freq: Dict[str, int] = defaultdict(int)
+        term_freqs: List[Counter[str]] = []
+        for doc in docs:
+            tokens = _tokens(doc["text"])
+            counts = Counter(tokens)
+            term_freqs.append(counts)
+            for token in counts:
+                doc_freq[token] += 1
+        self.vocab = {word: idx for idx, word in enumerate(sorted(doc_freq))}
+        total_docs = len(docs)
+        self.idf = [math.log((total_docs + 1) / (doc_freq[word] + 1)) + 1.0 for word in sorted(doc_freq)]
+        self.vecs = []
+        self.meta = docs
+        for counts in term_freqs:
+            items: List[Tuple[int, float]] = []
+            length = sum(counts.values()) or 1
+            norm_sq = 0.0
+            for word, freq in counts.items():
+                if word not in self.vocab:
+                    continue
+                idx = self.vocab[word]
+                value = (freq / length) * self.idf[idx]
+                items.append((idx, value))
+                norm_sq += value * value
+            norm = math.sqrt(norm_sq) if norm_sq > 0 else 1.0
+            self.vecs.append([(idx, val / norm) for idx, val in items])
+
+    def save(self, path: str) -> None:
+        """Serialise the index to ``path`` as JSON."""
+
+        with open(path, "w", encoding="utf-8") as handle:
+            json.dump(
+                {
+                    "vocab": self.vocab,
+                    "idf": self.idf,
+                    "vecs": self.vecs,
+                    "meta": self.meta,
+                },
+                handle,
+            )
+
+    @staticmethod
+    def load(path: str) -> "TfidfIndex":
+        """Load an index from disk."""
+
+        with open(path, "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        index = TfidfIndex()
+        index.vocab = {str(word): int(idx) for word, idx in payload["vocab"].items()}
+        index.idf = [float(value) for value in payload["idf"]]
+        index.vecs = [
+            [(int(position), float(weight)) for position, weight in row]
+            for row in payload["vecs"]
+        ]
+        index.meta = payload["meta"]
+        return index
+
+
+__all__ = ["TfidfIndex", "_tokens"]

--- a/modules/qlm_lab/qlm_lab/retrieval/ingest.py
+++ b/modules/qlm_lab/qlm_lab/retrieval/ingest.py
@@ -1,0 +1,48 @@
+"""Corpus ingestion helpers for building the retrieval index."""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict
+from pathlib import Path
+
+from .chunk import Chunk, by_lines
+
+TEXT_EXT = {".md", ".txt", ".py"}
+
+
+def read_text(path: str) -> str:
+    """Return the UTF-8 text content for ``path`` when supported."""
+
+    ext = Path(path).suffix.lower()
+    if ext not in TEXT_EXT:
+        return ""
+    try:
+        with open(path, "r", encoding="utf-8", errors="ignore") as handle:
+            return handle.read()
+    except OSError:
+        return ""
+
+
+def ingest(root: str, out_path: str) -> int:
+    """Walk ``root`` and write chunked corpus entries to ``out_path``."""
+
+    count = 0
+    root_path = Path(root)
+    out_file = Path(out_path)
+    out_file.parent.mkdir(parents=True, exist_ok=True)
+    with out_file.open("w", encoding="utf-8") as handle:
+        for dirpath, _, filenames in os.walk(root):
+            for filename in filenames:
+                path = os.path.join(dirpath, filename)
+                text = read_text(path)
+                if not text.strip():
+                    continue
+                rel = os.path.relpath(path, root_path)
+                for chunk in by_lines(text, path=path, doc_id=rel):
+                    handle.write(json.dumps(asdict(chunk), ensure_ascii=False) + "\n")
+                    count += 1
+    return count
+
+
+__all__ = ["Chunk", "ingest", "read_text", "TEXT_EXT"]

--- a/modules/qlm_lab/qlm_lab/retrieval/search.py
+++ b/modules/qlm_lab/qlm_lab/retrieval/search.py
@@ -1,0 +1,43 @@
+"""Cosine similarity search against the TF-IDF index."""
+from __future__ import annotations
+
+import math
+from collections import Counter
+from typing import Dict, List, Tuple
+
+from .index import TfidfIndex, _tokens
+
+
+def _dense_query(tokens: List[str], vocab: Dict[str, int], idf: List[float]) -> Dict[int, float]:
+    """Return a normalised sparse vector for ``tokens``."""
+
+    counts = Counter(tokens)
+    total = sum(counts.values()) or 1.0
+    vec: Dict[int, float] = {}
+    for word, freq in counts.items():
+        if word in vocab:
+            idx = vocab[word]
+            vec[idx] = (freq / total) * idf[idx]
+    norm = math.sqrt(sum(value * value for value in vec.values()) or 1.0)
+    return {idx: value / norm for idx, value in vec.items()}
+
+
+def topk(index: TfidfIndex, query: str, k: int = 5) -> List[Tuple[int, float]]:
+    """Return the top ``k`` results for ``query`` sorted by cosine score."""
+
+    tokens = _tokens(query)
+    if not tokens or not index.vecs:
+        return []
+    query_vec = _dense_query(tokens, index.vocab, index.idf)
+    scores: List[Tuple[int, float]] = []
+    for row_idx, row in enumerate(index.vecs):
+        score = 0.0
+        for col_idx, weight in row:
+            if col_idx in query_vec:
+                score += weight * query_vec[col_idx]
+        scores.append((row_idx, score))
+    scores.sort(key=lambda item: item[1], reverse=True)
+    return scores[:k]
+
+
+__all__ = ["topk"]

--- a/modules/qlm_lab/qlm_lab/tools/registry.py
+++ b/modules/qlm_lab/qlm_lab/tools/registry.py
@@ -1,13 +1,9 @@
+"""Tool registry helpers for the Toolformer runtime."""
 from __future__ import annotations
-
-"""Tool registry for mapping tag names to callables."""
 
 from typing import Any, Callable, Dict
 
-from . import la
-from . import math_cas
-from . import quantum_np as Q
-from . import viz as V
+from . import la, math_cas, quantum_np, viz
 
 
 class ToolRegistry:
@@ -17,27 +13,28 @@ class ToolRegistry:
         self._map: Dict[str, Callable[..., Any]] = {}
 
     def register(self, name: str, fn: Callable[..., Any]) -> None:
-        """Register ``fn`` under ``name``."""
-
         self._map[name] = fn
 
     def get(self, name: str) -> Callable[..., Any]:
-        """Return the callable registered for ``name``."""
-
         if name not in self._map:
             raise KeyError(f"Unknown tool '{name}'")
         return self._map[name]
+
+    def as_dict(self) -> Dict[str, Callable[..., Any]]:
+        return dict(self._map)
 
 
 def default_registry() -> ToolRegistry:
     """Populate a registry with the standard QLM tools."""
 
     reg = ToolRegistry()
-    reg.register("quantum_np.bell_phi_plus", Q.bell_phi_plus)
-    reg.register("quantum_np.measure_counts", Q.measure_counts)
-    reg.register("quantum_np.chsh_value_phi_plus", Q.chsh_value_phi_plus)
-    reg.register("quantum_np.qft_matrix", Q.qft_matrix)
-    reg.register("viz.hist", V.hist)
+    reg.register("quantum_np.bell_phi_plus", quantum_np.bell_phi_plus)
+    reg.register("quantum_np.measure_counts", quantum_np.measure_counts)
+    reg.register("quantum_np.chsh_value_phi_plus", quantum_np.chsh_value_phi_plus)
+    reg.register("quantum_np.qft_matrix", quantum_np.qft_matrix)
+    reg.register("viz.hist", viz.hist)
+    reg.register("viz.bloch", viz.bloch)
+    reg.register("viz.ascii_circuit", viz.ascii_circuit)
     if hasattr(la, "eig"):
         reg.register("la.eig", getattr(la, "eig"))
     if hasattr(math_cas, "simplify"):
@@ -46,28 +43,3 @@ def default_registry() -> ToolRegistry:
 
 
 __all__ = ["ToolRegistry", "default_registry"]
-"""Tool registry helpers for the Toolformer runtime."""
-from __future__ import annotations
-
-from typing import Dict, Callable, Any
-
-from . import quantum_np, viz
-
-Registry = Dict[str, Callable[..., Any]]
-
-
-def default_registry() -> Registry:
-    """Return the default mapping from tag names to callables."""
-
-    return {
-        "quantum_np.bell_phi_plus": quantum_np.bell_phi_plus,
-        "quantum_np.measure_counts": quantum_np.measure_counts,
-        "quantum_np.chsh_value_phi_plus": quantum_np.chsh_value_phi_plus,
-        "quantum_np.qft_matrix": quantum_np.qft_matrix,
-        "viz.hist": viz.hist,
-        "viz.bloch": viz.bloch,
-        "viz.ascii_circuit": viz.ascii_circuit,
-    }
-
-
-__all__ = ["default_registry", "Registry"]

--- a/modules/qlm_lab/qlm_lab/tools/viz.py
+++ b/modules/qlm_lab/qlm_lab/tools/viz.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 from pathlib import Path
 from typing import Dict, Iterable
 
@@ -10,7 +11,9 @@ import numpy as np
 from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 - ensures 3D toolkit registered
 
 ART_DIR = Path(__file__).resolve().parents[2] / "artifacts"
-ART_DIR.mkdir(exist_ok=True)
+ART_DIR.mkdir(parents=True, exist_ok=True)
+ROOT_ART_DIR = Path(__file__).resolve().parents[4] / "artifacts"
+ROOT_ART_DIR.mkdir(parents=True, exist_ok=True)
 
 __all__ = ["hist", "bloch", "ascii_circuit"]
 
@@ -32,6 +35,11 @@ def hist(probs: Dict[str, float], fname: str = "hist.png") -> str:
     plt.title("Distribution")
     fig.savefig(path, dpi=160, bbox_inches="tight")
     plt.close(fig)
+    root_path = ROOT_ART_DIR / fname
+    try:
+        shutil.copy2(path, root_path)
+    except Exception:  # pragma: no cover - best effort mirroring
+        pass
     return str(path)
 
 
@@ -56,6 +64,11 @@ def bloch(point: Iterable[float], fname: str = "bloch_q0.png") -> str:
     ax.set_box_aspect([1, 1, 1])
     fig.savefig(path, dpi=160, bbox_inches="tight")
     plt.close(fig)
+    root_path = ROOT_ART_DIR / fname
+    try:
+        shutil.copy2(path, root_path)
+    except Exception:  # pragma: no cover - best effort mirroring
+        pass
     return str(path)
 
 

--- a/modules/qlm_lab/tests/test_researcher_agent.py
+++ b/modules/qlm_lab/tests/test_researcher_agent.py
@@ -1,0 +1,31 @@
+import json
+
+from qlm_lab.agents.researcher import ARTIFACTS_DIR, CORPUS_PATH, INDEX_PATH, RAG_TOPK_PATH, Researcher
+from qlm_lab.bus import Bus
+from qlm_lab.proto import new
+from qlm_lab.retrieval.index import TfidfIndex
+from qlm_lab.retrieval.ingest import ingest
+
+
+def _prepare_index() -> None:
+    ARTIFACTS_DIR.mkdir(parents=True, exist_ok=True)
+    ingest("modules/qlm_lab/docs_local", str(CORPUS_PATH))
+    index = TfidfIndex()
+    index.build(str(CORPUS_PATH))
+    index.save(str(INDEX_PATH))
+
+
+def test_researcher_returns_citations():
+    _prepare_index()
+    bus = Bus()
+    researcher = Researcher(bus)
+    bus.subscribe(researcher)
+    results = []
+    bus.subscribe(lambda msg: results.append(msg))
+    bus.publish(new("tester", "researcher", "task", "retrieve", query="Bell CHSH", k=2))
+    assert any(msg.op == "citations" for msg in results)
+    assert RAG_TOPK_PATH.exists()
+    data = json.loads(RAG_TOPK_PATH.read_text(encoding="utf-8"))
+    assert len(data) >= 1
+    first = data[0]
+    assert {"path", "start", "end", "score", "text"} <= set(first)

--- a/modules/qlm_lab/tests/test_retrieval_stack.py
+++ b/modules/qlm_lab/tests/test_retrieval_stack.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+from qlm_lab.retrieval.ingest import ingest
+from qlm_lab.retrieval.index import TfidfIndex
+from qlm_lab.retrieval.search import topk
+
+ROOT = Path("modules/qlm_lab/docs_local")
+ART = Path("modules/qlm_lab/artifacts")
+
+
+def test_ingest_index_search():
+    ART.mkdir(exist_ok=True)
+    corpus = ART / "corpus.jsonl"
+    count = ingest(str(ROOT), str(corpus))
+    assert count > 0
+    index = TfidfIndex()
+    index.build(str(corpus))
+    index_path = ART / "index.json"
+    index.save(str(index_path))
+    assert index_path.exists()
+    hits = topk(index, "CHSH inequality", k=3)
+    assert hits
+    assert hits[0][1] >= 0.0

--- a/prism/agents/qlm_lab/manifest.yaml
+++ b/prism/agents/qlm_lab/manifest.yaml
@@ -1,6 +1,7 @@
 module: qlm_lab
 entrypoints:
   planner: qlm_lab.agents.planner:Planner
+  researcher: qlm_lab.agents.researcher:Researcher
   qlm: qlm_lab.agents.qlm:QLM
   critic: qlm_lab.agents.critic:Critic
   archivist: qlm_lab.agents.archivist:Archivist
@@ -10,3 +11,4 @@ policies:
 required_artifacts:
   - bell_hist.png
   - bell_hist_empirical.png
+  - rag_topk.json

--- a/prism/policies/gates/qlm_lab_rag.rego
+++ b/prism/policies/gates/qlm_lab_rag.rego
@@ -1,0 +1,7 @@
+package prism.gates.qlm_lab_rag
+
+default allow = false
+
+allow {
+  input.citations.count >= 2
+}


### PR DESCRIPTION
**Summary**

* QLM + LLM agents wired via bus/proto
* NumPy quantum tools (Bell, CHSH, Grover, QFT)
* Viz (Bloch/hist), lineage logs, demos, notebooks
* Tests + CI; Prism gate + manifest
* Local TF-IDF retrieval with Researcher citations and RAG demo

**Acceptance Evidence**

* CI run: [link]
* Artifacts: uploaded bundle
* Coverage JSON: attached
* Gate result: `allow=true`

**Notes**

* Qiskit wrappers stubbed; enable with `pip install qlm-lab[qiskit]` and `QISKIT_API_TOKEN`.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690da1a827788329bb300b352afad61f)