### PR TITLE
Add httpx TestClient compatibility shim

### DIFF
--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,0 +1,70 @@
+"""Runtime compatibility patches for the BlackRoad Prism test suite.
+
+This module is imported automatically by Python whenever it is present on the
+import path (see :mod:`site`).  We use it to keep third-party dependency
+behavior stable across the wide range of environments that run the tests.
+"""
+
+from __future__ import annotations
+
+from functools import wraps
+import inspect
+from typing import Any, Type
+
+
+def _patch_httpx_app_argument() -> None:
+    """Allow ``httpx`` clients to accept the deprecated ``app=`` argument.
+
+    FastAPI/Starlette's :class:`~fastapi.testclient.TestClient` (and several
+    other internal tests) still rely on passing ``app=...`` to
+    :class:`httpx.Client`/``AsyncClient``.  Newer releases of ``httpx`` removed
+    this parameter, expecting callers to construct an ``ASGITransport`` instead.
+
+    Rather than pinning an older version of ``httpx`` across the entire repo, we
+    adapt the new API surface so it remains backwards compatible.  When the
+    ``app`` keyword is provided we transparently create an ``ASGITransport`` and
+    forward it through ``transport=``.
+    """
+
+    try:
+        import httpx  # type: ignore
+    except Exception:  # pragma: no cover - optional dependency in some envs
+        return
+
+    transport_factory = getattr(httpx, "ASGITransport", None)
+    if transport_factory is None:  # pragma: no cover - extremely old httpx
+        return
+
+    def _needs_patch(cls: Type[Any]) -> bool:
+        if getattr(cls, "__blackroad_patched__", False):
+            return False
+        try:
+            sig = inspect.signature(cls.__init__)
+        except (TypeError, ValueError):  # pragma: no cover - builtin/extension
+            return False
+        return "app" not in sig.parameters
+
+    def _apply_patch(cls: Type[Any]) -> None:
+        if not _needs_patch(cls):
+            return
+
+        original_init = cls.__init__
+
+        @wraps(original_init)
+        def patched_init(self: Any, *args: Any, app: Any = None, **kwargs: Any) -> None:
+            if app is not None and "transport" not in kwargs:
+                try:
+                    kwargs["transport"] = transport_factory(app=app)
+                except Exception:  # pragma: no cover - defensive
+                    pass
+            original_init(self, *args, **kwargs)
+
+        cls.__init__ = patched_init  # type: ignore[assignment]
+        setattr(cls, "__blackroad_patched__", True)
+
+    for target in (httpx.Client, httpx.AsyncClient):
+        _apply_patch(target)
+
+
+_patch_httpx_app_argument()
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,21 +7,15 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Sequence
 import sys
 
-from pathlib import Path
-import sys
-
-import pytest
-
-
-# Ensure project root is on sys.path when tests are executed directly via pytest or
-# when individual modules are invoked as scripts (e.g. ``python tests/...``).
-# This mirrors the behavior of installing the package but keeps the test suite
-# lightweight for local development and CI runs.
-# Ensure the project root is importable even when pytest is executed via the
-# Pyenv shim (which sets ``sys.path[0]`` to the interpreter bin directory).
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
+
+# Ensure runtime compatibility patches (notably the httpx TestClient shim)
+# are installed before any of the FastAPI-based tests import TestClient.
+import sitecustomize  # noqa: F401  # pylint: disable=unused-import
+
+import pytest
 
 if TYPE_CHECKING:  # pragma: no cover - import-time typing only
     from bots import build_registry as BuildRegistryFunc


### PR DESCRIPTION
## Summary
- add a sitecustomize module that patches httpx Client/AsyncClient so FastAPI's TestClient can continue to pass the legacy `app=` keyword argument
- import the compatibility shim from tests/conftest.py to ensure the patch is active before any FastAPI-based tests instantiate a TestClient

## Testing
- pytest tests/test_pi_ping.py
- pytest tests/test_math_api.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69183fa4048c83299b490f2e6312f841)