### PR TITLE
feat: load miner controller profiles from config file

### DIFF
--- a/miners/bridge/miner_bridge.py
+++ b/miners/bridge/miner_bridge.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Poll XMRig's HTTP API and forward miner.sample events to Prism."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+from urllib.error import HTTPError, URLError
+from urllib.parse import urljoin
+from urllib.request import Request, urlopen
+
+LOGGER = logging.getLogger("miner-bridge")
+
+
+@dataclass
+class MinerSummary:
+    miner_id: str
+    recorded_at: datetime
+    pool: Optional[str]
+    hashrate_1m: Optional[float]
+    hashrate_15m: Optional[float]
+    shares_accepted: int
+    shares_rejected: int
+    shares_stale: int
+    latency_ms: Optional[float]
+    temperature_c: Optional[float]
+    last_share_diff: Optional[float]
+    last_share_at: Optional[datetime]
+
+    def to_payload(self) -> Dict[str, Any]:
+        return {
+            "miner_id": self.miner_id,
+            "timestamp": self.recorded_at.isoformat().replace("+00:00", "Z"),
+            "pool": self.pool,
+            "hashrate_1m": self.hashrate_1m,
+            "hashrate_15m": self.hashrate_15m,
+            "shares_accepted": self.shares_accepted,
+            "shares_rejected": self.shares_rejected,
+            "shares_stale": self.shares_stale,
+            "latency_ms": self.latency_ms,
+            "temperature_c": self.temperature_c,
+            "last_share_difficulty": self.last_share_diff,
+            "last_share_at": (
+                self.last_share_at.isoformat().replace("+00:00", "Z")
+                if self.last_share_at
+                else None
+            ),
+        }
+
+
+def iso_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _safe_float(value: Any) -> Optional[float]:
+    try:
+        if value is None:
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _safe_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+class MinerBridge:
+    def __init__(self) -> None:
+        self.xmrig_api = os.environ.get("XMRIG_API_URL", "http://localhost:18080").rstrip("/") + "/"
+        self.xmrig_token = os.environ.get("XMRIG_API_TOKEN")
+        self.prism_api = os.environ.get("PRISM_API_URL", "http://localhost:4000").rstrip("/") + "/"
+        self.prism_token = os.environ.get("PRISM_API_TOKEN")
+        self.miner_id = os.environ.get("MINER_ID", "xmrig")
+        self.interval = max(float(os.environ.get("POLL_INTERVAL", "15")), 5.0)
+        self.timeout = float(os.environ.get("HTTP_TIMEOUT", "5"))
+        self.last_good_shares: Optional[int] = None
+        self.last_share_diff: Optional[float] = None
+        self.last_share_at: Optional[datetime] = None
+
+    def run(self) -> None:
+        LOGGER.info("starting miner bridge", extra={"interval": self.interval})
+        while True:
+            try:
+                summary = self._fetch_summary()
+                if summary:
+                    payload = summary.to_payload()
+                    self._send_sample(payload)
+            except Exception as exc:  # noqa: BLE001 - log and continue loop
+                LOGGER.exception("bridge loop failed", exc_info=exc)
+            time.sleep(self.interval)
+
+    def _fetch_summary(self) -> Optional[MinerSummary]:
+        endpoint_candidates = ["2/summary", "1/summary", "summary"]
+        data: Optional[Dict[str, Any]] = None
+        for endpoint in endpoint_candidates:
+            try:
+                data = self._http_get_json(urljoin(self.xmrig_api, endpoint))
+            except HTTPError as exc:
+                if exc.code == 404:
+                    continue
+                LOGGER.warning("xmrig summary http error", extra={"code": exc.code})
+            except URLError as exc:
+                LOGGER.warning("xmrig summary unavailable", extra={"error": str(exc)})
+            if data:
+                break
+        if not data:
+            LOGGER.debug("no xmrig data available")
+            return None
+
+        results = data.get("results", {})
+        connection = data.get("connection", {})
+        hashrate = data.get("hashrate", {})
+        total = hashrate.get("total") if isinstance(hashrate, dict) else None
+        now = iso_now()
+
+        hr_1m: Optional[float] = None
+        hr_15m: Optional[float] = None
+        if isinstance(total, (list, tuple)):
+            if len(total) > 1:
+                hr_1m = _safe_float(total[1])
+            if len(total) > 2:
+                hr_15m = _safe_float(total[2])
+        elif isinstance(total, (int, float)):
+            hr_1m = float(total)
+
+        accepted = _safe_int(results.get("shares_good"))
+        total_shares = _safe_int(results.get("shares_total"))
+        rejected = max(total_shares - accepted, 0)
+        stale = _safe_int(results.get("shares_stale")) or rejected
+
+        diff_current = _safe_float(results.get("diff_current"))
+        if self.last_good_shares is None:
+            self.last_good_shares = accepted
+        elif accepted > self.last_good_shares:
+            self.last_good_shares = accepted
+            self.last_share_diff = diff_current
+            self.last_share_at = now
+
+        temp = self._extract_temperature(data)
+        latency = _safe_float(connection.get("ping"))
+
+        summary = MinerSummary(
+            miner_id=self.miner_id,
+            recorded_at=now,
+            pool=connection.get("pool"),
+            hashrate_1m=hr_1m,
+            hashrate_15m=hr_15m,
+            shares_accepted=accepted,
+            shares_rejected=rejected,
+            shares_stale=stale,
+            latency_ms=latency,
+            temperature_c=temp,
+            last_share_diff=self.last_share_diff,
+            last_share_at=self.last_share_at,
+        )
+        LOGGER.debug(
+            "xmrig sample",
+            extra={
+                "hashrate_1m": hr_1m,
+                "accepted": accepted,
+                "rejected": rejected,
+                "temp": temp,
+            },
+        )
+        return summary
+
+    def _send_sample(self, payload: Dict[str, Any]) -> None:
+        request = Request(
+            urljoin(self.prism_api, "api/miners/sample"),
+            data=json.dumps(payload).encode("utf-8"),
+            method="POST",
+            headers={"Content-Type": "application/json"},
+        )
+        if self.prism_token:
+            request.add_header("Authorization", f"Bearer {self.prism_token}")
+        try:
+            with urlopen(request, timeout=self.timeout) as response:
+                response.read()
+            LOGGER.info("sent miner.sample", extra={"accepted": payload.get("shares_accepted")})
+        except HTTPError as exc:
+            LOGGER.error(
+                "failed to push miner.sample",
+                extra={"status": exc.code, "reason": exc.reason},
+            )
+        except URLError as exc:
+            LOGGER.error("prism api unreachable", extra={"error": str(exc)})
+
+    def _http_get_json(self, url: str) -> Dict[str, Any]:
+        request = Request(url, headers={"Content-Type": "application/json"})
+        if self.xmrig_token:
+            request.add_header("Authorization", f"Bearer {self.xmrig_token}")
+        with urlopen(request, timeout=self.timeout) as response:
+            payload = response.read()
+            if not payload:
+                return {}
+            return json.loads(payload.decode("utf-8"))
+
+    @staticmethod
+    def _extract_temperature(data: Dict[str, Any]) -> Optional[float]:
+        cpu = data.get("cpu")
+        if isinstance(cpu, dict):
+            temp = cpu.get("temperature")
+            if temp is not None:
+                return _safe_float(temp)
+        temps = data.get("temperatures")
+        if isinstance(temps, (list, tuple)) and temps:
+            return _safe_float(temps[0])
+        return None
+
+
+def configure_logging() -> None:
+    level_name = os.environ.get("LOG_LEVEL", "INFO").upper()
+    level = getattr(logging, level_name, logging.INFO)
+    handler = logging.StreamHandler(stream=sys.stdout)
+    formatter = logging.Formatter("%(asctime)s %(levelname)s [%(name)s] %(message)s")
+    handler.setFormatter(formatter)
+    LOGGER.setLevel(level)
+    LOGGER.addHandler(handler)
+
+
+def main() -> None:
+    configure_logging()
+    MinerBridge().run()
+
+
+if __name__ == "__main__":
+    main()

--- a/miners/controller/controller.mjs
+++ b/miners/controller/controller.mjs
@@ -1,0 +1,343 @@
+#!/usr/bin/env node
+/*
+ * Lightweight controller to nudge low-power miners toward lower stales and thermals.
+ *
+ * - Polls Prism's miner telemetry API for recent samples
+ * - Scores profiles using a UCB1 multi-armed bandit
+ * - Applies pool changes via XMRig HTTP config
+ * - Enforces a duty cycle and thermal pause gate
+ */
+
+import { setTimeout as delay } from 'node:timers/promises';
+import { exec as execCb } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { createRequire } from 'node:module';
+import { promisify } from 'node:util';
+
+const exec = promisify(execCb);
+
+const PRISM_API_URL = (process.env.PRISM_API_URL ?? 'http://localhost:4000').replace(/\/$/, '');
+const PRISM_API_TOKEN = process.env.PRISM_API_TOKEN ?? '';
+const MINER_ID = process.env.MINER_ID ?? 'xmrig';
+const XMRIG_API_URL = (process.env.XMRIG_API_URL ?? 'http://localhost:18080').replace(/\/$/, '');
+const XMRIG_API_TOKEN = process.env.XMRIG_API_TOKEN ?? '';
+const POLL_INTERVAL_MS = Number(process.env.POLL_INTERVAL_MS ?? 60_000);
+const CYCLE_SECONDS = Number(process.env.DUTY_CYCLE_SECONDS ?? 900);
+const THERMAL_LIMIT = Number(process.env.THERMAL_LIMIT ?? 80);
+const COOLDOWN_MINUTES = Number(process.env.COOLDOWN_MINUTES ?? 10);
+const COMPOSE_FILE = process.env.COMPOSE_FILE ?? 'miners/miners-compose.yml';
+const DOCKER_SERVICE = process.env.DOCKER_SERVICE ?? 'xmrig';
+
+const PROFILE_CONFIG_PATH = process.env.PROFILE_CONFIG_PATH ?? process.env.PROFILES_FILE ?? '';
+
+function asArray(value) {
+  if (Array.isArray(value)) return value;
+  if (value && typeof value === 'object' && Array.isArray(value.profiles)) {
+    return value.profiles;
+  }
+  return [];
+}
+
+function normalizeProfile(raw, index) {
+  if (!raw || typeof raw !== 'object') return null;
+  const name = raw.name ?? `profile-${index + 1}`;
+  const dutyValue = Number(raw.duty ?? raw.pool?.duty);
+  const duty = Number.isFinite(dutyValue) ? Math.min(Math.max(dutyValue, 0), 1) : 1.0;
+  const tlsValue = raw.pool?.tls ?? raw.tls ?? false;
+  const pool = {
+    url: raw.pool?.url ?? raw.url ?? '',
+    user: raw.pool?.user ?? raw.user ?? '',
+    pass: raw.pool?.pass ?? raw.pass ?? 'x',
+    tls:
+      typeof tlsValue === 'string'
+        ? ['true', '1', 'yes', 'on'].includes(tlsValue.toLowerCase())
+        : Boolean(tlsValue),
+  };
+  if (!pool.url || !pool.user) {
+    return null;
+  }
+  return {
+    name,
+    pool,
+    duty,
+  };
+}
+
+function loadProfilesFromEnv() {
+  return [
+    {
+      name: 'pool-a',
+      pool: {
+        url: process.env.POOL_A_URL ?? 'stratum+tcp://poolA:3333',
+        user: process.env.POOL_A_USER ?? 'WALLET_OR_LOGIN',
+        pass: process.env.POOL_A_PASS ?? 'x',
+        tls: process.env.POOL_A_TLS === 'true',
+      },
+      duty: Number(process.env.POOL_A_DUTY ?? 1.0),
+    },
+    {
+      name: 'pool-b',
+      pool: {
+        url: process.env.POOL_B_URL ?? 'stratum+tcp://poolB:443',
+        user: process.env.POOL_B_USER ?? 'WALLET_OR_LOGIN',
+        pass: process.env.POOL_B_PASS ?? 'x',
+        tls: process.env.POOL_B_TLS !== 'false',
+      },
+      duty: Number(process.env.POOL_B_DUTY ?? 0.8),
+    },
+    {
+      name: 'p2pool-local',
+      pool: {
+        url: process.env.P2POOL_URL ?? 'stratum+tcp://p2pool:3333',
+        user: process.env.P2POOL_USER ?? 'WALLET_OR_LOGIN',
+        pass: process.env.P2POOL_PASS ?? 'x',
+        tls: false,
+      },
+      duty: Number(process.env.P2POOL_DUTY ?? 1.0),
+    },
+  ].filter((profile) => profile.pool.url && profile.pool.user);
+}
+
+function loadYamlModule() {
+  try {
+    const require = createRequire(import.meta.url);
+    const yaml = require('yaml');
+    if (yaml?.parse) {
+      return yaml.parse;
+    }
+  } catch (error) {
+    throw new Error(
+      "YAML profile config requested but the 'yaml' package is not installed. Install it or provide a JSON file."
+    );
+  }
+  throw new Error("Unable to load YAML parser from the 'yaml' package.");
+}
+
+function loadProfilesFromFile(filePath) {
+  const absolutePath = path.isAbsolute(filePath) ? filePath : path.resolve(process.cwd(), filePath);
+  const raw = fs.readFileSync(absolutePath, 'utf8');
+  const ext = path.extname(absolutePath).toLowerCase();
+  let document;
+  if (ext === '.yaml' || ext === '.yml') {
+    const parse = loadYamlModule();
+    document = parse(raw);
+  } else {
+    document = JSON.parse(raw);
+  }
+  return asArray(document)
+    .map((profile, index) => normalizeProfile(profile, index))
+    .filter((profile) => profile);
+}
+
+function loadProfiles() {
+  if (!PROFILE_CONFIG_PATH) {
+    return loadProfilesFromEnv();
+  }
+  try {
+    const loaded = loadProfilesFromFile(PROFILE_CONFIG_PATH);
+    if (loaded.length === 0) {
+      console.warn(
+        `[controller] profile config ${PROFILE_CONFIG_PATH} did not contain any usable entries; falling back to env defaults`
+      );
+      return loadProfilesFromEnv();
+    }
+    console.log(`[controller] loaded ${loaded.length} profiles from ${PROFILE_CONFIG_PATH}`);
+    return loaded;
+  } catch (error) {
+    console.error(`[controller] failed to load profiles from ${PROFILE_CONFIG_PATH}: ${error.message ?? error}`);
+    process.exit(1);
+  }
+}
+
+const profiles = loadProfiles();
+
+const stats = new Map(profiles.map((p) => [p.name, { plays: 0, reward: 0 }]));
+const lastSampleSeen = new Map();
+let currentProfile = null;
+let lastCycleStart = Date.now();
+let forcedPauseUntil = 0;
+let lastPauseState = null;
+
+function formatRelative(timestamp) {
+  const delta = Date.now() - new Date(timestamp).getTime();
+  if (!Number.isFinite(delta) || delta < 0) return 'now';
+  const seconds = Math.floor(delta / 1000);
+  if (seconds < 60) return `${seconds}s ago`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+  return `${Math.floor(seconds / 3600)}h ago`;
+}
+
+function scoreSample(sample) {
+  if (!sample) return 0;
+  const effective = sample.effective_hashrate ?? sample.hashrate_1m ?? 0;
+  const staleRate = sample.stale_rate ?? 0;
+  const temperature = sample.temperature_c ?? 0;
+  const stalePenalty = staleRate > 0.02 ? (staleRate * 200) : staleRate * 50;
+  const thermalPenalty = temperature > THERMAL_LIMIT ? (temperature - THERMAL_LIMIT) * 0.5 : 0;
+  return effective - stalePenalty - thermalPenalty;
+}
+
+function selectProfile(samplesByPool) {
+  const totalPlays = Array.from(stats.values()).reduce((sum, value) => sum + value.plays, 0) || 1;
+  let best = null;
+  let bestScore = Number.NEGATIVE_INFINITY;
+  for (const profile of profiles) {
+    const state = stats.get(profile.name);
+    const sample = samplesByPool.get(profile.pool.url) ?? samplesByPool.get(profile.name);
+    const reward = scoreSample(sample);
+  const sampleStamp = sample?.recorded_at ?? sample?.timestamp ?? null;
+    if (sample && sampleStamp && lastSampleSeen.get(profile.name) !== sampleStamp) {
+      state.reward += reward;
+      state.plays += 1;
+      lastSampleSeen.set(profile.name, sampleStamp);
+    }
+    const mean = state.plays ? state.reward / state.plays : 0;
+    const exploration = state.plays ? Math.sqrt((2 * Math.log(totalPlays + 1)) / state.plays) : Number.POSITIVE_INFINITY;
+    const ucb = mean + exploration;
+    if (ucb > bestScore) {
+      bestScore = ucb;
+      best = profile;
+    }
+  }
+  return best ?? profiles[0];
+}
+
+async function fetchLatestSamples() {
+  const url = `${PRISM_API_URL}/api/miners/latest?minerId=${encodeURIComponent(MINER_ID)}`;
+  const headers = PRISM_API_TOKEN ? { Authorization: `Bearer ${PRISM_API_TOKEN}` } : undefined;
+  const response = await fetch(url, { headers });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch miner samples: ${response.status}`);
+  }
+  return response.json();
+}
+
+async function getConfig() {
+  const headers = XMRIG_API_TOKEN ? { Authorization: `Bearer ${XMRIG_API_TOKEN}` } : undefined;
+  const response = await fetch(`${XMRIG_API_URL}/1/config`, { headers });
+  if (!response.ok) {
+    throw new Error(`Failed to read xmrig config: ${response.status}`);
+  }
+  return response.json();
+}
+
+async function putConfig(config) {
+  const headers = { 'Content-Type': 'application/json' };
+  if (XMRIG_API_TOKEN) headers.Authorization = `Bearer ${XMRIG_API_TOKEN}`;
+  const response = await fetch(`${XMRIG_API_URL}/1/config`, {
+    method: 'PUT',
+    headers,
+    body: JSON.stringify(config),
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to update xmrig config: ${response.status}`);
+  }
+}
+
+async function applyProfile(profile) {
+  const config = await getConfig();
+  const base = Array.isArray(config.pools) && config.pools.length > 0 ? config.pools[0] : {};
+  const updatedPool = {
+    ...base,
+    url: profile.pool.url,
+    user: profile.pool.user,
+    pass: profile.pool.pass ?? 'x',
+    tls: Boolean(profile.pool.tls),
+  };
+  config.pools = [updatedPool];
+  await putConfig(config);
+  currentProfile = profile;
+  lastCycleStart = Date.now();
+  console.log(`[controller] switched to ${profile.name} → ${profile.pool.url}`);
+}
+
+async function setMiningActive(active) {
+  if (!COMPOSE_FILE) return;
+  if (lastPauseState === active) return;
+  const action = active ? 'unpause' : 'pause';
+  try {
+    await exec(`docker compose -f ${COMPOSE_FILE} ${action} ${DOCKER_SERVICE}`);
+    lastPauseState = active;
+    console.log(`[controller] docker compose ${action} ${DOCKER_SERVICE}`);
+  } catch (error) {
+    console.warn('[controller] failed to toggle docker compose state', error.message ?? error);
+  }
+}
+
+function reconcileDutyCycle(profile) {
+  if (!profile) return;
+  if (profile.duty >= 0.999) {
+    if (Date.now() > forcedPauseUntil) {
+      setMiningActive(true).catch(console.error);
+    }
+    return;
+  }
+  const elapsed = (Date.now() - lastCycleStart) / 1000;
+  const cycle = CYCLE_SECONDS;
+  const onWindow = cycle * profile.duty;
+  const phase = elapsed % cycle;
+  const shouldMine = phase < onWindow && Date.now() > forcedPauseUntil;
+  setMiningActive(shouldMine).catch(console.error);
+}
+
+function ensureCooldown(sample) {
+  if (!sample?.temperature_c) return;
+  if (sample.temperature_c <= THERMAL_LIMIT) {
+    if (forcedPauseUntil && Date.now() > forcedPauseUntil) {
+      forcedPauseUntil = 0;
+      console.log('[controller] thermal cooldown finished');
+    }
+    return;
+  }
+  forcedPauseUntil = Date.now() + COOLDOWN_MINUTES * 60_000;
+  console.warn(
+    `[controller] temp ${sample.temperature_c.toFixed(1)}°C > ${THERMAL_LIMIT}°C → pausing for ${COOLDOWN_MINUTES}m`
+  );
+  setMiningActive(false).catch(console.error);
+}
+
+function mapSamples(samplesResponse) {
+  const samplesByPool = new Map();
+  if (!samplesResponse?.samples) return samplesByPool;
+  for (const sample of samplesResponse.samples) {
+    const key = sample.pool ?? sample.profile ?? 'default';
+    samplesByPool.set(key, sample);
+  }
+  return samplesByPool;
+}
+
+async function loop() {
+  if (profiles.length === 0) {
+    console.error('[controller] no profiles defined; aborting');
+    process.exit(1);
+  }
+
+  while (true) {
+    try {
+      const data = await fetchLatestSamples();
+      const samplesByPool = mapSamples(data);
+      const nextProfile = selectProfile(samplesByPool);
+      const activeSample = samplesByPool.get(nextProfile.pool.url);
+      ensureCooldown(activeSample);
+      if (!currentProfile || currentProfile.name !== nextProfile.name) {
+        await applyProfile(nextProfile);
+      }
+      reconcileDutyCycle(nextProfile);
+      if (activeSample?.last_share_at) {
+        console.log(
+          `[controller] ${nextProfile.name} effective ${(activeSample.effective_hashrate ?? activeSample.hashrate_1m ?? 0).toFixed(1)} H/s · stale ${(activeSample.stale_rate * 100).toFixed(2)}% · last share ${formatRelative(activeSample.last_share_at)}`
+        );
+      }
+    } catch (error) {
+      console.warn('[controller] loop error', error?.message ?? error);
+    }
+    await delay(POLL_INTERVAL_MS);
+  }
+}
+
+loop().catch((error) => {
+  console.error('[controller] fatal', error);
+  process.exit(1);
+});

--- a/miners/miners-compose.yml
+++ b/miners/miners-compose.yml
@@ -1,178 +1,169 @@
-version: '3.8'
+version: "3.8"
+
+# Low-power miner bundle with optional telemetry bridge and local p2pool.
+# Every service is opt-in. Edit the placeholders before enabling anything.
 services:
-  # --- Litecoin (LTC) learn-mode • CPU scrypt (utterly unprofitable, educational only) ---
-  # Real LTC mining requires Scrypt ASICs. This is a light CPU demo.
-services:
-  # --- Monero (xmrig) • CPU miner (learn-mode, throttled) ---
-  xmrig:
-    image: ghcr.io/xmrig/xmrig:latest
-    container_name: xmrig
-    command: >
-      -o POOL_HOST:PORT
-      -u YOUR_XMR_ADDRESS
-      --donate-level=0
-      --cpu-max-threads-hint=1
-    cpus: 0.25
-    environment:
-      # cap internal throttling further if desired:
-      - XMRIG_ALGO=rx/0
-    cpus: 0.25              # Docker-level CPU cap
-    mem_limit: 256m
+  # --- Monero p2pool (optional local stratum template cache) ---
+  p2pool:
+    image: ghcr.io/sethforprivacy/p2pool:latest
+    container_name: p2pool
     restart: unless-stopped
-    security_opt: [no-new-privileges:true]
-    read_only: true
+    command: >-
+      --wallet ${XMR_ADDRESS:-YOUR_XMR_ADDRESS}
+      --host 0.0.0.0
+      --port 3333
+      --rpc-port 37889
+      --daemon ${MONEROD_HOST:-host.docker.internal:18089}
+      --stratum 0.0.0.0:3333
+      --mini
+      --log-level 2
+    environment:
+      - P2POOL_DATA=/opt/p2pool
+    ports:
+      - "${P2POOL_PORT:-3333}:3333"
+      - "${P2POOL_API_PORT:-37889}:37889"
     volumes:
-      - /etc/localtime:/etc/localtime:ro
-    # enable manually:
-    # docker compose -f miners/miners-compose.yml up -d xmrig
+      - p2pool-data:/opt/p2pool
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:37889/stats"]
+      interval: 30s
+      timeout: 5s
+      retries: 10
 
-  # --- Verus (VRSC) • CPU miner (learn-mode) ---
-    # Enable manually:
-    # docker compose -f miners/miners-compose.yml up -d xmrig
-
-  # --- Verus (VRSC) • CPU miner (efficient but still tiny on a Pi) ---
-
-# Low-power miner bundle. Every service is capped, read-only where possible, and
-# requires manual activation. Copy to the device as ~/miners-compose.yml and edit
-# the placeholders before running `docker compose -f miners-compose.yml up -d <service>`.
-services:
-  # --- Monero (XMRig) — CPU miner for education ---
+  # --- Monero (xmrig) — CPU miner (learn-mode) ---
   xmrig:
     image: ghcr.io/xmrig/xmrig:latest
     container_name: xmrig
     command: >-
-      -o POOL_HOST:PORT
-      -u YOUR_XMR_ADDRESS
-      --tls
-      --donate-level=0
-      --cpu-max-threads-hint=1
-    cpus: 0.25                # hard cap ≈25% of one core
-    mem_limit: 256m
+      -o ${XMR_POOL_HOST:-p2pool:3333}
+      -u ${XMR_ADDRESS:-YOUR_XMR_ADDRESS}
+      -p ${XMR_POOL_PASSWORD:-x}
+      --algo=${XMRIG_ALGO:-rx/0}
+      --donate-level=${XMRIG_DONATE_LEVEL:-0}
+      --cpu-max-threads-hint=${XMRIG_THREAD_HINT:-1}
+      --hugepages
+      --http-enabled
+      --http-host=0.0.0.0
+      --http-port=18080
+      --http-access-token=${XMRIG_HTTP_TOKEN:-}
+      --http-no-restricted
+      --api-worker-id=${XMRIG_WORKER_ID:-jetson}
+    environment:
+      - TZ=UTC
+    cpus: ${XMRIG_CPUS:-0.5}
+    mem_limit: ${XMRIG_MEM_LIMIT:-512m}
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true
+    depends_on:
+      - p2pool
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:18080/1/summary"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
     read_only: true
+    tmpfs:
+      - /tmp
     volumes:
       - /etc/localtime:/etc/localtime:ro
-    deploy:
-      resources:
-        limits:
-          cpus: '0.25'
-    # Enable manually:
-    #   docker compose -f miners-compose.yml up -d xmrig
+
+  # --- Miner bridge → Prism telemetry ---
+  miner-bridge:
+    image: python:3.11-slim
+    container_name: miner-bridge
+    restart: unless-stopped
+    depends_on:
+      - xmrig
+    environment:
+      - XMRIG_API_URL=http://xmrig:18080
+      - XMRIG_API_TOKEN=${XMRIG_HTTP_TOKEN:-}
+      - PRISM_API_URL=${PRISM_API_URL:-http://prism-console-api:4000}
+      - PRISM_API_TOKEN=${PRISM_API_TOKEN:-}
+      - MINER_ID=${MINER_ID:-xmrig}
+      - POLL_INTERVAL=${MINER_BRIDGE_INTERVAL:-15}
+      - LOG_LEVEL=${MINER_BRIDGE_LOG_LEVEL:-INFO}
+    command: ["python", "-u", "/app/miner_bridge.py"]
+    volumes:
+      - ./bridge:/app:ro
 
   # --- Verus (VerusHash 2.2) — efficient CPU miner ---
   verusminer:
     image: krypt0nn/verus-miner:latest
     container_name: verusminer
     environment:
-      - POOL=POOL_HOST:PORT
-      - WALLET=YOUR_VRSC_ADDRESS
-      - PASSWORD=x
-      - THREADS=1
+      - POOL=${VERUS_POOL:-POOL_HOST:PORT}
+      - WALLET=${VERUS_ADDRESS:-YOUR_VRSC_ADDRESS}
+      - PASSWORD=${VERUS_PASSWORD:-x}
+      - THREADS=${VERUS_THREADS:-1}
     cpus: 0.25
     mem_limit: 256m
     restart: unless-stopped
-    security_opt: [no-new-privileges:true]
+    security_opt:
+      - no-new-privileges:true
     read_only: true
-    # enable:
-    # docker compose -f miners/miners-compose.yml up -d verusminer
+    profiles:
+      - manual
 
-  # --- Litecoin (LTC) • scrypt CPU demo (educational only) ---
+  # --- Litecoin (scrypt CPU demo; educational only) ---
   ltc-cpuminer:
     image: registry.gitlab.com/foss/cpuminer-multi:latest
     container_name: ltc-cpuminer
-    command: >
+    command: >-
       -a scrypt
-      -o stratum+tcp://POOL_HOST:PORT
-      -u YOUR_LTC_ADDRESS
-      -p x
-      -t 1
+      -o stratum+tcp://${LTC_POOL:-POOL_HOST:PORT}
+      -u ${LTC_ADDRESS:-YOUR_LTC_ADDRESS}
+      -p ${LTC_PASSWORD:-x}
+      -t ${LTC_THREADS:-1}
     cpus: 0.25
     mem_limit: 256m
     restart: unless-stopped
-    security_opt: [no-new-privileges:true]
+    security_opt:
+      - no-new-privileges:true
     read_only: true
-    # enable manually:
-    # docker compose -f miners/miners-compose.yml up -d ltc-cpuminer
+    profiles:
+      - manual
 
   # --- Generic cpuminer (multi-algo learn-mode) ---
   cpuminer-multi:
     image: registry.gitlab.com/foss/cpuminer-multi:latest
     container_name: cpuminer-multi
-    environment:
-      - ALGO=verushash   # or yespower / scrypt / sha256d (pick an easy pool)
-      - POOL=POOL_HOST:PORT
-      - USER=YOUR_ADDRESS
-      - PASS=x
-      - THREADS=1
-    command: >
-      -a ${ALGO}
-      -o stratum+tcp://${POOL}
-      -u ${USER}
-      -p ${PASS}
-      -t ${THREADS}
+    command: >-
+      -a ${CPUMINER_ALGO:-verushash}
+      -o stratum+tcp://${CPUMINER_POOL:-POOL_HOST:PORT}
+      -u ${CPUMINER_USER:-YOUR_ADDRESS}
+      -p ${CPUMINER_PASS:-x}
+      -t ${CPUMINER_THREADS:-1}
     cpus: 0.25
     mem_limit: 256m
     restart: unless-stopped
-    security_opt: [no-new-privileges:true]
-    read_only: true
-    # enable manually:
-    # docker compose -f miners/miners-compose.yml up -d cpuminer-multi
-    # enable:
-    # docker compose -f miners/miners-compose.yml up -d ltc-cpuminer
-
-  # --- Chia farmer (ULTRA low energy; pre-plotted drives needed) ---
-    # Enable:
-    # docker compose -f miners/miners-compose.yml up -d verusminer
-
-  # --- Chia farmer (ultra-low energy; pre-plotted drives needed) ---
     security_opt:
       - no-new-privileges:true
     read_only: true
-    # Enable manually:
-    #   docker compose -f miners-compose.yml up -d verusminer
+    profiles:
+      - manual
 
-  # --- Chia farmer/harvester role (plots must already exist) ---
+  # --- Chia farmer (plots must already exist) ---
   chia:
     image: ghcr.io/chia-network/chia:latest
     container_name: chia
     environment:
       - keys=none
-      - keys=none            # no private keys loaded on Pi
       - service=farm
       - log_level=INFO
       - TZ=UTC
     volumes:
       - ./chia:/root/.chia
       - /mnt/plots:/plots:ro
-      - /mnt/plots:/plots:ro  # mount your plots read-only
-    cpus: 0.2
-    mem_limit: 512m
-    restart: unless-stopped
-    security_opt: [no-new-privileges:true]
-    read_only: false
-    # enable:
-    # Enable:
-    # docker compose -f miners/miners-compose.yml up -d chia
-      - keys=none            # do not load private keys on this host
-      - service=farm         # farming only, no plotting
-      - TZ=UTC
-      - log_level=INFO
-    volumes:
-      - ./chia:/root/.chia   # config + logs persisted locally
-      - /mnt/plots:/plots:ro # mount pre-plotted drives read-only
-    ports: []                # no external ports exposed by default
     cpus: 0.2
     mem_limit: 512m
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true
     read_only: false
-    # Enable manually after plots are mounted:
-    #   docker compose -f miners-compose.yml up -d chia
+    profiles:
+      - manual
 
-# Stop with: docker compose -f miners-compose.yml stop <service>
-# Remove with: docker compose -f miners-compose.yml down <service>
-    # Enable:
-    # docker compose -f miners/miners-compose.yml up -d chia
+volumes:
+  p2pool-data:
+    driver: local

--- a/prism/apps/web/src/components/prism/MinerTiles.tsx
+++ b/prism/apps/web/src/components/prism/MinerTiles.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useState } from 'react';
+
+type MinerTile = {
+  id: string;
+  label: string;
+  value: string;
+  helper?: string | null;
+  intent?: 'good' | 'warning' | 'critical' | string | null;
+};
+
+type MinerTilesResponse = {
+  miner_id: string;
+  updated_at: string;
+  tiles: MinerTile[];
+};
+
+type Props = {
+  minerId?: string;
+  refreshMs?: number;
+};
+
+const INTENT_COLORS: Record<string, string> = {
+  good: '#16a34a',
+  warning: '#facc15',
+  critical: '#ef4444',
+};
+
+function borderColor(intent?: string | null): string {
+  if (!intent) return 'var(--accent)';
+  return INTENT_COLORS[intent] ?? 'var(--accent)';
+}
+
+export default function MinerTiles({ minerId = 'xmrig', refreshMs = 30000 }: Props) {
+  const [state, setState] = useState<MinerTilesResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const response = await fetch(`/miners/tiles?miner_id=${encodeURIComponent(minerId)}`);
+        if (!response.ok) {
+          throw new Error(`request failed with status ${response.status}`);
+        }
+        const json: MinerTilesResponse = await response.json();
+        if (!cancelled) {
+          setState(json);
+          setError(null);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      }
+    }
+
+    load();
+    const interval = window.setInterval(load, refreshMs);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [minerId, refreshMs]);
+
+  if (error) {
+    return (
+      <div className="card p-4 border border-red-500 text-sm text-red-200">
+        Miner telemetry unavailable: {error}
+      </div>
+    );
+  }
+
+  if (!state) {
+    return (
+      <div className="card p-4 text-sm text-slate-300" role="status">
+        Loading miner telemetry…
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="text-xs text-slate-400">Miner {state.miner_id} · updated {new Date(state.updated_at).toLocaleTimeString()}</div>
+      <div className="grid grid-cols-2 gap-3">
+        {state.tiles.map((tile) => (
+          <div
+            key={tile.id}
+            className="card p-4 space-y-1 border"
+            style={{ borderColor: borderColor(tile.intent), minHeight: '96px' }}
+          >
+            <div className="text-xs uppercase tracking-wide text-slate-400">{tile.label}</div>
+            <div className="text-xl font-semibold text-white">{tile.value}</div>
+            {tile.helper ? <div className="text-xs text-slate-400">{tile.helper}</div> : null}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/prism/apps/web/src/pages/Prism.tsx
+++ b/prism/apps/web/src/pages/Prism.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { PrismEvent, IntelligenceEvent } from '@prism/core';
 import Timeline from '../components/prism/Timeline';
+import MinerTiles from '../components/prism/MinerTiles';
 import IntelligenceTimeline from '../components/intelligence/Timeline';
 import { connect, connectIntelligence } from '../clients/sse';
 
@@ -26,7 +27,10 @@ export default function PrismPage() {
 
   return (
     <div style={{ display: 'grid', gap: '1.5rem', gridTemplateColumns: '1fr 1fr' }}>
-      <Timeline events={events} />
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+        <MinerTiles />
+        <Timeline events={events} />
+      </div>
       <IntelligenceTimeline events={intelEvents} />
     </div>
   );

--- a/services/prism-console-api/src/prism/models.py
+++ b/services/prism-console-api/src/prism/models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from datetime import datetime
 from typing import Optional
 
 from sqlmodel import Field, SQLModel
@@ -49,10 +50,28 @@ class Metric(SQLModel, table=True):
     status: str
 
 
+class MinerSample(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    miner_id: str
+    recorded_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+    pool: Optional[str] = None
+    profile: Optional[str] = None
+    hashrate_1m: Optional[float] = None
+    hashrate_15m: Optional[float] = None
+    shares_accepted: int = 0
+    shares_rejected: int = 0
+    shares_stale: int = 0
+    latency_ms: Optional[float] = None
+    temperature_c: Optional[float] = None
+    last_share_difficulty: Optional[float] = None
+    last_share_at: Optional[datetime] = None
+
+
 __all__ = [
     "Agent",
     "AgentEvent",
     "Runbook",
     "Setting",
     "Metric",
+    "MinerSample",
 ]

--- a/services/prism-console-api/src/prism/schemas/miners.py
+++ b/services/prism-console-api/src/prism/schemas/miners.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class MinerSampleIn(BaseModel):
+    miner_id: str
+    timestamp: Optional[datetime] = None
+    pool: Optional[str] = None
+    profile: Optional[str] = None
+    hashrate_1m: Optional[float] = None
+    hashrate_15m: Optional[float] = None
+    shares_accepted: int = 0
+    shares_rejected: int = 0
+    shares_stale: Optional[int] = None
+    latency_ms: Optional[float] = None
+    temperature_c: Optional[float] = None
+    last_share_difficulty: Optional[float] = None
+    last_share_at: Optional[datetime] = None
+
+
+class MinerSampleView(BaseModel):
+    miner_id: str
+    recorded_at: datetime
+    pool: Optional[str] = None
+    profile: Optional[str] = None
+    hashrate_1m: Optional[float] = None
+    hashrate_15m: Optional[float] = None
+    effective_hashrate: Optional[float] = None
+    stale_rate: float
+    shares_accepted: int
+    shares_rejected: int
+    shares_stale: int
+    latency_ms: Optional[float] = None
+    temperature_c: Optional[float] = None
+    last_share_difficulty: Optional[float] = None
+    last_share_at: Optional[datetime] = None
+
+
+class MinerSamplesResponse(BaseModel):
+    samples: list[MinerSampleView]
+    generated_at: datetime
+
+
+class MinerTile(BaseModel):
+    id: str
+    label: str
+    value: str
+    helper: Optional[str] = None
+    intent: Optional[str] = None
+
+
+class MinerTilesResponse(BaseModel):
+    miner_id: str
+    updated_at: datetime
+    tiles: list[MinerTile]
+
+
+__all__ = [
+    "MinerSampleIn",
+    "MinerSampleView",
+    "MinerSamplesResponse",
+    "MinerTile",
+    "MinerTilesResponse",
+]

--- a/services/prism-console-api/tests/integration/test_miners_api.py
+++ b/services/prism-console-api/tests/integration/test_miners_api.py
@@ -1,0 +1,37 @@
+from datetime import datetime
+
+
+def _headers():
+    return {"Authorization": "Bearer test-token"}
+
+
+def test_ingest_and_fetch_miner_samples(client):
+    payload = {
+        "miner_id": "xmrig",
+        "timestamp": datetime.utcnow().isoformat() + "Z",
+        "pool": "stratum+tcp://p2pool:3333",
+        "hashrate_1m": 1200.0,
+        "hashrate_15m": 1100.0,
+        "shares_accepted": 12,
+        "shares_rejected": 1,
+        "latency_ms": 42.0,
+        "temperature_c": 72.5,
+        "last_share_difficulty": 15000.0,
+        "last_share_at": datetime.utcnow().isoformat() + "Z",
+    }
+    response = client.post("/api/miners/sample", json=payload, headers=_headers())
+    assert response.status_code == 202
+
+    latest = client.get("/api/miners/latest", headers=_headers()).json()
+    assert latest["samples"], "expected at least one sample"
+    sample = latest["samples"][0]
+    assert sample["miner_id"] == "xmrig"
+    assert sample["stale_rate"] >= 0
+    assert sample["effective_hashrate"] <= payload["hashrate_1m"]
+
+    tiles_private = client.get("/api/miners/tiles", headers=_headers()).json()
+    ids = {tile["id"] for tile in tiles_private["tiles"]}
+    assert {"effective-hashrate", "stale-rate", "temperature", "last-share"}.issubset(ids)
+
+    tiles_public = client.get("/miners/tiles").json()
+    assert tiles_public["miner_id"] == "xmrig"

--- a/services/prism-console-api/tests/unit/test_miner_repo.py
+++ b/services/prism-console-api/tests/unit/test_miner_repo.py
@@ -1,0 +1,46 @@
+from datetime import datetime, timedelta
+
+from sqlmodel import Session, SQLModel, create_engine
+
+from prism.models import MinerSample
+from prism.repo import MinerRepository
+
+
+def test_miner_repository_tracks_latest_per_miner() -> None:
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+    now = datetime.utcnow()
+    samples = [
+        MinerSample(
+            miner_id="xmrig",
+            recorded_at=now - timedelta(minutes=5),
+            shares_accepted=5,
+            shares_rejected=0,
+            shares_stale=0,
+        ),
+        MinerSample(
+            miner_id="xmrig",
+            recorded_at=now - timedelta(minutes=1),
+            shares_accepted=8,
+            shares_rejected=1,
+            shares_stale=1,
+        ),
+        MinerSample(
+            miner_id="verus",
+            recorded_at=now - timedelta(minutes=2),
+            shares_accepted=3,
+            shares_rejected=0,
+            shares_stale=0,
+        ),
+    ]
+    with Session(engine) as session:
+        repo = MinerRepository(session)
+        for sample in samples:
+            repo.record_sample(sample)
+        latest_xmrig = repo.latest_for_miner("xmrig")
+        assert latest_xmrig is not None
+        assert latest_xmrig.recorded_at == samples[1].recorded_at
+        latest = repo.latest_by_miner()
+        assert set(latest) == {"xmrig", "verus"}
+        assert latest["xmrig"].recorded_at == samples[1].recorded_at
+        assert latest["verus"].recorded_at == samples[2].recorded_at


### PR DESCRIPTION
## Summary
- allow the miner controller to source pool profiles from an external JSON or YAML document via PROFILE_CONFIG_PATH
- add optional YAML parsing support and validation for loaded profiles while keeping environment defaults as a fallback
- document the new configuration flow in miners/README.md with an example profile file

## Testing
- not run (not applicable)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690eec34b32083299269372c43b84f2a)