### PR TITLE
Add offline policy service assets

### DIFF
--- a/offline_service/.gitignore
+++ b/offline_service/.gitignore
@@ -1,0 +1,2 @@
+audit.ndjson
+release/

--- a/offline_service/README.md
+++ b/offline_service/README.md
@@ -1,0 +1,24 @@
+# Offline Policy Service
+
+A lightweight policy evaluation surface for offline demos and QA. It exposes a minimal REST API for evaluating policies, verifying signed bundles, and remediating risky marketing copy.
+
+## Endpoints
+
+* `GET /health` — readiness probe.
+* `GET /api/policy/metrics` — snapshot of evaluation, attestation, and remediation counters.
+* `POST /api/policy/evaluate` — accepts `{ caseId, pqc, rules }` and returns the aggregate result.
+* `POST /api/policy/bundle` — verifies a bundle hash against an RSA signature and records the policy version.
+* `POST /api/policy/remediate` — rewrites banned marketing phrases and appends risk disclosures when needed.
+* `POST /api/attest/bundle` — records external attestation outcomes.
+
+The service writes a hash-chained ledger to `audit.ndjson` capturing each evaluation, remediation, and bundle verification.
+
+## Tooling
+
+* `ops.html` — lightweight dashboard that polls metrics every 10 seconds.
+* `demo.sh` — runs sample requests using the payloads under `demo/`.
+* `check.sh` — CI smoke test that starts the server, exercises the API, validates the audit ledger, and exits with `SMOKE OK` when successful.
+* `make_release.sh` — builds a signed tarball containing runtime artifacts under `release/`.
+* `audit_ledger.py` — verifies the integrity of the hash chain stored in `audit.ndjson`.
+
+To create a release bundle you must supply an RSA private key via the `SIGNING_KEY` environment variable or place it at `release/signing_key.pem`.

--- a/offline_service/audit_ledger.py
+++ b/offline_service/audit_ledger.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Utility helpers for inspecting the offline service audit ledger."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from collections import OrderedDict
+from typing import Iterable, Iterator, Tuple
+
+LEDGER_PATH = Path(__file__).with_name("audit.ndjson")
+
+
+def read_entries(path: Path) -> Iterator[dict]:
+  if not path.exists():
+    return
+  with path.open("r", encoding="utf-8") as handle:
+    for line_no, line in enumerate(handle, start=1):
+      line = line.strip()
+      if not line:
+        continue
+      try:
+        yield json.loads(line)
+      except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid json on line {line_no}") from exc
+
+
+def verify_chain(entries: Iterable[dict]) -> Tuple[int, bool]:
+  last_hash: str | None = None
+  count = 0
+  for entry in entries:
+    candidate = OrderedDict()
+    for key in ("ts", "event", "payload", "prevHash"):
+      if key in entry:
+        candidate[key] = entry[key]
+    payload = json.dumps(candidate, ensure_ascii=False, separators=(",", ":"))
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    if entry.get("hash") != digest:
+      return count, False
+    if entry.get("prevHash") != last_hash:
+      return count, False
+    last_hash = entry.get("hash")
+    count += 1
+  return count, True
+
+
+def main() -> None:
+  parser = argparse.ArgumentParser(description=__doc__)
+  parser.add_argument("--path", type=Path, default=LEDGER_PATH, help="Path to the audit.ndjson file")
+  args = parser.parse_args()
+  entries = list(read_entries(args.path))
+  count, ok = verify_chain(entries)
+  status = "OK" if ok else "BROKEN"
+  print(f"Ledger entries: {count}")
+  print(f"Chain status: {status}")
+  if not ok:
+    raise SystemExit(1)
+
+
+if __name__ == "__main__":
+  main()

--- a/offline_service/check.sh
+++ b/offline_service/check.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PORT="${PORT:-8787}"
+HOST="${HOST:-127.0.0.1}"
+BASE_URL="${BASE_URL:-http://${HOST}:${PORT}}"
+NODE="${NODE:-node}"
+
+TMPDIR="$(mktemp -d)"
+cleanup() {
+  local code=$?
+  if [[ -n "${SERVER_PID:-}" ]]; then
+    kill "${SERVER_PID}" 2>/dev/null || true
+    wait "${SERVER_PID}" 2>/dev/null || true
+  fi
+  rm -rf "${TMPDIR}"
+  trap - EXIT
+  exit $code
+}
+trap cleanup EXIT
+
+${NODE} "${ROOT}/server.js" >"${TMPDIR}/server.log" 2>&1 &
+SERVER_PID=$!
+
+for _ in {1..40}; do
+  if curl -sf "${BASE_URL}/health" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.25
+done
+
+curl -sf "${BASE_URL}/health" >/dev/null
+
+pass_result=$(curl -sf -X POST "${BASE_URL}/api/policy/evaluate" \
+  -H 'content-type: application/json' \
+  --data @"${ROOT}/demo/good_evaluation.json" | jq -r '.result')
+if [[ "${pass_result}" != "pass" ]]; then
+  echo "expected pass result, got ${pass_result}" >&2
+  exit 1
+fi
+
+fail_result=$(curl -sf -X POST "${BASE_URL}/api/policy/evaluate" \
+  -H 'content-type: application/json' \
+  --data @"${ROOT}/demo/fail_evaluation.json" | jq -r '.result')
+if [[ "${fail_result}" != "fail" ]]; then
+  echo "expected fail result, got ${fail_result}" >&2
+  exit 1
+fi
+
+remediation=$(curl -sf -X POST "${BASE_URL}/api/policy/remediate" \
+  -H 'content-type: application/json' \
+  --data @"${ROOT}/demo/remediation.json")
+remediated_copy=$(jq -r '.remediated' <<<"${remediation}")
+disclosure_flag=$(jq -r '.disclosureAdded' <<<"${remediation}")
+if [[ "${disclosure_flag}" != "true" ]]; then
+  echo "expected disclosure to be added" >&2
+  exit 1
+fi
+if [[ "${remediated_copy}" == *"Guaranteed"* ]]; then
+  echo "banned phrase still present" >&2
+  exit 1
+fi
+
+openssl genrsa -out "${TMPDIR}/signing_key.pem" 2048 >/dev/null 2>&1
+openssl rsa -in "${TMPDIR}/signing_key.pem" -pubout -out "${TMPDIR}/public.pem" >/dev/null 2>&1
+printf "policy bundle" >"${TMPDIR}/bundle.txt"
+hash_value=$(sha256sum "${TMPDIR}/bundle.txt" | awk '{print $1}')
+signature=$(printf "%s" "${hash_value}" | openssl dgst -sha256 -sign "${TMPDIR}/signing_key.pem" | openssl base64 -A)
+public_key=$(cat "${TMPDIR}/public.pem")
+
+bundle_payload=$(jq -n \
+  --arg hash "${hash_value}" \
+  --arg signature "${signature}" \
+  --arg publicKey "${public_key}" \
+  '{version:"ci-smoke", ruleCount:3, hash:$hash, signature:$signature, publicKey:$publicKey}')
+
+bundle_status=$(curl -sf -X POST "${BASE_URL}/api/policy/bundle" \
+  -H 'content-type: application/json' \
+  --data "${bundle_payload}" | jq -r '.status')
+if [[ "${bundle_status}" != "ok" ]]; then
+  echo "bundle verification failed" >&2
+  exit 1
+fi
+
+metrics=$(curl -sf "${BASE_URL}/api/policy/metrics")
+jq -e '.policy.pass == 1 and .policy.warn == 0 and .policy.fail == 1' <<<"${metrics}" >/dev/null
+jq -e '.attest.ok >= 0 and .attest.fail >= 0' <<<"${metrics}" >/dev/null
+jq -e '.remediation.total >= 1' <<<"${metrics}" >/dev/null
+jq -e '.lastBundle.status == "ok"' <<<"${metrics}" >/dev/null
+
+if [[ ! -s "${ROOT}/audit.ndjson" ]]; then
+  echo "audit ledger missing" >&2
+  exit 1
+fi
+
+python3 "${ROOT}/audit_ledger.py" --path "${ROOT}/audit.ndjson" >/dev/null
+
+echo "SMOKE OK"

--- a/offline_service/demo.sh
+++ b/offline_service/demo.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PORT="${PORT:-8787}"
+HOST="${HOST:-127.0.0.1}"
+BASE_URL="${BASE_URL:-http://${HOST}:${PORT}}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "# Hitting ${BASE_URL}"
+
+echo "# Health"
+curl -sf "${BASE_URL}/health" | jq
+
+echo "\n# Evaluate (pass)"
+curl -sf -X POST "${BASE_URL}/api/policy/evaluate" \
+  -H 'content-type: application/json' \
+  --data @"${ROOT}/demo/good_evaluation.json" | jq
+
+echo "\n# Evaluate (fail)"
+curl -sf -X POST "${BASE_URL}/api/policy/evaluate" \
+  -H 'content-type: application/json' \
+  --data @"${ROOT}/demo/fail_evaluation.json" | jq
+
+echo "\n# Remediate"
+curl -sf -X POST "${BASE_URL}/api/policy/remediate" \
+  -H 'content-type: application/json' \
+  --data @"${ROOT}/demo/remediation.json" | jq
+
+echo "\n# Metrics"
+curl -sf "${BASE_URL}/api/policy/metrics" | jq

--- a/offline_service/demo/README.md
+++ b/offline_service/demo/README.md
@@ -1,0 +1,9 @@
+# Offline Policy Demo
+
+This directory collects example payloads and scripts that exercise the offline policy server.
+
+* `good_evaluation.json` — a policy case with all rules passing.
+* `fail_evaluation.json` — a policy case that triggers a failure.
+* `remediation.json` — sample marketing copy that requires remediation.
+
+Use `demo.sh` from the repository root to replay these scenarios against a running server.

--- a/offline_service/demo/fail_evaluation.json
+++ b/offline_service/demo/fail_evaluation.json
@@ -1,0 +1,9 @@
+{
+  "caseId": "case-demo-fail",
+  "pqc": "off",
+  "rules": [
+    { "outcome": "pass" },
+    { "outcome": "warn" },
+    { "outcome": "fail" }
+  ]
+}

--- a/offline_service/demo/good_evaluation.json
+++ b/offline_service/demo/good_evaluation.json
@@ -1,0 +1,9 @@
+{
+  "caseId": "case-demo-pass",
+  "pqc": "on",
+  "rules": [
+    { "outcome": "pass" },
+    { "outcome": "pass" },
+    { "outcome": "pass" }
+  ]
+}

--- a/offline_service/demo/remediation.json
+++ b/offline_service/demo/remediation.json
@@ -1,0 +1,4 @@
+{
+  "marketing": "Guaranteed best returns with no risk.",
+  "productClass": "annuity"
+}

--- a/offline_service/make_release.sh
+++ b/offline_service/make_release.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RELEASE_DIR="${ROOT}/release"
+mkdir -p "${RELEASE_DIR}"
+
+SIGNING_KEY="${SIGNING_KEY:-${RELEASE_DIR}/signing_key.pem}"
+if [[ ! -f "${SIGNING_KEY}" ]]; then
+  echo "Signing key missing. Provide SIGNING_KEY or create ${SIGNING_KEY}." >&2
+  exit 1
+fi
+
+stamp="$(date +%Y%m%d_%H%M%S)"
+target_dir="${RELEASE_DIR}/offline_service_${stamp}"
+mkdir -p "${target_dir}"
+
+tarball="${target_dir}/offline_service_${stamp}.tgz"
+
+pushd "${ROOT}" >/dev/null
+  tar -czf "${tarball}" \
+    server.js \
+    ops.html \
+    audit_ledger.py \
+    demo \
+    demo.sh \
+    check.sh
+popd >/dev/null
+
+sha256sum "${tarball}" > "${target_dir}/sha256.txt"
+sha_value=$(cut -d' ' -f1 "${target_dir}/sha256.txt")
+
+openssl dgst -sha256 -sign "${SIGNING_KEY}" -out "${target_dir}/bundle.sig" "${tarball}"
+openssl base64 -A -in "${target_dir}/bundle.sig" -out "${target_dir}/bundle.sig.b64"
+
+printf "%s" "${sha_value}" | openssl dgst -sha256 -sign "${SIGNING_KEY}" | openssl base64 -A > "${target_dir}/sha256.sig"
+openssl rsa -in "${SIGNING_KEY}" -pubout -out "${target_dir}/public.pem" >/dev/null 2>&1
+
+cat <<MANIFEST > "${target_dir}/manifest.json"
+{
+  "created": "${stamp}",
+  "tarball": "$(basename "${tarball}")",
+  "sha256": "${sha_value}",
+  "sha256_signature": "$(cat "${target_dir}/sha256.sig")"
+}
+MANIFEST
+
+echo "Release package created: ${tarball}"
+echo "SHA-256: ${sha_value}"

--- a/offline_service/ops.html
+++ b/offline_service/ops.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Offline Policy Ops</title>
+    <style>
+      body {
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        margin: 2rem auto;
+        max-width: 720px;
+        line-height: 1.6;
+        color: #172b4d;
+      }
+      h1 {
+        margin-bottom: 0.25rem;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+        gap: 1rem;
+        margin: 1.5rem 0;
+      }
+      .card {
+        border: 1px solid #d9e2ec;
+        border-radius: 8px;
+        padding: 1rem;
+        background: #f8fafc;
+        box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+      }
+      .card strong {
+        display: block;
+        font-size: 1.25rem;
+      }
+      pre {
+        background: #0f172a;
+        color: #e2e8f0;
+        padding: 1rem;
+        border-radius: 8px;
+        overflow-x: auto;
+      }
+      footer {
+        font-size: 0.85rem;
+        color: #64748b;
+        margin-top: 2rem;
+        text-align: center;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Offline Policy Service</h1>
+    <p>
+      Snapshot of policy evaluation activity. Metrics refresh every 10 seconds.
+    </p>
+    <div class="grid">
+      <div class="card">
+        <span>Policy Pass</span>
+        <strong id="metric-pass">0</strong>
+      </div>
+      <div class="card">
+        <span>Policy Warn</span>
+        <strong id="metric-warn">0</strong>
+      </div>
+      <div class="card">
+        <span>Policy Fail</span>
+        <strong id="metric-fail">0</strong>
+      </div>
+      <div class="card">
+        <span>Attest OK</span>
+        <strong id="metric-attest-ok">0</strong>
+      </div>
+      <div class="card">
+        <span>Attest Fail</span>
+        <strong id="metric-attest-fail">0</strong>
+      </div>
+      <div class="card">
+        <span>Remediations</span>
+        <strong id="metric-remediation">0</strong>
+      </div>
+    </div>
+    <section>
+      <h2>Raw Metrics</h2>
+      <pre id="raw-json">{}</pre>
+    </section>
+    <footer>
+      Metrics served from <code>/api/policy/metrics</code>. Updated <span id="last-updated">never</span>.
+    </footer>
+    <script>
+      async function refresh() {
+        try {
+          const response = await fetch('/api/policy/metrics');
+          if (!response.ok) {
+            throw new Error('HTTP ' + response.status);
+          }
+          const payload = await response.json();
+          updateCards(payload);
+          document.getElementById('raw-json').textContent = JSON.stringify(payload, null, 2);
+          document.getElementById('last-updated').textContent = new Date().toLocaleTimeString();
+        } catch (err) {
+          document.getElementById('raw-json').textContent = 'Error loading metrics: ' + err.message;
+        }
+      }
+
+      function updateCards(data) {
+        const { policy = {}, attest = {}, remediation = {} } = data;
+        document.getElementById('metric-pass').textContent = policy.pass ?? 0;
+        document.getElementById('metric-warn').textContent = policy.warn ?? 0;
+        document.getElementById('metric-fail').textContent = policy.fail ?? 0;
+        document.getElementById('metric-attest-ok').textContent = attest.ok ?? 0;
+        document.getElementById('metric-attest-fail').textContent = attest.fail ?? 0;
+        document.getElementById('metric-remediation').textContent = remediation.total ?? 0;
+      }
+
+      refresh();
+      setInterval(refresh, 10_000);
+    </script>
+  </body>
+</html>

--- a/offline_service/server.js
+++ b/offline_service/server.js
@@ -1,0 +1,367 @@
+#!/usr/bin/env node
+import http from 'node:http';
+import { URL, fileURLToPath } from 'node:url';
+import * as fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const PORT = Number(process.env.PORT || 8787);
+const HOST = process.env.HOST || '0.0.0.0';
+const DATA_DIR = path.join(__dirname);
+const AUDIT_PATH = path.join(DATA_DIR, 'audit.ndjson');
+
+const bannedPhrases = [
+  { pattern: /guaranteed/gi, replacement: 'positioned', token: 'guaranteed' },
+  { pattern: /best/gi, replacement: 'competitive', token: 'best' },
+  { pattern: /no\s*risk/gi, replacement: 'managed risk', token: 'no risk' }
+];
+
+const riskyProducts = new Map(
+  Object.entries({
+    annuity: 'Disclosure: Annuities may include surrender charges and market exposure. Review the contract carefully before investing.',
+    derivative: 'Disclosure: Derivative products can amplify losses as well as gains. Ensure suitability for your objectives.',
+    'structured note': 'Disclosure: Structured notes are complex and may lose value. Assess issuer creditworthiness and liquidity.',
+    crypto: 'Disclosure: Digital assets are volatile and may lose significant value. Only invest what you can afford to lose.'
+  })
+);
+
+const metrics = {
+  policy: { pass: 0, warn: 0, fail: 0 },
+  ruleOutcomes: { pass: 0, warn: 0, fail: 0 },
+  errors: { input: 0, engine: 0, attest: 0 },
+  attest: { ok: 0, fail: 0 },
+  remediation: { total: 0 },
+  lastLatencyMs: { total: 0, engine: 0 },
+  lastBundle: null,
+  version: 'unknown',
+  ruleCount: 0,
+  startedAt: Date.now(),
+  lastUpdated: new Date().toISOString()
+};
+
+let lastAuditHash = null;
+initializeAuditHash();
+
+const server = http.createServer(async (req, res) => {
+  try {
+    const url = new URL(req.url, `http://${req.headers.host}`);
+    setCorsHeaders(res);
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204);
+      return res.end();
+    }
+    if (req.method === 'GET' && (url.pathname === '/' || url.pathname === '/ops.html' || url.pathname === '/ops')) {
+      return serveOps(res);
+    }
+    if (req.method === 'GET' && url.pathname === '/health') {
+      return respondJson(res, 200, { ok: true, uptime_seconds: Math.round((Date.now() - metrics.startedAt) / 1000) });
+    }
+    if (req.method === 'GET' && url.pathname === '/api/policy/metrics') {
+      return handleMetrics(res);
+    }
+    if (req.method === 'POST' && url.pathname === '/api/policy/evaluate') {
+      const body = await readJson(req, res);
+      if (body === undefined) {
+        return; // response handled in readJson
+      }
+      return handleEvaluate(res, body);
+    }
+    if (req.method === 'POST' && url.pathname === '/api/policy/bundle') {
+      const body = await readJson(req, res);
+      if (body === undefined) {
+        return;
+      }
+      return handleBundle(res, body);
+    }
+    if (req.method === 'POST' && url.pathname === '/api/policy/remediate') {
+      const body = await readJson(req, res);
+      if (body === undefined) {
+        return;
+      }
+      return handleRemediate(res, body);
+    }
+    if (req.method === 'POST' && url.pathname === '/api/attest/bundle') {
+      const body = await readJson(req, res);
+      if (body === undefined) {
+        return;
+      }
+      return handleAttest(res, body);
+    }
+    respondJson(res, 404, { error: 'not_found' });
+  } catch (err) {
+    console.error('Unhandled error', err);
+    respondJson(res, 500, { error: 'server_error' });
+  }
+});
+
+server.listen(PORT, HOST, () => {
+  console.log(`offline policy service listening on http://${HOST}:${PORT}`);
+});
+
+function setCorsHeaders(res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+}
+
+function serveOps(res) {
+  const opsPath = path.join(__dirname, 'ops.html');
+  if (!fs.existsSync(opsPath)) {
+    res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+    return res.end('ops dashboard missing');
+  }
+  const html = fs.readFileSync(opsPath);
+  res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+  res.end(html);
+}
+
+function handleMetrics(res) {
+  const uptimeSeconds = Math.max(0, Math.round((Date.now() - metrics.startedAt) / 1000));
+  metrics.lastUpdated = new Date().toISOString();
+  respondJson(res, 200, {
+    now: metrics.lastUpdated,
+    version: metrics.version,
+    ruleCount: metrics.ruleCount,
+    policy: { ...metrics.policy },
+    ruleOutcomes: { ...metrics.ruleOutcomes },
+    errors: { ...metrics.errors },
+    attest: { ...metrics.attest },
+    remediation: { ...metrics.remediation },
+    latency_ms: { ...metrics.lastLatencyMs },
+    uptime_seconds: uptimeSeconds,
+    lastBundle: metrics.lastBundle
+  });
+}
+
+function normalizeOutcome(outcome) {
+  if (outcome === 'warn' || outcome === 'fail') {
+    return outcome;
+  }
+  return 'pass';
+}
+
+function normalizePqc(value) {
+  if (value === 'on' || value === 'off') {
+    return value;
+  }
+  return 'unavailable';
+}
+
+function handleEvaluate(res, body) {
+  const caseId = typeof body?.caseId === 'string' ? body.caseId.trim() : '';
+  if (!caseId) {
+    metrics.errors.input += 1;
+    return respondJson(res, 400, { error: 'caseId_required' });
+  }
+  const pqc = normalizePqc(body?.pqc);
+  const rules = Array.isArray(body?.rules) ? body.rules : [];
+  const normalized = [];
+  const engineStart = process.hrtime.bigint();
+  for (const rule of rules) {
+    normalized.push(normalizeOutcome(rule?.outcome));
+  }
+  const counts = { pass: 0, warn: 0, fail: 0 };
+  for (const outcome of normalized) {
+    counts[outcome] += 1;
+  }
+  const result = counts.fail > 0 ? 'fail' : counts.warn > 0 ? 'warn' : 'pass';
+  const engineSeconds = Number(process.hrtime.bigint() - engineStart) / 1_000_000_000;
+  const totalSeconds = engineSeconds; // engine work dominates in this simple service
+  metrics.ruleOutcomes.pass += counts.pass;
+  metrics.ruleOutcomes.warn += counts.warn;
+  metrics.ruleOutcomes.fail += counts.fail;
+  metrics.policy[result] += 1;
+  metrics.lastLatencyMs.total = Math.round(totalSeconds * 1000);
+  metrics.lastLatencyMs.engine = Math.round(engineSeconds * 1000);
+  appendAudit('policy.evaluate', {
+    caseId,
+    result,
+    counts,
+    pqc,
+    ruleCount: normalized.length
+  });
+  respondJson(res, 200, {
+    caseId,
+    result,
+    counts,
+    pqc,
+    latency_ms: metrics.lastLatencyMs
+  });
+}
+
+function handleBundle(res, body) {
+  const version = typeof body?.version === 'string' ? body.version.trim() : 'unknown';
+  const ruleCount = Number.isFinite(body?.ruleCount) ? Math.max(0, Math.trunc(body.ruleCount)) : 0;
+  const bundleHash = typeof body?.hash === 'string' ? body.hash.trim() : '';
+  const signature = typeof body?.signature === 'string' ? body.signature.trim() : '';
+  const publicKey = typeof body?.publicKey === 'string' ? body.publicKey.trim() : '';
+  if (!bundleHash || !signature || !publicKey) {
+    metrics.errors.input += 1;
+    return respondJson(res, 400, { error: 'bundle_payload_invalid' });
+  }
+  const ok = verifySignature(bundleHash, signature, publicKey);
+  const status = ok ? 'ok' : 'fail';
+  metrics.attest[status] += 1;
+  metrics.version = version || 'unknown';
+  metrics.ruleCount = ruleCount;
+  metrics.lastBundle = { hash: bundleHash, status, version, ruleCount };
+  appendAudit('policy.bundle.verify', {
+    version: metrics.version,
+    ruleCount,
+    hash: bundleHash,
+    status
+  });
+  if (!ok) {
+    metrics.errors.attest += 1;
+    return respondJson(res, 422, { ok: false, status: 'fail', version: metrics.version });
+  }
+  respondJson(res, 200, { ok: true, status: 'ok', version: metrics.version });
+}
+
+function handleAttest(res, body) {
+  const status = body?.status === 'fail' ? 'fail' : 'ok';
+  const pqc = normalizePqc(body?.pqc);
+  metrics.attest[status] += 1;
+  if (status === 'fail') {
+    metrics.errors.attest += 1;
+  }
+  appendAudit('attest.bundle.report', { status, pqc, reason: body?.reason });
+  if (status === 'fail') {
+    return respondJson(res, 502, { ok: false, status, pqc, reason: body?.reason ?? 'no details' });
+  }
+  respondJson(res, 200, { ok: true, status, pqc });
+}
+
+function handleRemediate(res, body) {
+  const marketing = typeof body?.marketing === 'string' ? body.marketing : '';
+  const productClass = typeof body?.productClass === 'string' ? body.productClass.toLowerCase().trim() : '';
+  if (!marketing) {
+    metrics.errors.input += 1;
+    return respondJson(res, 400, { error: 'marketing_required' });
+  }
+  let remediated = marketing;
+  const touched = [];
+  for (const { pattern, replacement, token } of bannedPhrases) {
+    pattern.lastIndex = 0;
+    if (pattern.test(remediated)) {
+      remediated = remediated.replace(pattern, replacement);
+      touched.push(token);
+    }
+  }
+  const disclosure = riskyProducts.get(productClass);
+  let disclosureAdded = false;
+  if (disclosure) {
+    disclosureAdded = true;
+    remediated = ensureSentence(remediated);
+  }
+  metrics.remediation.total += 1;
+  appendAudit('policy.remediate', {
+    marketing,
+    remediated,
+    productClass,
+    disclosureAdded
+  });
+  respondJson(res, 200, {
+    marketing,
+    remediated: disclosure ? `${remediated} ${disclosure}` : remediated,
+    disclosureAdded,
+    disclosure: disclosure ?? null,
+    replacements: touched
+  });
+}
+
+function ensureSentence(text) {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return 'Updated copy forthcoming.';
+  }
+  if (/[.!?]$/.test(trimmed)) {
+    return trimmed;
+  }
+  return `${trimmed}.`;
+}
+
+function verifySignature(hashValue, signatureB64, publicKey) {
+  try {
+    const verifier = crypto.createVerify('RSA-SHA256');
+    verifier.update(hashValue, 'utf8');
+    verifier.end();
+    return verifier.verify(publicKey, Buffer.from(signatureB64, 'base64'));
+  } catch (err) {
+    console.error('verifySignature error', err);
+    return false;
+  }
+}
+
+function readJson(req, res) {
+  return new Promise((resolve) => {
+    let raw = '';
+    req.on('data', (chunk) => {
+      raw += chunk;
+      if (raw.length > 1_000_000) {
+        res.writeHead(413, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'payload_too_large' }));
+        req.destroy();
+      }
+    });
+    req.on('end', () => {
+      try {
+        const data = raw ? JSON.parse(raw) : {};
+        resolve(data);
+      } catch (err) {
+        metrics.errors.input += 1;
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'invalid_json' }));
+        resolve(undefined);
+      }
+    });
+    req.on('error', (err) => {
+      console.error('readJson error', err);
+      metrics.errors.engine += 1;
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'stream_error' }));
+      resolve(undefined);
+    });
+  });
+}
+
+function respondJson(res, status, data) {
+  res.writeHead(status, { 'Content-Type': 'application/json; charset=utf-8' });
+  res.end(JSON.stringify(data));
+}
+
+function initializeAuditHash() {
+  if (!fs.existsSync(AUDIT_PATH)) {
+    lastAuditHash = null;
+    return;
+  }
+  const lines = fs.readFileSync(AUDIT_PATH, 'utf8').trim().split('\n');
+  for (const line of lines) {
+    if (!line) continue;
+    try {
+      const parsed = JSON.parse(line);
+      if (parsed && typeof parsed.hash === 'string') {
+        lastAuditHash = parsed.hash;
+      }
+    } catch (err) {
+      console.warn('unable to parse audit line', err);
+    }
+  }
+}
+
+function appendAudit(event, payload) {
+  const base = {
+    ts: new Date().toISOString(),
+    event,
+    payload,
+    prevHash: lastAuditHash
+  };
+  const hash = crypto.createHash('sha256').update(JSON.stringify(base)).digest('hex');
+  const entry = { ...base, hash };
+  fs.appendFileSync(AUDIT_PATH, `${JSON.stringify(entry)}\n`);
+  lastAuditHash = hash;
+}
+


### PR DESCRIPTION
## Summary
- add a standalone offline policy service with remediation, metrics, bundle verification, and audit logging
- provide an ops dashboard plus demo payloads for quick evaluation and remediation checks
- supply a smoke test, release bundler, and audit ledger verifier scripts for CI and release automation

## Testing
- ./offline_service/check.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e8fe7672c8329915164f9bd717cad)