### PR TITLE
Add lightweight vault tooling

### DIFF
--- a/vault/.gitignore
+++ b/vault/.gitignore
@@ -1,0 +1,7 @@
+logs/
+snapshots/
+attest/
+sealed/
+state/
+__pycache__/
+*.pyc

--- a/vault/README.md
+++ b/vault/README.md
@@ -1,0 +1,17 @@
+# Memory Vault Utilities
+
+This directory provides a minimal toolkit for maintaining an append-only, tamper-evident event log without relying on a blockchain. It implements the workflow described in the accompanying proposal:
+
+* `write_event.py` appends JSONL events that are chained together with SHA-256 hashes.
+* `snapshot.py` rolls the current day's log entries into a manifest that records a Merkle root and metadata.
+* `verify.py` recomputes hashes for a given day to confirm the manifest matches the stored log.
+
+At runtime the scripts create the following subdirectories, which are ignored by Git:
+
+* `logs/` – append-only JSONL event files (one per day)
+* `snapshots/` – daily snapshot manifests
+* `attest/` – minisign signatures for manifests
+* `sealed/` – age-encrypted snapshot archives
+* `state/` – writer state (e.g., the latest chain hash) and key material
+
+See the inline documentation in each script for usage details. Combine the scripts with external tools such as `minisign`, `age`, and OpenTimestamps to produce signed, sealed snapshots that can be rotated to off-site storage.

--- a/vault/snapshot.py
+++ b/vault/snapshot.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+import hashlib
+import json
+import pathlib
+from datetime import datetime, timezone
+
+def sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+ROOT = pathlib.Path(__file__).resolve().parent
+LOGS = ROOT / "logs"
+SNAPSHOTS = ROOT / "snapshots"
+SNAPSHOTS.mkdir(parents=True, exist_ok=True)
+
+def merkle_root(hashes: list[str]) -> str:
+    layer = hashes[:]
+    if not layer:
+        return "0" * 64
+    while len(layer) > 1:
+        nxt: list[str] = []
+        for idx in range(0, len(layer), 2):
+            left = layer[idx]
+            right = layer[idx + 1] if idx + 1 < len(layer) else layer[idx]
+            nxt.append(sha256((left + right).encode()))
+        layer = nxt
+    return layer[0]
+
+def collect_hashes(day: str) -> tuple[list[str], int | None]:
+    path = LOGS / f"{day}.jsonl"
+    if not path.exists():
+        return [], None
+    hashes: list[str] = []
+    with path.open(encoding="utf-8") as fh:
+        for line in fh:
+            obj = json.loads(line)
+            hashes.append(obj["chain_hash"])
+    return hashes, path.stat().st_size
+
+def main() -> None:
+    now = datetime.now(timezone.utc).isoformat()
+    day = now[:10]
+    hashes, size_bytes = collect_hashes(day)
+    root_hash = merkle_root(hashes)
+    manifest = {
+        "ts": now,
+        "day": day,
+        "entries": len(hashes),
+        "bytes": size_bytes or 0,
+        "merkle_root": root_hash,
+        "algo": "sha256",
+    }
+    out_file = SNAPSHOTS / f"{day}.manifest.json"
+    out_file.write_text(json.dumps(manifest, indent=2, sort_keys=True))
+    print(out_file)
+
+if __name__ == "__main__":
+    main()

--- a/vault/verify.py
+++ b/vault/verify.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+import hashlib
+
+def sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+ROOT = pathlib.Path(__file__).resolve().parent
+
+def rebuild_chain(day: str) -> tuple[list[str], str | None]:
+    log_path = ROOT / "logs" / f"{day}.jsonl"
+    if not log_path.exists():
+        return [], None
+
+    prev = "0" * 64
+    chain_hashes: list[str] = []
+    with log_path.open(encoding="utf-8") as fh:
+        for line in fh:
+            obj = json.loads(line)
+            base = {"ts": obj["ts"], "content": obj["content"]}
+            content_hash = sha256(json.dumps(base, separators=(",", ":"), sort_keys=True).encode())
+            if obj["content_hash"] != content_hash:
+                raise ValueError("content_hash mismatch")
+            expected = sha256((prev + content_hash).encode())
+            if obj["chain_hash"] != expected:
+                raise ValueError("chain_hash mismatch")
+            chain_hashes.append(expected)
+            prev = expected
+    return chain_hashes, prev
+
+def merkle_root(hashes: list[str]) -> str:
+    if not hashes:
+        return "0" * 64
+    layer = hashes[:]
+    while len(layer) > 1:
+        nxt: list[str] = []
+        for idx in range(0, len(layer), 2):
+            left = layer[idx]
+            right = layer[idx + 1] if idx + 1 < len(layer) else layer[idx]
+            nxt.append(sha256((left + right).encode()))
+        layer = nxt
+    return layer[0]
+
+def verify_day(day: str) -> None:
+    manifest_path = ROOT / "snapshots" / f"{day}.manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    chain_hashes, _ = rebuild_chain(day)
+    root = merkle_root(chain_hashes)
+    if root != manifest["merkle_root"]:
+        raise ValueError("merkle root mismatch")
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        sys.exit("usage: verify.py YYYY-MM-DD")
+
+    day = sys.argv[1]
+    try:
+        verify_day(day)
+    except FileNotFoundError as exc:
+        sys.exit(f"missing file: {exc}")
+    except ValueError as exc:
+        sys.exit(f"verification failed: {exc}")
+    print("VERIFIED")
+
+if __name__ == "__main__":
+    main()

--- a/vault/write_event.py
+++ b/vault/write_event.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+import json
+import hashlib
+import pathlib
+import sys
+from datetime import datetime, timezone
+
+ROOT = pathlib.Path(__file__).resolve().parent
+LOGS = ROOT / "logs"
+STATE = ROOT / "state"
+LOGS.mkdir(parents=True, exist_ok=True)
+STATE.mkdir(parents=True, exist_ok=True)
+LAST = STATE / "last_chain_hash.txt"
+
+def sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("usage: write_event.py '<content string or JSON>'", file=sys.stderr)
+        sys.exit(1)
+
+    raw = sys.argv[1]
+    try:
+        content = json.loads(raw)
+    except json.JSONDecodeError:
+        content = {"text": raw}
+
+    ts = datetime.now(timezone.utc).isoformat()
+    base = {"ts": ts, "content": content}
+
+    content_bytes = json.dumps(base, separators=(",", ":"), sort_keys=True).encode()
+    content_hash = sha256(content_bytes)
+
+    prev_hash = LAST.read_text().strip() if LAST.exists() else "0" * 64
+    chain_hash = sha256((prev_hash + content_hash).encode())
+
+    line = {
+        **base,
+        "content_hash": content_hash,
+        "prev_hash": prev_hash,
+        "chain_hash": chain_hash,
+    }
+
+    day = ts[:10]
+    out_file = LOGS / f"{day}.jsonl"
+    with out_file.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(line, separators=(",", ":"), sort_keys=True) + "\n")
+
+    LAST.write_text(chain_hash)
+    print(chain_hash)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add append-only event writer, snapshot builder, and verifier scripts under vault/
- document workflow and ignore runtime directories for the memory vault utilities

## Testing
- python -m compileall vault

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f5c1b46a08329ad862133749bca1a)