### PR TITLE
Add Lucid Ego SQLite memory module

### DIFF
--- a/lucid_ego/__init__.py
+++ b/lucid_ego/__init__.py
@@ -1,0 +1,5 @@
+"""Lucid Ego lightweight local memory package."""
+
+from .db import LucidEgoDB, pack_f32, unpack_f32
+
+__all__ = ["LucidEgoDB", "pack_f32", "unpack_f32"]

--- a/lucid_ego/__main__.py
+++ b/lucid_ego/__main__.py
@@ -1,0 +1,10 @@
+"""Module entry-point for ``python -m lucid_ego``."""
+from __future__ import annotations
+
+import sys
+
+from .cli import main
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation guard
+    sys.exit(main())

--- a/lucid_ego/cli.py
+++ b/lucid_ego/cli.py
@@ -1,0 +1,247 @@
+"""Command line interface for the Lucid Ego local memory store."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+from .db import LucidEgoDB
+
+
+def positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:  # pragma: no cover - defensive branch
+        raise argparse.ArgumentTypeError("step index must be an integer") from exc
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("step index must be non-negative")
+    return parsed
+
+
+def parse_vector(values: str | Sequence[str]) -> Sequence[float]:
+    if isinstance(values, (list, tuple)):
+        joined = ",".join(values)
+    else:
+        joined = values
+    if not joined:
+        raise argparse.ArgumentTypeError("vector values may not be empty")
+    try:
+        return [float(item.strip()) for item in joined.split(",") if item.strip()]
+    except ValueError as exc:  # pragma: no cover - defensive branch
+        raise argparse.ArgumentTypeError("unable to parse vector values") from exc
+
+
+def parse_metadata(text: str | None) -> dict:
+    if not text:
+        return {}
+    try:
+        value = json.loads(text)
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive branch
+        raise argparse.ArgumentTypeError("metadata must be valid JSON") from exc
+    if not isinstance(value, dict):
+        raise argparse.ArgumentTypeError("metadata JSON must be an object")
+    return value
+
+
+def add_common_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--db",
+        default="lucid_ego.db",
+        help="Path to the SQLite database file (default: lucid_ego.db)",
+    )
+
+
+def command_init(args: argparse.Namespace) -> None:
+    db = LucidEgoDB(Path(args.db))
+    db.init()
+    print(f"Initialised Lucid Ego database at {Path(args.db).resolve()}")
+
+
+def command_agent_add(args: argparse.Namespace) -> None:
+    db = LucidEgoDB(Path(args.db))
+    agent_id = db.ensure_agent(args.name, role=args.role, agent_id=args.id)
+    print(agent_id)
+
+
+def command_run_start(args: argparse.Namespace) -> None:
+    db = LucidEgoDB(Path(args.db))
+    session_id = db.start_session(args.agent, label=args.label)
+    print(session_id)
+
+
+def command_run_end(args: argparse.Namespace) -> None:
+    db = LucidEgoDB(Path(args.db))
+    db.end_session(args.session)
+    print(args.session)
+
+
+def command_log(args: argparse.Namespace) -> None:
+    db = LucidEgoDB(Path(args.db))
+    log_id = db.log(args.session, args.level, args.channel, args.message)
+    print(log_id)
+
+
+def command_decision(args: argparse.Namespace) -> None:
+    db = LucidEgoDB(Path(args.db))
+    decision_id = db.record_decision(
+        args.session,
+        step_index=args.step,
+        prompt=args.prompt,
+        output=args.output,
+        rationale=args.rationale,
+        score=args.score,
+    )
+    print(decision_id)
+
+
+def command_embedding(args: argparse.Namespace) -> None:
+    db = LucidEgoDB(Path(args.db))
+    vector = parse_vector(args.vector)
+    metadata = parse_metadata(args.metadata)
+    embedding_id = db.add_embedding(
+        args.session,
+        ref_kind=args.ref_kind,
+        ref_id=args.ref_id,
+        model=args.model,
+        vector=vector,
+        metadata=metadata,
+    )
+    print(embedding_id)
+
+
+def command_dump(args: argparse.Namespace) -> None:
+    db = LucidEgoDB(Path(args.db))
+    if args.json:
+        print(db.dump_session(args.session))
+        return
+
+    bundle = db.get_session(args.session)
+    session = bundle["session"]
+    agent = bundle.get("agent") or {}
+    print(f"Session {session['id']} (agent={agent.get('name', 'unknown')} label={session.get('label')})")
+    print(f"  started: {session.get('started_at')} ended: {session.get('ended_at')}")
+    print("  Decisions:")
+    for decision in bundle["decisions"]:
+        print(
+            f"    [{decision['step_index']}] id={decision['id']} score={decision.get('score')}",
+        )
+        prompt = decision.get("prompt")
+        if prompt:
+            print(f"      prompt: {prompt[:120]}")
+        output = decision.get("output")
+        if output:
+            print(f"      output: {output[:120]}")
+        rationale = decision.get("rationale")
+        if rationale:
+            print(f"      rationale: {rationale[:120]}")
+    print("  Logs:")
+    for log in bundle["logs"][-args.tail :]:
+        print(f"    {log['ts']} {log.get('level', 'INFO')} {log.get('channel', '-')}: {log.get('message', '')}")
+    if bundle["artifacts"]:
+        print("  Artifacts:")
+        for artifact in bundle["artifacts"]:
+            print(
+                "    {id} {kind} -> {uri}".format(
+                    id=artifact["id"], kind=artifact.get("kind", ""), uri=artifact.get("uri", ""),
+                )
+            )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init_parser = subparsers.add_parser("init", help="initialise the database")
+    add_common_arguments(init_parser)
+    init_parser.set_defaults(func=command_init)
+
+    agent_parser = subparsers.add_parser("agent", help="manage agents")
+    add_common_arguments(agent_parser)
+    agent_sub = agent_parser.add_subparsers(dest="agent_command", required=True)
+    agent_add = agent_sub.add_parser("add", help="create or update an agent")
+    agent_add.add_argument("name", help="Agent display name")
+    agent_add.add_argument("--id", help="Optional agent id (defaults to UUID4)")
+    agent_add.add_argument("--role", help="Agent role or description")
+    add_common_arguments(agent_add)
+    agent_add.set_defaults(func=command_agent_add)
+
+    run_parser = subparsers.add_parser("run", help="manage sessions")
+    add_common_arguments(run_parser)
+    run_sub = run_parser.add_subparsers(dest="run_command", required=True)
+
+    run_start = run_sub.add_parser("start", help="start a session")
+    add_common_arguments(run_start)
+    run_start.add_argument("agent", help="Agent id")
+    run_start.add_argument("--label", help="Optional session label")
+    run_start.set_defaults(func=command_run_start)
+
+    run_end = run_sub.add_parser("end", help="end a session")
+    add_common_arguments(run_end)
+    run_end.add_argument("session", help="Session id")
+    run_end.set_defaults(func=command_run_end)
+
+    log_parser = subparsers.add_parser("log", help="append a log line")
+    add_common_arguments(log_parser)
+    log_parser.add_argument("session", help="Session id")
+    log_parser.add_argument("level", help="Log level", default="INFO")
+    log_parser.add_argument("channel", help="Log channel")
+    log_parser.add_argument("message", help="Log message")
+    log_parser.set_defaults(func=command_log)
+
+    decision_parser = subparsers.add_parser("decision", help="record a decision")
+    add_common_arguments(decision_parser)
+    decision_parser.add_argument("session", help="Session id")
+    decision_parser.add_argument("step", type=positive_int, help="Step index")
+    decision_parser.add_argument("--prompt", help="Prompt text")
+    decision_parser.add_argument("--output", help="Output text")
+    decision_parser.add_argument("--rationale", help="Decision rationale")
+    decision_parser.add_argument("--score", type=float, help="Confidence score")
+    decision_parser.set_defaults(func=command_decision)
+
+    embedding_parser = subparsers.add_parser("embedding", help="store an embedding")
+    add_common_arguments(embedding_parser)
+    embedding_parser.add_argument("session", help="Session id", nargs="?")
+    embedding_parser.add_argument("ref_kind", help="Reference kind, e.g. prompt or doc")
+    embedding_parser.add_argument("ref_id", help="Reference identifier")
+    embedding_parser.add_argument("model", help="Embedding model name")
+    embedding_parser.add_argument(
+        "--vector",
+        required=True,
+        help="Comma separated vector values (e.g. '0.1,0.2,0.3')",
+    )
+    embedding_parser.add_argument(
+        "--metadata",
+        help="JSON encoded metadata to store alongside the embedding",
+    )
+    embedding_parser.set_defaults(func=command_embedding)
+
+    dump_parser = subparsers.add_parser("dump", help="show session details")
+    add_common_arguments(dump_parser)
+    dump_parser.add_argument("session", help="Session id")
+    dump_parser.add_argument("--json", action="store_true", help="Emit raw JSON output")
+    dump_parser.add_argument(
+        "--tail",
+        type=positive_int,
+        default=25,
+        help="Number of log entries to display (default: 25)",
+    )
+    dump_parser.set_defaults(func=command_dump)
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    func = getattr(args, "func", None)
+    if func is None:
+        parser.print_help()
+        return 1
+    func(args)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation guard
+    sys.exit(main())

--- a/lucid_ego/db.py
+++ b/lucid_ego/db.py
@@ -1,0 +1,322 @@
+"""Core database helpers for the Lucid Ego memory store."""
+from __future__ import annotations
+
+import json
+import sqlite3
+import struct
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, MutableMapping, Optional, Sequence
+
+SCHEMA_VERSION = 1
+
+SCHEMA_STATEMENTS: Sequence[str] = (
+    """
+    CREATE TABLE IF NOT EXISTS agents (
+      id            TEXT PRIMARY KEY,
+      name          TEXT NOT NULL,
+      role          TEXT,
+      created_at    TEXT DEFAULT (datetime('now'))
+    );
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS sessions (
+      id            TEXT PRIMARY KEY,
+      agent_id      TEXT NOT NULL REFERENCES agents(id),
+      label         TEXT,
+      started_at    TEXT DEFAULT (datetime('now')),
+      ended_at      TEXT
+    );
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS decisions (
+      id            TEXT PRIMARY KEY,
+      session_id    TEXT NOT NULL REFERENCES sessions(id),
+      step_index    INTEGER NOT NULL,
+      prompt        TEXT,
+      output        TEXT,
+      rationale     TEXT,
+      score         REAL,
+      created_at    TEXT DEFAULT (datetime('now'))
+    );
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS artifacts (
+      id            TEXT PRIMARY KEY,
+      session_id    TEXT NOT NULL REFERENCES sessions(id),
+      decision_id   TEXT REFERENCES decisions(id),
+      kind          TEXT,
+      uri           TEXT,
+      sha256        TEXT,
+      bytes         BLOB
+    );
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS logs (
+      id            INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id    TEXT NOT NULL REFERENCES sessions(id),
+      ts            TEXT DEFAULT (datetime('now')),
+      level         TEXT,
+      channel       TEXT,
+      message       TEXT
+    );
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS embeddings (
+      id            TEXT PRIMARY KEY,
+      session_id    TEXT REFERENCES sessions(id),
+      ref_kind      TEXT,
+      ref_id        TEXT,
+      model         TEXT NOT NULL,
+      dim           INTEGER NOT NULL,
+      vector        BLOB NOT NULL,
+      metadata      TEXT,
+      created_at    TEXT DEFAULT (datetime('now'))
+    );
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS schema_version (
+      version     INTEGER PRIMARY KEY,
+      applied_at  TEXT DEFAULT (datetime('now'))
+    );
+    """,
+)
+
+PRAGMA_STATEMENTS: Sequence[str] = (
+    "PRAGMA journal_mode=WAL;",
+    "PRAGMA synchronous=NORMAL;",
+)
+
+
+@dataclass
+class LucidEgoDB:
+    """High-level interface for the Lucid Ego SQLite database."""
+
+    path: Path
+
+    def __init__(self, path: Path | str = Path("lucid_ego.db")) -> None:
+        self.path = Path(path)
+
+    # ------------------------------------------------------------------
+    # Connection helpers
+    # ------------------------------------------------------------------
+    def connect(self) -> sqlite3.Connection:
+        """Return a configured SQLite connection."""
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        con = sqlite3.connect(self.path)
+        con.row_factory = sqlite3.Row
+        for pragma in PRAGMA_STATEMENTS:
+            con.execute(pragma)
+        return con
+
+    # ------------------------------------------------------------------
+    # Schema management
+    # ------------------------------------------------------------------
+    def init(self) -> None:
+        """Initialise the database schema if it does not already exist."""
+        with self.connect() as con:
+            for statement in SCHEMA_STATEMENTS:
+                con.execute(statement)
+            con.execute(
+                "INSERT OR IGNORE INTO schema_version (version) VALUES (?)",
+                (SCHEMA_VERSION,),
+            )
+            con.commit()
+
+    # ------------------------------------------------------------------
+    # Agent + session helpers
+    # ------------------------------------------------------------------
+    def ensure_agent(self, name: str, role: Optional[str] = None, *, agent_id: str | None = None) -> str:
+        """Insert or update an agent record and return its id."""
+        agent_id = agent_id or str(uuid.uuid4())
+        with self.connect() as con:
+            con.execute(
+                """
+                INSERT INTO agents (id, name, role)
+                VALUES (?, ?, ?)
+                ON CONFLICT(id) DO UPDATE SET
+                  name=excluded.name,
+                  role=excluded.role
+                """,
+                (agent_id, name, role),
+            )
+            con.commit()
+        return agent_id
+
+    def start_session(self, agent_id: str, label: Optional[str] = None, *, session_id: Optional[str] = None) -> str:
+        """Create a new session entry and return its id."""
+        session_id = session_id or str(uuid.uuid4())
+        with self.connect() as con:
+            con.execute(
+                "INSERT INTO sessions (id, agent_id, label) VALUES (?, ?, ?)",
+                (session_id, agent_id, label),
+            )
+            con.commit()
+        return session_id
+
+    def end_session(self, session_id: str) -> None:
+        """Mark a session as finished."""
+        with self.connect() as con:
+            con.execute(
+                "UPDATE sessions SET ended_at = datetime('now') WHERE id = ?",
+                (session_id,),
+            )
+            con.commit()
+
+    # ------------------------------------------------------------------
+    # Logging and decisions
+    # ------------------------------------------------------------------
+    def log(self, session_id: str, level: str, channel: str, message: str) -> int:
+        """Append a log entry and return the log identifier."""
+        with self.connect() as con:
+            cursor = con.execute(
+                "INSERT INTO logs (session_id, level, channel, message) VALUES (?, ?, ?, ?)",
+                (session_id, level, channel, message),
+            )
+            con.commit()
+            return cursor.lastrowid
+
+    def record_decision(
+        self,
+        session_id: str,
+        step_index: int,
+        prompt: Optional[str],
+        output: Optional[str],
+        rationale: Optional[str] = None,
+        score: Optional[float] = None,
+        *,
+        decision_id: Optional[str] = None,
+    ) -> str:
+        """Store a decision entry and return its identifier."""
+        decision_id = decision_id or str(uuid.uuid4())
+        with self.connect() as con:
+            con.execute(
+                """
+                INSERT INTO decisions (id, session_id, step_index, prompt, output, rationale, score)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (decision_id, session_id, step_index, prompt, output, rationale, score),
+            )
+            con.commit()
+        return decision_id
+
+    def add_artifact(
+        self,
+        session_id: str,
+        kind: str,
+        uri: str,
+        *,
+        decision_id: Optional[str] = None,
+        sha256: Optional[str] = None,
+        inline_bytes: Optional[bytes] = None,
+        artifact_id: Optional[str] = None,
+    ) -> str:
+        """Attach an artifact to a session or decision."""
+        artifact_id = artifact_id or str(uuid.uuid4())
+        with self.connect() as con:
+            con.execute(
+                """
+                INSERT INTO artifacts (id, session_id, decision_id, kind, uri, sha256, bytes)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (artifact_id, session_id, decision_id, kind, uri, sha256, inline_bytes),
+            )
+            con.commit()
+        return artifact_id
+
+    # ------------------------------------------------------------------
+    # Embeddings
+    # ------------------------------------------------------------------
+    def add_embedding(
+        self,
+        session_id: Optional[str],
+        ref_kind: str,
+        ref_id: str,
+        model: str,
+        vector: Sequence[float],
+        *,
+        metadata: Optional[MutableMapping[str, Any]] = None,
+        embedding_id: Optional[str] = None,
+    ) -> str:
+        """Store or replace an embedding."""
+        embedding_id = embedding_id or str(uuid.uuid4())
+        blob = pack_f32(vector)
+        metadata_json = json.dumps(metadata or {})
+        with self.connect() as con:
+            con.execute(
+                """
+                INSERT OR REPLACE INTO embeddings
+                  (id, session_id, ref_kind, ref_id, model, dim, vector, metadata)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (embedding_id, session_id, ref_kind, ref_id, model, len(vector), blob, metadata_json),
+            )
+            con.commit()
+        return embedding_id
+
+    # ------------------------------------------------------------------
+    # Retrieval helpers
+    # ------------------------------------------------------------------
+    def get_session(self, session_id: str) -> Dict[str, Any]:
+        """Return a dictionary with session details, decisions, and logs."""
+        with self.connect() as con:
+            session_row = con.execute(
+                "SELECT * FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+            if session_row is None:
+                raise KeyError(f"Unknown session: {session_id}")
+
+            agent_row = con.execute(
+                "SELECT * FROM agents WHERE id = ?",
+                (session_row["agent_id"],),
+            ).fetchone()
+
+            decisions = con.execute(
+                "SELECT * FROM decisions WHERE session_id = ? ORDER BY step_index",
+                (session_id,),
+            ).fetchall()
+            logs = con.execute(
+                "SELECT * FROM logs WHERE session_id = ? ORDER BY ts",
+                (session_id,),
+            ).fetchall()
+            artifacts = con.execute(
+                "SELECT * FROM artifacts WHERE session_id = ? ORDER BY id",
+                (session_id,),
+            ).fetchall()
+
+        return {
+            "session": dict(session_row),
+            "agent": dict(agent_row) if agent_row else None,
+            "decisions": [dict(row) for row in decisions],
+            "logs": [dict(row) for row in logs],
+            "artifacts": [dict(row) for row in artifacts],
+        }
+
+    def dump_session(self, session_id: str) -> str:
+        """Return a JSON dump for a session (decisions, logs, artifacts)."""
+        payload = self.get_session(session_id)
+        return json.dumps(payload, indent=2, sort_keys=True)
+
+
+# ----------------------------------------------------------------------
+# Utility helpers
+# ----------------------------------------------------------------------
+
+def pack_f32(vector: Sequence[float]) -> bytes:
+    """Pack a vector of floats as little-endian float32 bytes."""
+    if not vector:
+        raise ValueError("Vector must contain at least one value")
+    return struct.pack(f"<{len(vector)}f", *vector)
+
+
+def unpack_f32(blob: bytes) -> List[float]:
+    """Unpack float32 bytes into a Python list."""
+    if len(blob) % 4:
+        raise ValueError("Embedding blob length must be divisible by 4")
+    count = len(blob) // 4
+    return list(struct.unpack(f"<{count}f", blob))
+
+
+__all__ = ["LucidEgoDB", "pack_f32", "unpack_f32", "SCHEMA_VERSION"]


### PR DESCRIPTION
## Summary
- add a lucid_ego SQLite helper module with schema management and persistence helpers
- implement a CLI that manages agents, sessions, logs, decisions, embeddings, and session dumps
- expose a module entry point so the toolkit can be executed via `python -m lucid_ego`

## Testing
- python -m py_compile lucid_ego/*.py
- python -m lucid_ego dump --db test_lucid.db d33d5d2d-dee8-4ac8-a9f7-0eb04b036ad6 --tail 10


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914e474f8f08329b60e3ddca9b77d23)