### PR TITLE
Ensure pytest can locate orchestrator package

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,18 @@ from __future__ import annotations
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Sequence
+import sys
 
 import pytest
+
+
+# Ensure project root is on sys.path when tests are executed directly via pytest or
+# when individual modules are invoked as scripts (e.g. ``python tests/...``).
+# This mirrors the behavior of installing the package but keeps the test suite
+# lightweight for local development and CI runs.
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
 
 if TYPE_CHECKING:  # pragma: no cover - import-time typing only
     from bots import build_registry as BuildRegistryFunc


### PR DESCRIPTION
## Summary
- add a lightweight sys.path shim in `tests/conftest.py` so the repository root is importable during tests
- document the reason for the shim to keep local and CI test execution predictable

## Testing
- `pytest tests/unit/test_redaction.py tests/fuzz/test_property_based.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916212f59b88329a3240967329117f2)