### PR TITLE
Add perspective depth solver and trigonometric root helpers

### DIFF
--- a/tools/number_theory/trig_roots.py
+++ b/tools/number_theory/trig_roots.py
@@ -1,0 +1,86 @@
+"""Trigonometric helpers for power/root operations."""
+
+from __future__ import annotations
+
+import argparse
+import math
+from typing import Sequence
+
+
+def sqrt01(x: float) -> float:
+    """Return the principal square-root for ``x`` in the unit interval.
+
+    Uses the exact trigonometric identity
+
+    .. math:: \sqrt{x} = \cos\left(\tfrac{1}{2}\arccos(2x - 1)\right)
+
+    which is valid for :math:`0 \le x \le 1`.
+    """
+
+    if not 0.0 <= x <= 1.0:
+        raise ValueError("sqrt01 expects 0 <= x <= 1")
+    return math.cos(0.5 * math.acos(2.0 * x - 1.0))
+
+
+def cheb_root(x: float, n: int) -> float:
+    """Return ``y`` such that ``T_n(y) = x`` using Chebyshev angle-splitting."""
+
+    if n <= 0:
+        raise ValueError("n must be a positive integer")
+    if not -1.0 <= x <= 1.0:
+        raise ValueError("|x| must not exceed 1 for the principal Chebyshev branch")
+    return math.cos(math.acos(x) / n)
+
+
+def log_spiral_pitch(c: float, power: float) -> float:
+    """Return the pitch of ``r = exp(c * theta)`` after ``z -> z**power``."""
+
+    if power == 0:
+        raise ValueError("power must be non-zero")
+    return c
+
+
+def demo_spiral_pitch(c: float, power: float) -> str:
+    """Produce a short report illustrating pitch invariance for a log-spiral."""
+
+    pitch = log_spiral_pitch(c, power)
+    lines = [
+        f"Input pitch: {c}",
+        f"Transform: z -> z^{power}",
+        f"Resulting pitch: {pitch}",
+    ]
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Trigonometric power/root utilities.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    sqrt_parser = subparsers.add_parser("sqrt", help="Evaluate sqrt(x) on [0,1] via cosine.")
+    sqrt_parser.add_argument("x", type=float, help="Value in [0,1] to evaluate.")
+
+    cheb_parser = subparsers.add_parser("cheb", help="Solve T_n(y) = x for y via angle division.")
+    cheb_parser.add_argument("x", type=float, help="Cosine value x in [-1,1].")
+    cheb_parser.add_argument("n", type=int, help="Positive integer power n.")
+
+    demo_parser = subparsers.add_parser(
+        "pitch", help="Demonstrate log-spiral pitch invariance under powers/roots."
+    )
+    demo_parser.add_argument("c", type=float, help="Log-spiral pitch constant c.")
+    demo_parser.add_argument("power", type=float, help="Power/root exponent to apply.")
+
+    args = parser.parse_args(argv)
+    if args.command == "sqrt":
+        value = sqrt01(args.x)
+        print(f"sqrt({args.x})={value}")
+    elif args.command == "cheb":
+        value = cheb_root(args.x, args.n)
+        print(f"cheb_root(x={args.x}, n={args.n})={value}")
+    else:
+        report = demo_spiral_pitch(args.c, args.power)
+        print(report)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/tools/projective/depth_solver.py
+++ b/tools/projective/depth_solver.py
@@ -1,0 +1,88 @@
+"""Perspective depth solver utilities."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Sequence
+
+
+def depth_from_rail(
+    z_a: float,
+    z_b: float,
+    s_a: float,
+    s_b: float,
+    s_c: float,
+) -> float:
+    """Return the physical depth of point ``C`` along a perspective rail.
+
+    Parameters
+    ----------
+    z_a, z_b:
+        Known scene depths (``Z_A`` and ``Z_B``) for two reference marks ``A`` and
+        ``B`` positioned along the same receding rail.
+    s_a, s_b, s_c:
+        Measured coordinates on the drawing (``s(A)``, ``s(B)``, ``s(C)``) taken
+        along the straight line that represents the rail.
+
+    The computation follows the closed-form projective relation::
+
+        alpha = (s_a - s_c) / (s_b - s_c)
+        Z_C = (alpha * Z_B - Z_A) / (alpha - 1)
+
+    Returns
+    -------
+    float
+        The recovered depth ``Z_C`` for the target point ``C``.
+
+    Raises
+    ------
+    ValueError
+        If any intermediate denominator is zero, indicating a degenerate
+        configuration of sample points.
+    """
+
+    denom_sb_sc = s_b - s_c
+    if denom_sb_sc == 0:
+        raise ValueError("s(B) and s(C) must be distinct to define the cross-ratio")
+
+    alpha = (s_a - s_c) / denom_sb_sc
+    denom_alpha = alpha - 1.0
+    if denom_alpha == 0:
+        raise ValueError("alpha must not equal 1; choose reference points spanning C")
+
+    return (alpha * z_b - z_a) / denom_alpha
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Compute the depth of a perspective point along a rail using the "
+            "cross-ratio relation with the far point at infinity."
+        )
+    )
+    parser.add_argument(
+        "depths",
+        nargs=2,
+        metavar=("Z_A", "Z_B"),
+        type=float,
+        help="Known physical depths for reference marks A and B.",
+    )
+    parser.add_argument(
+        "coords",
+        nargs=3,
+        metavar=("sA", "sB", "sC"),
+        type=float,
+        help="Measured drawing coordinates along the rail for A, B, and target C.",
+    )
+
+    args = parser.parse_args(argv)
+    z_a, z_b = args.depths
+    s_a, s_b, s_c = args.coords
+
+    z_c = depth_from_rail(z_a, z_b, s_a, s_b, s_c)
+    print(f"Z_C={z_c}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a perspective rail depth solver that evaluates the cross-ratio formula from known scene depths
- provide trigonometric helpers for square roots, Chebyshev roots, and a log-spiral pitch demonstration CLI

## Testing
- python -m compileall tools/projective/depth_solver.py tools/number_theory/trig_roots.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f902e4ed88329ba3d2f431cd2be11)