### PR TITLE
Add differentiable Amundson integrator for GKSL dynamics

### DIFF
--- a/quantum_lab/__init__.py
+++ b/quantum_lab/__init__.py
@@ -1,4 +1,4 @@
 """Quantum Lab package."""
-from quantum_lab.core import circuit, gates, measurement, noise, states
+from quantum_lab.core import circuit, gates, measurement, noise, open_system, states
 
-__all__ = ["circuit", "gates", "measurement", "noise", "states"]
+__all__ = ["circuit", "gates", "measurement", "noise", "open_system", "states"]

--- a/quantum_lab/core/open_system.py
+++ b/quantum_lab/core/open_system.py
@@ -1,0 +1,128 @@
+"""PyTorch utilities for Lindblad-style open quantum system integration."""
+from __future__ import annotations
+
+from typing import Callable, Iterable, Sequence
+
+import torch
+from torch import Tensor, nn
+
+
+Channel = Callable[[Tensor], Tensor]
+
+
+def dagger(tensor: Tensor) -> Tensor:
+    """Return the conjugate transpose of ``tensor``."""
+
+    return tensor.conj().transpose(-1, -2)
+
+
+def project_psd_trace1(rho: Tensor, eps: float = 1e-12) -> Tensor:
+    """Project ``rho`` onto the positive semidefinite, trace-1 manifold."""
+
+    rho = 0.5 * (rho + dagger(rho))
+    evals, evecs = torch.linalg.eigh(rho)
+    evals = torch.clamp(evals, min=0.0)
+    trace_value = evals.sum()
+    if trace_value.item() < eps:
+        evals = torch.zeros_like(evals)
+        evals[-1] = 1.0
+        trace_value = evals.sum()
+    evals = evals / trace_value
+    diag = torch.diag(evals).to(rho.dtype)
+    return evecs @ diag @ dagger(evecs)
+
+
+def gksl_rhs(rho: Tensor, hamiltonian: Tensor, lindblad_ops: Sequence[Tensor]) -> Tensor:
+    """Compute the GKSL right-hand side for ``rho``."""
+
+    unitary = -1j * (hamiltonian @ rho - rho @ hamiltonian)
+    dissip = torch.zeros_like(rho)
+    for L in lindblad_ops:
+        dissip = dissip + L @ rho @ dagger(L) - 0.5 * (dagger(L) @ L @ rho + rho @ dagger(L) @ L)
+    return unitary + dissip
+
+
+def apply_channel_mix(rho: Tensor, channels: Iterable[Channel], weights: Tensor) -> Tensor:
+    """Apply a convex combination of channels to ``rho`` with ``weights``."""
+
+    if rho.ndim != 2:
+        raise ValueError("rho must be a matrix (rank-2 tensor)")
+    if weights.ndim != 1:
+        raise ValueError("weights must be a 1D tensor")
+
+    norm = weights.sum()
+    if not torch.isclose(norm, torch.as_tensor(1.0, dtype=weights.dtype, device=weights.device)):
+        weights = weights / norm
+
+    channel_list = tuple(channels)
+    if len(channel_list) != len(weights):
+        raise ValueError("weights and channels must have the same length")
+
+    mixed = torch.zeros_like(rho)
+    for weight, channel in zip(weights, channel_list):
+        mixed = mixed + weight.to(rho.dtype) * channel(rho)
+    return mixed
+
+
+def kraus_channel(kraus_ops: Sequence[Tensor]) -> Channel:
+    """Create a channel callable from Kraus operators."""
+
+    kraus_ops = tuple(op.clone() for op in kraus_ops)
+
+    def channel(rho: Tensor) -> Tensor:
+        result = torch.zeros_like(rho)
+        for op in kraus_ops:
+            result = result + op @ rho @ dagger(op)
+        return result
+
+    return channel
+
+
+class AmundsonIntegrator(nn.Module):
+    """Differentiable integrator for the augmented GKSL dynamics."""
+
+    def __init__(
+        self,
+        hamiltonian: Tensor,
+        lindblad_ops: Sequence[Tensor],
+        channels: Sequence[Channel] | None = None,
+        dt: float = 0.01,
+        tau: float = 0.02,
+        lam: float = 0.1,
+    ) -> None:
+        super().__init__()
+        self.register_buffer("hamiltonian", hamiltonian.clone())
+        self.lindblad_ops = nn.ParameterList(
+            [nn.Parameter(op.clone(), requires_grad=False) for op in lindblad_ops]
+        )
+        self.channels = tuple(channels) if channels is not None else tuple()
+        self.dt = dt
+        self.tau = tau
+        self.lam = lam
+
+    def forward(self, rho: Tensor, weights: Tensor | None = None) -> Tensor:
+        """Advance ``rho`` by one integrator step."""
+
+        lindblad_ops = [op for op in self.lindblad_ops]
+        gksl = gksl_rhs(rho, self.hamiltonian, lindblad_ops)
+        rho_pred = project_psd_trace1(rho + self.tau * gksl)
+        temporal = rho_pred - rho
+
+        if self.channels and weights is None:
+            raise ValueError("weights must be provided when channels are defined")
+
+        w_term = torch.zeros_like(rho)
+        if self.channels:
+            rho_mix = apply_channel_mix(rho, self.channels, weights)
+            w_term = rho_mix - rho
+
+        rho_next = rho + self.dt * (gksl + self.lam * temporal + w_term)
+        return project_psd_trace1(rho_next)
+
+    def step_sequence(self, rho: Tensor, weights_sequence: Iterable[Tensor]) -> Tensor:
+        """Integrate ``rho`` over a sequence of weight vectors."""
+
+        state = rho
+        for weights in weights_sequence:
+            state = self.forward(state, weights)
+        return state

--- a/tests/test_amundson_integrator_module.py
+++ b/tests/test_amundson_integrator_module.py
@@ -1,0 +1,96 @@
+from pathlib import Path
+import sys
+
+import torch
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from quantum_lab.core.open_system import (  # noqa: E402
+    AmundsonIntegrator,
+    apply_channel_mix,
+    dagger,
+    kraus_channel,
+    project_psd_trace1,
+)
+
+
+def _two_level_setup():
+    dtype = torch.cdouble
+    sz = torch.tensor([[1.0, 0.0], [0.0, -1.0]], dtype=dtype)
+    hamiltonian = 0.5 * sz
+
+    sqrt = torch.sqrt
+    lindblad_ops = [
+        sqrt(torch.tensor(0.02, dtype=torch.double)).item()
+        * torch.tensor([[1.0, 0.0], [0.0, -1.0]], dtype=dtype),
+        sqrt(torch.tensor(0.04, dtype=torch.double)).item()
+        * torch.tensor([[0.0, 1.0], [0.0, 0.0]], dtype=dtype),
+    ]
+
+    gamma = 0.05
+    sqrt_1_minus_gamma = torch.sqrt(torch.tensor(1 - gamma, dtype=torch.double)).item()
+    sqrt_gamma = torch.sqrt(torch.tensor(gamma, dtype=torch.double)).item()
+    kraus_amp = (
+        torch.tensor([[1.0, 0.0], [0.0, sqrt_1_minus_gamma]], dtype=dtype),
+        torch.tensor([[0.0, sqrt_gamma], [0.0, 0.0]], dtype=dtype),
+    )
+
+    p_dephase = 0.03
+    sqrt_keep = torch.sqrt(torch.tensor(1 - p_dephase, dtype=torch.double)).item()
+    sqrt_flip = torch.sqrt(torch.tensor(p_dephase, dtype=torch.double)).item()
+    kraus_dephase = (
+        sqrt_keep * torch.eye(2, dtype=dtype),
+        sqrt_flip * torch.tensor([[1.0, 0.0], [0.0, -1.0]], dtype=dtype),
+    )
+
+    channels = [kraus_channel(kraus_dephase), kraus_channel(kraus_amp)]
+    return hamiltonian, lindblad_ops, channels
+
+
+def test_project_psd_trace1_returns_valid_density():
+    dtype = torch.cdouble
+    rho = torch.tensor([[1.2, 0.3 - 0.1j], [0.3 + 0.1j, -0.1]], dtype=dtype)
+    projected = project_psd_trace1(rho)
+    assert torch.allclose(projected, dagger(projected), atol=1e-8)
+    trace = torch.trace(projected).real.item()
+    assert abs(trace - 1.0) < 1e-10
+    eigvals = torch.linalg.eigvalsh(projected)
+    assert torch.all(eigvals >= -1e-10)
+
+
+def test_amundson_integrator_step_preserves_density_properties():
+    hamiltonian, lindblad_ops, channels = _two_level_setup()
+    rho0 = torch.tensor([[1.0, 0.0], [0.0, 0.0]], dtype=torch.cdouble)
+    integrator = AmundsonIntegrator(hamiltonian, lindblad_ops, channels, dt=0.005, tau=0.01, lam=0.2)
+    weights = torch.tensor([0.6, 0.4], dtype=torch.double)
+    rho1 = integrator(rho0, weights)
+    assert torch.allclose(rho1, dagger(rho1), atol=1e-8)
+    trace = torch.trace(rho1).real.item()
+    assert abs(trace - 1.0) < 1e-10
+    eigvals = torch.linalg.eigvalsh(rho1)
+    assert torch.all(eigvals >= -1e-10)
+
+
+def test_amundson_integrator_is_autograd_friendly():
+    hamiltonian, lindblad_ops, channels = _two_level_setup()
+    rho0 = torch.tensor([[1.0, 0.0], [0.0, 0.0]], dtype=torch.cdouble)
+    integrator = AmundsonIntegrator(hamiltonian, lindblad_ops, channels, dt=0.002, tau=0.01, lam=0.15)
+    weights_logits = torch.tensor([0.3, -0.1], dtype=torch.double, requires_grad=True)
+    weights = torch.softmax(weights_logits, dim=0)
+    rho1 = integrator(rho0, weights)
+    loss = rho1.abs().sum()
+    loss.backward()
+    assert weights_logits.grad is not None
+    assert torch.all(torch.isfinite(weights_logits.grad))
+
+
+def test_apply_channel_mix_normalizes_weights():
+    _, _, channels = _two_level_setup()
+    rho0 = torch.tensor([[0.7, 0.1], [0.1, 0.3]], dtype=torch.cdouble)
+    weights = torch.tensor([0.3, 0.3], dtype=torch.double)
+    mixed = apply_channel_mix(rho0, channels, weights)
+    manual_weights = torch.tensor([0.5, 0.5], dtype=torch.double)
+    mixed_manual = apply_channel_mix(rho0, channels, manual_weights)
+    assert torch.allclose(mixed, mixed_manual, atol=1e-8)


### PR DESCRIPTION
## Summary
- add a PyTorch-based open system toolkit implementing the augmented GKSL update with temporal and causal mixing terms
- expose the new module through the quantum_lab package exports
- cover the integrator with unit tests validating projection, density preservation, and autograd support

## Testing
- `pytest tests/test_amundson_integrator_module.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f5e3cb1f08329b71614620b73420d)