### PR TITLE
Modularize prism console main entrypoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,50 +1,25 @@
-"""Streamlit app for BlackRoad Prism Generator with GPT and voice input."""
+"""Streamlit entrypoint for the BlackRoad Prism Generator console."""
 
-import os
-import tempfile
+from __future__ import annotations
 
 import streamlit as st
-import whisper
-from openai import OpenAI
 
-st.set_page_config(layout="wide")
-st.title("BlackRoad Prism Generator with GPT + Voice Console")
+from prism_console import PRISM_APP
 
-_api_key = os.getenv("OPENAI_API_KEY")
-client = OpenAI(api_key=_api_key) if _api_key else None
-if not _api_key:
+client, api_key = PRISM_APP["create_client"]()
+
+st.set_page_config(**PRISM_APP["page_config"])
+st.title(PRISM_APP["metadata"]["title"])
+
+if not api_key:
     st.warning("OpenAI API key not set; responses will be unavailable.")
-# Initialize the OpenAI client if an API key is provided
-api_key = os.getenv("OPENAI_API_KEY")
-client = OpenAI(api_key=api_key) if api_key else None
-if client is None:
-    st.warning("OpenAI API key not set. Set OPENAI_API_KEY to enable responses.")
 
-
-@st.cache_resource
-def load_whisper_model():
-    """Load the Whisper model once and reuse across reruns."""
-    return whisper.load_model("base")
-
-def _transcribe_audio(uploaded_file) -> str:
-    """Transcribe an uploaded audio file using Whisper and clean up temp file."""
-    suffix = os.path.splitext(uploaded_file.name)[1] or ".wav"
-    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as temp_audio:
-        temp_audio.write(uploaded_file.read())
-        temp_path = temp_audio.name
-    model = load_whisper_model()
-    result = model.transcribe(temp_path)
-    os.remove(temp_path)
-    return result["text"]
-
-
-st.markdown(
-    "#### Speak or type an idea, formula, or question. The AI will respond and project a hologram:"
-)
+st.markdown(PRISM_APP["metadata"]["instructions"])
 
 audio_file = st.file_uploader("Upload your voice (mp3 or wav)", type=["mp3", "wav"])
+user_input = ""
 if audio_file is not None:
-    user_input = _transcribe_audio(audio_file)
+    user_input = PRISM_APP["transcribe_audio"](audio_file)
     st.markdown(f"**You said:** {user_input}")
 else:
     user_input = st.text_input("Or type here")
@@ -53,24 +28,7 @@ if user_input:
     if not client:
         st.error("OpenAI API key not set.")
     else:
-        st.session_state.setdefault(
-            "chat_history",
-            [
-                {
-                    "role": "system",
-                    "content": (
-                        "You are the BlackRoad Venture Console AI, a holographic assistant "
-                        "that replies with scientific and symbolic insights."
-                    ),
-                }
-            ],
-        )
-        st.session_state.chat_history.append({"role": "user", "content": user_input})
         placeholder = st.empty()
         placeholder.write("Processing request...")
-        response = client.chat.completions.create(
-            model="gpt-4o-mini", messages=st.session_state.chat_history
-        )
-        reply = response.choices[0].message["content"]
-        st.session_state.chat_history.append({"role": "assistant", "content": reply})
+        reply = PRISM_APP["run_completion"](client, user_input, st.session_state)
         placeholder.markdown(f"**AI:** {reply}")

--- a/prism_console/__init__.py
+++ b/prism_console/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for composing the Streamlit Prism console app."""
+
+from prism_console.app_registry import PRISM_APP
+
+__all__ = ["PRISM_APP"]

--- a/prism_console/app_registry.py
+++ b/prism_console/app_registry.py
@@ -1,0 +1,14 @@
+"""Central registry describing the working pieces of the console app."""
+
+from __future__ import annotations
+
+from . import audio, chat, config
+
+PRISM_APP = {
+    "page_config": config.PAGE_CONFIG,
+    "metadata": config.APP_METADATA,
+    "create_client": config.create_openai_client,
+    "transcribe_audio": audio.transcribe_audio,
+    "run_completion": chat.run_chat_completion,
+    "system_prompt": chat.SYSTEM_PROMPT,
+}

--- a/prism_console/audio.py
+++ b/prism_console/audio.py
@@ -1,0 +1,40 @@
+"""Audio transcription helpers used by the Streamlit console."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from typing import Protocol
+
+import streamlit as st
+import whisper
+
+
+class UploadedAudio(Protocol):
+    """Subset of Streamlit's UploadedFile API used for transcription."""
+
+    name: str
+
+    def read(self) -> bytes:  # pragma: no cover - defined by Streamlit
+        ...
+
+
+@st.cache_resource
+def load_whisper_model(model_size: str = "base"):
+    """Load and cache the Whisper model across Streamlit reruns."""
+
+    return whisper.load_model(model_size)
+
+
+def transcribe_audio(uploaded_file: UploadedAudio) -> str:
+    """Transcribe an uploaded audio file using Whisper."""
+
+    suffix = os.path.splitext(uploaded_file.name)[1] or ".wav"
+    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as temp_audio:
+        temp_audio.write(uploaded_file.read())
+        temp_path = temp_audio.name
+
+    model = load_whisper_model()
+    result = model.transcribe(temp_path)
+    os.remove(temp_path)
+    return result["text"]

--- a/prism_console/chat.py
+++ b/prism_console/chat.py
@@ -1,0 +1,30 @@
+"""Chat helpers for interacting with the OpenAI client."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from openai import OpenAI
+
+SYSTEM_PROMPT = (
+    "You are the BlackRoad Venture Console AI, a holographic assistant that replies "
+    "with scientific and symbolic insights."
+)
+
+
+def _ensure_history(session_state: Dict) -> List[Dict[str, str]]:
+    """Ensure the session state contains the seeded chat history."""
+
+    session_state.setdefault("chat_history", [{"role": "system", "content": SYSTEM_PROMPT}])
+    return session_state["chat_history"]
+
+
+def run_chat_completion(client: OpenAI, user_input: str, session_state: Dict) -> str:
+    """Send the conversation to OpenAI and persist the assistant reply."""
+
+    history = _ensure_history(session_state)
+    history.append({"role": "user", "content": user_input})
+    response = client.chat.completions.create(model="gpt-4o-mini", messages=history)
+    reply = response.choices[0].message["content"]
+    history.append({"role": "assistant", "content": reply})
+    return reply

--- a/prism_console/config.py
+++ b/prism_console/config.py
@@ -1,0 +1,26 @@
+"""Configuration helpers for the Prism console app."""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, Optional, Tuple
+
+from openai import OpenAI
+
+PAGE_CONFIG: Dict[str, str] = {"layout": "wide"}
+
+APP_METADATA: Dict[str, str] = {
+    "title": "BlackRoad Prism Generator with GPT + Voice Console",
+    "instructions": (
+        "#### Speak or type an idea, formula, or question. The AI will respond and "
+        "project a hologram:"
+    ),
+}
+
+
+def create_openai_client() -> Tuple[Optional[OpenAI], Optional[str]]:
+    """Create an OpenAI client and return it alongside the API key used."""
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    client = OpenAI(api_key=api_key) if api_key else None
+    return client, api_key


### PR DESCRIPTION
## Summary
- extract the audio transcription, chat, and configuration helpers into a new `prism_console` package
- expose those working pieces via a registry dictionary so the Streamlit entrypoint simply wires the app together
- simplify `main.py` to consume the registry, yielding a smaller surface for future reuse

## Testing
- python -m compileall main.py prism_console

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916322192608329b50f879304fe56eb)