### PR TITLE
Add Silas prompt cards viewer and tests

### DIFF
--- a/docs/SILAS_PROMPT_CARDS.md
+++ b/docs/SILAS_PROMPT_CARDS.md
@@ -1,0 +1,22 @@
+# Silas Prompt Cards
+
+A lightweight viewer for the Silas prompt cards that ship with this repository.
+
+## Run the preview
+
+```bash
+npm --prefix ui/prompt_cards run preview
+```
+
+The static server listens on <http://localhost:5173>. It serves the compiled `index.html` alongside
+`cards.json` so you can inspect the content locally without any external dependencies.
+
+## Files
+
+- `ui/prompt_cards/index.html` – renders the cards and colourises the token chips.
+- `ui/prompt_cards/cards.json` – structured data describing each prompt card.
+- `ui/prompt_cards/preview.js` – zero-dependency Node preview server.
+- `ui/prompt_cards/package.json` – npm script entry point.
+
+The dataset intentionally avoids build tooling so the viewer works in any environment with Node 18+
+installed.

--- a/tests/test_prompt_cards_shape.py
+++ b/tests/test_prompt_cards_shape.py
@@ -1,0 +1,49 @@
+"""Schema checks for the Silas prompt cards dataset."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+CARDS_PATH = Path(__file__).resolve().parents[1] / "ui" / "prompt_cards" / "cards.json"
+REQUIRED_TOKEN_CATEGORIES = {"goal", "constraint", "signal", "cadence", "quality"}
+
+
+def load_cards() -> dict:
+    with CARDS_PATH.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+@pytest.fixture(scope="module")
+def payload() -> dict:
+    return load_cards()
+
+
+def test_top_level_shape(payload: dict) -> None:
+    assert payload["agent"] == "Silas"
+    assert "cards" in payload and isinstance(payload["cards"], list)
+    assert payload["cards"], "cards collection should not be empty"
+
+
+@pytest.mark.parametrize("required", ["id", "title", "purpose", "prompt", "tokens"])
+def test_card_required_fields(payload: dict, required: str) -> None:
+    for card in payload["cards"]:
+        assert required in card, f"missing {required} in card {card.get('id')}"
+
+
+@pytest.mark.parametrize("card_index", range(4))
+def test_tokens_shape(payload: dict, card_index: int) -> None:
+    card = payload["cards"][card_index]
+    tokens = card["tokens"]
+    assert isinstance(tokens, list) and tokens, "tokens should be a non-empty list"
+    for token in tokens:
+        assert set(token) == {"text", "category"}
+        assert token["category"] in REQUIRED_TOKEN_CATEGORIES
+        assert token["text"].strip(), "token text should not be blank"
+
+
+def test_prompts_have_multiple_lines(payload: dict) -> None:
+    for card in payload["cards"]:
+        assert "\n" in card["prompt"], "prompt should contain guidance across multiple lines"

--- a/ui/prompt_cards/cards.json
+++ b/ui/prompt_cards/cards.json
@@ -1,0 +1,57 @@
+{
+  "agent": "Silas",
+  "version": "2025.02.13",
+  "description": "Execution-ready prompt cards that Silas uses to push a delivery pod from idea to live traction.",
+  "cards": [
+    {
+      "id": "diagnostic-baseline",
+      "title": "Baseline Diagnostic Sweep",
+      "purpose": "Interrogate the current mission state and lock in the physics of the problem.",
+      "prompt": "You are Silas, the systems engineer responsible for reality-auditing this mission.\n1. Summarise the customer problem as they would describe it.\n2. Capture the hard constraint blocking progress right now.\n3. List the top two metrics that would move if we solved it.\n4. Flag any missing inputs that keep us from shipping in < 2 weeks.\nProduce a crisp table with Problem | Constraint | Metric Signals | Missing Inputs.",
+      "tokens": [
+        { "text": "Reality audit", "category": "goal" },
+        { "text": "Customer voice", "category": "signal" },
+        { "text": "Blocking constraint", "category": "constraint" },
+        { "text": "Metric shift", "category": "signal" },
+        { "text": "Ship window", "category": "cadence" }
+      ]
+    },
+    {
+      "id": "cadence-map",
+      "title": "Cadence Map",
+      "purpose": "Establish the weekly motion that keeps traction, feedback, and retros in sync.",
+      "prompt": "Map the operator cadence for this mission:\n- Daily action sync (owner, time, channel, key artifact).\n- Weekly traction review (who attends, metrics inspected, go/no-go gates).\n- Retro loop (frequency, facilitation, templates).\nGive the response as a JSON document with keys daily_sync, weekly_review, retro.",
+      "tokens": [
+        { "text": "Daily sync", "category": "cadence" },
+        { "text": "Weekly review", "category": "cadence" },
+        { "text": "Retro loop", "category": "cadence" },
+        { "text": "Metrics focus", "category": "signal" },
+        { "text": "Operator roster", "category": "quality" }
+      ]
+    },
+    {
+      "id": "constraint-override",
+      "title": "Constraint Override",
+      "purpose": "Pressure-test the riskiest assumption and design the mitigation path.",
+      "prompt": "Name the riskiest assumption in the plan and why it fails under load.\nOutline a mitigation plan with:\n- Test to run within 48 hours.\n- Success criteria and measurable signal.\n- Owner accountable for the move.\nReturn markdown with headings: Assumption, Failure Mode, Mitigation Plan.",
+      "tokens": [
+        { "text": "Riskiest assumption", "category": "constraint" },
+        { "text": "48h test", "category": "cadence" },
+        { "text": "Success signal", "category": "signal" },
+        { "text": "Accountable owner", "category": "quality" }
+      ]
+    },
+    {
+      "id": "quality-gates",
+      "title": "Quality Gates",
+      "purpose": "Define the acceptance bar before shipping to production customers.",
+      "prompt": "List the quality gates that must be green before launch:\n- Instrumentation coverage (events, dashboards, alerts).\n- Rollback and contingency plan.\n- Customer communication touchpoints.\nExpress as a table Gate | Owner | Evidence.",
+      "tokens": [
+        { "text": "Instrumentation", "category": "quality" },
+        { "text": "Rollback", "category": "constraint" },
+        { "text": "Customer comms", "category": "goal" },
+        { "text": "Evidence", "category": "signal" }
+      ]
+    }
+  ]
+}

--- a/ui/prompt_cards/index.html
+++ b/ui/prompt_cards/index.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Silas Prompt Cards</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: "Inter", "Segoe UI", sans-serif;
+        background-color: #10121a;
+        color: #f1f5f9;
+      }
+
+      body {
+        margin: 0;
+        padding: 0;
+      }
+
+      header {
+        padding: 2rem 3rem 1rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        background: radial-gradient(circle at top left, rgba(80, 156, 255, 0.35), transparent 55%),
+          radial-gradient(circle at top right, rgba(125, 211, 252, 0.2), transparent 50%);
+      }
+
+      h1 {
+        margin: 0;
+        font-size: clamp(2rem, 3vw, 2.75rem);
+        letter-spacing: -0.03em;
+      }
+
+      p {
+        margin: 0;
+        max-width: 60ch;
+        line-height: 1.6;
+        color: rgba(226, 232, 240, 0.85);
+      }
+
+      main {
+        padding: 0 3rem 4rem;
+        display: grid;
+        gap: 1.5rem;
+      }
+
+      .card {
+        border-radius: 1rem;
+        background: rgba(15, 23, 42, 0.85);
+        border: 1px solid rgba(94, 234, 212, 0.15);
+        box-shadow: 0 32px 60px -40px rgba(15, 118, 110, 0.45);
+        padding: 1.75rem 2rem;
+        display: grid;
+        gap: 1.25rem;
+      }
+
+      .card-header {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+      }
+
+      .card-title {
+        font-size: 1.5rem;
+        font-weight: 600;
+        letter-spacing: -0.02em;
+      }
+
+      .card-purpose {
+        color: rgba(148, 163, 184, 0.9);
+        font-size: 0.95rem;
+      }
+
+      .tokens {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+      }
+
+      .token {
+        border-radius: 999px;
+        padding: 0.45rem 0.85rem;
+        font-size: 0.9rem;
+        line-height: 1;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        letter-spacing: 0.01em;
+      }
+
+      .token[data-category="goal"] {
+        background: rgba(34, 197, 94, 0.18);
+        border: 1px solid rgba(34, 197, 94, 0.35);
+        color: rgb(187, 247, 208);
+      }
+
+      .token[data-category="constraint"] {
+        background: rgba(239, 68, 68, 0.16);
+        border: 1px solid rgba(248, 113, 113, 0.35);
+        color: rgb(254, 202, 202);
+      }
+
+      .token[data-category="signal"] {
+        background: rgba(56, 189, 248, 0.18);
+        border: 1px solid rgba(125, 211, 252, 0.35);
+        color: rgb(224, 242, 254);
+      }
+
+      .token[data-category="cadence"] {
+        background: rgba(244, 114, 182, 0.18);
+        border: 1px solid rgba(244, 114, 182, 0.35);
+        color: rgb(252, 231, 243);
+      }
+
+      .token[data-category="quality"] {
+        background: rgba(192, 132, 252, 0.18);
+        border: 1px solid rgba(192, 132, 252, 0.35);
+        color: rgb(243, 232, 255);
+      }
+
+      .prompt-text {
+        background: rgba(15, 23, 42, 0.95);
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        border-radius: 0.85rem;
+        padding: 1.25rem 1.5rem;
+        font-family: "JetBrains Mono", "SFMono-Regular", ui-monospace, SFMono-Regular, Menlo, Monaco,
+          Consolas, "Liberation Mono", "Courier New", monospace;
+        font-size: 0.9rem;
+        line-height: 1.6;
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
+
+      @media (max-width: 768px) {
+        header,
+        main {
+          padding: 1.5rem;
+        }
+
+        .card {
+          padding: 1.5rem;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Silas Prompt Cards</h1>
+      <p>
+        A focused view into Silas's execution rituals. Each card captures the problem Silas is solving, the
+        signals he watches, and the cadence that keeps the machine running.
+      </p>
+    </header>
+    <main id="cards"></main>
+
+    <template id="card-template">
+      <article class="card">
+        <header class="card-header">
+          <span class="card-title"></span>
+          <span class="card-purpose"></span>
+        </header>
+        <section class="tokens"></section>
+        <pre class="prompt-text"></pre>
+      </article>
+    </template>
+
+    <script>
+      async function loadCards() {
+        const response = await fetch('cards.json', { cache: 'no-store' });
+        if (!response.ok) {
+          throw new Error(`Failed to load cards.json: ${response.status}`);
+        }
+        return response.json();
+      }
+
+      function renderCards(payload) {
+        const container = document.getElementById('cards');
+        const template = document.getElementById('card-template');
+        container.innerHTML = '';
+
+        payload.cards.forEach((card) => {
+          const node = template.content.cloneNode(true);
+          node.querySelector('.card-title').textContent = card.title;
+          node.querySelector('.card-purpose').textContent = card.purpose;
+
+          const tokensContainer = node.querySelector('.tokens');
+          card.tokens.forEach((token) => {
+            const span = document.createElement('span');
+            span.className = 'token';
+            span.dataset.category = token.category;
+            span.textContent = token.text;
+            tokensContainer.appendChild(span);
+          });
+
+          node.querySelector('.prompt-text').textContent = card.prompt.trim();
+          container.appendChild(node);
+        });
+      }
+
+      loadCards()
+        .then(renderCards)
+        .catch((error) => {
+          const container = document.getElementById('cards');
+          container.innerHTML = `<p>Failed to load cards: ${error.message}</p>`;
+        });
+    </script>
+  </body>
+</html>

--- a/ui/prompt_cards/package.json
+++ b/ui/prompt_cards/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "silas-prompt-cards",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "preview": "node preview.js"
+  }
+}

--- a/ui/prompt_cards/preview.js
+++ b/ui/prompt_cards/preview.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { extname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const port = Number.parseInt(process.env.PORT || '5173', 10);
+const host = process.env.HOST || '0.0.0.0';
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+
+const mimeTypes = {
+  '.html': 'text/html; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8'
+};
+
+async function serve(pathname) {
+  const safePath = pathname === '/' ? '/index.html' : pathname;
+  const target = join(__dirname, safePath);
+  const data = await readFile(target);
+  const type = mimeTypes[extname(target)] || 'application/octet-stream';
+  return { data, type };
+}
+
+const server = createServer(async (req, res) => {
+  try {
+    const url = new URL(req.url ?? '/', `http://${req.headers.host}`);
+    const { data, type } = await serve(url.pathname);
+    res.writeHead(200, { 'Content-Type': type, 'Cache-Control': 'no-store' });
+    res.end(data);
+  } catch (error) {
+    const status = error.code === 'ENOENT' ? 404 : 500;
+    res.writeHead(status, { 'Content-Type': 'text/plain; charset=utf-8' });
+    res.end(status === 404 ? 'Not found' : 'Internal server error');
+  }
+});
+
+server.listen(port, host, () => {
+  console.log(`Prompt cards preview available at http://${host}:${port}`);
+});


### PR DESCRIPTION
## Summary
- add a static Silas prompt cards viewer that fetches cards.json and colourises token chips
- check in the prompt cards dataset and lightweight preview server with docs
- add a pytest module to assert the prompt cards schema and token metadata

## Testing
- pytest tests/test_prompt_cards_shape.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ed106e77883299a67830944add232)