### PR TITLE
Fix duplicate session boot logic

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -187,53 +187,22 @@ export default function App(){
 
   useEffect(() => {
     const token = localStorage.getItem('token')
+
     if (!token) {
-      setAuthChecked(true)
       resetState()
+      setAuthChecked(true)
       return
     }
 
     setToken(token)
     ;(async () => {
       try {
-        const current = await me()
-        setUser(current)
+        const currentUser = await me()
+        setUser(currentUser)
         await bootData()
         connectSocket()
       } catch (err) {
         console.error('Failed to restore session', err)
-  // Restore auth token from local storage on load and reset when missing
-  useEffect(() => {
-    const token = localStorage.getItem('token')
-    if (!token) {
-      // Clear any lingering state when no token exists
-      resetState()
-      return
-    }
-    setToken(token)
-    ;(async () => {
-      try {
-        const u = await me()
-        setUser(u)
-        await bootData()
-        connectSocket()
-      } catch (e) {
-  // Restore auth token from local storage on load and clear state if missing
-  useEffect(()=>{
-    const token = localStorage.getItem('token')
-    setToken(token || '')
-    ;(async ()=>{
-      try {
-        if (token) {
-          const u = await me()
-          setUser(u)
-          await bootData()
-          connectSocket()
-        } else {
-          resetState()
-        }
-      } catch(e){
-        // Reset state on auth failure and log for debugging
         resetState()
       } finally {
         setAuthChecked(true)


### PR DESCRIPTION
## Summary
- collapse the multiple overlapping session-restoration effects in `App.jsx` into a single, well-scoped hook
- ensure auth state resets cleanly when no token is present or session recovery fails, while still booting data when it succeeds

## Testing
- `npm run build` *(fails: vite/esbuild cannot parse ../package.json due to duplicate keys and invalid JSON in the repository root)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69185dd359e48329b3e72b0a4213d4be)