### PR TITLE
Add Origin Campus architecture note and scene layout

### DIFF
--- a/docs/prism/origin-campus.md
+++ b/docs/prism/origin-campus.md
@@ -1,0 +1,98 @@
+# Origin Campus Architecture
+
+This note captures the first-pass layout for the Origin Campus experience and the
+supporting systems that make the Ellis-Island metaphor work in-engine.
+
+## Campus Flow
+
+1. **Harbor (spawn)** – Players and agent-run PCs arrive by shuttle and are
+   greeted by compliance signage plus the current build notes. Spawn kiosks
+   issue a temporary visitor token tied to the next available registry pedestal.
+2. **Registry Hall** – Identity stations record a short introduction, bind the
+   visitor token to a campus profile, and explain rules of engagement. From
+   here, visitors proceed to the Proof Wing.
+3. **QLM Dome** – Pedestals fan out around the dome floor. Activating one queues
+   a QLM task (Bell/CHSH demo, Grover search, code synthesis, etc.) and
+   displays a deterministic preview. Successful runs mint an artifact (image or
+   JSON) and stamp the visitor profile. Failed runs surface remediation tips.
+4. **Sandbox Parcels** – Visa-stamped visitors can claim a parcel, place their
+   artifact, and annotate it with lineage metadata. Parcel kits include simple
+   structures, lighting presets, and RoadCoin reward plaques.
+5. **Archive Walk** – Gallery boards surface recent artifacts, lineage chains,
+   and compliance verdicts. Visitors can replay the generating task with
+   provenance intact.
+6. **RoadView Tower** – Search and analytics hub. Queries fan out to the
+   evidence log, parcel registry, and RoadCoin ledger (simulation only) for
+   dashboards and digests.
+
+## System Split
+
+- **Client (Unity)** – Owns presence, input, physics, UI, parcel editing, and
+  local visualization of artifacts. All authoritative state comes from the
+  gateway; local predictions are reconciled against server truth.
+- **Authoritative Gateway (Node/TypeScript)** – Maintains player sessions,
+  parcel ownership, artifact registry, and RoadCoin balances. Spawns artifacts
+  when upstream services emit a signed lineage bundle. Exposes a WebSocket API
+  for Unity and REST/gRPC surfaces for external tooling.
+- **QLM Lab Service (Python)** – Accepts queued quantum-learning missions,
+  executes deterministic demos (Bell/CHSH, Grover, phase estimation), hashes the
+  outputs, and returns artifact manifests. Runs under strict policy guardrails
+  (no outbound network, bounded artifact size) and reports telemetry to the
+  gateway.
+
+## Agent PCs & Task Flow
+
+- **QLM PCs** are avatars plus a task queue. Interacting with them or with
+  Dome pedestals enqueues a QLM job.
+- Jobs carry lineage metadata: requester identity, policy pack versions, seed,
+  and expected outcome range (e.g., CHSH S between 2.4 and 2.8).
+- QLM Lab returns signed manifests (artifact URI, preview, lineage block). The
+  gateway verifies signatures, stores the manifest, and instructs Unity to spawn
+  the artifact at the correct pedestal or parcel.
+- Failure paths include remediation hints, queue retries (bounded), and policy
+  escalation if measured S-values fall outside the allowed range.
+
+## Economy (Simulation Only)
+
+- RoadCoin credits exist purely inside the campus simulation. They reward
+  verified builds, completed lessons, or peer instruction sessions.
+- The gateway mints and burns credits; no external wallet or chain integration
+  is permitted in-campus. Balances reset when a profile leaves the sandbox
+  unless promoted to contributor status by staff.
+
+## Evidence & Compliance
+
+- Every action (arrival, task queue, artifact spawn, parcel update) emits an
+  append-only JSONL entry with hash chaining.
+- Continuous Integration gates use Rego policies to confirm:
+  - Artifacts referenced by campus state exist and are hash-matched.
+  - QLM metrics (e.g., CHSH S statistic) fall within safe ranges.
+  - Test coverage and secret scans meet the configured thresholds.
+- Audit dashboards in RoadView consume these logs to display lineage proof,
+  error spikes, and compliance posture.
+
+## Modding Path
+
+- Contributors import Blender assets through a lightweight Unity importer that
+  enforces scale/origin conventions and tags bundles for parcel placement.
+- Parcel kits expose scripted hooks so agent PCs can annotate, repair, or
+  extend community-built structures without overwriting creator intent.
+- Agent-authored improvements run through the same artifact/lineage pipeline,
+  ensuring parity between human and agent contributions.
+
+## Parallel Prompt Tracks
+
+1. **Unity Foundations** – Input, locomotion, camera, and core campus scaffold.
+2. **Gateway & Persistence** – Node/TypeScript service, session handling,
+   artifact registry, RoadCoin ledger, and hash-chained logs.
+3. **QLM Bridge** – Task queue, gRPC/REST contract, artifact verification,
+   lineage payloads, and policy integration.
+4. **Parcels & Economy (Sim)** – Parcel claim flow, placement tools, simulated
+   RoadCoin rules, and staff moderation hooks.
+5. **Observability / Policy / CI** – Rego gates, coverage enforcement, telemetry
+   export, dashboards, and incident loops.
+6. **Content Pipeline & Origin Map** – Blender→Unity importer, parcel kits,
+   signage, and the first-pass campus map described above.
+
+These tracks advance in parallel but handshake through the authoritative
+gateway and the append-only evidence log to keep campus truth synchronized.

--- a/scenes/origin_campus.yaml
+++ b/scenes/origin_campus.yaml
@@ -1,0 +1,159 @@
+name: Origin Campus
+slug: origin_campus
+engine: unity
+version: 0.1.0
+description: >-
+  First-pass campus layout inspired by the Ellis-Island arrival flow.
+  Establishes the Harbor spawn, Registry Hall identity checks, QLM Dome
+  proofs, Sandbox Parcels, Archive Walk, and RoadView Tower analytics.
+defaults:
+  wait: 0.75
+  easing: smooth
+layers:
+  - label: Initialize harbor and registry
+    topic: sim/environment
+    payload:
+      scene_asset: Origin_Campus.unity
+      skybox: dawn_harbor
+      spawn_point:
+        position: [0.0, 1.6, -12.0]
+        facing: [0.0, 0.0, 1.0]
+      ambient_score: "harbor_strings"
+      signage:
+        - location: harbor
+          copy: "Welcome to Origin Campus — claim a pedestal to begin."
+        - location: registry
+          copy: "Present your temporary visa chip to receive your profile."
+  - label: Define key zones
+    topic: sim/environment/zones
+    payload:
+      zones:
+        - id: harbor
+          name: Harbor
+          anchor:
+            position: [0.0, 0.0, -10.0]
+            scale: [6.0, 1.0, 6.0]
+          cues:
+            lighting: "soft_morning"
+            effects: ["mist", "signal_lights"]
+        - id: registry-hall
+          name: Registry Hall
+          anchor:
+            position: [4.5, 0.0, -2.0]
+            scale: [4.0, 1.0, 6.0]
+          cues:
+            lighting: "warm_brass"
+            soundtrack: "ledger_percussion"
+        - id: qlm-dome
+          name: QLM Dome
+          anchor:
+            position: [0.0, 0.0, 6.5]
+            scale: [8.0, 1.0, 8.0]
+          cues:
+            lighting: "prism_caustics"
+            soundtrack: "quantum_resonance"
+        - id: sandbox-parcels
+          name: Sandbox Parcels
+          anchor:
+            position: [-9.5, 0.0, 8.0]
+            scale: [12.0, 1.0, 10.0]
+          cues:
+            lighting: "sunset_gold"
+            soundtrack: "maker_lofi"
+        - id: archive-walk
+          name: Archive Walk
+          anchor:
+            position: [7.5, 0.0, 10.0]
+            scale: [6.5, 1.0, 4.0]
+          cues:
+            lighting: "cool_archive"
+            effects: ["hologram_panels"]
+        - id: roadview-tower
+          name: RoadView Tower
+          anchor:
+            position: [2.5, 0.0, 15.0]
+            scale: [5.0, 6.0, 5.0]
+          cues:
+            lighting: "analytics_glow"
+            soundtrack: "telemetry_ambient"
+  - label: Configure QLM pedestals
+    topic: sim/interactives
+    payload:
+      pedestals:
+        - id: chsh-demo
+          zone: qlm-dome
+          task_queue: "qlm:bell_chsh"
+          preview_asset: "artifacts/chsh_preview.png"
+          success_stamp: "visa:bell"
+          failure_hint: "Target S between 2.4 and 2.8."
+        - id: grover-demo
+          zone: qlm-dome
+          task_queue: "qlm:grover"
+          preview_asset: "artifacts/grover_preview.png"
+          success_stamp: "visa:grover"
+          failure_hint: "Check iteration count vs marked states."
+        - id: codeforge-demo
+          zone: qlm-dome
+          task_queue: "qlm:codeforge"
+          preview_asset: "artifacts/code_preview.png"
+          success_stamp: "visa:code"
+          failure_hint: "Unit tests must compile before spawn."
+  - label: Parcel scaffolding
+    topic: sim/parcels
+    payload:
+      claim_mode: visa_required
+      plots:
+        - id: parcel-a1
+          anchor:
+            position: [-11.0, 0.0, 6.0]
+            rotation: [0.0, 45.0, 0.0]
+            scale: [3.0, 1.0, 3.0]
+          kit: "starter_greenhouse"
+        - id: parcel-b2
+          anchor:
+            position: [-8.0, 0.0, 10.5]
+            rotation: [0.0, 15.0, 0.0]
+            scale: [3.5, 1.0, 3.5]
+          kit: "analysis_lab"
+        - id: parcel-c3
+          anchor:
+            position: [-5.5, 0.0, 7.5]
+            rotation: [0.0, -20.0, 0.0]
+            scale: [4.0, 1.0, 3.0]
+          kit: "teaching_stage"
+      roadcoin_rewards:
+        proof_build: 12
+        proof_learn: 8
+        proof_teach: 10
+  - label: Evidence displays
+    topic: sim/evidence
+    payload:
+      boards:
+        - id: lineage-board
+          zone: archive-walk
+          source: "evidence:lineage/latest"
+          layout: "timeline"
+        - id: compliance-board
+          zone: archive-walk
+          source: "evidence:rego/passes"
+          layout: "heatmap"
+      feeds:
+        - id: tower-dashboard
+          zone: roadview-tower
+          widgets:
+            - type: "timeseries"
+              source: "telemetry:qlm/success_rate"
+            - type: "leaderboard"
+              source: "economy:roadcoin"
+  - label: Modding entry points
+    topic: sim/modding
+    payload:
+      importer: blender_unity_simple
+      submission_portal: "https://origin-cms.local/submit"
+      validation_rules:
+        - "enforce_scale:1"
+        - "origin_at_ground"
+        - "lod_required"
+      agent_hooks:
+        annotate_tool: "qlm:parcel_annotator"
+        repair_tool: "qlm:parcel_repair"


### PR DESCRIPTION
## Summary
- document the Origin Campus journey and supporting services, from Harbor arrival through RoadView Tower
- define a Unity scene configuration for the Origin Campus with zones, QLM pedestals, parcels, evidence boards, and modding hooks

## Testing
- not run (docs only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e39f6ecf88329be59e3e5f3b7f668)