### PR TITLE
Add domain automation runbook and Cloudflare IaC scaffolding

### DIFF
--- a/RUNBOOKS/blackroad-domain-automation.md
+++ b/RUNBOOKS/blackroad-domain-automation.md
@@ -1,0 +1,230 @@
+# BlackRoad Domain Automation Runbook
+
+_Last updated: 2025-XX-XX_
+
+## Purpose
+
+This runbook bundles the Codex prompt kits for automating DNS, email, app routing, mailboxes, subdomains, CI/CD, and baseline security for the BlackRoad constellation of domains. Use it to hand tasks to infra agents without rewriting specifications.
+
+### Domain Inventory
+
+- `blackroad.network`
+- `blackroad.systems`
+- `blackroad.me`
+- `blackroadai.com`
+- `blackroadqi.com`
+- `blackroadquantum.com`
+- `lucidia.earth`
+- `lucidia.studio`
+- `aliceqi.com`
+- `lucidiaqi.com`
+
+> **Note:** All domains are registered at GoDaddy. DNS authority is moved to Cloudflare, and Microsoft 365 provides email. Substitute `<tenant>` with the Microsoft 365 tenant hostname (e.g., `blackroad-net.mail.protection.outlook.com`). Create or share a `dmarc@<domain>` mailbox for aggregate/forensic reports.
+
+---
+
+## 1. DNS + Email Bootstrap (GoDaddy → Cloudflare/M365)
+
+**Codex Prompt — `DNS + Email Bootstrap`**
+
+```
+You are an infra engineer. Apply the following DNS plan.
+Registrars: GoDaddy (all domains)
+DNS Hosting: Cloudflare (authoritative)
+Email: Microsoft 365 (Exchange Online)
+Domains:
+  - blackroad.network
+  - blackroad.systems
+  - blackroad.me
+  - blackroadai.com
+  - blackroadqi.com
+  - blackroadquantum.com
+  - lucidia.earth
+  - lucidia.studio
+  - aliceqi.com
+  - lucidiaqi.com
+
+For EACH domain:
+1) Cloudflare zone: create and import existing DNS from GoDaddy; set Cloudflare as nameservers.
+2) Root and www routing:
+   - APEX → host app default (Vercel) via CNAME to `cname.vercel-dns.com` (or the Vercel-provided target).
+   - www → CNAME to the same Vercel target.
+3) Email (Microsoft 365):
+   - MX: `0 <tenant>.mail.protection.outlook.com`
+   - SPF (TXT @): `v=spf1 include:spf.protection.outlook.com -all`
+   - DKIM: enable in M365 admin, add 2 CNAMEs returned by M365 (selector1/selector2).
+   - DMARC (TXT _dmarc): `v=DMARC1; p=quarantine; rua=mailto:dmarc@<domain>; ruf=mailto:dmarc@<domain>; fo=1; sp=quarantine; aspf=s; adkim=s`
+4) Security:
+   - TLS-only (HTTPS redirect), HSTS preload off initially, on after validation.
+   - Cloudflare proxied orange-cloud for public hosts; DNS-only for MX/DKIM/DMARC.
+5) Utility records (per domain):
+   - `_github-challenge-<org>` TXT (if GitHub pages/verification needed)
+   - `_acme-challenge` TXT wildcard ready for Let’s Encrypt if not using Vercel auto
+6) Verification:
+   - Output `dig +short` checks for APEX, www, MX, SPF, DKIM, DMARC for each domain.
+   - Report any propagation or CAA conflicts; set CAA if needed:
+     `CAA 0 issue "letsencrypt.org"`
+     `CAA 0 issuewild "letsencrypt.org"`
+```
+
+---
+
+## 2. Multi-domain App Routing
+
+Choose the Vercel or self-hosted Nginx plan depending on the deployment target.
+
+### Codex Prompt — `Multi-Domain Router (Vercel)`
+
+```
+You are a Vercel engineer. Configure one monorepo with these projects and domains:
+
+Projects:
+- core-app (Next.js): blackroad.network (apex + www), blackroad.systems/docs
+- research (Next.js): blackroadquantum.com, blackroadqi.com, blackroadai.com
+- campus (Next.js): lucidia.earth, lucidia.studio
+- persona (Next.js): aliceqi.com, lucidiaqi.com
+
+Steps:
+1) For each project, add domains in Vercel -> Settings -> Domains.
+2) In each Next.js project, add `vercel.json`:
+   {
+     "rewrites": [
+       { "source": "/docs/:path*", "destination": "/api/docs?path=:path" }
+     ],
+     "headers": [
+       { "source": "/(.*)", "headers": [{ "key": "X-Frame-Options", "value": "DENY" }] }
+     ]
+   }
+3) Environment variables per project:
+   - ORG_NAME=BlackRoad
+   - PRIMARY_DOMAIN=<project domain>
+   - EMAIL_FROM="noreply@<project domain>"
+   - NEXTAUTH_URL=https://<project domain> (if auth)
+4) Add domain verification TXT if prompted by Vercel and confirm DNS.
+5) Output a summary: project → bound domains, CNAME targets, and HTTPS status.
+```
+
+### Codex Prompt — `Multi-Domain Router (Nginx, optional self-host)`
+
+```
+Create an Nginx config that routes based on Host header:
+
+server_names:
+  blackroad.network -> proxy_pass http://core-app:3000
+  blackroad.systems -> proxy_pass http://core-app:3000/docs
+  blackroadai.com, blackroadqi.com, blackroadquantum.com -> proxy_pass http://research:3001
+  lucidia.earth, lucidia.studio -> proxy_pass http://campus:3002
+  aliceqi.com, lucidiaqi.com -> proxy_pass http://persona:3003
+
+Include:
+- automatic HTTPS via certbot nginx plugin with separate certificates per domain
+- HTTP → HTTPS redirect
+- HSTS max-age=31536000 includeSubDomains preload (commented initially)
+- Rate limits: 200r/m per IP on /api/*
+- Security headers (CSP default-src 'self'; frame-ancestors 'none'; referrer-policy same-origin)
+
+Output a ready-to-run `/etc/nginx/sites-available/blackroad.conf` and symlink command.
+```
+
+---
+
+## 3. Microsoft 365 Mailboxes & Aliases
+
+**Codex Prompt — `Mailbox + Alias Setup`**
+
+```
+In Microsoft 365:
+Create shared mailboxes and aliases:
+
+Domains → blackroad.network
+- hello@, admin@, security@, billing@, careers@, ops@
+Domains → blackroadquantum.com
+- research@, papers@, lab@
+Domains → lucidia.earth
+- studio@, learn@, community@
+Domains → aliceqi.com
+- alexa@, press@
+
+Catch-all (transport rule): if recipient not found and domain in {blackroad.network, lucidia.earth, blackroadquantum.com, aliceqi.com, lucidiaqi.com}, redirect to catchall@blackroad.network.
+
+Enable DKIM per domain; enforce SPF hard-fail (-all).
+Create DMARC reports to dmarc@<domain> and external aggregator (optional).
+Return a CSV of created mailboxes + aliases.
+```
+
+---
+
+## 4. Agents & Services Subdomain Map
+
+**Codex Prompt — `Agents & Services Subdomain Plan`**
+
+```
+Define and create the following subdomains in Cloudflare DNS with proxied CNAMEs to Vercel/Nginx targets:
+
+blackroad.network
+- api.blackroad.network
+- app.blackroad.network
+- id.blackroad.network (OIDC/Keycloak or Clerk)
+- status.blackroad.network (Statuspage/BetterStack)
+- docs.blackroad.network (Docusaurus)
+
+blackroadquantum.com
+- lab.blackroadquantum.com (internal R&D)
+- data.blackroadquantum.com (object store or LakeFS)
+- zk.blackroadquantum.com (zkVM demos)
+
+lucidia.earth
+- city.lucidia.earth (campus map)
+- studio.lucidia.earth (creator tools)
+- learn.lucidia.earth (courses)
+
+aliceqi.com
+- journal.aliceqi.com
+- hub.aliceqi.com
+
+lucidiaqi.com
+- portal.lucidiaqi.com (persona/agent portal)
+
+Create records and output a table: host, type, target, proxied, TTL.
+```
+
+---
+
+## 5. CI/CD + Preview Links
+
+**Codex Prompt — `GitHub → Vercel CI/CD`**
+
+```
+Set up GitHub repos (monorepo or multi-repo). For each project:
+- GitHub → install Vercel app, connect repo.
+- Branch preview domains pattern: <branch>--<project>.vercel.app
+- Env var sync from Vercel to GitHub Actions (if needed).
+- Protect main with required checks: build, tests, Lighthouse ≥ 85.
+Output: list of repos, connected Vercel projects, preview URL patterns.
+```
+
+---
+
+## 6. Security & Telemetry Baseline
+
+**Codex Prompt — `Security + Telemetry Baseline`**
+
+```
+Across all apps, enable:
+- CSP, XFO, Referrer-Policy, Permissions-Policy headers
+- Structured audit logs (JSON) to a central sink (e.g., Loki)
+- Request IDs (traceparent), error sampling (Sentry)
+- Privacy page per domain at /privacy, Terms at /terms
+Return code snippets (Next.js middleware or Nginx) and a checklist per domain.
+```
+
+---
+
+## How to Use This Runbook
+
+1. Pick the relevant prompt and paste it into Codex/Copilot when delegating to an automation agent.
+2. Pair with the Terraform and JSON stubs in `infra/cloudflare/` to keep DNS records source-controlled.
+3. Track outputs (dig checks, CSVs, tables) in the incident or change ticket for traceability.
+4. Once DNS propagates and mail is validated, enable HSTS preload and tighten DMARC policies as needed.
+
+**Contacts:** Platform Engineering for Cloudflare/M365 admin rights, Creative Ops for lucidia.* content, and R&D for blackroadquantum.* environments.

--- a/infra/cloudflare/README.md
+++ b/infra/cloudflare/README.md
@@ -1,0 +1,24 @@
+# Cloudflare Automation Stubs
+
+These stubs pair with the **BlackRoad Domain Automation Runbook** (`RUNBOOKS/blackroad-domain-automation.md`). They let us stage DNS zones and records as code while we finish the full Terraform plan.
+
+## Files
+
+- `main.tf` — Minimal Terraform configuration to create Cloudflare zones and DNS records from variable maps.
+- `records.auto.tfvars.example` — Example variable payload describing the BlackRoad constellation of zones and records.
+- `zones.template.json` — JSON schema for the Codex agents when they need to emit zone state snapshots.
+
+## Usage
+
+1. Copy `records.auto.tfvars.example` to `records.auto.tfvars` and fill in production values (Cloudflare account IDs, record targets, Microsoft 365 tenant hostname, etc.).
+2. Export `CLOUDFLARE_API_TOKEN` with zone + DNS permissions and either set it via environment variable (`TF_VAR_cloudflare_api_token`) or interactively when Terraform prompts.
+3. Initialize and apply:
+   ```bash
+   cd infra/cloudflare
+   terraform init
+   terraform plan -var-file=records.auto.tfvars
+   terraform apply -var-file=records.auto.tfvars
+   ```
+4. When agents produce updates (e.g., new subdomains, DMARC tweaks), patch the tfvars file and re-run `terraform apply` to keep Cloudflare in sync.
+
+> **Safety:** Check the `plan` output for accidental deletions before applying. Add `allow_overwrite = true` to individual records if Cloudflare already contains them but Terraform must become the source of truth.

--- a/infra/cloudflare/main.tf
+++ b/infra/cloudflare/main.tf
@@ -1,0 +1,70 @@
+terraform {
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.0"
+    }
+  }
+}
+
+variable "cloudflare_api_token" {
+  description = "API token with permissions to manage zones and DNS records."
+  type        = string
+  sensitive   = true
+}
+
+variable "zones" {
+  description = "Map of zones to create/manage keyed by domain name."
+  type = map(object({
+    account_id = string
+    plan       = optional(string)
+  }))
+}
+
+variable "dns_records" {
+  description = "Nested map of DNS records keyed by zone then record key."
+  type = map(map(object({
+    type     = string
+    name     = string
+    content  = string
+    ttl      = optional(number, 300)
+    proxied  = optional(bool, false)
+    priority = optional(number)
+  })))
+  default = {}
+}
+
+provider "cloudflare" {
+  api_token = var.cloudflare_api_token
+}
+
+resource "cloudflare_zone" "domains" {
+  for_each   = var.zones
+  zone       = each.key
+  account_id = each.value.account_id
+  plan       = try(each.value.plan, null)
+}
+
+locals {
+  dns_records = length(var.dns_records) > 0 ? merge([
+    for zone, records in var.dns_records : {
+      for record_key, record in records :
+      "${zone}:${record_key}" => merge(record, { zone = zone })
+    }
+  ]...) : {}
+}
+
+resource "cloudflare_record" "records" {
+  for_each = {
+    for key, record in local.dns_records : key => record
+    if contains(keys(var.zones), lookup(record, "zone", ""))
+  }
+
+  zone_id  = cloudflare_zone.domains[each.value.zone].id
+  name     = each.value.name
+  type     = each.value.type
+  content  = each.value.content
+  ttl      = lookup(each.value, "ttl", 300)
+  proxied  = lookup(each.value, "proxied", false)
+  priority = lookup(each.value, "priority", null)
+}

--- a/infra/cloudflare/records.auto.tfvars.example
+++ b/infra/cloudflare/records.auto.tfvars.example
@@ -1,0 +1,442 @@
+zones = {
+  "blackroad.network" = {
+    account_id = "00000000000000000000000000000000"
+  }
+  "blackroad.systems" = {
+    account_id = "00000000000000000000000000000000"
+  }
+  "blackroad.me" = {
+    account_id = "00000000000000000000000000000000"
+  }
+  "blackroadai.com" = {
+    account_id = "00000000000000000000000000000000"
+  }
+  "blackroadqi.com" = {
+    account_id = "00000000000000000000000000000000"
+  }
+  "blackroadquantum.com" = {
+    account_id = "00000000000000000000000000000000"
+  }
+  "lucidia.earth" = {
+    account_id = "00000000000000000000000000000000"
+  }
+  "lucidia.studio" = {
+    account_id = "00000000000000000000000000000000"
+  }
+  "aliceqi.com" = {
+    account_id = "00000000000000000000000000000000"
+  }
+  "lucidiaqi.com" = {
+    account_id = "00000000000000000000000000000000"
+  }
+}
+
+dns_records = {
+  "blackroad.network" = {
+    apex_cname = {
+      type    = "CNAME"
+      name    = "@"
+      content = "cname.vercel-dns.com"
+      proxied = true
+    }
+    www_cname = {
+      type    = "CNAME"
+      name    = "www"
+      content = "cname.vercel-dns.com"
+      proxied = true
+    }
+    mx_primary = {
+      type     = "MX"
+      name     = "@"
+      content  = "<tenant>.mail.protection.outlook.com"
+      priority = 0
+      ttl      = 3600
+    }
+    spf_txt = {
+      type    = "TXT"
+      name    = "@"
+      content = "v=spf1 include:spf.protection.outlook.com -all"
+      ttl     = 3600
+    }
+    dkim_selector1 = {
+      type    = "CNAME"
+      name    = "selector1._domainkey"
+      content = "selector1-<tenant>._domainkey.<tenant>.onmicrosoft.com"
+    }
+    dkim_selector2 = {
+      type    = "CNAME"
+      name    = "selector2._domainkey"
+      content = "selector2-<tenant>._domainkey.<tenant>.onmicrosoft.com"
+    }
+    dmarc_txt = {
+      type    = "TXT"
+      name    = "_dmarc"
+      content = "v=DMARC1; p=quarantine; rua=mailto:dmarc@blackroad.network; ruf=mailto:dmarc@blackroad.network; fo=1; sp=quarantine; aspf=s; adkim=s"
+      ttl     = 3600
+    }
+    caa_letsencrypt = {
+      type    = "CAA"
+      name    = "@"
+      content = "0 issue \"letsencrypt.org\""
+    }
+    caa_letsencrypt_wild = {
+      type    = "CAA"
+      name    = "@"
+      content = "0 issuewild \"letsencrypt.org\""
+    }
+    api_cname = {
+      type    = "CNAME"
+      name    = "api"
+      content = "api-blackroad-network.example.vercel.app"
+      proxied = true
+    }
+    app_cname = {
+      type    = "CNAME"
+      name    = "app"
+      content = "app-blackroad-network.example.vercel.app"
+      proxied = true
+    }
+    id_cname = {
+      type    = "CNAME"
+      name    = "id"
+      content = "id-blackroad-network.example.vercel.app"
+      proxied = true
+    }
+    status_cname = {
+      type    = "CNAME"
+      name    = "status"
+      content = "status.blackroad.statuspage.io"
+      proxied = false
+    }
+    docs_cname = {
+      type    = "CNAME"
+      name    = "docs"
+      content = "docs-blackroad-network.example.vercel.app"
+      proxied = true
+    }
+    github_verify = {
+      type    = "TXT"
+      name    = "_github-challenge-blackroad"
+      content = "placeholder"
+    }
+    acme_wildcard = {
+      type    = "TXT"
+      name    = "_acme-challenge"
+      content = "placeholder"
+    }
+  }
+
+  "blackroad.systems" = {
+    apex_cname = {
+      type    = "CNAME"
+      name    = "@"
+      content = "cname.vercel-dns.com"
+      proxied = true
+    }
+    www_cname = {
+      type    = "CNAME"
+      name    = "www"
+      content = "cname.vercel-dns.com"
+      proxied = true
+    }
+    docs_path = {
+      type    = "CNAME"
+      name    = "docs"
+      content = "core-app.blackroad.network"
+      proxied = true
+    }
+    mx_primary = {
+      type     = "MX"
+      name     = "@"
+      content  = "<tenant>.mail.protection.outlook.com"
+      priority = 0
+      ttl      = 3600
+    }
+    spf_txt = {
+      type    = "TXT"
+      name    = "@"
+      content = "v=spf1 include:spf.protection.outlook.com -all"
+    }
+    dmarc_txt = {
+      type    = "TXT"
+      name    = "_dmarc"
+      content = "v=DMARC1; p=quarantine; rua=mailto:dmarc@blackroad.systems; ruf=mailto:dmarc@blackroad.systems; fo=1; sp=quarantine; aspf=s; adkim=s"
+    }
+  }
+
+  "blackroad.me" = {
+    apex_cname = {
+      type    = "CNAME"
+      name    = "@"
+      content = "cname.vercel-dns.com"
+      proxied = true
+    }
+    www_cname = {
+      type    = "CNAME"
+      name    = "www"
+      content = "cname.vercel-dns.com"
+      proxied = true
+    }
+  }
+
+  "blackroadai.com" = {
+    apex_cname = {
+      type    = "CNAME"
+      name    = "@"
+      content = "cname.vercel-dns.com"
+      proxied = true
+    }
+    www_cname = {
+      type    = "CNAME"
+      name    = "www"
+      content = "cname.vercel-dns.com"
+      proxied = true
+    }
+    mx_primary = {
+      type     = "MX"
+      name     = "@"
+      content  = "<tenant>.mail.protection.outlook.com"
+      priority = 0
+      ttl      = 3600
+    }
+    spf_txt = {
+      type    = "TXT"
+      name    = "@"
+      content = "v=spf1 include:spf.protection.outlook.com -all"
+    }
+    dmarc_txt = {
+      type    = "TXT"
+      name    = "_dmarc"
+      content = "v=DMARC1; p=quarantine; rua=mailto:dmarc@blackroadai.com; ruf=mailto:dmarc@blackroadai.com; fo=1; sp=quarantine; aspf=s; adkim=s"
+    }
+  }
+
+  "blackroadqi.com" = {
+    apex_cname = {
+      type    = "CNAME"
+      name    = "@"
+      content = "cname.vercel-dns.com"
+      proxied = true
+    }
+    www_cname = {
+      type    = "CNAME"
+      name    = "www"
+      content = "cname.vercel-dns.com"
+      proxied = true
+    }
+    mx_primary = {
+      type     = "MX"
+      name     = "@"
+      content  = "<tenant>.mail.protection.outlook.com"
+      priority = 0
+      ttl      = 3600
+    }
+    spf_txt = {
+      type    = "TXT"
+      name    = "@"
+      content = "v=spf1 include:spf.protection.outlook.com -all"
+    }
+    dmarc_txt = {
+      type    = "TXT"
+      name    = "_dmarc"
+      content = "v=DMARC1; p=quarantine; rua=mailto:dmarc@blackroadqi.com; ruf=mailto:dmarc@blackroadqi.com; fo=1; sp=quarantine; aspf=s; adkim=s"
+    }
+  }
+
+  "blackroadquantum.com" = {
+    apex_cname = {
+      type    = "CNAME"
+      name    = "@"
+      content = "cname.vercel-dns.com"
+      proxied = true
+    }
+    www_cname = {
+      type    = "CNAME"
+      name    = "www"
+      content = "cname.vercel-dns.com"
+      proxied = true
+    }
+    lab_cname = {
+      type    = "CNAME"
+      name    = "lab"
+      content = "lab-blackroad-quantum.example.vercel.app"
+      proxied = true
+    }
+    data_cname = {
+      type    = "CNAME"
+      name    = "data"
+      content = "data-blackroad-quantum.example.vercel.app"
+      proxied = true
+    }
+    zk_cname = {
+      type    = "CNAME"
+      name    = "zk"
+      content = "zk-blackroad-quantum.example.vercel.app"
+      proxied = true
+    }
+    mx_primary = {
+      type     = "MX"
+      name     = "@"
+      content  = "<tenant>.mail.protection.outlook.com"
+      priority = 0
+      ttl      = 3600
+    }
+    spf_txt = {
+      type    = "TXT"
+      name    = "@"
+      content = "v=spf1 include:spf.protection.outlook.com -all"
+    }
+    dmarc_txt = {
+      type    = "TXT"
+      name    = "_dmarc"
+      content = "v=DMARC1; p=quarantine; rua=mailto:dmarc@blackroadquantum.com; ruf=mailto:dmarc@blackroadquantum.com; fo=1; sp=quarantine; aspf=s; adkim=s"
+    }
+  }
+
+  "lucidia.earth" = {
+    apex_cname = {
+      type    = "CNAME"
+      name    = "@"
+      content = "cname.vercel-dns.com"
+      proxied = true
+    }
+    www_cname = {
+      type    = "CNAME"
+      name    = "www"
+      content = "cname.vercel-dns.com"
+      proxied = true
+    }
+    city_cname = {
+      type    = "CNAME"
+      name    = "city"
+      content = "city-lucidia.example.vercel.app"
+      proxied = true
+    }
+    studio_cname = {
+      type    = "CNAME"
+      name    = "studio"
+      content = "studio-lucidia.example.vercel.app"
+      proxied = true
+    }
+    learn_cname = {
+      type    = "CNAME"
+      name    = "learn"
+      content = "learn-lucidia.example.vercel.app"
+      proxied = true
+    }
+    mx_primary = {
+      type     = "MX"
+      name     = "@"
+      content  = "<tenant>.mail.protection.outlook.com"
+      priority = 0
+      ttl      = 3600
+    }
+    spf_txt = {
+      type    = "TXT"
+      name    = "@"
+      content = "v=spf1 include:spf.protection.outlook.com -all"
+    }
+    dmarc_txt = {
+      type    = "TXT"
+      name    = "_dmarc"
+      content = "v=DMARC1; p=quarantine; rua=mailto:dmarc@lucidia.earth; ruf=mailto:dmarc@lucidia.earth; fo=1; sp=quarantine; aspf=s; adkim=s"
+    }
+  }
+
+  "lucidia.studio" = {
+    apex_cname = {
+      type    = "CNAME"
+      name    = "@"
+      content = "cname.vercel-dns.com"
+      proxied = true
+    }
+    www_cname = {
+      type    = "CNAME"
+      name    = "www"
+      content = "cname.vercel-dns.com"
+      proxied = true
+    }
+  }
+
+  "aliceqi.com" = {
+    apex_cname = {
+      type    = "CNAME"
+      name    = "@"
+      content = "cname.vercel-dns.com"
+      proxied = true
+    }
+    www_cname = {
+      type    = "CNAME"
+      name    = "www"
+      content = "cname.vercel-dns.com"
+      proxied = true
+    }
+    journal_cname = {
+      type    = "CNAME"
+      name    = "journal"
+      content = "journal-aliceqi.example.vercel.app"
+      proxied = true
+    }
+    hub_cname = {
+      type    = "CNAME"
+      name    = "hub"
+      content = "hub-aliceqi.example.vercel.app"
+      proxied = true
+    }
+    mx_primary = {
+      type     = "MX"
+      name     = "@"
+      content  = "<tenant>.mail.protection.outlook.com"
+      priority = 0
+      ttl      = 3600
+    }
+    spf_txt = {
+      type    = "TXT"
+      name    = "@"
+      content = "v=spf1 include:spf.protection.outlook.com -all"
+    }
+    dmarc_txt = {
+      type    = "TXT"
+      name    = "_dmarc"
+      content = "v=DMARC1; p=quarantine; rua=mailto:dmarc@aliceqi.com; ruf=mailto:dmarc@aliceqi.com; fo=1; sp=quarantine; aspf=s; adkim=s"
+    }
+  }
+
+  "lucidiaqi.com" = {
+    apex_cname = {
+      type    = "CNAME"
+      name    = "@"
+      content = "cname.vercel-dns.com"
+      proxied = true
+    }
+    www_cname = {
+      type    = "CNAME"
+      name    = "www"
+      content = "cname.vercel-dns.com"
+      proxied = true
+    }
+    portal_cname = {
+      type    = "CNAME"
+      name    = "portal"
+      content = "portal-lucidiaqi.example.vercel.app"
+      proxied = true
+    }
+    mx_primary = {
+      type     = "MX"
+      name     = "@"
+      content  = "<tenant>.mail.protection.outlook.com"
+      priority = 0
+      ttl      = 3600
+    }
+    spf_txt = {
+      type    = "TXT"
+      name    = "@"
+      content = "v=spf1 include:spf.protection.outlook.com -all"
+    }
+    dmarc_txt = {
+      type    = "TXT"
+      name    = "_dmarc"
+      content = "v=DMARC1; p=quarantine; rua=mailto:dmarc@lucidiaqi.com; ruf=mailto:dmarc@lucidiaqi.com; fo=1; sp=quarantine; aspf=s; adkim=s"
+    }
+  }
+}

--- a/infra/cloudflare/zones.template.json
+++ b/infra/cloudflare/zones.template.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://raw.githubusercontent.com/cloudflare/json-schemas/main/dns-records/dns-records-schema.json",
+  "generated_at": "2025-01-01T00:00:00Z",
+  "description": "Template for Codex agents to snapshot Cloudflare zones for the BlackRoad constellation.",
+  "zones": [
+    {
+      "name": "blackroad.network",
+      "account_id": "00000000000000000000000000000000",
+      "name_servers": [
+        "ns1.cloudflare.com",
+        "ns2.cloudflare.com"
+      ],
+      "records": [
+        {
+          "type": "CNAME",
+          "name": "@",
+          "content": "cname.vercel-dns.com",
+          "proxied": true,
+          "ttl": 300
+        },
+        {
+          "type": "CNAME",
+          "name": "www",
+          "content": "cname.vercel-dns.com",
+          "proxied": true,
+          "ttl": 300
+        },
+        {
+          "type": "MX",
+          "name": "@",
+          "content": "<tenant>.mail.protection.outlook.com",
+          "priority": 0,
+          "ttl": 3600
+        },
+        {
+          "type": "TXT",
+          "name": "@",
+          "content": "v=spf1 include:spf.protection.outlook.com -all",
+          "ttl": 3600
+        },
+        {
+          "type": "TXT",
+          "name": "_dmarc",
+          "content": "v=DMARC1; p=quarantine; rua=mailto:dmarc@blackroad.network; ruf=mailto:dmarc@blackroad.network; fo=1; sp=quarantine; aspf=s; adkim=s",
+          "ttl": 3600
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a consolidated runbook of Codex prompt kits covering DNS, routing, email, CI/CD, and security tasks for the BlackRoad domains
- introduce Cloudflare Terraform scaffolding with token/zones/dns record variables to manage the constellation as code
- supply example tfvars and a JSON zone snapshot template to guide agents wiring records and mail settings

## Testing
- not run (documentation and IaC scaffolding only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e4ddd9e548329a98749898d607a06)