### PR TITLE
Add Amundson Set I tests and demo harness

### DIFF
--- a/docs/AMUNDSON_TESTS.md
+++ b/docs/AMUNDSON_TESTS.md
@@ -1,0 +1,28 @@
+# Amundson Test Pack (Set I)
+
+**What this validates**
+- Unified harmonic operator: finite, non-zero contour integral.
+- Fourier analyzer: finds 5 Hz and 10 Hz in a synthetic signal.
+- Ramanujan square: row/col/diag magic constraint holds.
+- Lindbladian (GKSL): dissipator returns Hermitian derivative.
+- Number theory utils: φ(30)=8, μ(60)=0, μ(30)=-1, factors(60)=[2,2,3,5].
+
+**Install & run**
+```bash
+python -m venv .venv && . .venv/bin/activate
+pip install -U pip pytest numpy scipy
+pytest -q
+# optional demo
+python scripts/demo_amundson_math_core.py
+```
+
+**File map**
+
+* `tests/test_*.py` → fast, deterministic tests (<1s each)
+* `scripts/demo_amundson_math_core.py` → prints a headline from each module
+
+**Notes**
+
+* Tests import from `agents.blackroad_agent_framework_package5`.
+* If class names shift, tweak the imports at the top of each test.
+

--- a/scripts/demo_amundson_math_core.py
+++ b/scripts/demo_amundson_math_core.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Quick demo harness: prints one headline result per module.
+Run:  python scripts/demo_amundson_math_core.py
+"""
+import numpy as np
+
+from agents.blackroad_agent_framework_package5 import (
+    AgentStateEnumerators,
+    FourierConsciousnessAnalyzer,
+    LindbladianSuperoperator,
+    RamanujanMagicSquare,
+    UnifiedHarmonicOperator,
+)
+
+
+def hr(name: str):
+    print("\n" + name)
+    print("-" * len(name))
+
+
+def demo_unified_harmonic():
+    hr("UNIFIED HARMONIC")
+    op = UnifiedHarmonicOperator()
+    val = op.compute_unified_action(n_points=720)
+    print(f"unified_action ≈ {val.real:.4f} + {val.imag:.4f}i | |val|={abs(val):.4f}")
+
+
+def demo_fourier():
+    hr("FOURIER CONSCIOUSNESS")
+    dt = 0.001
+    t = np.arange(0.0, 1.0, dt)
+    sig = np.sin(2 * np.pi * 5 * t) + 0.5 * np.sin(2 * np.pi * 10 * t)
+    freqs = FourierConsciousnessAnalyzer.resonance_frequencies(sig, dt=dt, threshold=0.25)
+    rounded = sorted(set(np.round(np.abs(freqs)).astype(int).tolist()))
+    print(f"resonances ≈ {rounded[:6]}")
+
+
+def demo_magic_square():
+    hr("RAMANUJAN MAGIC SQUARE")
+    ms = RamanujanMagicSquare()
+    square = ms.create_ramanujan_dob_square()
+    v = ms.verify_magic()
+    print(f"magic_constant={ms.magic_constant} | is_magic={v['is_magic']}")
+
+
+def demo_lindbladian():
+    hr("LINDBLADIAN")
+    L = LindbladianSuperoperator(n_dim=2)
+    sigma_minus = np.array([[0, 1], [0, 0]], dtype=complex)
+    L.add_lindblad_operator(sigma_minus, gamma=0.1)
+    rho = np.array([[0, 0], [0, 1]], dtype=complex)
+    D = L.lindblad_dissipator(rho)
+    tr = np.trace(D)
+    print(f"dρ/dt hermitian={np.allclose(D, D.conj().T)} | trace(dρ)={tr:.2e}")
+
+
+def demo_number_theory():
+    hr("AGENT STATE ENUMERATORS")
+    vals = [12, 30, 60, 100]
+    pairs = [(n, AgentStateEnumerators.euler_totient(n), AgentStateEnumerators.mobius(n)) for n in vals]
+    print("n | φ(n) | μ(n)")
+    for n, phi, mu in pairs:
+        print(f"{n:>3} | {phi:>4} | {mu:>2}")
+
+
+if __name__ == "__main__":
+    demo_unified_harmonic()
+    demo_fourier()
+    demo_magic_square()
+    demo_lindbladian()
+    demo_number_theory()
+    print("\nOK — Amundson Set I demo complete.")

--- a/tests/test_agent_state_enumerators.py
+++ b/tests/test_agent_state_enumerators.py
@@ -1,0 +1,8 @@
+from agents.blackroad_agent_framework_package5 import AgentStateEnumerators
+
+
+def test_number_theory_utilities():
+    assert AgentStateEnumerators.euler_totient(30) == 8
+    assert AgentStateEnumerators.mobius(60) == 0  # squared prime factor present
+    assert AgentStateEnumerators.mobius(30) == -1  # 3 distinct primes → (-1)^3
+    assert AgentStateEnumerators.prime_factors(60) == [2, 2, 3, 5]

--- a/tests/test_fourier_consciousness.py
+++ b/tests/test_fourier_consciousness.py
@@ -1,0 +1,15 @@
+import numpy as np
+
+from agents.blackroad_agent_framework_package5 import FourierConsciousnessAnalyzer
+
+
+def test_resonances_pick_expected_frequencies():
+    # 1 second duration at 1 kHz sample rate
+    dt = 0.001
+    t = np.arange(0.0, 1.0, dt)
+    sig = np.sin(2 * np.pi * 5 * t) + 0.5 * np.sin(2 * np.pi * 10 * t)
+    freqs = FourierConsciousnessAnalyzer.resonance_frequencies(sig, dt=dt, threshold=0.25)
+    # FFT returns ±freq; compare on absolute, rounded bins
+    rounded = set(np.round(np.abs(freqs)).astype(int).tolist())
+    assert 5 in rounded
+    assert 10 in rounded

--- a/tests/test_lindbladian_superoperator.py
+++ b/tests/test_lindbladian_superoperator.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+from agents.blackroad_agent_framework_package5 import LindbladianSuperoperator
+
+
+def is_hermitian(A: np.ndarray, tol: float = 1e-10) -> bool:
+    return np.allclose(A, A.conj().T, atol=tol)
+
+
+def test_gksl_dissipator_hermitian_derivative():
+    L = LindbladianSuperoperator(n_dim=2)
+    # Single Lindblad operator: sigma_minus
+    sigma_minus = np.array([[0, 1], [0, 0]], dtype=complex)
+    L.add_lindblad_operator(sigma_minus, gamma=0.1)
+    # Start from excited state density matrix
+    rho = np.array([[0, 0], [0, 1]], dtype=complex)
+    D = L.lindblad_dissipator(rho)
+    assert D.shape == (2, 2)
+    assert is_hermitian(D), "GKSL dissipator should yield Hermitian dρ/dt"

--- a/tests/test_ramanujan_magic_square.py
+++ b/tests/test_ramanujan_magic_square.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+from agents.blackroad_agent_framework_package5 import RamanujanMagicSquare
+
+
+def test_ramanujan_magic_square_verifies():
+    ms = RamanujanMagicSquare()
+    square = ms.create_ramanujan_dob_square()
+    v = ms.verify_magic()
+    assert square.shape == (4, 4)
+    assert v["is_magic"], "Square should satisfy magic constraints"
+    # All rows/cols equal the magic constant
+    target = ms.magic_constant
+    assert all(square[i, :].sum() == target for i in range(4))
+    assert all(square[:, j].sum() == target for j in range(4))
+    assert np.trace(square) == target
+    assert np.trace(np.fliplr(square)) == target

--- a/tests/test_set2_skeleton.py
+++ b/tests/test_set2_skeleton.py
@@ -1,0 +1,18 @@
+import pytest
+
+
+MODULES = [
+    "math.amundson.spiral_noether",
+    "math.amundson.qutrit_ternary",
+    "math.amundson.compliance_lagrangian",
+    "math.amundson.consensus_clock",
+    "math.amundson.thermo_ledger",
+    "math.amundson.spiral_rg",
+    "math.amundson.ladder_holography",
+]
+
+
+@pytest.mark.parametrize("modname", MODULES)
+def test_optional_modules_present(modname):
+    mod = pytest.importorskip(modname)
+    assert mod is not None

--- a/tests/test_unified_harmonic.py
+++ b/tests/test_unified_harmonic.py
@@ -1,0 +1,12 @@
+import numpy as np
+
+from agents.blackroad_agent_framework_package5 import UnifiedHarmonicOperator
+
+
+def test_unified_harmonic_action_is_finite_and_nonzero():
+    op = UnifiedHarmonicOperator()
+    val = op.compute_unified_action(n_points=512)
+    assert isinstance(val, complex)
+    assert np.isfinite(val.real)
+    assert np.isfinite(val.imag)
+    assert abs(val) > 0.0


### PR DESCRIPTION
## Summary
- add Amundson Set I regression tests for harmonic, Fourier, magic square, Lindbladian, and enumerator components
- document the suite and provide a demo harness script to preview key outputs
- include optional Set II skeleton tests that skip until future modules land

## Testing
- pytest tests/test_unified_harmonic.py tests/test_fourier_consciousness.py tests/test_ramanujan_magic_square.py tests/test_lindbladian_superoperator.py tests/test_agent_state_enumerators.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ec532c55c8329a24751e0831a2604)