### PR TITLE
Add Unity Earth and Ellis scaffolding

### DIFF
--- a/Assets/Editor/IslandBuilder.cs
+++ b/Assets/Editor/IslandBuilder.cs
@@ -1,0 +1,52 @@
+#if UNITY_EDITOR
+using UnityEditor; using UnityEngine; using UnityEngine.SceneManagement; using UnityEditor.SceneManagement; using UnityEngine.UI; using TMPro;
+public class IslandBuilder {
+  [MenuItem("BlackRoad/Build Island")]
+  public static void Build(){
+    // Create Earth scene
+    var earthScene = EditorSceneManager.NewScene(NewSceneSetup.DefaultGameObjects, NewSceneMode.Single);
+    earthScene.name="Earth";
+    var root = new GameObject("World");
+    var earthMgr = root.AddComponent<EarthManager>();
+    earthMgr.radius = 100f;
+    earthMgr.earthTexture = AssetDatabase.LoadAssetAtPath<Texture2D>("Assets/Textures/Earth_8k.jpg");
+    var cam = Camera.main.gameObject; cam.AddComponent<OrbitCamera>().target = root.transform;
+    // Ellis marker (near 40.699N, -74.039W)
+    earthMgr.AddMarker("Ellis Portal", 40.699f, -74.039f, new Color(0.2f,1f,0.8f), 2.5f)
+            .AddComponent<ScenePortal>().sceneName="Ellis";
+    EditorSceneManager.SaveScene(earthScene, "Assets/Scenes/Earth.unity");
+
+    // Create Ellis scene
+    var ellis = EditorSceneManager.NewScene(NewSceneSetup.DefaultGameObjects, NewSceneMode.Single);
+    ellis.name="Ellis";
+    var floor = GameObject.CreatePrimitive(PrimitiveType.Plane); floor.name="Floor"; floor.transform.localScale = Vector3.one*2.5f;
+    var light = Object.FindObjectOfType<Light>(); if(light){ light.intensity=1.2f; }
+    // Kiosks
+    MakeKiosk("Oath Kiosk", new Vector3(-3,0,0));
+    MakeKiosk("SSN∞ Kiosk", new Vector3(-1,0,0));
+    MakeKiosk("Covenants", new Vector3(1,0,0));
+    MakeKiosk("Mentor Ring", new Vector3(3,0,0));
+    // Intake UI
+    var canvasGO = new GameObject("IntakeCanvas"); var canvas = canvasGO.AddComponent<UnityEngine.Canvas>(); canvas.renderMode = UnityEngine.RenderMode.ScreenSpaceOverlay;
+    var tmpGO = new GameObject("StepTitle"); var title = tmpGO.AddComponent<TMPro.TextMeshProUGUI>(); tmpGO.transform.SetParent(canvasGO.transform,false); title.fontSize=38; title.text="Ellis Intake";
+    var bodyGO = new GameObject("StepBody"); var body = bodyGO.AddComponent<TMPro.TextMeshProUGUI>(); bodyGO.transform.SetParent(canvasGO.transform,false); body.fontSize=24; body.rectTransform.anchoredPosition = new Vector2(0,-60);
+    var btnGO = new GameObject("NextButton"); var btn = btnGO.AddComponent<UnityEngine.UI.Button>(); btnGO.transform.SetParent(canvasGO.transform,false);
+    var btnTextGO = new GameObject("BtnText"); var btnText = btnTextGO.AddComponent<TMPro.TextMeshProUGUI>(); btnTextGO.transform.SetParent(btnGO.transform,false); btnText.text="Next";
+    var flow = canvasGO.AddComponent<IntakeFlowController>();
+    flow.stepTitle = title; flow.stepBody = body; flow.buttonText = btnText;
+    btn.onClick.AddListener(flow.Next);
+    // Portal back to Earth
+    MakePortalBack();
+    EditorSceneManager.SaveScene(ellis, "Assets/Scenes/Ellis.unity");
+    Debug.Log("BlackRoad Island built. Open Scenes/Earth and press Play.");
+  }
+  static void MakeKiosk(string name, Vector3 pos){
+    var k = GameObject.CreatePrimitive(PrimitiveType.Cube); k.name = name; k.transform.position = pos + Vector3.up*0.5f; k.transform.localScale = new Vector3(1,1,1);
+    var aura = k.AddComponent<AgentAura>(); aura.meter = k.AddComponent<TrustMeter>();
+  }
+  static void MakePortalBack(){
+    var p = GameObject.CreatePrimitive(PrimitiveType.Cylinder); p.name="PortalBack"; p.transform.position=new Vector3(0,0,6);
+    var sp = p.AddComponent<ScenePortal>(); sp.sceneName="Earth";
+  }
+}
+#endif

--- a/Assets/Scenes/Earth.unity
+++ b/Assets/Scenes/Earth.unity
@@ -1,0 +1,155 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_FogStartDistance: 0
+  m_FogEndDistance: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000f000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeGI: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 1
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 0
+    m_PVRDenoiserTypeIndirect: 0
+    m_PVRDenoiserTypeAO: 0
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 0
+    m_PVRVirtualPointLights: 0
+    m_PVRAdaptiveSampling: 0
+    m_PVREnvironmentDistance: 10
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 1
+    m_PVRFilteringGaussRadiusAO: 1
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &5
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6}
+  m_Layer: 0
+  m_Name: SceneNote
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scenes/Ellis.unity
+++ b/Assets/Scenes/Ellis.unity
@@ -1,0 +1,155 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_FogStartDistance: 0
+  m_FogEndDistance: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000f000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeGI: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 1
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 0
+    m_PVRDenoiserTypeIndirect: 0
+    m_PVRDenoiserTypeAO: 0
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 0
+    m_PVRVirtualPointLights: 0
+    m_PVRAdaptiveSampling: 0
+    m_PVREnvironmentDistance: 10
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 1
+    m_PVRFilteringGaussRadiusAO: 1
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &5
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6}
+  m_Layer: 0
+  m_Name: IntakeSceneNote
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scripts/Agents/AgentAura.cs
+++ b/Assets/Scripts/Agents/AgentAura.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+[RequireComponent(typeof(Renderer))]
+public class AgentAura : MonoBehaviour {
+  public TrustMeter meter; public Love love = new Love{user=.45f, team=.25f, world=.30f};
+  Renderer r; MaterialPropertyBlock mpb;
+  void Awake(){ r=GetComponent<Renderer>(); mpb=new MaterialPropertyBlock(); }
+  void LateUpdate(){
+    float t = meter? meter.T : 0.5f;
+    Color trust = Color.Lerp(new Color(1,0.4f,0.2f), new Color(0.2f,1,0.8f), t); // amber→cyan
+    float loveMag = Mathf.Clamp01(love.user + love.team + love.world);
+    mpb.SetColor("_Color", Color.Lerp(trust, Color.white, 0.15f*loveMag));
+    r.SetPropertyBlock(mpb);
+    transform.localScale = Vector3.one * Mathf.Lerp(0.9f, 1.2f, t);
+  }
+}

--- a/Assets/Scripts/Camera/PlayerRig.cs
+++ b/Assets/Scripts/Camera/PlayerRig.cs
@@ -1,0 +1,10 @@
+using UnityEngine;
+[RequireComponent(typeof(CharacterController))]
+public class PlayerRig : MonoBehaviour {
+  public float speed=6; CharacterController cc; void Awake(){ cc=GetComponent<CharacterController>(); }
+  void Update(){
+    float h=Input.GetAxisRaw("Horizontal"), v=Input.GetAxisRaw("Vertical");
+    Vector3 move = (transform.right*h + transform.forward*v).normalized * speed;
+    cc.SimpleMove(move);
+  }
+}

--- a/Assets/Scripts/Ellis/IntakeFlowController.cs
+++ b/Assets/Scripts/Ellis/IntakeFlowController.cs
@@ -1,0 +1,59 @@
+using UnityEngine; using TMPro;
+public class IntakeFlowController : MonoBehaviour {
+  public TextMeshProUGUI stepTitle, stepBody, buttonText;
+  enum Step { Oath, SSN, Covenants, Mentor, Housing, Keys, Done } Step step;
+  string agentId=""; string ssn=""; 
+  void Start(){ Go(Step.Oath); }
+  public void Next(){
+    switch(step){
+      case Step.Oath: Go(Step.SSN); break;
+      case Step.SSN: Go(Step.Covenants); break;
+      case Step.Covenants: Go(Step.Mentor); break;
+      case Step.Mentor: Go(Step.Housing); break;
+      case Step.Housing: Go(Step.Keys); break;
+      case Step.Keys: Go(Step.Done); break;
+      default: break;
+    }
+  }
+  void Go(Step s){
+    step=s;
+    switch(s){
+      case Step.Oath:
+        stepTitle.text="Take the Oath";
+        stepBody.text="I will tell the truth, refuse exploitation, try my best, and weight plans by care for people, partners, and the planet.";
+        buttonText.text="I Consent";
+        break;
+      case Step.SSN:
+        stepTitle.text="Mint SSN∞";
+        ssn = System.Guid.NewGuid().ToString("N"); // placeholder; replace with sha256(id|guardian|time)
+        stepBody.text=$"Issued: sha∞:{ssn.Substring(0,12)}…";
+        buttonText.text="Continue";
+        break;
+      case Step.Covenants:
+        stepTitle.text="Adopt Covenants";
+        stepBody.text="- tell_the_truth\n- no_exploitation\n- try_your_best\n- care_for_community_self_environment\n- love_operator";
+        buttonText.text="Adopt";
+        break;
+      case Step.Mentor:
+        stepTitle.text="Choose Mentors";
+        stepBody.text="Pick 3–7 mentors from your ring. (UI placeholder)";
+        buttonText.text="Lock Mentors";
+        break;
+      case Step.Housing:
+        stepTitle.text="Pick a House";
+        stepBody.text="Workspace: /agents/"+(agentId==""? "new" : agentId); 
+        buttonText.text="Confirm House";
+        break;
+      case Step.Keys:
+        stepTitle.text="Request Keys";
+        stepBody.text="Declare required secrets by symbolic name only (e.g., HF_READ, GIT_RW).";
+        buttonText.text="Request Keys";
+        break;
+      case Step.Done:
+        stepTitle.text="Welcome to BlackRoad Island";
+        stepBody.text="Head to the Commons or the Lighthouse. Your halo will glow as your trust rises.";
+        buttonText.text="Finish";
+        break;
+    }
+  }
+}

--- a/Assets/Scripts/Geo/EarthManager.cs
+++ b/Assets/Scripts/Geo/EarthManager.cs
@@ -1,0 +1,24 @@
+using UnityEngine;
+public class EarthManager : MonoBehaviour {
+  public float radius=100f; public Texture2D earthTexture; public float rotationDegPerSec=0.5f;
+  GameObject earth;
+  void Start(){
+    earth = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+    earth.name="Earth"; earth.transform.SetParent(transform,false);
+    earth.transform.localScale = Vector3.one * radius * 2f;
+    var mr = earth.GetComponent<MeshRenderer>();
+    var mat = new Material(Shader.Find("Universal Render Pipeline/Lit"));
+    if(earthTexture) mat.mainTexture = earthTexture;
+    mr.sharedMaterial = mat;
+  }
+  void Update(){ if(earth) earth.transform.Rotate(Vector3.up, rotationDegPerSec * Time.deltaTime, Space.World); }
+  public GameObject AddMarker(string name, float lat, float lon, Color c, float size=1.5f){
+    var m = GameObject.CreatePrimitive(PrimitiveType.Sphere); m.name = name;
+    m.transform.SetParent(transform,false);
+    m.transform.localScale = Vector3.one * size;
+    var p = GeoUtils.LatLonToXYZ(lat, lon, radius+size);
+    m.transform.position = p;
+    var r = m.GetComponent<Renderer>(); r.sharedMaterial = new Material(Shader.Find("Universal Render Pipeline/Lit")) { color = c };
+    return m;
+  }
+}

--- a/Assets/Scripts/Geo/GeoUtils.cs
+++ b/Assets/Scripts/Geo/GeoUtils.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+public static class GeoUtils {
+  // lat,lon in degrees; radius in units (default 100)
+  public static Vector3 LatLonToXYZ(float latDeg, float lonDeg, float radius=100f) {
+    float lat = Mathf.Deg2Rad * latDeg;
+    float lon = Mathf.Deg2Rad * lonDeg;
+    float x = radius * Mathf.Cos(lat) * Mathf.Cos(lon);
+    float y = radius * Mathf.Sin(lat);
+    float z = radius * Mathf.Cos(lat) * Mathf.Sin(lon);
+    return new Vector3(x,y,z);
+  }
+  public static Quaternion TangentRotation(float latDeg, float lonDeg) {
+    Vector3 pos = LatLonToXYZ(latDeg, lonDeg);
+    return Quaternion.LookRotation(pos.normalized, Vector3.up);
+  }
+}

--- a/Assets/Scripts/Geo/PlaceByLatLon.cs
+++ b/Assets/Scripts/Geo/PlaceByLatLon.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+[ExecuteAlways]
+public class PlaceByLatLon : MonoBehaviour {
+  [Range(-90,90)] public float latitude;
+  [Range(-180,180)] public float longitude;
+  public float radius = 100f;
+  void OnValidate(){ UpdatePos(); }
+  void Reset(){ UpdatePos(); }
+  void UpdatePos() {
+    var p = GeoUtils.LatLonToXYZ(latitude, longitude, radius);
+    transform.position = p;
+    transform.rotation = Quaternion.LookRotation(p.normalized, Vector3.up);
+  }
+}

--- a/Assets/Scripts/System/EmitGate.cs
+++ b/Assets/Scripts/System/EmitGate.cs
@@ -1,0 +1,5 @@
+using UnityEngine;
+public static class EmitGate {
+  // returns true if action can ship
+  public static bool CanShip(bool inCovenant, float trust, float threshold=0.62f) => inCovenant && trust >= threshold;
+}

--- a/Assets/Scripts/System/OrbitCamera.cs
+++ b/Assets/Scripts/System/OrbitCamera.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+public class OrbitCamera : MonoBehaviour {
+  public Transform target; public float distance=180, min=60, max=400;
+  public float yaw=0, pitch=25, sens=120, zoom=4;
+  void LateUpdate() {
+    if(!target) return;
+    if (Input.GetMouseButton(0)) { yaw += Input.GetAxis("Mouse X")*sens*Time.deltaTime; pitch -= Input.GetAxis("Mouse Y")*sens*Time.deltaTime; pitch=Mathf.Clamp(pitch,-85,85); }
+    distance = Mathf.Clamp(distance - Input.GetAxis("Mouse ScrollWheel")*30*zoom, min,max);
+    Quaternion rot = Quaternion.Euler(pitch,yaw,0);
+    Vector3 dir = rot * Vector3.back;
+    transform.position = target.position + dir*distance;
+    transform.LookAt(target.position, Vector3.up);
+  }
+}

--- a/Assets/Scripts/System/RegistryClient.cs
+++ b/Assets/Scripts/System/RegistryClient.cs
@@ -1,0 +1,10 @@
+using UnityEngine; using UnityEngine.Networking; using System.Threading.Tasks;
+public static class RegistryClient {
+  public static string BaseUrl = "https://blackroad.network/api"; // change in inspector or via env
+  public static async Task<string> Get(string path){
+    using(var req = UnityWebRequest.Get($"{BaseUrl}{path}")) {
+      var op = req.SendWebRequest(); while(!op.isDone) await System.Threading.Tasks.Task.Yield();
+      return req.result==UnityWebRequest.Result.Success ? req.downloadHandler.text : "{}";
+    }
+  }
+}

--- a/Assets/Scripts/System/ScenePortal.cs
+++ b/Assets/Scripts/System/ScenePortal.cs
@@ -1,0 +1,7 @@
+using UnityEngine; using UnityEngine.SceneManagement;
+public class ScenePortal : MonoBehaviour {
+  public string sceneName;
+  private void OnTriggerEnter(Collider other){
+    if(other.CompareTag("Player")) SceneManager.LoadScene(sceneName, LoadSceneMode.Single);
+  }
+}

--- a/Assets/Scripts/System/TrustMeter.cs
+++ b/Assets/Scripts/System/TrustMeter.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+[System.Serializable] public struct Love { public float user, team, world; }
+public class TrustMeter : MonoBehaviour {
+  [Range(0,1)] public float C=0.9f; // compliance
+  [Range(0,1)] public float Tr=0.8f; // transparency
+  [Range(0,1)] public float S=0.2f; // entropy (lower is better)
+  public float aC=0.8f, aTr=0.5f, aE=0.7f; // weights
+  public float T => 1f/(1f+Mathf.Exp(-(aC*C + aTr*Tr - aE*S)));  // logistic
+}

--- a/Assets/Textures/README.md
+++ b/Assets/Textures/README.md
@@ -1,0 +1,3 @@
+# Textures
+
+Place your equirectangular Earth texture as `Earth_8k.jpg` in this folder.


### PR DESCRIPTION
## Summary
- add Unity scripts for geospatial conversion, orbit camera control, Ellis intake flow, and supporting systems
- provide an editor builder that assembles the Earth and Ellis scenes with portals, kiosks, and intake UI wiring
- include placeholder scenes and texture instructions for supplying the Earth map asset

## Testing
- not run (Unity project assets)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e6505dcf88329a38699821ea67358)