### PR TITLE
Add daily operations brief for 2025-11-08

### DIFF
--- a/status/2025-11-08.md
+++ b/status/2025-11-08.md
@@ -1,0 +1,12 @@
+# Daily Operations Brief — 2025-11-08
+
+## Platform & Tooling Health
+- **Cloudflare:** Incident window from 06:05–08:20 UTC caused onboarding failures for new R2 accounts. Existing buckets and clients remained healthy, but confirm any provisioning attempts during this span. Dallas (DFW) underwent scheduled maintenance on Nov 7 from 09:00–13:00 UTC, and Singapore experienced a network performance issue on Nov 7 that may have introduced alternate routing and extra latency for APAC flows.
+- **Amazon Web Services (us-east-1):** AWS reported elevated error rates and latencies around 07:11 UTC tied to DNS resolution for the DynamoDB API endpoint. Expect possible tail latency spikes or throttled launches across dependent services (Lambda, EC2, Step Functions) during that interval.
+- **GitHub:** No incidents reported in the last 48 hours; CI/CD pipelines relying on GitHub should have remained stable.
+
+## Recommended Actions
+- Review Cloudflare R2 onboarding/job logs for failures or retries during the 06:05–08:20 UTC window and validate provisioning success for newly created buckets or accounts.
+- Audit routing and latency metrics for APAC clients around the Nov 7 Singapore performance event and DFW maintenance window to confirm no persistent degradation.
+- Inspect AWS us-east-1 monitoring dashboards (DynamoDB, Lambda, EC2, Step Functions) for latency spikes or elevated error rates around 07:11 UTC, and backfill any failed runs.
+- Maintain current GitHub monitoring cadence; no additional response required unless upstream dependencies flag new issues.


### PR DESCRIPTION
## Summary
- add a daily operations brief dated 2025-11-08 covering Cloudflare, AWS, and GitHub status updates
- outline follow-up actions for Cloudflare R2 onboarding, regional routing, and AWS us-east-1 monitoring

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f4f6b400083298270a431deb01f9e)