### PR TITLE
Fix registry corruption and harden sync script

### DIFF
--- a/network/registry.json
+++ b/network/registry.json
@@ -1,6 +1,7 @@
-{"updated": null}
 {
   "network": "blackroad-mesh",
+  "version": 1,
+  "updated": "2025-10-27T15:08:00Z",
   "nodes": [
     {
       "id": "alice-pi400",
@@ -22,11 +23,5 @@
       "supervisor": "alice-pi400",
       "last_seen": "2025-10-27T15:08:00Z"
     }
-  ],
-  "updated": "2025-10-27T15:08:00Z",
-  "version": null
-{
-  "network": "blackroad-mesh",
-  "nodes": [],
-  "updated": null
+  ]
 }

--- a/usr/local/bin/blackroad-sync.sh
+++ b/usr/local/bin/blackroad-sync.sh
@@ -1,101 +1,136 @@
-#!/bin/bash
-# BlackRoad Agent Sync Script — runs on Alice (Pi 400)
-# Keeps all nodes in sync with the master GitHub repo
-
-set -euo pipefail
-
-REPO_DIR="/home/pi/blackroad-prism-console"
-REGISTRY_FILE="$REPO_DIR/network/registry.json"
-REMOTE_REPO="https://github.com/blackboxprogramming/blackroad-prism-console.git"
-NODES_FILE="$REPO_DIR/network/nodes.txt" # list of node hostnames or IPs
-
-cd "$REPO_DIR" || exit 1
-
-if ! git remote get-url origin >/dev/null 2>&1; then
-    git remote add origin "$REMOTE_REPO"
-fi
-
-echo "[BlackRoad] Checking for updates..."
-git fetch origin main
-
-LOCAL_HASH=$(git rev-parse HEAD)
-REMOTE_HASH=$(git rev-parse origin/main)
-
-if [ "$LOCAL_HASH" != "$REMOTE_HASH" ]; then
-    echo "[BlackRoad] New commit found, pulling updates..."
-    git pull origin main
-    TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-
-    # Log update to registry
-    if [ -f "$REGISTRY_FILE" ]; then
-        jq --arg time "$TIMESTAMP" '.updated = $time' "$REGISTRY_FILE" > "$REGISTRY_FILE.tmp" && mv "$REGISTRY_FILE.tmp" "$REGISTRY_FILE"
-    else
-        mkdir -p "$(dirname "$REGISTRY_FILE")"
-        printf '{"updated":"%s"}\n' "$TIMESTAMP" > "$REGISTRY_FILE"
-    fi
-
-    echo "[BlackRoad] Broadcasting update to nodes..."
-    if [ -f "$NODES_FILE" ]; then
-        while IFS= read -r NODE; do
-            [ -z "$NODE" ] && continue
-            case "$NODE" in 
-                \#*) continue ;;
-            esac
-            echo "  → Syncing $NODE"
-            ssh pi@"$NODE" "cd $REPO_DIR && git fetch origin main && git reset --hard origin/main && sudo systemctl restart blackroad-agent" &
-        done < "$NODES_FILE"
-        wait
-    else
-        echo "[BlackRoad] No nodes file found at $NODES_FILE."
-    fi
-else
-    echo "[BlackRoad] No new updates."
 #!/usr/bin/env bash
+# BlackRoad Agent Sync Script — runs on Alice (Pi 400)
+# Keeps all nodes in sync with the master GitHub repo and maintains the registry
+
 set -euo pipefail
 
 REPO_DIR=${REPO_DIR:-/home/pi/blackroad-prism-console}
 REGISTRY_FILE=${REGISTRY_FILE:-$REPO_DIR/network/registry.json}
 REPORT_DIR=${REPORT_DIR:-$REPO_DIR/network/reports}
+NODES_FILE=${NODES_FILE:-$REPO_DIR/network/nodes.txt}
 REMOTE_NAME=${REMOTE_NAME:-origin}
 REMOTE_BRANCH=${REMOTE_BRANCH:-main}
+REMOTE_URL=${REMOTE_URL:-https://github.com/blackboxprogramming/blackroad-prism-console.git}
+NETWORK_ID=${NETWORK_ID:-blackroad-mesh}
+REGISTRY_VERSION=${REGISTRY_VERSION:-1}
 
 log() {
   printf '[BlackRoad] %s\n' "$*"
 }
 
-cd "$REPO_DIR"
-
-log "Refreshing repository state from ${REMOTE_NAME}/${REMOTE_BRANCH}..."
-git fetch "$REMOTE_NAME" "$REMOTE_BRANCH"
-git checkout "$REMOTE_BRANCH"
-git pull --ff-only "$REMOTE_NAME" "$REMOTE_BRANCH"
-
-log "Merging incoming node reports..."
-mkdir -p "$REPORT_DIR"
-TMP_REG="$REPO_DIR/network/registry.tmp.json"
-trap 'rm -f "$TMP_REG" "$TMP_REG.tmp"' EXIT
-
-jq -n '{network: "blackroad-mesh", nodes: []}' > "$TMP_REG"
-
-shopt -s nullglob
-for f in "$REPORT_DIR"/*.json; do
-  if jq empty "$f" >/dev/null 2>&1; then
-    jq --slurpfile node "$f" '.nodes += $node' "$TMP_REG" > "$TMP_REG.tmp" && mv "$TMP_REG.tmp" "$TMP_REG"
-  else
-    log "Skipping invalid report: $f"
+ensure_remote() {
+  if git remote get-url "$REMOTE_NAME" >/dev/null 2>&1; then
+    return
   fi
-done
-shopt -u nullglob
+  log "Remote $REMOTE_NAME not found; adding $REMOTE_URL"
+  git remote add "$REMOTE_NAME" "$REMOTE_URL"
+}
 
-jq --arg time "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
-   '.updated = $time | .nodes |= sort_by(.id)' \
-   "$TMP_REG" > "$TMP_REG.tmp"
-mv "$TMP_REG.tmp" "$REGISTRY_FILE"
+update_checkout() {
+  ensure_remote
+  log "Refreshing repository state from ${REMOTE_NAME}/${REMOTE_BRANCH}..."
+  git fetch "$REMOTE_NAME" "$REMOTE_BRANCH"
 
-if git diff --quiet -- "$REGISTRY_FILE"; then
-  log "Registry unchanged; nothing to commit."
-else
+  local current_branch
+  current_branch=$(git rev-parse --abbrev-ref HEAD)
+  if [[ "$current_branch" != "$REMOTE_BRANCH" ]]; then
+    log "Switching to $REMOTE_BRANCH branch..."
+    git checkout "$REMOTE_BRANCH"
+  fi
+
+  local local_hash remote_hash
+  local_hash=$(git rev-parse HEAD)
+  remote_hash=$(git rev-parse "${REMOTE_NAME}/${REMOTE_BRANCH}")
+
+  if [[ "$local_hash" != "$remote_hash" ]]; then
+    log "Fast-forwarding local checkout to latest commit..."
+    git pull --ff-only "$REMOTE_NAME" "$REMOTE_BRANCH"
+  else
+    log "Local checkout already up to date."
+  fi
+}
+
+merge_reports() {
+  log "Merging incoming node reports into registry..."
+  mkdir -p "$(dirname "$REGISTRY_FILE")" "$REPORT_DIR"
+
+  local tmp_reg tmp_out
+  tmp_reg=$(mktemp "$REPO_DIR/network/registry.XXXXXX")
+  tmp_out="${tmp_reg}.tmp"
+  trap 'rm -f "$tmp_reg" "$tmp_out"' EXIT
+
+  jq -n \
+    --arg network "$NETWORK_ID" \
+    --arg version "$REGISTRY_VERSION" \
+    '{
+      network: $network,
+      version: (try ($version | tonumber) catch $version),
+      nodes: []
+    }' > "$tmp_reg"
+
+  shopt -s nullglob
+  for report in "$REPORT_DIR"/*.json; do
+    if jq empty "$report" >/dev/null 2>&1; then
+      jq --slurpfile node "$report" '.nodes += $node' "$tmp_reg" > "$tmp_out"
+      mv "$tmp_out" "$tmp_reg"
+    else
+      log "Skipping invalid report: $report"
+    fi
+  done
+  shopt -u nullglob
+
+  jq \
+    --arg time "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+    '.updated = $time | .nodes |= sort_by(.id)' \
+    "$tmp_reg" > "$tmp_out"
+  mv "$tmp_out" "$REGISTRY_FILE"
+  rm -f "$tmp_reg" "$tmp_out"
+  trap - EXIT
+}
+
+commit_registry_if_needed() {
+  if git diff --quiet -- "$REGISTRY_FILE"; then
+    log "Registry unchanged; nothing to commit."
+    return
+  fi
+
+  local timestamp
+  timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
   git add "$REGISTRY_FILE"
-  git commit -m "update: merged node reports $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  git commit -m "chore: merge node reports $timestamp"
   git push "$REMOTE_NAME" "$REMOTE_BRANCH"
-fi
+  log "Registry changes committed and pushed."
+}
+
+broadcast_updates() {
+  if [[ ! -f "$NODES_FILE" ]]; then
+    log "No nodes file found at $NODES_FILE; skipping broadcast."
+    return
+  fi
+
+  local nodes_started=false
+  while IFS= read -r node; do
+    [[ -z "$node" || "$node" == \#* ]] && continue
+    if [[ "$nodes_started" = false ]]; then
+      log "Broadcasting repo updates to fleet nodes..."
+      nodes_started=true
+    fi
+    log "  → Syncing $node"
+    ssh -o BatchMode=yes -o ConnectTimeout=10 "pi@$node" \
+      "cd $REPO_DIR && git fetch $REMOTE_NAME $REMOTE_BRANCH && git reset --hard ${REMOTE_NAME}/${REMOTE_BRANCH} && sudo systemctl restart blackroad-agent" &
+  done < "$NODES_FILE"
+  wait || true
+}
+
+main() {
+  cd "$REPO_DIR"
+
+  update_checkout
+  merge_reports
+  commit_registry_if_needed
+  broadcast_updates
+
+  log "Sync complete."
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- restore `network/registry.json` to a single valid snapshot with node metadata and versioning
- rebuild `usr/local/bin/blackroad-sync.sh` to merge node reports, ensure the remote is configured, and fan out updates cleanly

## Testing
- bash -n usr/local/bin/blackroad-sync.sh
- jq empty network/registry.json

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f6aba160c8329b844a21fe4339f70)