### PR TITLE
Add automated time machine metrics workflows

### DIFF
--- a/.github/workflows/autobuilder.yml
+++ b/.github/workflows/autobuilder.yml
@@ -1,0 +1,25 @@
+# .github/workflows/autobuilder.yml
+name: autobuilder
+on:
+  schedule:
+    - cron: "23 2 * * *"
+  workflow_dispatch: {}
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { ref: ${{ github.ref }} }
+      - name: Generate micro-fixes
+        run: |
+          node tools/autobuilder/make_fixes.js --index data/timemachine/index.json
+      - name: Create PR
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "autobuilder: perf+docs micro-fixes"
+          title: "Autobuilder: perf+docs micro-fixes"
+          labels: "autogen,canary:5%,low-risk"
+          branch: "autobuilder/${{ github.run_id }}"

--- a/.github/workflows/budget-gate.yml
+++ b/.github/workflows/budget-gate.yml
@@ -1,0 +1,21 @@
+# .github/workflows/budget-gate.yml
+name: budget-gate
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  check-budgets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Ensure KPIs present (compute if missing)
+        run: |
+          if [ ! -f data/kpis/latest.json ]; then
+            if [ -f data/timemachine/index.json ]; then
+              node tools/kpis/compute.js data/timemachine/index.json > data/kpis/latest.json
+            else
+              echo "No index found; skipping compute."
+            fi
+          fi
+      - name: Budget checks
+        run: node tools/policies/check_budgets.js data/kpis/latest.json

--- a/.github/workflows/kpi-pulse.yml
+++ b/.github/workflows/kpi-pulse.yml
@@ -1,0 +1,31 @@
+# .github/workflows/kpi-pulse.yml
+name: kpi-pulse
+on:
+  schedule:
+    - cron: "17 4 * * MON"
+  workflow_dispatch: {}
+jobs:
+  pulse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Compute KPIs
+        run: |
+          node --version
+          node tools/kpis/compute.js data/timemachine/index.json > data/kpis/latest.json
+      - name: Write Pulse
+        run: |
+          node tools/pulse/write.js data/kpis/latest.json > pulses/$(date +SYS-PERF-%Y-W%V).md
+      - name: Commit artifacts
+        run: |
+          git config user.name "prism-bot"
+          git config user.email "bot@blackroad.io"
+          git add data/kpis/latest.json pulses/
+          git commit -m "chore(pulse): weekly performance report" || echo "no changes"
+          git push || true
+      - name: Slack summary (optional)
+        if: ${{ secrets.SLACK_WEBHOOK_URL != '' }}
+        env:
+          WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          node tools/pulse/slack.js pulses/$(date +SYS-PERF-%Y-W%V).md "$WEBHOOK"

--- a/.github/workflows/time-machine-index.yml
+++ b/.github/workflows/time-machine-index.yml
@@ -1,0 +1,30 @@
+# .github/workflows/time-machine-index.yml
+name: time-machine-index
+on:
+  schedule:
+    - cron: "11 3 * * *"
+  workflow_dispatch: {}
+jobs:
+  index:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build index
+        run: |
+          python3 --version
+          python3 tools/timemachine/index.py \
+            --lh sites/blackroad/public/metrics/lh.json \
+            --ci sites/blackroad/public/metrics/ci.json \
+            --k6 logs/perf/k6_summary.json \
+            --runmeta run_meta.json \
+            --alerts data/aiops/alerts.jsonl \
+            --runtime logs/runtime \
+            --agents agents/lineage \
+            --out data/timemachine/index.json
+      - name: Commit index
+        run: |
+          git config user.name "prism-bot"
+          git config user.email "bot@blackroad.io"
+          git add data/timemachine/index.json
+          git commit -m "chore(tm): refresh index" || echo "no changes"
+          git push || true

--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,11 @@ ssh-*
 *.tar.gz
 *.npz
 *.npy
+# Time machine artifacts
+/data/kpis/latest.json
+/data/timemachine/index.json
+/data/aiops/actions.jsonl
+/pulses/
 *.pkl
 *.parquet
 *.feather

--- a/tools/autobuilder/make_fixes.js
+++ b/tools/autobuilder/make_fixes.js
@@ -1,0 +1,96 @@
+// tools/autobuilder/make_fixes.js
+// Usage: node tools/autobuilder/make_fixes.js --index data/timemachine/index.json
+import fs from "node:fs";
+import path from "node:path";
+
+const args = Object.fromEntries(process.argv.slice(2).map((x,i,arr)=>{
+  if (x.startsWith("--")) return [x.replace(/^--/,""), arr[i+1] && !arr[i+1].startsWith("--") ? arr[i+1] : true];
+  return [null,null];
+}).filter(Boolean));
+
+const INDEX = args.index || "data/timemachine/index.json";
+function ensureDir(p){ fs.mkdirSync(path.dirname(p), {recursive:true}); }
+function log(action, payload={}){
+  const line = JSON.stringify({ts:new Date().toISOString(), action, ...payload});
+  ensureDir("data/aiops/actions.jsonl");
+  fs.appendFileSync("data/aiops/actions.jsonl", line+"\n");
+}
+
+function upsertFile(p, content, tag){
+  const exists = fs.existsSync(p);
+  fs.mkdirSync(path.dirname(p), {recursive:true});
+  fs.writeFileSync(p, content, "utf8");
+  log("write_file", {path:p, tag, existed:exists});
+}
+
+const index = JSON.parse(fs.readFileSync(INDEX, "utf8"));
+
+//
+// 1) HTML tweaks (index.html) — add fetchpriority + alt; add preload hint if missing.
+//
+const INDEX_HTML = "sites/blackroad/public/index.html";
+if (fs.existsSync(INDEX_HTML)) {
+  let html = fs.readFileSync(INDEX_HTML, "utf8");
+  let changed = false;
+
+  // add fetchpriority="high" to first <img ...> if not present
+  html = html.replace(/<img([^>]*?)>/i, (m, attrs)=>{
+    if (/fetchpriority=/i.test(attrs)) return m;
+    changed = true;
+    if (!/alt=/i.test(attrs)) attrs += ' alt=""';
+    return `<img${attrs} fetchpriority="high">`;
+  });
+
+  // add a generic preload for first stylesheet/script if no preload present
+  if (!/rel=["']preload["']/.test(html)) {
+    const mCss = html.match(/href=["']([^"']+\.css)["']/i);
+    const mJs  = html.match(/src=["']([^"']+\.js)["']/i);
+    if (mCss) {
+      const link = `<link rel="preload" as="style" href="${mCss[1]}">`;
+      html = html.replace(/<head>/i, `<head>\n  ${link}`);
+      changed = true;
+    } else if (mJs) {
+      const link = `<link rel="preload" as="script" href="${mJs[1]}">`;
+      html = html.replace(/<head>/i, `<head>\n  ${link}`);
+      changed = true;
+    }
+  }
+
+  if (changed) {
+    fs.writeFileSync(INDEX_HTML, html, "utf8");
+    log("modify_html", {path: INDEX_HTML});
+  }
+}
+
+//
+// 2) Static hosting headers — write _headers for cache policy (safe)
+//
+const HEADERS = "sites/blackroad/public/_headers";
+if (!fs.existsSync(HEADERS)) {
+  const content = `/*
+  Cache-Control: no-store
+
+/assets/*
+  Cache-Control: public, max-age=604800, immutable
+`;
+  upsertFile(HEADERS, content, "cache_headers");
+}
+
+//
+// 3) robots.txt & sitemap.xml if missing
+//
+const ROBOTS = "sites/blackroad/public/robots.txt";
+if (!fs.existsSync(ROBOTS)) {
+  upsertFile(ROBOTS, `User-agent: *\nAllow: /\nSitemap: https://blackroad.io/sitemap.xml\n`, "robots");
+}
+const SITEMAP = "sites/blackroad/public/sitemap.xml";
+if (!fs.existsSync(SITEMAP)) {
+  upsertFile(SITEMAP, `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://blackroad.io/</loc></url>
+  <url><loc>https://blackroad.io/portal</loc></url>
+  <url><loc>https://blackroad.io/status</loc></url>
+</urlset>`, "sitemap");
+}
+
+console.log("Autobuilder completed.");

--- a/tools/kpis/compute.js
+++ b/tools/kpis/compute.js
@@ -1,0 +1,182 @@
+// tools/kpis/compute.js
+// Usage: node tools/kpis/compute.js data/timemachine/index.json > data/kpis/latest.json
+import fs from "node:fs";
+import path from "node:path";
+
+function readJSON(p) {
+  try { return JSON.parse(fs.readFileSync(p, "utf8")); } catch { return null; }
+}
+function ensureDir(p){ fs.mkdirSync(path.dirname(p), {recursive:true}); }
+
+function quantile(values, q){
+  const a=values.filter(v=>typeof v==="number" && !isNaN(v)).sort((x,y)=>x-y);
+  if(!a.length) return null;
+  const pos=(a.length-1)*q, base=Math.floor(pos), rest=pos-base;
+  return a[base] + (a[base+1]!==undefined ? rest*(a[base+1]-a[base]) : 0);
+}
+function median(vs){ return quantile(vs,0.5); }
+function avg(vs){
+  const a=vs.filter(v=>typeof v==="number" && !isNaN(v));
+  return a.length? a.reduce((s,v)=>s+v,0)/a.length : null;
+}
+
+function withinDays(tsIso, days){
+  if(!tsIso) return false;
+  const t = new Date(tsIso).getTime();
+  if (isNaN(t)) return false;
+  const now = Date.now();
+  return (now - t) <= days*24*3600*1000;
+}
+
+function computeKPIs(index){
+  const out = { generated_at: new Date().toISOString(), kpis: {}, flags: {}, notes: [] };
+
+  // LH (7d window)
+  const lh = (index.lh?.history)||[];
+  const lh7 = lh.filter(r => withinDays(r.ts, 7));
+  const get = (rows, k)=> rows.map(x=>x?.[k]).filter(n=>typeof n==="number");
+
+  const perf7 = avg(get(lh7,"perf"));
+  const a11y7 = avg(get(lh7,"a11y"));
+  const bp7 = avg(get(lh7,"bp"));
+  const seo7 = avg(get(lh7,"seo"));
+  const lcp7 = get(lh7,"LCP");
+  const tbt7 = get(lh7,"TBT");
+  const cls7 = get(lh7,"CLS");
+
+  const lcpCoverage7 = lcp7.length ? (lcp7.filter(v=>v<2000).length / lcp7.length) : null;
+  const tbtMedian7 = median(tbt7);
+  const lcpP75 = quantile(lcp7, 0.75);
+  const tbtP75 = quantile(tbt7, 0.75);
+  const clsP95_7 = quantile(cls7, 0.95);
+
+  out.kpis.web = {
+    perf_mean_7d: perf7,
+    a11y_mean_7d: a11y7,
+    bp_mean_7d: bp7,
+    seo_mean_7d: seo7,
+    lcp_p75_ms: lcpP75,
+    tbt_p75_ms: tbtP75,
+    lcp_lt2000_coverage_7d: lcpCoverage7,
+    tbt_median_7d: tbtMedian7,
+    cls_p95_7d: clsP95_7
+  };
+
+  // CI (7d)
+  const runs = (index.ci?.runs)||[];
+  const r7 = runs.filter(r => withinDays(r.ts, 7));
+  const total = r7.length;
+  const failed = r7.filter(r => (r.conclusion||"").toLowerCase().includes("fail")).length;
+  const failureRate = total? failed/total : null;
+
+  // naive MTTR: for each failed run, time to next success in same workflow
+  let mttrMs = null;
+  if (r7.length){
+    const byWf = {};
+    for (const r of r7){
+      const k = r.name||"";
+      (byWf[k] ||= []).push(r);
+    }
+    const diffs=[];
+    for (const [_, arr] of Object.entries(byWf)){
+      arr.sort((a,b)=> new Date(a.ts)-new Date(b.ts));
+      for (let i=0;i<arr.length;i++){
+        if ((arr[i].conclusion||"").toLowerCase().includes("fail")){
+          const next = arr.slice(i+1).find(x=> (x.conclusion||"").toLowerCase().includes("success"));
+          if (next){
+            diffs.push(new Date(next.ts)-new Date(arr[i].ts));
+          }
+        }
+      }
+    }
+    if (diffs.length) mttrMs = avg(diffs);
+  }
+
+  // Deploy frequency (successful runs with 'deploy' in name)
+  const deploys = r7.filter(r => /deploy/i.test(r.name||"") && /(success|completed)/i.test(r.conclusion||"")).length;
+
+  out.kpis.ci = {
+    failure_rate_7d: failureRate,
+    mttr_ms_7d: mttrMs,
+    deploys_per_7d: deploys
+  };
+
+  // k6 latest summary + components
+  const k6sum = index.k6?.summary || {};
+  const comps = index.k6?.components || [];
+  const k6 = {
+    http_reqs_rate: k6sum.http_reqs_rate ?? null,
+    duration_p95: k6sum.duration_p95 ?? null,
+    components: {}
+  };
+  for (const c of comps){
+    if (!c?.component) continue;
+    k6.components[c.component] = { p50: c.p50 ?? null, p90: c.p90 ?? null, p95: c.p95 ?? null };
+  }
+  out.kpis.k6 = k6;
+
+  // Simulation (7d)
+  const simRuns = (index.sim?.runs)||[];
+  const sim7 = simRuns.filter(r => withinDays(r.generated_at, 7));
+  const solidMae = avg(sim7.map(r => r?.solid?.mae));
+  const solidRmse = avg(sim7.map(r => r?.solid?.rmse));
+  const solidPass = avg(sim7.map(r => r?.solid?.pass_fraction));
+  const fluidMae = avg(sim7.map(r => r?.fluid?.mae));
+  const fluidRmse = avg(sim7.map(r => r?.fluid?.rmse));
+  const fluidPass = avg(sim7.map(r => r?.fluid?.pass_fraction));
+  out.kpis.sim = {
+    solid: { mae_mean_7d: solidMae, rmse_mean_7d: solidRmse, pass_fraction_mean_7d: solidPass },
+    fluid: { mae_mean_7d: fluidMae, rmse_mean_7d: fluidRmse, pass_fraction_mean_7d: fluidPass }
+  };
+
+  // Alerts (7d)
+  const alerts = (index.alerts?.alerts)||[];
+  const alerts7 = alerts.filter(a => withinDays(a.ts || a.time || a.timestamp, 7));
+  out.kpis.alerts = { volume_7d: alerts7.length };
+
+  // Agent coverage (best-effort)
+  const agentItems = (index.agents?.items)||[];
+  out.kpis.agents = {
+    tracked_files: agentItems.length
+  };
+
+  // Budgets / SLO flags (v1)
+  const budgets = {
+    web: { perf: 0.93, a11y: 0.98, lcp_p75_ms: 2000, tbt_p75_ms: 150, cls_p95: 0.1 },
+    k6: { frontend_p95_ms: 250, quantum_p95_ms: 1200, materials_p95_ms: 1400 },
+    ci: { failure_rate: 0.02, mttr_ms: 2*60*60*1000, deploys_min_7d: 3 }
+  };
+
+  // Evaluate flags
+  function ok(b){ return b===null || b===undefined ? null : Boolean(b); }
+
+  out.flags = {
+    web: {
+      perf_ok: ok(perf7!==null && perf7>=budgets.web.perf),
+      a11y_ok: ok(a11y7!==null && a11y7>=budgets.web.a11y),
+      lcp_ok: ok(lcpP75!==null && lcpP75<=budgets.web.lcp_p75_ms),
+      tbt_ok: ok(tbtP75!==null && tbtP75<=budgets.web.tbt_p75_ms),
+      cls_ok: ok(clsP95_7!==null && clsP95_7<=budgets.web.cls_p95)
+    },
+    ci: {
+      failure_rate_ok: ok(failureRate!==null && failureRate<=budgets.ci.failure_rate),
+      mttr_ok: ok(mttrMs!==null && mttrMs<=budgets.ci.mttr_ms),
+      deploys_ok: ok(deploys!==null && deploys>=budgets.ci.deploys_min_7d)
+    },
+    k6: {
+      frontend_ok: ok((k6.components?.frontend?.p95 ?? null) !== null && k6.components.frontend.p95 <= budgets.k6.frontend_p95_ms),
+      quantum_ok: ok((k6.components?.["quantum-lab"]?.p95 ?? null) !== null && k6.components["quantum-lab"].p95 <= budgets.k6.quantum_p95_ms),
+      materials_ok: ok((k6.components?.["materials-service"]?.p95 ?? null) !== null && k6.components["materials-service"].p95 <= budgets.k6.materials_p95_ms)
+    }
+  };
+
+  out.budgets = budgets;
+  return out;
+}
+
+const input = process.argv[2] || "data/timemachine/index.json";
+const index = readJSON(input) || {};
+const out = computeKPIs(index);
+ensureDir("data/kpis/latest.json");
+fs.writeFileSync("data/kpis/latest.json", JSON.stringify(out, null, 2));
+process.stdout.write(JSON.stringify(out, null, 2));

--- a/tools/policies/check_budgets.js
+++ b/tools/policies/check_budgets.js
@@ -1,0 +1,33 @@
+// tools/policies/check_budgets.js
+// Usage: node tools/policies/check_budgets.js data/kpis/latest.json
+import fs from "node:fs";
+
+const file = process.argv[2] || "data/kpis/latest.json";
+const latest = JSON.parse(fs.readFileSync(file, "utf8"));
+
+function fail(msg){ console.error("❌", msg); process.exitCode = 1; }
+function ok(msg){ console.log("✅", msg); }
+
+const f = latest.flags || {};
+const checks = [
+  ["web.perf_ok", f.web?.perf_ok],
+  ["web.a11y_ok", f.web?.a11y_ok],
+  ["web.lcp_ok", f.web?.lcp_ok],
+  ["web.tbt_ok", f.web?.tbt_ok],
+  ["web.cls_ok", f.web?.cls_ok],
+  ["ci.failure_rate_ok", f.ci?.failure_rate_ok],
+  ["ci.mttr_ok", f.ci?.mttr_ok],
+  ["ci.deploys_ok", f.ci?.deploys_ok],
+  ["k6.frontend_ok", f.k6?.frontend_ok],
+  ["k6.quantum_ok", f.k6?.quantum_ok],
+  ["k6.materials_ok", f.k6?.materials_ok],
+];
+
+let anyFail = false;
+for (const [name, flag] of checks){
+  if (flag === null || flag === undefined) { console.log("–", name, "n/a"); continue; }
+  if (flag){ ok(name); } else { fail(name); anyFail = true; }
+}
+
+if (anyFail) process.exit(1);
+console.log("All budgets satisfied.");

--- a/tools/pulse/slack.js
+++ b/tools/pulse/slack.js
@@ -1,0 +1,23 @@
+// tools/pulse/slack.js
+// Usage: node tools/pulse/slack.js pulses/SYS-PERF-YYYY-WW.md "$SLACK_WEBHOOK_URL"
+import fs from "node:fs";
+
+const file = process.argv[2];
+const url = process.argv[3];
+if (!file || !url) {
+  console.error("Usage: node tools/pulse/slack.js <pulse.md> <SLACK_WEBHOOK_URL>");
+  process.exit(2);
+}
+const text = fs.readFileSync(file, "utf8").slice(0, 3000); // Slack limit-ish
+const payload = { text: `*${file}*\n${text}` };
+
+const res = await fetch(url, {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify(payload)
+});
+if (!res.ok) {
+  console.error("Slack post failed:", res.status, await res.text());
+  process.exit(1);
+}
+console.log("Posted to Slack:", file);

--- a/tools/pulse/write.js
+++ b/tools/pulse/write.js
@@ -1,0 +1,63 @@
+// tools/pulse/write.js
+// Usage: node tools/pulse/write.js data/kpis/latest.json > pulses/SYS-PERF-YYYY-WW.md
+import fs from "node:fs";
+import path from "node:path";
+
+function isoWeek(dt=new Date()){
+  const d=new Date(Date.UTC(dt.getFullYear(), dt.getMonth(), dt.getDate()));
+  const dayNum = d.getUTCDay()||7; d.setUTCDate(d.getUTCDate()+4-dayNum);
+  const yearStart=new Date(Date.UTC(d.getUTCFullYear(),0,1));
+  const week=Math.ceil((((d - yearStart) / 86400000) + 1)/7);
+  return {year:d.getUTCFullYear(), week};
+}
+function readJSON(p){ try{return JSON.parse(fs.readFileSync(p,"utf8"));}catch{return null;} }
+function pct(x){ return (x==null)? "—" : (Math.round(x*1000)/10).toFixed(1)+"%"; }
+function num(x, unit=""){ return (x==null)? "—" : `${Math.round(x)}${unit}`; }
+function ms(x){ return (x==null)? "—" : `${Math.round(x)} ms`; }
+function okBadge(b){ return b==null ? "–" : (b? "🟢" : "🔴"); }
+function ensureDir(p){ fs.mkdirSync(path.dirname(p), {recursive:true}); }
+
+const latest = readJSON(process.argv[2] || "data/kpis/latest.json") || {};
+const {year, week} = isoWeek();
+const title = `SYS-PERF-${year}-W${String(week).padStart(2,"0")}`;
+
+const web = latest.kpis?.web||{};
+const ci = latest.kpis?.ci||{};
+const k6 = latest.kpis?.k6||{};
+const sim = latest.kpis?.sim||{};
+const flags = latest.flags||{};
+
+const md = `# 📈 Performance & Reliability Pulse — ${title}
+
+## Summary
+- Web: perf=${web.perf_mean_7d??"—"} a11y=${web.a11y_mean_7d??"—"} LCP p75=${ms(web.lcp_p75_ms)} TBT p75=${ms(web.tbt_p75_ms)}
+- CI: failure rate=${pct(ci.failure_rate_7d)} MTTR=${ms(ci.mttr_ms_7d)} deploys/7d=${ci.deploys_per_7d??"—"}
+- k6 p95: ${Object.entries(k6.components||{}).map(([k,v])=>`${k}:${ms(v.p95)}`).join("  ")}
+- Sim(solid): MAE=${sim.solid?.mae_mean_7d??"—"} RMSE=${sim.solid?.rmse_mean_7d??"—"} pass=${pct(sim.solid?.pass_fraction_mean_7d)}
+
+## Budgets / SLOs
+- Web: ${okBadge(flags.web?.perf_ok)} perf≥${latest.budgets?.web?.perf}  ${okBadge(flags.web?.a11y_ok)} a11y≥${latest.budgets?.web?.a11y}  ${okBadge(flags.web?.lcp_ok)} LCP p75≤${latest.budgets?.web?.lcp_p75_ms}ms  ${okBadge(flags.web?.tbt_ok)} TBT p75≤${latest.budgets?.web?.tbt_p75_ms}ms  ${okBadge(flags.web?.cls_ok)} CLS p95≤${latest.budgets?.web?.cls_p95}
+- CI: ${okBadge(flags.ci?.failure_rate_ok)} fail≤${pct(latest.budgets?.ci?.failure_rate)}  ${okBadge(flags.ci?.mttr_ok)} MTTR≤${ms(latest.budgets?.ci?.mttr_ms)}  ${okBadge(flags.ci?.deploys_ok)} deploys≥${latest.budgets?.ci?.deploys_min_7d}
+- k6: ${okBadge(flags.k6?.frontend_ok)} frontend p95≤${ms(latest.budgets?.k6?.frontend_p95_ms)}  ${okBadge(flags.k6?.quantum_ok)} quantum p95≤${ms(latest.budgets?.k6?.quantum_p95_ms)}  ${okBadge(flags.k6?.materials_ok)} materials p95≤${ms(latest.budgets?.k6?.materials_p95_ms)}
+
+## Details
+### Web (7d)
+- perf=${web.perf_mean_7d??"—"}, a11y=${web.a11y_mean_7d??"—"}, best-practices=${web.bp_mean_7d??"—"}, SEO=${web.seo_mean_7d??"—"}
+- LCP<2s coverage=${pct(web.lcp_lt2000_coverage_7d)}  TBT median=${ms(web.tbt_median_7d)}  CLS p95=${web.cls_p95_7d??"—"}
+
+### CI (7d)
+- failures/total=${pct(ci.failure_rate_7d)}  MTTR=${ms(ci.mttr_ms_7d)}  deploys=${ci.deploys_per_7d??"—"}
+
+### k6 (latest)
+${Object.entries(k6.components||{}).map(([k,v])=>`- ${k}: p50=${ms(v.p50)} p90=${ms(v.p90)} p95=${ms(v.p95)}`).join("\n")}
+
+### Simulation (7d)
+- solid: MAE=${sim.solid?.mae_mean_7d??"—"}, RMSE=${sim.solid?.rmse_mean_7d??"—"}, pass=${pct(sim.solid?.pass_fraction_mean_7d)}
+- fluid: MAE=${sim.fluid?.mae_mean_7d??"—"}, RMSE=${sim.fluid?.rmse_mean_7d??"—"}, pass=${pct(sim.fluid?.pass_fraction_mean_7d)}
+
+`;
+
+const outPath = `pulses/${title}.md`;
+ensureDir(outPath);
+fs.writeFileSync(outPath, md, "utf8");
+process.stdout.write(md);

--- a/tools/timemachine/index.py
+++ b/tools/timemachine/index.py
@@ -1,0 +1,213 @@
+# tools/timemachine/index.py
+# Usage:
+#   python tools/timemachine/index.py \
+#     --lh sites/blackroad/public/metrics/lh.json \
+#     --ci sites/blackroad/public/metrics/ci.json \
+#     --k6 logs/perf/k6_summary.json \
+#     --runmeta run_meta.json \
+#     --alerts data/aiops/alerts.jsonl \
+#     --runtime logs/runtime \
+#     --agents agents/lineage \
+#     --out data/timemachine/index.json
+from __future__ import annotations
+import argparse, json, os, re, sys
+from pathlib import Path
+from datetime import datetime, timezone
+
+
+def _read_text(p: Path) -> str | None:
+    try:
+        return p.read_text(encoding="utf-8")
+    except Exception:
+        return None
+
+
+def _read_json(p: Path):
+    try:
+        if not p.exists():
+            return None
+        return json.loads(p.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+
+def _ensure_dir(p: Path) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+
+
+def parse_lighthouse(p: Path):
+    j = _read_json(p)
+    if not j:
+        return {"history": []}
+    # Accept either {"updatedAt":..., "history":[...]} or raw list
+    hist = j.get("history", j if isinstance(j, list) else [])
+    out = []
+    for row in hist:
+        try:
+            out.append(
+                {
+                    "ts": row.get("ts"),
+                    "perf": row.get("perf"),
+                    "a11y": row.get("a11y"),
+                    "bp": row.get("bp"),
+                    "seo": row.get("seo"),
+                    "LCP": row.get("LCP"),
+                    "FCP": row.get("FCP"),
+                    "CLS": row.get("CLS"),
+                    "TBT": row.get("TBT"),
+                    "notes": row.get("notes"),
+                }
+            )
+        except Exception:
+            continue
+    return {"history": out}
+
+
+def parse_ci(p: Path):
+    j = _read_json(p)
+    if not j:
+        return {"runs": []}
+    runs = j.get("runs", j.get("history", j))
+    out = []
+    for r in runs or []:
+        out.append(
+            {
+                "ts": r.get("ts") or r.get("updatedAt"),
+                "name": r.get("name") or r.get("workflow"),
+                "conclusion": r.get("conclusion") or r.get("status"),
+                "duration_ms": r.get("duration_ms") or r.get("durationMs"),
+                "sha": r.get("sha"),
+                "url": r.get("url") or r.get("html_url"),
+            }
+        )
+    return {"runs": out}
+
+
+def parse_k6(p: Path):
+    j = _read_json(p)
+    if not j:
+        return {"components": [], "raw": None}
+    metrics = j.get("metrics", j)
+    comps = []
+    re_comp = re.compile(r"http_req_duration\{component:([a-zA-Z0-9_\-]+)\}")
+    for key, val in metrics.items():
+        m = re_comp.match(key)
+        if m and isinstance(val, dict):
+            comp = m.group(1)
+            p50 = val.get("med") or val.get("p(50)")
+            p90 = val.get("p(90)")
+            p95 = val.get("p(95)")
+            comps.append({"component": comp, "p50": p50, "p90": p90, "p95": p95})
+    # overall rates and checks if present
+    http_reqs = metrics.get("http_reqs", {})
+    checks = metrics.get("checks", {})
+    summary = {
+        "http_reqs_count": http_reqs.get("count"),
+        "http_reqs_rate": http_reqs.get("rate"),
+        "checks_passes": checks.get("passes"),
+        "checks_fails": checks.get("fails"),
+        "duration_avg": (metrics.get("http_req_duration") or {}).get("avg"),
+        "duration_p95": (metrics.get("http_req_duration") or {}).get("p(95)"),
+    }
+    return {"components": comps, "summary": summary}
+
+
+def parse_runmeta(p: Path):
+    j = _read_json(p)
+    if not j:
+        return {"runs": []}
+    # Single run_meta.json
+    metrics = j.get("metrics", {})
+    return {
+        "runs": [
+            {
+                "run_id": j.get("run_id"),
+                "generated_at": j.get("generated_at"),
+                "solid": metrics.get("solid"),
+                "fluid": metrics.get("fluid"),
+                "artifacts": j.get("artifacts"),
+            }
+        ]
+    }
+
+
+def parse_alerts(p: Path):
+    if not p.exists():
+        return {"alerts": []}
+    out = []
+    for line in (_read_text(p) or "").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            j = json.loads(line)
+            out.append(j)
+        except Exception:
+            continue
+    return {"alerts": out}
+
+
+def parse_runtime(dirp: Path):
+    if not dirp.exists():
+        return {"files": []}
+    files = []
+    for root, _, names in os.walk(dirp):
+        for n in names:
+            fp = Path(root) / n
+            try:
+                stat = fp.stat()
+                files.append(
+                    {
+                        "path": str(fp),
+                        "bytes": stat.st_size,
+                        "mtime": datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat(),
+                    }
+                )
+            except Exception:
+                continue
+    return {"files": files}
+
+
+def parse_agents(dirp: Path):
+    if not dirp.exists():
+        return {"items": []}
+    items = []
+    for root, _, names in os.walk(dirp):
+        for n in names:
+            fp = Path(root) / n
+            if not fp.suffix.lower() in {".json", ".jsonl", ".md"}:
+                continue
+            size = fp.stat().st_size if fp.exists() else None
+            items.append({"path": str(fp), "bytes": size})
+    return {"items": items}
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Build unified Time Machine index")
+    ap.add_argument("--lh", type=Path, default=Path("sites/blackroad/public/metrics/lh.json"))
+    ap.add_argument("--ci", type=Path, default=Path("sites/blackroad/public/metrics/ci.json"))
+    ap.add_argument("--k6", type=Path, default=Path("logs/perf/k6_summary.json"))
+    ap.add_argument("--runmeta", type=Path, default=Path("run_meta.json"))
+    ap.add_argument("--alerts", type=Path, default=Path("data/aiops/alerts.jsonl"))
+    ap.add_argument("--runtime", type=Path, default=Path("logs/runtime"))
+    ap.add_argument("--agents", type=Path, default=Path("agents/lineage"))
+    ap.add_argument("--out", type=Path, default=Path("data/timemachine/index.json"))
+    args = ap.parse_args()
+
+    out = {
+        "generated_at": datetime.now(tz=timezone.utc).isoformat(),
+        "lh": parse_lighthouse(args.lh),
+        "ci": parse_ci(args.ci),
+        "k6": parse_k6(args.k6),
+        "sim": parse_runmeta(args.runmeta),
+        "alerts": parse_alerts(args.alerts),
+        "runtime": parse_runtime(args.runtime),
+        "agents": parse_agents(args.agents),
+    }
+    _ensure_dir(args.out)
+    args.out.write_text(json.dumps(out, indent=2), encoding="utf-8")
+    print(f"Wrote {args.out}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add tooling to build the unified time machine index and derive KPIs, pulses, and safety policies
- schedule nightly index refreshes, weekly KPI pulse generation, daily autobuilder runs, and PR budget gates
- ignore generated KPI, index, autobuilder, and pulse artifacts in version control

## Testing
- python3 -m compileall tools/timemachine
- node --check tools/kpis/compute.js
- node --check tools/pulse/write.js
- node --check tools/pulse/slack.js
- node --check tools/autobuilder/make_fixes.js
- node --check tools/policies/check_budgets.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ea937c5b08329a7bbac60b1e6e6ae)