### PR TITLE
Add CI smoke workflow and tests for timekeys normalization

### DIFF
--- a/.github/workflows/timekeys-smoke.yml
+++ b/.github/workflows/timekeys-smoke.yml
@@ -1,0 +1,11 @@
+name: timekeys-smoke
+on: [push, pull_request]
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: python -m tools.timekeys_cli "2025-11-08T03:39:26.836533Z"

--- a/tests/time/test_timekeys.py
+++ b/tests/time/test_timekeys.py
@@ -1,0 +1,53 @@
+"""Tests for the ``tools.timekeys`` utilities."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+import sys
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+import pytest
+
+from tools.timekeys import normalize_time_string
+
+
+@pytest.mark.parametrize(
+    "dayfirst, expected",
+    [
+        (True, datetime(2024, 5, 4, 1, 2, 3, 123456)),
+        (False, datetime(2024, 4, 5, 1, 2, 3, 123456)),
+    ],
+)
+def test_normalize_time_string_dayfirst(dayfirst: bool, expected: datetime) -> None:
+    """Ensure ambiguous dates are parsed according to the ``dayfirst`` flag."""
+
+    result = normalize_time_string(
+        "04:05:2024 01:02:03.123456",
+        dayfirst=dayfirst,
+    )
+    assert result.tzinfo is not None
+    assert result.tzinfo.key == "UTC"
+    assert result.replace(tzinfo=None) == expected
+
+
+@pytest.mark.parametrize(
+    "timestamp, microseconds",
+    [
+        ("2024-01-02T03:04:05:123456Z", 123456),
+        ("2024-01-02T03:04:05:123456789Z", 123456),
+    ],
+)
+def test_normalize_time_string_fractional_seconds(
+    timestamp: str, microseconds: int
+) -> None:
+    """Compact fractional-second formats normalise to microsecond precision."""
+
+    result = normalize_time_string(timestamp)
+    assert result.tzinfo is not None
+    assert result.microsecond == microseconds
+    assert result.tzinfo.key == "UTC"


### PR DESCRIPTION
## Summary
- add a GitHub Actions smoke workflow that exercises the timekeys CLI on pushes and pull requests
- add pytest coverage for the day-first flag and compact fractional-second parsing in `normalize_time_string`

## Testing
- pytest tests/time/test_timekeys.py
- python -m tools.timekeys_cli "2025-11-08T03:39:26.836533Z"


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f137232a48329a2ea20c8912101f3)