### PR TITLE
CI: expand pytest workflow matrix coverage

### DIFF
--- a/.github/workflows/language-python312-pytest.yml
+++ b/.github/workflows/language-python312-pytest.yml
@@ -13,8 +13,13 @@ concurrency:
 
 jobs:
   test:
-    name: Python 3.12 • Pytest
-    runs-on: ubuntu-latest
+    name: Pytest • ${{ matrix.python-version }} (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.11", "pypy3.11"]
     timeout-minutes: 30
 
     steps:
@@ -24,7 +29,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: ${{ matrix.python-version }}
           cache: 'pip'
           cache-dependency-path: |
             requirements*.txt
@@ -61,10 +66,10 @@ jobs:
             --junitxml=reports/junit/pytest.xml \
             -o junit_family=xunit2
 
-      - name: Upload reports on failure
+      - name: Upload reports on failure (${{ matrix.os }}-${{ matrix.python-version }})
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: python312-pytest-reports
+          name: python-pytest-reports-${{ matrix.os }}-${{ matrix.python-version }}
           path: reports
           if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- convert the pytest workflow into an OS/Python matrix for CPython 3.11 and PyPy 3.11
- run the job on both ubuntu-latest and macos-latest runners using matrix values
- give each failure artifact a matrix-specific name so all reports are kept

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f288e89c08329b5bec9121e61dd67)