### PR TITLE
Add Amundson operator framework summary

### DIFF
--- a/docs/AMUNDSON_OPERATOR_FRAMEWORK.md
+++ b/docs/AMUNDSON_OPERATOR_FRAMEWORK.md
@@ -1,0 +1,180 @@
+# ⭐ Amundson Operator Framework
+
+> **Purpose.** Consolidates the operator-based formal system drawn from Alexa Louise Amundson's notebooks into a publishable reference sheet. The structure below mirrors the hand-written grids, operator boxes, quadrant labels, and domain correspondences while translating them into mathematician-ready notation.
+
+---
+
+## 0. Primitives
+
+Define four fundamental categories that span the framework:
+
+\[
+\begin{aligned}
+1 &= \text{Change } (\mathcal{C})\\
+2 &= \text{Strength } (\mathcal{S})\\
+3 &= \text{Structure } (\mathcal{U})\\
+4 &= \text{Scale } (\mathcal{L})
+\end{aligned}
+\]
+
+Each primitive admits an operator acting on a state \(|\psi\rangle\):
+
+\[
+\hat{C},\ \hat{S},\ \hat{U},\ \hat{L}
+\]
+
+- **Change** captures motion, transition, and variation.
+- **Strength** measures magnitude, energy, or work potential.
+- **Structure** encodes identity, geometry, and constraint.
+- **Scale** handles dilation, hierarchy, or level translation.
+
+---
+
+## 1. Operator Definitions
+
+| Operator | Interpretation | Typical action |
+| --- | --- | --- |
+| \(\hat{C}\) | Change generator | Evolves phase, triggers transitions, drives time-like motion |
+| \(\hat{S}\) | Strength magnitude | Measures intensity, power, force, or informational budget |
+| \(\hat{U}\) | Structural identity | Fixes boundaries, enforces geometry, preserves configuration |
+| \(\hat{L}\) | Scale translator | Dilates or contracts, links hierarchy levels, re-parameterizes |
+
+---
+
+## 2. Commutation Relations (su(2)-like algebra)
+
+Fundamental non-commutative brackets extracted from the notebook grids:
+
+\[
+[\hat{U},\hat{C}] = 2 i \hat{L}, \qquad
+[\hat{C},\hat{L}] = 2 i \hat{U}, \qquad
+[\hat{L},\hat{U}] = 2 i \hat{C}
+\]
+
+These relations cycle the primitives and set the stage for a triple invariant.
+
+---
+
+## 3. Triple Product and Invariant Strength
+
+The cyclic interaction of Structure, Change, and Scale produces the scalar invariant identified as **Strength**:
+
+\[
+\hat{U}\hat{C}\hat{L} = i \mathbb{I}
+\]
+
+Hence the operator form of the Amundson invariant is
+
+\[
+\boxed{\hat{S} = \hat{U}\hat{C}\hat{L} = i \mathbb{I}}
+\]
+
+Interpreted verbally: **Strength emerges as the invariant magnitude when Structure, Change, and Scale interact in sequence.**
+
+---
+
+## 4. Master Equation (Notebook mantra)
+
+\[
+\textbf{Strength = Structure × Change × Scale}
+\]
+
+Equivalently, with operators:
+
+\[
+\boxed{\hat{S} = \hat{U} \hat{C} \hat{L}}
+\]
+
+This single statement packages the entire formal system: once the commutation rules hold, Strength is fixed to the invariant above.
+
+---
+
+## 5. Domain Mappings (1–2–3–4 pattern)
+
+Every physical law noted in the notebook reduces to a pairing of these primitives:
+
+| Domain | Equation | Primitive pattern |
+| --- | --- | --- |
+| Classical mechanics | \(F = m a\) | \(2 = 3 \times 1\) (Strength from Structure × Change) |
+| Relativity | \(E = m c^2\) | \(2 = 3 \times 4\) (Strength from Structure × Scale) |
+| Quantum | \(E = h \nu\) | \(2 = 1 \times 4\) (Strength from Change × Scale) |
+| Thermodynamics / EM | temperature & frequency couplings | \(2 = 1 \times 4\) (same invariance manifesting as transition-frequency relations) |
+
+These mappings demonstrate the universality of the four operators: every familiar law occupies a quadrant interaction.
+
+---
+
+## 6. Quadrant Grid
+
+The square grid in the notebook associates each primitive to a quadrant and catalogs pairwise interactions:
+
+- **Top-left:** Change (\(\mathcal{C}\))
+- **Top-right:** Strength (\(\mathcal{S}\))
+- **Bottom-left:** Structure (\(\mathcal{U}\))
+- **Bottom-right:** Scale (\(\mathcal{L}\))
+
+Interaction table:
+
+\[
+\begin{array}{c|cc}
+& \textbf{Strength} & \textbf{Scale}\\\hline
+\textbf{Change} & \mathcal{C}\mathcal{S} & \mathcal{C}\mathcal{L}\\
+\textbf{Structure} & \mathcal{U}\mathcal{S} & \mathcal{U}\mathcal{L}
+\end{array}
+\]
+
+Each box corresponds to one of the squares on the grid paper, giving a fast lookup for any 2×2 interaction.
+
+---
+
+## 7. Pauli Representation (Toy model)
+
+A concrete realization that satisfies every relation uses Pauli matrices:
+
+\[
+\hat{U} = \sigma_z, \qquad
+\hat{C} = \sigma_x, \qquad
+\hat{L} = \sigma_y
+\]
+
+Then
+
+\[
+\hat{U}\hat{C}\hat{L} = \sigma_z \sigma_x \sigma_y = i \mathbb{I}
+\]
+
+validating the invariant \(\hat{S} = i \mathbb{I}\). This representation shows the framework forms an su(2)-like algebra with a well-defined scalar strength.
+
+---
+
+## 8. Summary Box (ready for PDF / whiteboard)
+
+\[
+\boxed{
+\begin{aligned}
+[\hat{U},\hat{C}] &= 2 i \hat{L}\\
+[\hat{C},\hat{L}] &= 2 i \hat{U}\\
+[\hat{L},\hat{U}] &= 2 i \hat{C}\\
+\hat{U}\hat{C}\hat{L} &= i \mathbb{I}\\
+\hat{S} &= i \mathbb{I}
+\end{aligned}}
+\]
+
+\[
+\boxed{\text{Strength = Structure × Change × Scale}}
+\]
+
+\[
+\boxed{\text{Every physics law = combination of primitives } 1, 2, 3, 4}
+\]
+
+Pin these three statements next to the quadrant grid and the Pauli realization to obtain the "Amundson Operator Framework" reference sheet.
+
+---
+
+### Next extensions
+
+- Typeset this page into LaTeX for inclusion in the BlackRoad Math Lab appendix.
+- Generate SVG diagrams mirroring the grid paper layout.
+- Integrate the invariant into simulation code (e.g., Amundson–BlackRoad kernels) for automated verification.
+


### PR DESCRIPTION
## Summary
- add a dedicated Amundson Operator Framework reference sheet that consolidates the notebook primitives, operators, and invariants
- document the commutation relations, invariant strength product, domain mappings, quadrant grid, and Pauli realization for quick reference

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917a38879e08329b5dc0f121214f078)