### PR TITLE
Add projective depth solver and trig root utilities

### DIFF
--- a/README_Amundson_tools.txt
+++ b/README_Amundson_tools.txt
@@ -1,0 +1,30 @@
+Amundson Tool Drops
+===================
+
+This bundle installs two stand-alone utilities:
+
+* ``tools/projective/depth_solver.py`` — compute depth along a single rail
+  or beam using projective cross-ratios.  The script accepts either raw
+  pixel coordinates (``--A/--B/--C``) or scalar positions you already
+  measured along the rail (``--s``).  Optional ``--vanish`` coordinates let
+  you supply an explicit vanishing point when it is known.
+* ``tools/number_theory/trig_roots.py`` — trigonometric helpers for unit
+  interval square-roots, Chebyshev-style ``n``\ th roots on ``[-1, 1]``,
+  and complex polar roots/powers.
+
+Usage examples mirror the drop message:
+
+.. code-block:: bash
+
+   # Perspective depth along a measured rail
+   python tools/projective/depth_solver.py --ZA 0 --ZB 1 \
+     --A 100,400 --B 350,220 --C 270,260 --pretty
+
+   # Pre-measured scalars along the rail
+   python tools/projective/depth_solver.py --ZA 0 --ZB 1 --s 0,5.0,8.25 --pretty
+
+   # Trigonometric root/power helpers
+   python tools/number_theory/trig_roots.py sqrt01 --x 0.36
+   python tools/number_theory/trig_roots.py cheb --x 0.2 --n 5
+   python tools/number_theory/trig_roots.py root --a 3 --b 4 --n 5 --k 2
+   python tools/number_theory/trig_roots.py power --a 0.5 --b -0.5 --n 8

--- a/tools/number_theory/trig_roots.py
+++ b/tools/number_theory/trig_roots.py
@@ -1,0 +1,102 @@
+"""Trigonometric root and power helpers for the Amundson toolchain."""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from typing import Dict, Optional, Sequence
+
+
+def sqrt_unit_interval(x: float) -> float:
+    """Return ``sqrt(x)`` using a cosine half-angle identity."""
+
+    if not 0.0 <= x <= 1.0:
+        raise ValueError("sqrt01 expects x in [0, 1]")
+    return math.cos(0.5 * math.acos(2.0 * x - 1.0))
+
+
+def chebyshev_nth_root(x: float, n: int) -> float:
+    """Chebyshev-style ``n``\ th root on [-1, 1]."""
+
+    if not -1.0 <= x <= 1.0:
+        raise ValueError("cheb expects x in [-1, 1]")
+    if n == 0:
+        raise ValueError("cheb expects a non-zero n")
+    return math.cos(math.acos(x) / n)
+
+
+def complex_to_polar(a: float, b: float) -> Dict[str, float]:
+    r = math.hypot(a, b)
+    theta = math.atan2(b, a)
+    return {"r": r, "theta": theta}
+
+
+def complex_root(a: float, b: float, n: int, k: int) -> Dict[str, float]:
+    if n <= 0:
+        raise ValueError("n must be positive")
+    polar = complex_to_polar(a, b)
+    magnitude = polar["r"] ** (1.0 / n)
+    angle = (polar["theta"] + 2.0 * math.pi * k) / n
+    return {"real": magnitude * math.cos(angle), "imag": magnitude * math.sin(angle)}
+
+
+def complex_power(a: float, b: float, n: int) -> Dict[str, float]:
+    polar = complex_to_polar(a, b)
+    magnitude = polar["r"] ** n
+    angle = polar["theta"] * n
+    return {"real": magnitude * math.cos(angle), "imag": magnitude * math.sin(angle)}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="cmd", required=True)
+
+    sqrt_parser = subparsers.add_parser("sqrt01", help="Exact sqrt on [0,1]")
+    sqrt_parser.add_argument("--x", type=float, required=True)
+    sqrt_parser.add_argument("--pretty", action="store_true")
+
+    cheb_parser = subparsers.add_parser("cheb", help="Chebyshev nth-root on [-1,1]")
+    cheb_parser.add_argument("--x", type=float, required=True)
+    cheb_parser.add_argument("--n", type=int, required=True)
+    cheb_parser.add_argument("--pretty", action="store_true")
+
+    root_parser = subparsers.add_parser("root", help="Complex nth root")
+    root_parser.add_argument("--a", type=float, required=True)
+    root_parser.add_argument("--b", type=float, required=True)
+    root_parser.add_argument("--n", type=int, required=True)
+    root_parser.add_argument("--k", type=int, default=0)
+    root_parser.add_argument("--pretty", action="store_true")
+
+    power_parser = subparsers.add_parser("power", help="Complex power via polar form")
+    power_parser.add_argument("--a", type=float, required=True)
+    power_parser.add_argument("--b", type=float, required=True)
+    power_parser.add_argument("--n", type=int, required=True)
+    power_parser.add_argument("--pretty", action="store_true")
+    return parser
+
+
+def dispatch(cmd: str, args: argparse.Namespace) -> Dict[str, float]:
+    if cmd == "sqrt01":
+        return {"sqrt": sqrt_unit_interval(args.x)}
+    if cmd == "cheb":
+        return {"root": chebyshev_nth_root(args.x, args.n)}
+    if cmd == "root":
+        return complex_root(args.a, args.b, args.n, args.k)
+    if cmd == "power":
+        return complex_power(args.a, args.b, args.n)
+    raise ValueError(f"Unknown command: {cmd}")
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    payload = dispatch(args.cmd, args)
+    if getattr(args, "pretty", False):
+        print(json.dumps(payload, indent=2))
+    else:
+        print(json.dumps(payload))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/tools/projective/depth_solver.py
+++ b/tools/projective/depth_solver.py
@@ -1,0 +1,213 @@
+"""Perspective depth solver using cross-ratio interpolation.
+
+This helper works with a single calibrated rail (or any straight
+feature) and estimates the depth of a target point ``C`` once the
+endpoint depths ``ZA`` and ``ZB`` are known.  The solver operates purely
+on projective geometry: it converts the chosen points into a 1D
+coordinate system along the rail, computes the cross-ratio between the
+three samples (``A``, ``B``, ``C``) and the vanishing point, and maps the
+result back to the requested depth unit.
+
+Two measurement modes are supported:
+
+``--A/--B/--C``
+    Raw 2D image coordinates (``x,y``) for the samples.  The script
+    projects them onto the rail defined by ``A`` and ``B`` and derives a
+    consistent 1D scale.
+``--s``
+    Pre-measured scalars ``sA,sB,sC`` along the rail.  These might come
+    from ruler measurements on the print, a CAD export, or any other
+    scalar parameterisation you already prepared.
+
+An optional ``--vanish`` argument can be used when the rail's vanishing
+point is known in the image.  If omitted, the solver assumes that the
+1D parameterisation already has the vanishing point at infinity (which is
+true for ruler measurements or when the rail is parallel to the image
+plane).
+
+Example
+-------
+
+.. code-block:: bash
+
+    python tools/projective/depth_solver.py --ZA 0 --ZB 1 \
+      --A 100,400 --B 350,220 --C 270,260 --pretty
+
+    python tools/projective/depth_solver.py --ZA 0 --ZB 1 \
+      --s 0,5.0,8.25 --pretty
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from dataclasses import dataclass
+from typing import Iterable, Optional, Sequence, Tuple
+
+
+@dataclass(frozen=True)
+class RailPoints:
+    """Container describing three aligned samples on the rail."""
+
+    sA: float
+    sB: float
+    sC: float
+    sV: Optional[float] = None
+
+    @classmethod
+    def from_coords(
+        cls,
+        a: Sequence[float],
+        b: Sequence[float],
+        c: Sequence[float],
+        vanish: Optional[Sequence[float]] = None,
+    ) -> "RailPoints":
+        """Create a :class:`RailPoints` instance from 2D coordinates.
+
+        The method flattens the 2D data into a 1D coordinate system that is
+        aligned with the rail.  The axis origin is anchored at ``A``.
+        """
+
+        def to_vector(pt: Sequence[float]) -> Tuple[float, float]:
+            if len(pt) != 2:
+                raise ValueError("Coordinates must be 2D (x,y)")
+            return float(pt[0]), float(pt[1])
+
+        ax, ay = to_vector(a)
+        bx, by = to_vector(b)
+        cx, cy = to_vector(c)
+        direction = (bx - ax, by - ay)
+        norm = math.hypot(*direction)
+        if norm == 0:
+            raise ValueError("Points A and B must not coincide")
+        ux, uy = direction[0] / norm, direction[1] / norm
+
+        def project(px: float, py: float) -> float:
+            return (px - ax) * ux + (py - ay) * uy
+
+        sA = 0.0
+        sB = project(bx, by)
+        sC = project(cx, cy)
+        sV = None
+        if vanish is not None:
+            vx, vy = to_vector(vanish)
+            sV = project(vx, vy)
+        return cls(sA=sA, sB=sB, sC=sC, sV=sV)
+
+    @classmethod
+    def from_scalars(cls, scalars: Iterable[float]) -> "RailPoints":
+        scalars = list(float(v) for v in scalars)
+        if len(scalars) != 3:
+            raise ValueError("Expected three scalars for sA,sB,sC")
+        return cls(sA=scalars[0], sB=scalars[1], sC=scalars[2])
+
+    def cross_ratio_parameter(self) -> float:
+        """Return the cross-ratio parameter ``alpha``.
+
+        ``alpha`` captures the projective interpolation factor between the
+        known depths.  When a vanishing point is available we use the full
+        cross-ratio, otherwise we fall back to the simplified form where the
+        vanishing point lies at infinity.
+        """
+
+        if self.sC == self.sB:
+            raise ValueError("Point C coincides with B in the chosen scale")
+
+        numerator = self.sC - self.sA
+        denominator = self.sC - self.sB
+        alpha = numerator / denominator
+        if self.sV is not None:
+            if self.sV == self.sA:
+                raise ValueError("Vanishing point coincides with A")
+            if self.sV == self.sB:
+                raise ValueError("Vanishing point coincides with B")
+            alpha *= (self.sV - self.sB) / (self.sV - self.sA)
+        return alpha
+
+
+def parse_point(value: str) -> Tuple[float, float]:
+    try:
+        x_str, y_str = value.split(",", 1)
+        return float(x_str.strip()), float(y_str.strip())
+    except ValueError as exc:  # pragma: no cover - defensive parsing
+        raise argparse.ArgumentTypeError(
+            f"Could not parse coordinate '{value}'. Expected 'x,y'."
+        ) from exc
+
+
+def parse_scalars(value: str) -> Tuple[float, float, float]:
+    try:
+        parts = [float(part.strip()) for part in value.split(",")]
+    except ValueError as exc:  # pragma: no cover - defensive parsing
+        raise argparse.ArgumentTypeError(
+            f"Could not parse scalars '{value}'. Expected comma-separated floats."
+        ) from exc
+    if len(parts) != 3:
+        raise argparse.ArgumentTypeError(
+            f"Expected three scalars for sA,sB,sC, received {len(parts)}"
+        )
+    return parts[0], parts[1], parts[2]
+
+
+def solve_depth(points: RailPoints, za: float, zb: float) -> Tuple[float, float]:
+    """Compute the projective interpolation coefficient and depth."""
+
+    alpha = points.cross_ratio_parameter()
+    if math.isclose(alpha, 1.0):
+        raise ValueError("Degenerate configuration: alpha approaches 1")
+    zc = (za - alpha * zb) / (1.0 - alpha)
+    return alpha, zc
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ZA", type=float, required=True, help="Depth at point A")
+    parser.add_argument("--ZB", type=float, required=True, help="Depth at point B")
+
+    parser.add_argument("--A", type=parse_point, help="Pixel coordinate for point A")
+    parser.add_argument("--B", type=parse_point, help="Pixel coordinate for point B")
+    parser.add_argument("--C", type=parse_point, help="Pixel coordinate for point C")
+    parser.add_argument(
+        "--vanish",
+        type=parse_point,
+        help="Optional vanishing point coordinate for the rail",
+    )
+    parser.add_argument(
+        "--s",
+        type=parse_scalars,
+        help="Comma-separated scalar measurements sA,sB,sC",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Pretty-print the resulting JSON",
+    )
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.s is None:
+        if args.A is None or args.B is None or args.C is None:
+            parser.error("Provide either --s or all of --A/--B/--C")
+        points = RailPoints.from_coords(args.A, args.B, args.C, args.vanish)
+    else:
+        if args.A or args.B or args.C:
+            parser.error("Use either scalar measurements or raw coordinates, not both")
+        points = RailPoints.from_scalars(args.s)
+        if args.vanish is not None:
+            parser.error("Vanishing point can only be used with coordinate input")
+
+    alpha, zc = solve_depth(points, args.ZA, args.ZB)
+    payload = {"alpha": alpha, "ZC": zc}
+    if args.pretty:
+        print(json.dumps(payload, indent=2))
+    else:
+        print(json.dumps(payload))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a projective rail depth solver that accepts either raw coordinates or pre-measured scalars
- add trigonometric root and power helpers plus a README describing the drop and usage examples

## Testing
- python tools/projective/depth_solver.py --ZA 0 --ZB 1 --s 0,5.0,8.25 --pretty
- python tools/projective/depth_solver.py --ZA 0 --ZB 1 --A 100,400 --B 350,220 --C 270,260 --pretty
- python tools/number_theory/trig_roots.py sqrt01 --x 0.36 --pretty
- python tools/number_theory/trig_roots.py cheb --x 0.2 --n 5 --pretty
- python tools/number_theory/trig_roots.py root --a 3 --b 4 --n 5 --k 2 --pretty
- python tools/number_theory/trig_roots.py power --a 0.5 --b -0.5 --n 8 --pretty

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f91ab98a883298aa41e22b200cd92)