### PR TITLE
Add Amundson VI–VIII instruments and Collatz/Fibonacci pack

### DIFF
--- a/docs/amundson_blackroad_tree.md
+++ b/docs/amundson_blackroad_tree.md
@@ -7,14 +7,26 @@ packages/
     ├── spiral.py        # AM-1/2/3 spiral kernels
     ├── autonomy.py      # BR-1/2 transport + BR-7 trust step
     ├── coupling.py      # BR-6 curvature ↔ a-field helpers
-    └── thermo.py        # Landauer helpers and provenance
+    ├── thermo.py        # Landauer helpers and provenance
+    ├── resolution.py    # Auto-resolve coherence payloads (units + why-map)
+    ├── projective.py    # AM-VI projective phase integrator
+    ├── ladder.py        # AM-VII quadratic ladder invariants
+    ├── chebyshev.py     # AM-VIII resonance metrics
+    ├── collatz.py       # BR-8 Collatz flow instrument
+    └── fib_pascal.py    # Fibonacci–Pascal invariants and golden step
 
 srv/
 └── lucidia-math/
-    └── ui.py            # Flask service exposing AMBR endpoints
+    └── ui.py            # Flask service exposing AMBR endpoints + new instruments
 
 tests/
-└── test_amundson_blackroad.py  # V1–V4 validation suite
+└── …
+    ├── test_am6_projective_phase.py
+    ├── test_am7_quadratic_ladder.py
+    ├── test_am8_chebyshev.py
+    ├── test_br8_collatz.py
+    ├── test_fib_pascal.py
+    └── test_resolution.py
 
 .github/
 └── workflows/

--- a/frontend/EQUATIONS_LAB.md
+++ b/frontend/EQUATIONS_LAB.md
@@ -7,6 +7,10 @@ The Equations Lab brings the Amundson–BlackRoad measurement stack into a brows
 - **AM-2 Simulator** – adjust the dissipative (`γ`), coupling (`κ`), and evidence (`η`) coefficients. A live chart plots amplitude and phase trajectories while the stability eigenvalues and spiral entropy ledger update on each fetch.
 - **BR-1/2 Transport** – drive the autonomy continuity equation with adjustable step count, mobility, and trust potentials. The plot compares the initial and evolved densities and reports mass conservation errors to the 1e-3 acceptance target.
 - **AM-4 Energy Ledger** – submit temperature, phase, and amplitude deltas to compute the discrete energy increment. The Landauer floor check flags whether irreversible work exceeds the thermodynamic minimum.
+- **AM-VI Projective Phase** – explore the projective coordinate `u = tan(θ/2)` to avoid singularities near `π/2`. The panel reports `(a_dot, u_dot, θ_dot)` with next-step estimates and highlights the lifted response.
+- **AM-VIII Resonance Scanner** – sweep harmonics up to `n_max` and visualise when `θ/π` locks to rational ratios. Resonance peaks return the numerator `p`, denominator `n`, and a dimensionless score.
+- **BR-8 Collatz Flow** – move a discrete mass distribution through Collatz iterations while tracking Landauer energy. The card reports mass preservation, irreversible energy (`J`), and the pushed-forward histogram.
+- **Fib–Pascal Instrument** – fetch Pascal rows, diagonal sums, and the matching Fibonacci target in one call. The UI confirms `Σ diagonal = F_{n+1}` and exposes the `F`-matrix pairs for quick inspection.
 
 ## Usage
 

--- a/packages/amundson_blackroad/README.md
+++ b/packages/amundson_blackroad/README.md
@@ -1,0 +1,19 @@
+# Amundson–BlackRoad Instruments
+
+## Resolution (Auto Resolver)
+Fills coherence payloads with contextual defaults (`rad`, `J`, dimensionless gains) and returns a provenance map explaining each value.
+
+## Projective Phase (AM-VI)
+Integrates the AM-2 dynamics in the projective coordinate `u = tan(θ/2)` to keep phase derivatives finite near `π/2`, reporting `a_dot`, `u_dot`, and `θ_dot` in `1/s` and `rad/s`.
+
+## Quadratic Ladder (AM-VII)
+Tabulates special-angle sin/cos/tan triples and verifies the identity `sin²θ = (1 - cos 2θ)/2` to `1e-12`, keeping all quantities dimensionless.
+
+## Chebyshev Resonance (AM-VIII)
+Evaluates Chebyshev polynomials to expose when `θ/π` approaches rational ratios, returning harmonic indices `n`, numerators `p`, and resonance scores (dimensionless).
+
+## Collatz Flow (BR-8)
+Advects integer mass distributions through the Collatz map while tracking Landauer energy (`J`) using `k_B T ln 2` per irreversible step and ensuring total mass conservation.
+
+## Fibonacci–Pascal Instrument
+Provides Pascal rows and diagonal sums alongside Fibonacci targets (`1` units) and a golden-ratio rotation step that updates amplitude (dimensionless) and phase (`rad`).

--- a/packages/amundson_blackroad/__init__.py
+++ b/packages/amundson_blackroad/__init__.py
@@ -1,62 +1,54 @@
 """Core kernels for the Amundson-BlackRoad simulations."""
 
-from .spiral import (
-    simulate_am2,
-    am2_step,
-    field_lift,
-    jacobian_am2,
-    fixed_point_stability,
-    StabilityReport,
-)
 from .autonomy import (
-    step_transport,
-    simulate_transport,
-    conserved_mass,
     compute_flux,
+    conserved_mass,
+    simulate_transport,
+    step_transport,
     trust_field_step,
 )
-from .coupling import curvature_source, couple_curvature_response
+from .coupling import couple_curvature_response, curvature_source
 from .curvature import simulate_a_field
+from .resolution import AmbrContext, K_BOLTZMANN, resolve_coherence_inputs
+from .spiral import (
+    StabilityReport,
+    am2_step,
+    field_lift,
+    fixed_point_stability,
+    jacobian_am2,
+    simulate_am2,
+)
 from .thermo import (
-    K_BOLTZMANN,
-    spiral_entropy,
-    energy_increment,
-    landauer_min,
-    landauer_floor,
-    irreversible_energy,
     annotate_run_with_thermo,
-from .thermo import (
+    energy_increment,
+    irreversible_energy,
     landauer_floor,
     landauer_min,
-    irreversible_energy,
-    annotate_run_with_thermo,
     spiral_entropy,
-    energy_increment,
 )
 
 __all__ = [
-    "simulate_am2",
+    "compute_flux",
+    "conserved_mass",
+    "simulate_transport",
+    "step_transport",
+    "trust_field_step",
+    "couple_curvature_response",
+    "curvature_source",
+    "simulate_a_field",
+    "AmbrContext",
+    "K_BOLTZMANN",
+    "resolve_coherence_inputs",
+    "StabilityReport",
     "am2_step",
     "field_lift",
-    "jacobian_am2",
     "fixed_point_stability",
-    "StabilityReport",
-    "step_transport",
-    "simulate_transport",
-    "conserved_mass",
-    "compute_flux",
-    "trust_field_step",
-    "curvature_source",
-    "couple_curvature_response",
-    "simulate_a_field",
-    "K_BOLTZMANN",
-    "spiral_entropy",
+    "jacobian_am2",
+    "simulate_am2",
+    "annotate_run_with_thermo",
     "energy_increment",
-    "landauer_min",
+    "irreversible_energy",
     "landauer_floor",
     "landauer_min",
-    "irreversible_energy",
-    "annotate_run_with_thermo",
     "spiral_entropy",
-    "energy_increment",
 ]

--- a/packages/amundson_blackroad/chebyshev.py
+++ b/packages/amundson_blackroad/chebyshev.py
@@ -1,0 +1,105 @@
+"""Chebyshev resonance utilities for Amundson VIII."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+
+def _prepare_array(x: float | np.ndarray) -> tuple[np.ndarray, bool]:
+    """Coerce ``x`` to an array while recording whether it was scalar."""
+
+    arr = np.asarray(x, dtype=float)
+    return arr, np.isscalar(x)
+
+
+def Tn(n: int, x: float | np.ndarray) -> float | np.ndarray:
+    """Evaluate the Chebyshev polynomial of the first kind ``Tₙ(x)``."""
+
+    if n < 0:
+        raise ValueError("order must be non-negative")
+    x_arr, is_scalar = _prepare_array(x)
+    if n == 0:
+        result = np.ones_like(x_arr)
+    elif n == 1:
+        result = x_arr.copy()
+    else:
+        t0 = np.ones_like(x_arr)
+        t1 = x_arr.copy()
+        for _ in range(2, n + 1):
+            t0, t1 = t1, 2.0 * x_arr * t1 - t0
+        result = t1
+    if is_scalar:
+        return float(np.squeeze(result))
+    return result
+
+
+def Un(n: int, x: float | np.ndarray) -> float | np.ndarray:
+    """Evaluate the Chebyshev polynomial of the second kind ``Uₙ(x)``."""
+
+    if n < 0:
+        raise ValueError("order must be non-negative")
+    x_arr, is_scalar = _prepare_array(x)
+    if n == 0:
+        result = np.ones_like(x_arr)
+    elif n == 1:
+        result = 2.0 * x_arr
+    else:
+        u0 = np.ones_like(x_arr)
+        u1 = 2.0 * x_arr
+        for _ in range(2, n + 1):
+            u0, u1 = u1, 2.0 * x_arr * u1 - u0
+        result = u1
+    if is_scalar:
+        return float(np.squeeze(result))
+    return result
+
+
+def cos_n_theta(theta: float | np.ndarray, n: int) -> float | np.ndarray:
+    """Compute ``cos(nθ)`` by evaluating ``Tₙ(cos θ)``."""
+
+    theta_arr, is_scalar = _prepare_array(theta)
+    result = Tn(n, np.cos(theta_arr))
+    if is_scalar:
+        return float(np.squeeze(result))
+    return result
+
+
+def resonance_score(theta: float, n_max: int, *, eps: float = 1e-9) -> dict:
+    """Return resonance metrics for harmonics up to ``n_max``.
+
+    Parameters
+    ----------
+    theta:
+        Phase angle in radians (rad).
+    n_max:
+        Highest harmonic considered.
+    eps:
+        Regularisation parameter preventing division by zero.
+
+    Returns
+    -------
+    dict
+        Dictionary containing arrays ``n`` (harmonic index), ``p`` (nearest
+        numerator), ``approx`` (rational approximation of ``θ/π``), and
+        ``score`` (dimensionless resonance score).
+    """
+
+    if n_max <= 0:
+        raise ValueError("n_max must be positive")
+    frac = theta / math.pi
+    n_values = np.arange(1, n_max + 1, dtype=int)
+    numerators = np.rint(frac * n_values).astype(int)
+    ratios = numerators / n_values
+    delta = np.abs(frac - ratios)
+    scores = 1.0 / (delta + eps)
+    return {
+        "n": n_values,
+        "p": numerators,
+        "approx": ratios,
+        "score": scores,
+    }
+
+
+__all__ = ["Tn", "Un", "cos_n_theta", "resonance_score"]

--- a/packages/amundson_blackroad/collatz.py
+++ b/packages/amundson_blackroad/collatz.py
@@ -1,0 +1,122 @@
+"""Collatz flow instrument (BR-8) with energetic accounting."""
+
+from __future__ import annotations
+
+import math
+from collections import defaultdict
+from typing import Dict, Mapping, Tuple
+
+from .resolution import K_BOLTZMANN
+
+
+def next_collatz(n: int) -> int:
+    """Return the next Collatz iterate for ``n ≥ 1``.
+
+    Parameters
+    ----------
+    n:
+        Positive integer input on :math:`\mathbb{N}`.
+
+    Returns
+    -------
+    int
+        Next Collatz iterate on :math:`\mathbb{N}`.
+    """
+
+    if n < 1:
+        raise ValueError("Collatz sequence defined for n ≥ 1")
+    return n // 2 if n % 2 == 0 else 3 * n + 1
+
+
+def collatz_walk(n: int, limit: int) -> Tuple[list[int], int]:
+    """Return the Collatz trajectory and irreversible step count.
+
+    Parameters
+    ----------
+    n:
+        Positive integer initial state.
+    limit:
+        Maximum number of transitions evaluated.
+
+    Returns
+    -------
+    list[int], int
+        Sequence of visited states and the number of irreversible steps.
+    """
+
+    if limit <= 0:
+        raise ValueError("limit must be positive")
+    if n < 1:
+        raise ValueError("Collatz sequence defined for n ≥ 1")
+
+    path = [n]
+    current = n
+    for _ in range(limit):
+        if current == 1:
+            break
+        current = next_collatz(current)
+        path.append(current)
+    return path, len(path) - 1
+
+
+def collatz_landauer_cost(n: int, temperature_K: float, *, limit: int = 256) -> float:
+    """Compute the minimal irreversible energy for ``n`` at ``temperature_K``.
+
+    Energy is reported in joules (J) assuming one bit erased per transition.
+    """
+
+    _, steps = collatz_walk(n, limit)
+    return K_BOLTZMANN * temperature_K * math.log(2.0) * steps
+
+
+def collatz_pushforward(
+    distribution: Mapping[int, float],
+    steps: int,
+    *,
+    temperature_K: float = 300.0,
+) -> Tuple[Dict[int, float], float]:
+    """Propagate a discrete mass distribution through Collatz dynamics.
+
+    Parameters
+    ----------
+    distribution:
+        Mapping of positive integers to non-negative mass (dimensionless).
+    steps:
+        Number of Collatz transitions to apply.
+    temperature_K:
+        Bath temperature in kelvin (K).
+
+    Returns
+    -------
+    Tuple[Dict[int, float], float]
+        Updated distribution and cumulative Landauer energy in joules (J).
+    """
+
+    if steps < 0:
+        raise ValueError("steps must be non-negative")
+    current = defaultdict(float)
+    for state, mass in distribution.items():
+        if state < 1:
+            raise ValueError("states must be positive integers")
+        if mass == 0:
+            continue
+        current[int(state)] += float(mass)
+
+    total_energy = 0.0
+    for _ in range(steps):
+        next_dist = defaultdict(float)
+        for state, mass in current.items():
+            target = next_collatz(state)
+            next_dist[target] += mass
+            total_energy += mass * K_BOLTZMANN * temperature_K * math.log(2.0)
+        current = next_dist
+
+    return dict(sorted(current.items())), total_energy
+
+
+__all__ = [
+    "next_collatz",
+    "collatz_walk",
+    "collatz_landauer_cost",
+    "collatz_pushforward",
+]

--- a/packages/amundson_blackroad/fib_pascal.py
+++ b/packages/amundson_blackroad/fib_pascal.py
@@ -1,0 +1,113 @@
+"""Fibonacci–Pascal instrument combining combinatorics and golden flows."""
+
+from __future__ import annotations
+
+import math
+from typing import List, Tuple
+
+import numpy as np
+
+PHI = (1.0 + math.sqrt(5.0)) / 2.0
+F_MATRIX = np.array([[1.0, 1.0], [1.0, 0.0]], dtype=float)
+
+
+def fib(n: int) -> int:
+    """Return the nth Fibonacci number with ``F₀ = 0`` and ``F₁ = 1``.
+
+    Parameters
+    ----------
+    n:
+        Sequence index (dimensionless).
+
+    Returns
+    -------
+    int
+        Dimensionless Fibonacci value.
+    """
+
+    if n < 0:
+        raise ValueError("n must be non-negative")
+    a, b = 0, 1
+    for _ in range(n):
+        a, b = b, a + b
+    return a
+
+
+def fibs(k: int) -> List[int]:
+    """Return the first ``k`` Fibonacci numbers.
+
+    Parameters
+    ----------
+    k:
+        Number of terms requested (dimensionless).
+    """
+
+    if k < 0:
+        raise ValueError("k must be non-negative")
+    seq: List[int] = []
+    a, b = 0, 1
+    for _ in range(k):
+        seq.append(a)
+        a, b = b, a + b
+    return seq
+
+
+def pascal_row(n: int) -> List[int]:
+    """Return the nth Pascal row (0-indexed).
+
+    Parameters
+    ----------
+    n:
+        Row index (dimensionless).
+    """
+
+    if n < 0:
+        raise ValueError("n must be non-negative")
+    return [math.comb(n, k) for k in range(n + 1)]
+
+
+def pascal_diagonal_sums(n: int) -> int:
+    """Return the shallow diagonal sum equal to ``F_{n+1}``.
+
+    Returns the diagonal sum as a dimensionless integer.
+    """
+
+    if n < 0:
+        raise ValueError("n must be non-negative")
+    total = 0
+    for k in range(n + 1):
+        total += math.comb(n - k, k)
+    return total
+
+
+def golden_rotation_step(a: float, theta: float, eta: float) -> Tuple[float, float]:
+    """Apply a golden-ratio rotation step to ``(a, θ)``.
+
+    Parameters
+    ----------
+    a:
+        Amplitude (dimensionless).
+    theta:
+        Phase in radians (rad).
+    eta:
+        Increment magnitude (dimensionless).
+
+    Returns
+    -------
+    Tuple[float, float]
+        Updated amplitude and phase (rad).
+    """
+
+    delta_a = eta / PHI
+    delta_theta = eta / (PHI**2)
+    return a + delta_a, theta + delta_theta
+
+
+__all__ = [
+    "fib",
+    "fibs",
+    "F_MATRIX",
+    "pascal_row",
+    "pascal_diagonal_sums",
+    "golden_rotation_step",
+]

--- a/packages/amundson_blackroad/ladder.py
+++ b/packages/amundson_blackroad/ladder.py
@@ -1,0 +1,87 @@
+"""Quadratic ladder invariants for Amundson VII."""
+
+from __future__ import annotations
+
+import math
+from typing import List, Sequence, Tuple
+
+import numpy as np
+
+_LADDER_ANGLES: Tuple[float, ...] = (
+    0.0,
+    math.pi / 6,
+    math.pi / 4,
+    math.pi / 3,
+    math.pi / 2,
+)
+
+
+def sin2_ladder() -> List[float]:
+    """Return sin² ladder values for canonical special angles.
+
+    The returned values are dimensionless and correspond to
+    :math:`\theta \in \{0, \pi/6, \pi/4, \pi/3, \pi/2\}` measured in radians.
+    """
+
+    return [math.sin(theta) ** 2 for theta in _LADDER_ANGLES]
+
+
+def special_angles() -> List[Tuple[float, float, float]]:
+    """Return ``(sin, cos, tan)`` tuples for the ladder angles.
+
+    Each tuple contains dimensionless trigonometric values evaluated in radians.
+    ``tan`` is reported as ``inf`` when :math:`\cos\theta` vanishes.
+    """
+
+    triples: List[Tuple[float, float, float]] = []
+    for theta in _LADDER_ANGLES:
+        sin_theta = math.sin(theta)
+        cos_theta = math.cos(theta)
+        tan_theta = math.tan(theta) if abs(cos_theta) > 1e-15 else float("inf")
+        triples.append((sin_theta, cos_theta, tan_theta))
+    return triples
+
+
+def ladder_identity_residuals(angles: Sequence[float] | None = None) -> np.ndarray:
+    """Compute residuals of ``sin²θ - (1 - cos 2θ)/2`` for supplied angles.
+
+    Parameters
+    ----------
+    angles:
+        Iterable of angles in radians. Defaults to the canonical ladder.
+
+    Returns
+    -------
+    np.ndarray
+        Residuals in dimensionless units.
+    """
+
+    if angles is None:
+        angles = _LADDER_ANGLES
+    return np.array(
+        [math.sin(theta) ** 2 - 0.5 * (1.0 - math.cos(2.0 * theta)) for theta in angles],
+        dtype=float,
+    )
+
+
+def verify_ladder_identity(*, tol: float = 1e-12, angles: Sequence[float] | None = None) -> bool:
+    """Return ``True`` when the quadratic identity holds within ``tol``.
+
+    Parameters
+    ----------
+    tol:
+        Absolute tolerance for the identity residuals (dimensionless).
+    angles:
+        Optional override for the angles tested (radians).
+    """
+
+    residuals = ladder_identity_residuals(angles)
+    return bool(np.all(np.abs(residuals) <= tol))
+
+
+__all__ = [
+    "sin2_ladder",
+    "special_angles",
+    "ladder_identity_residuals",
+    "verify_ladder_identity",
+]

--- a/packages/amundson_blackroad/projective.py
+++ b/packages/amundson_blackroad/projective.py
@@ -1,0 +1,138 @@
+"""Projective AM-2 integration utilities (Amundson VI)."""
+
+from __future__ import annotations
+
+import math
+from typing import Tuple
+
+import numpy as np
+
+from .spiral import FieldLift, PhiTransform, am2_step
+
+
+def u_from_theta(theta: float) -> float:
+    """Map the phase angle to projective coordinate ``u = tan(θ / 2)``.
+
+    Parameters
+    ----------
+    theta:
+        Phase angle measured in radians (rad).
+
+    Returns
+    -------
+    float
+        Projective coordinate ``u`` (dimensionless).
+    """
+
+    return math.tan(0.5 * theta)
+
+
+def theta_from_u(u: float) -> float:
+    """Recover the phase angle from projective coordinate ``u``.
+
+    Parameters
+    ----------
+    u:
+        Projective coordinate (dimensionless).
+
+    Returns
+    -------
+    float
+        Phase angle :math:`\theta` in radians (rad).
+    """
+
+    return 2.0 * math.atan(u)
+
+
+def projective_am2_step(
+    a: float,
+    u: float,
+    gamma: float,
+    kappa: float,
+    eta: float,
+    omega0: float = 1.0,
+    *,
+    phi: PhiTransform | None = None,
+    lift_fn: FieldLift | None = None,
+) -> Tuple[float, float, float, float]:
+    """Return AM-2 derivatives using projective phase coordinates.
+
+    Returns
+    -------
+    a_dot, u_dot, theta_dot, response:
+        Time derivatives with units ``a_dot`` (1/s), ``u_dot`` (1/s),
+        ``theta_dot`` (rad/s), alongside the lifted response (arbitrary units).
+    """
+
+    theta = theta_from_u(u)
+    a_dot, theta_dot, response = am2_step(
+        a, theta, gamma, kappa, eta, omega0, phi=phi, lift_fn=lift_fn
+    )
+    u_dot = 0.5 * (1.0 + u**2) * theta_dot
+    return a_dot, u_dot, theta_dot, response
+
+
+def simulate_projective_am2(
+    T: float = 10.0,
+    dt: float = 1e-3,
+    a0: float = 0.1,
+    *,
+    theta0: float | None = 0.0,
+    u0: float | None = None,
+    gamma: float = 0.3,
+    kappa: float = 0.7,
+    eta: float = 0.5,
+    omega0: float = 1.0,
+    phi: PhiTransform | None = None,
+    lift_fn: FieldLift | None = None,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Simulate AM-2 dynamics in projective phase coordinates.
+
+    Returns
+    -------
+    t, a, u, theta, response:
+        Arrays containing time samples (s), amplitudes (dimensionless),
+        projective coordinate (dimensionless), recovered phase (rad), and
+        lifted response (arbitrary units).
+    """
+
+    if dt <= 0:
+        raise ValueError("time step must be positive")
+    if T <= 0:
+        raise ValueError("horizon must be positive")
+
+    n_steps = int(np.ceil(T / dt)) + 1
+    t = np.linspace(0.0, dt * (n_steps - 1), n_steps)
+    a = np.empty(n_steps, dtype=float)
+    u = np.empty(n_steps, dtype=float)
+    theta = np.empty(n_steps, dtype=float)
+    response = np.empty(n_steps, dtype=float)
+
+    if u0 is None:
+        if theta0 is None:
+            raise ValueError("either theta0 or u0 must be supplied")
+        u_init = u_from_theta(theta0)
+        theta_init = float(theta0)
+    else:
+        u_init = float(u0)
+        theta_init = theta_from_u(u_init)
+
+    a[0] = a0
+    u[0] = u_init
+    theta[0] = theta_init
+
+    a_dot, u_dot, theta_dot, resp = projective_am2_step(
+        a0, u_init, gamma, kappa, eta, omega0, phi=phi, lift_fn=lift_fn
+    )
+    response[0] = resp
+
+    for i in range(1, n_steps):
+        a_dot, u_dot, theta_dot, resp = projective_am2_step(
+            a[i - 1], u[i - 1], gamma, kappa, eta, omega0, phi=phi, lift_fn=lift_fn
+        )
+        a[i] = a[i - 1] + dt * a_dot
+        u[i] = u[i - 1] + dt * u_dot
+        theta[i] = theta_from_u(u[i])
+        response[i] = resp
+
+    return t, a, u, theta, response

--- a/packages/amundson_blackroad/resolution.py
+++ b/packages/amundson_blackroad/resolution.py
@@ -1,0 +1,120 @@
+"""Utilities for resolving missing Amundson inputs with units."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Tuple, Any
+
+K_BOLTZMANN: float = 1.380649e-23
+"""Boltzmann constant in joules per kelvin (J/K)."""
+
+
+@dataclass
+class AmbrContext:
+    """Contextual defaults for coherence resolution.
+
+    Attributes
+    ----------
+    last_phi_x: float
+        Last observed phase component :math:`\phi_x` in radians.
+    last_phi_y: float
+        Last observed phase component :math:`\phi_y` in radians.
+    default_temperature_K: float
+        Reference temperature in kelvin (K) for thermal defaults.
+    default_r: float
+        Default coherence amplitude in arbitrary units.
+    """
+
+    last_phi_x: float
+    last_phi_y: float
+    default_temperature_K: float = 300.0
+    default_r: float = 1.0
+
+
+def resolve_coherence_inputs(
+    ctx: AmbrContext,
+    **payload: Any,
+) -> Tuple[Dict[str, float], List[str], Dict[str, str]]:
+    """Resolve missing coherence inputs and explain the defaults.
+
+    Parameters
+    ----------
+    ctx:
+        Context providing recent phase history and thermal defaults.
+    **payload:
+        Arbitrary keyword inputs to be completed. Values are dimensioned as
+        follows: phases in radians, amplitudes dimensionless, and temperatures
+        in kelvin.
+
+    Returns
+    -------
+    resolved:
+        Mapping of completed inputs. Energy terms are measured in joules (J).
+    missing:
+        Ordered list of field names that were inferred rather than supplied.
+    why:
+        Explanation for each populated value, including supplied entries.
+    """
+
+    resolved: Dict[str, float] = {}
+    missing: List[str] = []
+    why: Dict[str, str] = {}
+
+    # Copy provided payload while filtering out None placeholders.
+    for key, value in payload.items():
+        if value is not None:
+            resolved[key] = value
+
+    def _set_default(key: str, value: float, explanation: str) -> None:
+        if key not in resolved:
+            resolved[key] = value
+            missing.append(key)
+            why[key] = explanation
+
+    _set_default("omega_0", 1.0, "Default angular frequency ω₀ = 1.0 rad/s.")
+    _set_default("lambda_", 0.5, "Default coupling λ = 0.5 (dimensionless).")
+    _set_default("eta", 0.2, "Default dissipation η = 0.2 (dimensionless).")
+    _set_default(
+        "phi_x",
+        ctx.last_phi_x,
+        "Phase φ_x inherited from context history (rad).",
+    )
+    _set_default(
+        "phi_y",
+        ctx.last_phi_y,
+        "Phase φ_y inherited from context history (rad).",
+    )
+    _set_default(
+        "r",
+        ctx.default_r,
+        "Amplitude r seeded from context default (dimensionless).",
+    )
+    _set_default(
+        "amplitude",
+        1.0,
+        "Unit amplitude used when no magnitude supplied (dimensionless).",
+    )
+
+    temperature_default = ctx.default_temperature_K
+    if "temperature_K" in resolved:
+        temperature = resolved["temperature_K"]
+    else:
+        temperature = temperature_default
+        _set_default(
+            "temperature_K",
+            temperature_default,
+            "Context-provided temperature baseline (K).",
+        )
+
+    if "k_b_t" not in resolved:
+        resolved["k_b_t"] = K_BOLTZMANN * float(temperature)
+        missing.append("k_b_t")
+        why[
+            "k_b_t"
+        ] = f"Computed k_B·T from temperature_K={temperature:.3f} K (J)."
+
+    for key in resolved:
+        if key not in why:
+            why[key] = "Provided explicitly in payload."
+
+    return resolved, missing, why

--- a/srv/lucidia-math/ui.py
+++ b/srv/lucidia-math/ui.py
@@ -1,36 +1,21 @@
 """User-facing interfaces for the Lucidia math platform."""
 
-"""CLI helpers and Flask application for Lucidia Infinity Math."""
 from __future__ import annotations
 
+import importlib.util
 import json
-from typing import Callable, Dict
+import sys
+from pathlib import Path
+from typing import Any, Callable, Dict
+
+from flask import Flask, jsonify, request, send_from_directory
 
 from . import finance, fractals, logic, numbers, primes, proofs, waves
-from .api_ambr import app  # FastAPI application exposed for runtime
-
-MENU: Dict[str, Callable[[], object]] = {
-    "Logic": lambda: logic.persist_truth_table(
-        logic.generate_truth_table(["A", "B"], expression="A and not B")
-    ).as_posix(),
-    "Primes": lambda: primes.demo(),
-    "Proofs": lambda: proofs.demo(),
-    "Waves": lambda: waves.demo(),
-    "Finance": finance.demo,
-    "Numbers": numbers.demo,
-    "Fractals": lambda: fractals.demo(),
-from flask import Flask, jsonify
-
+from .api_ambr import ambr_api, bp as ambr_bp, run_am2_simulation, run_transport_simulation
+from .api_math import mandelbrot_counts, math_api, primes_payload, sine_wave_samples, truth_table_payload
 from packages.textviz import pgm_p2
 
-from .api_ambr import ambr_api, run_am2_simulation, run_transport_simulation
-from .api_math import (
-    mandelbrot_counts,
-    math_api,
-    primes_payload,
-    sine_wave_samples,
-    truth_table_payload,
-)
+MENU: Dict[str, Callable[[], Dict[str, object]]] = {}
 
 
 def _demo_am2() -> Dict[str, object]:
@@ -57,11 +42,7 @@ def _demo_transport() -> Dict[str, object]:
 
 def _demo_mandelbrot() -> Dict[str, object]:
     counts = mandelbrot_counts(40, 40, 40, -2.0, 1.0, -1.5, 1.5)
-    return {
-        "format": "PGM",
-        "sample": pgm_p2(counts).splitlines()[:10],
-        "units": {"format": "portable-graymap"},
-    }
+    return {"format": "PGM", "sample": pgm_p2(counts).splitlines()[:10], "units": {"format": "portable-graymap"}}
 
 
 def _demo_primes() -> Dict[str, object]:
@@ -74,21 +55,24 @@ def _demo_logic() -> Dict[str, object]:
 
 def _demo_wave() -> Dict[str, object]:
     xs, ys = sine_wave_samples(1.0, 0.0, 16, 1.0)
-    return {
-        "x": xs,
-        "y": ys,
-        "units": {"x": "s", "y": "arb"},
+    return {"x": xs, "y": ys, "units": {"x": "s", "y": "arb"}}
+
+
+MENU.update(
+    {
+        "AM-2": _demo_am2,
+        "Transport": _demo_transport,
+        "Mandelbrot": _demo_mandelbrot,
+        "Primes": _demo_primes,
+        "Logic": _demo_logic,
+        "Wave": _demo_wave,
+        "Finance": finance.demo,
+        "Numbers": numbers.demo,
+        "Fractals": lambda: fractals.demo(),
+        "Proofs": lambda: proofs.demo(),
+        "Waves": lambda: waves.demo(),
     }
-
-
-MENU: Dict[str, Callable[[], Dict[str, object]]] = {
-    "AM-2": _demo_am2,
-    "Transport": _demo_transport,
-    "Mandelbrot": _demo_mandelbrot,
-    "Primes": _demo_primes,
-    "Logic": _demo_logic,
-    "Wave": _demo_wave,
-}
+)
 
 
 def repl() -> None:
@@ -136,17 +120,47 @@ def demo() -> None:
 
     repl()
 
+
 interactive_app = create_app()
-
-# Flask API for the Infinity Math system.
-from pathlib import Path
-
-from flask import Flask, jsonify, send_from_directory
-
-from .api_ambr import bp as ambr_bp
 
 BASE_DIR = Path(__file__).resolve().parent
 OUTPUT_DIR = BASE_DIR / "output"
+_AMBR_ROOT = Path(__file__).resolve().parents[2] / "packages" / "amundson_blackroad"
+
+
+def _safe_float(value: Any, default: float | None = None) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _safe_int(value: Any, default: int | None = None) -> int | None:
+    try:
+        return int(value) if value is not None else default
+    except (TypeError, ValueError):
+        return default
+
+
+def _load_ambr_module(name: str):
+    module_name = f"amundson_blackroad.{name}"
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+    path = _AMBR_ROOT / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"unable to load module {module_name}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+resolution = _load_ambr_module("resolution")
+projective = _load_ambr_module("projective")
+chebyshev = _load_ambr_module("chebyshev")
+collatz = _load_ambr_module("collatz")
+fib_pascal = _load_ambr_module("fib_pascal")
 
 api_app = Flask(__name__)
 api_app.register_blueprint(ambr_bp)
@@ -161,11 +175,149 @@ def health() -> tuple:
 @api_app.get("/api/math/<path:subpath>")
 def get_output(subpath: str):
     """Serve generated artifacts from the output tree."""
+
     return send_from_directory(OUTPUT_DIR, subpath)
+
+
+@api_app.get("/api/ambr/resolve")
+def resolve_endpoint():
+    args = request.args
+    ctx = resolution.AmbrContext(
+        last_phi_x=_safe_float(args.get("last_phi_x"), 0.0) or 0.0,
+        last_phi_y=_safe_float(args.get("last_phi_y"), 0.0) or 0.0,
+        default_temperature_K=_safe_float(args.get("default_temperature_K"), 300.0) or 300.0,
+        default_r=_safe_float(args.get("default_r"), 1.0) or 1.0,
+    )
+    payload: Dict[str, float] = {}
+    for key in ("omega_0", "lambda_", "eta", "phi_x", "phi_y", "r", "amplitude", "temperature_K", "k_b_t"):
+        value = _safe_float(args.get(key))
+        if value is not None:
+            payload[key] = value
+    resolved, missing, why = resolution.resolve_coherence_inputs(ctx, **payload)
+    units = {
+        "omega_0": "rad/s",
+        "lambda_": "1",
+        "eta": "1",
+        "phi_x": "rad",
+        "phi_y": "rad",
+        "r": "1",
+        "amplitude": "1",
+        "temperature_K": "K",
+        "k_b_t": "J",
+    }
+    return jsonify({"resolved": resolved, "missing": missing, "why": why, "units": units})
+
+
+@api_app.post("/api/ambr/am6/projective_step")
+def projective_step():
+    body = request.get_json(force=True)
+    a = _safe_float(body.get("a"), 0.0) or 0.0
+    gamma = _safe_float(body.get("gamma"), 0.3) or 0.3
+    kappa = _safe_float(body.get("kappa"), 0.7) or 0.7
+    eta = _safe_float(body.get("eta"), 0.5) or 0.5
+    omega0 = _safe_float(body.get("omega0"), 1.0) or 1.0
+    if "u" in body:
+        u = _safe_float(body.get("u"), 0.0) or 0.0
+        theta = projective.theta_from_u(u)
+    else:
+        theta = _safe_float(body.get("theta"), 0.0) or 0.0
+        u = projective.u_from_theta(theta)
+    a_dot, u_dot, theta_dot, response = projective.projective_am2_step(a, u, gamma, kappa, eta, omega0)
+    dt = _safe_float(body.get("dt"))
+    payload: Dict[str, Any] = {
+        "theta": theta,
+        "u": u,
+        "a": a,
+        "derivatives": {"a_dot": a_dot, "u_dot": u_dot, "theta_dot": theta_dot},
+        "response": response,
+        "units": {
+            "theta": "rad",
+            "u": "1",
+            "a": "1",
+            "a_dot": "1/s",
+            "u_dot": "1/s",
+            "theta_dot": "rad/s",
+        },
+    }
+    if dt is not None and dt > 0:
+        u_next = u + dt * u_dot
+        payload["next_state"] = {
+            "a": a + dt * a_dot,
+            "u": u_next,
+            "theta": projective.theta_from_u(u_next),
+        }
+        payload["units"]["dt"] = "s"
+        payload["dt"] = dt
+    return jsonify(payload)
+
+
+@api_app.get("/api/ambr/am8/resonance")
+def resonance_endpoint():
+    theta = _safe_float(request.args.get("theta"))
+    if theta is None:
+        return jsonify({"error": "theta required"}), 400
+    n_max = _safe_int(request.args.get("n_max"), 10) or 10
+    scores = chebyshev.resonance_score(theta, n_max)
+    return jsonify(
+        {
+            "theta": theta,
+            "n": scores["n"].tolist(),
+            "p": scores["p"].tolist(),
+            "approx": scores["approx"].tolist(),
+            "score": scores["score"].tolist(),
+            "units": {"theta": "rad", "score": "1"},
+        }
+    )
+
+
+@api_app.post("/api/ambr/br8/collatz_push")
+def collatz_push():
+    body = request.get_json(force=True)
+    raw_dist = body.get("A", {})
+    distribution: Dict[int, float] = {}
+    for key, value in raw_dist.items():
+        state = _safe_int(key)
+        mass = _safe_float(value)
+        if state is None or mass is None:
+            continue
+        distribution[state] = mass
+    steps = _safe_int(body.get("steps"), 1) or 1
+    temperature = _safe_float(body.get("temperature_K"), 300.0) or 300.0
+    next_dist, energy = collatz.collatz_pushforward(distribution, steps, temperature_K=temperature)
+    return jsonify(
+        {
+            "A_next": {str(k): v for k, v in next_dist.items()},
+            "delta_E_min_J": energy,
+            "total_mass": sum(next_dist.values()),
+            "units": {"delta_E_min_J": "J", "temperature_K": "K"},
+            "temperature_K": temperature,
+        }
+    )
+
+
+@api_app.get("/api/ambr/fibpascal/row")
+def fib_pascal_row():
+    n = _safe_int(request.args.get("n"), 0)
+    if n is None or n < 0:
+        return jsonify({"error": "n must be non-negative"}), 400
+    row = fib_pascal.pascal_row(n)
+    diagonal = fib_pascal.pascal_diagonal_sums(n)
+    fib_target = fib_pascal.fib(n + 1)
+    return jsonify(
+        {
+            "row": row,
+            "n": n,
+            "fib_target": fib_target,
+            "diagonal_sum": diagonal,
+            "matches_fibonacci": diagonal == fib_target,
+            "units": {"row": "1", "fib_target": "1"},
+        }
+    )
 
 
 if __name__ == "__main__":
     api_app.run(host="127.0.0.1", port=8500)
+
 __all__ = ["repl", "app"]
 
 app = create_app()

--- a/tests/test_am6_projective_phase.py
+++ b/tests/test_am6_projective_phase.py
@@ -1,0 +1,53 @@
+"""Tests for the Amundson VI projective phase mapping."""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+import sys
+from pathlib import Path
+from types import ModuleType
+
+MODULE_DIR = Path(__file__).resolve().parents[1] / "packages" / "amundson_blackroad"
+MODULE_PATH = MODULE_DIR / "projective.py"
+
+PARENT_NAME = "amundson_blackroad"
+if PARENT_NAME not in sys.modules:
+    package = ModuleType(PARENT_NAME)
+    package.__path__ = [str(MODULE_DIR)]
+    sys.modules[PARENT_NAME] = package
+
+SPEC = importlib.util.spec_from_file_location(f"{PARENT_NAME}.projective", MODULE_PATH)
+assert SPEC and SPEC.loader
+projective = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = projective
+SPEC.loader.exec_module(projective)
+
+u_from_theta = projective.u_from_theta
+theta_from_u = projective.theta_from_u
+projective_am2_step = projective.projective_am2_step
+
+
+def test_projective_round_trip_near_pi_over_two() -> None:
+    """u = tan(theta/2) remains well-behaved near π/2."""
+
+    theta = math.pi / 2 - 1e-9
+    u = u_from_theta(theta)
+    theta_back = theta_from_u(u)
+    assert math.isclose(theta_back, theta, rel_tol=0.0, abs_tol=1e-9)
+
+
+def test_projective_derivative_stays_finite() -> None:
+    """The projective derivative does not diverge at the polar seam."""
+
+    theta = math.pi / 2 - 1e-6
+    u = u_from_theta(theta)
+    a_dot, u_dot, theta_dot, _ = projective_am2_step(
+        a=0.4, u=u, gamma=0.2, kappa=0.3, eta=0.5, omega0=1.2
+    )
+
+    assert math.isfinite(u_dot)
+    assert math.isfinite(theta_dot)
+    assert abs(math.tan(theta)) > 1e6  # highlight singular original coordinate
+    assert abs(u) < 10.0  # Projective coordinate stays bounded
+    assert abs(a_dot) < 10.0

--- a/tests/test_am7_quadratic_ladder.py
+++ b/tests/test_am7_quadratic_ladder.py
@@ -1,0 +1,65 @@
+"""Tests for Amundson VII quadratic ladder invariants."""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+import sys
+from pathlib import Path
+from types import ModuleType
+
+MODULE_DIR = Path(__file__).resolve().parents[1] / "packages" / "amundson_blackroad"
+MODULE_PATH = MODULE_DIR / "ladder.py"
+
+PARENT_NAME = "amundson_blackroad"
+if PARENT_NAME not in sys.modules:
+    package = ModuleType(PARENT_NAME)
+    package.__path__ = [str(MODULE_DIR)]
+    sys.modules[PARENT_NAME] = package
+
+SPEC = importlib.util.spec_from_file_location(f"{PARENT_NAME}.ladder", MODULE_PATH)
+assert SPEC and SPEC.loader
+ladder = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = ladder
+SPEC.loader.exec_module(ladder)
+
+sin2_ladder = ladder.sin2_ladder
+special_angles = ladder.special_angles
+ladder_identity_residuals = ladder.ladder_identity_residuals
+verify_ladder_identity = ladder.verify_ladder_identity
+
+
+def test_ladder_values_match_quadratic_sequence() -> None:
+    """sin² ladder reproduces the expected quadratic fractions."""
+
+    values = sin2_ladder()
+    expected = [0.0, 0.25, 0.5, 0.75, 1.0]
+    for got, want in zip(values, expected):
+        assert math.isclose(got, want, rel_tol=0.0, abs_tol=1e-12)
+
+
+def test_special_angle_triples() -> None:
+    """sin, cos, tan triples align with exact radicals."""
+
+    triples = special_angles()
+    roots = [
+        (0.0, 1.0, 0.0),
+        (0.5, math.sqrt(3) / 2.0, 1.0 / math.sqrt(3)),
+        (math.sqrt(2) / 2.0, math.sqrt(2) / 2.0, 1.0),
+        (math.sqrt(3) / 2.0, 0.5, math.sqrt(3)),
+        (1.0, 0.0, math.inf),
+    ]
+    for triple, reference in zip(triples, roots):
+        for got, want in zip(triple, reference):
+            if math.isinf(want):
+                assert math.isinf(got)
+            else:
+                assert math.isclose(got, want, rel_tol=0.0, abs_tol=1e-12)
+
+
+def test_quadratic_identity_holds() -> None:
+    """sin²θ and (1 - cos 2θ)/2 coincide to machine precision."""
+
+    residuals = ladder_identity_residuals()
+    assert float(abs(residuals).max()) <= 1e-12
+    assert verify_ladder_identity(tol=1e-12)

--- a/tests/test_am8_chebyshev.py
+++ b/tests/test_am8_chebyshev.py
@@ -1,0 +1,51 @@
+"""Tests for Amundson VIII Chebyshev resonance helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+import sys
+from pathlib import Path
+from types import ModuleType
+
+MODULE_DIR = Path(__file__).resolve().parents[1] / "packages" / "amundson_blackroad"
+MODULE_PATH = MODULE_DIR / "chebyshev.py"
+
+PARENT_NAME = "amundson_blackroad"
+if PARENT_NAME not in sys.modules:
+    package = ModuleType(PARENT_NAME)
+    package.__path__ = [str(MODULE_DIR)]
+    sys.modules[PARENT_NAME] = package
+
+SPEC = importlib.util.spec_from_file_location(f"{PARENT_NAME}.chebyshev", MODULE_PATH)
+assert SPEC and SPEC.loader
+chebyshev = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = chebyshev
+SPEC.loader.exec_module(chebyshev)
+
+cos_n_theta = chebyshev.cos_n_theta
+Tn = chebyshev.Tn
+Un = chebyshev.Un
+resonance_score = chebyshev.resonance_score
+
+
+def test_chebyshev_matches_cosine_multiple() -> None:
+    """Tₙ(cos θ) reproduces cos(nθ) for sample harmonics."""
+
+    theta = 0.37
+    for n in range(0, 6):
+        expected = math.cos(n * theta)
+        got = cos_n_theta(theta, n)
+        assert math.isclose(got, expected, rel_tol=0.0, abs_tol=1e-12)
+
+
+def test_resonance_peaks_on_rational_ratio() -> None:
+    """Resonance scores spike when θ/π is rational."""
+
+    theta = math.pi * 2.0 / 5.0
+    summary = resonance_score(theta, 6)
+    scores = summary["score"]
+    max_index = int(scores.argmax())
+    assert summary["n"][max_index] == 5
+    assert scores[max_index] > 1e8
+    assert math.isclose(summary["approx"][max_index], 0.4, abs_tol=1e-12)

--- a/tests/test_br8_collatz.py
+++ b/tests/test_br8_collatz.py
@@ -1,0 +1,70 @@
+"""Tests for the BR-8 Collatz flow instrument."""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+import sys
+from pathlib import Path
+from types import ModuleType
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+PACKAGE_DIR = BASE_DIR / "packages" / "amundson_blackroad"
+COLLATZ_PATH = PACKAGE_DIR / "collatz.py"
+RESOLUTION_PATH = PACKAGE_DIR / "resolution.py"
+
+PARENT_NAME = "amundson_blackroad"
+if PARENT_NAME not in sys.modules:
+    package = ModuleType(PARENT_NAME)
+    package.__path__ = [str(PACKAGE_DIR)]
+    sys.modules[PARENT_NAME] = package
+
+collatz_spec = importlib.util.spec_from_file_location(f"{PARENT_NAME}.collatz", COLLATZ_PATH)
+resolution_spec = importlib.util.spec_from_file_location(f"{PARENT_NAME}.resolution", RESOLUTION_PATH)
+assert collatz_spec and collatz_spec.loader
+assert resolution_spec and resolution_spec.loader
+collatz = importlib.util.module_from_spec(collatz_spec)
+resolution = importlib.util.module_from_spec(resolution_spec)
+sys.modules[collatz_spec.name] = collatz
+sys.modules[resolution_spec.name] = resolution
+resolution_spec.loader.exec_module(resolution)
+collatz_spec.loader.exec_module(collatz)
+
+next_collatz = collatz.next_collatz
+collatz_walk = collatz.collatz_walk
+collatz_landauer_cost = collatz.collatz_landauer_cost
+collatz_pushforward = collatz.collatz_pushforward
+K_BOLTZMANN = resolution.K_BOLTZMANN
+
+
+def test_collatz_walk_small_seed() -> None:
+    """Collatz walk for n=3 matches the known trajectory."""
+
+    path, steps = collatz_walk(3, limit=10)
+    assert path == [3, 10, 5, 16, 8, 4, 2, 1]
+    assert steps == 7
+
+
+def test_landauer_cost_matches_step_count() -> None:
+    """Landauer energy equals k_B T ln 2 times transition count."""
+
+    temperature = 300.0
+    _, steps = collatz_walk(5, limit=20)
+    expected = K_BOLTZMANN * temperature * math.log(2.0) * steps
+    assert math.isclose(
+        collatz_landauer_cost(5, temperature, limit=20), expected, rel_tol=0.0, abs_tol=1e-18
+    )
+
+
+def test_pushforward_preserves_mass_and_energy_accumulates() -> None:
+    """Mass stays constant while Landauer cost scales with steps."""
+
+    distribution = {3: 1.0, 4: 0.5}
+    temperature = 310.0
+    steps = 2
+    next_dist, energy = collatz_pushforward(distribution, steps, temperature_K=temperature)
+
+    assert math.isclose(sum(distribution.values()), sum(next_dist.values()), rel_tol=0.0, abs_tol=1e-12)
+    assert next_dist == {1: 0.5, 5: 1.0}
+    expected_energy = sum(distribution.values()) * steps * K_BOLTZMANN * temperature * math.log(2.0)
+    assert math.isclose(energy, expected_energy, rel_tol=0.0, abs_tol=1e-18)

--- a/tests/test_fib_pascal.py
+++ b/tests/test_fib_pascal.py
@@ -1,0 +1,67 @@
+"""Tests for the Fibonacci–Pascal instrument."""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import numpy as np
+
+MODULE_DIR = Path(__file__).resolve().parents[1] / "packages" / "amundson_blackroad"
+MODULE_PATH = MODULE_DIR / "fib_pascal.py"
+
+PARENT_NAME = "amundson_blackroad"
+if PARENT_NAME not in sys.modules:
+    package = ModuleType(PARENT_NAME)
+    package.__path__ = [str(MODULE_DIR)]
+    sys.modules[PARENT_NAME] = package
+
+SPEC = importlib.util.spec_from_file_location(f"{PARENT_NAME}.fib_pascal", MODULE_PATH)
+assert SPEC and SPEC.loader
+fib_pascal = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = fib_pascal
+SPEC.loader.exec_module(fib_pascal)
+
+fib = fib_pascal.fib
+fibs = fib_pascal.fibs
+F_MATRIX = fib_pascal.F_MATRIX
+pascal_row = fib_pascal.pascal_row
+pascal_diagonal_sums = fib_pascal.pascal_diagonal_sums
+golden_rotation_step = fib_pascal.golden_rotation_step
+PHI = fib_pascal.PHI
+
+
+def test_fibonacci_sequence_prefix() -> None:
+    """The Fibonacci helper returns the expected prefix."""
+
+    assert fibs(7) == [0, 1, 1, 2, 3, 5, 8]
+    assert fib(10) == 55
+
+
+def test_pascal_rows_and_diagonals_match_fibonacci() -> None:
+    """Pascal diagonals equal ``F_{n+1}`` for n ≤ 20."""
+
+    assert pascal_row(5) == [1, 5, 10, 10, 5, 1]
+    for n in range(0, 21):
+        assert pascal_diagonal_sums(n) == fib(n + 1)
+
+
+def test_f_matrix_generates_successive_pairs() -> None:
+    """The Fibonacci matrix reproduces successive pairs via matrix powers."""
+
+    vector = np.array([[1.0], [0.0]])
+    for n in range(1, 6):
+        powered = np.linalg.matrix_power(F_MATRIX, n) @ vector
+        assert math.isclose(powered[0, 0], fib(n + 1), rel_tol=0.0, abs_tol=1e-12)
+        assert math.isclose(powered[1, 0], fib(n), rel_tol=0.0, abs_tol=1e-12)
+
+
+def test_golden_rotation_step_is_stable() -> None:
+    """Golden rotation keeps updates bounded and deterministic."""
+
+    a_next, theta_next = golden_rotation_step(1.0, 0.0, eta=0.05)
+    assert math.isclose(a_next, 1.0 + 0.05 / PHI, rel_tol=0.0, abs_tol=1e-12)
+    assert math.isclose(theta_next, 0.05 / (PHI**2), rel_tol=0.0, abs_tol=1e-12)

--- a/tests/test_resolution.py
+++ b/tests/test_resolution.py
@@ -1,0 +1,74 @@
+"""Tests for the Amundson coherence auto-resolver."""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+import sys
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "packages" / "amundson_blackroad" / "resolution.py"
+SPEC = importlib.util.spec_from_file_location("amundson_blackroad.resolution", MODULE_PATH)
+assert SPEC and SPEC.loader
+resolution = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = resolution
+SPEC.loader.exec_module(resolution)
+
+K_BOLTZMANN = resolution.K_BOLTZMANN
+AmbrContext = resolution.AmbrContext
+resolve_coherence_inputs = resolution.resolve_coherence_inputs
+
+
+def test_resolver_infers_defaults() -> None:
+    """Missing parameters are filled with documented defaults."""
+
+    ctx = AmbrContext(last_phi_x=0.25, last_phi_y=-0.1)
+    resolved, missing, why = resolve_coherence_inputs(ctx)
+
+    expected_defaults = {
+        "omega_0": 1.0,
+        "lambda_": 0.5,
+        "eta": 0.2,
+        "phi_x": 0.25,
+        "phi_y": -0.1,
+        "r": 1.0,
+        "amplitude": 1.0,
+        "temperature_K": ctx.default_temperature_K,
+    }
+    for key, value in expected_defaults.items():
+        assert math.isclose(resolved[key], value, rel_tol=0.0, abs_tol=1e-12)
+        assert key in missing
+        assert key in why
+
+    assert "k_b_t" in resolved
+    assert "k_b_t" in missing
+    assert why["k_b_t"].startswith("Computed k_B")
+
+
+def test_resolver_respects_payload_temperature() -> None:
+    """The thermal product k_B T follows the supplied temperature."""
+
+    ctx = AmbrContext(last_phi_x=1.1, last_phi_y=0.2)
+    resolved, missing, _ = resolve_coherence_inputs(ctx, temperature_K=350.0)
+
+    assert math.isclose(
+        resolved["k_b_t"],
+        K_BOLTZMANN * 350.0,
+        rel_tol=0.0,
+        abs_tol=1e-12,
+    )
+    assert "temperature_K" not in missing
+
+
+def test_resolver_uses_context_phases_when_not_supplied() -> None:
+    """Context phases become defaults while explicit inputs bypass missing log."""
+
+    ctx = AmbrContext(last_phi_x=0.9, last_phi_y=0.7)
+    resolved, missing, why = resolve_coherence_inputs(ctx, phi_x=0.1)
+
+    assert math.isclose(resolved["phi_x"], 0.1)
+    assert "phi_x" not in missing
+    assert why["phi_x"] == "Provided explicitly in payload."
+
+    assert math.isclose(resolved["phi_y"], 0.7)
+    assert "phi_y" in missing


### PR DESCRIPTION
## Summary
- add resolution, projective, ladder, chebyshev, collatz, and fib_pascal modules with dedicated pytest suites
- expose new AM-VI, AM-VIII, BR-8, and Fibonacci–Pascal endpoints via the Lucidia math UI and document their Equations Lab panels
- update Amundson documentation with the expanded instrument tree and README summaries

## Testing
- pytest tests/test_resolution.py tests/test_am6_projective_phase.py tests/test_am7_quadratic_ladder.py tests/test_am8_chebyshev.py tests/test_br8_collatz.py tests/test_fib_pascal.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f1f707bcc8329bcdf3bd8501e03df)