### PR TITLE
Document OFAC sanctions playbook and align risk records

### DIFF
--- a/compliance/ofac_sanctions_playbook.md
+++ b/compliance/ofac_sanctions_playbook.md
@@ -1,0 +1,51 @@
+# OFAC Sanctions Response Playbook – DPRK Cheil Credit Bank Cluster (Nov 2025)
+
+## Overview
+On **4 November 2025**, the U.S. Treasury's Office of Foreign Assets Control (OFAC) designated **53 cryptocurrency addresses** associated with Cheil Credit Bank (CCB), a North Korean financial institution under sanction since 2017. Blockchain analytics providers (Elliptic, TRM Labs) report that the cluster:
+
+- Holds approximately **USD 5.4 million** in digital assets.
+- Receives steady "payroll-like" inflows tied to overseas IT worker networks attributed to the DPRK.
+- Has historic touchpoints with major centralized exchanges, signalling potential downstream exposure for service providers.
+
+This designation fits within a broader enforcement campaign responding to DPRK cyber-enabled theft exceeding **USD 3 billion** over the past three years (more than USD 2 billion in 2025 alone).
+
+## Immediate Response Checklist
+1. **Sanctions Screening Update**
+   - Import the 53 addresses (plus near-cluster derivatives) into screening lists for wallet vetting, transaction monitoring, and customer onboarding.
+   - Re-run nightly batch screening against historical counterparties to identify past exposure.
+
+2. **Counterparty & Flow Analysis**
+   - Execute graph clustering (forward and backward) from the designated addresses to flag first- and second-hop entities.
+   - Escalate any direct hits or high-probability indirect links to compliance/legal for review and potential Suspicious Activity Reports (SARs).
+
+3. **Exchange / VASP Assurance**
+   - Secure written confirmation from each exchange, broker, or hosted wallet provider that they have ingested the new designations.
+   - Capture evidence of their screening controls (policy excerpts, SOC reports, API logs).
+
+4. **Governance Communication**
+   - Brief General Counsel, Chief Compliance Officer, and Risk leadership on the exposure, remediation plan, and regulator expectations.
+   - Document board-level notification if policy requires.
+
+5. **Controls & Documentation**
+   - Update AML/CTF policies and customer risk-scoring models to reference the OFAC action.
+   - Preserve audit trails: address ingestion logs, alert review notes, outreach emails, SAR filings, and decision records.
+
+## Technical Integration Notes
+- **Data Sources**: ingest address lists from OFAC (SDN XML/CSV), Elliptic, TRM Labs, and any other trusted blockchain intelligence partners.
+- **Automation**: extend sanctions microservice to support incremental address loads, deduplication, and cluster tagging (e.g., `ofac_ccb_nov2025`).
+- **Alert Prioritization**: score alerts higher when transactions originate from payroll-like patterns or route through known DPRK exchange funnels.
+- **Testing**: add regression tests that simulate inbound transfers from sanctioned addresses and assert block/alert behaviour.
+
+## Regulatory Follow-Through
+- File required notifications or SARs based on jurisdictional thresholds.
+- Monitor OFAC, FinCEN, and allied (EU/UK/KR) bulletins for follow-on designations.
+- Schedule a post-incident review within 30 days to assess control performance and residual risk.
+
+## Ownership
+- **Primary**: Compliance (Sanctions Operations Lead)
+- **Supporting**: Risk Engineering, Legal, Security Intelligence
+
+## References
+- OFAC SDN List Update – 4 Nov 2025 (Cheil Credit Bank cluster)
+- Elliptic: *OFAC lists 53 crypto addresses of sanctioned North Korean Cheil Credit Bank*
+- TRM Labs: *US Treasury sanctions DPRK bankers and front companies laundering proceeds from cybercrime and IT worker operations*

--- a/risk/compliance_mapping.yaml
+++ b/risk/compliance_mapping.yaml
@@ -8,3 +8,8 @@
   internal_policy: 'User access review'
   evidence:
     - ev2
+- framework: OFAC
+  control: 'Sanctions due diligence – Nov 2025 DPRK update'
+  internal_policy: 'Sanctions screening and escalation playbook'
+  evidence:
+    - ofac_ccb_cluster_playbook

--- a/risk/evidence.yaml
+++ b/risk/evidence.yaml
@@ -8,3 +8,8 @@
   timestamp: '2024-06-15T09:30:00Z'
   hash: 'sha256:def456'
   reviewer: bob
+- id: ofac_ccb_cluster_playbook
+  source_system: InternalDocs
+  timestamp: '2025-11-05T08:00:00Z'
+  hash: 'sha256:placeholder-for-ofac-playbook'
+  reviewer: compliance-ops

--- a/risk/register.yaml
+++ b/risk/register.yaml
@@ -19,17 +19,10 @@
   impact: 0.7
   mitigation: 'Regular training and audits'
   residual_risk: 0.07
-  description: "Data breach"
-  likelihood: 0.3
-  impact: 0.8
-  mitigation: "Encrypt data and monitor access"
-- id: R2
-  description: "Service outage"
+- id: R4
+  description: 'Sanctions exposure to DPRK-linked crypto wallets'
+  owner: compliance
   likelihood: 0.2
   impact: 0.9
-  mitigation: "Multi-region deployment"
-- id: R3
-  description: "Compliance violation"
-  likelihood: 0.1
-  impact: 0.7
-  mitigation: "Regular training and audits"
+  mitigation: 'Implement OFAC Nov 2025 sanctions playbook and continuous wallet screening'
+  residual_risk: 0.18


### PR DESCRIPTION
## Summary
- add a detailed OFAC sanctions response playbook for the November 2025 Cheil Credit Bank address designations
- clean up the risk register and capture a new sanctions exposure entry referencing the playbook
- extend compliance mappings and evidence records to link the new sanctions controls

## Testing
- not run (documentation and configuration updates only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f4fb2bbcc83298132727867cb655f)