### PR TITLE
Implement PostSlackMessage Slack webhook integration

### DIFF
--- a/harness/runner.go
+++ b/harness/runner.go
@@ -1,8 +1,11 @@
 package harness
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"os"
 	"time"
 )
 
@@ -110,6 +113,26 @@ func EmitComplianceNotification(dec RuleDecision) error {
 }
 
 func PostSlackMessage(channel string, payload map[string]any) error {
-	// TODO: wire into Slack API client or webhook
+	webhookURL := os.Getenv("SLACK_WEBHOOK_URL")
+	if webhookURL == "" {
+		return fmt.Errorf("SLACK_WEBHOOK_URL is not set")
+	}
+
+	payload["channel"] = channel
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal slack payload: %w", err)
+	}
+
+	resp, err := http.Post(webhookURL, "application/json", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("post to slack: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("slack webhook returned status %d", resp.StatusCode)
+	}
 	return nil
 }

--- a/harness/runner_test.go
+++ b/harness/runner_test.go
@@ -1,0 +1,64 @@
+package harness
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestPostSlackMessage_Success(t *testing.T) {
+	var received map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+			t.Errorf("expected application/json, got %s", ct)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&received); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	t.Setenv("SLACK_WEBHOOK_URL", srv.URL)
+
+	err := PostSlackMessage("#secops", map[string]any{
+		"text": "test alert",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if received["channel"] != "#secops" {
+		t.Errorf("expected channel #secops, got %v", received["channel"])
+	}
+	if received["text"] != "test alert" {
+		t.Errorf("expected text 'test alert', got %v", received["text"])
+	}
+}
+
+func TestPostSlackMessage_MissingWebhookURL(t *testing.T) {
+	t.Setenv("SLACK_WEBHOOK_URL", "")
+
+	err := PostSlackMessage("#general", map[string]any{"text": "hello"})
+	if err == nil {
+		t.Fatal("expected error when SLACK_WEBHOOK_URL is empty")
+	}
+}
+
+func TestPostSlackMessage_NonOKStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	t.Setenv("SLACK_WEBHOOK_URL", srv.URL)
+
+	err := PostSlackMessage("#secops", map[string]any{"text": "test"})
+	if err == nil {
+		t.Fatal("expected error on non-2xx status")
+	}
+}


### PR DESCRIPTION
Wire the PostSlackMessage stub into a real Slack webhook call using
the SLACK_WEBHOOK_URL environment variable. The function JSON-encodes
the payload with the target channel and POSTs it to the configured
webhook, returning errors for missing config or non-2xx responses.

Add tests covering the success path, missing env var, and error status.

https://claude.ai/code/session_01ViAgYUjmCpm8mtuq7722aF