### PR TITLE
Add BTC-ETH liquidity tug-of-war market update

### DIFF
--- a/sites/blackroad/content/blog/btc-eth-liquidity-tug-of-war-nov-2025.md
+++ b/sites/blackroad/content/blog/btc-eth-liquidity-tug-of-war-nov-2025.md
@@ -1,0 +1,36 @@
+---
+title: "BTC-ETH Liquidity Tug-of-War"
+date: "2025-11-12"
+tags: [crypto, markets, regulation]
+description: "Bitcoin stalls near $103K as ETF inflows return and a CFTC oversight bill looms, keeping operators on alert for a 112K breakout or 100K slide."
+---
+
+Markets opened mid-week with a skittish tape. Bitcoin is rotating around **$103,246** after a **$1,574** pullback on the session, while Ethereum slips to roughly **$3,434** on a **$114** decline. Intraday ranges remain wide—BTC printed a **$105,465** high against a **$102,460** low; ETH travelled **$3,590** to **$3,405**—a reminder that liquidity is fading once the order book moves a few thousand dollars away from spot.
+
+## Tape and liquidations
+
+- **Liquidation sweeps**: Roughly **$380 million** of positions were forced out across the last 24 hours, including **$81 million** tied to BTC and **$72 million** from ETH contracts. Dealers are still short gamma above $110K, so any grind higher through stale shorts could force accelerated hedging.
+- **Heatmap focus**: Visible liquidity clusters stack offers above the **$112K** band. That supply represents both resting interest from ETF creation desks and discretionary traders fading spikes; absorbing it cleanly is the bullish trigger.
+- **Downside watch**: If spot loses the psychological **$100K** handle, there is thin historical volume until the mid-$90Ks. Prepare RFQ desks for wider spreads and re-margin fast if that threshold cracks.
+
+## ETF flows and structural posture
+
+- **Inflows are back**: U.S. spot Bitcoin ETFs recorded about **$300 million** in net creations today. After last week’s outflow streak, this signals that allocators are still recycling cash into BTC when volatility presents a discount.
+- **Basis implications**: Expect tighter spot-futures basis as APs lean into creations. Desk heads should re-check funding ladders before the U.S. close; higher borrow demand is likely if the rally resumes.
+
+## Regulatory draft: expanded CFTC remit
+
+The Senate Agriculture Committee’s bipartisan discussion draft would hand the **CFTC** clearer authority over spot digital commodity markets.
+
+- **Digital commodity scope**: Bitcoin and similar assets land squarely inside the bill’s definition, pulling custodians, brokers, and certain wallet providers into a federal registration regime.
+- **Customer protection hooks**: Segregation of customer funds and new custodial reporting will require ops teams to audit trust arrangements and third-party storage agreements.
+- **DeFi and "mixed" transactions**: Sections on decentralized protocols remain open-ended. Expect further markup and comment opportunities, but start cataloging which services rely on automated market makers or hybrid payment flows.
+
+## Playbook for the next move
+
+1. **Mark the triggers**: Breaks **above $112K** or **below $100K** should automatically notify risk, trading, and custody leads. Program alerts in internal dashboards now.
+2. **Flow dashboards**: Expand ETF monitoring to track fund-level creations and redemptions intraday; re-balance liquidity provisioning around AP demand spikes.
+3. **Compliance prep**: Inventory entities that would require CFTC registration. Draft contingency timelines for licensing, customer asset segregation, and new reporting pipelines.
+4. **Client comms**: If ETF inflows continue, package a briefing on how structural demand may accelerate any breakout; if not, prepare a risk note on the liquidation cascade scenario.
+
+Volatility is the feature, not the bug. Operators who anchor to the order-book physics and pending regulation will out-execute the field when the next impulse arrives.


### PR DESCRIPTION
## Summary
- add a BlackRoad blog post covering the current BTC/ETH liquidity tug-of-war, ETF flow return, and the CFTC oversight draft

## Testing
- not run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914e41a765c83298fbfd715e4bbac49)