### PR TITLE
Fix npm workspace install configuration

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
-registry=http://verdaccio.internal:4873
-strict-ssl=false
+registry=https://registry.npmjs.org/

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "blackroad-prism-console",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "workspaces": [
         "frontend"
       ],

--- a/package.json
+++ b/package.json
@@ -11,9 +11,10 @@
     "frontend"
   ],
   "scripts": {
-    "dev": "npm --prefix frontend run dev",
-    "build": "npm --prefix frontend run build",
-    "preview": "npm --prefix frontend run preview",
-    "test": "npm --prefix frontend run test"
+    "dev": "npm run dev --workspace frontend",
+    "build": "npm run build --workspace frontend",
+    "preview": "npm run preview --workspace frontend",
+    "test": "npm run test --workspace frontend",
+    "postinstall": "npm install --prefix frontend"
   }
 }


### PR DESCRIPTION
## Summary
- point npm to the public registry so installs work outside of the internal network
- run workspace scripts via npm workspaces helpers and ensure frontend dependencies install during postinstall

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69150d0d27208329904c80da87ab57ca)