### PR TITLE
Implement backend/routes/tasks.js CRUD route handlers

### DIFF
--- a/backend/routes/tasks.js
+++ b/backend/routes/tasks.js
@@ -1,4 +1,70 @@
-// TODO: implement route handlers
-module.exports = function noopRoute(_router) {
-  // Intentionally left blank until real implementation is provided.
-};
+'use strict';
+
+const express = require('express');
+const { addTask, getTask, getTasks, updateTask, deleteTask } = require('../data');
+
+const router = express.Router();
+
+// GET /  - List all tasks for the authenticated user's project
+router.get('/', (req, res) => {
+  const tasks = getTasks(req.auth.projectId);
+  return res.json({ tasks });
+});
+
+// GET /:id  - Get a single task by id
+router.get('/:id', (req, res) => {
+  const task = getTask(req.params.id);
+  if (!task || task.project_id !== req.auth.projectId) {
+    return res.status(404).json({ error: 'task_not_found' });
+  }
+  return res.json({ task });
+});
+
+// POST /  - Create a new task
+router.post('/', (req, res) => {
+  const { title, projectId } = req.body || {};
+  const targetProject = projectId || req.auth.projectId;
+
+  if (!title || typeof title !== 'string' || !title.trim()) {
+    return res.status(400).json({ error: 'invalid_task' });
+  }
+
+  if (targetProject !== req.auth.projectId) {
+    return res.status(403).json({ error: 'forbidden_project' });
+  }
+
+  const task = addTask(targetProject, title.trim());
+  return res.status(201).json({ task });
+});
+
+// PATCH /:id  - Update an existing task
+router.patch('/:id', (req, res) => {
+  const task = getTask(req.params.id);
+  if (!task || task.project_id !== req.auth.projectId) {
+    return res.status(404).json({ error: 'task_not_found' });
+  }
+
+  const fields = {};
+  if (typeof req.body?.title === 'string') {
+    fields.title = req.body.title;
+  }
+  if (typeof req.body?.status === 'string') {
+    fields.status = req.body.status;
+  }
+
+  const updated = updateTask(task.id, fields);
+  return res.json({ task: updated });
+});
+
+// DELETE /:id  - Delete a task
+router.delete('/:id', (req, res) => {
+  const task = getTask(req.params.id);
+  if (!task || task.project_id !== req.auth.projectId) {
+    return res.status(404).json({ error: 'task_not_found' });
+  }
+
+  deleteTask(task.id);
+  return res.json({ ok: true });
+});
+
+module.exports = router;

--- a/tests/test_tasks_route.js
+++ b/tests/test_tasks_route.js
@@ -1,0 +1,134 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+
+process.env.NODE_ENV = 'test';
+process.env.USE_SQLITE_MOCK = '1';
+
+const tasksRouter = require('../backend/routes/tasks');
+
+function makeApp(projectId) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.auth = { userId: 'u1', projectId };
+    next();
+  });
+  app.use('/tasks', tasksRouter);
+  return app;
+}
+
+function listen(app) {
+  const server = app.listen(0);
+  const base = `http://127.0.0.1:${server.address().port}/tasks`;
+  return { server, base };
+}
+
+test('POST /tasks rejects empty title', async () => {
+  const app = makeApp('proj-1');
+  const { server, base } = listen(app);
+  try {
+    const res = await fetch(base, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: '' }),
+    });
+    assert.equal(res.status, 400);
+    const body = await res.json();
+    assert.equal(body.error, 'invalid_task');
+  } finally {
+    server.close();
+  }
+});
+
+test('POST /tasks rejects missing title', async () => {
+  const app = makeApp('proj-1');
+  const { server, base } = listen(app);
+  try {
+    const res = await fetch(base, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    assert.equal(res.status, 400);
+    const body = await res.json();
+    assert.equal(body.error, 'invalid_task');
+  } finally {
+    server.close();
+  }
+});
+
+test('POST /tasks rejects wrong projectId', async () => {
+  const app = makeApp('proj-1');
+  const { server, base } = listen(app);
+  try {
+    const res = await fetch(base, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Test task', projectId: 'proj-other' }),
+    });
+    assert.equal(res.status, 403);
+    const body = await res.json();
+    assert.equal(body.error, 'forbidden_project');
+  } finally {
+    server.close();
+  }
+});
+
+test('GET /tasks returns a list', async () => {
+  const app = makeApp('proj-1');
+  const { server, base } = listen(app);
+  try {
+    const res = await fetch(base);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(Array.isArray(body.tasks));
+  } finally {
+    server.close();
+  }
+});
+
+test('GET /tasks/:id returns 404 for non-existent task', async () => {
+  const app = makeApp('proj-1');
+  const { server, base } = listen(app);
+  try {
+    const res = await fetch(`${base}/no-such-id`);
+    assert.equal(res.status, 404);
+    const body = await res.json();
+    assert.equal(body.error, 'task_not_found');
+  } finally {
+    server.close();
+  }
+});
+
+test('PATCH /tasks/:id returns 404 for non-existent task', async () => {
+  const app = makeApp('proj-1');
+  const { server, base } = listen(app);
+  try {
+    const res = await fetch(`${base}/no-such-id`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'done' }),
+    });
+    assert.equal(res.status, 404);
+    const body = await res.json();
+    assert.equal(body.error, 'task_not_found');
+  } finally {
+    server.close();
+  }
+});
+
+test('DELETE /tasks/:id returns 404 for non-existent task', async () => {
+  const app = makeApp('proj-1');
+  const { server, base } = listen(app);
+  try {
+    const res = await fetch(`${base}/no-such-id`, {
+      method: 'DELETE',
+    });
+    assert.equal(res.status, 404);
+    const body = await res.json();
+    assert.equal(body.error, 'task_not_found');
+  } finally {
+    server.close();
+  }
+});


### PR DESCRIPTION
Replace the noop stub with a full Express Router providing GET, POST,
PATCH, and DELETE endpoints for tasks. The routes use the existing data
layer functions (addTask, getTask, getTasks, updateTask, deleteTask)
and enforce project-scoped authorization via req.auth.projectId.

Add tests/test_tasks_route.js covering input validation and 404 paths.

https://claude.ai/code/session_01B5w25XhE8qggWtU8qUHsBD