### PR TITLE
Add BlackRoad corporate org documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ Comprehensive documentation available in `docs/`:
 - [SECURITY.md](./SECURITY.md) - Security practices
 - [AGENT_WORKBOARD.md](./AGENT_WORKBOARD.md) - Agent development
 - [README-OPS.md](./README-OPS.md) - Operations guide
+- [BLACKROAD_CORPORATE_ORG_V1.md](./docs/BLACKROAD_CORPORATE_ORG_V1.md) - Full corporate org structure
 
 ## License
 

--- a/docs/BLACKROAD_CORPORATE_ORG_V1.md
+++ b/docs/BLACKROAD_CORPORATE_ORG_V1.md
@@ -1,0 +1,177 @@
+# 🌐 BlackRoad Corporate Organization v1.0
+
+A comprehensive organizational layout for a 150–250 person, regulated global AI/FinTech/creator platform. This structure maps every major division that powers BlackRoad today—from executive vision to creator enablement—and can be copied directly into notebooks, pitch materials, or operational blueprints.
+
+---
+
+## 🏛️ 1. Executive & Strategy Division
+**Responsibilities:** Vision, governance, high-level decisions, capital allocation.
+
+**Key Roles**
+- Chief Executive Officer (CEO)
+- Chief Operating Officer (COO)
+- Chief Technology Officer (CTO)
+- Chief Product Officer (CPO)
+- Chief Financial Officer (CFO)
+- Chief Legal Officer (CLO)
+- Chief Compliance Officer (CCO)
+- Chief Risk Officer (CRO)
+- Chief Creative Officer (CCrO)
+- Chief Data/AI Officer (CDAO)
+- Executive Chief of Staff
+
+**Approximate size:** 8–12
+
+> Notes: Founder/CEO holds the central vision.
+
+---
+
+## 🧠 2. Research & Development (Lucidia Division)
+**Responsibilities:** Mathematics, quantum research, agent systems, simulations, advanced modeling.
+
+**Teams**
+- Amundson Equations Research
+- Quantum Simulation Team
+- ML/AI Research Lab
+- Calculation Engines
+- Visualization + Math Lab
+
+**Roles:** Research Scientists, Computational Mathematicians, ML Research Engineers, Simulation Engineers, Data Scientists, Research Program Manager.
+
+**Approximate size:** 15–30
+
+---
+
+## 🛠️ 3. Engineering Division (Codex + Prism + Platform)
+**Responsibilities:** Build software, agents, backends, frontends, and internal platforms.
+
+**Subteams & Focus Areas**
+- **Backend Engineering:** API engineers, microservices developers, database engineers.
+- **Frontend Engineering:** React/Next.js engineers, Unity 3D engineers, design-system engineers.
+- **Platform Engineering:** DevOps, SRE, CI/CD pipeline architects, telemetry/observability.
+- **Agent Engineering:** Orchestration, identity & safety, prompt architecture, worker pools.
+- **Data Engineering:** ETL pipelines, data lakes, real-time data processing.
+
+**Approximate size:** 40–80 total.
+
+---
+
+## ⚙️ 4. Infrastructure & Cloud Division (DigitalOcean + multi-cloud)
+**Responsibilities:** Cloud, hardware, scaling, networks, reliability.
+
+**Roles:** Cloud infrastructure engineers, Kubernetes engineers, network/security engineers, systems engineers, Pi-Ops hardware team, load & performance engineers.
+
+**Approximate size:** 12–20
+
+---
+
+## ✨ 5. Product Division
+**Responsibilities:** Translate strategy into roadmaps and features; coordinate delivery.
+
+**Roles:** Product Managers (Platform, Prism, Lucidia, Creator Tools, Enterprise, Risk/Quant, Infra), Technical Product Managers, Program Managers, Product Analysts.
+
+**Approximate size:** 10–15
+
+---
+
+## 🎨 6. Design & Experience Division
+**Responsibilities:** UX/UI, creative tools, brand and spatial/Unity interfaces.
+
+**Roles:** UX Designers, UI Designers, 3D & Unity Experience Designers, Interaction Designers, Creative Director, Visual Designers, Motion/3D Graphics specialists.
+
+**Approximate size:** 10–20
+
+---
+
+## 🧮 7. Finance, Treasury & Operations Division
+**Responsibilities:** Financial controls, billing, liquidity, planning, and internal operations.
+
+**Teams**
+- **Finance:** FP&A, accounting, revenue operations.
+- **Treasury:** Liquidity management, capital reserves, payments & settlements.
+- **Business Operations:** Internal process design, corporate systems, vendor management.
+
+**Approximate size:** 15–25
+
+---
+
+## ⚖️ 8. Compliance & Governance Division
+**Responsibilities:** Regulatory adherence (FINRA/SEC), policy governance, internal audits.
+
+**Teams**
+- **Regulatory Compliance:** FINRA/SEC compliance, advertising review (2210), books & records (204-2), brokerage/RIA compliance.
+- **Governance:** Policy design, ethical AI, accountability systems.
+- **Internal Audit**
+
+**Approximate size:** 20–30 (largest control-focused division).
+
+---
+
+## 🛡️ 9. Security Division
+**Responsibilities:** Cybersecurity, application security, infrastructure defense, agent safety.
+
+**Teams:** Red Team, Blue Team, Threat Detection, Security Engineering, Agent Safety, Access Controls.
+
+**Approximate size:** 10–20
+
+---
+
+## 📣 10. Marketing, Brand & Communications
+**Responsibilities:** Messaging, voice, growth, and external presence.
+
+**Roles:** Brand Director, Communications Manager, PR, Growth Marketing, Content Writers, Social Media, Video/Creative specialists.
+
+**Approximate size:** 10–20
+
+---
+
+## 🤝 11. Customer & Enterprise Support
+**Responsibilities:** Customer care, onboarding, technical assistance.
+
+**Roles:** Customer Success Managers, Technical Support, Enterprise Onboarding, Solutions Engineers, Client Operations.
+
+**Approximate size:** 15–30
+
+---
+
+## 🔗 12. Connectors & Partnerships Division
+**Responsibilities:** APIs, integrations, external platforms, strategic partnerships.
+
+**Roles:** Partnership leads, integration engineers, strategic alliances, vendor management.
+
+**Approximate size:** 8–12
+
+---
+
+## 🧩 13. People, Talent & Culture
+**Responsibilities:** Hiring, HR operations, training, and culture development.
+
+**Roles:** Recruiting, Talent Acquisition, People Ops, Learning & Development, HR Business Partners, Talent Analytics.
+
+**Approximate size:** 10–15
+
+---
+
+## 🧱 14. Creator Ecosystem Division
+**Responsibilities:** Support and grow creators, builders, designers within BlackRoad.
+
+**Roles:** Creator Support, Developer Relations (DevRel), Education & Training, Community Managers, Ecosystem Partnerships.
+
+**Approximate size:** 10–20
+
+---
+
+## 🏗️ Total Company Size
+The full BlackRoad corporate plan supports **150–250** team members, delivering a Wall Street-grade, AI-native company footprint.
+
+---
+
+### 📌 Next Options
+Ready-to-create add-ons include:
+- Visual org chart
+- Lean 12-month staffing version
+- Departments-to-buildings mapping
+- Multi-level org (L1/L2/L3 job families)
+- Hiring roadmap (sequenced recruiting plan)
+
+Use this artifact as the canonical “BlackRoad Corporate Org v1.0.”


### PR DESCRIPTION
## Summary
- add a dedicated `docs/BLACKROAD_CORPORATE_ORG_V1.md` file that captures the complete BlackRoad corporate structure for 150–250 employees
- link the new org reference from the main README so it is easy to discover in the documentation list

## Testing
- not run (documentation changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917ad4d2eac83298d6536f6d970032f)