### PR TITLE
Add miner bridge sidecar for Prism events

### DIFF
--- a/miners/miners-compose.yml
+++ b/miners/miners-compose.yml
@@ -1,51 +1,24 @@
-version: '3.8'
-services:
-  # --- Litecoin (LTC) learn-mode • CPU scrypt (utterly unprofitable, educational only) ---
-  # Real LTC mining requires Scrypt ASICs. This is a light CPU demo.
-services:
-  # --- Monero (xmrig) • CPU miner (learn-mode, throttled) ---
-  xmrig:
-    image: ghcr.io/xmrig/xmrig:latest
-    container_name: xmrig
-    command: >
-      -o POOL_HOST:PORT
-      -u YOUR_XMR_ADDRESS
-      --donate-level=0
-      --cpu-max-threads-hint=1
-    cpus: 0.25
-    environment:
-      # cap internal throttling further if desired:
-      - XMRIG_ALGO=rx/0
-    cpus: 0.25              # Docker-level CPU cap
-    mem_limit: 256m
-    restart: unless-stopped
-    security_opt: [no-new-privileges:true]
-    read_only: true
-    volumes:
-      - /etc/localtime:/etc/localtime:ro
-    # enable manually:
-    # docker compose -f miners/miners-compose.yml up -d xmrig
-
-  # --- Verus (VRSC) • CPU miner (learn-mode) ---
-    # Enable manually:
-    # docker compose -f miners/miners-compose.yml up -d xmrig
-
-  # --- Verus (VRSC) • CPU miner (efficient but still tiny on a Pi) ---
+version: "3.8"
 
 # Low-power miner bundle. Every service is capped, read-only where possible, and
-# requires manual activation. Copy to the device as ~/miners-compose.yml and edit
-# the placeholders before running `docker compose -f miners-compose.yml up -d <service>`.
+# requires manual activation. Copy to a device as ./miners-compose.yml and edit
+# the placeholders before running:
+#   docker compose -f miners-compose.yml up -d <service>
 services:
   # --- Monero (XMRig) — CPU miner for education ---
   xmrig:
     image: ghcr.io/xmrig/xmrig:latest
     container_name: xmrig
     command: >-
-      -o POOL_HOST:PORT
-      -u YOUR_XMR_ADDRESS
+      -o ${XMRIG_POOL:-POOL_HOST:PORT}
+      -u ${XMRIG_WALLET:-YOUR_XMR_ADDRESS}
       --tls
       --donate-level=0
-      --cpu-max-threads-hint=1
+      --cpu-max-threads-hint=${XMRIG_THREADS_HINT:-1}
+      --http-host=0.0.0.0
+      --http-port=18080
+    environment:
+      - XMRIG_ALGO=${XMRIG_ALGO:-rx/0}
     cpus: 0.25                # hard cap ≈25% of one core
     mem_limit: 256m
     restart: unless-stopped
@@ -54,125 +27,121 @@ services:
     read_only: true
     volumes:
       - /etc/localtime:/etc/localtime:ro
-    deploy:
-      resources:
-        limits:
-          cpus: '0.25'
-    # Enable manually:
-    #   docker compose -f miners-compose.yml up -d xmrig
+    ports:
+      - "${XMRIG_HTTP_PORT:-18080}:18080"   # optional: expose the HTTP summary
 
   # --- Verus (VerusHash 2.2) — efficient CPU miner ---
   verusminer:
     image: krypt0nn/verus-miner:latest
     container_name: verusminer
     environment:
-      - POOL=POOL_HOST:PORT
-      - WALLET=YOUR_VRSC_ADDRESS
-      - PASSWORD=x
-      - THREADS=1
+      - POOL=${VERUS_POOL:-POOL_HOST:PORT}
+      - WALLET=${VERUS_WALLET:-YOUR_VRSC_ADDRESS}
+      - PASSWORD=${VERUS_PASSWORD:-x}
+      - THREADS=${VERUS_THREADS:-1}
+    command: >-
+      --api-bind 0.0.0.0:4068
     cpus: 0.25
     mem_limit: 256m
     restart: unless-stopped
-    security_opt: [no-new-privileges:true]
+    security_opt:
+      - no-new-privileges:true
     read_only: true
-    # enable:
-    # docker compose -f miners/miners-compose.yml up -d verusminer
+    ports:
+      - "${VERUS_API_PORT:-4068}:4068"
 
   # --- Litecoin (LTC) • scrypt CPU demo (educational only) ---
   ltc-cpuminer:
     image: registry.gitlab.com/foss/cpuminer-multi:latest
     container_name: ltc-cpuminer
-    command: >
+    command: >-
       -a scrypt
-      -o stratum+tcp://POOL_HOST:PORT
-      -u YOUR_LTC_ADDRESS
-      -p x
-      -t 1
+      -o ${LTC_POOL:-stratum+tcp://POOL_HOST:PORT}
+      -u ${LTC_WALLET:-YOUR_LTC_ADDRESS}
+      -p ${LTC_PASSWORD:-x}
+      -t ${LTC_THREADS:-1}
+      --api-bind 0.0.0.0:4048
     cpus: 0.25
     mem_limit: 256m
     restart: unless-stopped
-    security_opt: [no-new-privileges:true]
+    security_opt:
+      - no-new-privileges:true
     read_only: true
-    # enable manually:
-    # docker compose -f miners/miners-compose.yml up -d ltc-cpuminer
+    ports:
+      - "${LTC_API_PORT:-4048}:4048"
 
   # --- Generic cpuminer (multi-algo learn-mode) ---
   cpuminer-multi:
     image: registry.gitlab.com/foss/cpuminer-multi:latest
     container_name: cpuminer-multi
     environment:
-      - ALGO=verushash   # or yespower / scrypt / sha256d (pick an easy pool)
-      - POOL=POOL_HOST:PORT
-      - USER=YOUR_ADDRESS
-      - PASS=x
-      - THREADS=1
-    command: >
+      - ALGO=${CPUMINER_ALGO:-verushash}
+      - POOL=${CPUMINER_POOL:-POOL_HOST:PORT}
+      - USER=${CPUMINER_USER:-YOUR_ADDRESS}
+      - PASS=${CPUMINER_PASS:-x}
+      - THREADS=${CPUMINER_THREADS:-1}
+    command: >-
       -a ${ALGO}
       -o stratum+tcp://${POOL}
       -u ${USER}
       -p ${PASS}
       -t ${THREADS}
+      --api-bind 0.0.0.0:4050
     cpus: 0.25
     mem_limit: 256m
     restart: unless-stopped
-    security_opt: [no-new-privileges:true]
-    read_only: true
-    # enable manually:
-    # docker compose -f miners/miners-compose.yml up -d cpuminer-multi
-    # enable:
-    # docker compose -f miners/miners-compose.yml up -d ltc-cpuminer
-
-  # --- Chia farmer (ULTRA low energy; pre-plotted drives needed) ---
-    # Enable:
-    # docker compose -f miners/miners-compose.yml up -d verusminer
-
-  # --- Chia farmer (ultra-low energy; pre-plotted drives needed) ---
     security_opt:
       - no-new-privileges:true
     read_only: true
-    # Enable manually:
-    #   docker compose -f miners-compose.yml up -d verusminer
+    ports:
+      - "${CPUMINER_API_PORT:-4050}:4050"
 
   # --- Chia farmer/harvester role (plots must already exist) ---
   chia:
     image: ghcr.io/chia-network/chia:latest
     container_name: chia
     environment:
-      - keys=none
-      - keys=none            # no private keys loaded on Pi
-      - service=farm
-      - log_level=INFO
-      - TZ=UTC
-    volumes:
-      - ./chia:/root/.chia
-      - /mnt/plots:/plots:ro
-      - /mnt/plots:/plots:ro  # mount your plots read-only
-    cpus: 0.2
-    mem_limit: 512m
-    restart: unless-stopped
-    security_opt: [no-new-privileges:true]
-    read_only: false
-    # enable:
-    # Enable:
-    # docker compose -f miners/miners-compose.yml up -d chia
       - keys=none            # do not load private keys on this host
       - service=farm         # farming only, no plotting
-      - TZ=UTC
-      - log_level=INFO
+      - TZ=${TZ:-UTC}
+      - log_level=${CHIA_LOG_LEVEL:-INFO}
     volumes:
       - ./chia:/root/.chia   # config + logs persisted locally
       - /mnt/plots:/plots:ro # mount pre-plotted drives read-only
-    ports: []                # no external ports exposed by default
     cpus: 0.2
     mem_limit: 512m
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true
     read_only: false
-    # Enable manually after plots are mounted:
-    #   docker compose -f miners-compose.yml up -d chia
+    ports:
+      - "${CHIA_RPC_PORT:-8555}:8555"
 
-# Stop with: docker compose -f miners-compose.yml stop <service>
-# Remove with: docker compose -f miners-compose.yml down <service>
-    # Enable:
-    # docker compose -f miners/miners-compose.yml up -d chia
+  # --- Miner bridge sidecar -> Prism events ---
+  miner-bridge:
+    image: node:20-alpine
+    container_name: miner-bridge
+    working_dir: /app
+    volumes:
+      - ./tools/miners:/app
+    environment:
+      PRISM_API: ${PRISM_API}
+      PRISM_TOKEN: ${PRISM_TOKEN}
+      PRISM_ORG_ID: ${PRISM_ORG_ID:-default}
+      MINER_AGENT_ID: ${MINER_AGENT_ID:-miner:xmrig}
+      XMRIG_URL: ${XMRIG_URL:-http://xmrig:18080/2/summary}
+      XMRIG_POLL_MS: ${XMRIG_POLL_MS:-15000}
+      VERUS_URL: ${VERUS_URL:-http://verusminer:4068}
+      VERUS_POLL_MS: ${VERUS_POLL_MS:-20000}
+      VERUS_AGENT_ID: ${VERUS_AGENT_ID:-miner:verus}
+      LTC_URL: ${LTC_URL:-http://ltc-cpuminer:4048}
+      LTC_POLL_MS: ${LTC_POLL_MS:-20000}
+      LTC_AGENT_ID: ${LTC_AGENT_ID:-miner:ltc}
+      CHIA_URL: ${CHIA_URL:-http://chia:8555/summary}
+      CHIA_POLL_MS: ${CHIA_POLL_MS:-60000}
+      CHIA_AGENT_ID: ${CHIA_AGENT_ID:-farmer:chia}
+    command: ["sh", "-c", "npm install --omit=dev && node bridge.js"]
+    depends_on:
+      xmrig:
+        condition: service_started
+    restart: unless-stopped

--- a/tools/miners/bridge.js
+++ b/tools/miners/bridge.js
@@ -1,0 +1,195 @@
+// tools/miners/bridge.js
+// Polls miner summary endpoints and posts miner.sample events to Prism.
+// OPSEC: no wallet keys, no secrets in logs.
+
+import fetch from "node-fetch";
+
+const PRISM_API = process.env.PRISM_API; // e.g. http://localhost:4000 or your gateway
+const PRISM_TOKEN = process.env.PRISM_TOKEN || ""; // if your /events needs auth
+const ORG_ID = process.env.PRISM_ORG_ID || "default";
+
+if (!PRISM_API) {
+  console.error("Set PRISM_API (e.g., http://localhost:4000)");
+  process.exit(1);
+}
+
+const watchers = [];
+
+const xmrigUrl = process.env.XMRIG_URL || "http://xmrig:18080/2/summary";
+if (xmrigUrl) {
+  watchers.push({
+    miner: "xmrig",
+    agentId: process.env.MINER_AGENT_ID || "miner:xmrig",
+    pollMs: coercePoll(process.env.XMRIG_POLL_MS, 15_000),
+    request: () => ({ url: xmrigUrl, init: { method: "GET" } }),
+    parser: parseXmrig,
+  });
+}
+
+const verusUrl = process.env.VERUS_URL || process.env.VERUS_SUMMARY_URL || null;
+if (verusUrl) {
+  watchers.push({
+    miner: "verusminer",
+    agentId: process.env.VERUS_AGENT_ID || "miner:verus",
+    pollMs: coercePoll(process.env.VERUS_POLL_MS, 20_000),
+    request: () => cpuminerRequest(verusUrl),
+    parser: parseCpuminer("verusminer"),
+  });
+}
+
+const ltcUrl = process.env.LTC_URL || process.env.LTC_SUMMARY_URL || null;
+if (ltcUrl) {
+  watchers.push({
+    miner: "ltc-cpuminer",
+    agentId: process.env.LTC_AGENT_ID || "miner:ltc",
+    pollMs: coercePoll(process.env.LTC_POLL_MS, 20_000),
+    request: () => cpuminerRequest(ltcUrl),
+    parser: parseCpuminer("ltc-cpuminer"),
+  });
+}
+
+const chiaUrl = process.env.CHIA_URL || process.env.CHIA_SUMMARY_URL || null;
+if (chiaUrl) {
+  watchers.push({
+    miner: "chia",
+    agentId: process.env.CHIA_AGENT_ID || "farmer:chia",
+    pollMs: coercePoll(process.env.CHIA_POLL_MS, 60_000),
+    request: () => ({ url: chiaUrl, init: { method: "GET" } }),
+    parser: parseChia,
+  });
+}
+
+if (watchers.length === 0) {
+  console.warn("No miner endpoints configured. Set XMRIG_URL / VERUS_URL / LTC_URL / CHIA_URL env vars.");
+}
+
+watchers.forEach((watcher) => {
+  const poll = async () => {
+    try {
+      const { url, init } = watcher.request();
+      const response = await fetch(url, init);
+      if (!response.ok) throw new Error(`${watcher.miner} ${response.status}`);
+      const summary = await response.json();
+      const payload = watcher.parser(summary);
+      payload.ts = new Date().toISOString();
+
+      await postSample(watcher.miner, watcher.agentId, payload);
+    } catch (error) {
+      console.error(`[bridge] ${watcher.miner} error:`, error.message);
+    }
+  };
+
+  console.log(
+    `[bridge] watcher ready for ${watcher.miner} (agent ${watcher.agentId}) every ${watcher.pollMs}ms`
+  );
+  poll();
+  setInterval(poll, watcher.pollMs);
+});
+
+function coercePoll(value, fallback) {
+  const parsed = Number.parseInt(value ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function cpuminerRequest(url) {
+  const endpoint = url.endsWith("/") ? url : `${url}/`;
+  return {
+    url: endpoint,
+    init: {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ command: "summary" }),
+    },
+  };
+}
+
+async function postSample(miner, agentId, payload) {
+  const ev = {
+    type: "miner.sample",
+    orgId: ORG_ID,
+    agentId,
+    payload: { miner, ...payload },
+  };
+
+  const res = await fetch(`${PRISM_API}/events`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...(PRISM_TOKEN ? { authorization: `Bearer ${PRISM_TOKEN}` } : {}),
+    },
+    body: JSON.stringify(ev),
+  });
+
+  if (!res.ok) {
+    const txt = await res.text();
+    console.error(`[bridge] prism events POST failed (${miner}):`, res.status, txt.slice(0, 200));
+    return;
+  }
+
+  console.log(
+    `[bridge] posted miner.sample for ${miner}: ${payload.shares_accepted ?? "?"}/${payload.shares_rejected ?? "?"} @ ${payload.hashrate_1m ?? payload.hashrate ?? payload.hashrate_khs ?? "?"}`
+  );
+}
+
+function parseXmrig(summary) {
+  return {
+    pool: summary.connection?.pool || summary.connection?.url || null,
+    hashrate_1m: summary.hashrate?.total?.[0] ?? summary.hashrate?.total?.[1] ?? null,
+    hashrate_15m: summary.hashrate?.total?.[2] ?? null,
+    shares_accepted:
+      summary.results?.shares_good ?? summary.results?.accepted ?? summary.results?.shares ?? null,
+    shares_rejected: summary.results?.shares_bad ?? summary.results?.rejected ?? null,
+    shares_total: summary.results?.shares_total ?? null,
+  };
+}
+
+function parseCpuminer(miner) {
+  return (summary) => {
+    const stats = Array.isArray(summary.SUMMARY) ? summary.SUMMARY[0] : null;
+    if (!stats) {
+      throw new Error("no SUMMARY block in cpuminer API response");
+    }
+
+    const accepted = stats.Accepted ?? stats.accepted ?? stats.Shares_Accepted ?? null;
+    const rejected = stats.Rejected ?? stats.rejected ?? stats.Shares_Rejected ?? null;
+    const total = stats.Shares_Total ?? (accepted != null && rejected != null ? accepted + rejected : null);
+    const khs = stats.KHS ?? stats["KHS 5s"] ?? stats["KHS av"] ?? null;
+
+    return {
+      algo: stats.Algorithm || stats.ALGO || null,
+      hashrate_khs: khs,
+      hashrate_1m: khs != null ? khs * 1000 : null,
+      shares_accepted: accepted,
+      shares_rejected: rejected,
+      shares_total: total,
+      pool: stats["Stratum Active"] ? stats["Stratum URL"] || null : null,
+    };
+  };
+}
+
+function parseChia(summary) {
+  const farmer = summary.farmer ?? summary;
+  const plots = farmer.plots ?? farmer.plot_count ?? farmer.totalPlots ?? null;
+
+  return {
+    status: farmer.status ?? farmer.farmer_status ?? null,
+    signage_points_last_24h:
+      farmer.signage_points_last_24h ??
+      farmer.signagePointsLast24H ??
+      summary.signage_points_last_24h ??
+      null,
+    plots_total: typeof plots === "number" ? plots : plots?.total ?? null,
+    plots_farmer: farmer.plots_farmer ?? plots?.farmer ?? null,
+    plots_harvester: farmer.plots_harvester ?? plots?.harvester ?? null,
+    space_bytes:
+      farmer.space_bytes ??
+      farmer.total_size_bytes ??
+      farmer.space?.bytes ??
+      summary.total_size_bytes ??
+      null,
+    last_height_farmed: farmer.last_height_farmed ?? summary.last_height_farmed ?? null,
+    wallet_balance_xch: farmer.wallet_balance_xch ?? summary.wallet_balance_xch ?? null,
+  };
+}

--- a/tools/miners/package.json
+++ b/tools/miners/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "miner-bridge",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "node-fetch": "^3.3.2"
+  }
+}


### PR DESCRIPTION
## Summary
- clean up the miners docker-compose file and expose summary APIs for the bundled miners
- add a Node-based miner-bridge sidecar that polls miner stats and posts miner.sample events to Prism
- provide a minimal package.json for the bridge with the node-fetch dependency

## Testing
- Not run (docker is not available in the execution environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690eeb92ec288329bc266b4aec5b935f)