### PR TITLE
feat(qlm-lab): add FastAPI bridge service

### DIFF
--- a/modules/qlm_lab/README.md
+++ b/modules/qlm_lab/README.md
@@ -32,3 +32,20 @@ make lint
 ```
 
 Use `make notebooks` to execute and store evaluated notebooks with outputs saved next to the originals.
+
+## Bridge API
+
+Spin up the FastAPI bridge to expose the orchestrator over HTTP:
+
+```bash
+uvicorn qlm_lab.api:create_app --factory --port 8061
+```
+
+Key endpoints:
+
+- `GET /health` – readiness probe.
+- `POST /runs` – execute a goal (e.g. `{ "goal": "bell-lab-demo" }`) and receive the message log plus artifact summary.
+- `GET /artifacts` – list generated artifacts for inspection or download.
+- `GET /lineage?limit=20` – stream recent lineage events captured during runs.
+
+Responses include critic summaries and serialized bus messages so clients can mirror state into other engines.

--- a/modules/qlm_lab/pyproject.toml
+++ b/modules/qlm_lab/pyproject.toml
@@ -2,7 +2,7 @@
 name = "qlm-lab"
 version = "0.1.2"
 requires-python = ">=3.11"
-dependencies = ["numpy", "matplotlib", "sympy", "pyyaml"]
+dependencies = ["numpy", "matplotlib", "sympy", "pyyaml", "fastapi>=0.110"]
 
 [project.optional-dependencies]
 qiskit = ["qiskit", "qiskit-aer"]

--- a/modules/qlm_lab/qlm_lab/api.py
+++ b/modules/qlm_lab/qlm_lab/api.py
@@ -1,0 +1,132 @@
+"""FastAPI bridge exposing the QLM orchestrator via HTTP."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Mapping
+
+import numpy as np
+from fastapi import FastAPI, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from . import lineage
+from .agents.orchestrator import Orchestrator
+from .proto import Msg
+
+
+class BridgeMessage(BaseModel):
+    """Serializable representation of a bus message."""
+
+    id: str
+    sender: str
+    recipient: str
+    kind: str
+    op: str
+    args: Dict[str, Any]
+    ts: float
+
+    @staticmethod
+    def _coerce(value: Any) -> Any:
+        """Convert values into JSON-friendly primitives."""
+
+        if isinstance(value, Path):
+            return str(value)
+        if isinstance(value, np.generic):
+            return value.item()
+        if isinstance(value, (list, tuple, set)):
+            return [BridgeMessage._coerce(item) for item in value]
+        if isinstance(value, Mapping):
+            return {str(key): BridgeMessage._coerce(val) for key, val in value.items()}
+        return value
+
+    @classmethod
+    def from_msg(cls, message: Msg) -> "BridgeMessage":
+        return cls(
+            id=message.id,
+            sender=message.sender,
+            recipient=message.recipient,
+            kind=message.kind,
+            op=message.op,
+            args={str(key): cls._coerce(val) for key, val in message.args.items()},
+            ts=float(message.ts),
+        )
+
+
+class ArtifactSummary(BaseModel):
+    """Summary of artifacts produced by a bridge run."""
+
+    count: int
+    files: List[str]
+
+
+class RunRequest(BaseModel):
+    goal: str = Field(..., min_length=1, description="Planner goal to execute (e.g. 'bell-lab-demo').")
+    message_budget: int = Field(
+        128,
+        ge=1,
+        le=1024,
+        description="Maximum number of bus messages permitted for a run.",
+    )
+
+
+class RunResponse(BaseModel):
+    goal: str
+    message_count: int
+    messages: List[BridgeMessage]
+    artifacts: ArtifactSummary
+
+
+def _load_lineage(limit: int | None = None) -> List[Dict[str, Any]]:
+    path = lineage.LINEAGE_PATH
+    if not path.exists():
+        return []
+    lines = path.read_text(encoding="utf-8").splitlines()
+    if limit is not None:
+        lines = lines[-limit:]
+    events: List[Dict[str, Any]] = []
+    for line in lines:
+        try:
+            data = json.loads(line)
+        except json.JSONDecodeError:  # pragma: no cover - defensive guard for manual edits
+            continue
+        events.append(data)
+    return events
+
+
+def create_app(orchestrator_factory: Callable[[], Orchestrator] | None = None) -> FastAPI:
+    """Instantiate the FastAPI bridge application."""
+
+    orchestrator_factory = orchestrator_factory or Orchestrator
+    app = FastAPI(title="QLM Bridge", version="0.1.0", description="Expose the QLM orchestrator over HTTP.")
+
+    @app.get("/health")
+    def health() -> Dict[str, str]:
+        return {"status": "ok"}
+
+    @app.post("/runs", response_model=RunResponse)
+    def run_goal(request: RunRequest) -> RunResponse:
+        orchestrator = orchestrator_factory()
+        message_count = orchestrator.run_goal(request.goal)
+        if message_count > request.message_budget:
+            raise HTTPException(status_code=422, detail="message budget exceeded")
+        messages = [BridgeMessage.from_msg(msg) for msg in orchestrator.bus.history()]
+        artifacts = ArtifactSummary(**lineage.artifact_index())
+        return RunResponse(
+            goal=request.goal,
+            message_count=message_count,
+            messages=messages,
+            artifacts=artifacts,
+        )
+
+    @app.get("/artifacts", response_model=ArtifactSummary)
+    def get_artifacts() -> ArtifactSummary:
+        return ArtifactSummary(**lineage.artifact_index())
+
+    @app.get("/lineage")
+    def get_lineage(limit: int = Query(50, ge=1, le=500)) -> List[Dict[str, Any]]:
+        return _load_lineage(limit)
+
+    return app
+
+
+__all__ = ["create_app", "RunRequest", "RunResponse", "BridgeMessage", "ArtifactSummary"]

--- a/modules/qlm_lab/tests/test_bridge_api.py
+++ b/modules/qlm_lab/tests/test_bridge_api.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from qlm_lab import lineage
+from qlm_lab.api import create_app
+from qlm_lab.tools import viz
+
+
+@pytest.fixture(autouse=True)
+def isolate_artifacts(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(lineage, "ARTIFACTS_DIR", artifact_root)
+    monkeypatch.setattr(lineage, "ROOT_ARTIFACTS_DIR", artifact_root)
+    monkeypatch.setattr(lineage, "LINEAGE_PATH", artifact_root / "lineage.jsonl")
+    monkeypatch.setattr(lineage, "ROOT_LINEAGE_PATH", artifact_root / "lineage.jsonl")
+    monkeypatch.setattr(viz, "ART_DIR", artifact_root)
+    monkeypatch.setattr(viz, "ROOT_ART_DIR", artifact_root)
+    yield
+
+
+def _build_client() -> TestClient:
+    app = create_app()
+    return TestClient(app)
+
+
+def test_run_goal_returns_messages_and_artifacts():
+    client = _build_client()
+    response = client.post("/runs", json={"goal": "bell-lab-demo"})
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["goal"] == "bell-lab-demo"
+    assert payload["message_count"] > 0
+    assert any(msg["recipient"] == "critic" for msg in payload["messages"])
+    assert payload["artifacts"]["count"] >= 1
+
+
+def test_run_goal_enforces_message_budget():
+    client = _build_client()
+    response = client.post("/runs", json={"goal": "bell-lab-demo", "message_budget": 1})
+    assert response.status_code == 422
+    detail = response.json().get("detail")
+    assert "budget" in detail
+
+
+def test_lineage_endpoint_respects_limit():
+    client = _build_client()
+    client.post("/runs", json={"goal": "bell-lab-demo"})
+    response = client.get("/lineage", params={"limit": 3})
+    assert response.status_code == 200
+    entries = response.json()
+    assert 0 < len(entries) <= 3
+
+
+def test_artifacts_endpoint_exposes_summary():
+    client = _build_client()
+    client.post("/runs", json={"goal": "bell-lab-demo"})
+    response = client.get("/artifacts")
+    assert response.status_code == 200
+    summary = response.json()
+    assert summary["count"] >= 1
+    assert all(isinstance(name, str) for name in summary["files"])


### PR DESCRIPTION
## Summary
- expose the QLM orchestrator through a FastAPI bridge with run, artifact, and lineage endpoints
- add pytest coverage for the new bridge and ensure artifact isolation during tests
- document bridge usage and declare the FastAPI dependency in the module packaging

## Testing
- pytest modules/qlm_lab/tests/test_bridge_api.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e3b91306483299745648049effcad)