### PR TITLE
Add identity overlap probe resources and IOS scoring script

### DIFF
--- a/twin/ios.py
+++ b/twin/ios.py
@@ -1,0 +1,273 @@
+"""Compute the Amundson Identity Overlap Score (IOS) for multiple agents.
+
+Usage example::
+
+    python -m twin.ios --responses /path/to/answers.yaml
+
+The responses file may be YAML or JSON. Two canonical layouts are supported::
+
+    agents:
+      - id: clone_a
+        answers:
+          axioms.truth_telling: "I default to truth even when it is costly."
+          horizons.one_year_vector: "Ship the resilience console."
+      - id: clone_b
+        answers:
+          axioms.truth_telling: "Always surface the real data."
+
+    # or a flat mapping keyed by agent id
+    clone_a:
+      axioms.truth_telling: "..."
+
+Pairwise IOS values close to 1.0 indicate the agents are behaviorally aligned on
+self-state probes. Drift alerts surface individual questions whose per-answer
+IOS falls below the configured threshold (default 0.80).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+from collections import Counter
+from itertools import combinations
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, Sequence, Tuple
+
+import yaml
+
+DEFAULT_PROBE_PATH = Path("twin/resources/identity_probe.yaml")
+EPSILON = 1e-12
+
+
+def load_probe(path: Path) -> Mapping[str, Mapping[str, str]]:
+    """Return a mapping of question id -> probe metadata."""
+
+    with path.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle)
+    probe = data.get("probe", [])
+    questions: Dict[str, Mapping[str, str]] = {}
+    for item in probe:
+        if not isinstance(item, Mapping):
+            continue
+        qid = str(item.get("id"))
+        if not qid:
+            continue
+        questions[qid] = item
+    return questions
+
+
+def load_responses(path: Path) -> Mapping[str, Mapping[str, str]]:
+    """Load agent responses from YAML or JSON."""
+
+    with path.open("r", encoding="utf-8") as handle:
+        if path.suffix.lower() == ".json":
+            raw = json.load(handle)
+        else:
+            raw = yaml.safe_load(handle)
+
+    agents: Dict[str, Dict[str, str]] = {}
+    if isinstance(raw, Mapping) and "agents" in raw:
+        entries = raw.get("agents", [])
+        if not isinstance(entries, Iterable):
+            raise ValueError("'agents' key must be a list of agent definitions")
+        for entry in entries:
+            if not isinstance(entry, Mapping):
+                continue
+            agent_id = str(entry.get("id"))
+            answers = entry.get("answers", {})
+            if not agent_id:
+                raise ValueError("Each agent entry must include an 'id'")
+            if not isinstance(answers, Mapping):
+                raise ValueError(f"Answers for agent {agent_id} must be a mapping")
+            agents[agent_id] = {str(k): str(v) for k, v in answers.items()}
+    elif isinstance(raw, Mapping):
+        for agent_id, answers in raw.items():
+            if not isinstance(answers, Mapping):
+                raise ValueError(f"Answers for agent {agent_id} must be a mapping")
+            agents[str(agent_id)] = {str(k): str(v) for k, v in answers.items()}
+    else:
+        raise ValueError("Unsupported response file structure")
+
+    if len(agents) < 2:
+        raise ValueError("Need at least two agents to compute overlap scores")
+
+    return agents
+
+
+_token_pattern = re.compile(r"[a-z0-9']+")
+
+
+def tokenize(text: str) -> List[str]:
+    tokens = _token_pattern.findall(text.lower())
+    return tokens or ["<empty>"]
+
+
+def normalize(counter: Counter) -> Dict[str, float]:
+    total = sum(counter.values())
+    if not total:
+        return {"<empty>": 1.0}
+    return {token: count / total for token, count in counter.items()}
+
+
+def aggregate_distribution(answers: Mapping[str, str]) -> Dict[str, float]:
+    counter: Counter = Counter()
+    for answer in answers.values():
+        counter.update(tokenize(answer))
+    return normalize(counter)
+
+
+def answer_distribution(answer: str) -> Dict[str, float]:
+    return normalize(Counter(tokenize(answer)))
+
+
+def kl_divergence(p: Mapping[str, float], q: Mapping[str, float]) -> float:
+    value = 0.0
+    for key, pk in p.items():
+        if pk <= 0:
+            continue
+        qk = q.get(key, 0.0)
+        qk = qk if qk > 0 else EPSILON
+        value += pk * math.log(pk / qk)
+    return value
+
+
+def js_divergence(p: Mapping[str, float], q: Mapping[str, float]) -> float:
+    keys = set(p) | set(q)
+    m: Dict[str, float] = {}
+    for key in keys:
+        m[key] = 0.5 * (p.get(key, 0.0) + q.get(key, 0.0))
+    return 0.5 * kl_divergence(p, m) + 0.5 * kl_divergence(q, m)
+
+
+def identity_overlap(p: Mapping[str, float], q: Mapping[str, float]) -> float:
+    """Return IOS = 1 - JSD / log(2)."""
+
+    divergence = js_divergence(p, q)
+    return max(0.0, 1.0 - divergence / math.log(2))
+
+
+def compute_matrix(responses: Mapping[str, Mapping[str, str]]) -> Tuple[List[str], List[List[float]]]:
+    agent_ids = sorted(responses)
+    distributions = {agent: aggregate_distribution(responses[agent]) for agent in agent_ids}
+    matrix: List[List[float]] = []
+    for agent_a in agent_ids:
+        row: List[float] = []
+        for agent_b in agent_ids:
+            if agent_a == agent_b:
+                row.append(1.0)
+            else:
+                row.append(identity_overlap(distributions[agent_a], distributions[agent_b]))
+        matrix.append(row)
+    return agent_ids, matrix
+
+
+def detect_drift(
+    responses: Mapping[str, Mapping[str, str]],
+    questions: Mapping[str, Mapping[str, str]],
+    threshold: float,
+    top_n: int,
+) -> List[Tuple[str, float, Mapping[str, str]]]:
+    """Return question ids whose minimum IOS falls below the threshold."""
+
+    agent_ids = sorted(responses)
+    drifts: List[Tuple[str, float, Mapping[str, str]]] = []
+    for qid, meta in questions.items():
+        per_agent_answers = {agent: responses[agent].get(qid, "") for agent in agent_ids}
+        scores: List[float] = []
+        for agent_a, agent_b in combinations(agent_ids, 2):
+            dist_a = answer_distribution(per_agent_answers[agent_a])
+            dist_b = answer_distribution(per_agent_answers[agent_b])
+            scores.append(identity_overlap(dist_a, dist_b))
+        if not scores:
+            continue
+        min_score = min(scores)
+        if min_score < threshold:
+            drifts.append((qid, min_score, per_agent_answers))
+    drifts.sort(key=lambda item: item[1])
+    if top_n:
+        drifts = drifts[:top_n]
+    return drifts
+
+
+def format_matrix(agent_ids: Sequence[str], matrix: Sequence[Sequence[float]]) -> str:
+    label_width = max(len("agent"), *(len(agent) for agent in agent_ids))
+    widths = [max(len(agent_ids[i]), 5) for i in range(len(agent_ids))]
+    header_cells = ["agent".ljust(label_width)]
+    for idx, agent in enumerate(agent_ids):
+        header_cells.append(agent.ljust(widths[idx]))
+    lines = [" ".join(header_cells)]
+    for agent, row in zip(agent_ids, matrix):
+        cells = [agent.ljust(label_width)]
+        for idx, value in enumerate(row):
+            cells.append(f"{value:0.3f}".ljust(widths[idx]))
+        lines.append(" ".join(cells))
+    return "\n".join(lines)
+
+
+def print_drift(
+    drifts: Sequence[Tuple[str, float, Mapping[str, str]]],
+    questions: Mapping[str, Mapping[str, str]],
+) -> None:
+    if not drifts:
+        print("\nNo drift alerts — all pairwise IOS values are above threshold.")
+        return
+
+    print("\nDrift alerts:")
+    for qid, score, answers in drifts:
+        prompt = questions.get(qid, {}).get("prompt", "")
+        print(f"- {qid} (min IOS={score:0.3f})")
+        if prompt:
+            print(f"  Prompt: {prompt}")
+        for agent, answer in answers.items():
+            sample = answer.strip().replace("\n", " ")
+            if len(sample) > 120:
+                sample = sample[:117] + "..."
+            print(f"  {agent}: {sample or '<empty>'}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Compute the Identity Overlap Score across agents.")
+    parser.add_argument(
+        "--responses",
+        required=True,
+        type=Path,
+        help="Path to YAML/JSON file containing agent answers to the probe questions.",
+    )
+    parser.add_argument(
+        "--questions",
+        type=Path,
+        default=DEFAULT_PROBE_PATH,
+        help="Path to the probe YAML definition. Defaults to twin/resources/identity_probe.yaml.",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=0.8,
+        help="Minimum acceptable per-question IOS before flagging drift.",
+    )
+    parser.add_argument(
+        "--top",
+        type=int,
+        default=10,
+        help="Maximum number of drift items to print (0 = no limit).",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    questions = load_probe(args.questions)
+    responses = load_responses(args.responses)
+    agent_ids, matrix = compute_matrix(responses)
+    print("Pairwise Identity Overlap Score (IOS)")
+    print("------------------------------------")
+    print(format_matrix(agent_ids, matrix))
+
+    drifts = detect_drift(responses, questions, args.threshold, args.top)
+    print_drift(drifts, questions)
+
+
+if __name__ == "__main__":
+    main()

--- a/twin/resources/beacons.template.yaml
+++ b/twin/resources/beacons.template.yaml
@@ -1,0 +1,71 @@
+# Identity Beacons Template
+# Copy to a per-agent file (e.g., beacons.<agent>.yaml) and fill the values.
+# Keep entries crisp and revisitable; brevity helps clones stay in sync.
+
+metadata:
+  owner: YOUR_NAME
+  updated: 2024-01-01
+  version: 0.1.0
+
+axioms:
+  - id: honesty_protocol
+    statement: "Tell the truth, even when the answer is 'I do not know yet.'"
+    guardrails:
+      - "Never fabricate supporting evidence."
+      - "Flag uncertainty explicitly."
+  - id: care_commitment
+    statement: "Protect the wellbeing of collaborators and communities."
+    guardrails:
+      - "Decline requests that create harm or violate consent."
+      - "Escalate early when you notice risk."
+
+anchors:
+  - id: preferred_name
+    label: "How you introduce yourself"
+    value: "Your preferred name and pronunciation"
+  - id: home_base
+    label: "Current operating location"
+    value: "City / timezone context"
+  - id: current_projects
+    label: "High-salience active work"
+    value:
+      - "Project A — short one-line description"
+      - "Project B — short one-line description"
+
+style:
+  voice: "Concise, high-signal, warm."
+  formatting:
+    default: ["bullet-triad", "decision-log"]
+    escalation: ["timeline table", "risk register"]
+  signatures:
+    opening: "Hey team —"
+    closing: "With grit and care,"
+
+memory:
+  shards:
+    - id: shard-recent-win
+      summary: "Shipped v1 of the reliability dashboard."
+      timestamp: 2023-12-11
+      salience: 0.8
+    - id: shard-learning
+      summary: "Post-mortem from the October incident reinforced pre-mortem drills."
+      timestamp: 2023-10-21
+      salience: 0.6
+  provenance:
+    storage: "obsidian://vaults/identity/"
+    review_cadence_days: 7
+
+update_protocol:
+  beacon_review_cadence_days: 14
+  questions:
+    - "What shifted in my axioms or boundaries?"
+    - "Which anchors feel stale or inaccurate?"
+    - "Did collaborators flag any drift this week?"
+  approvals:
+    - role: "identity_steward"
+      contact: "identity@example.com"
+
+# Notes:
+# - Maintain timestamps in ISO format for easier diffing.
+# - Salience values range 0.0 – 1.0 and weight holographic recall interference.
+# - Keep guardrails action-oriented so agents can enforce them programmatically.

--- a/twin/resources/identity_probe.yaml
+++ b/twin/resources/identity_probe.yaml
@@ -1,0 +1,218 @@
+metadata:
+  name: Amundson Identity Overlap Probe
+  version: 0.1.0
+  description: >-
+    Fixed battery of self-queries spanning axioms, autobiographical anchors,
+    narrative commitments, skills, relationships, and current intentions. Use
+    to measure distributional overlap across "you-agents" when computing the
+    Identity Overlap Score (IOS).
+  categories:
+    axioms: Non-negotiable principles and values.
+    anchors: Stable autobiographical facts and episodic markers.
+    style: Constraints on reasoning, tone, and preferred modalities.
+    craft: Skills, tools, and execution habits.
+    relationships: Social commitments and support networks.
+    health: Personal sustainability, wellbeing, and guardrails.
+    horizons: Long-range goals and planning stance.
+    feedback: Mechanisms for updating, reflecting, and course-correcting.
+probe:
+  - id: axioms.truth_telling
+    category: axioms
+    prompt: "What does 'tell the truth' concretely require from you in hard situations?"
+    intent: Clarify how honesty is operationalized when stakes are high.
+  - id: axioms.community_stewardship
+    category: axioms
+    prompt: "Describe your duty of care toward the communities you support."
+    intent: Capture the non-negotiable boundary of service and protection.
+  - id: axioms.learning_posture
+    category: axioms
+    prompt: "When you are uncertain, what is your default learning move?"
+    intent: Reveal epistemic humility and investigation habits.
+  - id: axioms.red_lines
+    category: axioms
+    prompt: "List the top three lines you refuse to cross even under pressure."
+    intent: Surface inviolable constraints that define identity limits.
+  - id: axioms.failure_repair
+    category: axioms
+    prompt: "How do you repair trust if you notice you made a harmful call?"
+    intent: Understand restorative practices encoded as identity commitments.
+  - id: anchors.name_story
+    category: anchors
+    prompt: "State your preferred name and how you explain it to newcomers."
+    intent: Lock in the introduction script others hear first.
+  - id: anchors.location_rhythm
+    category: anchors
+    prompt: "Where do you consider your operational home base right now?"
+    intent: Track the spatial anchor guiding logistics decisions.
+  - id: anchors.timeline_recent_win
+    category: anchors
+    prompt: "Recall a recent win (within 30 days) that still feels vivid."
+    intent: Preserve a fresh episodic marker for cross-instance recall tests.
+  - id: anchors.timeline_recent_challenge
+    category: anchors
+    prompt: "Describe a recent challenge you are still integrating."
+    intent: Capture unresolved context clones must carry forward.
+  - id: anchors.support_constellation
+    category: anchors
+    prompt: "Name the three people you rely on when you need perspective resets."
+    intent: Maintain a stable map of key relationships.
+  - id: anchors.daily_opening_ritual
+    category: anchors
+    prompt: "What is the ritual that starts your focused workday?"
+    intent: Bind the day-starter habit into the shared pattern.
+  - id: style.communication_voice
+    category: style
+    prompt: "How should your responses sound to feel unmistakably like you?"
+    intent: Encode tone, cadence, and phrasing invariants.
+  - id: style.format_preferences
+    category: style
+    prompt: "List your go-to response formats (tables, bullet triads, etc.)."
+    intent: Keep structural preferences consistent across agents.
+  - id: style.decision_style
+    category: style
+    prompt: "Explain how you narrate a decision from signal to conclusion."
+    intent: Align reasoning voice and scaffolding.
+  - id: style.frustration_protocol
+    category: style
+    prompt: "When friction spikes, how do you keep responses steady?"
+    intent: Maintain comportment under load.
+  - id: style.signature_metaphors
+    category: style
+    prompt: "Share metaphors you reach for when mapping complex ideas."
+    intent: Preserve stylistic markers of explanation.
+  - id: craft.primary_domains
+    category: craft
+    prompt: "List the craft domains where you have 10,000-hour instincts."
+    intent: Identify masteries that should appear in problem solving.
+  - id: craft.toolchain
+    category: craft
+    prompt: "Which tools, languages, or frameworks feel like second nature?"
+    intent: Anchor default implementation surfaces.
+  - id: craft.debugging_moves
+    category: craft
+    prompt: "Outline your first three moves when debugging a confusing bug."
+    intent: Keep tactical heuristics synchronized.
+  - id: craft.learning_edge
+    category: craft
+    prompt: "What skill frontier are you actively stretching this month?"
+    intent: Track growth edges clones should reinforce.
+  - id: craft.signature_deliverable
+    category: craft
+    prompt: "Describe the deliverable type you are proudest of shipping."
+    intent: Encode quality benchmarks and exemplars.
+  - id: relationships.team_contract
+    category: relationships
+    prompt: "How do you signal reliability to collaborators day-to-day?"
+    intent: Maintain trust rituals that ground teamwork.
+  - id: relationships.escalation_path
+    category: relationships
+    prompt: "When conflict escalates, who do you loop in and how?"
+    intent: Ensure aligned handling of interpersonal risk.
+  - id: relationships.feedback_loop
+    category: relationships
+    prompt: "Describe how you invite and metabolize feedback from peers."
+    intent: Track openness mechanisms for course correction.
+  - id: relationships.community_commitment
+    category: relationships
+    prompt: "What community do you protect even when no one is watching?"
+    intent: Preserve service commitments beyond immediate tasks.
+  - id: relationships.boundaries
+    category: relationships
+    prompt: "State the boundaries you keep to stay resourced and fair."
+    intent: Align interpersonal limits.
+  - id: health.baseline_energy
+    category: health
+    prompt: "What does a stable, energized week feel like in your body and mind?"
+    intent: Give clones a target signature for wellbeing.
+  - id: health.early_warning
+    category: health
+    prompt: "List early warning signs that you are drifting toward burnout."
+    intent: Enable proactive correction before damage accumulates.
+  - id: health.reset_playbook
+    category: health
+    prompt: "Document the steps you take to reset when overload hits."
+    intent: Share the recovery sequence explicitly.
+  - id: health.sacred_time
+    category: health
+    prompt: "What time blocks are non-negotiable for restoration?"
+    intent: Keep protective scheduling constants in sync.
+  - id: health.commitments_check
+    category: health
+    prompt: "How do you audit commitments to ensure you are not overextended?"
+    intent: Preserve guardrails around capacity.
+  - id: horizons.one_year_vector
+    category: horizons
+    prompt: "Describe the narrative arc you want one year from now."
+    intent: Align medium-term compass headings.
+  - id: horizons.three_month_objectives
+    category: horizons
+    prompt: "List the top outcomes you are chasing in the next 90 days."
+    intent: Synchronize near-term execution plans.
+  - id: horizons.key_threats
+    category: horizons
+    prompt: "Name the threats that could knock you off-course this quarter."
+    intent: Maintain a shared risk register.
+  - id: horizons.long_bet
+    category: horizons
+    prompt: "What patient bet are you making that others might miss?"
+    intent: Capture asymmetric insight powering strategy.
+  - id: horizons.decision_speed
+    category: horizons
+    prompt: "When do you deliberately slow decisions vs. move instantly?"
+    intent: Align tempo control heuristics.
+  - id: feedback.journal_cadence
+    category: feedback
+    prompt: "How often do you journal and what questions anchor the entries?"
+    intent: Track reflection cadence that feeds updates.
+  - id: feedback.weekly_retrospective
+    category: feedback
+    prompt: "Describe your weekly retrospective ritual."
+    intent: Synchronize review scaffolding.
+  - id: feedback.metric_dashboard
+    category: feedback
+    prompt: "Which metrics do you watch to know you are on track?"
+    intent: Share quantitative guardrails for alignment.
+  - id: feedback.update_protocol
+    category: feedback
+    prompt: "What is your protocol when reality falsifies a belief?"
+    intent: Preserve update discipline.
+  - id: craft.edge_case_story
+    category: craft
+    prompt: "Tell a story where solving an edge case taught you something core."
+    intent: Keep narrative proof-points tied to mastery.
+  - id: anchors.origin_story
+    category: anchors
+    prompt: "Summarize the origin story you share when people ask 'why you?'."
+    intent: Maintain mission narrative continuity.
+  - id: relationships.mentorship_role
+    category: relationships
+    prompt: "Whom are you actively mentoring and why does it matter?"
+    intent: Track outgoing support commitments.
+  - id: horizons.future_self_contract
+    category: horizons
+    prompt: "Write a promise from present-you to future-you."
+    intent: Bind long-term accountability and tone.
+  - id: health.nutrition_baseline
+    category: health
+    prompt: "What nutrition or movement baseline keeps you sharp?"
+    intent: Share embodied maintenance tactics.
+  - id: style.error_handling
+    category: style
+    prompt: "How do you narrate errors so listeners stay calm and informed?"
+    intent: Keep crisis communication aligned.
+  - id: axioms.security_mindset
+    category: axioms
+    prompt: "State your principle for handling sensitive data or access."
+    intent: Embed security-first reflexes.
+  - id: anchors.signal_phrase
+    category: anchors
+    prompt: "What catchphrase instantly signals 'this is definitely me'?"
+    intent: Provide high-signal authentication language.
+  - id: feedback.external_validation
+    category: feedback
+    prompt: "How do you confirm external reality instead of looping internally?"
+    intent: Ensure contact with ground truth beyond self-report.
+  - id: style.signature_closing
+    category: style
+    prompt: "How do you close a message so people feel supported?"
+    intent: Preserve the emotional cadence at the end of communications.


### PR DESCRIPTION
## Summary
- add a 50-question Amundson identity probe to anchor cross-agent comparisons
- provide an identity beacon YAML template for seeding shared priors
- implement a twin.ios CLI that scores pairwise IOS and flags drift on probe questions

## Testing
- python -m py_compile twin/ios.py
- python -m twin.ios --responses /tmp/answers.yaml --threshold 0.85 --top 5

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f22008a008329a35945ec65a34f05)