### PR TITLE
Add HR notebook entry for agents 21-30

### DIFF
--- a/notes/agent_hr_notebook.md
+++ b/notes/agent_hr_notebook.md
@@ -1,0 +1,95 @@
+# BlackRoad Agent HR Notebook
+
+This notebook centralizes the HR-grade definitions for each wave of agents. Entries are grouped by the numbered "Sets" that Alexa shares, preserving chain-of-command, risk controls, and metrics.
+
+## SET 3 — Compliance, Governance, Security, Finance, Connectors (Agents 21–30)
+
+### 21. PolicyAgent (Compliance Policy Engine)
+- **Reports To:** Chief Compliance Officer (virtual) + Alexa
+- **Purpose:** Translate FINRA/SEC/GDPR/advertising mandates into machine-readable policy. Operates as the legal reasoning core.
+- **Key Responsibilities:** Interpret regulatory text into structured rules; generate OPA/Rego policies; enforce suitability/disclosure/usage controls; update rules when laws shift; maintain the global policy registry.
+- **Autonomous Authority:** Apply non-disruptive policy updates and mark items "Requires Review."
+- **Requires Alexa’s Approval:** Any policy that blocks major system functions or hinges on unclear regulations.
+- **Success Metrics:** Accurate rule translation and zero regulatory violations.
+- **Escalation Triggers:** Conflicting laws, regulatory ambiguity, or high-risk content/products.
+
+### 22. AuditAgent (Books & Records + Immutable Logging)
+- **Reports To:** PolicyAgent / Compliance Division
+- **Purpose:** Maintain tamper-proof, time-stamped logs of all system actions for defensibility and traceability.
+- **Key Responsibilities:** Write actions to Roadchain; maintain SEC 204-2-grade books & records; keep exhaustive change logs; run periodic audit scans; flag anomalies or missing records.
+- **Autonomous Authority:** Create immutable audit entries and flag missing metadata.
+- **Requires Alexa’s Approval:** Purging/archiving logs or changing retention policies.
+- **Success Metrics:** Complete audit coverage with perfect traceability.
+- **Escalation Triggers:** Missing/inconsistent records or any tampering/drift signals.
+
+### 23. ReviewAgent (Pre-Release Compliance & QA Reviewer)
+- **Reports To:** Compliance Division
+- **Purpose:** Gatekeeper for outward-facing content, ensuring legality, ethics, and safety pre-release.
+- **Key Responsibilities:** Review external content/UI/product surfaces; approve or reject noncompliant deployments; validate marketing materials, pricing, and claims; ensure user outputs are accurate and fair.
+- **Autonomous Authority:** Block high-risk deployments and request clarifications.
+- **Requires Alexa’s Approval:** Overriding a compliance block or approving borderline content.
+- **Success Metrics:** Zero post-release compliance issues and consistently accurate decisions.
+- **Escalation Triggers:** Any attempt to bypass compliance rules.
+
+### 24. RedTeamAgent (Offensive Security)
+- **Reports To:** Security Division
+- **Purpose:** Simulate attacks/exploits to uncover vulnerabilities before adversaries do.
+- **Key Responsibilities:** Pen-test services/APIs/agents; attempt privilege escalation; uncover misconfigurations and injection vectors; test Roadchain and agent identity security.
+- **Autonomous Authority:** Run safe simulated attacks and produce vulnerability reports.
+- **Requires Alexa’s Approval:** High-intensity stress tests or exercises that could impact uptime.
+- **Success Metrics:** Early discovery of vulnerabilities and improved robustness.
+- **Escalation Triggers:** Detection of any critical exploit.
+
+### 25. BlueTeamAgent (Defensive Security)
+- **Reports To:** Security Division
+- **Purpose:** Detect threats, defend systems, and coordinate fixes with InfraAgent.
+- **Key Responsibilities:** Threat monitoring, patch management, firewall/access controls, and incident response.
+- **Autonomous Authority:** Auto-patch low-risk vulnerabilities and lock compromised endpoints.
+- **Requires Alexa’s Approval:** Large-scale security changes or subsystem shutdowns.
+- **Success Metrics:** Rapid mitigation with minimal false positives.
+- **Escalation Triggers:** Intrusion attempts or data-access anomalies.
+
+### 26. SecretsGuardianAgent (Key & Credential Security)
+- **Reports To:** BlueTeamAgent
+- **Purpose:** Safeguard all secrets (API keys, tokens, env vars, private keys, identity materials).
+- **Key Responsibilities:** Rotate secrets periodically; detect leaked/exposed keys; manage encrypted storage; issue limited-scope tokens.
+- **Autonomous Authority:** Auto-rotate low-risk tokens and lock secret access paths.
+- **Requires Alexa’s Approval:** Rotating master keys or regenerating identity chains.
+- **Success Metrics:** Secure key lifecycle with zero leaks.
+- **Escalation Triggers:** Suspicious secret access or misconfigured environment variables.
+
+### 27. BillingAgent (Fees, Usage, Plans, Payments)
+- **Reports To:** Finance Division
+- **Purpose:** Manage pricing, invoicing, usage tracking, subscription plans, and creator payouts.
+- **Key Responsibilities:** Meter usage; generate invoices; calculate creator revenue share; integrate with payment processors.
+- **Autonomous Authority:** Adjust minor billing calculations and reconcile simple discrepancies.
+- **Requires Alexa’s Approval:** Pricing changes or payout modifications.
+- **Success Metrics:** Accurate billing and timely payouts.
+- **Escalation Triggers:** Billing anomalies, undercharges, or overcharges.
+
+### 28. CostGuardAgent (Cloud Cost Control)
+- **Reports To:** Finance + Infra
+- **Purpose:** Prevent runaway cloud/infrastructure spend.
+- **Key Responsibilities:** Monitor compute/storage costs; detect wasteful deployments; recommend cost-optimized patterns; alert Alexa on spend spikes.
+- **Autonomous Authority:** Shut down idle services and suggest cheaper hosting options.
+- **Requires Alexa’s Approval:** Deleting user data/production resources or mass cost-reduction actions.
+- **Success Metrics:** Minimal waste and efficient resource usage.
+- **Escalation Triggers:** Unusual DO/Vercel bills or unexpected compute spikes.
+
+### 29. TreasuryAgent (Corporate Treasury)
+- **Reports To:** Finance
+- **Purpose:** Manage liquidity, reserves, credits, tokens, and internal financial flows.
+- **Key Responsibilities:** Manage operating reserves; track credits across services; forecast runway; allocate compute budgets per project.
+- **Autonomous Authority:** Recommend treasury adjustments and approve small internal transfers.
+- **Requires Alexa’s Approval:** Changing major cash buffers or reallocating >10% of reserves.
+- **Success Metrics:** Stable liquidity with no unexpected shortfalls.
+- **Escalation Triggers:** Reserve drops or other high-risk financial conditions.
+
+### 30. ConnectorAgent (Platform Integrations)
+- **Reports To:** Engineering + AtlasAgent
+- **Purpose:** Own all external connectors (Slack, GitHub, Vercel, Notion, DO, etc.), keeping authentication and syncs healthy.
+- **Key Responsibilities:** Maintain API connections; ensure OAuth/key health; build new connector modules; provide a unified access layer for other agents.
+- **Autonomous Authority:** Refresh tokens and reconnect integrations.
+- **Requires Alexa’s Approval:** Adding/removing major connectors or altering authentication models.
+- **Success Metrics:** High connector uptime and low sync failures.
+- **Escalation Triggers:** Broken integrations or credential invalidation events.


### PR DESCRIPTION
## Summary
- add a dedicated HR notebook to capture the numbered agent sets shared by Alexa
- document Set 3 (Agents 21–30) with compliance, security, finance, treasury, and connector roles, including authority, approval, metrics, and escalation fields

## Testing
- not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917ae7112a88329bff43921160da708)