### PR TITLE
Add 2025-11-12 operations brief

### DIFF
--- a/status/2025-11-12.md
+++ b/status/2025-11-12.md
@@ -1,0 +1,13 @@
+# Daily Operations Brief — 2025-11-12
+
+## Platform & Tooling Health
+- **OpenAI:** Reported increased latency in the Vector Stores API around 05:55 UTC on Nov 12. Mitigations are in place, but expect slower file ingestion or retrieval for RAG workflows while monitoring continues.
+- **GitHub Actions:** Large hosted runners experienced delays between approximately 18:02–19:40 UTC on Nov 11. Mitigation is reported complete and new jobs should dispatch without added queue time.
+- **Cloudflare:** Scheduled maintenance is underway across multiple datacenters (FRA, KIV, TLV, HYD, KIX, DAC, SAN, ARN, and others) from Nov 10–12. Temporary latency increases or rerouted traffic are possible while work proceeds.
+- **Amazon Web Services (us-east-1):** No new outages were reported in the last 48 hours, but the October disruption underscores the need to keep failover strategies ready for regional impact.
+
+## Recommended Actions
+- Track latency and error rates for vector store ingestion and retrieval pipelines. Flag slow indexing or search times to avoid back-pressure in RAG-driven agents.
+- Review GitHub Actions telemetry for large-runner jobs that started during the Nov 11 incident window and re-run any builds that stalled or timed out.
+- Validate Cloudflare routing, latency, and failover behavior across the affected metros through Nov 12, especially for clients that rely on edge proximity.
+- Reaffirm multi-region resilience plans for AWS us-east-1 workloads, ensuring asynchronous workflows and alerting are tuned for renewed disruption.


### PR DESCRIPTION
## Summary
- add a 2025-11-12 daily operations brief covering OpenAI vector store latency, GitHub hosted runner delays, Cloudflare maintenance, and AWS resilience posture

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914e407fca48329b204fed6bd6ee0ca)