### PR TITLE
Add November 2025 bitcoin mining market brief

### DIFF
--- a/miners/market-brief-2025-11-07.md
+++ b/miners/market-brief-2025-11-07.md
@@ -1,0 +1,21 @@
+# Bitcoin Mining Market Brief — 7 Nov 2025
+
+## Network & Difficulty
+- **Network hash-rate:** 7-day SMA slipped ~1.2% week-over-week (≈1,134 EH/s → ≈1,120 EH/s).
+- **Upcoming difficulty adjustment:** projected for ~12 Nov 2025 with an estimated −2.8% change.
+
+## Revenue Pressure
+- **Hash-price:** hovering near US$42–43 per PH/s per day amid light fee revenue and elevated difficulty.
+- **Margin impact:** even with the anticipated difficulty dip, revenue-per-TH remains compressed; operators must keep focusing on cost discipline.
+
+## Operational Implications
+- **Efficiency focus:** prioritize rigs with top-tier J/TH and prune the tail of inefficient hardware.
+- **Demand response edge:** in ERCOT and similar markets, miners that can rapidly curtail or shift load are earning higher premiums / avoided charges.
+- **Protocol watch:** Stratum V2 + SRI stack remains in alpha/beta testing; no major fleet migrations announced in the last two weeks.
+
+## Near-Term Actions to Consider
+1. Model breakevens with a 2–3% lower difficulty but flat hash-price to confirm short-lived relief.
+2. Rebalance deployment toward sites with flexible power contracts or active demand-response participation.
+3. Track Stratum V2 readiness from pool vendors, but defer large migrations until stable releases land.
+
+*Sources: Hashrate Index, CoinWarz, Bitget Research, POWER Magazine (Texas policy update).* 


### PR DESCRIPTION
## Summary
- add a November 2025 bitcoin mining market brief covering network metrics and revenue pressure
- highlight operational implications and immediate actions for miners in light of ERCOT policy shifts and Stratum V2 status

## Testing
- not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f50577bdc8329bcb5357329c3f5ca)