### PR TITLE
Add CLI utilities for zeta pitch and phase flow experiments

### DIFF
--- a/docs/riemann_pitch.md
+++ b/docs/riemann_pitch.md
@@ -1,58 +1,86 @@
-# Amundson–ζ Pitch Field
+# Amundson–ζ Pitch (c_ζ)
 
-The Amundson spiral pitch captures how quickly a complex trajectory grows radially
-compared to its angular sweep.  For an analytic function $f$ sampled along a path
-$\gamma(t)$ we write
+Given $f(s) = \zeta(s)$ on $\Re(s) = \tfrac12$, define
+\[
+  c_\zeta(t) = \frac{\frac{\mathrm d}{\mathrm dt} \ln \lvert \zeta(\tfrac12 + it)\rvert}{\frac{\mathrm d}{\mathrm dt} \arg \zeta(\tfrac12 + it)}
+\]
+whenever the denominator is non-zero.
+
+**Rationale**
+
+- The argument principle relates the winding of $\arg \zeta$ around zeros to zero counts.
+- $c_\zeta$ is the ratio of radial growth to angular sweep of $\zeta(s)$ as $s$ moves vertically.
+- Near zeros both numerator and denominator are governed by $\zeta'/\zeta$; $c_\zeta$ captures the local geometry in a scalar.
+
+**What to look for**
+
+- Empirical distribution of $c_\zeta$ between consecutive zeros.
+- Scaling of $c_\zeta$ statistics vs. zero height.
+- Correlation between spikes in $c_\zeta$ and zero spacing (GUE heuristics).
+
+No claim on the Riemann Hypothesis is made; this is a geometric diagnostic to organise data.
+
+---
+
+## Background
+
+The Amundson spiral pitch captures how quickly a complex trajectory grows radially compared
+with its angular sweep.  For an analytic function $f$ sampled along a path $\gamma(t)$ we write
 \[
   c_f(t) = \frac{\frac{\mathrm d}{\mathrm dt} \ln \lvert f(\gamma(t))\rvert}{\frac{\mathrm d}{\mathrm dt} \arg f(\gamma(t))},
 \]
-whenever the denominator is non-zero.  On the Riemann critical line the path is
-$s(t) = \tfrac12 + it$ and we can express derivatives through the logarithmic
-slope of $\zeta$:
+whenever the denominator is non-zero.  On the Riemann critical line the path is $s(t) = \tfrac12 + it$,
+and the logarithmic derivative of $\zeta$ decomposes neatly:
 \[
-  \frac{\mathrm d}{\mathrm dt} \log \zeta(s(t)) = \frac{\mathrm d}{\mathrm dt}\big(\ln \lvert \zeta(s(t))\rvert + i\,\arg \zeta(s(t))\big)
+  \frac{\mathrm d}{\mathrm dt} \log \zeta(s(t))
+  = \frac{\mathrm d}{\mathrm dt}\big(\ln \lvert \zeta(s(t))\rvert + i\,\arg \zeta(s(t))\big)
   = i\,\frac{\zeta'(s(t))}{\zeta(s(t))}.
 \]
-The real part controls radial growth, the imaginary part controls angular motion,
-and their ratio is the pitch $c_\zeta(t)$.
+The real part controls radial growth, the imaginary part controls angular motion, and their ratio is the pitch $c_\zeta(t)$.
 
-## Sampling workflow
+## Using the tooling
 
-The module `tools.number_theory.zeta_pitch` contains helpers to evaluate the
-pitch numerically with only `mpmath` as a dependency.  Typical usage:
+The module `tools.number_theory.zeta_pitch` provides both a Python API and a command-line harness
+for sampling the pitch with only `mpmath` (and optionally Matplotlib) as dependencies.
+
+Typical Python usage mirrors the previous helper-centric workflow:
 
 ```python
 from tools.number_theory import zeta_pitch
 
-# Sample a uniform grid on the critical line.
 samples = zeta_pitch.sample_interval(14.0, 40.0, num_points=512)
-
-# Persist the raw data for further analysis.
 zeta_pitch.write_csv(samples, "riemann_pitch.csv")
-
-# Optionally visualise the pitch next to |ζ| (requires matplotlib).
 zeta_pitch.plot_pitch(samples, path="riemann_pitch.png")
 ```
 
-Each sample records $t$, $\zeta(\tfrac12 + it)$, the logarithmic derivative, and
-the resulting pitch.  Near zeros the denominator approaches zero, so the pitch
-exhibits spikes whose distribution can be studied across zero gaps.
+The `write_csv` helper records $t$, $\zeta(\tfrac12 + it)$, the unwrapped phase, derivatives of
+$\ln |\zeta|$ and $\arg \zeta$, plus the resulting pitch $c_\zeta$.  Near zeros the denominator
+approaches zero, so the pitch exhibits spikes whose distribution can be studied across zero gaps.
+
+For a standalone run (matching the internal "paste-ready" script) install the numerical
+dependencies and invoke the CLI:
+
+```bash
+pip install mpmath matplotlib
+python tools/number_theory/zeta_pitch.py --tmin 10 --tmax 200 --n 4000 \
+  --csv data/zeta/pitch_10_200.csv --png data/zeta/pitch_10_200.png
+```
+
+This will materialise a CSV containing columns `[t, real, imag, logabs, theta_unwrapped, dlog_dt,
+dtheta_dt, c_pitch]` and optionally a PNG visualisation of $c_\zeta$ over the sampled interval.
 
 ## Relation to the argument principle
 
-Writing $\log \zeta$ in terms of magnitude and phase shows that the pitch is an
-observable derived from the same data appearing in the argument principle.  For
-an integration contour crossing successive zeros, both $\ln \lvert \zeta \rvert$
-and $\arg \zeta$ exhibit sawtooth behaviour.  The pitch compresses their joint
-dynamics into a single scalar field that highlights how sharply the phase winds
-relative to radial motion.
+Writing $\log \zeta$ in terms of magnitude and phase shows that the pitch is an observable derived
+from the same data appearing in the argument principle.  For an integration contour crossing
+successive zeros, both $\ln \lvert \zeta \rvert$ and $\arg \zeta$ exhibit sawtooth behaviour.  The
+pitch compresses their joint dynamics into a single scalar field that highlights how sharply the
+phase winds relative to radial motion.
 
 Investigations suggested in the Riemann brief include:
 
 * comparing the distribution of $c_\zeta(t)$ between consecutive zeros,
 * measuring low-order moments of $c_\zeta$ against zero spacing statistics, and
-* rescaling samples to probe whether the pitch stabilises to universal limits
-  (GUE heuristics).
+* rescaling samples to probe whether the pitch stabilises to universal limits (GUE heuristics).
 
-The `zeta_pitch` module exists to make these experiments painless: evaluate,
-save, and explore.
+The `zeta_pitch` tooling exists to make these experiments painless: evaluate, save, and explore.

--- a/tools/number_theory/zeta_pitch.py
+++ b/tools/number_theory/zeta_pitch.py
@@ -1,7 +1,7 @@
 """Utilities for sampling the Amundson pitch of the Riemann zeta function.
 
 The *pitch* associated to a complex trajectory describes the ratio between
-radial growth and angular sweep of the image curve.  For an analytic function
+radial growth and angular sweep of the image curve. For an analytic function
 ``f`` evaluated along the critical line ``s(t) = 1/2 + i t`` we can express the
 pitch purely in terms of the logarithmic derivative of ``f``:
 
@@ -10,18 +10,19 @@ pitch purely in terms of the logarithmic derivative of ``f``:
     c_f(t) = \frac{\mathrm d \ln |f(s(t))| / \mathrm d t}{\mathrm d \arg f(s(t)) / \mathrm d t}.
 
 This module provides helpers to evaluate ``c_f`` for the Riemann zeta function
-``ζ`` using modest numerical precision.  The implementation relies only on
-``mpmath`` and Matplotlib (for optional plotting).
+``ζ`` using modest numerical precision. The implementation relies only on
+``mpmath`` and Matplotlib (for optional plotting) and now includes a command
+line harness that mirrors the standalone script used in exploratory notebooks.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from pathlib import Path
-from typing import Iterable, List, Sequence
-
+import argparse
 import csv
 import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Sequence, Tuple
 
 import mpmath as mp
 
@@ -29,6 +30,8 @@ try:  # Optional plotting dependency.
     import matplotlib.pyplot as plt
 except Exception:  # pragma: no cover - matplotlib is optional.
     plt = None
+
+PitchArrays = Tuple[List[float], List[float], List[float], List[float], List[float], List[float]]
 
 
 @dataclass(frozen=True)
@@ -52,6 +55,27 @@ class ZetaPitchSample:
 
         return math.atan2(self.zeta.imag, self.zeta.real)
 
+    @property
+    def log_magnitude(self) -> float:
+        """Return ``log |ζ(1/2 + i t)|`` with ``-inf`` at zeros."""
+
+        magnitude = self.magnitude
+        return math.log(magnitude) if magnitude > 0 else float("-inf")
+
+    @property
+    def dlog_dt(self) -> float:
+        """Return the derivative of ``log |ζ|`` when available."""
+
+        value = self.log_derivative.real
+        return value if math.isfinite(value) else math.nan
+
+    @property
+    def dtheta_dt(self) -> float:
+        """Return the derivative of ``arg ζ`` when available."""
+
+        value = self.log_derivative.imag
+        return value if math.isfinite(value) else math.nan
+
 
 def _zeta_at(t: float) -> complex:
     """Evaluate ``ζ`` on the critical line with high precision."""
@@ -69,19 +93,27 @@ def _zeta_time_derivative(t: float, h: float) -> complex:
     return complex((z_plus - z_minus) / (2 * h))
 
 
-def _pitch_from_values(zeta_val: complex, d_zeta_dt: complex) -> float:
-    """Compute the Amundson pitch from ``ζ`` and its time derivative."""
+def _pitch_from_log_derivative(log_derivative: complex) -> float:
+    """Compute the Amundson pitch from the logarithmic derivative."""
+
+    real = log_derivative.real
+    imag = log_derivative.imag
+    if not (math.isfinite(real) and math.isfinite(imag)):
+        return math.nan
+    if abs(imag) <= 1e-12:
+        return math.nan
+    return real / imag
+
+
+def _pitch_from_values(zeta_val: complex, d_zeta_dt: complex) -> tuple[complex, float]:
+    """Return ``(log_derivative, pitch)`` computed from ``ζ`` and its derivative."""
 
     if zeta_val == 0:
-        return math.inf
+        nan = float("nan")
+        return complex(nan, nan), math.nan
 
     log_derivative = d_zeta_dt / zeta_val
-    # Along ``s = 1/2 + i t`` we have ``d/dt log ζ = log_derivative``.
-    numerator = log_derivative.real
-    denominator = log_derivative.imag
-    if denominator == 0:
-        return math.inf if numerator > 0 else -math.inf
-    return numerator / denominator
+    return log_derivative, _pitch_from_log_derivative(log_derivative)
 
 
 def sample_zeta_pitch(
@@ -100,22 +132,25 @@ def sample_zeta_pitch(
         A list of :class:`ZetaPitchSample` entries ordered as ``t_values``.
     """
 
-    mp.mp.dps = mp_dps
-    samples: List[ZetaPitchSample] = []
-    for t in t_values:
-        zeta_val = _zeta_at(t)
-        d_zeta_dt = _zeta_time_derivative(t, h)
-        log_derivative = d_zeta_dt / zeta_val if zeta_val != 0 else complex("nan")
-        pitch = _pitch_from_values(zeta_val, d_zeta_dt)
-        samples.append(
-            ZetaPitchSample(
-                t=float(t),
-                zeta=zeta_val,
-                log_derivative=log_derivative,
-                pitch=pitch,
+    old_dps = mp.mp.dps
+    mp.mp.dps = max(old_dps, mp_dps)
+    try:
+        samples: List[ZetaPitchSample] = []
+        for t in t_values:
+            zeta_val = _zeta_at(t)
+            d_zeta_dt = _zeta_time_derivative(t, h)
+            log_derivative, pitch = _pitch_from_values(zeta_val, d_zeta_dt)
+            samples.append(
+                ZetaPitchSample(
+                    t=float(t),
+                    zeta=zeta_val,
+                    log_derivative=log_derivative,
+                    pitch=pitch,
+                )
             )
-        )
-    return samples
+        return samples
+    finally:
+        mp.mp.dps = old_dps
 
 
 def sample_interval(
@@ -135,33 +170,62 @@ def sample_interval(
     return sample_zeta_pitch(grid, h=h, mp_dps=mp_dps)
 
 
+def _unwrap_phases(phases: Sequence[float]) -> List[float]:
+    if not phases:
+        return []
+    unwrapped = [phases[0]]
+    offset = 0.0
+    for idx in range(1, len(phases)):
+        delta = phases[idx] - phases[idx - 1]
+        while delta <= -math.pi:
+            delta += 2 * math.pi
+            offset += 2 * math.pi
+        while delta > math.pi:
+            delta -= 2 * math.pi
+            offset -= 2 * math.pi
+        unwrapped.append(phases[idx] + offset)
+    return unwrapped
+
+
+def _format_finite(value: float) -> float | str:
+    return value if math.isfinite(value) else ""
+
+
 def write_csv(samples: Iterable[ZetaPitchSample], path: Path | str) -> None:
     """Persist ``ζ`` pitch samples to ``path`` as CSV."""
 
-    fieldnames = ["t", "real", "imag", "log_derivative_real", "log_derivative_imag", "pitch"]
+    sample_list = list(samples)
+    phases = _unwrap_phases([sample.phase for sample in sample_list])
+    fieldnames = [
+        "t",
+        "real",
+        "imag",
+        "logabs",
+        "theta_unwrapped",
+        "dlog_dt",
+        "dtheta_dt",
+        "c_pitch",
+    ]
     with Path(path).open("w", newline="") as handle:
         writer = csv.DictWriter(handle, fieldnames=fieldnames)
         writer.writeheader()
-        for sample in samples:
+        for sample, theta in zip(sample_list, phases):
             writer.writerow(
                 {
-                    "t": sample.t,
-                    "real": sample.zeta.real,
-                    "imag": sample.zeta.imag,
-                    "log_derivative_real": sample.log_derivative.real,
-                    "log_derivative_imag": sample.log_derivative.imag,
-                    "pitch": sample.pitch,
+                    "t": float(sample.t),
+                    "real": float(sample.zeta.real),
+                    "imag": float(sample.zeta.imag),
+                    "logabs": float(sample.log_magnitude),
+                    "theta_unwrapped": float(theta),
+                    "dlog_dt": _format_finite(sample.dlog_dt),
+                    "dtheta_dt": _format_finite(sample.dtheta_dt),
+                    "c_pitch": _format_finite(sample.pitch),
                 }
             )
 
 
 def plot_pitch(samples: Sequence[ZetaPitchSample], *, path: Path | str | None = None) -> None:
-    """Plot ``c_ζ(t)`` for visual inspection.
-
-    The plot shows the pitch together with the magnitude of ``ζ``.  When
-    ``path`` is ``None`` a window is displayed (if Matplotlib is available).
-    Otherwise the plot is saved to ``path``.
-    """
+    """Plot ``c_ζ(t)`` for visual inspection."""
 
     if plt is None:  # pragma: no cover - plotting is optional.
         raise RuntimeError("Matplotlib is required for plotting but is not available")
@@ -189,10 +253,76 @@ def plot_pitch(samples: Sequence[ZetaPitchSample], *, path: Path | str | None = 
     plt.close(fig)
 
 
+def compute(
+    tmin: float,
+    tmax: float,
+    n: int,
+    dps: int,
+    *,
+    h: float = 1e-4,
+    return_samples: bool = False,
+) -> PitchArrays | tuple[Sequence[ZetaPitchSample], PitchArrays]:
+    """Compute pitch statistics on a uniform grid.
+
+    When ``return_samples`` is ``True`` the list of :class:`ZetaPitchSample`
+    instances used to assemble the arrays is returned as well. This mirrors the
+    behaviour of the standalone script shared in internal notebooks while keeping
+    the richer API available to library callers.
+    """
+
+    samples = sample_interval(tmin, tmax, num_points=n, h=h, mp_dps=dps)
+    phases = _unwrap_phases([sample.phase for sample in samples])
+    ts = [sample.t for sample in samples]
+    logabs = [sample.log_magnitude for sample in samples]
+    dlog = [sample.dlog_dt for sample in samples]
+    dtheta = [sample.dtheta_dt for sample in samples]
+    pitches = [sample.pitch for sample in samples]
+    result: PitchArrays = (ts, logabs, phases, dlog, dtheta, pitches)
+    if return_samples:
+        return samples, result
+    return result
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """CLI entry-point used for quick experiments."""
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tmin", type=float, default=10.0)
+    parser.add_argument("--tmax", type=float, default=100.0)
+    parser.add_argument("--n", type=int, default=2000)
+    parser.add_argument("--dps", type=int, default=80)
+    parser.add_argument("--csv", default="data/zeta/pitch.csv")
+    parser.add_argument("--png", default="")
+    parser.add_argument("--h", type=float, default=1e-4, help="Finite-difference step for dζ/dt")
+    args = parser.parse_args(argv)
+
+    samples, arrays = compute(args.tmin, args.tmax, args.n, args.dps, h=args.h, return_samples=True)
+
+    csv_path = Path(args.csv)
+    csv_path.parent.mkdir(parents=True, exist_ok=True)
+    write_csv(samples, csv_path)
+
+    if args.png:
+        try:
+            png_path = Path(args.png)
+            png_path.parent.mkdir(parents=True, exist_ok=True)
+            plot_pitch(samples, path=png_path)
+        except Exception as exc:  # pragma: no cover - optional plotting.
+            print(f"Plot skipped: {exc}")
+
+    # Arrays are returned for callers that want to manipulate them immediately.
+    _ = arrays
+
+
 __all__ = [
     "ZetaPitchSample",
     "sample_zeta_pitch",
     "sample_interval",
     "write_csv",
     "plot_pitch",
+    "compute",
 ]
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point.
+    main()


### PR DESCRIPTION
## Summary
- extend `tools/number_theory/zeta_pitch` with CLI helpers that mirror the exploratory script, CSV export, and optional plotting
- add XY-style gradient flow harness to `tools/complexity/phase_sat_flow` with Erdős–Rényi generation, edgelist loading, and JSON reporting
- refresh the Amundson–ζ pitch documentation to include the new rationale, usage guidance, and command-line example

## Testing
- pytest python/tests/test_zeta_pitch.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f75e80f508329848310019d9bdf1c)