### PR TITLE
Add spiral pitch analytics utility and KPI

### DIFF
--- a/kpi/catalog.yaml
+++ b/kpi/catalog.yaml
@@ -24,3 +24,8 @@ kpis:
     formula: distinct(active_users_last_24h)
     owner: Product
     target: 5000
+  - name: SpiralPitchConsistency
+    source: analytics
+    formula: 1 - MSE(log|z| - (c * theta + b)) / Var(log|z|)
+    owner: Research
+    target: 0.9

--- a/tests/test_spiral_pitch.py
+++ b/tests/test_spiral_pitch.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from utils.spiral_pitch import analyze_spiral_trace
+
+
+def test_log_spiral_pitch_and_reconstruction_matches_exact() -> None:
+    theta = np.linspace(0.0, 4.0 * np.pi, 200)
+    pitch_true = 0.2
+    intercept = -0.3
+    z = np.exp((pitch_true * theta + intercept) + 1j * theta)
+
+    pitch, score, reconstruction = analyze_spiral_trace(z)
+
+    assert pytest.approx(pitch_true, rel=1e-6, abs=1e-6) == pitch
+    assert score > 0.999999
+    np.testing.assert_allclose(reconstruction, z, rtol=1e-9, atol=1e-9)
+
+
+def test_noisy_spiral_retains_pitch_signal_and_reasonable_score() -> None:
+    rng = np.random.default_rng(42)
+    theta = np.linspace(0.0, 6.0 * np.pi, 500)
+    pitch_true = -0.05
+    intercept = 0.4
+    magnitude_noise = 0.03 * rng.standard_normal(theta.shape)
+    phase_noise = 0.01 * rng.standard_normal(theta.shape)
+    rho = pitch_true * theta + intercept + magnitude_noise
+    noisy_theta = theta + phase_noise
+    z_noisy = np.exp(rho + 1j * noisy_theta)
+
+    pitch, score, reconstruction = analyze_spiral_trace(z_noisy)
+
+    assert pytest.approx(pitch_true, rel=1e-2, abs=1e-3) == pitch
+    assert 0.7 < score < 1.0
+    assert reconstruction.shape == z_noisy.shape
+
+
+def test_raises_on_zero_samples() -> None:
+    z = np.array([1 + 0j, 0 + 0j, 1j])
+    with pytest.raises(ValueError):
+        analyze_spiral_trace(z)

--- a/utils/spiral_pitch.py
+++ b/utils/spiral_pitch.py
@@ -1,0 +1,67 @@
+"""Utilities for estimating log-spiral pitch and fit quality."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def analyze_spiral_trace(z: np.ndarray) -> tuple[float, float, np.ndarray]:
+    """Estimate the log-spiral pitch and reconstruction for a complex trace.
+
+    Parameters
+    ----------
+    z:
+        Complex-valued samples describing the trajectory to analyse. The trace
+        must be non-zero everywhere so that the logarithm of the magnitude is
+        well defined.
+
+    Returns
+    -------
+    pitch:
+        The growth-per-radian (``c``) obtained from the least-squares fit of
+        ``log|z|`` against the unwrapped phase ``theta``.
+    spiralness:
+        A unitless goodness-of-fit score defined as
+        ``1 - MSE(log|z| - (c * theta + b)) / Var(log|z|)``. Values near 1
+        indicate that the trace closely follows a logarithmic spiral.
+    reconstruction:
+        Samples of the best-fit logarithmic spiral, matching the shape of the
+        input trace.
+
+    Raises
+    ------
+    ValueError
+        If the input trace is empty or contains zeros.
+    """
+
+    samples = np.asarray(z, dtype=np.complex128)
+    if samples.size == 0:
+        raise ValueError("Input trace must contain at least one complex sample.")
+    if np.any(samples == 0):
+        raise ValueError("Input trace must be non-zero everywhere.")
+
+    flat = samples.reshape(-1)
+    theta = np.unwrap(np.angle(flat))
+    rho = np.log(np.abs(flat))
+
+    design = np.vstack([theta, np.ones_like(theta)]).T
+    coeffs, *_ = np.linalg.lstsq(design, rho, rcond=None)
+    pitch, intercept = coeffs
+
+    fitted_rho = design @ coeffs
+    errors = rho - fitted_rho
+    mse = np.mean(errors**2)
+    variance = np.var(rho)
+
+    if variance == 0:
+        spiralness = 1.0 if np.allclose(mse, 0.0) else 0.0
+    else:
+        spiralness = 1.0 - (mse / variance)
+
+    reconstruction_flat = np.exp(fitted_rho + 1j * theta)
+    reconstruction = reconstruction_flat.reshape(samples.shape)
+
+    return float(pitch), float(spiralness), reconstruction
+
+
+__all__ = ["analyze_spiral_trace"]


### PR DESCRIPTION
## Summary
- add a reusable utility to estimate log-spiral pitch, spiralness, and reconstruction
- cover the new helper with deterministic unit tests
- register the SpiralPitchConsistency metric in the KPI catalog

## Testing
- pytest tests/test_spiral_pitch.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f04aa0d848329a3aed9ddc710e362)