### PR TITLE
Improve magic link email templates

### DIFF
--- a/br-prism-console/templates/magic-link.html
+++ b/br-prism-console/templates/magic-link.html
@@ -1,17 +1,24 @@
 <!doctype html>
 <html lang="en">
-  <meta charset="utf-8">
-  <title>Sign in to PRISM</title>
-  <body style="font-family:system-ui,-apple-system,sans-serif;background:#f9f9f9;padding:32px;color:#111;">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Sign in to PRISM</title>
+  </head>
+  <body style="margin:0;font-family:system-ui,-apple-system,sans-serif;background:#f9f9f9;padding:32px;color:#111;">
     <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width:480px;margin:0 auto;background:#fff;padding:32px;border-radius:8px;">
-      <tr><td>
-        <h1 style="font-size:20px;margin:0 0 16px;">Sign in to PRISM</h1>
-        <p style="margin:0 0 24px;">Click the button below to finish signing in:</p>
-        <p style="text-align:center;margin:32px 0;">
-          <a href="{{magic_link}}" style="background:#000;color:#fff;padding:12px 24px;text-decoration:none;border-radius:6px;font-weight:600;">Sign in</a>
-        </p>
-        <p style="font-size:12px;color:#555;">This link expires in 15 minutes. If you didn’t request it, you can ignore this email.</p>
-      </td></tr>
+      <tr>
+        <td>
+          <h1 style="font-size:20px;margin:0 0 16px;">Sign in to PRISM</h1>
+          <p style="margin:0 0 24px;">Click the button below to finish signing in.</p>
+          <p style="text-align:center;margin:32px 0;">
+            <a href="{{magic_link}}" style="display:inline-block;background:#000;color:#fff;padding:12px 24px;text-decoration:none;border-radius:6px;font-weight:600;">Sign in</a>
+          </p>
+          <p style="font-size:12px;color:#555;">This link expires in 15 minutes. If you didn’t request it, you can ignore this email.</p>
+          <p style="font-size:12px;color:#555;margin-top:16px;">If the button above doesn’t work, copy and paste this link into your browser:</p>
+          <p style="font-size:12px;color:#111;word-break:break-all;">{{magic_link}}</p>
+        </td>
+      </tr>
     </table>
   </body>
 </html>

--- a/br-prism-console/templates/magic-link.txt
+++ b/br-prism-console/templates/magic-link.txt
@@ -3,4 +3,6 @@ Sign in to PRISM
 Click the link below to finish signing in (valid for 15 minutes):
 {{magic_link}}
 
+If the link above doesn’t open automatically, copy and paste it into your browser.
+
 If you didn’t request this, you can safely ignore it.


### PR DESCRIPTION
## Summary
- wrap the HTML template with a proper head element and provide a fallback link for the button
- add guidance to the text email for copying the URL if automatic open fails

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691024b9147883298e7043e534c1c379)