### PR TITLE
Document manual override steps for merge queue

### DIFF
--- a/docs/MERGE_QUEUE.md
+++ b/docs/MERGE_QUEUE.md
@@ -79,3 +79,21 @@ Common `type` values:
 - `error`
 
 This structure makes it easy to stream the audit log to any downstream analytics system if needed.
+
+---
+
+## Manual Merge Override Procedure
+
+The queue is designed to keep `main` green, but administrators can still land a change when CI is unavailable or failing for
+reasons unrelated to the patch:
+
+1. **Relax branch protection just for the override.** Go to **Settings → Branches → main → Edit rule**, disable the failing
+   status checks (or uncheck "Require status checks to pass before merging"), and make sure "Enforce for administrators" is
+   turned off. Re-enable the protections immediately after the merge.
+2. **Merge outside the queue.** Leave the `queue:ready` label off and either use the GitHub UI or run `gh pr merge <pr-number>
+   --merge --admin` so the override is logged.
+3. **Restore automation and clean up.** Turn protections back on, then run `scripts/cleanup-merged-branches.sh` to prune merged
+   branches. If you often need this escape hatch, consider adding a `manual-merge` label and updating
+   `.github/workflows/auto-merge.yml` to skip failing checks when that label is present.
+
+Document the reason for the manual merge in a PR comment to maintain the audit trail even when CI was bypassed.

--- a/docs/MERGE_QUEUE_PRIMER.md
+++ b/docs/MERGE_QUEUE_PRIMER.md
@@ -71,6 +71,25 @@ Consider a merge queue when any of the following apply:
 
 ---
 
+## Manual Overrides for Administrators
+
+Sometimes you need to land a critical fix even though a required check is red or unavailable. Repository administrators can keep
+control without tearing down the merge queue entirely by following this playbook:
+
+1. **Temporarily relax branch protection.** Navigate to **Settings → Branches → main → Edit rule**, uncheck "Require status
+   checks to pass before merging" (or the specific failing checks), and ensure "Enforce for administrators" stays disabled while
+   you complete the override. Re-enable the protections immediately afterward.
+2. **Bypass the queue on purpose.** Skip adding the `queue:ready` label and merge manually through the GitHub UI, or run `gh pr
+   merge <pr-number> --merge --admin` so the admin bypass records in the audit trail.
+3. **Optionally gate with a label.** If you prefer automation, introduce a `manual-merge` label and tweak
+   `.github/workflows/auto-merge.yml` so the workflow ignores failing checks whenever that label is present.
+4. **Run the cleanup helper.** Execute `scripts/cleanup-merged-branches.sh` after the override so stale branches disappear from
+   the remote.
+
+Leave a short PR comment explaining why the override was necessary. That keeps the audit trail intact even when CI was skipped.
+
+---
+
 ## Metrics to Watch
 
 - **Lead time to merge**: Track queue wait plus CI runtime; aim for less than 2× the CI duration.


### PR DESCRIPTION
## Summary
- add an administrator manual-override playbook to the merge queue primer
- document the manual merge procedure alongside the merge queue operations guide

## Testing
- not run (documentation only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912bfac0cf48329b8c413dc45d34e6b)