### PR TITLE
Add payment link support to paperwork scaffolding

### DIFF
--- a/data/templates/invoice.mustache
+++ b/data/templates/invoice.mustache
@@ -11,3 +11,9 @@ Items:
 Total: {{total}} {{currency}}
 Terms: {{terms}}
 Due: {{due_at}}
+{{#payment_link}}
+Payment link: {{payment_link}}
+{{/payment_link}}
+{{^payment_link}}
+Payment: Reply with AP portal link for secure bank info upload.
+{{/payment_link}}

--- a/finance/funding-intake-kit.md
+++ b/finance/funding-intake-kit.md
@@ -24,7 +24,7 @@
 
 1. **Entity & EIN** (any of: existing LLC/C-Corp/sole prop).
 2. **Bank account** (business if you have it; personal only as last resort).
-3. **Payment rails**: ACH/wire instructions ready; optional Stripe link.
+3. **Payment rails**: Secure ACH payment link ready; only upload bank details inside the client's AP portal if they insist.
 4. **Paperwork**: Short **MSA + SOW** or a one-page Service Order.
 5. **Tax form**: US clients usually ask for **W-9** (or W-8 if non-US).
 
@@ -40,7 +40,7 @@ Deliverables:
   • Weeks 2–3: Deploy Prism + OpenTelemetry; dashboards live
   • Week 4: Policies + training; runbooks handed over
 Fees: USD $50,000 fixed, 50% due at signing, 50% at Week 4
-Payment: ACH/Wire within 5 business days of invoice
+Payment: ACH via secure payment link within 5 business days of invoice
 IP: Pre-existing IP remains owner’s; client receives usage rights to outputs
 Confidentiality: Mutual; 2 years; carve-outs for public info/order of court
 Limitation of Liability: Capped at fees paid; no consequential damages
@@ -56,14 +56,11 @@ Email: {ap@client.com}
 
 Description: Prism Console POC (per Service Order)
 Amount Due: $25,000 (50% upfront)
-Due: Net 5 (ACH/Wire)
+Due: Net 5
 
-ACH/Wire Instructions:
-Bank: _______________________
-Routing (ABA): ______________
-Account: ____________________
-Account Name: BlackRoad ______
-Memo: BR-{YYYYMMDD-001}
+Payment: Pay via secure link — {PAYMENT_LINK}
+If AP requires a direct bank upload, reply: "Reply with AP portal link for secure bank info upload."
+Notes: W-9 (EIN only) available on request.
 ```
 
 ---
@@ -138,9 +135,9 @@ Reference: SAFE — {Investor Name}
 ## Banking & Payments Quickstart
 
 * Prefer **business banking**; keep funds separate from personal.
-* Provide both **ACH** and **wire** options.
-* Keep a **standard wiring block** handy; include invoice number in memo.
-* For cards/ACH online, set up a simple **payment link** (optional).
+* Offer a secure **ACH payment link**; only share wire instructions inside a verified AP portal.
+* Keep a **standard wiring block** handy for portal uploads; include invoice number in memo.
+* Maintain a hosted **payment link** (Stripe, QuickBooks, PayPal) so no bank numbers travel by email.
 
 ---
 

--- a/paperwork/deal.yml
+++ b/paperwork/deal.yml
@@ -1,0 +1,31 @@
+# Prism Console Proof-of-Concept paperwork scaffold
+# Update buyer/seller context before running the paperwork agent.
+deal:
+  name: "Prism Console POC"
+  start_date: "TBD"
+  duration_weeks: 4
+  buyer:
+    company: "Example Co"
+    contact:
+      name: "<Primary contact>"
+      email: "billing@example.com"
+  seller:
+    entity: "Alexa L. Amundson (sole proprietor)"
+    ein: "XX-XXXXXXX"
+    remit_to:
+      email: "alexa@example.com"
+      mailing_address: "<Remit address>"
+  scope:
+    - "Week 1: Agent inventory & risk assessment"
+    - "Weeks 2-3: Deploy Prism + OpenTelemetry, dashboards live"
+    - "Week 4: Policies, training, runbooks"
+  pricing:
+    currency: USD
+    total: 50000
+    deposit_percent: 50
+    balance_due_event: "Week 4 sign-off"
+  payment_terms: "Net 5"
+  payment_link: "https://pay.example.com/prism-console"
+  notes:
+    - "Provide W-9 with EIN (no SSN)."
+    - "If the client requires bank upload, request secure AP portal access."

--- a/scripts/generate_invoice.js
+++ b/scripts/generate_invoice.js
@@ -1,6 +1,6 @@
-const fs = require('fs');
-const path = require('path');
-const mustache = require('mustache');
+import fs from 'node:fs';
+import path from 'node:path';
+import mustache from 'mustache';
 
 function today() {
   return new Date().toISOString().slice(0, 10);
@@ -26,7 +26,8 @@ const invoice = {
   items: [{ sku: 'BLACKROAD-PRO', qty: 1, unit: 1200 }],
   currency: base.currency,
   terms: base.terms,
-  due_at: new Date(Date.now() + 30 * 86400000).toISOString()
+  due_at: new Date(Date.now() + 30 * 86400000).toISOString(),
+  payment_link: process.env.PAYMENT_LINK || ''
 };
 
 invoice.total = invoice.items.reduce((sum, item) => sum + item.qty * item.unit, 0);


### PR DESCRIPTION
## Summary
- add a paperwork/deal.yml scaffold with a payment_link field and updated compliance notes
- update the invoice mustache template and generator to emit payment links or a secure fallback message
- refresh the funding intake kit to steer users toward secure ACH links instead of emailing bank numbers

## Testing
- ⚠️ `node scripts/generate_invoice.js` *(fails: repository does not vend the mustache dependency in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690eea4ade548329b6a4f092e7f806ac)