### PR TITLE
Improve AM-2 projective seam regression tests

### DIFF
--- a/tests/test_am6_projective_phase.py
+++ b/tests/test_am6_projective_phase.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from types import ModuleType
 
+import pytest
+
 MODULE_DIR = Path(__file__).resolve().parents[1] / "packages" / "amundson_blackroad"
 MODULE_PATH = MODULE_DIR / "projective.py"
 
@@ -26,14 +28,17 @@ SPEC.loader.exec_module(projective)
 u_from_theta = projective.u_from_theta
 theta_from_u = projective.theta_from_u
 projective_am2_step = projective.projective_am2_step
+simulate_projective_am2 = projective.simulate_projective_am2
 
 
-def test_projective_round_trip_near_pi_over_two() -> None:
-    """u = tan(theta/2) remains well-behaved near π/2."""
+@pytest.mark.parametrize("theta", [math.pi / 2 - 1e-9, -(math.pi / 2 - 1e-9)])
+def test_projective_round_trip_near_pi_over_two(theta: float) -> None:
+    """u = tan(theta/2) remains well-behaved near ±π/2."""
 
-    theta = math.pi / 2 - 1e-9
     u = u_from_theta(theta)
     theta_back = theta_from_u(u)
+    assert math.isfinite(u)
+    assert math.isfinite(theta_back)
     assert math.isclose(theta_back, theta, rel_tol=0.0, abs_tol=1e-9)
 
 
@@ -51,3 +56,17 @@ def test_projective_derivative_stays_finite() -> None:
     assert abs(math.tan(theta)) > 1e6  # highlight singular original coordinate
     assert abs(u) < 10.0  # Projective coordinate stays bounded
     assert abs(a_dot) < 10.0
+
+
+def test_simulate_projective_am2_round_trip() -> None:
+    """simulate_projective_am2 keeps projective coordinates finite near the seam."""
+
+    eps = 1e-9
+    t, a, u, theta, response = simulate_projective_am2(T=2e-3, dt=2e-4, theta0=math.pi / 2 - eps)
+
+    for series in (t, a, u, theta, response):
+        assert all(math.isfinite(value) for value in series)
+
+    theta_round_trip = [theta_from_u(value) for value in u]
+    max_error = max(abs(expected - actual) for expected, actual in zip(theta, theta_round_trip))
+    assert max_error < 1e-9


### PR DESCRIPTION
## Summary
- parameterize the projective round-trip check across both hemispheres with tight tolerances
- add a simulate_projective_am2 regression that ensures finite outputs and round-trip fidelity near the seam

## Testing
- pytest tests/test_am6_projective_phase.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f2872612083299eeaf0aca3f28ad0)