### PR TITLE
Add pagination controls to PR cleanup bot

### DIFF
--- a/agents/pr_cleanup_bot.py
+++ b/agents/pr_cleanup_bot.py
@@ -19,15 +19,25 @@ class PullRequestCleanupBot:
         repo: Repository in ``owner/name`` format.
         token: GitHub token with repo scope. Uses ``GITHUB_TOKEN`` env var if omitted.
         days: Items with no updates for this many days are considered stale.
+        max_pull_requests: Cap on how many open PRs are inspected per run. Defaults to
+            the first 20 so that smaller bursts are handled quickly but can be
+            increased (up to 2000) when a backlog builds up.
+        page_size: GitHub API page size (1–100) used while paging through open PRs.
     """
 
     repo: str
     token: Optional[str] = None
     days: int = 30
+    max_pull_requests: int = 20
+    page_size: int = 50
 
     def __post_init__(self) -> None:
         if self.token is None:
             self.token = os.getenv("GITHUB_TOKEN")
+        if not 1 <= self.max_pull_requests <= 2000:
+            raise ValueError("max_pull_requests must be between 1 and 2000")
+        if not 1 <= self.page_size <= 100:
+            raise ValueError("page_size must be between 1 and 100")
 
     def _headers(self) -> dict:
         headers = {
@@ -38,13 +48,29 @@ class PullRequestCleanupBot:
             headers["Authorization"] = f"token {self.token}"
         return headers
 
-    def get_open_pull_requests(self) -> List[dict]:
-        """Return all open pull requests for the repository."""
+    def get_open_pull_requests(self, limit: Optional[int] = None) -> List[dict]:
+        """Return open pull requests for the repository up to ``limit``."""
 
-        url = f"https://api.github.com/repos/{self.repo}/pulls?state=open"
-        response = requests.get(url, headers=self._headers(), timeout=10)
-        response.raise_for_status()
-        return response.json()
+        limit = limit or self.max_pull_requests
+        if limit <= 0:
+            return []
+
+        pulls: List[dict] = []
+        page = 1
+        per_page = min(self.page_size, 100)
+        while len(pulls) < limit:
+            params = {"state": "open", "per_page": per_page, "page": page}
+            url = f"https://api.github.com/repos/{self.repo}/pulls"
+            response = requests.get(url, params=params, headers=self._headers(), timeout=10)
+            response.raise_for_status()
+            data = response.json()
+            if not data:
+                break
+            pulls.extend(data)
+            if len(data) < per_page:
+                break
+            page += 1
+        return pulls[:limit]
 
     def close_pull_request(self, number: int) -> dict:
         """Close a pull request by number."""
@@ -102,9 +128,31 @@ def main(argv: List[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("repo", help="Repository in owner/name format")
     parser.add_argument("--days", type=int, default=30, help="Days to consider stale")
+    parser.add_argument(
+        "--max-open",
+        type=int,
+        default=20,
+        help="Maximum number of open pull requests to inspect (1-2000)",
+    )
+    parser.add_argument(
+        "--page-size",
+        type=int,
+        default=50,
+        help="GitHub API page size for pull request listing (1-100)",
+    )
     args = parser.parse_args(argv)
 
-    bot = PullRequestCleanupBot(repo=args.repo, days=args.days)
+    if not 1 <= args.max_open <= 2000:
+        parser.error("--max-open must be between 1 and 2000")
+    if not 1 <= args.page_size <= 100:
+        parser.error("--page-size must be between 1 and 100")
+
+    bot = PullRequestCleanupBot(
+        repo=args.repo,
+        days=args.days,
+        max_pull_requests=args.max_open,
+        page_size=args.page_size,
+    )
     closed = bot.close_stale_pull_requests()
     for pr_number in closed:
         print(f"Closed pull request #{pr_number}")


### PR DESCRIPTION
## Summary
- add configurable limits to the PR cleanup bot so it can focus on the first 20 open pull requests or scale up to 2000 when necessary
- paginate GitHub API calls using a tunable page size for better performance on large repositories
- expose `--max-open` and `--page-size` flags in the CLI with input validation

## Testing
- python -m py_compile agents/pr_cleanup_bot.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916594166188329adeaad6614e6667b)