### PR TITLE
Implement PostSlackMessage Slack webhook integration in harness

### DIFF
--- a/harness/runner.go
+++ b/harness/runner.go
@@ -1,8 +1,11 @@
 package harness
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"os"
 	"time"
 )
 
@@ -109,7 +112,37 @@ func EmitComplianceNotification(dec RuleDecision) error {
 	return PostSlackMessage("#secops", payload)
 }
 
+// slackHTTPClient is the HTTP client used for Slack webhook requests.
+// Exported as a variable to allow tests to inject a custom transport.
+var slackHTTPClient = &http.Client{Timeout: 10 * time.Second}
+
 func PostSlackMessage(channel string, payload map[string]any) error {
-	// TODO: wire into Slack API client or webhook
+	webhookURL := os.Getenv("SLACK_WEBHOOK_URL")
+	if webhookURL == "" {
+		return nil
+	}
+
+	msg := map[string]any{
+		"channel": channel,
+	}
+	for k, v := range payload {
+		msg[k] = v
+	}
+
+	body, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("slack: marshal payload: %w", err)
+	}
+
+	resp, err := slackHTTPClient.Post(webhookURL, "application/json", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("slack: post webhook: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("slack: webhook returned status %d", resp.StatusCode)
+	}
+
 	return nil
 }

--- a/harness/runner_test.go
+++ b/harness/runner_test.go
@@ -1,0 +1,79 @@
+package harness
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+func TestPostSlackMessage_NoWebhookURL(t *testing.T) {
+	os.Unsetenv("SLACK_WEBHOOK_URL")
+	err := PostSlackMessage("#general", map[string]any{"text": "hello"})
+	if err != nil {
+		t.Fatalf("expected nil error when SLACK_WEBHOOK_URL is unset, got: %v", err)
+	}
+}
+
+func TestPostSlackMessage_Success(t *testing.T) {
+	var received map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("expected Content-Type application/json, got %s", r.Header.Get("Content-Type"))
+		}
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &received); err != nil {
+			t.Fatalf("failed to unmarshal request body: %v", err)
+		}
+		w.WriteHeader(200)
+		w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	old := os.Getenv("SLACK_WEBHOOK_URL")
+	os.Setenv("SLACK_WEBHOOK_URL", srv.URL)
+	defer os.Setenv("SLACK_WEBHOOK_URL", old)
+
+	err := PostSlackMessage("#secops", map[string]any{
+		"text": ":rotating_light: test alert",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if received["channel"] != "#secops" {
+		t.Errorf("expected channel #secops, got %v", received["channel"])
+	}
+	if received["text"] != ":rotating_light: test alert" {
+		t.Errorf("expected text ':rotating_light: test alert', got %v", received["text"])
+	}
+}
+
+func TestPostSlackMessage_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+	}))
+	defer srv.Close()
+
+	old := os.Getenv("SLACK_WEBHOOK_URL")
+	os.Setenv("SLACK_WEBHOOK_URL", srv.URL)
+	defer os.Setenv("SLACK_WEBHOOK_URL", old)
+
+	err := PostSlackMessage("#general", map[string]any{"text": "test"})
+	if err == nil {
+		t.Fatal("expected error for 500 response, got nil")
+	}
+}
+
+func TestPostSlackMessage_InvalidURL(t *testing.T) {
+	old := os.Getenv("SLACK_WEBHOOK_URL")
+	os.Setenv("SLACK_WEBHOOK_URL", "http://127.0.0.1:0/nonexistent")
+	defer os.Setenv("SLACK_WEBHOOK_URL", old)
+
+	err := PostSlackMessage("#general", map[string]any{"text": "test"})
+	if err == nil {
+		t.Fatal("expected error for unreachable URL, got nil")
+	}
+}


### PR DESCRIPTION
Wire PostSlackMessage into an actual Slack incoming webhook, resolving
the TODO in harness/runner.go. When SLACK_WEBHOOK_URL is set, compliance
notifications are POSTed as JSON to the configured endpoint. When unset,
the function remains a silent no-op for backward compatibility.

Adds unit tests covering success, missing env var, server errors, and
unreachable URL scenarios.

https://claude.ai/code/session_01DAN1jd26awCC7SeaP9Jxm9