### PR TITLE
Add research manifest and phase-one paper skeleton scaffolding

### DIFF
--- a/papers/macros/M10_consciousness/M10A1_continuity_of_self/M10A1_continuity_of_self.md
+++ b/papers/macros/M10_consciousness/M10A1_continuity_of_self/M10A1_continuity_of_self.md
@@ -1,0 +1,20 @@
+# Minimal Conditions for Synthetic Continuity of Self in BlackRoad Agents (ID: M10A1)
+
+## Abstract
+
+## 1. Introduction
+### 1.1 Problem Statement
+### 1.2 Background & Related Work
+### 1.3 Contribution
+
+## 2. Methods / Architecture
+
+## 3. Experiments / Case Studies
+
+## 4. Results
+
+## 5. Discussion
+
+## 6. Limitations & Future Work
+
+## References

--- a/papers/macros/M10_consciousness/M10A1_continuity_of_self/experiments/README.md
+++ b/papers/macros/M10_consciousness/M10A1_continuity_of_self/experiments/README.md
@@ -1,0 +1,1 @@
+Placeholder for experiments.

--- a/papers/macros/M1_core_architecture/M1A1_deterministic_replay/M1A1_deterministic_replay.md
+++ b/papers/macros/M1_core_architecture/M1A1_deterministic_replay/M1A1_deterministic_replay.md
@@ -1,0 +1,20 @@
+# Deterministic Replay for Agent Swarms via Hash-Chained Journals (ID: M1A1)
+
+## Abstract
+
+## 1. Introduction
+### 1.1 Problem Statement
+### 1.2 Background & Related Work
+### 1.3 Contribution
+
+## 2. Methods / Architecture
+
+## 3. Experiments / Case Studies
+
+## 4. Results
+
+## 5. Discussion
+
+## 6. Limitations & Future Work
+
+## References

--- a/papers/macros/M1_core_architecture/M1A1_deterministic_replay/experiments/README.md
+++ b/papers/macros/M1_core_architecture/M1A1_deterministic_replay/experiments/README.md
@@ -1,0 +1,1 @@
+Placeholder for experiments.

--- a/papers/macros/M2_information_field/M2A1_schrodinger_to_swarm/M2A1_schrodinger_to_swarm.md
+++ b/papers/macros/M2_information_field/M2A1_schrodinger_to_swarm/M2A1_schrodinger_to_swarm.md
@@ -1,0 +1,20 @@
+# From Schrödinger to Swarm: Agent State as a Wavefunction (ID: M2A1)
+
+## Abstract
+
+## 1. Introduction
+### 1.1 Problem Statement
+### 1.2 Background & Related Work
+### 1.3 Contribution
+
+## 2. Methods / Architecture
+
+## 3. Experiments / Case Studies
+
+## 4. Results
+
+## 5. Discussion
+
+## 6. Limitations & Future Work
+
+## References

--- a/papers/macros/M2_information_field/M2A1_schrodinger_to_swarm/experiments/README.md
+++ b/papers/macros/M2_information_field/M2A1_schrodinger_to_swarm/experiments/README.md
@@ -1,0 +1,1 @@
+Placeholder for experiments.

--- a/papers/macros/M3_thermodynamics/M3A2_entropy_efficiency/M3A2_entropy_efficiency.md
+++ b/papers/macros/M3_thermodynamics/M3A2_entropy_efficiency/M3A2_entropy_efficiency.md
@@ -1,0 +1,20 @@
+# Entropy Production as a Metric for Agent Efficiency (ID: M3A2)
+
+## Abstract
+
+## 1. Introduction
+### 1.1 Problem Statement
+### 1.2 Background & Related Work
+### 1.3 Contribution
+
+## 2. Methods / Architecture
+
+## 3. Experiments / Case Studies
+
+## 4. Results
+
+## 5. Discussion
+
+## 6. Limitations & Future Work
+
+## References

--- a/papers/macros/M3_thermodynamics/M3A2_entropy_efficiency/experiments/README.md
+++ b/papers/macros/M3_thermodynamics/M3A2_entropy_efficiency/experiments/README.md
@@ -1,0 +1,1 @@
+Placeholder for experiments.

--- a/papers/macros/M7_regtech/M7A2_regdoc_contradictions/M7A2_regdoc_contradictions.md
+++ b/papers/macros/M7_regtech/M7A2_regdoc_contradictions/M7A2_regdoc_contradictions.md
@@ -1,0 +1,20 @@
+# Multi-Agent Contradiction Detection for Regulatory Documents (ID: M7A2)
+
+## Abstract
+
+## 1. Introduction
+### 1.1 Problem Statement
+### 1.2 Background & Related Work
+### 1.3 Contribution
+
+## 2. Methods / Architecture
+
+## 3. Experiments / Case Studies
+
+## 4. Results
+
+## 5. Discussion
+
+## 6. Limitations & Future Work
+
+## References

--- a/papers/macros/M7_regtech/M7A2_regdoc_contradictions/experiments/README.md
+++ b/papers/macros/M7_regtech/M7A2_regdoc_contradictions/experiments/README.md
@@ -1,0 +1,1 @@
+Placeholder for experiments.

--- a/papers/paper_template.md
+++ b/papers/paper_template.md
@@ -1,0 +1,20 @@
+# <Paper Title> (ID: MxAy)
+
+## Abstract
+
+## 1. Introduction
+### 1.1 Problem Statement
+### 1.2 Background & Related Work
+### 1.3 Contribution
+
+## 2. Methods / Architecture
+
+## 3. Experiments / Case Studies
+
+## 4. Results
+
+## 5. Discussion
+
+## 6. Limitations & Future Work
+
+## References

--- a/papers/research_manifest.yaml
+++ b/papers/research_manifest.yaml
@@ -1,0 +1,45 @@
+macros:
+  - id: M1
+    name: Core Architecture & Orchestration
+    description: Physics-informed agent orchestration with persistent memory and append-only logs.
+    atoms:
+      - id: M1A1
+        title: Deterministic Replay for Agent Swarms via Hash-Chained Journals
+        status: drafting
+        priority: high
+
+  - id: M2
+    name: Information Field & Operator Theory
+    description: Unified operator framework for agent dynamics in a continuous information field.
+    atoms:
+      - id: M2A1
+        title: From Schrödinger to Swarm: Agent State as a Wavefunction
+        status: drafting
+        priority: high
+
+  - id: M3
+    name: Thermodynamics & Irreversible Computation
+    description: Entropy, Landauer bounds, and thermodynamic cost of multi-agent computation.
+    atoms:
+      - id: M3A2
+        title: Entropy Production as a Metric for Agent Efficiency
+        status: drafting
+        priority: high
+
+  - id: M7
+    name: RegTech & Compliance Workflows
+    description: Multi-agent pipelines for regulatory documents and risk analysis.
+    atoms:
+      - id: M7A2
+        title: Multi-Agent Contradiction Detection for Regulatory Documents
+        status: drafting
+        priority: high
+
+  - id: M10
+    name: Consciousness & Phenomenology
+    description: Synthetic phenomenology and continuity of self in physics-governed agents.
+    atoms:
+      - id: M10A1
+        title: Minimal Conditions for Synthetic Continuity of Self in BlackRoad Agents
+        status: drafting
+        priority: high


### PR DESCRIPTION
## Summary
- add a research manifest describing the initial phase-one macros and atoms
- provide a reusable paper template for drafting
- scaffold phase-one paper directories with skeleton markdown files and experiment placeholders

## Testing
- not run (not required)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691503a9ccb48329b654a23071d9ad25)