### PR TITLE
Expand default mention automation

### DIFF
--- a/.github/mention-routes.yml
+++ b/.github/mention-routes.yml
@@ -17,5 +17,20 @@
       "mention": "@alexalouise"
     }
   ],
-  "always": ["@copilot", "@dependabot", "@claude", "@codex", "@blackboxprogramming"]
+  "always": [
+    "@copilot",
+    "@dependabot",
+    "@claude",
+    "@codex",
+    "@blackboxprogramming",
+    "@blackroad",
+    "@cadillac",
+    "@lucidia",
+    "@cecilia",
+    "@gitguardian",
+    "@slackbot",
+    "@blackroadagents",
+    "@vercel",
+    "@github-actions"
+  ]
 }


### PR DESCRIPTION
## Summary
- expand the mention routes configuration to always tag the requested automation accounts

## Testing
- not run (not required)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69150b975b188329a884a7a8e1d6228a)