### PR TITLE
Add reflection spiral loss estimator CLI

### DIFF
--- a/tools/rf/__init__.py
+++ b/tools/rf/__init__.py
@@ -1,0 +1,1 @@
+"""RF-specific utilities for spiral-based estimators."""

--- a/tools/rf/spiral_loss.py
+++ b/tools/rf/spiral_loss.py
@@ -1,0 +1,313 @@
+"""Estimate transmission-line attenuation/dispersion from reflection spirals.
+
+This module provides a command-line entry point for estimating the pitch of a
+reflection coefficient spiral traced on a Smith chart.  The logarithmic pitch
+is related to the distributed attenuation (alpha) and phase constant (beta)
+through the identity
+
+    c = d(ln|Gamma|) / d(theta) = -alpha / beta.
+
+Given reflection data sampled along a transmission line (typically by sliding a
+probe or shunt termination), the script determines the local pitch, the
+corresponding attenuation and phase constant, and a "spiralness" score that
+quantifies how well the observed trajectory matches an ideal log spiral.
+
+Example usage:
+
+    $ python -m tools.rf.spiral_loss trace.csv --distance distance_mm \
+          --real real --imag imag
+
+The utility accepts CSV files with or without headers.  The reflection
+coefficient can be supplied either as real/imaginary columns or as magnitude
+and phase (degrees).  Results are printed as a short text report that is easy to
+pipe into downstream tools.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Sequence, Tuple
+
+import numpy as np
+
+
+# ---------------------------------------------------------------------------
+# Data containers
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ReflectionTrace:
+    """Reflection coefficient samples along a one-dimensional sweep."""
+
+    position: np.ndarray  # distance or other monotonic sweep variable
+    gamma: np.ndarray  # complex reflection coefficient samples
+
+    def __post_init__(self) -> None:
+        if self.position.ndim != 1 or self.gamma.ndim != 1:
+            raise ValueError("position and gamma must be 1-D arrays")
+        if self.position.size != self.gamma.size:
+            raise ValueError("position and gamma must have the same length")
+        if not np.all(np.isfinite(self.position)):
+            raise ValueError("position array contains non-finite values")
+        if not np.all(np.isfinite(self.gamma)):
+            raise ValueError("gamma array contains non-finite values")
+
+
+@dataclass
+class SpiralEstimate:
+    """Summary of the log-spiral regression."""
+
+    pitch: float
+    spiralness: float
+    rho_slope: float
+    rho_intercept: float
+
+
+@dataclass
+class LineEstimate:
+    """Derived per-unit attenuation and phase constants."""
+
+    alpha: float
+    beta: float
+    slope_theta_vs_position: float
+
+
+# ---------------------------------------------------------------------------
+# Core computations
+# ---------------------------------------------------------------------------
+
+def unwrap_angle(z: np.ndarray) -> np.ndarray:
+    """Return the unwrapped angle of a complex array."""
+
+    return np.unwrap(np.angle(z))
+
+
+def spiral_pitch(gamma: np.ndarray) -> SpiralEstimate:
+    """Estimate the logarithmic pitch of a complex spiral.
+
+    Parameters
+    ----------
+    gamma:
+        Complex reflection coefficient samples.  The samples should follow the
+        ordering of the sweep variable.
+
+    Returns
+    -------
+    SpiralEstimate
+        pitch
+            The slope ``d ln|Gamma| / d theta`` obtained via least-squares.
+        spiralness
+            One minus the ratio of residual variance to signal variance.  This
+            approaches 1.0 when the samples lie on an ideal spiral and 0 when
+            they are circular/noisy.
+        rho_slope, rho_intercept
+            Regression coefficients for ln|Gamma| = slope * theta + intercept.
+    """
+
+    if gamma.ndim != 1:
+        raise ValueError("gamma must be a 1-D array")
+
+    theta = unwrap_angle(gamma)
+    rho = np.log(np.abs(gamma) + 1e-30)
+    A = np.vstack([theta, np.ones_like(theta)]).T
+    slope, intercept = np.linalg.lstsq(A, rho, rcond=None)[0]
+    rho_hat = slope * theta + intercept
+    resid = rho - rho_hat
+    var_rho = np.var(rho)
+    spiralness = 1.0 if var_rho == 0 else 1.0 - np.var(resid) / var_rho
+    spiralness = float(np.clip(spiralness, 0.0, 1.0))
+    return SpiralEstimate(float(slope), spiralness, float(slope), float(intercept))
+
+
+def beta_from_trace(trace: ReflectionTrace) -> LineEstimate:
+    """Compute the phase constant beta from theta(position).
+
+    Returns ``LineEstimate`` with placeholder alpha (set later), beta, and the
+    slope ``d theta / d position``.
+    """
+
+    theta = unwrap_angle(trace.gamma)
+    B = np.vstack([trace.position, np.ones_like(trace.position)]).T
+    slope, _ = np.linalg.lstsq(B, theta, rcond=None)[0]
+
+    # For a reflection measured along a line: theta(position) ≈ -2 * beta * x + c
+    beta = -0.5 * slope
+    return LineEstimate(alpha=float("nan"), beta=float(beta), slope_theta_vs_position=float(slope))
+
+
+def estimate_line(trace: ReflectionTrace) -> Tuple[SpiralEstimate, LineEstimate]:
+    """Estimate spiral pitch and convert it into line parameters."""
+
+    spiral = spiral_pitch(trace.gamma)
+    line = beta_from_trace(trace)
+    line = LineEstimate(alpha=-spiral.pitch * line.beta, beta=line.beta, slope_theta_vs_position=line.slope_theta_vs_position)
+    return spiral, line
+
+
+# ---------------------------------------------------------------------------
+# File parsing helpers
+# ---------------------------------------------------------------------------
+
+def _read_csv(path: Path) -> Tuple[List[str], List[List[float]]]:
+    with path.open("r", newline="") as handle:
+        reader = csv.reader(handle)
+        rows: List[List[float]] = []
+        headers: List[str] = []
+        for idx, row in enumerate(reader):
+            if not row:
+                continue
+            if idx == 0 and _row_is_header(row):
+                headers = [cell.strip() for cell in row]
+                continue
+            try:
+                rows.append([float(cell) for cell in row])
+            except ValueError as exc:  # pragma: no cover - handled by CLI
+                raise ValueError(f"Non-numeric value found on line {idx+1}") from exc
+    if not rows:
+        raise ValueError("input file contains no data rows")
+    return headers, rows
+
+
+def _row_is_header(row: Sequence[str]) -> bool:
+    for cell in row:
+        try:
+            float(cell)
+            return False
+        except ValueError:
+            continue
+    return True
+
+
+def load_trace(
+    path: Path,
+    distance_column: str | int | None,
+    real_column: str | int | None,
+    imag_column: str | int | None,
+    magnitude_column: str | int | None,
+    phase_column: str | int | None,
+    phase_degrees: bool,
+) -> ReflectionTrace:
+    """Load a reflection trace from a CSV-like text file."""
+
+    headers, rows = _read_csv(path)
+    columns = list(zip(*rows))  # transpose
+
+    def resolve(column: str | int | None, purpose: str) -> np.ndarray:
+        if column is None:
+            raise ValueError(f"{purpose} column must be specified")
+        if isinstance(column, int):
+            idx = column
+        else:
+            if not headers:
+                raise ValueError("column names were provided but input file has no header")
+            try:
+                idx = headers.index(column)
+            except ValueError as exc:
+                raise ValueError(f"column '{column}' not found in header {headers}") from exc
+        try:
+            data = np.asarray(columns[idx], dtype=float)
+        except IndexError as exc:
+            raise ValueError(f"column index {idx} out of range for input with {len(columns)} columns") from exc
+        return data
+
+    position = resolve(distance_column, "distance")
+
+    if real_column is not None and imag_column is not None:
+        real = resolve(real_column, "real")
+        imag = resolve(imag_column, "imaginary")
+        gamma = real + 1j * imag
+    elif magnitude_column is not None and phase_column is not None:
+        mag = resolve(magnitude_column, "magnitude")
+        phase = resolve(phase_column, "phase")
+        if phase_degrees:
+            phase = np.deg2rad(phase)
+        gamma = mag * np.exp(1j * phase)
+    else:
+        raise ValueError("must supply either real+imag columns or magnitude+phase columns")
+
+    # Sort by position to guard against reversed traces.
+    sort_idx = np.argsort(position)
+    position = position[sort_idx]
+    gamma = gamma[sort_idx]
+
+    return ReflectionTrace(position=position, gamma=gamma)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("trace", type=Path, help="CSV file containing the reflection trace")
+    parser.add_argument("--distance", dest="distance", required=True, help="Distance column (name or zero-based index)")
+    parser.add_argument("--real", dest="real", help="Real part column (name or index)")
+    parser.add_argument("--imag", dest="imag", help="Imaginary part column (name or index)")
+    parser.add_argument("--magnitude", dest="magnitude", help="Magnitude column (name or index)")
+    parser.add_argument("--phase", dest="phase", help="Phase column (name or index)")
+    parser.add_argument("--phase-degrees", dest="phase_degrees", action="store_true", help="Interpret phase column as degrees")
+    parser.add_argument("--alpha-units", dest="alpha_units", default="nepers", help="Label for alpha units (default: nepers)")
+    parser.add_argument("--beta-units", dest="beta_units", default="rad/m", help="Label for beta units (default: rad/m)")
+    return parser
+
+
+def _coerce_column(value: str | None) -> str | int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return value
+
+
+def format_report(path: Path, spiral: SpiralEstimate, line: LineEstimate, alpha_units: str, beta_units: str) -> str:
+    alpha = line.alpha
+    beta = line.beta
+    alpha_mag = abs(alpha)
+    lines = [
+        f"Trace: {path}",
+        f"Pitch (d ln|Gamma| / d theta): {spiral.pitch:+.6f}",
+        f"Spiralness (0=circle, 1=ideal spiral): {spiral.spiralness:.3f}",
+        f"Beta estimate: {beta:+.6f} {beta_units}",
+        f"Alpha estimate (signed): {alpha:+.6f} {alpha_units}",
+        f"Alpha magnitude: {alpha_mag:.6f} {alpha_units}",
+        f"Slope dtheta/dx: {line.slope_theta_vs_position:+.6f} rad/unit",
+    ]
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    distance = _coerce_column(args.distance)
+    real = _coerce_column(args.real)
+    imag = _coerce_column(args.imag)
+    magnitude = _coerce_column(args.magnitude)
+    phase = _coerce_column(args.phase)
+
+    try:
+        trace = load_trace(
+            path=args.trace,
+            distance_column=distance,
+            real_column=real,
+            imag_column=imag,
+            magnitude_column=magnitude,
+            phase_column=phase,
+            phase_degrees=args.phase_degrees,
+        )
+        spiral, line = estimate_line(trace)
+    except Exception as exc:  # pragma: no cover - CLI level error reporting
+        parser.error(str(exc))
+        return 2
+
+    print(format_report(args.trace, spiral, line, args.alpha_units, args.beta_units))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add an RF utility that regresses the logarithmic pitch of a reflection spiral
- infer attenuation and phase constants from the pitch and report a spiralness score
- support CSV traces with real/imag or magnitude/phase data plus CLI reporting

## Testing
- python -m tools.rf.spiral_loss --help

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f0d6cc0548329b04aa1ca2fcbecbe)