### PR TITLE
Strengthen Amundson math core tests

### DIFF
--- a/docs/AMUNDSON_TESTS.md
+++ b/docs/AMUNDSON_TESTS.md
@@ -4,7 +4,7 @@
 - Unified harmonic operator: finite, non-zero contour integral.
 - Fourier analyzer: finds 5 Hz and 10 Hz in a synthetic signal.
 - Ramanujan square: row/col/diag magic constraint holds.
-- Lindbladian (GKSL): dissipator returns Hermitian derivative.
+- Lindbladian (GKSL): dissipator returns Hermitian derivative; GKSL coefficient matrix must be positive semidefinite.
 - Number theory utils: φ(30)=8, μ(60)=0, μ(30)=-1, factors(60)=[2,2,3,5].
 
 **Install & run**

--- a/tests/test_agent_state_enumerators.py
+++ b/tests/test_agent_state_enumerators.py
@@ -1,3 +1,10 @@
+from pathlib import Path
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
 from agents.blackroad_agent_framework_package5 import AgentStateEnumerators
 
 

--- a/tests/test_fourier_consciousness.py
+++ b/tests/test_fourier_consciousness.py
@@ -1,4 +1,11 @@
+from pathlib import Path
+import sys
+
 import numpy as np
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
 
 from agents.blackroad_agent_framework_package5 import FourierConsciousnessAnalyzer
 

--- a/tests/test_lindbladian_superoperator.py
+++ b/tests/test_lindbladian_superoperator.py
@@ -1,6 +1,17 @@
-import numpy as np
+from pathlib import Path
+import sys
 
-from agents.blackroad_agent_framework_package5 import LindbladianSuperoperator
+import numpy as np
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from agents.blackroad_agent_framework_package5 import (
+    GKSLMasterEquation,
+    LindbladianSuperoperator,
+)
 
 
 def is_hermitian(A: np.ndarray, tol: float = 1e-10) -> bool:
@@ -17,3 +28,23 @@ def test_gksl_dissipator_hermitian_derivative():
     D = L.lindblad_dissipator(rho)
     assert D.shape == (2, 2)
     assert is_hermitian(D), "GKSL dissipator should yield Hermitian dρ/dt"
+
+
+def test_gksl_matrix_requires_positive_semidefinite():
+    gksl = GKSLMasterEquation(n_dim=2)
+    gksl.set_operators([np.array([[0, 1], [0, 0]], dtype=complex)])
+    with pytest.raises(ValueError):
+        gksl.set_gksl_matrix(np.array([[-0.1]], dtype=complex))
+
+
+def test_gksl_dissipator_matches_superoperator_path():
+    gksl = GKSLMasterEquation(n_dim=2)
+    sigma_minus = np.array([[0, 1], [0, 0]], dtype=complex)
+    gksl.set_operators([sigma_minus])
+    gksl.set_gksl_matrix(np.array([[0.05]], dtype=complex))
+    rho = np.array([[0, 0], [0, 1]], dtype=complex)
+
+    dissipator = gksl.gksl_dissipator(rho)
+
+    assert dissipator.shape == (2, 2)
+    assert is_hermitian(dissipator)

--- a/tests/test_ramanujan_magic_square.py
+++ b/tests/test_ramanujan_magic_square.py
@@ -1,4 +1,11 @@
+from pathlib import Path
+import sys
+
 import numpy as np
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
 
 from agents.blackroad_agent_framework_package5 import RamanujanMagicSquare
 

--- a/tests/test_unified_harmonic.py
+++ b/tests/test_unified_harmonic.py
@@ -1,4 +1,11 @@
+from pathlib import Path
+import sys
+
 import numpy as np
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
 
 from agents.blackroad_agent_framework_package5 import UnifiedHarmonicOperator
 


### PR DESCRIPTION
## Summary
- ensure the Amundson tests import the math core modules by prepending the repository root to PYTHONPATH
- add regression coverage for GKSLMasterEquation positive semidefinite validation and dissipator hermiticity
- document the GKSL PSD requirement in the Amundson test pack guide

## Testing
- pytest tests/test_lindbladian_superoperator.py -q
- pytest tests/test_unified_harmonic.py tests/test_fourier_consciousness.py tests/test_ramanujan_magic_square.py tests/test_agent_state_enumerators.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ec84aec28832983e4ddcf091d291c)