### PR TITLE
Fix reroute workflow to dispatch auto mention job

### DIFF
--- a/.github/workflows/route-on-comment.yml
+++ b/.github/workflows/route-on-comment.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Dispatch auto-mention
         uses: benc-uk/workflow-dispatch@4c044c1613fabbe5250deadc65452d54c4ad4fc7 # v1.2.4
         with:
-          workflow: Auto mention teams
+          workflow: Auto mention on PRs
           ref: ${{ github.ref }}
           inputs: |
             pull_number=${{ steps.pr.outputs.number }}


### PR DESCRIPTION
## Summary
- update the route-on-comment workflow to dispatch the Auto mention on PRs workflow by its current name
- ensure /route comments correctly trigger the automation that pings @copilot, @dependabot, @claude, @codex, and @blackboxprogramming

## Testing
- not run (workflow change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69118aa5ed4c83298189d92715fbcdeb)