### PR TITLE
Fix qlm-lab pyproject config

### DIFF
--- a/modules/qlm_lab/pyproject.toml
+++ b/modules/qlm_lab/pyproject.toml
@@ -2,11 +2,26 @@
 name = "qlm-lab"
 version = "0.1.3"
 requires-python = ">=3.11"
-dependencies = ["numpy", "matplotlib", "sympy", "pyyaml", "fastapi>=0.110"]
+dependencies = [
+    "fastapi>=0.110",
+    "matplotlib",
+    "numpy",
+    "pyyaml",
+    "sympy",
+]
 
 [project.optional-dependencies]
-qiskit = ["qiskit", "qiskit-aer"]
-viz = ["matplotlib"]
+qiskit = [
+    "qiskit",
+    "qiskit-aer",
+]
+viz = [
+    "matplotlib",
+]
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
 pythonpath = ["."]


### PR DESCRIPTION
## Summary
- normalize the qlm-lab pyproject by formatting dependency lists and ensuring optional groups remain consistent
- add an explicit build-system table so the configuration is valid for packaging tools

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69164d9adadc8329b1588ac489e42ea1)