### PR TITLE
Add OpenID credential flow and DIDComm agent scaffolding

### DIFF
--- a/services/prism/internal/http/oidc_handlers.go
+++ b/services/prism/internal/http/oidc_handlers.go
@@ -1,0 +1,130 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/blackroad/prism-console/services/prism/internal/service"
+)
+
+type batchCredentialRequest struct {
+	Requests []service.CredentialRequest `json:"requests"`
+}
+
+type batchCredentialResponse struct {
+	Credentials []service.CredentialResponse `json:"credentials"`
+}
+
+func (a *API) handleOID4VCICredential(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req service.CredentialRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	resp, err := a.svc.IssueCredential(r.Context(), req)
+	if err != nil {
+		status, msg := classifyServiceError(err)
+		http.Error(w, msg, status)
+		return
+	}
+	writeJSON(w, resp)
+}
+
+func (a *API) handleOID4VCIBatchCredential(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var payload batchCredentialRequest
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	resp, err := a.svc.BatchIssueCredential(r.Context(), payload.Requests)
+	if err != nil {
+		status, msg := classifyServiceError(err)
+		http.Error(w, msg, status)
+		return
+	}
+	writeJSON(w, batchCredentialResponse{Credentials: resp})
+}
+
+func (a *API) handleOIDC4VPAuthorize(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req service.PresentationAuthorizationRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	resp, err := a.svc.AuthorizePresentation(r.Context(), req)
+	if err != nil {
+		status, msg := classifyServiceError(err)
+		http.Error(w, msg, status)
+		return
+	}
+	writeJSON(w, resp)
+}
+
+func (a *API) handleOIDC4VPCallback(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var submission service.PresentationSubmission
+	if err := json.NewDecoder(r.Body).Decode(&submission); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	record, err := a.svc.CompletePresentation(r.Context(), submission)
+	if err != nil {
+		status, msg := classifyServiceError(err)
+		http.Error(w, msg, status)
+		return
+	}
+	writeJSON(w, record)
+}
+
+func (a *API) handleDIDCommRegister(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req service.DIDCommRegistration
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	channel, err := a.svc.RegisterDIDCommChannel(r.Context(), req)
+	if err != nil {
+		status, msg := classifyServiceError(err)
+		http.Error(w, msg, status)
+		return
+	}
+	writeJSON(w, channel)
+}
+
+func classifyServiceError(err error) (int, string) {
+	switch {
+	case errors.Is(err, service.ErrCredentialSubjectMissing),
+		errors.Is(err, service.ErrCredentialTypeMissing),
+		errors.Is(err, service.ErrPresentationRequestInvalid),
+		errors.Is(err, service.ErrPresentationSubmissionInvalid),
+		errors.Is(err, service.ErrPresentationNonceUnknown),
+		errors.Is(err, service.ErrPresentationNonceExpired),
+		errors.Is(err, service.ErrDIDRequired),
+		errors.Is(err, service.ErrDIDCommEndpointRequired):
+		return http.StatusBadRequest, err.Error()
+	case errors.Is(err, service.ErrDIDCommAgentUnavailable):
+		return http.StatusServiceUnavailable, err.Error()
+	default:
+		return http.StatusInternalServerError, err.Error()
+	}
+}

--- a/services/prism/internal/http/server.go
+++ b/services/prism/internal/http/server.go
@@ -23,6 +23,11 @@ func (a *API) Router() http.Handler {
 	mux.HandleFunc("/api/health.json", a.handleHealth)
 	mux.HandleFunc("/api/echo", a.handleEcho)
 	mux.HandleFunc("/api/mini/infer", a.handleMiniInfer)
+	mux.HandleFunc("/api/oid4vci/credential", a.handleOID4VCICredential)
+	mux.HandleFunc("/api/oid4vci/batch_credential", a.handleOID4VCIBatchCredential)
+	mux.HandleFunc("/api/oidc4vp/authorize", a.handleOIDC4VPAuthorize)
+	mux.HandleFunc("/api/oidc4vp/callback", a.handleOIDC4VPCallback)
+	mux.HandleFunc("/api/didcomm/register", a.handleDIDCommRegister)
 	return mux
 }
 

--- a/services/prism/internal/service/didcomm.go
+++ b/services/prism/internal/service/didcomm.go
@@ -1,0 +1,114 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+var (
+	// ErrDIDCommAgentUnavailable is returned when registering without a configured agent.
+	ErrDIDCommAgentUnavailable = errors.New("service: didcomm agent unavailable")
+	// ErrDIDRequired indicates the DID was missing from the registration payload.
+	ErrDIDRequired = errors.New("service: did is required")
+	// ErrDIDCommEndpointRequired indicates the DIDComm service endpoint was omitted.
+	ErrDIDCommEndpointRequired = errors.New("service: didcomm endpoint is required")
+)
+
+// DIDCommRegistration models the DID and endpoint metadata advertised by the holder wallet.
+type DIDCommRegistration struct {
+	DID         string            `json:"did"`
+	Endpoint    string            `json:"endpoint"`
+	RoutingKeys []string          `json:"routing_keys,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+}
+
+// DIDCommChannel captures the resolved DIDComm service endpoint registered with Prism.
+type DIDCommChannel struct {
+	DID          string            `json:"did"`
+	Endpoint     string            `json:"endpoint"`
+	RoutingKeys  []string          `json:"routing_keys,omitempty"`
+	Metadata     map[string]string `json:"metadata,omitempty"`
+	RegisteredAt time.Time         `json:"registered_at"`
+}
+
+// DIDCommAgent stores DIDComm channel registrations in-memory for follow-up messaging.
+type DIDCommAgent struct {
+	mu       sync.RWMutex
+	channels map[string]DIDCommChannel
+}
+
+// NewDIDCommAgent constructs an empty DIDComm agent registry.
+func NewDIDCommAgent() *DIDCommAgent {
+	return &DIDCommAgent{channels: make(map[string]DIDCommChannel)}
+}
+
+// Register stores or updates a DIDComm channel for the provided DID.
+func (a *DIDCommAgent) Register(_ context.Context, reg DIDCommRegistration, now time.Time) (DIDCommChannel, error) {
+	if reg.DID == "" {
+		return DIDCommChannel{}, ErrDIDRequired
+	}
+	if reg.Endpoint == "" {
+		return DIDCommChannel{}, ErrDIDCommEndpointRequired
+	}
+	channel := DIDCommChannel{
+		DID:          reg.DID,
+		Endpoint:     reg.Endpoint,
+		RoutingKeys:  append([]string(nil), reg.RoutingKeys...),
+		Metadata:     cloneStringMap(reg.Metadata),
+		RegisteredAt: now,
+	}
+	a.mu.Lock()
+	a.channels[reg.DID] = channel
+	a.mu.Unlock()
+	return channel, nil
+}
+
+// Channels returns a snapshot of the registered DIDComm channels.
+func (a *DIDCommAgent) Channels() []DIDCommChannel {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	out := make([]DIDCommChannel, 0, len(a.channels))
+	for _, channel := range a.channels {
+		out = append(out, channel)
+	}
+	return out
+}
+
+// RegisterDIDCommChannel records a DIDComm endpoint for follow-up communications.
+func (s *Service) RegisterDIDCommChannel(ctx context.Context, reg DIDCommRegistration) (DIDCommChannel, error) {
+	if reg.DID == "" {
+		return DIDCommChannel{}, ErrDIDRequired
+	}
+	if reg.Endpoint == "" {
+		return DIDCommChannel{}, ErrDIDCommEndpointRequired
+	}
+	if s.agent == nil {
+		return DIDCommChannel{}, ErrDIDCommAgentUnavailable
+	}
+	channel, err := s.agent.Register(ctx, reg, s.now())
+	if err != nil {
+		return DIDCommChannel{}, err
+	}
+	return channel, nil
+}
+
+// DIDCommChannels exposes the registered DIDComm channels.
+func (s *Service) DIDCommChannels() []DIDCommChannel {
+	if s.agent == nil {
+		return nil
+	}
+	return s.agent.Channels()
+}
+
+func cloneStringMap(in map[string]string) map[string]string {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/services/prism/internal/service/openid.go
+++ b/services/prism/internal/service/openid.go
@@ -1,0 +1,255 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+var (
+	// ErrCredentialSubjectMissing indicates the credential request lacked a subject DID.
+	ErrCredentialSubjectMissing = errors.New("service: credential request must include subject_did")
+	// ErrCredentialTypeMissing indicates the credential request lacked a credential type.
+	ErrCredentialTypeMissing = errors.New("service: credential request must include credential_type")
+	// ErrPresentationRequestInvalid indicates the authorization request was missing required fields.
+	ErrPresentationRequestInvalid = errors.New("service: presentation request requires client_id and redirect_uri")
+	// ErrPresentationSubmissionInvalid indicates the presentation submission payload was incomplete.
+	ErrPresentationSubmissionInvalid = errors.New("service: presentation submission requires nonce and subject_did")
+	// ErrPresentationNonceUnknown indicates a nonce was not previously issued.
+	ErrPresentationNonceUnknown = errors.New("service: presentation nonce not recognized")
+	// ErrPresentationNonceExpired indicates a nonce was issued but is no longer valid.
+	ErrPresentationNonceExpired = errors.New("service: presentation nonce has expired")
+)
+
+// CredentialRequest represents the JSON payload accepted by the OID4VCI credential endpoint.
+type CredentialRequest struct {
+	CredentialType string                 `json:"credential_type"`
+	SubjectDID     string                 `json:"subject_did"`
+	Format         string                 `json:"format"`
+	Claims         map[string]interface{} `json:"claims,omitempty"`
+	DIDComm        *DIDCommRegistration   `json:"didcomm,omitempty"`
+}
+
+// CredentialResponse is returned to the wallet when issuing a credential.
+type CredentialResponse struct {
+	Format     string                 `json:"format"`
+	Credential map[string]interface{} `json:"credential"`
+	Nonce      string                 `json:"nonce"`
+	DIDComm    *DIDCommChannel        `json:"didcomm,omitempty"`
+}
+
+// IssuedCredential captures metadata about issued credentials for auditing.
+type IssuedCredential struct {
+	Nonce           string    `json:"nonce"`
+	SubjectDID      string    `json:"subject_did"`
+	CredentialType  string    `json:"credential_type"`
+	Format          string    `json:"format"`
+	DIDCommEndpoint string    `json:"didcomm_endpoint,omitempty"`
+	IssuedAt        time.Time `json:"issued_at"`
+}
+
+// PresentationAuthorizationRequest captures the OIDC4VP authorization request parameters.
+type PresentationAuthorizationRequest struct {
+	ClientID               string                 `json:"client_id"`
+	RedirectURI            string                 `json:"redirect_uri"`
+	Scope                  []string               `json:"scope,omitempty"`
+	State                  string                 `json:"state,omitempty"`
+	PresentationDefinition map[string]interface{} `json:"presentation_definition,omitempty"`
+}
+
+// PresentationAuthorization represents the authorize response returned to the relying party.
+type PresentationAuthorization struct {
+	AuthorizationURL string    `json:"authorization_url"`
+	Nonce            string    `json:"nonce"`
+	ExpiresAt        time.Time `json:"expires_at"`
+}
+
+// PresentationSubmission represents the wallet callback payload with the verifiable presentation.
+type PresentationSubmission struct {
+	Nonce      string                 `json:"nonce"`
+	SubjectDID string                 `json:"subject_did"`
+	VPToken    map[string]interface{} `json:"vp_token"`
+}
+
+// PresentationRecord captures successful presentation verifications.
+type PresentationRecord struct {
+	Nonce       string    `json:"nonce"`
+	SubjectDID  string    `json:"subject_did"`
+	ClientID    string    `json:"client_id"`
+	RedirectURI string    `json:"redirect_uri"`
+	VerifiedAt  time.Time `json:"verified_at"`
+}
+
+type presentationNonce struct {
+	ClientID    string
+	RedirectURI string
+	ExpiresAt   time.Time
+}
+
+// IssueCredential synthesizes a minimal Verifiable Credential response for OID4VCI wallets.
+func (s *Service) IssueCredential(ctx context.Context, req CredentialRequest) (CredentialResponse, error) {
+	_ = ctx
+	if req.SubjectDID == "" {
+		return CredentialResponse{}, ErrCredentialSubjectMissing
+	}
+	if req.CredentialType == "" {
+		return CredentialResponse{}, ErrCredentialTypeMissing
+	}
+	format := req.Format
+	if format == "" {
+		format = "vc+sd-jwt"
+	}
+	credentialSubject := map[string]interface{}{"id": req.SubjectDID}
+	for k, v := range req.Claims {
+		credentialSubject[k] = v
+	}
+	issuedAt := s.now()
+	credential := map[string]interface{}{
+		"@context":          []string{"https://www.w3.org/2018/credentials/v1"},
+		"type":              []string{"VerifiableCredential", req.CredentialType},
+		"issuer":            "did:prism:issuer", // placeholder issuer DID
+		"issuanceDate":      issuedAt.Format(time.RFC3339),
+		"credentialSubject": credentialSubject,
+	}
+	nonce := uuid.NewString()
+	var didcommChannel *DIDCommChannel
+	if req.DIDComm != nil {
+		registration := *req.DIDComm
+		if registration.DID == "" {
+			registration.DID = req.SubjectDID
+		}
+		channel, err := s.RegisterDIDCommChannel(ctx, registration)
+		if err != nil {
+			return CredentialResponse{}, err
+		}
+		didcommChannel = &channel
+	}
+
+	s.mu.Lock()
+	s.issuedCredentials = append(s.issuedCredentials, IssuedCredential{
+		Nonce:           nonce,
+		SubjectDID:      req.SubjectDID,
+		CredentialType:  req.CredentialType,
+		Format:          format,
+		DIDCommEndpoint: endpointFromChannel(didcommChannel),
+		IssuedAt:        issuedAt,
+	})
+	s.mu.Unlock()
+
+	return CredentialResponse{
+		Format:     format,
+		Credential: credential,
+		Nonce:      nonce,
+		DIDComm:    didcommChannel,
+	}, nil
+}
+
+// BatchIssueCredential issues multiple credentials in one request per OID4VCI batch semantics.
+func (s *Service) BatchIssueCredential(ctx context.Context, requests []CredentialRequest) ([]CredentialResponse, error) {
+	responses := make([]CredentialResponse, 0, len(requests))
+	for _, req := range requests {
+		resp, err := s.IssueCredential(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+		responses = append(responses, resp)
+	}
+	return responses, nil
+}
+
+// AuthorizePresentation prepares an authorization request URL and stores a nonce for later verification.
+func (s *Service) AuthorizePresentation(ctx context.Context, req PresentationAuthorizationRequest) (PresentationAuthorization, error) {
+	_ = ctx
+	if req.ClientID == "" || req.RedirectURI == "" {
+		return PresentationAuthorization{}, ErrPresentationRequestInvalid
+	}
+	nonce := uuid.NewString()
+	expiresAt := s.now().Add(5 * time.Minute)
+
+	query := url.Values{}
+	query.Set("client_id", req.ClientID)
+	query.Set("response_type", "code")
+	query.Set("nonce", nonce)
+	if len(req.Scope) > 0 {
+		query.Set("scope", strings.Join(req.Scope, " "))
+	}
+	if req.State != "" {
+		query.Set("state", req.State)
+	}
+	authorizationURL := fmt.Sprintf("%s?%s", req.RedirectURI, query.Encode())
+
+	s.mu.Lock()
+	s.presentationNonces[nonce] = presentationNonce{
+		ClientID:    req.ClientID,
+		RedirectURI: req.RedirectURI,
+		ExpiresAt:   expiresAt,
+	}
+	s.mu.Unlock()
+
+	return PresentationAuthorization{
+		AuthorizationURL: authorizationURL,
+		Nonce:            nonce,
+		ExpiresAt:        expiresAt,
+	}, nil
+}
+
+// CompletePresentation verifies the nonce issued during authorization and records the presentation.
+func (s *Service) CompletePresentation(ctx context.Context, submission PresentationSubmission) (PresentationRecord, error) {
+	_ = ctx
+	if submission.Nonce == "" || submission.SubjectDID == "" {
+		return PresentationRecord{}, ErrPresentationSubmissionInvalid
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	req, ok := s.presentationNonces[submission.Nonce]
+	if !ok {
+		return PresentationRecord{}, ErrPresentationNonceUnknown
+	}
+	if s.now().After(req.ExpiresAt) {
+		delete(s.presentationNonces, submission.Nonce)
+		return PresentationRecord{}, ErrPresentationNonceExpired
+	}
+	delete(s.presentationNonces, submission.Nonce)
+
+	record := PresentationRecord{
+		Nonce:       submission.Nonce,
+		SubjectDID:  submission.SubjectDID,
+		ClientID:    req.ClientID,
+		RedirectURI: req.RedirectURI,
+		VerifiedAt:  s.now(),
+	}
+	s.presentationRecords = append(s.presentationRecords, record)
+	return record, nil
+}
+
+// IssuedCredentials returns a copy of the issued credential metadata.
+func (s *Service) IssuedCredentials() []IssuedCredential {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]IssuedCredential, len(s.issuedCredentials))
+	copy(out, s.issuedCredentials)
+	return out
+}
+
+// PresentationHistory returns a copy of the recorded presentation verifications.
+func (s *Service) PresentationHistory() []PresentationRecord {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]PresentationRecord, len(s.presentationRecords))
+	copy(out, s.presentationRecords)
+	return out
+}
+
+func endpointFromChannel(channel *DIDCommChannel) string {
+	if channel == nil {
+		return ""
+	}
+	return channel.Endpoint
+}


### PR DESCRIPTION
## Summary
- add OID4VCI issuance endpoints, OIDC4VP authorize/callback handlers, and DIDComm registration routes to the Prism HTTP API
- implement in-memory DIDComm agent registry with credential issuance, batch issuance, and presentation workflows in the service layer
- expand unit tests to cover issuance, presentation, and DIDComm flows through both service and HTTP layers

## Testing
- GOWORK=off go test ./services/prism/...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f540290bc8329bfcde2bf1f37d452)